### PR TITLE
[misc] fix: fix auto-label for forked pr

### DIFF
--- a/.github/workflows/auto_label_issue_and_pr.yml
+++ b/.github/workflows/auto_label_issue_and_pr.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, edited]
   pull_request_target:
     types: [opened, edited, ready_for_review, synchronize]
+  pull_request:
+    types: [opened, edited, ready_for_review, synchronize]
   # Trigger on comments in the main conversation (Issues & PRs)
   issue_comment:
     types: [created]


### PR DESCRIPTION
### What does this PR do?

fix auto-label for forked pr 

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
