### PR TITLE
[model] feat: add parallel plan and varlen attention support for Qwen3OmniMoe

### DIFF
--- a/veomni/models/transformers/qwen3_omni_moe/parallel_plan.py
+++ b/veomni/models/transformers/qwen3_omni_moe/parallel_plan.py
@@ -1,0 +1,18 @@
+from torch.distributed._tensor import Shard
+
+from ....distributed.parallel_plan import ParallelPlan
+
+
+def get_parallel_plan():
+    # NOTE: Expert Parallelism (EP) with FSDP2 is NOT ready for this model yet.
+    # This parallel plan is only added to prevent errors during model initialization.
+    # TODO: Implement proper EP support for Qwen3OmniMoe.
+    ep_plan = {
+        "thinker.model.layers.*.mlp.experts.*.gate_proj.weight": Shard(0),
+        "thinker.model.layers.*.mlp.experts.*.up_proj.weight": Shard(0),
+        "thinker.model.layers.*.mlp.experts.*.down_proj.weight": Shard(0),
+    }
+    parallel_plan = ParallelPlan(
+        ep_plan=ep_plan,
+    )
+    return parallel_plan


### PR DESCRIPTION
### What does this PR do?

> Add parallel plan support and extend varlen attention compatibility for Qwen3OmniMoe model.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `core`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, torch, liger-kernals,fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, torch, liger-kernals] feat: dynamic batching`

### Test

> N/A - Requires manual validation with Qwen3OmniMoe model.

### API and Usage Example

> No API changes. The parallel plan is automatically applied via `apply_veomni_qwen3_omni_moe_patch()`.

### Design & Code Changes

1. **Varlen Attention Support**: Replace hardcoded `flash_attention_2` checks with `VARLEN_ATTENTION_TYPES` for broader compatibility
   - `Qwen3OmniMoeAudioEncoder`: attention mask creation
   - `Qwen3OmniMoeVisionAttention`: attention computation path

2. **Parallel Plan**: Add `parallel_plan.py` with EP sharding plan for MoE expert layers
   - Shard expert weights (`gate_proj`, `up_proj`, `down_proj`) on dimension 0
   - Note: EP with FSDP2 is not fully ready yet, this is a placeholder to prevent init errors

3. **Patch Application**: Wire up `get_parallel_plan` method to `Qwen3OmniMoePreTrainedModel`

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
