### PR TITLE
[misc] fix: Remove pip related logic in Dockerfile.cu129 to avoid 403 failures.

### DIFF
--- a/docker/cuda/Dockerfile.cu129
+++ b/docker/cuda/Dockerfile.cu129
@@ -8,7 +8,6 @@ ENV PIP_ROOT_USER_ACTION=ignore
 
 # Define installation arguments
 ARG APT_SOURCE=https://mirrors.tuna.tsinghua.edu.cn/ubuntu/
-# ARG PIP_INDEX=https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 
 # Set apt source
 # ubuntu 24.04
@@ -60,15 +59,6 @@ RUN groupadd python-users && \
     chmod g+s /usr/local/lib/python3.12/dist-packages/
 
 USER tiger
-
-# Change pip source
-#RUN pip config set global.index-url "${PIP_INDEX}" && \
-#    pip config set global.extra-index-url "${PIP_INDEX}" && \
-#    pip config set global.no-cache-dir "true" && \
-#    python -m pip install --upgrade pip
-
-# Upgrade pip
-# RUN pip3 install --no-cache-dir -U pip setuptools requests wheel --upgrade
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.9.8 /uv /uvx /bin/


### PR DESCRIPTION
### What does this PR do?

The pip related commands caused the following 403 errors in the internal docker build pipeline.

<img width="1383" height="601" alt="image" src="https://github.com/user-attachments/assets/c2f84240-a7fa-4325-a804-222c21b97fc4" />


Since we have already fully migrated to `uv` to manage deps in CI, there is no need to run pip commands in docker. So we just choose to delete them


### Test

Tested internally with a build.

