### PR TITLE
[model] fix: Switch qwen3 and seed_oss to veomni defined GradientCheckpointingLayer

### DIFF
--- a/veomni/models/transformers/qwen3/modeling_qwen3.py
+++ b/veomni/models/transformers/qwen3/modeling_qwen3.py
@@ -7,7 +7,6 @@ from transformers.cache_utils import Cache, DynamicCache, SlidingWindowCache, St
 from transformers.generation import GenerationMixin
 from transformers.modeling_attn_mask_utils import AttentionMaskConverter
 from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
-from transformers.modeling_layer import GradientCheckpointingLayer
 from transformers.modeling_outputs import (
     BaseModelOutputWithPast,
     CausalLMOutputWithPast,
@@ -29,6 +28,7 @@ from ....distributed.sequence_parallel import slice_position_embedding
 from ....ops.loss import causallm_loss_function
 from ....utils import logging
 from ....utils.import_utils import is_liger_kernel_available, is_torch_npu_available
+from ...module_utils import GradientCheckpointingLayer
 
 
 if is_torch_flex_attn_available():

--- a/veomni/models/transformers/seed_oss/modeling_seed_oss.py
+++ b/veomni/models/transformers/seed_oss/modeling_seed_oss.py
@@ -24,7 +24,6 @@ from transformers.modeling_layers import (
     GenericForQuestionAnswering,
     GenericForSequenceClassification,
     GenericForTokenClassification,
-    GradientCheckpointingLayer,
 )
 from transformers.modeling_outputs import (
     BaseModelOutputWithPast,
@@ -43,6 +42,7 @@ from ....distributed.sequence_parallel import slice_position_embedding
 from ....ops.loss import causallm_loss_function
 from ....utils import logging
 from ....utils.import_utils import is_liger_kernel_available
+from ...module_utils import GradientCheckpointingLayer
 
 
 if is_liger_kernel_available():


### PR DESCRIPTION

### What does this PR do?

Before this fix, importing qwen3 dense model always has a failure in transformers 4.51.x environment since
qwen3 dense modeling imports the transfromers GradientCheckpointingLayer which is introduced in 4.52+

So we switch back to veomni defined GradientCheckpointingLayer and also update seed_oss impl to do that for 
consistency (note that seed_oss still needs transformers 4.56+)

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `core`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `
  - If this PR involves multiple modules, separate them with `,` like `[megatron, torch, liger-kernals,fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, torch, liger-kernals] feat: dynamic batching`

### Test

Tested locally and no longer see errors.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [x] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
