### PR TITLE
[model] feat: Add supported transformers version range in model/processor/config registry.

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Run ops tests
         run: |
           uv run --frozen pytest -s -x tests/ops
+      - name: Run utils tests
+        run: |
+          uv run --frozen pytest -s -x tests/utils
 
   cleanup:
     runs-on: ubuntu-latest

--- a/tests/utils/test_registry.py
+++ b/tests/utils/test_registry.py
@@ -1,0 +1,196 @@
+from unittest.mock import patch
+
+import pytest
+from packaging.version import Version
+
+from veomni.utils.registry import _DEFAULT_TRANSFORMERS_VERSION, Registry
+
+
+@pytest.fixture(autouse=True)
+def clear_lru_cache():
+    """Clear the _get_transformers_version lru_cache before each test."""
+    from veomni.utils.registry import _get_transformers_version
+
+    _get_transformers_version.cache_clear()
+    yield
+    _get_transformers_version.cache_clear()
+
+
+def _mock_version(version_str):
+    """Return a patch context that mocks _get_transformers_version to return the given version."""
+    return patch(
+        "veomni.utils.registry._get_transformers_version",
+        return_value=Version(version_str),
+    )
+
+
+class TestVersionAwareRegistry:
+    def test_default_version_constraint_is_v4(self):
+        """Registrations without explicit version default to >=4,<5."""
+        reg = Registry("test")
+
+        @reg.register("foo")
+        def foo_func():
+            return "foo_v4"
+
+        entries = reg._global_mapping["foo"]
+        assert len(entries) == 1
+        assert entries[0][0] == _DEFAULT_TRANSFORMERS_VERSION
+
+    def test_lookup_matches_v4(self):
+        """With transformers 4.x installed, v4 registration is returned."""
+        reg = Registry("test")
+
+        @reg.register("foo")
+        def foo_v4():
+            return "v4"
+
+        @reg.register("foo", transformers_version=">=5,<6")
+        def foo_v5():
+            return "v5"
+
+        with _mock_version("4.57.0"):
+            assert reg["foo"]() == "v4"
+
+    def test_lookup_matches_v5(self):
+        """With transformers 5.x installed, v5 registration is returned."""
+        reg = Registry("test")
+
+        @reg.register("foo")
+        def foo_v4():
+            return "v4"
+
+        @reg.register("foo", transformers_version=">=5,<6")
+        def foo_v5():
+            return "v5"
+
+        with _mock_version("5.1.0"):
+            assert reg["foo"]() == "v5"
+
+    def test_lookup_raises_on_version_mismatch(self):
+        """If only v4 is registered but v5 is installed, a clear error is raised."""
+        reg = Registry("test")
+
+        @reg.register("bar")
+        def bar_v4():
+            return "v4"
+
+        with _mock_version("5.0.0"):
+            with pytest.raises(ValueError, match="not compatible with transformers 5.0.0"):
+                reg["bar"]
+
+    def test_lookup_raises_on_unknown_key(self):
+        """Looking up an unregistered key raises ValueError."""
+        reg = Registry("test")
+        with _mock_version("4.57.0"):
+            with pytest.raises(ValueError, match="Unknown test name"):
+                reg["nonexistent"]
+
+    def test_duplicate_version_registration_raises(self):
+        """Registering the same key with the same version range raises ValueError."""
+        reg = Registry("test")
+
+        @reg.register("dup")
+        def dup1():
+            return "first"
+
+        with pytest.raises(ValueError, match="already registered"):
+
+            @reg.register("dup")
+            def dup2():
+                return "second"
+
+    def test_valid_keys_filters_by_version(self):
+        """valid_keys() only returns keys compatible with the current transformers version."""
+        reg = Registry("test")
+
+        @reg.register("v4_only")
+        def v4_only():
+            pass
+
+        @reg.register("v5_only", transformers_version=">=5,<6")
+        def v5_only():
+            pass
+
+        @reg.register("both_v4")
+        def both_v4():
+            pass
+
+        @reg.register("both_v4", transformers_version=">=5,<6")
+        def both_v5():
+            pass
+
+        with _mock_version("4.57.0"):
+            keys = reg.valid_keys()
+            assert "v4_only" in keys
+            assert "v5_only" not in keys
+            assert "both_v4" in keys
+
+        with _mock_version("5.1.0"):
+            keys = reg.valid_keys()
+            assert "v4_only" not in keys
+            assert "v5_only" in keys
+            assert "both_v4" in keys
+
+    def test_local_override_bypasses_version_check(self):
+        """Local overrides (via __setitem__) bypass version matching."""
+        reg = Registry("test")
+
+        @reg.register("foo")
+        def foo_v4():
+            return "v4"
+
+        def local_foo():
+            return "local"
+
+        reg["foo"] = local_foo
+
+        with _mock_version("5.0.0"):
+            assert reg["foo"]() == "local"
+
+    def test_direct_registration_without_decorator(self):
+        """register(key, func) direct call works with version constraint."""
+        reg = Registry("test")
+
+        def my_func():
+            return "direct"
+
+        reg.register("direct_key", my_func, transformers_version=">=5,<6")
+
+        with _mock_version("5.2.0"):
+            assert reg["direct_key"]() == "direct"
+
+        with _mock_version("4.57.0"):
+            with pytest.raises(ValueError, match="not compatible"):
+                reg["direct_key"]
+
+    def test_iter_includes_all_keys(self):
+        """__iter__ includes all global keys regardless of version."""
+        reg = Registry("test")
+
+        @reg.register("a")
+        def a():
+            pass
+
+        @reg.register("b", transformers_version=">=5,<6")
+        def b():
+            pass
+
+        with _mock_version("4.57.0"):
+            all_keys = list(reg)
+            assert "a" in all_keys
+            assert "b" in all_keys
+
+    def test_len_counts_all_keys(self):
+        """__len__ counts all keys regardless of version."""
+        reg = Registry("test")
+
+        @reg.register("a")
+        def a():
+            pass
+
+        @reg.register("b", transformers_version=">=5,<6")
+        def b():
+            pass
+
+        assert len(reg) == 2

