### PR TITLE
[misc] fix: use dedicated Gloo process group for HF safetensor save to avoid NCCL timeouts

### DIFF
--- a/veomni/utils/save_safetensor_utils.py
+++ b/veomni/utils/save_safetensor_utils.py
@@ -110,6 +110,7 @@ def _save_hf_safetensor_distributed(
     fqn_to_index_mapping: Optional[Dict[str, int]],
     model_assets: Optional[Sequence],
     is_rank_0: bool,
+    timeout: datetime.timedelta,
 ):
     """Distributed HuggingFace safetensors save using HuggingFaceStorageWriter (PyTorch >= 2.9).
 
@@ -132,7 +133,7 @@ def _save_hf_safetensor_distributed(
     # Use a dedicated Gloo process group for DCP save coordination and barriers.
     # Each rank writes its own safetensor shards, and rank 0 performs consolidation,
     # We set a large timeout to accommodate I/O time.
-    gloo_group = dist.new_group(backend="gloo", timeout=datetime.timedelta(hours=2)) if dist.is_initialized() else None
+    gloo_group = dist.new_group(backend="gloo", timeout=timeout) if dist.is_initialized() else None
 
     storage_writer = TimedHuggingFaceStorageWriter(
         path=save_path,
@@ -204,6 +205,7 @@ def save_hf_safetensor(
     # Distributed only
     model: Optional[torch.nn.Module] = None,
     fqn_to_index_mapping: Optional[Dict[str, int]] = None,
+    timeout: datetime.timedelta = datetime.timedelta(minutes=120),
 ):
     """Save model weights in HuggingFace safetensors format.
 
@@ -232,6 +234,8 @@ def save_hf_safetensor(
         model: [Distributed only] Live FSDP model for distributed save.
         fqn_to_index_mapping: [Distributed only] Maps FQNs to safetensors file indices
             for multi-file output.
+        timeout: [Distributed only] Timeout for the Gloo process group used in
+            distributed save coordination. Defaults to 120 minutes.
     """
     from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
 
@@ -251,7 +255,9 @@ def save_hf_safetensor(
             dist.barrier()
 
     if use_distributed:
-        _save_hf_safetensor_distributed(model, save_hf_safetensor_path, fqn_to_index_mapping, model_assets, is_rank_0)
+        _save_hf_safetensor_distributed(
+            model, save_hf_safetensor_path, fqn_to_index_mapping, model_assets, is_rank_0, timeout
+        )
     else:
         # Legacy path is rank-0 only; non-rank-0 waits at the barrier below
         if is_rank_0:


### PR DESCRIPTION
  ### Summary

  - Replace the default NCCL process group with a dedicated Gloo group (2h timeout) during `dcp.save()` coordination, preventing NCCL timeouts on slow I/O during HuggingFace
  safetensor checkpoint writes.
  - Add per-rank timing logs for shard write and consolidation phases via `_TimedHuggingFaceStorageWriter` mixin, improving checkpoint I/O observability.
  - Add overall wall-clock timing for `save_hf_safetensor` and propagate `is_rank_0` to the distributed save path for consistent rank-0 gating.

#### Example log of the job saving a Qwen3-4B model to mounted HDFS
[save_safetensor_utils.py:70] 03/16/2026 06:36:32 >> Skipping weight not in HF weight_map: lm_head.weight
[save_safetensor_utils.py:147] 03/16/2026 06:36:32 >> Starting dcp.save()...
[save_safetensor_utils.py:94] 03/16/2026 06:36:35 >> [Rank 3] Shard write took 2.79s
[save_safetensor_utils.py:94] 03/16/2026 06:36:35 >> [Rank 1] Shard write took 2.81s
[save_safetensor_utils.py:94] 03/16/2026 06:36:35 >> [Rank 4] Shard write took 2.95s
[save_safetensor_utils.py:94] 03/16/2026 06:36:35 >> [Rank 7] Shard write took 2.99s
[save_safetensor_utils.py:94] 03/16/2026 06:36:35 >> [Rank 5] Shard write took 3.06s
[save_safetensor_utils.py:94] 03/16/2026 06:36:35 >> [Rank 0] Shard write took 3.16s
[save_safetensor_utils.py:94] 03/16/2026 06:36:35 >> [Rank 2] Shard write took 3.22s
[save_safetensor_utils.py:94] 03/16/2026 06:36:35 >> [Rank 6] Shard write took 3.38s
[save_safetensor_utils.py:99] 03/16/2026 06:36:35 >> [Rank 0] Start consolidation
[save_safetensor_utils.py:103] 03/16/2026 06:38:33 >> [Rank 0] finish (consolidation) took 117.67s
[save_safetensor_utils.py:162] 03/16/2026 06:38:34 >> dcp.save() save took 121.97s
[save_safetensor_utils.py:278] 03/16/2026 06:38:34 >> save_hf_safetensor total time: 123.06s