### PR TITLE
[misc] feat: option to profile rank0 only or all the ranks

### DIFF
--- a/scripts/profile/merge_chrome_trace.py
+++ b/scripts/profile/merge_chrome_trace.py
@@ -1,0 +1,111 @@
+import argparse
+import glob
+import gzip
+import json
+import os
+from typing import List
+
+
+def merge_traces_direct(input_patterns: List[str], output: str):
+    """
+    Directly merge PyTorch trace files without timeline alignment.
+    Each rank will maintain its original timestamps.
+    """
+    merged = {"schemaVersion": 1, "deviceProperties": [], "traceEvents": []}
+
+    for pattern in input_patterns:
+        files = sorted(glob.glob(pattern))
+
+        for i, file_path in enumerate(files):
+            print(f"Processing {file_path}...")
+
+            # Extract rank from filename
+            rank = None
+            if "rank" in file_path:
+                rank_part = file_path.split("rank")[1].split("_")[0]
+                try:
+                    rank = int(rank_part)
+                except ValueError:
+                    rank = i
+            else:
+                rank = i
+
+            # Open gzipped or regular JSON
+            if file_path.endswith(".gz"):
+                with gzip.open(file_path, "rt") as f:
+                    data = json.load(f)
+            else:
+                with open(file_path) as f:
+                    data = json.load(f)
+
+            # Merge device properties
+            if "deviceProperties" in data:
+                for device in data["deviceProperties"]:
+                    device_copy = device.copy()
+                    device_copy["name"] = f"Rank {rank} - {device.get('name', 'Unknown Device')}"
+                    merged["deviceProperties"].append(device_copy)
+
+            # Add trace events with rank identification
+            if "traceEvents" in data:
+                for event in data["traceEvents"]:
+                    event_copy = event.copy()
+
+                    # Add rank information to event names
+                    if "name" in event_copy:
+                        event_copy["name"] = f"[R{rank}] {event_copy['name']}"
+
+                    # Modify process/thread IDs to separate ranks
+                    if "pid" in event_copy:
+                        if isinstance(event_copy["pid"], str):
+                            event_copy["pid"] = f"rank{rank}_{event_copy['pid']}"
+                        else:
+                            event_copy["pid"] = int(event_copy["pid"]) + (rank * 1000)
+                    else:
+                        event_copy["pid"] = rank * 1000
+
+                    if "tid" in event_copy:
+                        if isinstance(event_copy["tid"], str):
+                            event_copy["tid"] = f"rank{rank}_{event_copy['tid']}"
+                        else:
+                            event_copy["tid"] = int(event_copy["tid"]) + (rank * 1000)
+                    else:
+                        event_copy["tid"] = rank * 1000
+
+                    merged["traceEvents"].append(event_copy)
+
+    # Sort events by timestamp
+    merged["traceEvents"].sort(key=lambda x: x.get("ts", 0))
+
+    print(f"Writing merged trace to {output}...")
+    print(f"Total events: {len(merged['traceEvents'])}")
+
+    # Write compressed JSON
+    if not output.endswith(".gz"):
+        output += ".gz"
+
+    with gzip.open(output, "wt") as f:
+        json.dump(merged, f, separators=(",", ":"))
+
+    print(f"Merged trace saved as {output}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Merge PyTorch profiler traces.")
+    parser.add_argument("--input-dir", type=str, required=True, help="Directory containing input trace files")
+    parser.add_argument(
+        "--pattern",
+        type=str,
+        default="veomni_rank*.pt.trace.json.gz",
+        help="Filename pattern for trace files (default: veomni_rank*.pt.trace.json.gz)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="merged_trace.json.gz",
+        help="Output merged JSON file (default: merged_trace.json)",
+    )
+
+    args = parser.parse_args()
+
+    input_path = os.path.join(args.input_dir, args.pattern)
+    merge_traces_direct([input_path], args.output)

--- a/tasks/omni/train_flux.py
+++ b/tasks/omni/train_flux.py
@@ -327,19 +327,20 @@ def main():
                 config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
             )
 
