### PR TITLE
[config] feat: add qwen3_vl flops estimation

### DIFF
--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -69,6 +69,8 @@ class VeomniFlopsCounter:
             # the only difference between Qwen2 and Qwen2.5 for counting flops is the window attention
             # used in the ViT for Qwen2.5VL which is considered in the _estimate_qwen2_vl_flops function.
             "qwen2_5_vl": self._estimate_qwen2_vl_flops,
+            # qwen3_vl's vit uses full self attention while qwen2-vl/qwen2.5-vl uses window attention.
+            "qwen3_vl": self._estimate_qwen3_vl_flops,
             "deepseek_v3": self._estimate_deepseek_v3_flops,
             "qwen3_moe": self._estimate_qwen3_moe_flops,
             "llama": self._estimate_llama_flops,
@@ -312,6 +314,97 @@ class VeomniFlopsCounter:
         flops_all_token = dense_N_flops + attn_qkv_flops + vit_flops
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
+
+    def _estimate_qwen3_vl_flops(self, tokens_sum, batch_seqlens, delta_time, **kargs):
+        # qwen3_vl uses text_config and vision_config to distinguish configs of different parts.
+        hidden_size = self.config.text_config.hidden_size
+        vocab_size = self.config.text_config.vocab_size
+        num_hidden_layers = self.config.text_config.num_hidden_layers
+        num_key_value_heads = self.config.text_config.num_key_value_heads
+        num_attention_heads = self.config.text_config.num_attention_heads
+        intermediate_size = self.config.text_config.intermediate_size
+
+        head_dim = hidden_size // num_attention_heads
+        q_size = num_attention_heads * head_dim
+        k_size = num_key_value_heads * head_dim
+        v_size = num_key_value_heads * head_dim
+
+        # non-attn per layer parm
+        mlp_N = hidden_size * intermediate_size * 3
+        attn_linear_N = hidden_size * (q_size + k_size + v_size + num_attention_heads * head_dim)
+        emd_and_lm_head_N = vocab_size * hidden_size * 2
+        # non-attn all_layer parm
+        dense_N = (mlp_N + attn_linear_N) * num_hidden_layers + emd_and_lm_head_N
+        # non-attn all_layer & all_token fwd & bwd flops
+        dense_N_flops = 6 * dense_N * tokens_sum
+
+        # qwen3_vl uses deepstack to merge visual embeds and text embeds, but it has no tensor operation.
+
+        # attn all_layer & all_token fwd & bwd flops
+        seqlen_square_sum = 0
+        for seqlen in batch_seqlens:
+            seqlen_square_sum += seqlen * seqlen
+        attn_qkv_flops = 12 * seqlen_square_sum * head_dim * num_attention_heads * num_hidden_layers
+
+        # vit flops
+        image_seqlens = kargs.get("image_seqlens", None)
+        if image_seqlens is not None:
+            vit_flops = self._estimate_qwen3_vit_flop(image_seqlens, self.config.vision_config)
+        else:
+            vit_flops = 0
+
+        # all_layer & all_token fwd & bwd flops
+        flops_all_token = dense_N_flops + attn_qkv_flops + vit_flops
+        flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
+        return flops_achieved
+
+    def _estimate_qwen3_vit_flop(self, image_seqlens, config):
+        """
+        Estimate the FLOPS of the vision encoder for Qwen2 and Qwen2.5
+        """
+
+        if config is None:
+            return 0
+        tokens_sum = sum(image_seqlens)
+
+        num_heads = config.num_heads
+        depth = config.depth
+
+        dim = config.hidden_size
+        mlp_hidden_dim = config.intermediate_size
+        out_hidden_size = config.out_hidden_size
+
+        spatial_merge_size = config.spatial_merge_size
+
+        head_dim = dim // num_heads
+
+        # every vision token's patch_embed comes from a conv of (C, T, H, W) -> (dim,)
+        patch_embed_N = dim * config.in_channels * config.temporal_patch_size * config.patch_size * config.patch_size
+        # Qwen3 VL vision mlp does not use GLU, thus 2.
+        mlp_N = dim * mlp_hidden_dim * 2
+        attn_linear_N = dim * (4 * dim)  # qkv and output proj
+        merger_N = (out_hidden_size + (dim * (spatial_merge_size**2))) * (dim * (spatial_merge_size**2))
+
+        # Qwen3 VL uses deep stack, one merger for every deepstack layer
+        deepstack_merger_N = merger_N * len(config.deepstack_visual_indexes)
+        # non-attn all_layer parm
+        dense_N = patch_embed_N + (mlp_N + attn_linear_N) * depth + deepstack_merger_N + merger_N
+
+        # non-attn all_layer & all_token fwd & bwd flops
+        dense_N_flops = 6 * dense_N * tokens_sum
+
+        # In Qwen3 VL, full attention is used in all vision layers.
+        full_attn_layer_num = depth
+
+        # full attn layer & all_token fwd & bwd flops
+        seqlen_square_sum = 0
+        for seqlen in image_seqlens:
+            seqlen_square_sum += seqlen * seqlen
+        attn_qkv_flops = 12 * seqlen_square_sum * head_dim * num_heads * full_attn_layer_num
+
+        vit_flops = dense_N_flops + attn_qkv_flops
+
+        return vit_flops
 
     def _estimate_qwen_vit_flop(self, image_seqlens, config):
         """


### PR DESCRIPTION
### What does this PR do?

Implement estimate_func for qwen3_vl in `utils/count_flops.py`

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `core`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `
  - If this PR involves multiple modules, separate them with `,` like `[megatron, torch, liger-kernals,fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, torch, liger-kernals] feat: dynamic batching`

### Test

N/A

### API and Usage Example

N/A

### Design & Code Changes

This PR implements flops estimation for qwen3_vl on top of qwen2/2.5-vl.

Notes:
1. qwen3_vl uses different config structure other than qwen2/2.5, distinguishing text_config and vision_config.
2. qwen3_vl uses deep stack in its ViT, introducing extra flops for each deepstack layer of PatchMerger
3. qwen3_vl uses full attention for all ViT layers, no window-attn used

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
