### PR TITLE
[data] fix: interleave iterable dataset sharding

### DIFF
--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -366,11 +366,10 @@ def build_interleave_dataset(
         logger.info_rank0("Start building iterable multisource dataset")
 
         def add_ds_idx_to_iterable(dataset, ds_idx, source_name):
-            def gen():
-                for x in dataset:
-                    yield {**x, "ds_idx": ds_idx, "source_name": source_name}
+            def trans_example(example):
+                return {**example, "ds_idx": ds_idx, "source_name": source_name}
 
-            return HFIterableDataset.from_generator(gen)
+            return dataset.map(trans_example)
 
         for idx, source in enumerate(sources):
             dataset = build_iterable_dataset(source, namespace=namespace, seed=seed)


### PR DESCRIPTION
### What does this PR do?

about issue #168
turn to use `map` to transfer each example for adding `ds_idx` and `source_name` rather than `from_gen`.

It would help for maintaining the `n_shards` propety, and enable multi working loading in interleaved dataset.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test

### API and Usage Example


### Design & Code Changes

see issue #168 

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: **already covered**
