### PR TITLE
[misc] fix: bump transformers5-exp to 5.2.0 and fix no_split_modules merges

### DIFF
--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -282,7 +282,7 @@ model = build_parallelize_model(
     enable_gradient_checkpointing=args.train.enable_gradient_checkpointing, # enable gradient checkpointing
     init_device=args.train.init_device, # model init device
     enable_fsdp_offload=args.train.enable_fsdp_offload, # enable fsdp offload
-    basic_modules=model._no_split_modules + args.model.basic_modules, # FSDP basic modules
+    basic_modules=list(set(getattr(model, "_no_split_modules", None) or []) | set(args.model.basic_modules)), # FSDP basic modules
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   # Comment out transformers version for pip user compatibility (not to accidentally install v5 which is still WIP
   # and experimental)
   # For uv user: The actual version is controlled by the "transformers-stable" default
-  # dependency-group (==4.57.3) or by the "transformers5-exp" optional extra (==5.1.0).
+  # dependency-group (==4.57.3) or by the "transformers5-exp" optional extra (==5.2.0).
   # For pip user: please install 4.57.3 manually via pip install transformers==4.57.3.
   # "transformers==4.57.3",
   "psutil",
@@ -103,7 +103,7 @@ trl = [
 # See https://github.com/ByteDance-Seed/VeOmni/issues/468 for the progress.
 # Usage: `uv sync --no-group transformers-stable --extra transformers5-exp --extra <other extra>`.
 transformers5-exp = [
-  "transformers==5.1.0"
+  "transformers==5.2.0"
 ]
 
 [dependency-groups]

--- a/tasks/train_torch.py
+++ b/tasks/train_torch.py
@@ -164,7 +164,7 @@ def main():
         enable_mixed_precision=args.train.enable_mixed_precision,
         enable_gradient_checkpointing=args.train.enable_gradient_checkpointing,
         enable_fsdp_offload=args.train.enable_fsdp_offload,
-        basic_modules=model._no_split_modules + args.model.basic_modules,
+        basic_modules=list(set(getattr(model, "_no_split_modules", None) or []) | set(args.model.basic_modules)),
         enable_reentrant=args.train.enable_reentrant,
         enable_forward_prefetch=args.train.enable_forward_prefetch,
     )

--- a/tests/checkpoints/test_trainer_saveload.py
+++ b/tests/checkpoints/test_trainer_saveload.py
@@ -204,7 +204,7 @@ def main():
         enable_mixed_precision=args.train.enable_mixed_precision,
         enable_gradient_checkpointing=args.train.enable_gradient_checkpointing,
         enable_fsdp_offload=args.train.enable_fsdp_offload,
-        basic_modules=model._no_split_modules + args.model.basic_modules,
+        basic_modules=list(set(getattr(model, "_no_split_modules", None) or []) | set(args.model.basic_modules)),
         enable_reentrant=args.train.enable_reentrant,
         enable_forward_prefetch=args.train.enable_forward_prefetch,
     )

--- a/tests/utils/test_checkpointer.py
+++ b/tests/utils/test_checkpointer.py
@@ -83,7 +83,7 @@ def run_checkpointer_test():
         enable_gradient_checkpointing=args.train.enable_gradient_checkpointing,
         init_device=args.train.init_device,
         enable_fsdp_offload=args.train.enable_fsdp_offload,
-        basic_modules=model._no_split_modules + args.model.basic_modules,
+        basic_modules=list(set(getattr(model, "_no_split_modules", None) or []) | set(args.model.basic_modules)),
         enable_reentrant=args.train.enable_reentrant,
         enable_forward_prefetch=args.train.enable_forward_prefetch,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2621,7 +2621,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.1.0"
