### PR TITLE
[docs] fix: correct typos in documentation

### DIFF
--- a/docs/key_features/ep_fsdp2.md
+++ b/docs/key_features/ep_fsdp2.md
@@ -59,7 +59,7 @@ In summary,
 
 At this step, you already understand how EP+FSDP2 is designed in VeOmni which is sufficient to setup the training! If you are not interested in the implementation details, you can skip the following sections.
 
-The methods discussed in the following sections are trasparent to the end users and automically applied by VeOmni, without any additional efforts to configure.
+The methods discussed in the following sections are transparent to the end users and automatically applied by VeOmni, without any additional efforts to configure.
 
 ## Expert Parallelism Details
 
@@ -69,7 +69,7 @@ As a model-centric framework, VeOmni registers leaf expert weight keys, i.e, "fu
 
 In this way, each model exposes `get_parallel_plan()` method which returns a `ParallelPlan` containing an `ep_plan` dict. Keys are parameter FQN patterns that identify expert weights; values are `Shard(dim=...)` telling which tensor dimension is sharded across EP ranks (in this case always dim-0 to shard expert number).
 
-After applying EP sharding on these registered modules, we immediately drop their device mesh info by replacing the parameter with its local shard. This is because we do not want to gather them back during experts computation like FSDP, we would mauanlly control how EP ranks interact with each other in the model's fused MoE implementation.
+After applying EP sharding on these registered modules, we immediately drop their device mesh info by replacing the parameter with its local shard. This is because we do not want to gather them back during experts computation like FSDP, we would manually control how EP ranks interact with each other in the model's fused MoE implementation.
 
 > In this way, we also avoid using experimental APIs like TorchTitan to override TP-oriented `parallelize_module` to implement EP.
 
@@ -79,7 +79,7 @@ After applying EP sharding on these registered modules, we immediately drop thei
 
 ### Sharding from the bottom up
 
-FSDP2 relis on `fully_shard`, which should be applied in a bottom-up fashion.
+FSDP2 relies on `fully_shard`, which should be applied in a bottom-up fashion.
 
 For EP+FSDP2, a simplified view looks like:
 
@@ -129,7 +129,7 @@ After loading process, we drop EP-dim again to avoid confusing the FSDP process 
 
 Note that this is implemented in `ModelState` class, which is used for saving checkpoints only. So, the other calls of `model.state_dict()` is not affected.
 
