### PR TITLE
[task] fix: Add enable_high_precision_for_bf16 to all trainers missing it.

### DIFF
--- a/tasks/omni/train_flux.py
+++ b/tasks/omni/train_flux.py
@@ -160,6 +160,7 @@ def main():
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend())
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)
+    helper.enable_high_precision_for_bf16()
     if args.train.global_rank == 0:
         save_args(args, args.train.output_dir)
     # Gradient checkpointing debug

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -103,6 +103,7 @@ def main():
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group()
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)
+    helper.enable_high_precision_for_bf16()
     if args.train.local_rank == 0:
         helper.enable_third_party_logging()
 

--- a/tasks/omni/train_qwen_vl.py
+++ b/tasks/omni/train_qwen_vl.py
@@ -94,6 +94,7 @@ def main():
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend())
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)
+    helper.enable_high_precision_for_bf16()
     if args.train.local_rank == 0:
         helper.enable_third_party_logging()
 

--- a/tasks/omni/train_wan.py
+++ b/tasks/omni/train_wan.py
@@ -92,6 +92,7 @@ def main():
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend())
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)
+    helper.enable_high_precision_for_bf16()
     if args.train.global_rank == 0:
         save_args(args, args.train.output_dir)
 

--- a/tasks/train_torch.py
+++ b/tasks/train_torch.py
@@ -61,6 +61,7 @@ def main():
     logger.info_rank0(json.dumps(asdict(args), indent=2))
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)
+    helper.enable_high_precision_for_bf16()
     if args.train.local_rank == 0:
         helper.enable_third_party_logging()
 


### PR DESCRIPTION
We already have some trainers calling enable_high_precision_for_bf16 in it which basically does:

```
def enable_high_precision_for_bf16():
    """
    Set high accumulation dtype for matmul and reduction.
    """
    if IS_CUDA_AVAILABLE:
        torch.backends.cuda.matmul.allow_tf32 = False
        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False

    if IS_NPU_AVAILABLE:
        torch.npu.matmul.allow_tf32 = False
        torch.npu.matmul.allow_bf16_reduced_precision_reduction = False
```

See https://docs.pytorch.org/docs/stable/notes/cuda.html#reduced-precision-reduction-in-bf16-gemms

usually we should always perform mma accumulation in FP32 in training settings to avoid accumulation precision issues.
