### PR TITLE
Bug: Training script with rm-pad-id will only train on subset of dataset.

### DIFF
--- a/docs/tutorials/model_loader.md
+++ b/docs/tutorials/model_loader.md
@@ -16,7 +16,7 @@ VeOmni uses a model registry system that allows you to:
 1. Support both HuggingFace models and their custom implementations
 2. Register your custom model implementation
 3. Automatically load the appropriate model based on the configuration
- 
+
 ## 🔍 Model Registry System
 
 To enable users to quickly train models from HuggingFace and flexibly train custom models, VeOmni adopts a model registration system to support model loading and initialization. This design is inspired by [vLLM](https://github.com/vllm-project/vllm) and [SGLang](https://github.com/sgl-project/sglang). An overall architecture diagram is shown below.
@@ -81,11 +81,11 @@ class YourCustomConfig(PretrainedConfig):
 
 class YourCustomModel(PreTrainedModel):
     config_class = YourCustomConfig
-    
+
     def __init__(self, config):
         super().__init__(config)
         # Initialize your model components
-        
+
     def forward(self, input_ids, **kwargs):
         ...
 

--- a/tasks/omni/train_qwen2_5_vl.py
+++ b/tasks/omni/train_qwen2_5_vl.py
@@ -463,7 +463,7 @@ def main():
 
         data_loader_tqdm.close()
         start_step = 0
-        helper.print_device_mem_info(f"VRAM usage after epoch {epoch+1}")
+        helper.print_device_mem_info(f"VRAM usage after epoch {epoch + 1}")
         if args.train.save_epochs and (epoch + 1) % args.train.save_epochs == 0:
             helper.empty_cache()
             save_checkpoint_path = os.path.join(args.train.save_checkpoint_path, f"global_step_{global_step}")

--- a/tasks/train_torch.py
+++ b/tasks/train_torch.py
@@ -237,6 +237,7 @@ def main():
 
             try:
                 micro_batches: List[Dict[str, Any]] = next(data_iterator)
+                micro_batches.pop("id", None)  # maybe has another option to remove id
             except StopIteration:
                 logger.info(f"epoch:{epoch} Dataloader finished with drop_last {args.data.drop_last}")
                 break

--- a/tests/datasets/test_rm_pad.py
+++ b/tests/datasets/test_rm_pad.py
@@ -1,0 +1,115 @@
+from functools import partial
+
+import torch
+import torch.distributed as dist
+from datasets import load_dataset
+from tqdm import tqdm
+
+from veomni.data import (
+    MappingDataset,
+    build_chat_template,
+    build_dataloader,
+)
+from veomni.data.data_transform import process_sft_example
+from veomni.distributed.parallel_state import get_parallel_state, init_parallel_state
+from veomni.models import build_tokenizer
+from veomni.utils import helper
+from veomni.utils.dist_utils import all_reduce
+
+
+logger = helper.create_logger(__name__)
+
+
+if __name__ == "__main__":
+    dist.init_process_group(backend="gloo")
+    init_parallel_state(
+        dp_size=4,
+        tp_size=1,
+        ep_size=1,
+        pp_size=1,
+        cp_size=1,
+        ulysses_size=1,
+        dp_mode="dp",
+    )
+    dataset_path = "glaiveai/glaive-code-assistant-v2"
+    dataset_iterator = load_dataset(dataset_path, split="train").select(range(1000))
+    dataset_iterator = dataset_iterator.map(
+        lambda x: {
+            "messages": [{"role": "user", "content": x["question"]}, {"role": "assistant", "content": x["answer"]}]
+        }
+    )
+    dataset_iterator = dataset_iterator.add_column("id", range(len(dataset_iterator)))
+    tokenizer = build_tokenizer("Qwen/Qwen2.5-Coder-32B-Instruct")
+    chat_template = build_chat_template("chatml", tokenizer)
+    transform = partial(
+        process_sft_example,
+        chat_template=chat_template,
+        max_seq_len=2048,
+        text_keys=["messages"],
+    )
+    train_dataset = MappingDataset(data=dataset_iterator, transform=transform)
+    total_train_dataset = len(train_dataset)
+    total_tokens = 0
+
+    for item in train_dataset:
+        for sub_item in item:
+            total_tokens += len(sub_item["input_ids"])
+
+    train_steps = total_tokens / (4096 * 128)
+
+    train_dataloader = build_dataloader(
+        dataset=train_dataset,
+        micro_batch_size=4,
+        global_batch_size=128,
+        dataloader_batch_size=4,
+        seed=44,
+        max_seq_len=4096,
+        train_steps=train_steps,
+        rmpad=True,
+        rmpad_with_pos_ids=True,
+        bsz_warmup_ratio=0.0,
+        bsz_warmup_init_mbtoken=0,
+        dyn_bsz_margin=0,
+        dyn_bsz_buffer_size=0,
+        num_workers=2,
+        drop_last=True,
+        pin_memory=False,
+        prefetch_factor=2,
+    )
+
+    total_samples_data_loader = 0
+    list_ids = []
+    for batch in tqdm(train_dataloader):
+        assert len(batch) == 128 // (4 * 4), "len(batch) should be equally 128 / world_size / micro_batch_size"
+        for micro_batch in batch:
+            position_ids = micro_batch["position_ids"]
+            # we will calculate the total number of samples in the data loader by summing the total number of 0 in the position_ids
+            total_zeros = (position_ids == 0).sum()
+            total_samples_data_loader += total_zeros
+            list_ids.extend(micro_batch["id"].tolist())
+
+    # How to collect the ids from all the workers?
+    all_list_ids = [None for _ in range(dist.get_world_size())]
+    dist.all_gather_object(all_list_ids, list_ids, group=get_parallel_state().fsdp_group)
+    all_list_ids = sum(all_list_ids, [])
+    all_list_ids = sum(all_list_ids, [])
+    total_unique_ids = len(set(all_list_ids))
+    total_samples_data_loader = float(total_samples_data_loader)
+    total_samples_data_loader = all_reduce(
+        total_samples_data_loader, op="sum", group=get_parallel_state().fsdp_group, device=torch.device("cpu")
+    )  # we get the total number of samples in the data loader
+
+    if dist.get_rank() == 0:
+        print(f"Total samples in the data loader: {total_samples_data_loader}")
+        print(f"Total samples in the dataset: {total_train_dataset}")
+        print(f"Total unique ids: {total_unique_ids}")
+
+# Before fix the bug, the result is:
+# Total samples in the data loader: 1226.0
+# Total samples in the dataset: 1000
+# Total unique ids: 248
+
+# After fix the bug, the result is:
+# Total samples in the data loader: 1237.0
+# Total samples in the dataset: 1000
+# Total unique ids: 992

--- a/veomni/data/__init__.py
+++ b/veomni/data/__init__.py
@@ -24,7 +24,7 @@ from .data_collator import (
     UnpackDataCollator,
 )
 from .data_loader import build_dataloader
-from .dataset import build_iterative_dataset, build_mapping_dataset
+from .dataset import MappingDataset, build_iterative_dataset, build_mapping_dataset
 from .multimodal.data_collator import (
     OmniDataCollatorWithPacking,
     OmniDataCollatorWithPadding,

--- a/veomni/data/batching_strategy.py
+++ b/veomni/data/batching_strategy.py
@@ -165,7 +165,7 @@ class TextBatchingStrategy(BaseBatchingStrategy):
 
     def put_item(self, item: Dict[str, Any]):
         if len(item["input_ids"]) == 1:
-            print("WARNING: EMPTY STRING.")
+            print("WARNING: EMPTY STRING.", item)
             return
         self.buffer.append(item)
 

--- a/veomni/data/chat_template.py
+++ b/veomni/data/chat_template.py
@@ -228,7 +228,7 @@ class ChatmlTemplate(ChatTemplate):
             content_ids = self.tokenizer.encode(content_str, add_special_tokens=False)
             input_ids += content_ids
             attention_mask += [1] * len(content_ids)
-            if message["loss_mask"] == 1:
+            if message.get("loss_mask", 1) == 1:
                 labels += content_ids
             else:
                 labels += [IGNORE_INDEX] * len(content_ids)

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -107,7 +107,7 @@ class DataCollatorWithPacking(DataCollator):
         seqlens = torch.tensor([len(feature["input_ids"]) for feature in features], dtype=torch.long)
         batch = {"cu_seqlens": len2culen(seqlens)}
         for input_name in features[0].keys():
-            if input_name in ("input_ids", "attention_mask", "labels"):
+            if input_name in ("input_ids", "attention_mask", "labels", "id"):
                 batch[input_name] = torch.cat([feature[input_name] for feature in features])
             else:
                 batch[input_name] = default_collate([feature[input_name] for feature in features])
@@ -124,7 +124,7 @@ class DataCollatorWithPositionIDs(DataCollator):
     def __call__(self, features: Sequence[Dict[str, "torch.Tensor"]]) -> Dict[str, "torch.Tensor"]:
         batch = {}
         for input_name in features[0].keys():
-            if input_name in ("input_ids", "attention_mask", "labels", "position_ids"):
+            if input_name in ("input_ids", "attention_mask", "labels", "position_ids", "id"):
                 batch[input_name] = torch.cat([feature[input_name] for feature in features], dim=-1).unsqueeze(0)
             else:
                 batch[input_name] = default_collate([feature[input_name] for feature in features])
@@ -158,7 +158,12 @@ class UnpackDataCollator(DataCollator):
     """
 
     def __call__(self, features: Sequence[Dict[str, "torch.Tensor"]]) -> Dict[str, "torch.Tensor"]:
-        return features[0]
+        if len(features) == 0:
+            raise ValueError("features is empty")
+        if isinstance(features[0], list):
+            return [f for feature in features for f in feature]
+        else:
+            return features
 
 
 @dataclass

--- a/veomni/data/data_transform.py
+++ b/veomni/data/data_transform.py
@@ -57,12 +57,16 @@ def process_pretrain_example(
         raise ValueError(f"text_keys must be a string or a list of strings, but got {type(text_keys)}")
 
     tokens = tokenizer.encode(text_example, add_special_tokens=False) + [tokenizer.eos_token_id]
+    current_id = 0
+    if "id" in example:
+        current_id = example["id"]
     for input_ids in split_into_chunks(tokens, max_seq_len):
         examples.append(
             {
                 "input_ids": torch.tensor(input_ids),
                 "attention_mask": torch.tensor([1] * len(input_ids)),
                 "labels": torch.tensor(input_ids),
+                "id": torch.tensor(current_id).view(1),
             }
         )
 
@@ -89,4 +93,6 @@ def process_sft_example(
 
     tokenized_example = chat_template.encode_messages(text_example, max_seq_len=max_seq_len)
     tokenized_example = {k: torch.tensor(v) for k, v in tokenized_example.items()}
+    if "id" in example:
+        tokenized_example["id"] = torch.tensor(example["id"]).view(1)
     return [tokenized_example]

--- a/veomni/data/dynamic_batching.py
+++ b/veomni/data/dynamic_batching.py
@@ -138,7 +138,6 @@ class DynamicBatchSizeDataLoader:
             # put processing_item to buffer
             if isinstance(processing_item, dict):
                 processing_item = [processing_item]
-
             for item in processing_item:
                 self.batching_strategy.put_item(item)
 

--- a/veomni/models/transformers/deepseek_v3/modeling_deepseek.py
+++ b/veomni/models/transformers/deepseek_v3/modeling_deepseek.py
@@ -65,10 +65,10 @@ from ....utils.import_utils import is_liger_kernel_available
 
 
 if is_liger_kernel_available():
+    from liger_kernel.ops.swiglu import LigerSiLUMulFunction
     from liger_kernel.transformers import LigerFusedLinearCrossEntropyLoss  # type: ignore
     from liger_kernel.transformers.rms_norm import LigerRMSNorm
     from liger_kernel.transformers.rope import liger_rotary_pos_emb
-    from liger_kernel.ops.swiglu import LigerSiLUMulFunction
 
 
 logger = logging.get_logger(__name__)
@@ -310,9 +310,7 @@ class DeepseekV3MLP(nn.Module):
 
     def forward(self, x):
         if is_liger_kernel_available():
-            down_proj = self.down_proj(
-                LigerSiLUMulFunction.apply(self.gate_proj(x), self.up_proj(x))
-            )
+            down_proj = self.down_proj(LigerSiLUMulFunction.apply(self.gate_proj(x), self.up_proj(x)))
         else:
             down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
 

--- a/veomni/utils/dist_utils.py
+++ b/veomni/utils/dist_utils.py
@@ -38,12 +38,13 @@ def all_reduce(
     data: Union[int, float, List[Union[int, float]], "torch.Tensor"],
     op: Literal["mean", "sum", "max"] = "mean",
     group: Optional["ProcessGroup"] = None,
+    device: Optional[torch.device] = torch.device("cuda"),
 ) -> Union[int, float, List[Union[int, float]]]:
     """
     Performs all reduce in the given process group.
     """
     if not isinstance(data, torch.Tensor):
-        data = torch.tensor(data, dtype=torch.float, device="cuda")
+        data = torch.tensor(data, dtype=torch.float, device=device)
 
     reduce_ops = {"mean": dist.ReduceOp.SUM, "sum": dist.ReduceOp.SUM, "max": dist.ReduceOp.MAX}
     dist.all_reduce(data, op=reduce_ops[op], group=group)


### PR DESCRIPTION

If we use the rmpad_with_pos_ids or rmpad mode, we will train on only a subset of the full dataset.
This is due to the behavior of the  [UnpackDataCollator()](https://github.com/ByteDance-Seed/VeOmni/blob/bc0967c500a0cd34c89b2eaf7056ebb618ee5999/veomni/data/data_loader.py#L115) function, which selects only the first sample in each training batch.

Please see the comment in the script: [test_rm_pad_dataset.py](https://github.com/TueVNguyen/VeOmni/blob/d7de8259a301aaf44e1811716b582e23ad6e5f4a/tests/datasets/test_rm_pad.py#L107)

----
```bash
# Before fix the bug, the result is:
# Total samples in the data loader: 1226.0
# Total samples in the dataset: 1000
# Total unique ids got from dataset: 248

# After fix the bug, the result is:
# Total samples in the data loader: 1237.0
# Total samples in the dataset: 1000
# Total unique ids  got from dataset: 992
 ```