### PR TITLE
[ops]feat: support npu fused moe

### DIFF
--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Run fsdp2/ep+fsdp2 clip grad norm test
         run: |
           pytest -s -x tests/utils/test_ep_clip_grad_norm.py
+      - name: Run e2e dcp save and load test
+        run: |
+          pytest -s -x tests/checkpoints/test_trainer_saveload.py
       - name: Run data tests
         run: |
           pytest -s -x tests/data

--- a/veomni/ops/group_gemm/kernel/npu_group_gemm.py
+++ b/veomni/ops/group_gemm/kernel/npu_group_gemm.py
@@ -1,0 +1,55 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch_npu
+
+
+class GmmFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, weight, group_list):
+        ctx.save_for_backward(x, weight)
+        ctx.group_list = group_list
+
+        fwd_output = torch_npu.npu_grouped_matmul(
+            [x], [weight], bias=None, group_list=group_list, split_item=2, group_type=0, group_list_type=1
+        )[0]
+        return fwd_output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input_tensor, weight = ctx.saved_tensors
+        group_list = ctx.group_list
+
+        weight = torch.transpose(weight, 1, 2)
+        grad_input = torch_npu.npu_grouped_matmul(
+            [grad_output], [weight], bias=None, group_list=group_list, split_item=2, group_type=0, group_list_type=1
+        )[0]
+
+        grad_weight = torch_npu.npu_grouped_matmul(
+            [input_tensor.T],
+            [grad_output],
+            bias=None,
+            group_list=group_list,
+            split_item=3,
+            group_type=2,
+            group_list_type=1,
+        )[0]
+
+        return grad_input, grad_weight, None
+
+
+def npu_group_gemm(x, weight, group_list):
+    output = GmmFunction.apply(x, weight, group_list)
+    return output