-## Acknoledgements
+## Acknowledgements
 
 We largely refer the implementations in [TorchTitan](https://github.com/pytorch/torchtitan) to address the consequences of mixed sharding.
 

--- a/docs/key_features/ulysses.md
+++ b/docs/key_features/ulysses.md
@@ -142,7 +142,7 @@ from veomni.distributed.sequence_parallel import (
     reduce_sequence_parallel_loss,
 )
 # Step1: Create a sequence parallel group
-# VeOmni will construct a sequence parllel group based on the parallel size
+# VeOmni will construct a sequence parallel group based on the parallel size
 
 # Step2: Shard input sequences
 # Suppose we get an input x of shape [batch_size, seq_len, dim]

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -8,9 +8,9 @@
 | model.tokenizer_path | str | Path to the tokenizer | model.model_path |
 | model.encoders | dict | Configuration file for multi-modal encoders | {} |
 | model.decoders | dict | Configuration file for multi-modal decoders | {} |
-| model.input_encoder | str: {"encoder", "decoder"} | Use the encoder of the encoder or decoder to encode the input image | encoder |
-| model.output_encoder | str: {"encoder", "decoder"} | Use the encoder of the encoder or decoder to encode the output image | decoder |
-| model.encode_target | bool | Used to encode the training data for the diffusion model | False |
+| model.input_encoder | str: {"encoder", "decoder"} | Use the encoder or decoder to encode the input image | encoder |
+| model.output_encoder | str: {"encoder", "decoder"} | Use the encoder or decoder to encode the output image | decoder |
+| model.encode_target | bool | Whether to encode the training data for the diffusion model | False |
 
 ## Data configuration arguments
 
@@ -19,7 +19,7 @@
 | data.train_path | str | Path of training dataset | Required |
 | data.train_size | int | Total number of tokens in the training set | 10,000,000 |
 | data.data_type | str: {"plaintext", "conversation"} | Dataset type.  | conversation |
-| data.dataloader_type | str: {"native"} | Use the pytorch dataloader or  | native |
+| data.dataloader_type | str: {"native"} | Type of the dataloader | native |
 | data.datasets_type | str: {"mapping", "iterable"} | Dataset type. `IterativeDataset` or `MappingDataset`, or your custom datsets | mapping |
 | data.text_keys | str: {"content_split", "messages"} | The key corresponding to the text samples in the data dictionary. Generally, it is "content_split" for pretraining and "messages" for SFT. | content_split |
 | data.image_keys | str | The key corresponding to the image samples in the data dictionary. Generally, it is "images". | images |

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -12,14 +12,14 @@
    ```
 
 3. **Create Custom Task Directory**  
-    [`train_torch.py`](https://github.com/ByteDance-Seed/VeOmni/blob/main/tasks/train_torch.py) can be used for most of task pre-training and post-training tasks, youcan just modify the train config to complete your task. However, if you want to create a new task, you can copy the `train_torch.py` file from the `tasks` directory and modify it. like [`tasks/omni/train_qwen2_vl.py`](https://github.com/ByteDance-Seed/VeOmni/blob/main/tasks/omni/train_qwen2_vl.py)
+    [`train_torch.py`](https://github.com/ByteDance-Seed/VeOmni/blob/main/tasks/train_torch.py) can be used for most of task pre-training and post-training tasks, you can just modify the train config to complete your task. However, if you want to create a new task, you can copy the `train_torch.py` file from the `tasks` directory and modify it. like [`tasks/omni/train_qwen2_vl.py`](https://github.com/ByteDance-Seed/VeOmni/blob/main/tasks/omni/train_qwen2_vl.py)
     ```bash
     mkdir tasks/your_task
     cp tasks/train_torch.py tasks/your_task/train.py
     ```
 
 4. **Launch Custom Training**  
-    you  can overwrite the default arguments in train yaml by passing them to the script.
+    You can overwrite the default arguments in train yaml by passing them to the script.
     ```bash
     bash train.sh tasks/your_task/train.py \
         $CONFIG.yaml \
@@ -123,9 +123,9 @@ train_dataset = build_dataset(
 >
 > args.train.compute_train_steps is used to compute the number of training steps. without this, the train steps will be computed incorrectly.
 >
-> if you dataset is iterable, you are recommended to add data.train_size(the token you want to comsume) to the config file, the `train_steps` will approximate to `train_size / (global_batch_size * max_seq_len)`(without any warm strategy).
+> If your dataset is iterable, you are recommended to add data.train_size (the token you want to consume) to the config file, the `train_steps` will approximate to `train_size / (global_batch_size * max_seq_len)` (without any warm strategy).
 >
-> if you dataset is mapping, you are recommended to add pass the len(train_dataset) to the `train_steps` to compute the correct train steps.
+> If your dataset is mapping, you are recommended to pass len(train_dataset) to the `train_steps` to compute the correct train steps.
 
 ### Custom Datasets
 VeOmni is a flexible framework that supports custom datasets. You can implement your own dataset function and use it with VeOmni.
@@ -138,7 +138,7 @@ def build_custom_dataset(data_path, transform)-> Dataset:
 elif args.data.datasets_type == "custom":
     logger.info_rank0("Start building custom dataset")
     train_dataset = build_custom_dataset(args.data.train_path, transform=transform)
-    args.train.compute_train_steps(args.data.max_seq_len, args.data.train_size, len(train_dataset)) # compute train steps, remove the len(train_dataset) if you dataset is iterable
+    args.train.compute_train_steps(args.data.max_seq_len, args.data.train_size, len(train_dataset)) # compute train steps, remove the len(train_dataset) if your dataset is iterable
 ```
 
 ### Data Transform (Preprocess)
@@ -194,9 +194,9 @@ class CustomTemplate(ChatTemplate):
 
 ## DataLoader
 VeOmni offered a flexible and powerful dataloader implementation, which supports
-- both padding and remove padding(packing) strategy
+- both padding and remove padding (packing) strategy
 - dynamic batching strategy
--
+
 (source code: [veomni/data/data_loader.py](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/data/data_loader.py)):
 
 ```python

--- a/docs/usage/support_new_models.md
+++ b/docs/usage/support_new_models.md
@@ -385,7 +385,7 @@ __all__ = [
 
 Export the model class:
 ```python
-# Register the cutomized model in __init__.py so that VeOmni uses our custom modeling/config/processor code instead of the Hugging Face version
+# Register the customized model in __init__.py so that VeOmni uses our custom modeling/config/processor code instead of the Hugging Face version
 from ...loader import MODEL_CONFIG_REGISTRY, MODELING_REGISTRY, MODEL_PROCESSOR_REGISTRY
 
 @MODEL_CONFIG_REGISTRY.register("qwen3_vl_moe")


### PR DESCRIPTION
### What does this PR do?

Fix typos and improve descriptions in documentation files:
- `docs/usage/basic_modules.md`: Fix `youcan` → `you can`, `comsume` → `consume`, `you dataset` → `your dataset`, remove stray hyphen
- `docs/key_features/ep_fsdp2.md`: Fix `trasparent` → `transparent`, `automically` → `automatically`, `mauanlly` → `manually`, `relis` → `relies`, `Acknoledgements` → `Acknowledgements`
- `docs/key_features/ulysses.md`: Fix `parllel` → `parallel`
- `docs/usage/support_new_models.md`: Fix `cutomized` → `customized`
- `docs/usage/arguments.md`: Fix truncated description and improve clarity

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/ByteDance-Seed/VeOmni/pulls?q=is%3Apr+typo
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

N/A - Documentation only changes.

### API and Usage Example

N/A - No API changes.

### Design & Code Changes

Minor text corrections in documentation files.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Documentation-only PR, no code changes to test.