### PR TITLE
Add TensorBoard support for training metrics logging

### DIFF
--- a/docs/tutorials/tensorboard_and_wandb.md
+++ b/docs/tutorials/tensorboard_and_wandb.md
@@ -1,0 +1,76 @@
+# TensorBoard and Wandb
+
+This guide explains how to use TensorBoard and Wandb to log and monitor your training process. Both tools can be enabled simultaneously or used independently.
+
+## TensorBoard
+
+TensorBoard provides local visualization of training metrics and can be enabled by adding the following configuration to your training config file:
+
+```yaml
+train:
+  output_dir: output
+  use_tensorboard: true 
+  tensorboard_dir: "./output/tensorboard"
+```
+
+After training starts, launch TensorBoard with:
+
+```bash
+tensorboard --logdir ./output/tensorboard
+```
+
+Then open your browser and navigate to `http://localhost:6006` to view the training metrics.
+
+## Wandb
+
+Wandb provides cloud-based experiment tracking and visualization. To use Wandb, configure it in your training config file:
+
+```yaml
+train:
+  output_dir: output
+  use_wandb: true
+  wandb_project: VeOmni
+  wandb_name: exp_train_qwen3_vl_moe
+```
+
+**Configuration parameters:**
+- `wandb_project`: The project name (outer-level path) that groups related experiments together in Wandb. This is like a folder that contains multiple runs.
+- `wandb_name`: The experiment name (run name) that identifies a specific training run within the project. Each run in the same project should have a unique name.
+
+Before training, authenticate with Wandb using one of the following methods:
+
+```bash
+# Method 1: Interactive login
+wandb login
+
+# Method 2: Set API key as environment variable
+export WANDB_API_KEY=your_api_key
+```
+
+After training starts, you can view the training process in the [Wandb dashboard](https://wandb.ai).
+
+## Using Both TensorBoard and Wandb
+
+You can enable both TensorBoard and Wandb simultaneously to leverage the benefits of both tools:
+
+```yaml
+train:
+  output_dir: output
+  use_tensorboard: true
+  tensorboard_dir: "./output/tensorboard"
+  use_wandb: true
+  wandb_project: VeOmni
+  wandb_name: exp_train_qwen3_vl_moe
+```
+
+You can also override these settings via command-line arguments:
+
+```bash
+bash train.sh tasks/omni/train_qwen3_vl.py configs/multimodal/qwen3_vl/qwen3_vl_moe.yaml \
+  --train.use_tensorboard true \
+  --train.use_wandb true
+```
+
+This allows you to:
+- View real-time metrics locally with TensorBoard
+- Track experiments in the cloud with Wandb for collaboration and comparison

--- a/tasks/omni/train_qwen2_vl.py
+++ b/tasks/omni/train_qwen2_vl.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List
 
 import torch
 import torch.distributed as dist
-import wandb
 from PIL import Image
 from tqdm import trange
 
@@ -31,6 +30,7 @@ from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models import build_foundation_model, build_processor, save_model_assets, save_model_weights
 from veomni.optim import build_lr_scheduler, build_optimizer
 from veomni.utils import helper
+from veomni.utils.metric_logger import Logger
 from veomni.utils.arguments import DataArguments, ModelArguments, TrainingArguments, parse_args, save_args
 from veomni.utils.device import (
     get_device_type,
@@ -284,13 +284,18 @@ def main():
     )
 
     if args.train.global_rank == 0:
-        if args.train.use_wandb:
-            wandb.init(
-                project=args.train.wandb_project,
-                name=args.train.wandb_name,
-                config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
-            )
+        metric_logger = Logger(
+            use_wandb=args.train.use_wandb,
+            wandb_project=args.train.wandb_project,
+            wandb_name=args.train.wandb_name,
+            use_tensorboard=args.train.use_tensorboard,
+            tensorboard_dir=args.train.tensorboard_dir,
+            config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
+        )
+    else:
+        metric_logger = None
 
+    if args.train.global_rank == 0:
         model_assets = [model_config, processor]
         save_model_assets(args.train.model_assets_dir, model_assets)
 
@@ -409,12 +414,11 @@ def main():
             data_loader_tqdm.set_postfix_str(f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}")
             data_loader_tqdm.update()
 
-            if args.train.global_rank == 0:
-                if args.train.use_wandb:
-                    train_metrics.update(
-                        {"training/loss": total_loss, "training/grad_norm": grad_norm, "training/lr": lr}
-                    )
-                    wandb.log(train_metrics, step=global_step)
+            if args.train.global_rank == 0 and metric_logger:
+                train_metrics.update(
+                    {"training/loss": total_loss, "training/grad_norm": grad_norm, "training/lr": lr}
+                )
+                metric_logger.log(train_metrics, step=global_step)
 
             if args.train.profile_this_rank and global_step <= args.train.profile_end_step:
                 profiler.step()

--- a/tasks/omni/train_qwen_vl.py
+++ b/tasks/omni/train_qwen_vl.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import torch
 import torch.distributed as dist
-import wandb
 from tqdm import trange
 
 from tasks.data.vlm_data_process import (
@@ -32,6 +31,7 @@ from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models import build_foundation_model, build_processor, save_model_assets, save_model_weights
 from veomni.optim import build_lr_scheduler, build_optimizer
 from veomni.utils import helper
+from veomni.utils.metric_logger import Logger
 from veomni.utils.arguments import DataArguments, ModelArguments, TrainingArguments, parse_args, save_args
 from veomni.utils.device import (
     get_device_type,
@@ -265,13 +265,18 @@ def main():
     )
 
     if args.train.global_rank == 0:
-        if args.train.use_wandb:
-            wandb.init(
-                project=args.train.wandb_project,
-                name=args.train.wandb_name,
-                config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
-            )
+        metric_logger = Logger(
+            use_wandb=args.train.use_wandb,
+            wandb_project=args.train.wandb_project,
+            wandb_name=args.train.wandb_name,
+            use_tensorboard=args.train.use_tensorboard,
+            tensorboard_dir=args.train.tensorboard_dir,
+            config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
+        )
+    else:
+        metric_logger = None
 
+    if args.train.global_rank == 0:
         model_assets = [model_config, processor]
         save_model_assets(args.train.model_assets_dir, model_assets)
 
@@ -412,12 +417,11 @@ def main():
             data_loader_tqdm.set_postfix_str(f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}")
             data_loader_tqdm.update()
 
-            if args.train.global_rank == 0:
-                if args.train.use_wandb:
-                    train_metrics.update(
-                        {"training/loss": total_loss, "training/grad_norm": grad_norm, "training/lr": lr}
-                    )
-                    wandb.log(train_metrics, step=global_step)
+            if args.train.global_rank == 0 and metric_logger:
+                train_metrics.update(
+                    {"training/loss": total_loss, "training/grad_norm": grad_norm, "training/lr": lr}
+                )
+                metric_logger.log(train_metrics, step=global_step)
 
             if args.train.profile_this_rank and global_step <= args.train.profile_end_step:
                 profiler.step()

--- a/tasks/omni/train_wan.py
+++ b/tasks/omni/train_wan.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
-import wandb
 from tqdm import trange
 
 from veomni.checkpoint import build_checkpointer, ckpt_to_state_dict
@@ -22,6 +21,7 @@ from veomni.models import (
 from veomni.optim import build_lr_scheduler, build_optimizer
 from veomni.schedulers.flow_match import FlowMatchScheduler
 from veomni.utils import helper
+from veomni.utils.metric_logger import Logger
 from veomni.utils.arguments import (
     DataArguments,
     ModelArguments,
@@ -209,13 +209,18 @@ def main():
     )
 
     if args.train.global_rank == 0:
-        if args.train.use_wandb:
-            wandb.init(
-                project=args.train.wandb_project,
-                name=args.train.wandb_name,
-                config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
-            )
+        metric_logger = Logger(
+            use_wandb=args.train.use_wandb,
+            wandb_project=args.train.wandb_project,
+            wandb_name=args.train.wandb_name,
+            use_tensorboard=args.train.use_tensorboard,
+            tensorboard_dir=args.train.tensorboard_dir,
+            config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
+        )
+    else:
+        metric_logger = None
 
+    if args.train.global_rank == 0:
         model_assets = [model_config]
         save_model_assets(args.train.model_assets_dir, model_assets)
 
@@ -390,12 +395,11 @@ def main():
             )
             data_loader_tqdm.update()
 
-            if args.train.global_rank == 0:
-                if args.train.use_wandb:
-                    train_metrics.update(
-                        {"training/loss": total_loss, "training/grad_norm": grad_norm, "training/lr": lr}
-                    )
-                    wandb.log(train_metrics, step=global_step)
+            if args.train.global_rank == 0 and metric_logger:
+                train_metrics.update(
+                    {"training/loss": total_loss, "training/grad_norm": grad_norm, "training/lr": lr}
+                )
+                metric_logger.log(train_metrics, step=global_step)
 
             if args.train.profile_this_rank and global_step <= args.train.profile_end_step:
                 profiler.step()
@@ -428,9 +432,8 @@ def main():
             logger.info_rank0(
                 f"Epoch {epoch + 1} completed, epoch_time={epoch_time:.4f}s, epoch_loss={epoch_loss / args.train.train_steps:.4f}"
             )
-        if args.train.global_rank == 0:
-            if args.train.use_wandb:
-                wandb.log({"training/loss_per_epoch": epoch_loss / args.train.train_steps}, step=global_step)
+        if args.train.global_rank == 0 and metric_logger:
+            metric_logger.log({"training/loss_per_epoch": epoch_loss / args.train.train_steps}, step=global_step)
         if args.train.save_epochs and (epoch + 1) % args.train.save_epochs == 0:
             helper.empty_cache()
             save_checkpoint_path = os.path.join(args.train.save_checkpoint_path, f"global_step_{global_step}")

--- a/veomni/utils/arguments.py
+++ b/veomni/utils/arguments.py
@@ -483,6 +483,14 @@ class TrainingArguments:
         default=None,
         metadata={"help": "Wandb experiment name."},
     )
+    use_tensorboard: bool = field(
+        default=False,
+        metadata={"help": "Use tensorboard to log experiment."},
+    )
+    tensorboard_dir: Optional[str] = field(
+        default=None,
+        metadata={"help": "Directory to save tensorboard logs."},
+    )
     enable_profiling: bool = field(
         default=False,
         metadata={"help": "Enable profiling."},

--- a/veomni/utils/metric_logger.py
+++ b/veomni/utils/metric_logger.py
@@ -1,0 +1,103 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Training metrics logger supporting wandb and tensorboard."""
+
+import os
+from typing import Any, Dict, Optional
+
+import torch
+
+from veomni.utils import logging
+
+logger = logging.get_logger(__name__)
+
+
+class Logger:
+    """
+    Unified logger supporting both wandb and tensorboard.
+    """
+
+    def __init__(
+        self,
+        use_wandb: bool = False,
+        wandb_project: Optional[str] = None,
+        wandb_name: Optional[str] = None,
+        use_tensorboard: bool = False,
+        tensorboard_dir: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ):
+        self.use_wandb = use_wandb
+        self.use_tensorboard = use_tensorboard
+        self.wandb_writer = None
+        self.tensorboard_writer = None
+
+        if self.use_wandb:
+            try:
+                import wandb
+
+                self.wandb_writer = wandb
+                self.wandb_writer.init(
+                    project=wandb_project,
+                    name=wandb_name,
+                    config=config,
+                )
+            except ImportError:
+                logger.warning("wandb is not installed, skipping wandb initialization")
+                self.use_wandb = False
+
+        if self.use_tensorboard:
+            try:
+                from torch.utils.tensorboard import SummaryWriter
+
+                if tensorboard_dir is None:
+                    raise ValueError("tensorboard_dir must be provided when use_tensorboard is True")
+
+                os.makedirs(tensorboard_dir, exist_ok=True)
+                self.tensorboard_writer = SummaryWriter(log_dir=tensorboard_dir)
+                logger.info(f"TensorBoard logging initialized at {tensorboard_dir}")
+            except ImportError:
+                logger.warning("tensorboard is not installed, skipping tensorboard initialization")
+                self.use_tensorboard = False
+
+    def log(self, metrics: Dict[str, Any], step: int):
+        """
+        Log metrics to both wandb and tensorboard if enabled.
+
+        Args:
+            metrics: Dictionary of metrics to log
+            step: Global step number
+        """
+        if self.use_wandb and self.wandb_writer:
+            self.wandb_writer.log(metrics, step=step)
+
+        if self.use_tensorboard and self.tensorboard_writer:
+            for key, value in metrics.items():
+                # Convert tensor to scalar if needed
+                if isinstance(value, torch.Tensor):
+                    if value.numel() == 1:
+                        value = value.item()
+                    else:
+                        value = value.mean().item()
+
+                # Log scalar values
+                if isinstance(value, (int, float)):
+                    self.tensorboard_writer.add_scalar(key, value, step)
+
+    def close(self):
+        """Close all loggers."""
+        if self.use_tensorboard and self.tensorboard_writer:
+            self.tensorboard_writer.close()
+


### PR DESCRIPTION
## Summary

Add TensorBoard support for training metrics logging alongside existing Wandb support. #187 

## Changes

- **Add unified Logger class** (`veomni/utils/metric_logger.py`): Support both Wandb and TensorBoard logging with a single interface
- **Add TensorBoard configuration options** (`veomni/utils/arguments.py`):
  - `use_tensorboard`: Enable/disable TensorBoard logging
  - `tensorboard_dir`: Directory to save TensorBoard logs
- **Update training scripts**: Refactor all training scripts (`train_flux.py`, `train_qwen_vl.py`, `train_qwen2_vl.py`, `train_omni_model.py`, `train_wan.py`, `train_torch.py`) to use the unified Logger
- **Add documentation** (`docs/tutorials/tensorboard_and_wandb.md`) [link](https://github.com/iqiancheng/VeOmni/blob/tensorboard/docs/tutorials/tensorboard_and_wandb.md): Guide on how to set up and use both TensorBoard and Wandb

## Usage

Users can now enable TensorBoard logging by adding to their config:

```yaml
train:
  use_tensorboard: true
  tensorboard_dir: "./output/tensorboard"
```

Both TensorBoard and Wandb can be enabled simultaneously for local and cloud-based experiment tracking.

## Testing

- Verified TensorBoard logging works correctly
- Verified Wandb logging remains functional
- Verified both can be enabled simultaneously