--- a/veomni/ops/npu_fused_moe.py
+++ b/veomni/ops/npu_fused_moe.py
@@ -1,0 +1,186 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import List, Optional
+
+import torch
+import torch.distributed as dist
+import torch_npu
+
+from veomni.distributed.moe.comm import all_to_all
+from veomni.distributed.moe.moe_utils import sort_chunks_by_idxs
+from veomni.ops.group_gemm.kernel.npu_group_gemm import npu_group_gemm
+from veomni.utils.device import stream_synchronize
+
+
+def npu_fused_moe_forward(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_weight: torch.Tensor,
+    fc1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+) -> torch.Tensor:
+    hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+    permuted_hidden_states, row_ids_map = torch_npu.npu_moe_token_permute(
+        hidden_states, selected_experts.to(torch.int32)
+    )
+    tokens_per_expert = torch.histc(selected_experts, bins=num_experts, min=0, max=num_experts)
+
+    fc1_weight = torch.cat([fc1_1_weight, fc1_2_weight], dim=1).transpose(1, 2)
+    intermediate_hidden_states = npu_group_gemm(permuted_hidden_states, fc1_weight, tokens_per_expert)
+    intermediate_activations = torch_npu.npu_swiglu(intermediate_hidden_states, dim=-1)
+    output = npu_group_gemm(intermediate_activations, fc2_weight.transpose(1, 2), tokens_per_expert)
+    hidden_states = torch_npu.npu_moe_token_unpermute(output, row_ids_map, probs=routing_weights)
+    return hidden_states
+
+
+def npu_ep_fused_moe_forward(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_weight: torch.Tensor,
+    fc1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    ep_group: Optional[dist.ProcessGroup] = None,
+) -> torch.Tensor:
+    hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+    input_splits, output_splits, num_global_tokens_per_local_expert, num_global_sum_tokens_per_local_expert = (
+        dispatch_preprocess(selected_experts, num_experts, ep_group)
+    )
+    hidden_states, unpermute_indices = alltoall_dispatch(
+        hidden_states,
+        selected_experts,
+        input_splits,
+        output_splits,
+        num_experts,
+        num_global_tokens_per_local_expert,
+        ep_group,
+    )
+
+    fc1_weight = torch.cat([fc1_1_weight, fc1_2_weight], dim=1).transpose(1, 2)
+    intermediate_hidden_states = npu_group_gemm(hidden_states, fc1_weight, num_global_sum_tokens_per_local_expert)
+    intermediate_activations = torch_npu.npu_swiglu(intermediate_hidden_states, dim=-1)
+    hidden_states = npu_group_gemm(
+        intermediate_activations, fc2_weight.transpose(1, 2), num_global_sum_tokens_per_local_expert
+    )
+
+    hidden_states = alltoall_combine(
+        hidden_states,
+        routing_weights,
+        unpermute_indices,
+        input_splits,
+        output_splits,
+        num_experts,
+        num_global_tokens_per_local_expert,
+        ep_group,
+    )
+    return hidden_states
+
+
+def dispatch_preprocess(
+    selected_experts: torch.Tensor,
+    num_global_experts: int,
+    ep_group: Optional[dist.ProcessGroup] = None,
+):
+    if ep_group is None:
+        ep_size = 1
+        ep_rank = 0
+    else:
+        ep_size = dist.get_world_size(ep_group)
+        ep_rank = dist.get_rank(ep_group)
+    assert num_global_experts % ep_size == 0, (
+        f"Number of experts ({num_global_experts}) must be divisible by expert parallel size ({ep_size})."
+    )
+    num_local_experts = num_global_experts // ep_size
+
+    num_local_tokens_per_expert = torch.bincount(selected_experts.view(-1), minlength=num_global_experts)
+
+    if ep_group is None or ep_size <= 1:
+        num_global_tokens_per_expert = num_local_tokens_per_expert.view(1, -1)
+    else:
+        num_global_tokens_per_expert = torch.zeros(
+            ep_size,
+            num_global_experts,
+            dtype=num_local_tokens_per_expert.dtype,
+            device=num_local_tokens_per_expert.device,
+        )
+        dist.all_gather_into_tensor(num_global_tokens_per_expert, num_local_tokens_per_expert, group=ep_group)
+
+    start_idx, end_idx = ep_rank * num_local_experts, (ep_rank + 1) * num_local_experts
+    num_global_tokens_per_local_expert = num_global_tokens_per_expert[:, start_idx:end_idx].contiguous()
+
+    input_splits = num_local_tokens_per_expert.reshape(ep_size, num_local_experts).sum(dim=1).tolist()
+    output_splits = num_global_tokens_per_local_expert.sum(dim=1).tolist()
+
+    num_global_sum_tokens_per_local_expert = num_global_tokens_per_local_expert.sum(dim=0)
+    num_global_tokens_per_local_expert = num_global_tokens_per_local_expert.to(torch.device("cpu"), non_blocking=True)
+    return input_splits, output_splits, num_global_tokens_per_local_expert, num_global_sum_tokens_per_local_expert
+
+
+def alltoall_dispatch(
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    input_splits: List,
+    output_splits: List,
+    num_global_experts: int,
+    num_global_tokens_per_local_expert: torch.Tensor,
+    ep_group: Optional[dist.ProcessGroup] = None,
+):
+    hidden_states, unpermute_indices = torch_npu.npu_moe_token_permute(hidden_states, selected_experts.to(torch.int32))
+    hidden_states = all_to_all(ep_group, hidden_states, output_splits, input_splits)
+
+    stream_synchronize()
+    ep_size = 1 if ep_group is None else dist.get_world_size(ep_group)
+    num_local_experts = num_global_experts // ep_size
+    assert num_global_experts % ep_size == 0, (
+        f"Number of experts ({num_global_experts}) must be divisible by expert parallel size ({ep_size})."
+    )
+    permute_order = torch.arange(num_global_experts).reshape(-1, num_local_experts).T.ravel().tolist()
+    hidden_states = sort_chunks_by_idxs(
+        hidden_states,
+        num_global_tokens_per_local_expert.ravel(),
+        permute_order,
+    )
+    return hidden_states, unpermute_indices
+
+
+def alltoall_combine(
+    hidden_states: torch.Tensor,
+    routing_weights: torch.Tensor,
+    unpermute_indices: torch.Tensor,
+    input_splits: List,
+    output_splits: List,
+    num_global_experts: int,
+    num_global_tokens_per_local_expert: torch.Tensor,
+    ep_group: Optional[dist.ProcessGroup] = None,
+):
+    ep_size = 1 if ep_group is None else dist.get_world_size(ep_group)
+    num_local_experts = num_global_experts // ep_size
+    assert num_global_experts % ep_size == 0, (
+        f"Number of experts ({num_global_experts}) must be divisible by expert parallel size ({ep_size})."
+    )
+    unpermute_order = torch.arange(num_global_experts).reshape(num_local_experts, -1).T.ravel().tolist()
+    hidden_states = sort_chunks_by_idxs(
+        hidden_states,
+        num_global_tokens_per_local_expert.T.ravel(),
+        unpermute_order,
+    )
+
+    hidden_states = all_to_all(ep_group, hidden_states, input_splits, output_splits)
+    hidden_states = torch_npu.npu_moe_token_unpermute(hidden_states, unpermute_indices, probs=routing_weights)
+    return hidden_states

