### PR TITLE
[ckpt] fix: rank for get last iteraton for non-dcp path

### DIFF
--- a/veomni/utils/arguments.py
+++ b/veomni/utils/arguments.py
@@ -626,7 +626,7 @@ class TrainingArguments:
             from .checkpoint_utils import get_checkpoint_path
 
             self.load_checkpoint_path = get_checkpoint_path(
-                output_dir=self.output_dir, is_rank0=self.local_rank == 0, ckpt_manager=self.ckpt_manager
+                output_dir=self.output_dir, is_local_rank0=self.local_rank == 0, ckpt_manager=self.ckpt_manager
             )
 
         # save paths

--- a/veomni/utils/checkpoint_utils.py
+++ b/veomni/utils/checkpoint_utils.py
@@ -97,11 +97,11 @@ def dcp_get_last_iteration(output_dir):
     return max(valid_steps)
 
 
-def get_checkpoint_path(output_dir, is_rank0: bool, ckpt_manager: str):
+def get_checkpoint_path(output_dir, is_local_rank0: bool, ckpt_manager: str):
     if ckpt_manager == "dcp":
         iteration = dcp_get_last_iteration(output_dir)
     else:  # OmniStore or BCP
-        iteration = get_last_iteration(output_dir, is_rank0)
+        iteration = get_last_iteration(output_dir, is_local_rank0)
 
     if not iteration:
         logger.warning_rank0("Failed to find latest checkpoint path, will start training from step 0...")


### PR DESCRIPTION
For non-dcp path, `is_rank0` is used for downloading checkpoints to every node. 
Here we should use local_rank==0 instead of global_rank==0