### PR TITLE
[model] fix: handle audio_seqlens=None in video branch

### DIFF
--- a/veomni/models/transformers/qwen2_5_omni/modeling_qwen2_5_omni.py
+++ b/veomni/models/transformers/qwen2_5_omni/modeling_qwen2_5_omni.py
@@ -192,7 +192,9 @@ def Qwen2_5OmniPreTrainedModelForConditionalGeneration_get_rope_index(
 
                 elif min_ed == ed_video:
                     # --- Patch.1 ---
-                    if audio_seqlens[audio_idx] == 0:
+                    if audio_seqlens is None:
+                        use_audio_in_video = False
+                    elif audio_seqlens[audio_idx] == 0:
                         use_audio_in_video = False
                         audio_idx += 1
                     else:


### PR DESCRIPTION
Now, we set audio_seqlens=None when the video sample doesn't have audio features at all. 
During training process, I noticed the video branch did not guard against this None case. And it caused a crash on any video-without-audio sample in LLaVA_Video dataset.
So I add a none check before access.