### PR TITLE
fix: use argument global_rank to check is rank 0 in get_checkpoint_path

### DIFF
--- a/veomni/utils/arguments.py
+++ b/veomni/utils/arguments.py
@@ -596,7 +596,7 @@ class TrainingArguments:
         if self.load_checkpoint_path == "auto":
             from .checkpoint_utils import get_checkpoint_path
 
-            self.load_checkpoint_path = get_checkpoint_path(self.output_dir)
+            self.load_checkpoint_path = get_checkpoint_path(self.output_dir, is_rank0=self.global_rank == 0)
 
         # save paths
         self.save_checkpoint_path = os.path.join(self.output_dir, "checkpoints")

--- a/veomni/utils/checkpoint_utils.py
+++ b/veomni/utils/checkpoint_utils.py
@@ -24,9 +24,9 @@ except ImportError:
     from .hdfs_io import copy, exists
 
 
-def get_last_iteration(output_dir):
+def get_last_iteration(output_dir, is_rank0: bool):
     meta_file = "latest_checkpointed_iteration.txt"
-    if dist.get_global_rank() == 0:
+    if is_rank0:
         latest_file = os.path.join(output_dir, "checkpoints", meta_file)
         if exists(latest_file):
             copy(latest_file, meta_file)
@@ -39,14 +39,14 @@ def get_last_iteration(output_dir):
         iteration = 0
 
     dist.barrier()
-    if dist.get_global_rank() == 0:
+    if is_rank0:
         if os.path.exists(meta_file):
             os.remove(meta_file)
 
     return iteration
 
 
-def get_checkpoint_path(output_dir):
-    iteration = get_last_iteration(output_dir)
+def get_checkpoint_path(output_dir, is_rank0: bool):
+    iteration = get_last_iteration(output_dir, is_rank0)
     if iteration:
         return os.path.join(output_dir, "checkpoints", f"global_step_{iteration}")


### PR DESCRIPTION
# problem
currently in trainer, we usually parse argument as the first statement before initializing dist group. 

However, when parsing checkpoint path (tirggered when `load_checkpoint_path=auto`), it calls dist.get_global_rank() which panics:

<img width="1280" height="141" alt="image" src="https://github.com/user-attachments/assets/c7740191-ae41-4124-bd8b-16f6579c9b80" />

# Fix

Since we only need to check if it's rank0, we can just use `Argument.global_rank == 0` to check

# Tested

Started a local training task and setting `load_checkpoint_path=auto` to trigger the changed path and it works properly now.