-        if args.train.enable_profiling:
-            profiler = helper.create_profiler(
-                start_step=args.train.profile_start_step,
-                end_step=args.train.profile_end_step,
-                trace_dir=args.train.profile_trace_dir,
-                record_shapes=args.train.profile_record_shapes,
-                profile_memory=args.train.profile_profile_memory,
-                with_stack=args.train.profile_with_stack,
-            )
-            profiler.start()
-
         model_assets = [model_config]
         save_model_assets(args.train.model_assets_dir, model_assets)
+
+    if args.train.profile_this_rank:
+        profiler = helper.create_profiler(
+            start_step=args.train.profile_start_step,
+            end_step=args.train.profile_end_step,
+            trace_dir=args.train.profile_trace_dir,
+            record_shapes=args.train.profile_record_shapes,
+            profile_memory=args.train.profile_profile_memory,
+            with_stack=args.train.profile_with_stack,
+            global_rank=args.train.global_rank,
+        )
+        profiler.start()
 
     flow_scheduler = FlowMatchScheduler(
         shift=5,
@@ -501,10 +502,11 @@ def main():
                     )
                     wandb.log(train_metrics, step=global_step)
 
-                if args.train.enable_profiling and global_step <= args.train.profile_end_step:
-                    profiler.step()
-                    if global_step == args.train.profile_end_step:
-                        profiler.stop()
+            if args.train.profile_this_rank and global_step <= args.train.profile_end_step:
+                profiler.step()
+                if global_step == args.train.profile_end_step:
+                    profiler.stop()
+
             if args.train.save_steps and global_step % args.train.save_steps == 0:
                 helper.empty_cache()
                 save_checkpoint_path = os.path.join(args.train.save_checkpoint_path, f"global_step_{global_step}")

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -357,6 +357,9 @@ def main():
                 config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
             )
 
+        model_assets = [model_config, processor]
+        save_model_assets(args.train.model_assets_dir, model_assets)
+
     if args.train.profile_this_rank:
         profiler = helper.create_profiler(
             start_step=args.train.profile_start_step,
@@ -368,9 +371,6 @@ def main():
             global_rank=args.train.global_rank,
         )
         profiler.start()
-
-        model_assets = [model_config, processor]
-        save_model_assets(args.train.model_assets_dir, model_assets)
 
     start_epoch, start_step, global_step = 0, 0, 0
     save_checkpoint_path = None

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -357,16 +357,17 @@ def main():
                 config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
             )
 
-        if args.train.enable_profiling:
-            profiler = helper.create_profiler(
-                start_step=args.train.profile_start_step,
-                end_step=args.train.profile_end_step,
-                trace_dir=args.train.profile_trace_dir,
-                record_shapes=args.train.profile_record_shapes,
-                profile_memory=args.train.profile_profile_memory,
-                with_stack=args.train.profile_with_stack,
-            )
-            profiler.start()
+    if args.train.profile_this_rank:
+        profiler = helper.create_profiler(
+            start_step=args.train.profile_start_step,
+            end_step=args.train.profile_end_step,
+            trace_dir=args.train.profile_trace_dir,
+            record_shapes=args.train.profile_record_shapes,
+            profile_memory=args.train.profile_profile_memory,
+            with_stack=args.train.profile_with_stack,
+            global_rank=args.train.global_rank,
+        )
+        profiler.start()
 
         model_assets = [model_config, processor]
         save_model_assets(args.train.model_assets_dir, model_assets)
@@ -499,13 +500,11 @@ def main():
                     train_metrics.update({f"training/{k}": v for k, v in step_info.items()})
                     wandb.log(train_metrics, step=global_step)
 
