### PR TITLE
[model] fix: correct output tensor shape in Qwen3MoeSparseFusedMoeBlock

### DIFF
--- a/veomni/models/transformers/qwen3_moe/modeling_qwen3_moe.py
+++ b/veomni/models/transformers/qwen3_moe/modeling_qwen3_moe.py
@@ -445,7 +445,7 @@ class Qwen3MoeSparseFusedMoeBlock(nn.Module):
         final_hidden_states = self.experts(
             hidden_states, routing_weights=routing_weights, selected_experts=selected_experts
         )
-
+        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
         return final_hidden_states, router_logits
 
 


### PR DESCRIPTION
This PR fixes a critical tensor shape mismatch bug that occurs under specific conditions: 
- when moe_implementation is set to "fused" 
- micro batch size is greater than 1. 

Previously, this combination would trigger a runtime error (shape mismatch) because final_hidden_states was not properly reshaped back to its original dimensions.