--- a/veomni/utils/import_utils.py
+++ b/veomni/utils/import_utils.py
@@ -83,6 +83,11 @@ def is_torch_version_greater_than(value: str) -> bool:
     return _get_package_version("torch") >= version.parse(value)
 
 
+def get_transformers_version() -> "Version":
+    """Return the installed transformers version as a packaging.version.Version."""
+    return _get_package_version("transformers")
+
+
 @lru_cache
 def is_transformers_version_greater_or_equal_to(value: str) -> bool:
     return _get_package_version("transformers") >= version.parse(value)

--- a/veomni/utils/registry.py
+++ b/veomni/utils/registry.py
@@ -1,4 +1,23 @@
+from functools import lru_cache
 from typing import Callable, List, MutableMapping, Optional, Type, Union
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+
+@lru_cache
+def _get_transformers_version() -> Version:
+    from veomni.utils.import_utils import _get_package_version
+
+    return _get_package_version("transformers")
+
+
+def _matches_transformers_version(spec_str: str) -> bool:
+    return _get_transformers_version() in SpecifierSet(spec_str)
+
+
+# Default version constraint for existing v4 registrations
+_DEFAULT_TRANSFORMERS_VERSION = ">=4,<5"
 
 
 class Registry(MutableMapping):
@@ -14,11 +33,22 @@ class Registry(MutableMapping):
 
     def __getitem__(self, key):
         # First check if instance has a local override
-        if key not in self.valid_keys():
-            raise ValueError(f"Unknown {self._name} name: {key}. No {self._name} registered for this source.")
         if key in self._local_mapping:
             return self._local_mapping[key]
-        return self._global_mapping[key]
+
+        if key not in self._global_mapping:
+            raise ValueError(f"Unknown {self._name} name: {key}. No {self._name} registered for this source.")
+
+        entries = self._global_mapping[key]
+        for version_spec, func in entries:
+            if _matches_transformers_version(version_spec):
+                return func
+
+        raise ValueError(
+            f"{self._name} '{key}' is registered but not compatible with "
+            f"transformers {_get_transformers_version()}. "
+            f"Available version ranges: {[e[0] for e in entries]}"
+        )
 
     def __setitem__(self, key, value):
         # Allow local update of the default functions without impacting other instances
@@ -34,20 +64,49 @@ class Registry(MutableMapping):
     def __len__(self):
         return len(self._global_mapping.keys() | self._local_mapping.keys())
 
-    def register(self, key: str, cls_or_func: Optional[Union[Type, Callable]] = None):
+    def register(
+        self,
+        key: str,
+        cls_or_func: Optional[Union[Type, Callable]] = None,
+        *,
+        transformers_version: str = _DEFAULT_TRANSFORMERS_VERSION,
+    ):
+        """Register a class or function with a transformers version constraint.
+
+        Args:
+            key: The registry key to register under.
+            cls_or_func: The class or function to register. If None, returns a decorator.
+            transformers_version: Version specifier string, e.g. ">=4,<5" or ">=5,<6".
+                Defaults to ">=4,<5" for backward compatibility.
+        """
         if cls_or_func is not None:
-            self._global_mapping[key] = cls_or_func
+            self._global_mapping.setdefault(key, [])
+            self._global_mapping[key].append((transformers_version, cls_or_func))
             return cls_or_func
 
         def decorator(cls_or_func):
-            if key in self._global_mapping:
-                raise ValueError(
-                    f"{self._name} for '{key}' is already registered. Cannot register duplicate {self._name}."
-                )
-            self._global_mapping.update({key: cls_or_func})
+            entries = self._global_mapping.get(key, [])
+            # Check for duplicate version range registration
+            for existing_spec, _ in entries:
+                if existing_spec == transformers_version:
+                    raise ValueError(
+                        f"{self._name} for '{key}' with transformers_version='{transformers_version}' "
+                        f"is already registered. Cannot register duplicate {self._name}."
+                    )
+            self._global_mapping.setdefault(key, [])
+            self._global_mapping[key].append((transformers_version, cls_or_func))
             return cls_or_func
 
         return decorator
 
     def valid_keys(self) -> List[str]:
-        return list(self.keys())
+        """Return keys that have at least one entry matching the current transformers version."""
+        valid = set()
+        for key in self._local_mapping:
+            valid.add(key)
+        for key, entries in self._global_mapping.items():
+            for version_spec, _ in entries:
+                if _matches_transformers_version(version_spec):
+                    valid.add(key)
+                    break
+        return list(valid)


### PR DESCRIPTION
Part of https://github.com/ByteDance-Seed/VeOmni/issues/468

Since transformers v5 requires new modeling code anyway, allow to register transformers version range along with model/process/config in Registry.