-                if args.train.enable_profiling and global_step <= args.train.profile_end_step:
-                    profiler.step()
-                    if global_step == args.train.profile_end_step:
-                        profiler.stop()
-                        helper.upload_trace(
-                            args.train.wandb_project, args.train.wandb_name, args.train.profile_trace_dir
-                        )
+            if args.train.profile_this_rank and global_step <= args.train.profile_end_step:
+                profiler.step()
+                if global_step == args.train.profile_end_step:
+                    profiler.stop()
+                    helper.upload_trace(args.train.wandb_project, args.train.wandb_name, args.train.profile_trace_dir)
 
             if args.train.save_steps and global_step % args.train.save_steps == 0:
                 helper.empty_cache()

--- a/tasks/omni/train_qwen2_5_vl.py
+++ b/tasks/omni/train_qwen2_5_vl.py
@@ -290,19 +290,20 @@ def main():
                 config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
             )
 
-        if args.train.enable_profiling:
-            profiler = helper.create_profiler(
-                start_step=args.train.profile_start_step,
-                end_step=args.train.profile_end_step,
-                trace_dir=args.train.profile_trace_dir,
-                record_shapes=args.train.profile_record_shapes,
-                profile_memory=args.train.profile_profile_memory,
-                with_stack=args.train.profile_with_stack,
-            )
-            profiler.start()
-
         model_assets = [model_config, processor]
         save_model_assets(args.train.model_assets_dir, model_assets)
+
+    if args.train.profile_this_rank:
+        profiler = helper.create_profiler(
+            start_step=args.train.profile_start_step,
+            end_step=args.train.profile_end_step,
+            trace_dir=args.train.profile_trace_dir,
+            record_shapes=args.train.profile_record_shapes,
+            profile_memory=args.train.profile_profile_memory,
+            with_stack=args.train.profile_with_stack,
+            global_rank=args.train.global_rank,
+        )
+        profiler.start()
 
     start_epoch, start_step, global_step = 0, 0, 0
     save_checkpoint_path = None
@@ -413,10 +414,10 @@ def main():
                     )
                     wandb.log(train_metrics, step=global_step)
 
-                if args.train.enable_profiling and global_step <= args.train.profile_end_step:
-                    profiler.step()
-                    if global_step == args.train.profile_end_step:
-                        profiler.stop()
+            if args.train.profile_this_rank and global_step <= args.train.profile_end_step:
+                profiler.step()
+                if global_step == args.train.profile_end_step:
+                    profiler.stop()
 
             if args.train.save_steps and global_step % args.train.save_steps == 0:
                 helper.empty_cache()

--- a/tasks/omni/train_qwen2_vl.py
+++ b/tasks/omni/train_qwen2_vl.py
@@ -291,19 +291,20 @@ def main():
                 config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
             )
 
-        if args.train.enable_profiling:
-            profiler = helper.create_profiler(
-                start_step=args.train.profile_start_step,
-                end_step=args.train.profile_end_step,
-                trace_dir=args.train.profile_trace_dir,
-                record_shapes=args.train.profile_record_shapes,
-                profile_memory=args.train.profile_profile_memory,
-                with_stack=args.train.profile_with_stack,
-            )
-            profiler.start()
-
         model_assets = [model_config, processor]
         save_model_assets(args.train.model_assets_dir, model_assets)
+
+    if args.train.profile_this_rank:
+        profiler = helper.create_profiler(
+            start_step=args.train.profile_start_step,
+            end_step=args.train.profile_end_step,
+            trace_dir=args.train.profile_trace_dir,
+            record_shapes=args.train.profile_record_shapes,
+            profile_memory=args.train.profile_profile_memory,
+            with_stack=args.train.profile_with_stack,
+            global_rank=args.train.global_rank,
+        )
+        profiler.start()
 
     start_epoch, start_step, global_step = 0, 0, 0
     save_checkpoint_path = None
@@ -415,13 +416,11 @@ def main():
                     )
                     wandb.log(train_metrics, step=global_step)
 
