### PR TITLE
[ckpt][fix]release cuda mem after dcp sync save

### DIFF
--- a/veomni/checkpoint/checkpointer.py
+++ b/veomni/checkpoint/checkpointer.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import os
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
-import gc
 
 import torch
 import torch.distributed as dist
@@ -23,9 +23,10 @@ from torch.distributed._tensor import DeviceMesh, DTensor, Shard
 
 from ..distributed.parallel_state import get_parallel_state
 from ..utils.checkpoint_utils import _GLOBAL_STEP_PREFIX
+from ..utils.device import empty_cache, synchronize
 from ..utils.import_utils import is_torch_version_greater_than
 from ..utils.logging import get_logger
-from ..utils.device import synchronize, empty_cache
+
 
 if is_torch_version_greater_than("2.4"):
     import torch.distributed.checkpoint as dcp
@@ -373,7 +374,6 @@ class DistributedCheckpointer(CheckpointerBase):
             gc.collect()
             empty_cache()
             synchronize()
-
 
         logger.info_rank0(f"Saved checkpoint to {checkpoint_dir}")
 


### PR DESCRIPTION
### What does this PR do?

>when using torch dcp to save ckpt during training, theres a big chance that dcp would create a bunch of cuda mem that wont release by SYS automatically which may cause potential OOM.  Its better to release it mannualy.   Only torch.cuda.empty_cache() cant release those mem(may be some recycle ref created by dcp), need gc.collect() first 



<img width="1600" height="1200" alt="image" src="https://github.com/user-attachments/assets/94555008-7e08-4d3f-b2b8-7e79b7383260" />


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `core`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `
  - If this PR involves multiple modules, separate them with `,` like `[megatron, torch, liger-kernals,fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, torch, liger-kernals] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [x] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
