### PR TITLE
[perf]Add zero2 in parallelize_model_fsdp1

### DIFF
--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -93,7 +93,7 @@ def parallelize_model_fsdp1(
     """
     Applies EP (when enabled) + FSDP1 parallel strategy to the model.
     """
-    assert  enable_full_shard and enable_shard_grad_op, "You must explicitly specify enable_full_shard as False if enable_shard_grad_op is set to True"
+    assert  not (enable_full_shard and enable_shard_grad_op), "You must explicitly specify enable_full_shard as False if enable_shard_grad_op is set to True"
     parallel_state = get_parallel_state()
 
     if parallel_state.ep_enabled:
@@ -116,7 +116,6 @@ def parallelize_model_fsdp1(
         strategy = ShardingStrategy.HYBRID_SHARD if enable_full_shard else ShardingStrategy._HYBRID_SHARD_ZERO2
     else:
         strategy = ShardingStrategy.FULL_SHARD if enable_full_shard else ShardingStrategy.SHARD_GRAD_OP
-
     fsdp_kwargs = {
         "auto_wrap_policy": wrap_policy,
         "ignored_states": fsdp_no_shard_states,


### PR DESCRIPTION
### What does this PR do?
1、Enable `ShardingStrategy._HYBRID_SHARD_ZERO2` in parallelize_model_fsdp1
2、Enable `use_orig_params` to configure
> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test
1、When memory is sufficient, the `ShardingStrategy.SHARD_GRAD_OP` or `ShardingStrategy._HYBRID_SHARD_ZERO2` configuration can be enabled, preventing parameters from being resharded after the `forward`, thus avoiding the `all_gather` operation before the `backward`.We conducted experiments using a shallower `qwen2-vl` on these two configurations, achieved a 14% performance improvement.
<img width="1781" height="213" alt="image" src="https://github.com/user-attachments/assets/0872580a-0e78-453f-899d-958813c8c551" />
<img width="1826" height="200" alt="image" src="https://github.com/user-attachments/assets/f1548813-0afb-4664-8747-e5e23461a3ba" />
Note that specific performance improvements depend on the model itself.

2、We noticed that the `use_orig_params` parameter is hardcoded to `true`. While it demonstrates advantages in various aspects, such as debugging and grouping optimizers, setting `use_orig_params=False` still has its uses if extreme training performance is desired. Therefore, we recommend making this parameter configurable.
We also conducted experiments on shallower qwen2vl, and found that `using_params=false` resulted in faster training speed.
<img width="1293" height="672" alt="image" src="https://github.com/user-attachments/assets/8c7add67-53f9-409c-84c8-4bf31a0724b6" />
<img width="1287" height="358" alt="image" src="https://github.com/user-attachments/assets/966662ec-fa3c-46b9-a016-250a947e23aa" />

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
