### PR TITLE
enhance logs with tflops/mfu

### DIFF
--- a/tasks/train_torch.py
+++ b/tasks/train_torch.py
@@ -327,7 +327,12 @@ def main():
             lr = max(lr_scheduler.get_last_lr())
             train_metrics = environ_meter.step(delta_time, global_step=global_step)
 
-            data_loader_tqdm.set_postfix_str(f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}")
+            mfu_pct = train_metrics.get("mfu", 0) * 100
+            tflops_rank = train_metrics.get("flops_achieved_per_rank(T)", 0)
+            data_loader_tqdm.set_postfix_str(
+                f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}, "
+                f"TFLOPS/rank: {tflops_rank:.1f}, MFU: {mfu_pct:.1f}%"
+            )
             data_loader_tqdm.update()
 
             if args.train.global_rank == 0:

--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import os
 from transformers import PretrainedConfig
 
 from . import logging
@@ -33,7 +34,15 @@ def get_device_flops(unit="T"):
             ptr += 1
         return number
 
-    device_name = get_device_name()
+    # Allow manual override via environment variable (for hacked GPU names)
+    override_gpu = os.environ.get("VEOMNI_GPU_TYPE", "")
+    if override_gpu:
+        device_name = override_gpu
+        if int(os.environ.get("RANK", "0")) == 0:
+            logger.info(f"Using manually specified GPU type: {device_name} (override VEOMNI_GPU_TYPE)")
+    else:
+        device_name = get_device_name()
+
     flops = float("inf")  # INF flops for unkown gpu type
     if "H100" in device_name or "H800" in device_name:
         flops = 989e12

--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -38,8 +38,6 @@ def get_device_flops(unit="T"):
     override_gpu = os.environ.get("VEOMNI_GPU_TYPE", "")
     if override_gpu:
         device_name = override_gpu
-        if int(os.environ.get("RANK", "0")) == 0:
-            logger.info(f"Using manually specified GPU type: {device_name} (override VEOMNI_GPU_TYPE)")
     else:
         device_name = get_device_name()
 

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -230,6 +230,8 @@ class EnvironMeter:
         else:
             flops_achieved, flops_promised = self.estimate_flops(self.batch_seqlens, delta_time)
 
+        # Store per-rank flops before all_reduce
+        flops_achieved_per_rank = flops_achieved
         flops_achieved, batch_tokens, real_global_batch_size = all_reduce(
             (flops_achieved, sum(self.batch_seqlens), len(self.batch_seqlens)),
             op="sum",
@@ -257,6 +259,7 @@ class EnvironMeter:
 
         metrics = {
             "flops_achieved(T)": flops_achieved,
+            "flops_achieved_per_rank(T)": flops_achieved_per_rank,
             "flops_promised(T)": flops_promised,
             "mfu": mfu,
             "training/avg_effective_len": avg_effective_len,


### PR DESCRIPTION
### What does this PR do?

> 1. Add **VEOMNI_GPU_TYPE** environment to specific the GPU type ( Optional, for some scenes identify the GPU type incorrectly).
> 2. Show tflops(per_rank) and mfu in training logs( For performance check).

### API and Usage Example

```python
# set real GPU type
export VEOMNI_GPU_TYPE=h100
...
```
- as shown below:
<img width="1204" height="263" alt="企业微信截图_5e3fc85d-76d3-4598-831b-2a561605e3f5" src="https://github.com/user-attachments/assets/b4293f48-eee2-4d46-93ec-4f33aa46e6a6" />

