### PR TITLE
[optim, config] feat: add support for Muon optimizer via dion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ gpu = [
   "liger-kernel",
   "flash-attn",
   "hf_transfer",
+  "dion",
 ]
 megatron = [
   "megatron-energon>=7.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ torchvision = [ # npu aarch64 need install torchvison from pytorch-cpu
 torchaudio = { index = "pytorch" }
 # Download flash-attn wheel directly to avoid build issues.
 flash-attn = { url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.8cxx11abiTRUE-cp311-cp311-linux_x86_64.whl", marker = "extra == 'gpu' or extra == 'sglang'" }
+dion = [{ git = "https://github.com/microsoft/dion.git", rev = "0360f9b" }]
 
 [[tool.uv.index]]
 name = "pytorch"

--- a/veomni/utils/arguments.py
+++ b/veomni/utils/arguments.py
@@ -296,7 +296,7 @@ class TrainingArguments:
         metadata={"help": "Parameters without weight decay, for example, bias."},
     )
 
-    optimizer: Literal["adamw", "anyprecision_adamw"] = field(
+    optimizer: Literal["adamw", "anyprecision_adamw", "muon"] = field(
         default="adamw",
         metadata={"help": "Optimizer. Default to adamw."},
     )


### PR DESCRIPTION
This PR introduces support for the Muon optimizer (Momentum Orthogonalized Optimizer) using the dion backend.
It implements a hybrid optimization strategy where:

Muon is applied to high-dimensional parameters (2D+ matrices), excluding embeddings and the LM head, and with rms-normalization.

AdamW is used as the fallback for 1D tensors (vectors), embeddings, and the LM head.

This implementation requires DeviceMesh for distributed training and adds dion as a project dependency.

### Test
<img width="1101" height="635" alt="Screenshot 2025-11-24 at 6 59 38 PM" src="https://github.com/user-attachments/assets/513ec73e-db4e-4ac7-a540-9b0199e5ccfb" />

Validated by running qwen3_vl_8b with optimizer="muon" on a 2xH100 node with seq-len = 32784. 

(adamw ooms with same hyperparams)

### API and Usage Example

To use the Muon optimizer, simply update the optimizer argument in your configuration or CLI. No extra configuration is needed for the parameter splitting logic; it is handled automatically.

### Design & Code Changes

This PR modifies how parameter groups are constructed in `build_optimizer` without fsdp2. Before, if the parameter groups were created outside of the ```build_optimizer``` call without fsdp2, weight decay wouldn't be applied. Now, muon (if_enabled) and weight decay are automatically applied to any parameter group passed into ```build_optimizer```.