--- a/veomni/utils/device.py
+++ b/veomni/utils/device.py
@@ -80,6 +80,16 @@ def synchronize() -> None:
     get_torch_device().synchronize()
 
 
+def stream_synchronize() -> None:
+    """Execute device stream synchronize operation."""
+    if IS_CUDA_AVAILABLE:
+        torch.cuda.current_stream().synchronize()
+    elif IS_NPU_AVAILABLE:
+        torch.npu.current_stream().synchronize()
+    else:
+        synchronize()
+
+
 def empty_cache() -> None:
     """Execute torch empty cache operation."""
     get_torch_device().empty_cache()


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

support EP fused moe ops on  npu device
* `torch_npu.npu_grouped_matmul`
* `torch_npu.npu_moe_token_permute`
* `torch_npu.npu_moe_token_unpermute`

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

We conducted local testing (on qwen3 moe, ep=2 & ep=1, num layers=1 )on the performance and precision of these three scenarios (fused & eager & no ep), and the comparison results showed consistent precision with performance benefits

1、use eager implement
```
Epoch 1/1:   0%|          | 0/3828049 [00:05<?, ?it/s, loss: 11.41, grad_norm: 29.46, lr: 1.12e-08]
Epoch 1/1:   0%|          | 1/3828049 [00:05<5818:42:32,  5.47s/it, loss: 11.41, grad_norm: 29.46, lr: 1.12e-08]
Epoch 1/1:   0%|          | 1/3828049 [00:08<5818:42:32,  5.47s/it, loss: 11.58, grad_norm: 29.15, lr: 2.24e-08]
Epoch 1/1:   0%|          | 2/3828049 [00:08<4333:03:49,  4.07s/it, loss: 11.58, grad_norm: 29.15, lr: 2.24e-08]
Epoch 1/1:   0%|          | 2/3828049 [00:11<4333:03:49,  4.07s/it, loss: 11.27, grad_norm: 30.07, lr: 3.36e-08]
Epoch 1/1:   0%|          | 3/3828049 [00:11<3771:08:48,  3.55s/it, loss: 11.27, grad_norm: 30.07, lr: 3.36e-08]
Epoch 1/1:   0%|          | 3/3828049 [00:14<3771:08:48,  3.55s/it, loss: 11.47, grad_norm: 29.36, lr: 4.48e-08]
Epoch 1/1:   0%|          | 4/3828049 [00:14<3476:43:31,  3.27s/it, loss: 11.47, grad_norm: 29.36, lr: 4.48e-08]
Epoch 1/1:   0%|          | 4/3828049 [00:17<3476:43:31,  3.27s/it, loss: 11.46, grad_norm: 29.61, lr: 5.60e-08]
Epoch 1/1:   0%|          | 5/3828049 [00:17<3328:39:15,  3.13s/it, loss: 11.46, grad_norm: 29.61, lr: 5.60e-08]
Epoch 1/1:   0%|          | 5/3828049 [00:20<3328:39:15,  3.13s/it, loss: 11.37, grad_norm: 28.89, lr: 6.72e-08]
Epoch 1/1:   0%|          | 6/3828049 [00:20<3260:21:02,  3.07s/it, loss: 11.37, grad_norm: 28.89, lr: 6.72e-08]
Epoch 1/1:   0%|          | 6/3828049 [00:22<3260:21:02,  3.07s/it, loss: 11.58, grad_norm: 29.79, lr: 7.84e-08]
Epoch 1/1:   0%|          | 7/3828049 [00:22<3138:11:21,  2.95s/it, loss: 11.58, grad_norm: 29.79, lr: 7.84e-08]
Epoch 1/1:   0%|          | 7/3828049 [00:26<3138:11:21,  2.95s/it, loss: 11.66, grad_norm: 29.54, lr: 8.96e-08]
Epoch 1/1:   0%|          | 8/3828049 [00:26<3207:20:49,  3.02s/it, loss: 11.66, grad_norm: 29.54, lr: 8.96e-08]
Epoch 1/1:   0%|          | 8/3828049 [00:28<3207:20:49,  3.02s/it, loss: 11.56, grad_norm: 29.12, lr: 1.01e-07]
Epoch 1/1:   0%|          | 9/3828049 [00:28<3123:02:55,  2.94s/it, loss: 11.56, grad_norm: 29.12, lr: 1.01e-07]
Epoch 1/1:   0%|          | 9/3828049 [00:31<3123:02:55,  2.94s/it, loss: 11.47, grad_norm: 28.91, lr: 1.12e-07]
Epoch 1/1:   0%|          | 10/3828049 [00:31<3180:43:31,  2.99s/it, loss: 11.47, grad_norm: 28.91, lr: 1.12e-07]
Epoch 1/1:   0%|          | 10/3828049 [00:34<3180:43:31,  2.99s/it, loss: 11.47, grad_norm: 29.66, lr: 1.23e-07]
Epoch 1/1:   0%|          | 11/3828049 [00:34<3120:53:16,  2.93s/it, loss: 11.47, grad_norm: 29.66, lr: 1.23e-07]
Epoch 1/1:   0%|          | 11/3828049 [00:37<3120:53:16,  2.93s/it, loss: 11.62, grad_norm: 29.34, lr: 1.34e-07]
Epoch 1/1:   0%|          | 12/3828049 [00:37<3062:47:06,  2.88s/it, loss: 11.62, grad_norm: 29.34, lr: 1.34e-07]
Epoch 1/1:   0%|          | 12/3828049 [00:40<3062:47:06,  2.88s/it, loss: 11.63, grad_norm: 30.80, lr: 1.46e-07]
Epoch 1/1:   0%|          | 13/3828049 [00:40<3086:47:20,  2.90s/it, loss: 11.63, grad_norm: 30.80, lr: 1.46e-07]
Epoch 1/1:   0%|          | 13/3828049 [00:43<3086:47:20,  2.90s/it, loss: 11.75, grad_norm: 28.15, lr: 1.57e-07]
Epoch 1/1:   0%|          | 14/3828049 [00:43<3274:37:05,  3.08s/it, loss: 11.75, grad_norm: 28.15, lr: 1.57e-07]
Epoch 1/1:   0%|          | 14/3828049 [00:47<3274:37:05,  3.08s/it, loss: 11.56, grad_norm: 29.35, lr: 1.68e-07]
Epoch 1/1:   0%|          | 15/3828049 [00:47<3311:43:28,  3.11s/it, loss: 11.56, grad_norm: 29.35, lr: 1.68e-07]
Epoch 1/1:   0%|          | 15/3828049 [00:49<3311:43:28,  3.11s/it, loss: 11.63, grad_norm: 30.15, lr: 1.79e-07]
Epoch 1/1:   0%|          | 16/3828049 [00:49<3221:34:22,  3.03s/it, loss: 11.63, grad_norm: 30.15, lr: 1.79e-07]
Epoch 1/1:   0%|          | 16/3828049 [00:52<3221:34:22,  3.03s/it, loss: 11.47, grad_norm: 30.08, lr: 1.90e-07]
Epoch 1/1:   0%|          | 17/3828049 [00:52<3146:10:22,  2.96s/it, loss: 11.47, grad_norm: 30.08, lr: 1.90e-07]
Epoch 1/1:   0%|          | 17/3828049 [00:55<3146:10:22,  2.96s/it, loss: 11.48, grad_norm: 28.15, lr: 2.02e-07]
Epoch 1/1:   0%|          | 18/3828049 [00:55<3054:16:01,  2.87s/it, loss: 11.48, grad_norm: 28.15, lr: 2.02e-07]
Epoch 1/1:   0%|          | 18/3828049 [00:58<3054:16:01,  2.87s/it, loss: 11.38, grad_norm: 30.66, lr: 2.13e-07]
Epoch 1/1:   0%|          | 19/3828049 [00:58<3057:38:14,  2.88s/it, loss: 11.38, grad_norm: 30.66, lr: 2.13e-07]
Epoch 1/1:   0%|          | 19/3828049 [01:01<3057:38:14,  2.88s/it, loss: 11.53, grad_norm: 29.73, lr: 2.24e-07]
Epoch 1/1:   0%|          | 20/3828049 [01:01<3039:54:48,  2.86s/it, loss: 11.53, grad_norm: 29.73, lr: 2.24e-07]
Epoch 1/1:   0%|          | 20/3828049 [01:03<3039:54:48,  2.86s/it, loss: 11.37, grad_norm: 29.09, lr: 2.35e-07]
```

