### PR TITLE
[ops] feat: Optimize Wan2.1 Performance on Ascend NPU with Patches

### DIFF
--- a/veomni/models/transformers/wan/modeling_wan.py
+++ b/veomni/models/transformers/wan/modeling_wan.py
@@ -32,7 +32,8 @@ from veomni.distributed.sequence_parallel import (
 )
 
 from ....utils import logging
-from ....utils.import_utils import (is_liger_kernel_available,
+from ....utils.import_utils import (
+    is_liger_kernel_available,
     is_torch_npu_available,
     is_transformers_version_greater_or_equal_to,
 )
@@ -653,11 +654,12 @@ class WanModel(PreTrainedModel):
 if is_liger_kernel_available():
     RMSNorm = LigerRMSNorm
     logger.info_rank0("Apply liger kernel to Wan.")
-    
+
 if is_torch_npu_available() and is_transformers_version_greater_or_equal_to("4.50.4"):
     from .npu_patch import apply_wan_npu_patch
+
     apply_wan_npu_patch()
-    
+
 try:
     from veomni.ops.dit.rope_wan.rotary import apply_rotary_emb
 

--- a/veomni/models/transformers/wan/npu_patch.py
+++ b/veomni/models/transformers/wan/npu_patch.py
@@ -17,8 +17,9 @@ def rope_apply_fused(x, **kwargs):
     head_dim = kwargs.pop("head_dim")
     x = rearrange(x, "b s (n d) -> b s n d", d=head_dim)
     x_float = x.to(torch.float32)
-    x_out = torch_npu.npu_rotary_mul(x_float, cos, sin, rotary_mode='interleave').flatten(-2)
+    x_out = torch_npu.npu_rotary_mul(x_float, cos, sin, rotary_mode="interleave").flatten(-2)
     return x_out.to(x.dtype)
+
 
 def apply_wan_npu_patch():
     # Patches for wan2.1 Model


### PR DESCRIPTION
### What does this PR do?
Add fused operators for RMSNorm and RoPE on NPU to the Wan2.1 model.
> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
