### PR TITLE
[ckpt] fix: remove unnecessary path joining for dcp

### DIFF
--- a/veomni/checkpoint/format_utils.py
+++ b/veomni/checkpoint/format_utils.py
@@ -118,6 +118,7 @@ def dcp_to_torch_state_dict(save_checkpoint_path: Union[str, os.PathLike]) -> ST
         no_dist=True,
     )
     if "state" in state_dict:
+        # this happens when the model state dicts are flatten during saving
         state_dict = state_dict["state"]
 
     return state_dict["model"]


### PR DESCRIPTION
DCP checkpoints no longer have separate "model" and "optimizer" folders for checkpoints but a unified storage.