1、use fused implement
```
Epoch 1/1:   0%|          | 0/3828049 [00:04<?, ?it/s, loss: 11.41, grad_norm: 29.47, lr: 1.12e-08]
Epoch 1/1:   0%|          | 1/3828049 [00:04<4616:33:45,  4.34s/it, loss: 11.41, grad_norm: 29.47, lr: 1.12e-08]
Epoch 1/1:   0%|          | 1/3828049 [00:06<4616:33:45,  4.34s/it, loss: 11.58, grad_norm: 29.15, lr: 2.24e-08]
Epoch 1/1:   0%|          | 2/3828049 [00:06<3036:06:24,  2.86s/it, loss: 11.58, grad_norm: 29.15, lr: 2.24e-08]
Epoch 1/1:   0%|          | 2/3828049 [00:07<3036:06:24,  2.86s/it, loss: 11.27, grad_norm: 30.07, lr: 3.36e-08]
Epoch 1/1:   0%|          | 3/3828049 [00:07<2427:40:15,  2.28s/it, loss: 11.27, grad_norm: 30.07, lr: 3.36e-08]
Epoch 1/1:   0%|          | 3/3828049 [00:09<2427:40:15,  2.28s/it, loss: 11.47, grad_norm: 29.34, lr: 4.48e-08]
Epoch 1/1:   0%|          | 4/3828049 [00:09<2050:15:25,  1.93s/it, loss: 11.47, grad_norm: 29.34, lr: 4.48e-08]
Epoch 1/1:   0%|          | 4/3828049 [00:10<2050:15:25,  1.93s/it, loss: 11.46, grad_norm: 29.61, lr: 5.60e-08]
Epoch 1/1:   0%|          | 5/3828049 [00:10<1853:57:58,  1.74s/it, loss: 11.46, grad_norm: 29.61, lr: 5.60e-08]
Epoch 1/1:   0%|          | 5/3828049 [00:12<1853:57:58,  1.74s/it, loss: 11.37, grad_norm: 28.89, lr: 6.72e-08]
Epoch 1/1:   0%|          | 6/3828049 [00:12<1790:48:15,  1.68s/it, loss: 11.37, grad_norm: 28.89, lr: 6.72e-08]
Epoch 1/1:   0%|          | 6/3828049 [00:13<1790:48:15,  1.68s/it, loss: 11.58, grad_norm: 29.78, lr: 7.84e-08]
Epoch 1/1:   0%|          | 7/3828049 [00:13<1670:39:49,  1.57s/it, loss: 11.58, grad_norm: 29.78, lr: 7.84e-08]
Epoch 1/1:   0%|          | 7/3828049 [00:15<1670:39:49,  1.57s/it, loss: 11.66, grad_norm: 29.53, lr: 8.96e-08]
Epoch 1/1:   0%|          | 8/3828049 [00:15<1731:10:40,  1.63s/it, loss: 11.66, grad_norm: 29.53, lr: 8.96e-08]
Epoch 1/1:   0%|          | 8/3828049 [00:16<1731:10:40,  1.63s/it, loss: 11.56, grad_norm: 29.13, lr: 1.01e-07]
Epoch 1/1:   0%|          | 9/3828049 [00:16<1652:53:39,  1.55s/it, loss: 11.56, grad_norm: 29.13, lr: 1.01e-07]
Epoch 1/1:   0%|          | 9/3828049 [00:18<1652:53:39,  1.55s/it, loss: 11.47, grad_norm: 28.91, lr: 1.12e-07]
Epoch 1/1:   0%|          | 10/3828049 [00:18<1699:48:58,  1.60s/it, loss: 11.47, grad_norm: 28.91, lr: 1.12e-07]
Epoch 1/1:   0%|          | 10/3828049 [00:19<1699:48:58,  1.60s/it, loss: 11.47, grad_norm: 29.66, lr: 1.23e-07]
Epoch 1/1:   0%|          | 11/3828049 [00:19<1651:07:39,  1.55s/it, loss: 11.47, grad_norm: 29.66, lr: 1.23e-07]
Epoch 1/1:   0%|          | 11/3828049 [00:21<1651:07:39,  1.55s/it, loss: 11.62, grad_norm: 29.34, lr: 1.34e-07]
Epoch 1/1:   0%|          | 12/3828049 [00:21<1598:56:17,  1.50s/it, loss: 11.62, grad_norm: 29.34, lr: 1.34e-07]
Epoch 1/1:   0%|          | 12/3828049 [00:22<1598:56:17,  1.50s/it, loss: 11.63, grad_norm: 30.80, lr: 1.46e-07]
Epoch 1/1:   0%|          | 13/3828049 [00:22<1613:27:58,  1.52s/it, loss: 11.63, grad_norm: 30.80, lr: 1.46e-07]
Epoch 1/1:   0%|          | 13/3828049 [00:24<1613:27:58,  1.52s/it, loss: 11.75, grad_norm: 28.15, lr: 1.57e-07]
Epoch 1/1:   0%|          | 14/3828049 [00:24<1795:13:31,  1.69s/it, loss: 11.75, grad_norm: 28.15, lr: 1.57e-07]
Epoch 1/1:   0%|          | 14/3828049 [00:26<1795:13:31,  1.69s/it, loss: 11.56, grad_norm: 29.35, lr: 1.68e-07]
Epoch 1/1:   0%|          | 15/3828049 [00:26<1820:20:47,  1.71s/it, loss: 11.56, grad_norm: 29.35, lr: 1.68e-07]
Epoch 1/1:   0%|          | 15/3828049 [00:28<1820:20:47,  1.71s/it, loss: 11.63, grad_norm: 30.14, lr: 1.79e-07]
Epoch 1/1:   0%|          | 16/3828049 [00:28<1746:24:49,  1.64s/it, loss: 11.63, grad_norm: 30.14, lr: 1.79e-07]
Epoch 1/1:   0%|          | 16/3828049 [00:29<1746:24:49,  1.64s/it, loss: 11.47, grad_norm: 30.10, lr: 1.90e-07]
Epoch 1/1:   0%|          | 17/3828049 [00:29<1667:16:55,  1.57s/it, loss: 11.47, grad_norm: 30.10, lr: 1.90e-07]
Epoch 1/1:   0%|          | 17/3828049 [00:30<1667:16:55,  1.57s/it, loss: 11.48, grad_norm: 28.14, lr: 2.02e-07]
Epoch 1/1:   0%|          | 18/3828049 [00:30<1594:21:21,  1.50s/it, loss: 11.48, grad_norm: 28.14, lr: 2.02e-07]
Epoch 1/1:   0%|          | 18/3828049 [00:32<1594:21:21,  1.50s/it, loss: 11.38, grad_norm: 30.64, lr: 2.13e-07]
Epoch 1/1:   0%|          | 19/3828049 [00:32<1587:20:43,  1.49s/it, loss: 11.38, grad_norm: 30.64, lr: 2.13e-07]
Epoch 1/1:   0%|          | 19/3828049 [00:33<1587:20:43,  1.49s/it, loss: 11.53, grad_norm: 29.73, lr: 2.24e-07]
Epoch 1/1:   0%|          | 20/3828049 [00:33<1561:11:20,  1.47s/it, loss: 11.53, grad_norm: 29.73, lr: 2.24e-07]
Epoch 1/1:   0%|          | 20/3828049 [00:35<1561:11:20,  1.47s/it, loss: 11.37, grad_norm: 29.09, lr: 2.35e-07]
```
3、no ep implement
```
Epoch 1/1:   0%|          | 0/3828049 [00:04<?, ?it/s, loss: 11.41, grad_norm: 29.50, lr: 1.12e-08]
Epoch 1/1:   0%|          | 1/3828049 [00:04<4275:39:26,  4.02s/it, loss: 11.41, grad_norm: 29.50, lr: 1.12e-08]
Epoch 1/1:   0%|          | 1/3828049 [00:05<4275:39:26,  4.02s/it, loss: 11.58, grad_norm: 29.12, lr: 2.24e-08]
Epoch 1/1:   0%|          | 2/3828049 [00:05<2936:58:47,  2.76s/it, loss: 11.58, grad_norm: 29.12, lr: 2.24e-08]
Epoch 1/1:   0%|          | 2/3828049 [00:07<2936:58:47,  2.76s/it, loss: 11.27, grad_norm: 30.12, lr: 3.36e-08]
Epoch 1/1:   0%|          | 3/3828049 [00:07<2380:30:14,  2.24s/it, loss: 11.27, grad_norm: 30.12, lr: 3.36e-08]
Epoch 1/1:   0%|          | 3/3828049 [00:08<2380:30:14,  2.24s/it, loss: 11.47, grad_norm: 29.38, lr: 4.48e-08]
Epoch 1/1:   0%|          | 4/3828049 [00:08<2049:37:20,  1.93s/it, loss: 11.47, grad_norm: 29.38, lr: 4.48e-08]
Epoch 1/1:   0%|          | 4/3828049 [00:10<2049:37:20,  1.93s/it, loss: 11.46, grad_norm: 29.62, lr: 5.60e-08]
Epoch 1/1:   0%|          | 5/3828049 [00:10<1877:57:20,  1.77s/it, loss: 11.46, grad_norm: 29.62, lr: 5.60e-08]
Epoch 1/1:   0%|          | 5/3828049 [00:12<1877:57:20,  1.77s/it, loss: 11.37, grad_norm: 29.00, lr: 6.72e-08]
Epoch 1/1:   0%|          | 6/3828049 [00:12<1836:51:42,  1.73s/it, loss: 11.37, grad_norm: 29.00, lr: 6.72e-08]
Epoch 1/1:   0%|          | 6/3828049 [00:13<1836:51:42,  1.73s/it, loss: 11.58, grad_norm: 29.75, lr: 7.84e-08]
Epoch 1/1:   0%|          | 7/3828049 [00:13<1728:22:49,  1.63s/it, loss: 11.58, grad_norm: 29.75, lr: 7.84e-08]
Epoch 1/1:   0%|          | 7/3828049 [00:15<1728:22:49,  1.63s/it, loss: 11.66, grad_norm: 29.50, lr: 8.96e-08]
Epoch 1/1:   0%|          | 8/3828049 [00:15<1786:03:51,  1.68s/it, loss: 11.66, grad_norm: 29.50, lr: 8.96e-08]
Epoch 1/1:   0%|          | 8/3828049 [00:16<1786:03:51,  1.68s/it, loss: 11.56, grad_norm: 29.00, lr: 1.01e-07]
Epoch 1/1:   0%|          | 9/3828049 [00:16<1713:43:24,  1.61s/it, loss: 11.56, grad_norm: 29.00, lr: 1.01e-07]
Epoch 1/1:   0%|          | 9/3828049 [00:18<1713:43:24,  1.61s/it, loss: 11.47, grad_norm: 29.00, lr: 1.12e-07]
Epoch 1/1:   0%|          | 10/3828049 [00:18<1763:19:04,  1.66s/it, loss: 11.47, grad_norm: 29.00, lr: 1.12e-07]
Epoch 1/1:   0%|          | 10/3828049 [00:20<1763:19:04,  1.66s/it, loss: 11.47, grad_norm: 29.62, lr: 1.23e-07]
Epoch 1/1:   0%|          | 11/3828049 [00:20<1721:13:57,  1.62s/it, loss: 11.47, grad_norm: 29.62, lr: 1.23e-07]
Epoch 1/1:   0%|          | 11/3828049 [00:21<1721:13:57,  1.62s/it, loss: 11.62, grad_norm: 29.38, lr: 1.34e-07]
Epoch 1/1:   0%|          | 12/3828049 [00:21<1671:48:32,  1.57s/it, loss: 11.62, grad_norm: 29.38, lr: 1.34e-07]
Epoch 1/1:   0%|          | 12/3828049 [00:23<1671:48:32,  1.57s/it, loss: 11.63, grad_norm: 30.75, lr: 1.46e-07]
Epoch 1/1:   0%|          | 13/3828049 [00:23<1689:04:04,  1.59s/it, loss: 11.63, grad_norm: 30.75, lr: 1.46e-07]
Epoch 1/1:   0%|          | 13/3828049 [00:25<1689:04:04,  1.59s/it, loss: 11.75, grad_norm: 28.12, lr: 1.57e-07]
Epoch 1/1:   0%|          | 14/3828049 [00:25<1861:52:25,  1.75s/it, loss: 11.75, grad_norm: 28.12, lr: 1.57e-07]
Epoch 1/1:   0%|          | 14/3828049 [00:27<1861:52:25,  1.75s/it, loss: 11.56, grad_norm: 29.38, lr: 1.68e-07]
Epoch 1/1:   0%|          | 15/3828049 [00:27<1919:30:11,  1.81s/it, loss: 11.56, grad_norm: 29.38, lr: 1.68e-07]
Epoch 1/1:   0%|          | 15/3828049 [00:28<1919:30:11,  1.81s/it, loss: 11.63, grad_norm: 30.12, lr: 1.79e-07]
Epoch 1/1:   0%|          | 16/3828049 [00:28<1840:41:33,  1.73s/it, loss: 11.63, grad_norm: 30.12, lr: 1.79e-07]
Epoch 1/1:   0%|          | 16/3828049 [00:30<1840:41:33,  1.73s/it, loss: 11.47, grad_norm: 30.00, lr: 1.90e-07]
Epoch 1/1:   0%|          | 17/3828049 [00:30<1751:53:45,  1.65s/it, loss: 11.47, grad_norm: 30.00, lr: 1.90e-07]
Epoch 1/1:   0%|          | 17/3828049 [00:31<1751:53:45,  1.65s/it, loss: 11.48, grad_norm: 28.25, lr: 2.02e-07]
Epoch 1/1:   0%|          | 18/3828049 [00:31<1671:36:51,  1.57s/it, loss: 11.48, grad_norm: 28.25, lr: 2.02e-07]
Epoch 1/1:   0%|          | 18/3828049 [00:33<1671:36:51,  1.57s/it, loss: 11.38, grad_norm: 30.62, lr: 2.13e-07]
Epoch 1/1:   0%|          | 19/3828049 [00:33<1669:35:23,  1.57s/it, loss: 11.38, grad_norm: 30.62, lr: 2.13e-07]
Epoch 1/1:   0%|          | 19/3828049 [00:34<1669:35:23,  1.57s/it, loss: 11.53, grad_norm: 29.75, lr: 2.24e-07]
Epoch 1/1:   0%|          | 20/3828049 [00:34<1639:23:39,  1.54s/it, loss: 11.53, grad_norm: 29.75, lr: 2.24e-07]
Epoch 1/1:   0%|          | 20/3828049 [00:36<1639:23:39,  1.54s/it, loss: 11.37, grad_norm: 29.12, lr: 2.35e-07]
```
### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
