### PR TITLE
[model] fix:avoid cpu-device sync for qwenvl on npu

### DIFF
--- a/veomni/models/transformers/qwen3_vl/modeling_qwen3_vl.py
+++ b/veomni/models/transformers/qwen3_vl/modeling_qwen3_vl.py
@@ -56,6 +56,7 @@ from ....distributed.sequence_parallel import (
 from ....distributed.sequence_parallel.ulysses import _Gather
 from ....ops.loss import causallm_loss_function
 from ....utils import helper
+from ....utils.device import is_torch_npu_available
 
 
 logger = helper.create_logger(__name__)
@@ -792,6 +793,9 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         deepstack_feature_lists = []
         # Modification: calculate max_seqlen from cu_seqlens here to avoid per layer CPU-GPU sync
         max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().detach().cpu().item()
+        # Modification: move cu_seqlens to cpu when using NPU to avoid per layer CPU-GPU sync when using FA
+        if is_torch_npu_available():
+            cu_seqlens = cu_seqlens.cpu()
         for layer_num, blk in enumerate(self.blocks):
             hidden_states = blk(
                 hidden_states,


### PR DESCRIPTION
### What does this PR do?

1. For qwenvl model, place cu_seqlens on the CPU in advance to avoid triggering synchronization on the npu flash attention.
2. Minor fix to avoid an extra clone

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `core`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `
  - If this PR involves multiple modules, separate them with `,` like `[megatron, torch, liger-kernals,fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, torch, liger-kernals] feat: dynamic batching`


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [x] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
