### PR TITLE
feat: support megatron-energon dataset

### DIFF
--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -19,6 +19,7 @@ from veomni.data import (
     build_dataloader,
     build_iterative_dataset,
     build_mapping_dataset,
+    build_energon_dataset,
     build_multimodal_chat_template,
 )
 from veomni.data.constants import IGNORE_INDEX
@@ -235,6 +236,17 @@ def main():
         elif args.data.datasets_type == "mapping":
             logger.info_rank0("Start building mapping dataset")
             train_dataset = build_mapping_dataset(args.data.train_path, transform=transform)
+            args.train.compute_train_steps(args.data.max_seq_len, args.data.train_size, len(train_dataset))
+        elif args.data.datasets_type == "energon":
+            logger.info_rank0("Start building Megatron-Energon native dataset")
+            train_dataset = build_energon_dataset(
+                args.data.train_path, 
+                transform=transform,
+                max_samples_per_sequence=args.data.max_samples_per_sequence if hasattr(args.data, 'max_samples_per_sequence') else None,
+                virtual_epoch_length=args.data.virtual_epoch_length if hasattr(args.data, 'virtual_epoch_length') else None,
+                shuffle_buffer_size=args.data.shuffle_buffer_size if hasattr(args.data, 'shuffle_buffer_size') else None,
+                num_workers=args.data.num_workers,
+            )
             args.train.compute_train_steps(args.data.max_seq_len, args.data.train_size, len(train_dataset))
 
         train_dataloader = build_dataloader(

--- a/tasks/train_torch.py
+++ b/tasks/train_torch.py
@@ -16,6 +16,7 @@ from veomni.data import (
     build_dataloader,
     build_iterative_dataset,
     build_mapping_dataset,
+    build_energon_dataset,
 )
 from veomni.data.data_transform import process_pretrain_example, process_sft_example
 from veomni.distributed.offloading import build_activation_offloading_context
@@ -93,6 +94,17 @@ def main():
         elif args.data.datasets_type == "mapping":
             logger.info_rank0("Start building mapping dataset")
             train_dataset = build_mapping_dataset(args.data.train_path, transform=transform)
+            args.train.compute_train_steps(args.data.max_seq_len, args.data.train_size, len(train_dataset))
+        elif args.data.datasets_type == "energon":
+            logger.info_rank0("Start building Megatron-Energon native dataset")
+            train_dataset = build_energon_dataset(
+                args.data.train_path, 
+                transform=transform,
+                max_samples_per_sequence=args.data.max_samples_per_sequence if hasattr(args.data, 'max_samples_per_sequence') else None,
+                virtual_epoch_length=args.data.virtual_epoch_length if hasattr(args.data, 'virtual_epoch_length') else None,
+                shuffle_buffer_size=args.data.shuffle_buffer_size if hasattr(args.data, 'shuffle_buffer_size') else None,
+                num_workers=args.data.num_workers,
+            )
             args.train.compute_train_steps(args.data.max_seq_len, args.data.train_size, len(train_dataset))
 
         train_dataloader = build_dataloader(

--- a/veomni/data/__init__.py
+++ b/veomni/data/__init__.py
@@ -24,7 +24,11 @@ from .data_collator import (
     UnpackDataCollator,
 )
 from .data_loader import build_dataloader
-from .dataset import build_iterative_dataset, build_mapping_dataset
+from .dataset import (
+    build_iterative_dataset, 
+    build_mapping_dataset,
+    build_energon_dataset,
+)
 from .multimodal.data_collator import (
     OmniDataCollatorWithPacking,
     OmniDataCollatorWithPadding,

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -101,6 +101,117 @@ class IterativeDataset(IterableDataset):
         self._data.set_epoch(epoch)
 
 
+class EnergonDataset(IterativeDataset):
+    """
+    A specialized wrapper for Megatron-Energon datasets that provides:
+    - Automatic WorkerConfig management
+    - TextSample to dict conversion
+    - Native state management using save_state/restore_state
+    - Epoch-based state reset
+    
+    Args:
+        data (Dataset): underlying Megatron-Energon dataset
+        transform (Optional[Callable]): transform function
+    """
+
+    def __init__(self, data: "Dataset", transform: Optional[Callable] = None):
+        self._data = data
+        self._transform = transform
+
+    def __len__(self):
+        """Get the length of the dataset."""
+        if hasattr(self._data, '__len__'):
+            return len(self._data)
+
+    def __iter__(self):
+        """Iterate over the dataset with WorkerConfig management and TextSample conversion."""
+        # For Megatron-Energon datasets, we need to set up the WorkerConfig properly
+        if hasattr(self._data, 'worker_config'):
+            try:
+                from megatron.energon import WorkerConfig
+                # Ensure active_worker_config is None before activation
+                WorkerConfig.active_worker_config = None
+                # Activate the worker config
+                self._data.worker_config.worker_activate(sample_index=0)
+                logger.debug("Activated WorkerConfig for Megatron-Energon dataset")
+            except Exception as e:
+                logger.warning(f"Failed to activate WorkerConfig: {e}")
+        
+        try:
+            for sample in self._data:
+                # Convert Megatron-Energon TextSample to dict for compatibility
+                if hasattr(sample, '__dict__') and not isinstance(sample, dict):
+                    # Convert TextSample or similar objects to dict
+                    sample_dict = {}
+                    for key, value in sample.__dict__.items():
+                        if not key.startswith('_'):  # Skip private attributes
+                            sample_dict[key] = value
+                    
+                    # Handle special case for TextSample
+                    if hasattr(sample, 'text'):
+                        sample_dict['text'] = sample.text
+                    
+                    sample = sample_dict
+                
+                if self._transform is not None:
+                    yield self._transform(sample)
+                else:
+                    yield sample
+        finally:
+            # Clean up WorkerConfig
+            if hasattr(self._data, 'worker_config'):
+                try:
+                    self._data.worker_config.worker_deactivate()
+                    logger.debug("Deactivated WorkerConfig for Megatron-Energon dataset")
+                except Exception as e:
+                    logger.warning(f"Failed to deactivate WorkerConfig: {e}")
+
+    def load_state_dict(self, state_dict):
+        """Load the state of the dataset from checkpointing."""
+        if hasattr(self._data, 'restore_state'):
+            # Use Megatron-Energon's native restore_state method
+            try:
+                self._data.restore_state(state_dict["dataset"])
+            except Exception as e:
+                logger.warning(f"Failed to restore state using restore_state: {e}")
+        elif hasattr(self._data, 'load_state_dict'):
+            # Fallback to load_state_dict if available
+            self._data.load_state_dict(state_dict["dataset"])
+        else:
+            logger.warning(f"Dataset {type(self._data).__name__} does not support state restoration")
+
+    def state_dict(self):
+        """Get the state of the dataset for checkpointing."""
+        if hasattr(self._data, 'save_state'):
+            # Use Megatron-Energon's native save_state method
+            try:
+                state = self._data.save_state()
+                return {"dataset": state}
+            except Exception as e:
+                logger.warning(f"Failed to save state using save_state: {e}")
+                return {"dataset": {}}
+        elif hasattr(self._data, 'state_dict'):
+            # Fallback to state_dict if available
+            return {"dataset": self._data.state_dict()}
+        else:
+            # Return empty state dict for datasets that don't support state management
+            return {"dataset": {}}
+
+    def set_epoch(self, epoch: int):
+        """Set the epoch for the dataset."""
+        if hasattr(self._data, 'set_epoch'):
+            self._data.set_epoch(epoch)
+        elif hasattr(self._data, 'reset_state_deep'):
+            # For Megatron-Energon datasets, reset state when epoch changes
+            try:
+                self._data.reset_state_deep()
+                logger.debug(f"Reset state for epoch {epoch}")
+            except Exception as e:
+                logger.warning(f"Failed to reset state for epoch {epoch}: {e}")
+        else:
+            logger.debug(f"Dataset {type(self._data).__name__} does not support set_epoch or state reset")
+
+
 def build_dummy_dataset(size: int, max_seq_len: int) -> "Dataset":
     return DummyDataset(size=size, seq_length=max_seq_len)
 
@@ -178,3 +289,102 @@ def build_iterative_dataset(
     dataset = split_dataset_by_node(dataset, parallel_state.dp_rank, parallel_state.dp_size)
 
     return IterativeDataset(dataset, transform)
+
+
+def build_energon_dataset(
+    data_path: str,
+    transform: Optional[Callable] = None,
+    namespace: Literal["train", "test"] = "train",
+    max_samples_per_sequence: Optional[int] = None,
+    virtual_epoch_length: Optional[int] = 0,
+    shuffle_buffer_size: Optional[int] = None,
+    num_workers: Optional[int] = None,
+) -> "Dataset":
+    """
+    Build Megatron-Energon native dataset using the official get_train_dataset function.
+    
+    This is the recommended way to use Megatron-Energon datasets as it provides:
+    - Automatic length calculation based on virtual_epoch_length
+    - Built-in field mapping (txt -> text)
+    - Professional streaming dataset support
+    - Built-in error handling and performance optimizations
+    
+    Args:
+        data_path (str): Path to the energon dataset directory
+        transform (Optional[Callable]): Transform function to apply to samples
+        namespace (Literal["train", "test"]): Dataset namespace (not used for energon)
+        max_samples_per_sequence (Optional[int]): Maximum samples per sequence
+        virtual_epoch_length (Optional[int]): Virtual epoch length for length calculation
+        shuffle_buffer_size (Optional[int]): Shuffle buffer size
+        num_workers (Optional[int]): Number of workers (if None, will be auto-detected)
+    
+    Returns:
+        Dataset: Megatron-Energon native dataset
+    """
+    try:
+        from megatron.energon import get_train_dataset, WorkerConfig
+        from megatron.energon.epathlib import EPath
+    except ImportError:
+        raise ImportError(
+            "Megatron-Energon is not installed. Please install it with: "
+            "pip install megatron-energon"
+        )
+    
+    # Get parallel state for distributed training
+    parallel_state = get_parallel_state()
+    
+    # Auto-detect number of workers if not provided
+    if num_workers is None:
+        # Try to get from environment or use a reasonable default
+        num_workers = int(os.environ.get('TORCH_DATA_WORKERS', '1'))
+
+    # Create base WorkerConfig
+    base_worker_config = WorkerConfig(
+        rank=parallel_state.dp_rank,
+        world_size=parallel_state.dp_size,
+        num_workers=num_workers
+    )
+    
+    # Wrap it with our compatible version
+    worker_config = base_worker_config
+    
+    logger.info(f"Created WorkerConfig: rank={parallel_state.dp_rank}, world_size={parallel_state.dp_size}")
+
+    if virtual_epoch_length is None:
+        # Estimate based on data path - look for .nv-meta/info.json
+        try:
+            meta_path = os.path.join(data_path, ".nv-meta", "info.json")
+            if os.path.exists(meta_path):
+                import json
+                with open(meta_path, 'r') as f:
+                    info = json.load(f)
+                    if 'splits' in info and 'train' in info['splits']:
+                        virtual_epoch_length = info['splits']['train'].get('num_samples', 1000000)
+                    else:
+                        virtual_epoch_length = 0
+        except Exception as e:
+            logger.warning(f"Could not determine virtual_epoch_length from metadata: {e}")
+        if virtual_epoch_length is None:
+            virtual_epoch_length = 0  # Fallback
+
+    logger.info(f"Building Megatron-Energon native dataset from {data_path}")
+    logger.info(f"  - max_samples_per_sequence: {max_samples_per_sequence}")
+    logger.info(f"  - virtual_epoch_length: {virtual_epoch_length}")
+    logger.info(f"  - shuffle_buffer_size: {shuffle_buffer_size}")
+
+    # Get the dataset using Megatron-Energon's official function
+    dataset = get_train_dataset(
+        path=data_path,
+        split_part=namespace,
+        worker_config=worker_config,
+        batch_size=None,  # No batching at dataset level
+        shuffle_buffer_size=shuffle_buffer_size,
+        max_samples_per_sequence=max_samples_per_sequence,
+        virtual_epoch_length=virtual_epoch_length,
+        repeat=True,  # Always repeat for training
+    )
+    
+    logger.info(f"Dataset type: {type(dataset)} Dataset length: {len(dataset)}")
+    
+    # Wrap in our EnergonDataset for Megatron-Energon specific functionality
+    return EnergonDataset(dataset, transform)

--- a/veomni/utils/arguments.py
+++ b/veomni/utils/arguments.py
@@ -136,7 +136,7 @@ class DataArguments:
         default="native",
         metadata={"help": "Type of the dataloader."},
     )
-    datasets_type: Literal["mapping", "iterable"] = field(
+    datasets_type: Literal["mapping", "iterable", "energon"] = field(
         default="mapping",
         metadata={"help": "Type of the datasets."},
     )


### PR DESCRIPTION
### What does this PR do?
Support load [Megatron-Energon](https://github.com/NVIDIA/Megatron-Energon) Dataset

> Megatron-Energon_ offers enhanced efficiency, flexibility, scalability and rich metadata support, making it an ideal choice for large-scale distributed training

### API and Usage Example

add **energon** datasets_type
- usage:
```sh
    # use megatron-energon type dataset
    --data.train_path $DATA_PATH \
    --data.datasets_type energon \
```

- example script:
```sh
MODEL_PATH=/cpfs/user/weishi/models/Qwen3-30B-A3B
SAVE_PATH=Qwen3-30B-A3B
CONFIG=configs/pretrain/qwen3-moe.yaml
DATA_PATH=/prodcpfs/user/weishi/data/text_data_converted/pile_test/webdataset
bash train.sh tasks/train_torch.py $CONFIG \
    --model.model_path ${MODEL_PATH} \
    --data.train_path $DATA_PATH \
    --data.num_workers 32 \
    --data.datasets_type energon \
    --train.global_batch_size 128 \
    --train.lr 5e-7 \
    --train.ulysses_parallel_size 1 \
    --train.save_steps 10 \
    --train.max_steps 20 \
    --train.ckpt_manager dcp \
    --train.output_dir ${SAVE_PATH}
```

- dataset logs:
<img width="1630" height="787" alt="image" src="https://github.com/user-attachments/assets/b2ee2fb5-91fc-40d8-a001-6f73702030bd" />
