### PR TITLE
[model] fix: Fused operator fix for qwen3vl

### DIFF
--- a/.github/workflows/docker-build-ascend-a2.yml
+++ b/.github/workflows/docker-build-ascend-a2.yml
@@ -3,7 +3,7 @@ name: docker-build-ascend-a2
 on:
   workflow_dispatch:
   push:
-    branches: [ "dev/docker_workflow" ]
+    branches: [ "main" ]
     paths:
       - "docker/ascend/Dockerfile.ascend_8.3.rc2_a2"
       - ".github/workflows/docker-build-ascend-a2.yml"
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-ascend-image-a2:
-    if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'phdddd' }}
+    if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'ByteDance-Seed' }}
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-build-ascend-image-a2

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -30,9 +30,9 @@ permissions:
 
 jobs:
   npu_unit_tests:
-    if: github.repository_owner == 'phdddd'
+    if: github.repository_owner == 'ByteDance-Seed'
     name: VeOmni Ascend test (self-host)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, npu-0]
     timeout-minutes: 60 # Increase this timeout value as needed
     container:
       image: quay.io/ascend/veomni:veomni-8.3.rc2-910b-ubuntu22.04-py3.11-latest


### PR DESCRIPTION
### What does this PR do?

The previous implementation of the fusion operator involved invasive modifications to the original code. This version optimizes the fusion operator to eliminate such invasive changes.

### Testing

**Fused baseline**
 ```
Epoch 1/2:   0%|          | 0/500 [00:17<?, ?it/s, loss: 1.60, grad_norm: 24.74, lr: 1.00e-05]
Epoch 1/2:   0%|          | 1/500 [00:17<2:24:59, 17.43s/it, loss: 1.60, grad_norm: 24.74, lr: 1.00e-05]
Epoch 1/2:   0%|          | 1/500 [00:26<2:24:59, 17.43s/it, loss: 1.23, grad_norm: 20.88, lr: 1.00e-05]
Epoch 1/2:   0%|          | 2/500 [00:26<1:43:28, 12.47s/it, loss: 1.23, grad_norm: 20.88, lr: 1.00e-05]
Epoch 1/2:   0%|          | 2/500 [00:35<1:43:28, 12.47s/it, loss: 1.00, grad_norm: 6.67, lr: 1.00e-05] 
Epoch 1/2:   1%|          | 3/500 [00:35<1:30:23, 10.91s/it, loss: 1.00, grad_norm: 6.67, lr: 1.00e-05]
Epoch 1/2:   1%|          | 3/500 [00:44<1:30:23, 10.91s/it, loss: 0.97, grad_norm: 4.94, lr: 1.00e-05]
Epoch 1/2:   1%|          | 4/500 [00:44<1:23:02, 10.05s/it, loss: 0.97, grad_norm: 4.94, lr: 1.00e-05]
Epoch 1/2:   1%|          | 4/500 [00:53<1:23:02, 10.05s/it, loss: 0.98, grad_norm: 7.18, lr: 1.00e-05]
Epoch 1/2:   1%|          | 5/500 [00:53<1:19:14,  9.61s/it, loss: 0.98, grad_norm: 7.18, lr: 1.00e-05]
Epoch 1/2:   1%|          | 5/500 [01:01<1:19:14,  9.61s/it, loss: 0.95, grad_norm: 4.61, lr: 1.00e-05]
Epoch 1/2:   1%|          | 6/500 [01:01<1:16:40,  9.31s/it, loss: 0.95, grad_norm: 4.61, lr: 1.00e-05]
Epoch 1/2:   1%|          | 6/500 [01:10<1:16:40,  9.31s/it, loss: 0.90, grad_norm: 5.42, lr: 1.00e-05]
Epoch 1/2:   1%|▏         | 7/500 [01:10<1:15:15,  9.16s/it, loss: 0.90, grad_norm: 5.42, lr: 1.00e-05]
Epoch 1/2:   1%|▏         | 7/500 [01:19<1:15:15,  9.16s/it, loss: 0.92, grad_norm: 5.05, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 8/500 [01:19<1:14:20,  9.07s/it, loss: 0.92, grad_norm: 5.05, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 8/500 [01:28<1:14:20,  9.07s/it, loss: 0.90, grad_norm: 4.25, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 9/500 [01:28<1:13:50,  9.02s/it, loss: 0.90, grad_norm: 4.25, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 9/500 [01:37<1:13:50,  9.02s/it, loss: 0.90, grad_norm: 24.77, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 10/500 [01:37<1:12:48,  8.91s/it, loss: 0.90, grad_norm: 24.77, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 10/500 [01:45<1:12:48,  8.91s/it, loss: 0.91, grad_norm: 4.74, lr: 1.00e-05] 
Epoch 1/2:   2%|▏         | 11/500 [01:45<1:12:11,  8.86s/it, loss: 0.91, grad_norm: 4.74, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 11/500 [01:54<1:12:11,  8.86s/it, loss: 0.91, grad_norm: 3.76, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 12/500 [01:54<1:11:45,  8.82s/it, loss: 0.91, grad_norm: 3.76, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 12/500 [02:03<1:11:45,  8.82s/it, loss: 0.89, grad_norm: 2.94, lr: 1.00e-05]
Epoch 1/2:   3%|▎         | 13/500 [02:03<1:11:18,  8.79s/it, loss: 0.89, grad_norm: 2.94, lr: 1.00e-05]
Epoch 1/2:   3%|▎         | 13/500 [02:12<1:11:18,  8.79s/it, loss: 0.88, grad_norm: 2.38, lr: 1.00e-05]
Epoch 1/2:   3%|▎         | 14/500 [02:12<1:11:05,  8.78s/it, loss: 0.88, grad_norm: 2.38, lr: 1.00e-05]
Epoch 1/2:   3%|▎         | 14/500 [02:20<1:11:05,  8.78s/it, loss: 0.88, grad_norm: 3.04, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 15/500 [02:20<1:11:22,  8.83s/it, loss: 0.88, grad_norm: 3.04, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 15/500 [02:29<1:11:22,  8.83s/it, loss: 0.89, grad_norm: 2.69, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 16/500 [02:29<1:10:46,  8.77s/it, loss: 0.89, grad_norm: 2.69, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 16/500 [02:38<1:10:46,  8.77s/it, loss: 0.89, grad_norm: 3.67, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 17/500 [02:38<1:10:38,  8.77s/it, loss: 0.89, grad_norm: 3.67, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 17/500 [02:47<1:10:38,  8.77s/it, loss: 0.88, grad_norm: 2.93, lr: 9.99e-06]
Epoch 1/2:   4%|▎         | 18/500 [02:47<1:10:16,  8.75s/it, loss: 0.88, grad_norm: 2.93, lr: 9.99e-06]
Epoch 1/2:   4%|▎         | 18/500 [02:55<1:10:16,  8.75s/it, loss: 0.88, grad_norm: 2.44, lr: 9.99e-06]
Epoch 1/2:   4%|▍         | 19/500 [02:55<1:10:06,  8.74s/it, loss: 0.88, grad_norm: 2.44, lr: 9.99e-06]
Epoch 1/2:   4%|▍         | 19/500 [03:04<1:10:06,  8.74s/it, loss: 0.88, grad_norm: 4.66, lr: 9.99e-06]
Epoch 1/2:   4%|▍         | 20/500 [03:04<1:09:46,  8.72s/it, loss: 0.88, grad_norm: 4.66, lr: 9.99e-06]
Epoch 1/2:   4%|▍         | 20/500 [03:14<1:09:46,  8.72s/it, loss: 0.85, grad_norm: 2.51, lr: 9.99e-06]
Epoch 1/2:   4%|▍         | 21/500 [03:14<1:11:53,  9.01s/it, loss: 0.85, grad_norm: 2.51, lr: 9.99e-06]
 ```

