### PR TITLE
fix: qwen2 vl yaml

### DIFF
--- a/configs/multimodal/qwen2_vl/qwen2_vl.yaml
+++ b/configs/multimodal/qwen2_vl/qwen2_vl.yaml
@@ -1,5 +1,5 @@
 model:
-  model_path: qwen2vl-7b-instruct
+  model_path: Qwen/Qwen2-VL-7B-Instruct
 
 data:
   dataloader_type: native


### PR DESCRIPTION
### What does this PR do?

Fix qwen2VL config to use huggingface model name

### Test
Previous run will cause OSError: qwen2vl-7b-instruct is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'
After the fix the model can be successfully downloaded

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [x] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
