### PR TITLE
[config] feat: add wandb_id parameter for resuming wandb runs

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -73,6 +73,7 @@
 | train.use_wandb | bool | Whether to enable byted wandb experiment logging.                                                                                                                              | False |
 | train.wandb_project | str | Name of the wandb experiment project.                                                                                                                                          | VeOmni |
 | train.wandb_name | str | Name of the wandb experiment.                                                                                                                                                  | None |
+| train.wandb_id | str | Wandb run ID for resuming a previous run. When specified, training logs will continue in the existing wandb run.                                                              | None |
 | train.enable_profiling | bool | Whether to use torch profiling.                                                                                                                                                | False |
 | train.profile_start_step | int | Starting step of profiling.                                                                                                                                                    | 1 |
 | train.profile_end_step | int | Ending step of profiling.                                                                                                                                                      | 2 |

--- a/tasks/train_torch.py
+++ b/tasks/train_torch.py
@@ -187,6 +187,8 @@ def main():
             wandb.init(
                 project=args.train.wandb_project,
                 name=args.train.wandb_name,
+                id=args.train.wandb_id,
+                resume="allow" if args.train.wandb_id else None,
                 settings=wandb.Settings(console="off"),
                 config={**vars(args.model), **vars(args.data), **vars(args.train)},  # flatten dict
             )

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -538,6 +538,10 @@ class TrainingArguments:
         default=None,
         metadata={"help": "Wandb experiment name."},
     )
+    wandb_id: Optional[str] = field(
+        default=None,
+        metadata={"help": "Wandb run ID for resuming a previous run."},
+    )
     enable_profiling: bool = field(
         default=False,
         metadata={"help": "Enable profiling."},


### PR DESCRIPTION
### What does this PR do?

Add `wandb_id` argument to `TrainingArguments` to support resuming a previous wandb run when continuing training from a checkpoint. This allows users to keep all training metrics in a single wandb run instead of creating a new one after each resume.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/ByteDance-Seed/VeOmni/pulls?q=is%3Apr+wandb
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test

Tested locally:
- Training starts normally without `wandb_id` (creates new wandb run) ✓
- Training resumes to the correct wandb run when `wandb_id` is specified ✓

### API and Usage Example

```yaml
train:
  use_wandb: true
  wandb_project: my-project
  wandb_name: my-experiment
  wandb_id: abc123def  # Optional: specify to resume an existing run
```

When `wandb_id` is not specified or set to `null`, behavior remains unchanged (creates a new run).

### Design & Code Changes

1. **`veomni/arguments/arguments_types.py`**: Add `wandb_id` field to `TrainingArguments`
2. **`tasks/train_torch.py`**: Pass `id` and `resume="allow"` to `wandb.init()` when `wandb_id` is specified
3. **`docs/usage/arguments.md`**: Add documentation for the new parameter

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: This feature only affects wandb logging behavior which requires wandb credentials and cannot be tested in CI.