-                if args.train.enable_profiling and global_step <= args.train.profile_end_step:
-                    profiler.step()
-                    if global_step == args.train.profile_end_step:
-                        profiler.stop()
-                        helper.upload_trace(
-                            args.train.wandb_project, args.train.wandb_name, args.train.profile_trace_dir
-                        )
+            if args.train.profile_this_rank and global_step <= args.train.profile_end_step:
+                profiler.step()
+                if global_step == args.train.profile_end_step:
+                    profiler.stop()
+                    helper.upload_trace(args.train.wandb_project, args.train.wandb_name, args.train.profile_trace_dir)
 
             if args.train.save_steps and global_step % args.train.save_steps == 0:
                 helper.empty_cache()

--- a/tasks/train_torch.py
+++ b/tasks/train_torch.py
@@ -205,20 +205,21 @@ def main():
                 config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
             )
 
-        if args.train.enable_profiling:
-            profiler = helper.create_profiler(
-                start_step=args.train.profile_start_step,
-                end_step=args.train.profile_end_step,
-                trace_dir=args.train.profile_trace_dir,
-                record_shapes=args.train.profile_record_shapes,
-                profile_memory=args.train.profile_profile_memory,
-                with_stack=args.train.profile_with_stack,
-            )
-            profiler.start()
-
         # save model_assets before training
         model_assets = [model_config, tokenizer if args.data.data_type == "plaintext" else chat_template]
         save_model_assets(args.train.model_assets_dir, model_assets)
+
+    if args.train.profile_this_rank:
+        profiler = helper.create_profiler(
+            start_step=args.train.profile_start_step,
+            end_step=args.train.profile_end_step,
+            trace_dir=args.train.profile_trace_dir,
+            record_shapes=args.train.profile_record_shapes,
+            profile_memory=args.train.profile_profile_memory,
+            with_stack=args.train.profile_with_stack,
+            global_rank=args.train.global_rank,
+        )
+        profiler.start()
 
     start_epoch, start_step, global_step = 0, 0, 0
     save_checkpoint_path = None
@@ -336,10 +337,10 @@ def main():
                     )
                     wandb.log(train_metrics, step=global_step)
 
-                if args.train.enable_profiling and global_step <= args.train.profile_end_step:
-                    profiler.step()
-                    if global_step == args.train.profile_end_step:
-                        profiler.stop()
+            if args.train.profile_this_rank and global_step <= args.train.profile_end_step:
+                profiler.step()
+                if global_step == args.train.profile_end_step:
+                    profiler.stop()
 
             if args.train.save_steps and global_step % args.train.save_steps == 0:
                 helper.empty_cache()

--- a/veomni/utils/arguments.py
+++ b/veomni/utils/arguments.py
@@ -499,7 +499,12 @@ class TrainingArguments:
         default=True,
         metadata={"help": "Whether or not to record the stack traces."},
     )
-    profile_rank0_only: bool = field(default=True, metadata={"help": "whether to profile rank0 only"})
+    profile_rank0_only: bool = field(
+        default=True,
+        metadata={
+            "help": "whether to profile rank0 only. When false, every rank will be profiled; Please expect many files to save, which can be slow and take a lot of disk space."
+        },
+    )
     max_steps: Optional[int] = field(
         default=None,
         metadata={"help": "Max training steps per epoch. (for debug)"},
@@ -619,6 +624,9 @@ class TrainingArguments:
             if self.profile_rank0_only:
                 self.profile_this_rank = self.global_rank == 0
             else:
+                logger.warning_rank0(
+                    "Profiling on ALL ranks is enabled. This would save a lot of files which takes time and space."
+                )
                 self.profile_this_rank = True
         else:
             self.profile_this_rank = False

--- a/veomni/utils/arguments.py
+++ b/veomni/utils/arguments.py
@@ -499,6 +499,7 @@ class TrainingArguments:
         default=True,
         metadata={"help": "Whether or not to record the stack traces."},
     )
