### PR TITLE
[ops, perf] feat: Liger-Kernel is now available for NPU

### DIFF
--- a/veomni/models/transformers/qwen3/npu_patch.py
+++ b/veomni/models/transformers/qwen3/npu_patch.py
@@ -2,6 +2,11 @@ import torch_npu
 import transformers.models.qwen3.modeling_qwen3 as hf_qwen3
 
 from ....ops.npu_patch import npu_fused_operator
+from ....utils import logging
+from ....utils.import_utils import is_liger_kernel_available
+
+
+logger = logging.get_logger(__name__)
 
 
 def rms_norm_forward_npu(self, x):
@@ -24,3 +29,18 @@ def apply_qwen3_npu_patch():
     # Patches for Qwen3 Model
     hf_qwen3.apply_rotary_pos_emb = npu_fused_operator.apply_rotary_pos_emb_npu
     hf_qwen3.Qwen3RMSNorm.forward = npu_fused_operator.rms_norm_forward_npu
+
+    # ================================================================
+    # PATCH: apply_rotary_pos_emb, Qwen3RMSNorm, Qwen3MLP
+    # Patch with Liger Kernel
+    # ================================================================
+    if is_liger_kernel_available():
+        from liger_kernel.transformers.rms_norm import LigerRMSNorm
+        from liger_kernel.transformers.rope import liger_rotary_pos_emb
+        from liger_kernel.transformers.swiglu import LigerSwiGLUMLP
+
+        hf_qwen3.apply_rotary_pos_emb = liger_rotary_pos_emb
+        hf_qwen3.Qwen3RMSNorm = LigerRMSNorm
+        hf_qwen3.Qwen3MLP = LigerSwiGLUMLP
+
+        logger.info_rank0("Apply liger kernel to Qwen3.")


### PR DESCRIPTION
### What does this PR do?

As title, this pr enables the use of `Liger-Kernel` on npu. A Qwen3-8B SFT fine-tuning example is provided to illustrate its application.

It should be noted that this marks only the initial phase of our work. Moving forward, we have the following plans centered around `Liger-Kernel`:

- Currently, this PR only integrates three kernels: `LigerRMSNorm`, `liger_rotary_pos_emb`, and `LigerSwiGLUMLP`. Additional kernels will be introduced as Liger-Kernel + NPU matures.
- Currently, Liger Kernel can only compile the `main` branch. We will actively collaborate with the `Liger-Kernel` community to promote the release.
- **`Liger-Kernel` and `torch_npu` fused operators largely overlap in functionality but are not mutually exclusive. `torch_npu` is for commercial deployment. `Liger-Kernel`, characterized by its active community and `triton-ascend` implementation, allows engineers to easily modify the code to validate their own acceleration methods. Thus, this pr keeps the `torch_npu` patches and offers `Liger-Kernel` as an optional community alternative.**
- For details on the remaining plans, see: https://github.com/linkedin/Liger-Kernel/issues/969

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test

- Curve Liger-Kernel: Results of SFT using this PR's code.
- Curve torch_npu: Results maintained from the original code run, utilizing `npu_fused_operator.apply_rotary_pos_emb_npu` and `npu_fused_operator.rms_norm_forward_npu`.
- Curve raw_data: Neither is used.

<img width="655" height="354" alt="image" src="https://github.com/user-attachments/assets/a5ed6b65-6f8c-4d38-b773-c7fbba1c2c9a" />

<img width="658" height="355" alt="image" src="https://github.com/user-attachments/assets/62fe6a06-ac87-40fe-9fa6-609ac7081308" />


**Loss Chart: Demonstrating that integrating `Liger-Kernel` does not affect SFT accuracy.**

**Mem Chart: The output of `torch.npu.memory_reserved()` (MB) validates that `Liger-Kernel` integration reduces VRAM usage.**

### API and Usage Example

```python
bash train.sh tasks/train_torch.py configs/sft/qwen3_sft.yaml
```

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
