### PR TITLE
[model] fix: Update `@check_model_inputs` decorator for transformers 4.57+ compatibility

### DIFF
--- a/veomni/models/transformers/qwen3_vl/modeling_qwen3_vl.py
+++ b/veomni/models/transformers/qwen3_vl/modeling_qwen3_vl.py
@@ -855,7 +855,7 @@ class Qwen3VLTextModel(Qwen3VLPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    @check_model_inputs
+    @check_model_inputs()
     @auto_docstring
     def forward(
         self,
@@ -1191,7 +1191,7 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
     #     return special_image_mask, special_video_mask
 
     @auto_docstring
-    @check_model_inputs
+    @check_model_inputs()
     def forward(
         self,
         input_ids: torch.LongTensor = None,
@@ -1587,7 +1587,7 @@ class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
         fake_model = SimpleNamespace(config=self.config)
         return partial(get_position_id, Qwen3VLModel.get_rope_index, fake_model)
 
-    @check_model_inputs
+    @check_model_inputs()
     @replace_return_docstrings(output_type=Qwen3VLCausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
     def forward(
         self,

--- a/veomni/models/transformers/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/veomni/models/transformers/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -1012,7 +1012,7 @@ class Qwen3VLMoeTextModel(Qwen3VLMoePreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    @check_model_inputs
+    @check_model_inputs()
     @auto_docstring
     def forward(
         self,
@@ -1404,7 +1404,7 @@ class Qwen3VLMoeModel(Qwen3VLMoePreTrainedModel):
     #     return special_image_mask, special_video_mask
 
     @auto_docstring
-    @check_model_inputs
+    @check_model_inputs()
     def forward(
         self,
         input_ids: torch.LongTensor = None,
@@ -1843,7 +1843,7 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMi
         fake_model = SimpleNamespace(config=self.config)
         return partial(get_position_id, Qwen3VLMoeModel.get_rope_index, fake_model)
 
-    @check_model_inputs
+    @check_model_inputs()
     @replace_return_docstrings(output_type=Qwen3VLMoeCausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
     def forward(
         self,

--- a/veomni/models/transformers/seed_oss/modeling_seed_oss.py
+++ b/veomni/models/transformers/seed_oss/modeling_seed_oss.py
@@ -360,7 +360,7 @@ class SeedOssModel(SeedOssPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    @check_model_inputs
+    @check_model_inputs()
     @auto_docstring
     def forward(
         self,


### PR DESCRIPTION
### What does this PR do?

> Fixes compatibility issues with transformers 4.57+ by updating the `@check_model_inputs` decorator usage from `@check_model_inputs` to `@check_model_inputs()`. This resolves a runtime error where the model forward method incorrectly rejected valid keyword arguments like `pixel_values` and `image_mask`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: N/A (Bug fix for API compatibility)
- [x] Format the PR title as `[{modules}] {type}: {description}`
  - `{modules}`: model
  - `{type}`: fix
  - This PR does not break any existing API

### Test

> This fix addresses a critical runtime error during training. The error manifested as:
> ```
> TypeError: check_model_inputs.<locals>.wrapped_fn() got an unexpected keyword argument 'pixel_values'
> ```
>
> After the fix, models can be instantiated and accept all valid forward arguments without decorator-related errors.

### API and Usage Example

> No API changes for end users. This is an internal fix to ensure compatibility with transformers library version 4.57.3.

### Design & Code Changes

**Root Cause:**
In transformers 4.57+, `check_model_inputs` changed from a simple decorator to a decorator factory that requires parentheses. The old usage `@check_model_inputs` incorrectly passes the forward function as an argument instead of calling the decorator factory.

**Changes:**
- Updated `veomni/models/transformers/qwen3_vl/modeling_qwen3_vl.py`: Fixed 3 occurrences (lines 858, 1194, 1590)
- Updated `veomni/models/transformers/qwen3_vl_moe/modeling_qwen3_vl_moe.py`: Fixed 3 occurrences (lines 1015, 1407, 1846)
- Updated `veomni/models/transformers/seed_oss/modeling_seed_oss.py`: Fixed 1 occurrence (line 363)

Changed pattern:
```python
# Before (incorrect for transformers 4.57+)
@check_model_inputs
def forward(...):

# After (correct)
@check_model_inputs()
def forward(...):
```

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: This is a compatibility fix for an external library API change. Existing tests will validate the fix once they run with transformers 4.57+.
