### PR TITLE
[model] fix: repeat  all2all in Wan2.1 ulysses.

### DIFF
--- a/veomni/models/transformers/wan/modeling_wan.py
+++ b/veomni/models/transformers/wan/modeling_wan.py
@@ -24,7 +24,6 @@ from transformers.modeling_utils import PreTrainedModel
 
 from veomni.distributed.parallel_state import get_parallel_state
 from veomni.distributed.sequence_parallel import (
-    gather_heads_scatter_seq,
     gather_outputs,
     gather_seq_scatter_heads,
     get_ulysses_sequence_parallel_world_size,


### PR DESCRIPTION
The gather-scatter is already conducted in the modified flash-attention. Which is conflict with the one in `modeling_wan.py`