### PR TITLE
[misc] feat: update uv support for aarch platform for Ascend+Kunpeng …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,12 @@ dit = [
   "bitsandbytes>=0.46.0,<=0.47.0"
 ]
 npu = [
-  "torch==2.6.0; platform_machine == 'aarch64'",
-  "torchvision==0.21.0; platform_machine == 'aarch64'",
-  "torchaudio==2.6.0; platform_machine == 'aarch64'",
-  "torch==2.6.0+cpu; platform_machine != 'aarch64'",
-  "torchvision==0.21.0+cpu; platform_machine != 'aarch64'",
-  "torchaudio==2.6.0+cpu; platform_machine != 'aarch64'",
-  "torch-npu==2.6.0",
+  "torch==2.7.1+cpu",
+  "torch-npu==2.7.1",
+  "torchvision==0.22.1; platform_machine == 'aarch64'",
+  "torchaudio==2.7.1; platform_machine == 'aarch64'",
+  "torchvision==0.22.1+cpu; platform_machine != 'aarch64'",
+  "torchaudio==2.7.1+cpu; platform_machine != 'aarch64'",
   "decorator>=5.2.1",
   "einops>=0.8.1",
   "scipy>=1.16.2"
@@ -109,12 +108,11 @@ override-dependencies = [
     "torchvision==0.22.1+cu128; (extra == 'gpu')",
     # Adding explicit override for other backends as well. Otherwise these libraries
     # will be excluded for other backends.
-    "torch==2.6.0; (extra == 'npu') and (platform_machine == 'aarch64')",
-    "torchaudio==2.6.0; (extra == 'npu') and (platform_machine == 'aarch64')",
-    "torchvision==0.21.0; (extra == 'npu') and (platform_machine == 'aarch64')",
-    "torch==2.6.0+cpu; (extra == 'npu') and (platform_machine != 'aarch64')",
-    "torchaudio==2.6.0+cpu; (extra == 'npu') and (platform_machine != 'aarch64')",
-    "torchvision==0.21.0+cpu; (extra == 'npu') and (platform_machine != 'aarch64')",
+    "torch==2.7.1+cpu; extra == 'npu'",
+    "torchaudio==2.7.1; (extra == 'npu') and (platform_machine == 'aarch64')",
+    "torchvision==0.22.1; (extra == 'npu') and (platform_machine == 'aarch64')",
+    "torchaudio==2.7.1+cpu; (extra == 'npu') and (platform_machine != 'aarch64')",
+    "torchvision==0.22.1+cpu; (extra == 'npu') and (platform_machine != 'aarch64')",
     # Fixate to a specific transformers version since upgrading transformers is a large task.
     "transformers==4.56.2",
 ]
@@ -132,7 +130,7 @@ torchvision = [
   # npu aarch64 need install torchvison from pytorch-cpu
   { index = "pytorch-cpu", marker = "extra == 'npu' and platform_machine == 'aarch64'" },
   { index = "pytorch", marker = "extra == 'npu' and platform_machine != 'aarch64'" },
-  { index = "pytorch", marker = "extra != 'npu' and platform_machine != 'aarch64'" },
+  { index = "pytorch", marker = "extra != 'npu'"},
 ]
 torchaudio = {index = "pytorch"}
 # Currently flash-attn is limited by diffusers (<=2.7.4).


### PR DESCRIPTION
…device

Ascend(NPU)+Kunpeng(CPU)

### What does this PR do?
1. 昇腾的NPU卡用的cpu硬件分成A+K(Kungpeng cpu，是arm架构)和A+X(x86架构)两种，arm和x86下对应的torch的wheel包不一样，主要涉及`torchvision`/`torchaudio`因此在依赖组中要区分开。(大部分npu卡用的是a+k)
2. 升级torch_npu版本为最新稳定版本2.7.1。

Current `pyproject.toml` file do not support `aarch64` platform when install npu dependency as described in issue: https://github.com/ByteDance-Seed/VeOmni/issues/147

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `core`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `
  - If this PR involves multiple modules, separate them with `,` like `[megatron, torch, liger-kernals,fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, torch, liger-kernals] feat: dynamic batching`

### Test
after this pr, `uv sync --extra npu` success , tested on A2(A+X) and A3(A+K):
```bash
root@localhost:/home/data/veomni/tmp/VeOmni# uv sync --extra npu --allow-insecure-host github.com --allow-insecure-host  pythonhosted.org
warning: `VIRTUAL_ENV=/home/data/veomni/VeOmni/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Resolved 157 packages in 4.01s
      Built veomni @ file://home/data/veomni/tmp/VeOmni
Prepared 1 package in 482ms
Installed 80 packages in 187ms
 + aiohappyeyeballs==2.6.1
 + aiohttp==3.12.15
 + aiosignal==1.4.0
 + annotated-types==0.7.0
 + attrs==25.3.0
 + blobfile==3.1.0
 + certifi==2025.8.3
 + cfgv==3.4.0
 + charset-normalizer==3.4.3
 + click==8.3.0
 + datasets==2.21.0
 + diffusers==0.31.0
 + dill==0.3.8
 + distlib==0.4.0
 + expecttest==0.3.0
 + filelock==3.19.1
 + frozenlist==1.7.0
 + fsspec==2024.6.1
 + gitdb==4.0.12
 + gitpython==3.1.45
 + hf-xet==1.1.10
 + huggingface-hub==0.35.1
 + identify==2.6.14
 + idna==3.10
 + importlib-metadata==8.7.0
 + iniconfig==2.1.0
 + jinja2==3.1.6
 + lxml==6.0.2
 + markupsafe==3.0.3
 + mpmath==1.3.0
 + multidict==6.6.4
 + multiprocess==0.70.16
 + networkx==3.5
 + nodeenv==1.9.1
 + numpy==2.3.3
 + packaging==25.0
 + pandas==2.3.2
 + pillow==11.3.0
 + platformdirs==4.4.0
 + pluggy==1.6.0
 + pre-commit==4.3.0
 + propcache==0.3.2
 + protobuf==3.20.3
 + psutil==7.1.0
 + pyarrow==21.0.0
 + pycryptodomex==3.23.0
 + pydantic==2.11.9
 + pydantic-core==2.33.2
 + pytest==7.4.4
 + python-dateutil==2.9.0.post0
 + pytz==2025.2
 + pyyaml==6.0.3
 + regex==2025.9.18
 + requests==2.32.5
 + ruff==0.13.2
 + safetensors==0.6.2
 + sentry-sdk==2.39.0
 + six==1.17.0
 + smmap==5.0.2
 + sympy==1.13.1
 + tiktoken==0.11.0
 + timm==1.0.20
 + tokenizers==0.22.1
 + torch==2.6.0+cpu
 + torch-npu==2.6.0
 + torchaudio==2.6.0
 + torchdata==0.11.0
 + torchvision==0.21.0
 + tqdm==4.67.1
 + transformers==4.56.2
 + typing-extensions==4.15.0
 + typing-inspection==0.4.1
 + tzdata==2025.2
 + urllib3==2.5.0
 + veomni==0.1.0 (from file://home/data/veomni/tmp/VeOmni)
 + virtualenv==20.34.0
 + wandb==0.22.0
 + xxhash==3.5.0
 + yarl==1.20.1
 + zipp==3.23.0
```
### API and Usage Example

No

### Design & Code Changes
seperate `torch/torchaudio/torchvision` dependency on `aarch64` or not `aarch64` platform

 
### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [x] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
