### PR TITLE
[ci] fix: handle pull_request_target event in auto_label workflow

### DIFF
--- a/.github/workflows/auto_label_issue_and_pr.yml
+++ b/.github/workflows/auto_label_issue_and_pr.yml
@@ -61,7 +61,7 @@ jobs:
 
               console.log(`Checking comment on #${targetNumber}`);
 
-            } else if (eventName === 'pull_request') {
+            } else if (eventName === 'pull_request' || eventName === 'pull_request_target') {
               // Case B: PR Opened/Edited
               // Check Title only (standard practice to avoid noise from long descriptions)
               const target = payload.pull_request;


### PR DESCRIPTION
### What does this PR do?
Fixes the auto_label workflow crash when triggered by pull_request_target events.

  Root Cause:The workflow listens to both pull_request and pull_request_target events (line 6-9), but the event handler only
  checked for eventName === 'pull_request' (line 64). When triggered by pull_request_target, the code fell through to the else
  branch, attempting to read payload.issue.title which is undefined for PR events.

  Fix:Updated the condition to eventName === 'pull_request' || eventName === 'pull_request_target' so both events correctly
  access payload.pull_request.title.

  Previous Error:
  Event triggered: pull_request_target
  TypeError: Cannot read properties of undefined (reading 'title')
      at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:36187:16),
  <anonymous>:50:25)