+version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra == 'extra-6-veomni-npu-aarch64' and extra == 'extra-6-veomni-transformers5-exp' and extra != 'group-6-veomni-transformers-stable') or (platform_python_implementation != 'CPython' and sys_platform == 'linux' and extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra == 'extra-6-veomni-npu-aarch64' and extra == 'extra-6-veomni-transformers5-exp' and extra != 'group-6-veomni-transformers-stable')",
@@ -2656,9 +2656,9 @@ dependencies = [
     { name = "tqdm", marker = "(extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu') or (extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu-aarch64') or (extra == 'extra-6-veomni-npu' and extra == 'extra-6-veomni-npu-aarch64') or (extra != 'extra-6-veomni-npu-aarch64' and extra == 'extra-6-veomni-transformers5-exp') or (extra != 'extra-6-veomni-npu-aarch64' and extra != 'group-6-veomni-transformers-stable') or (extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra == 'extra-6-veomni-transformers5-exp') or (extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra != 'group-6-veomni-transformers-stable')" },
     { name = "typer-slim", marker = "(extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu') or (extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu-aarch64') or (extra == 'extra-6-veomni-npu' and extra == 'extra-6-veomni-npu-aarch64') or (extra != 'extra-6-veomni-npu-aarch64' and extra == 'extra-6-veomni-transformers5-exp') or (extra != 'extra-6-veomni-npu-aarch64' and extra != 'group-6-veomni-transformers-stable') or (extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra == 'extra-6-veomni-transformers5-exp') or (extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra != 'group-6-veomni-transformers-stable')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/1d/a7d91500a6c02ec76058bc9e65fcdec1bdb8882854dec8e4adf12d0aa8b0/transformers-5.1.0.tar.gz", hash = "sha256:c60d6180e5845ea1b4eed38d7d1b06fcc4cc341c6b7fa5c1dc767d7e25fe0139", size = 8531810, upload-time = "2026-02-05T15:41:42.932Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/7e/8a0c57d562015e5b16c97c1f0b8e0e92ead2c7c20513225dc12c2043ba9f/transformers-5.2.0.tar.gz", hash = "sha256:0088b8b46ccc9eff1a1dca72b5d618a5ee3b1befc3e418c9512b35dea9f9a650", size = 8618176, upload-time = "2026-02-16T18:54:02.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/66/57042d4b0f1ede8046d7ae6409bf3640df996e9cbc3fe20467aa29badc54/transformers-5.1.0-py3-none-any.whl", hash = "sha256:de534b50c9b2ce6217fc56421075a1734241fb40704fdc90f50f6a08fc533d59", size = 10276537, upload-time = "2026-02-05T15:41:40.358Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/93/79754b0ca486e556c2b95d4f5afc66aaf4b260694f3d6e1b51da2d036691/transformers-5.2.0-py3-none-any.whl", hash = "sha256:9ecaf243dc45bee11a7d93f8caf03746accc0cb069181bbf4ad8566c53e854b4", size = 10403304, upload-time = "2026-02-16T18:53:59.699Z" },
 ]
 
 [[package]]
