### PR TITLE
[config] fix: remove torch extra from transformers dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "torchdata>=0.8.0,<1.0",
   "tiktoken>=0.9.0",
   "diffusers>=0.30.0,<=0.31.0",
-  "transformers[torch]==4.57.3",
+  "transformers==4.57.3",
   "psutil",
   "timm",
   "wandb",

--- a/uv.lock
+++ b/uv.lock
@@ -2607,7 +2607,7 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'gpu'", specifier = "==0.23.0+cu128", index = "https://download.pytorch.org/whl/" },
     { name = "torchvision", marker = "extra == 'npu'", specifier = "==0.22.1+cpu", index = "https://download.pytorch.org/whl/" },
     { name = "torchvision", marker = "extra == 'npu-aarch64'", specifier = "==0.22.1", index = "https://download.pytorch.org/whl/" },
-    { name = "transformers", extras = ["torch"], specifier = "==4.57.3" },
+    { name = "transformers", specifier = "==4.57.3" },
     { name = "trl", marker = "extra == 'trl'", specifier = "<=0.9.6" },
     { name = "wandb" },
 ]


### PR DESCRIPTION
### What does this PR do?

Remove the `[torch]` extra from the `transformers` dependency specification in `pyproject.toml`. The torch extra is redundant since torch is already explicitly specified as a dependency in the project, and keeping it may cause dependency resolution conflicts or unnecessary reinstallations.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: https://github.com/ByteDance-Seed/VeOmni/pulls?q=is%3Apr+transformers
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}`: `config`
  - `{type}`: `fix`
  - Title: `[config] fix: remove torch extra from transformers dependency`

### Test

This is a dependency configuration change. The project should continue to work as before since:
- Torch is already explicitly declared as a dependency
- The transformers version remains pinned at 4.57.3
- No functional code changes

### API and Usage Example

No API changes. The dependency change is transparent to users.

### Design & Code Changes

**Files Changed:**
- `pyproject.toml`: Changed `transformers[torch]==4.57.3` to `transformers==4.57.3`
- `uv.lock`: Updated lockfile to reflect the dependency change

**Rationale:**
The `[torch]` extra in transformers is unnecessary because:
1. Torch is already explicitly specified as a dependency
2. The extra may cause redundant installations or version conflicts
3. Cleaner dependency specification without extras

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: This is a dependency configuration change that doesn't require additional tests beyond existing CI checks.