### PR TITLE
[config] feat:  add MFU calculation for qwen3_vl_moe

### DIFF
--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -359,9 +359,7 @@ class VeomniFlopsCounter:
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
-
     def _estimate_qwen3_vl_moe_flops(self, tokens_sum, batch_seqlens, delta_time, **kargs):
-
         # qwen3_vl uses text_config and vision_config to distinguish configs of different parts.
         hidden_size = self.config.text_config.hidden_size
         vocab_size = self.config.text_config.vocab_size
@@ -372,7 +370,11 @@ class VeomniFlopsCounter:
         moe_intermediate_size = self.config.text_config.moe_intermediate_size
         moe_num_expert = self.config.text_config.num_experts
         moe_topk = self.config.text_config.num_experts_per_tok
-        head_dim = getattr(self.config.text_config, "head_dim", self.config.text_config.hidden_size // self.config.text_config.num_attention_heads)
+        head_dim = getattr(
+            self.config.text_config,
+            "head_dim",
+            self.config.text_config.hidden_size // self.config.text_config.num_attention_heads,
+        )
         q_size = num_attention_heads * head_dim
         k_size = num_key_value_heads * head_dim
         v_size = num_key_value_heads * head_dim
@@ -400,7 +402,6 @@ class VeomniFlopsCounter:
             vit_flops = self._estimate_qwen3_vit_flop(image_seqlens, self.config.vision_config)
         else:
             vit_flops = 0
-        print("vit_flops:",vit_flops)
         # all_layer & all_token fwd & bwd flops
         flops_all_token = dense_N_flops + attn_qkv_flops + vit_flops
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12


### PR DESCRIPTION
### What does this PR do?

Implement estimate_func for qwen3_vl in utils/count_flops.py

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test


![img_v3_02to_af480adf-a709-44a1-bf44-247207992ffg](https://github.com/user-attachments/assets/1acde0cb-cbc3-4418-929a-a575903b891b)


### API and Usage Example

N/A

### Design & Code Changes

This PR implements flops estimation for qwen3_vl_moe on top of qwen2/2.5-vl/qwen3_vl.

Notes:

qwen3_vl_moe retains the core architectural characteristics of qwen3_vl — including the distinct configuration structure that clearly distinguishes between text_config (text configuration) and vision_config (vision configuration) — while the key distinction lies in the integration of the MoE (Mixture of Experts) mechanism into its existing framework.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