@@ -2698,7 +2698,7 @@ dependencies = [
     { name = "datasets" },
     { name = "numpy" },
     { name = "transformers", version = "4.57.3", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu') or (extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu-aarch64') or (extra == 'extra-6-veomni-npu' and extra == 'extra-6-veomni-npu-aarch64') or (extra != 'extra-6-veomni-npu-aarch64' and extra == 'group-6-veomni-transformers-stable') or (extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra == 'group-6-veomni-transformers-stable')" },
-    { name = "transformers", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu') or (extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu-aarch64') or (extra == 'extra-6-veomni-npu' and extra == 'extra-6-veomni-npu-aarch64') or (extra != 'extra-6-veomni-npu-aarch64' and extra == 'extra-6-veomni-transformers5-exp') or (extra != 'extra-6-veomni-npu-aarch64' and extra != 'group-6-veomni-transformers-stable') or (extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra == 'extra-6-veomni-transformers5-exp') or (extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra != 'group-6-veomni-transformers-stable')" },
+    { name = "transformers", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu') or (extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu-aarch64') or (extra == 'extra-6-veomni-npu' and extra == 'extra-6-veomni-npu-aarch64') or (extra != 'extra-6-veomni-npu-aarch64' and extra == 'extra-6-veomni-transformers5-exp') or (extra != 'extra-6-veomni-npu-aarch64' and extra != 'group-6-veomni-transformers-stable') or (extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra == 'extra-6-veomni-transformers5-exp') or (extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra != 'group-6-veomni-transformers-stable')" },
     { name = "tyro" },
 ]
 wheels = [
@@ -2853,7 +2853,7 @@ npu-aarch64 = [
     { name = "torchvision", version = "0.22.1+cpu", source = { registry = "https://download.pytorch.org/whl/" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-veomni-npu-aarch64') or (platform_python_implementation != 'CPython' and sys_platform == 'linux' and extra == 'extra-6-veomni-npu-aarch64') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-veomni-npu-aarch64') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-veomni-transformers5-exp' and extra == 'group-6-veomni-transformers-stable') or (sys_platform == 'darwin' and extra == 'extra-6-veomni-npu' and extra == 'extra-6-veomni-npu-aarch64') or (sys_platform == 'linux' and extra == 'extra-6-veomni-npu' and extra == 'extra-6-veomni-npu-aarch64') or (sys_platform == 'linux' and extra == 'extra-6-veomni-transformers5-exp' and extra == 'group-6-veomni-transformers-stable') or (sys_platform == 'darwin' and extra != 'extra-6-veomni-npu-aarch64' and extra == 'extra-6-veomni-transformers5-exp' and extra == 'group-6-veomni-transformers-stable') or (sys_platform == 'darwin' and extra != 'extra-6-veomni-gpu' and extra != 'extra-6-veomni-npu' and extra == 'extra-6-veomni-transformers5-exp' and extra == 'group-6-veomni-transformers-stable') or (extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu') or (extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu-aarch64') or (extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-transformers5-exp' and extra == 'group-6-veomni-transformers-stable')" },
 ]
 transformers5-exp = [
-    { name = "transformers", version = "5.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "transformers", version = "5.2.0", source = { registry = "https://pypi.org/simple" } },
 ]
 trl = [
     { name = "trl" },
@@ -2937,7 +2937,7 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'gpu'", specifier = "==0.24.1+cu129", index = "https://download.pytorch.org/whl/" },
     { name = "torchvision", marker = "extra == 'npu'", specifier = "==0.22.1+cpu", index = "https://download.pytorch.org/whl/" },
     { name = "torchvision", marker = "extra == 'npu-aarch64'", specifier = "==0.22.1", index = "https://download.pytorch.org/whl/" },
-    { name = "transformers", marker = "extra == 'transformers5-exp'", specifier = "==5.1.0" },
+    { name = "transformers", marker = "extra == 'transformers5-exp'", specifier = "==5.2.0" },
     { name = "trl", marker = "extra == 'trl'", specifier = "<=0.9.6" },
     { name = "wandb" },
 ]

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -254,7 +254,8 @@ def parallelize_model_fsdp2(
     parallel_state = get_parallel_state()
 
     # Step 0: Get target classes to shard later
-    target_classes = set((getattr(model, "_no_split_modules", []) or []) + (basic_modules or []))
+    model_no_split_modules = getattr(model, "_no_split_modules", None) or []
+    target_classes = set(model_no_split_modules) | set(basic_modules or [])
     # Make a list of tuples that contains layer's name and module
     decoder_blocks: List[Tuple[str, nn.Module]] = [
         (fqn, mod) for fqn, mod in model.named_modules() if mod.__class__.__name__ in target_classes


### PR DESCRIPTION

  ## Summary

  This PR updates the experimental Transformers v5 dependency to `5.2.0` and fixes `_no_split_modules` handling for
  Transformers v5, where `_no_split_modules` can be `set[str] | list[str] | None`.

https://github.com/huggingface/transformers/pull/43712 adds the typing hints as `_no_split_modules: set[str] | list[str] | None = None` which would makes the merge of `model._no_split_modules` and `args.model.basic_modules` to fail due to list/set mismatching, so always merging them as sets and convert back as list.

Note that this change should be backward compatible with 4.57.x versions.

  ## Changes

Bump the v5 uv branch to use the latest 5.2.0 from 5.1.0
  - Bumped `transformers5-exp` from `5.1.0` to `5.2.0`.
  - Regenerated lock entries to match `5.2.0`.


Fix the set handling in code: 
  - Made FSDP2 target class merge robust to set/list/None and removed duplicates using set union.
    - `veomni/distributed/torch_parallelize.py:257`
    - `veomni/distributed/torch_parallelize.py:258`
  - Updated training/test call sites to merge `model._no_split_modules` and `args.model.basic_modules` via set union,
  then convert to list.
  - Updated user docs snippet to match runtime behavior.

  ## Rationale

  Transformers v5 allows `_no_split_modules` to be a `set`, so list concatenation can break (`TypeError`) and can also
  introduce duplicates. Set union handles all supported types and deduplicates module names cleanly.


Trained with qwen3 8b on 8xA100 with 4.57.3 still works: 
<img width="324" height="333" alt="image" src="https://github.com/user-attachments/assets/cbeba635-be59-4e7f-9a55-6acb75debabd" />