**Fused with Rope and RmsNorm**
 ```
Epoch 1/2:   0%|          | 0/500 [00:17<?, ?it/s, loss: 1.59, grad_norm: 24.20, lr: 1.00e-05]
Epoch 1/2:   0%|          | 1/500 [00:17<2:23:01, 17.20s/it, loss: 1.59, grad_norm: 24.20, lr: 1.00e-05]
Epoch 1/2:   0%|          | 1/500 [00:25<2:23:01, 17.20s/it, loss: 1.23, grad_norm: 22.09, lr: 1.00e-05]
Epoch 1/2:   0%|          | 2/500 [00:25<1:40:55, 12.16s/it, loss: 1.23, grad_norm: 22.09, lr: 1.00e-05]
Epoch 1/2:   0%|          | 2/500 [00:34<1:40:55, 12.16s/it, loss: 1.00, grad_norm: 5.96, lr: 1.00e-05] 
Epoch 1/2:   1%|          | 3/500 [00:34<1:28:13, 10.65s/it, loss: 1.00, grad_norm: 5.96, lr: 1.00e-05]
Epoch 1/2:   1%|          | 3/500 [00:43<1:28:13, 10.65s/it, loss: 0.97, grad_norm: 4.11, lr: 1.00e-05]
Epoch 1/2:   1%|          | 4/500 [00:43<1:20:35,  9.75s/it, loss: 0.97, grad_norm: 4.11, lr: 1.00e-05]
Epoch 1/2:   1%|          | 4/500 [00:51<1:20:35,  9.75s/it, loss: 0.98, grad_norm: 7.46, lr: 1.00e-05]
Epoch 1/2:   1%|          | 5/500 [00:51<1:16:29,  9.27s/it, loss: 0.98, grad_norm: 7.46, lr: 1.00e-05]
Epoch 1/2:   1%|          | 5/500 [00:59<1:16:29,  9.27s/it, loss: 0.95, grad_norm: 4.87, lr: 1.00e-05]
Epoch 1/2:   1%|          | 6/500 [00:59<1:14:00,  8.99s/it, loss: 0.95, grad_norm: 4.87, lr: 1.00e-05]
Epoch 1/2:   1%|          | 6/500 [01:08<1:14:00,  8.99s/it, loss: 0.90, grad_norm: 2.81, lr: 1.00e-05]
Epoch 1/2:   1%|▏         | 7/500 [01:08<1:12:35,  8.84s/it, loss: 0.90, grad_norm: 2.81, lr: 1.00e-05]
Epoch 1/2:   1%|▏         | 7/500 [01:16<1:12:35,  8.84s/it, loss: 0.91, grad_norm: 23.39, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 8/500 [01:16<1:11:33,  8.73s/it, loss: 0.91, grad_norm: 23.39, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 8/500 [01:25<1:11:33,  8.73s/it, loss: 0.92, grad_norm: 6.76, lr: 1.00e-05] 
Epoch 1/2:   2%|▏         | 9/500 [01:25<1:11:29,  8.74s/it, loss: 0.92, grad_norm: 6.76, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 9/500 [01:34<1:11:29,  8.74s/it, loss: 0.92, grad_norm: 4.43, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 10/500 [01:34<1:10:38,  8.65s/it, loss: 0.92, grad_norm: 4.43, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 10/500 [01:42<1:10:38,  8.65s/it, loss: 0.91, grad_norm: 2.87, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 11/500 [01:42<1:10:00,  8.59s/it, loss: 0.91, grad_norm: 2.87, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 11/500 [01:51<1:10:00,  8.59s/it, loss: 0.91, grad_norm: 3.85, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 12/500 [01:51<1:09:29,  8.54s/it, loss: 0.91, grad_norm: 3.85, lr: 1.00e-05]
Epoch 1/2:   2%|▏         | 12/500 [01:59<1:09:29,  8.54s/it, loss: 0.89, grad_norm: 3.46, lr: 1.00e-05]
Epoch 1/2:   3%|▎         | 13/500 [01:59<1:08:55,  8.49s/it, loss: 0.89, grad_norm: 3.46, lr: 1.00e-05]
Epoch 1/2:   3%|▎         | 13/500 [02:07<1:08:55,  8.49s/it, loss: 0.88, grad_norm: 2.71, lr: 1.00e-05]
Epoch 1/2:   3%|▎         | 14/500 [02:07<1:08:38,  8.47s/it, loss: 0.88, grad_norm: 2.71, lr: 1.00e-05]
Epoch 1/2:   3%|▎         | 14/500 [02:16<1:08:38,  8.47s/it, loss: 0.88, grad_norm: 2.75, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 15/500 [02:16<1:08:57,  8.53s/it, loss: 0.88, grad_norm: 2.75, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 15/500 [02:24<1:08:57,  8.53s/it, loss: 0.89, grad_norm: 2.62, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 16/500 [02:24<1:08:22,  8.48s/it, loss: 0.89, grad_norm: 2.62, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 16/500 [02:33<1:08:22,  8.48s/it, loss: 0.88, grad_norm: 2.57, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 17/500 [02:33<1:08:18,  8.49s/it, loss: 0.88, grad_norm: 2.57, lr: 9.99e-06]
Epoch 1/2:   3%|▎         | 17/500 [02:41<1:08:18,  8.49s/it, loss: 0.88, grad_norm: 3.17, lr: 9.99e-06]
Epoch 1/2:   4%|▎         | 18/500 [02:41<1:08:04,  8.47s/it, loss: 0.88, grad_norm: 3.17, lr: 9.99e-06]
Epoch 1/2:   4%|▎         | 18/500 [02:50<1:08:04,  8.47s/it, loss: 0.88, grad_norm: 2.67, lr: 9.99e-06]
Epoch 1/2:   4%|▍         | 19/500 [02:50<1:07:57,  8.48s/it, loss: 0.88, grad_norm: 2.67, lr: 9.99e-06]
Epoch 1/2:   4%|▍         | 19/500 [02:58<1:07:57,  8.48s/it, loss: 0.88, grad_norm: 2.54, lr: 9.99e-06]
Epoch 1/2:   4%|▍         | 20/500 [02:58<1:07:42,  8.46s/it, loss: 0.88, grad_norm: 2.54, lr: 9.99e-06]
Epoch 1/2:   4%|▍         | 20/500 [03:07<1:07:42,  8.46s/it, loss: 0.85, grad_norm: 2.36, lr: 9.99e-06]
 ```

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
