### PR TITLE
[misc] feat: add skip_ulysses flag to bypass Ulysses logic in flash_attention_forward

### DIFF
--- a/veomni/ops/attention.py
+++ b/veomni/ops/attention.py
@@ -41,7 +41,7 @@ def flash_attention_forward(
     sliding_window: Optional[int] = None,
     softcap: Optional[float] = None,
     implementation: Optional[Literal["fa2", "lego", "fa3"]] = None,
-    skip_ulysses: bool = False, # Skip ulysses for some ViT cases like internvl3.5
+    skip_ulysses: bool = False,  # Skip ulysses for some ViT cases like internvl3.5
     **kwargs,
 ) -> Tuple[torch.Tensor, None]:
     if kwargs.get("output_attentions", False) or kwargs.get("head_mask", None) is not None:

--- a/veomni/ops/attention.py
+++ b/veomni/ops/attention.py
@@ -41,6 +41,7 @@ def flash_attention_forward(
     sliding_window: Optional[int] = None,
     softcap: Optional[float] = None,
     implementation: Optional[Literal["fa2", "lego", "fa3"]] = None,
+    skip_ulysses: bool = False, # Skip ulysses for some ViT cases like internvl3.5
     **kwargs,
 ) -> Tuple[torch.Tensor, None]:
     if kwargs.get("output_attentions", False) or kwargs.get("head_mask", None) is not None:
@@ -64,7 +65,7 @@ def flash_attention_forward(
 
     # Ulysses patch
     ulysses_enabled = get_parallel_state().ulysses_enabled
-    if ulysses_enabled:
+    if ulysses_enabled and not skip_ulysses:
         ulysses_group = get_parallel_state().ulysses_group
         # Sanity Check & Repeat Key & Value
         ulysses_size = get_parallel_state().ulysses_size
@@ -149,7 +150,7 @@ def flash_attention_forward(
         )
 
     # Ulysses patch
-    if ulysses_enabled:
+    if ulysses_enabled and not skip_ulysses:
         ulysses_group = get_parallel_state().ulysses_group
         if attn_output.ndim == 4 and attn_output.size(0) == 1:
             attn_output = attn_output.squeeze(0)


### PR DESCRIPTION
This PR introduces a new optional parameter, skip_ulysses, to the flash_attention_forward function, allowing selective bypassing of the Ulysses-specific logic during attention computation. This is useful in special cases (e.g., ViT of InternVL 3.5) where the Ulysses logic is either unnecessary or causes issues — for example, when sequence parallelism is used but the split is done along the batch dimension instead of the sequence dimension for the ViT. Later language models still use the standard Ulysses attention logic, so we should keep ulysses_enabled set to True even when skipping Ulysses attention for ViT models during sequence parallelism.