### PR TITLE
[task]fix: fix train.sh NPROC_PER_NODE calculation logic on the NPU

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -8,10 +8,18 @@ export TORCH_NCCL_AVOID_RECORD_STREAMS=1
 NNODES=${NNODES:=1}
 if command -v nvidia-smi &> /dev/null && nvidia-smi --list-gpus &> /dev/null; then
   # GPU
-  NPROC_PER_NODE=${NPROC_PER_NODE:=$(nvidia-smi --list-gpus | wc -l)}
+  if [[ -n "${CUDA_VISIBLE_DEVICES}" ]]; then
+    NPROC_PER_NODE=${NPROC_PER_NODE:=$(echo "${CUDA_VISIBLE_DEVICES}" | tr ',' '\n' | wc -l)}
+  else
+    NPROC_PER_NODE=${NPROC_PER_NODE:=$(nvidia-smi --list-gpus | wc -l)}
+  fi
 else
   # NPU
-  NPROC_PER_NODE=${NPROC_PER_NODE:=$(ll /dev/davinci* | grep -v "davinci_manager" | wc -l)}
+  if [[ -n "${ASCEND_RT_VISIBLE_DEVICES}" ]]; then
+    NPROC_PER_NODE=${NPROC_PER_NODE:=$(echo "${ASCEND_RT_VISIBLE_DEVICES}" | tr ',' '\n' | wc -l)}
+  else
+    NPROC_PER_NODE=${NPROC_PER_NODE:=$(ls -l /dev/davinci* | grep -v "davinci_manager" | wc -l)}
+  fi
 fi
 NODE_RANK=${NODE_RANK:=0}
 MASTER_ADDR=${MASTER_ADDR:=0.0.0.0}


### PR DESCRIPTION
### What does this PR do?

This PR fixes the incompatibility issue in the `train.sh` script's NPROC_PER_NODE calculation logic on the NPU platform. It utilizes a filtering approach to count the number of NPU cards based on the Da Vinci architecture, ensuring that the logic for determining the number of devices is compatible with both GPUs and other hardware.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `core`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `
  - If this PR involves multiple modules, separate them with `,` like `[megatron, torch, liger-kernals,fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, torch, liger-kernals] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
