### PR TITLE
[ci] fix: use wheel URLs to avoid build dependencies in CI 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,8 @@ torchaudio = { index = "pytorch" }
 # Download flash-attn wheel directly to avoid build issues.
 flash-attn = { url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.8cxx11abiTRUE-cp311-cp311-linux_x86_64.whl", marker = "extra == 'gpu' or extra == 'sglang'" }
 flash-attn-3 = { url = "https://github.com/windreamer/flash-attention3-wheels/releases/download/2025.09.28/flash_attn_3-3.0.0b1%2B20250928.cu128torch280cxx11abitrue.5059fd-cp39-abi3-linux_x86_64.whl", marker = "extra == 'gpu'"}
+# Download av wheel directly to avoid FFmpeg build dependency issues in CI.
+av = { url = "https://files.pythonhosted.org/packages/f8/9a/8ffabfcafb42154b4b3a67d63f9b69e68fa8c34cb39ddd5cb813dd049ed4/av-14.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", marker = "extra == 'audio' or extra == 'video'" }
 
 [[tool.uv.index]]
 name = "pytorch"


### PR DESCRIPTION
### What does this PR do?

> Fix CI dependency installation failures by using pre-built wheel URLs for `av` dependencies. This avoids FFmpeg build requirement for `av` package in CI environments.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

> CI workflows should pass without FFmpeg build errors.

### API and Usage Example

> No API changes.

### Design & Code Changes

> - Add `av` wheel URL in `pyproject.toml` to download pre-built binary instead of building from source

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: CI configuration change, validated by workflow runs.