### PR TITLE
[logging] fix: the logging lineno of log_rank0

### DIFF
--- a/veomni/utils/logging.py
+++ b/veomni/utils/logging.py
@@ -111,6 +111,7 @@ def set_verbosity_info() -> None:
 
 def info_rank0(self: "logging.Logger", *args, **kwargs) -> None:
     if int(os.getenv("LOCAL_RANK", "0")) == 0:
+        kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
         self.info(*args, **kwargs)
 
 
@@ -119,6 +120,7 @@ logging.Logger.info_rank0 = info_rank0
 
 def debug_rank0(self: "logging.Logger", *args, **kwargs) -> None:
     if int(os.getenv("LOCAL_RANK", "0")) == 0:
+        kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
         self.debug(*args, **kwargs)
 
 
@@ -127,6 +129,7 @@ logging.Logger.debug_rank0 = debug_rank0
 
 def warning_rank0(self: "logging.Logger", *args, **kwargs) -> None:
     if int(os.getenv("LOCAL_RANK", "0")) == 0:
+        kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
         self.warning(*args, **kwargs)
 
 
@@ -136,6 +139,7 @@ logging.Logger.warning_rank0 = warning_rank0
 @lru_cache(None)
 def warning_once(self, *args, **kwargs) -> None:
     if int(os.getenv("LOCAL_RANK", "0")) == 0:
+        kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
         self.warning_rank0(*args, **kwargs)
 
 


### PR DESCRIPTION


### What does this PR do?

turn the stacklevel +1 to get the correct called position of `info_rank0`, `warning_rank0`, `debug_rank0` method.
fix issue #157 

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `core`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `
  - If this PR involves multiple modules, separate them with `,` like `[megatron, torch, liger-kernals,fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, torch, liger-kernals] feat: dynamic batching`

### Test

can be tested by ci

### API and Usage Example

Any training/inference scripts that import the model with `logger.info_rank0` will see the logging info change

the minimum call can be just the import command like

```bash
python -m veomni.models
```


### Design & Code Changes

force the stacklevel up to 1/2

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [x] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: cover by original tests
