### PR TITLE
[task] fix: correct loss scaling with sequence parallel enabled

### DIFF
--- a/tasks/train_torch.py
+++ b/tasks/train_torch.py
@@ -292,7 +292,7 @@ def main():
 
                 length_in_micro_batch = torch.sum(micro_batch["labels"] != IGNORE_INDEX)
                 loss: "torch.Tensor" = (
-                    model_outputs.loss * length_in_micro_batch / length_in_batch * get_parallel_state().dp_size
+                    model_outputs.loss * length_in_micro_batch / length_in_batch * get_parallel_state().fsdp_size
                 )
 
                 with model_bwd_context:


### PR DESCRIPTION
### What does this PR do?

Fixes incorrect loss calculation when Sequence Parallel (SP) is enabled. The previous implementation used `dp_size` for loss scaling, which doesn't account for the SP dimension, causing loss values to be incorrectly scaled down by `sp_size` factor in pure SP or mixed DP+SP configurations.

**Impact**: Affects all training runs with `ulysses_size > 1` or `cp_size > 1`.

### Checklist Before Starting

- [x] Search for similar PRs: No existing PRs found
- [x] Format PR title as `[task] fix: correct loss scaling with sequence parallel enabled`

### Test

#### Validation

**Before Fix (8 GPUs, SP=8, DP=1):**
- Per-token loss = 1.0, each GPU has 100 tokens
- `length_in_batch = 800` (all-reduced across fsdp_group)
- `loss = 1.0 × 100 / 800 × 1 = 0.125` ❌ **Incorrect** (8x smaller)

**After Fix (8 GPUs, SP=8, DP=1):**
- Per-token loss = 1.0, each GPU has 100 tokens
- `length_in_batch = 800` (all-reduced across fsdp_group)
- `loss = 1.0 × 100 / 800 × 8 = 1.0` ✅ **Correct**

**Backward compatibility:**
- Pure DP: `dp_size == fsdp_size` → no behavior change
- Pure SP / DP+SP: Now correctly scaled

### API and Usage Example

No API changes. Internal bug fix only.

### Design & Code Changes

#### Root Cause

Loss calculation with token-level weighting:

```python
length_in_batch = all_reduce(length_in_batch, op="sum", group=get_parallel_state().fsdp_group)
loss = outputs.loss * length_in_micro_batch / length_in_batch * get_parallel_state().dp_size
```

**Issue**: `fsdp_group` spans `dp_size × sp_size` ranks, but scaling used only `dp_size`.

#### Changes

File changed: `tasks/train_torch.py:295`

**Before:**
```python
loss = model_outputs.loss * length_in_micro_batch / length_in_batch * get_parallel_state().dp_size
```

**After:**
```python
loss = model_outputs.loss * length_in_micro_batch / length_in_batch * get_parallel_state().fsdp_size
```

#### Key Definitions

- `dp_size`: Data parallel size (excludes SP)
- `fsdp_size = world_size / (pp_size × tp_size)`: Includes DP and SP
- `fsdp_group`: All-reduce group spanning `dp_size × sp_size` ranks

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Apply pre-commit checks: `make commit && make style && make quality`
- [ ] Add unit tests (requires SP environment mocking, can follow up)
- [x] Validated through mathematical derivation and code review
