### PR TITLE
 [misc] fix: print log twice bug

### DIFF
--- a/tasks/omni/train_flux.py
+++ b/tasks/omni/train_flux.py
@@ -490,7 +490,8 @@ def main():
             train_metrics = environ_meter.step(delta_time, global_step=global_step)
 
             data_loader_tqdm.set_postfix_str(
-                f"loss: {total_loss:.4f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}, step_time: {delta_time:.2f}s"
+                f"loss: {total_loss:.4f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}, step_time: {delta_time:.2f}s",
+                refresh=False,
             )
             data_loader_tqdm.update()
 

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -463,7 +463,7 @@ def main():
                     "lr": lr,
                 }
             )
-            data_loader_tqdm.set_postfix_str({k: f"{v:.2f}" for k, v in step_info.items() if k != "lr"})
+            data_loader_tqdm.set_postfix_str({k: f"{v:.2f}" for k, v in step_info.items() if k != "lr"}, refresh=False)
             data_loader_tqdm.update()
 
             if args.train.global_rank == 0:

--- a/tasks/omni/train_qwen2_vl.py
+++ b/tasks/omni/train_qwen2_vl.py
@@ -45,9 +45,7 @@ if TYPE_CHECKING:
 
     from veomni.data.chat_template import ChatTemplate
 
-
 logger = helper.create_logger(__name__)
-
 
 MAX_PIXELS = 768 * 28 * 28
 ROLE_MAPPING = {
@@ -393,7 +391,9 @@ def main():
             lr = max(lr_scheduler.get_last_lr())
             train_metrics = environ_meter.step(delta_time, global_step=global_step)
 
-            data_loader_tqdm.set_postfix_str(f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}")
+            data_loader_tqdm.set_postfix_str(
+                f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}", refresh=False
+            )
             data_loader_tqdm.update()
 
             if args.train.global_rank == 0:

--- a/tasks/omni/train_qwen_vl.py
+++ b/tasks/omni/train_qwen_vl.py
@@ -44,9 +44,7 @@ from veomni.utils.dist_utils import all_reduce
 if TYPE_CHECKING:
     pass
 
-
 logger = helper.create_logger(__name__)
-
 
 MAX_PIXELS = 768 * 28 * 28
 ROLE_MAPPING = {
@@ -389,7 +387,9 @@ def main():
             lr = max(lr_scheduler.get_last_lr())
             train_metrics = environ_meter.step(delta_time, global_step=global_step)
 
-            data_loader_tqdm.set_postfix_str(f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}")
+            data_loader_tqdm.set_postfix_str(
+                f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}", refresh=False
+            )
             data_loader_tqdm.update()
 
             if args.train.global_rank == 0:

--- a/tasks/omni/train_wan.py
+++ b/tasks/omni/train_wan.py
@@ -385,7 +385,8 @@ def main():
             train_metrics = environ_meter.step(delta_time, global_step=global_step)
 
             data_loader_tqdm.set_postfix_str(
-                f"loss: {total_loss:.4f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}, step_time: {delta_time:.2f}s"
+                f"loss: {total_loss:.4f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}, step_time: {delta_time:.2f}s",
+                refresh=False,
             )
             data_loader_tqdm.update()
 

--- a/tasks/train_torch.py
+++ b/tasks/train_torch.py
@@ -304,7 +304,9 @@ def main():
             lr = max(lr_scheduler.get_last_lr())
             train_metrics = environ_meter.step(delta_time, global_step=global_step)
 
-            data_loader_tqdm.set_postfix_str(f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}")
+            data_loader_tqdm.set_postfix_str(
+                f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}", refresh=False
+            )
             data_loader_tqdm.update()
 
             if args.train.global_rank == 0:

--- a/tests/checkpoints/test_trainer_saveload.py
+++ b/tests/checkpoints/test_trainer_saveload.py
@@ -276,7 +276,9 @@ def main():
 
             lr = max(lr_scheduler.get_last_lr())
 
-            data_loader_tqdm.set_postfix_str(f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}")
+            data_loader_tqdm.set_postfix_str(
+                f"loss: {total_loss:.2f}, grad_norm: {grad_norm:.2f}, lr: {lr:.2e}", refresh=False
+            )
             data_loader_tqdm.update()
 
         data_loader_tqdm.close()


### PR DESCRIPTION
### What does this PR do?
In the current training script `train_xx.py`, when updating the loss string in `data_loader_tqdm`, it will use `data_loader_tqdm.set_postfix_str` and `data_loader_tqdm.update()`. The `set_postfix_str` defaults to `refresh=True`, then `set_postfix_str` and `update` all will call `Tqdm.refresh()`, causing print twice when output redirect. 

For details, see issues321 https://github.com/ByteDance-Seed/VeOmni/issues/223. 

This PR fixes the issue by manually setting `refresh` to `False` in `set_postfix_str`.



### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
