### PR TITLE
[misc] fix: remove buggy memory timeline export

### DIFF
--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -622,30 +622,21 @@ def create_profiler(
 
         # torch_npu does not support export gzip trace json directly
         trace_file_extention = "pt.trace.json" if IS_NPU_AVAILABLE else "pt.trace.json.gz"
-        memory_timeline_file_extention = "html"
         gpu_memory_file_extension = "pkl"
 
         if trace_dir.startswith("hdfs://"):
             hdfs_io.makedirs(trace_dir, exist_ok=True)
             os.makedirs(CACHE_DIR, exist_ok=True)
             trace_file = os.path.join(CACHE_DIR, f"veomni_rank{global_rank}_{time}.{trace_file_extention}")
-            memory_timeline_file = os.path.join(
-                CACHE_DIR, f"veomni_rank{global_rank}_{time}.{memory_timeline_file_extention}"
-            )
             gpu_memory_file = os.path.join(CACHE_DIR, f"veomni_rank{global_rank}_{time}.{gpu_memory_file_extension}")
         else:
             os.makedirs(trace_dir, exist_ok=True)
             trace_file = os.path.join(trace_dir, f"veomni_rank{global_rank}_{time}.{trace_file_extention}")
-            memory_timeline_file = os.path.join(
-                trace_dir, f"veomni_rank{global_rank}_{time}.{memory_timeline_file_extention}"
-            )
             gpu_memory_file = os.path.join(trace_dir, f"veomni_rank{global_rank}_{time}.{gpu_memory_file_extension}")
 
         p.export_chrome_trace(trace_file)
         logger.info(f"Profiling result saved at {trace_file}.")
 
-        p.export_memory_timeline(memory_timeline_file)
-        logger.info(f"Profiling memory timeline saved at {memory_timeline_file}.")
         if IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE:
             get_torch_device().memory._dump_snapshot(gpu_memory_file)
             logger.info(f"Profiling memory visualization saved at {gpu_memory_file}.")
@@ -664,9 +655,6 @@ def create_profiler(
         if trace_dir.startswith("hdfs://"):
             copy(trace_file, trace_dir)
             logger.info(f"Profiling result uploaded to {trace_dir}.")
-
-            copy(memory_timeline_file, trace_dir)
-            logger.info(f"Profiling memory timeline uploaded to {trace_dir}.")
 
         if VEOMNI_UPLOAD_CMD:
             try:


### PR DESCRIPTION
Remove `export_memeory_timeline` in torch profiler since it is not helpful and often buggy