+    profile_rank0_only: bool = field(default=True, metadata={"help": "whether to profile rank0 only"})
     max_steps: Optional[int] = field(
         default=None,
         metadata={"help": "Max training steps per epoch. (for debug)"},
@@ -612,6 +613,15 @@ class TrainingArguments:
         self.save_checkpoint_path = os.path.join(self.output_dir, "checkpoints")
         self.step2token_path = os.path.join(self.output_dir, "step2token.json")
         self.model_assets_dir = os.path.join(self.output_dir, "model_assets")
+
+        # determine whether to profile this rank
+        if self.enable_profiling:
+            if self.profile_rank0_only:
+                self.profile_this_rank = self.global_rank == 0
+            else:
+                self.profile_this_rank = True
+        else:
+            self.profile_this_rank = False
 
     def compute_train_steps(
         self, max_seq_len: Optional[int] = None, train_size: Optional[int] = None, dataset_length: Optional[int] = None

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -594,7 +594,13 @@ class ProfilerWithMem:
 
 
 def create_profiler(
-    start_step: int, end_step: int, trace_dir: str, record_shapes: bool, profile_memory: bool, with_stack: bool
+    start_step: int,
+    end_step: int,
+    trace_dir: str,
+    record_shapes: bool,
+    profile_memory: bool,
+    with_stack: bool,
+    global_rank: int,
 ):
     """
     Creates a profiler to record the CPU and CUDA activities. Default export to trace.json.
@@ -622,14 +628,18 @@ def create_profiler(
         if trace_dir.startswith("hdfs://"):
             hdfs_io.makedirs(trace_dir, exist_ok=True)
             os.makedirs(CACHE_DIR, exist_ok=True)
-            trace_file = os.path.join(CACHE_DIR, f"veomni_rank0_{time}.{trace_file_extention}")
-            memory_timeline_file = os.path.join(CACHE_DIR, f"veomni_rank0_{time}.{memory_timeline_file_extention}")
-            gpu_memory_file = os.path.join(CACHE_DIR, f"veomni_rank0_{time}.{gpu_memory_file_extension}")
+            trace_file = os.path.join(CACHE_DIR, f"veomni_rank{global_rank}_{time}.{trace_file_extention}")
+            memory_timeline_file = os.path.join(
+                CACHE_DIR, f"veomni_rank{global_rank}_{time}.{memory_timeline_file_extention}"
+            )
+            gpu_memory_file = os.path.join(CACHE_DIR, f"veomni_rank{global_rank}_{time}.{gpu_memory_file_extension}")
         else:
             os.makedirs(trace_dir, exist_ok=True)
-            trace_file = os.path.join(trace_dir, f"veomni_rank0_{time}.{trace_file_extention}")
-            memory_timeline_file = os.path.join(trace_dir, f"veomni_rank0_{time}.{memory_timeline_file_extention}")
-            gpu_memory_file = os.path.join(trace_dir, f"veomni_rank0_{time}.{gpu_memory_file_extension}")
+            trace_file = os.path.join(trace_dir, f"veomni_rank{global_rank}_{time}.{trace_file_extention}")
+            memory_timeline_file = os.path.join(
+                trace_dir, f"veomni_rank{global_rank}_{time}.{memory_timeline_file_extention}"
+            )
+            gpu_memory_file = os.path.join(trace_dir, f"veomni_rank{global_rank}_{time}.{gpu_memory_file_extension}")
 
         p.export_chrome_trace(trace_file)
         logger.info(f"Profiling result saved at {trace_file}.")
@@ -693,7 +703,7 @@ def create_profiler(
         with_modules=True,
         with_stack=with_stack,
     )
-    if IS_CUDA_AVAILABLE:
+    if IS_CUDA_AVAILABLE and profile_memory:
         return ProfilerWithMem(base_profiler)
     else:
         return base_profiler


### PR DESCRIPTION
Adding `profile_rank0_only` option (default as true) to end user.
Then a `profile_this_rank` argument is determined in the post init of training arguments.
Trainer script would leverage `profile_this_rank` to decide whether to create a profiler on this rank.
Consequently, we add a `global_rank` option to `create_profiler` for correct naming profile artifacts.

Also provides a script to merge profiles:
```
python scripts/profile/merge_chrome_trace.py --input-dir ./trace
```

* Comes with a fix to only use `ProfileWithMem` profiler when `profile_memory` is true instead of when CUDA is available.
