### PR TITLE
[omni, model] feat: add fused MoE forward and EP support for Qwen3-Omni-MoE thinker

### DIFF
--- a/veomni/models/transformers/qwen3_omni_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_omni_moe/__init__.py
@@ -35,8 +35,6 @@ def register_qwen3_omni_moe_modeling(architecture: str):
     )
 
     apply_veomni_qwen3_omni_moe_patch()
-    if "ForConditionalGeneration" in architecture:
-        return Qwen3OmniMoeForConditionalGeneration
     if "ThinkerTextModel" in architecture:
         return Qwen3OmniMoeThinkerTextModel
     if "ThinkerForConditionalGeneration" in architecture:
@@ -45,6 +43,8 @@ def register_qwen3_omni_moe_modeling(architecture: str):
         return Qwen3OmniMoeTalkerModel
     if "TalkerForConditionalGeneration" in architecture:
         return Qwen3OmniMoeTalkerForConditionalGeneration
+    if "ForConditionalGeneration" in architecture:
+        return Qwen3OmniMoeForConditionalGeneration
     return Qwen3OmniMoeForConditionalGeneration
 
 

--- a/veomni/models/transformers/qwen3_omni_moe/parallel_plan.py
+++ b/veomni/models/transformers/qwen3_omni_moe/parallel_plan.py
@@ -4,13 +4,13 @@ from ....distributed.parallel_plan import ParallelPlan
 
 
 def get_parallel_plan():
-    # NOTE: Expert Parallelism (EP) with FSDP2 is NOT ready for this model yet.
-    # This parallel plan is only added to prevent errors during model initialization.
-    # TODO: Implement proper EP support for Qwen3OmniMoe.
+    # Thinker experts use stacked 3-D weight tensors (num_experts, out, in),
+    # so EP shards along dim-0 (the expert dimension).
+    # NOTE: Talker training is not supported yet. Only thinker EP is planned here.
     ep_plan = {
-        "thinker.model.layers.*.mlp.experts.*.gate_proj.weight": Shard(0),
-        "thinker.model.layers.*.mlp.experts.*.up_proj.weight": Shard(0),
-        "thinker.model.layers.*.mlp.experts.*.down_proj.weight": Shard(0),
+        "thinker.model.layers.*.mlp.experts.gate_proj": Shard(0),
+        "thinker.model.layers.*.mlp.experts.up_proj": Shard(0),
+        "thinker.model.layers.*.mlp.experts.down_proj": Shard(0),
     }
     parallel_plan = ParallelPlan(
         ep_plan=ep_plan,


### PR DESCRIPTION
### What does this PR do?

> Enables fused MoE forward and Expert Parallelism (EP) for the Qwen3-Omni-MoE **thinker** text model, following the same pattern as Qwen3-VL-MoE. The talker is left as a TODO.
>
> The key change is replacing the HF `nn.ModuleList`-based per-expert MLP with a new `Qwen3OmniMoeThinkerTextExperts` module that stores weights as stacked 3-D tensors `(num_experts, out, in)`, compatible with both the fused grouped-GEMM kernel and FSDP2 EP sharding.

Note: the weights of the Qwen3OmniMoe need to merged by the script: https://github.com/ByteDance-Seed/VeOmni/pull/495

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: https://github.com/ByteDance-Seed/VeOmni/pulls?q=fused+moe
- [ ] Format the PR title as `[{modules}] {type}: {description}`

### Test

Validated by running `tests/models/omni/test_qwen3_omni_moe.py` — HF eager vs VeOmni eager vs VeOmni fused loss/gnorm comparison passes.

### API and Usage Example

Set `_moe_implementation = "fused"` in the thinker config to enable the fused path:

```python
config._moe_implementation = "fused"
model = build_foundation_model(config_path=..., ...)
```

No API changes to the training scripts.

### Design & Code Changes

**`modeling_qwen3_omni_moe.py`**

- Add `Qwen3OmniMoeThinkerTextExperts` — replaces `nn.ModuleList` with stacked `nn.Parameter` tensors (`gate_proj`, `up_proj`, `down_proj` each of shape `(num_experts, out, in)`). Supports:
  - `fused_forward`: calls `fused_moe_forward` kernel (training, `_moe_implementation="fused"`)
  - `eager_forward`: loop-per-expert path (inference / eager mode)
  - `_load_from_state_dict`: transparently converts HF per-expert format (`experts.{i}.{proj}.weight`) to stacked format on load, so both original HF and pre-merged checkpoints are accepted
- Patch `Qwen3OmniMoeThinkerTextSparseMoeBlock.__init__` to instantiate `Qwen3OmniMoeThinkerTextExperts` instead of `nn.ModuleList`
- Patch `Qwen3OmniMoeThinkerTextSparseMoeBlock.forward` to pass `routing_weights` and `selected_experts` directly to the experts module
- Patch `Qwen3OmniMoeThinkerForConditionalGeneration.__init__` to propagate `config._moe_implementation` → `config.text_config._moe_implementation` before the text model is built; guarded against multiple calls to `apply_veomni_qwen3_omni_moe_patch()` to prevent infinite recursion

**`parallel_plan.py`**

- Update EP plan key paths from `experts.*.{proj}.weight` (per-expert ModuleList paths) to `experts.{proj}` (stacked Parameter paths), with `Shard(0)` on the expert dimension
- TODO comment added for talker EP plan

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: covered by existing `test_qwen3_omni_moe.py`
