### PR TITLE
[model] fix: add freqs split for RoPE within Context Parallelism

### DIFF
--- a/veomni/models/transformers/wan/modeling_wan.py
+++ b/veomni/models/transformers/wan/modeling_wan.py
@@ -614,11 +614,13 @@ class WanModel(PreTrainedModel):
             .reshape(f * h * w, 1, -1)
             .to(x.device)
         )
-        cos = freqs.real.squeeze().contiguous()
-        sin = freqs.imag.squeeze().contiguous()
 
         if get_parallel_state().ulysses_enabled:
             x = slice_input_tensor_scale_grad(x, dim=1)
+            freqs = slice_input_tensor_scale_grad(freqs, dim=0)
+
+        cos = freqs.real.squeeze().contiguous()
+        sin = freqs.imag.squeeze().contiguous()
 
         for block in self.blocks:
             if self.training and self.gradient_checkpointing:


### PR DESCRIPTION
### What does this PR do?

When Context Parallel (CP) is enabled (e.g., ulysses_size > 1), the input query/key tensors x are sharded along the sequence dimension (dim 1) via slice_input_tensor_scale_grad. However, the pre-computed RoPE parameters (freqs, cos, sin) retained the global sequence length.

We simply added slicing for freqs and used the sliced freqs to compute cos and sin as a quick fix for this error.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
