### PR TITLE
perf: set reshard_after_forward to False for modules without MixedPrecision

### DIFF
--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -307,6 +307,7 @@ def parallelize_model_fsdp2(
         fsdp_kwargs_without_mp = dict(fsdp_kwargs)
         fsdp_kwargs_without_mp.pop("mp_policy", None)
         # for high-precision modules, we do not reshard them after forward to avoid all-gather them in backward
+        # these modules will stay in GPU memory so please ensure high-precision modules do not contain too many parameters
         fsdp_kwargs_without_mp["reshard_after_forward"] = False
     else:
         mp_ignored_classes = None


### PR DESCRIPTION
For modules sharded without mixed precision on purpose like gating modules, we set `reshard_after_forward` to false for them to avoid all-gather them in the backward