### PR TITLE
[model] fix: for Qwen3-Embedding series, override architectures to Qwen3Model

### DIFF
--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -82,7 +82,9 @@ def build_foundation_model(
         if ("qwen3" in name) and ("embedding" in name):
             config.architectures = ["Qwen3Model"]
             config.tie_word_embeddings = False
-            logger.info_rank0("For Qwen3-Embedding series, override architectures to Qwen3Model. Because their config.json incorrectly lists Qwen3ForCausalLM, which would otherwise create a CausalLM model with lm_head.")
+            logger.info_rank0(
+                "For Qwen3-Embedding series, override architectures to Qwen3Model. Because their config.json incorrectly lists Qwen3ForCausalLM, which would otherwise create a CausalLM model with lm_head."
+            )
 
     if moe_implementation is not None:
         if moe_implementation not in ["eager", "fused"]:


### PR DESCRIPTION
For Qwen3-Embedding series, override architectures to "Qwen3Model", because their config.json incorrectly lists "Qwen3ForCausalLM", which would otherwise create a CausalLM model with lm_head.
