### PR TITLE
[DELETED]

### DIFF
--- a/veomni/models/transformers/qwen3_omni_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_omni_moe/__init__.py
@@ -25,14 +25,15 @@ def register_qwen3_omni_moe_config():
 
 @MODELING_REGISTRY.register("qwen3_omni_moe")
 def register_qwen3_omni_moe_modeling(architecture: str):
-    from .modeling_qwen3_omni_moe import (
+    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
         Qwen3OmniMoeForConditionalGeneration,
         Qwen3OmniMoeTalkerForConditionalGeneration,
         Qwen3OmniMoeTalkerModel,
         Qwen3OmniMoeThinkerForConditionalGeneration,
         Qwen3OmniMoeThinkerTextModel,
-        apply_veomni_qwen3_omni_moe_patch,
     )
+
+    from .modeling_qwen3_omni_moe import apply_veomni_qwen3_omni_moe_patch
 
     apply_veomni_qwen3_omni_moe_patch()
     if "ThinkerTextModel" in architecture:

--- a/veomni/models/transformers/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/veomni/models/transformers/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -13,55 +13,124 @@
 # limitations under the License.
 #
 # Patch for transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe
-# Adds support for: Sequence Parallelism (SP), FSDP, Liger kernel, pre-computed masks,
+# Adds support for: Sequence Parallelism (SP), FSDP, Expert Parallelism (EP),
+# Liger kernel, fused MoE, pre-computed masks,
 # VeOmni data constants, and multiprocessing-compatible position ID generation.
 
 from functools import partial
 from types import SimpleNamespace
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 import transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe as hf_qwen3_omni_moe
-from torch.nn import CrossEntropyLoss
-from transformers import (
-    Qwen3OmniMoeForConditionalGeneration,
-    Qwen3OmniMoeTalkerForConditionalGeneration,
-    Qwen3OmniMoeTalkerModel,
-    Qwen3OmniMoeThinkerForConditionalGeneration,
-    Qwen3OmniMoeThinkerTextModel,
-)
 from transformers.cache_utils import DynamicCache
 from transformers.masking_utils import create_causal_mask
 from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
-from transformers.modeling_outputs import BaseModelOutputWithPast
+from transformers.modeling_outputs import BaseModelOutput, BaseModelOutputWithPast
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 from transformers.processing_utils import Unpack
 
 from ....data.constants import AUDIO_INPUT_INDEX, IGNORE_INDEX, IMAGE_INPUT_INDEX, VIDEO_INPUT_INDEX
 from ....distributed.parallel_state import get_parallel_state
 from ....distributed.sequence_parallel import (
     gather_heads_scatter_seq,
+    gather_outputs,
     gather_seq_scatter_heads,
-    reduce_sequence_parallel_loss,
+    slice_input_tensor,
     slice_position_embedding,
     sp_pad_and_slice,
+    unpad_tensor,
 )
 from ....distributed.sequence_parallel.ulysses import _Gather
+from ....ops import fused_moe_forward
+from ....ops.fused_cross_entropy import ForCausalLMLoss
 from ....utils import logging
-from ....utils.import_utils import is_liger_kernel_available
+from ..attention_utils import VARLEN_ATTENTION_TYPES
 
-
-if is_liger_kernel_available():
-    from liger_kernel.transformers import LigerFusedLinearCrossEntropyLoss  # type: ignore
 
 logger = logging.get_logger(__name__)
 
 
 # ================================================================
+# PATCH: Qwen3OmniMoeVisionAttention.forward
+# 1. [SP] Use VARLEN_ATTENTION_TYPES instead of hardcoded "flash_attention_2"
+#    so that flash_attention_3 and other varlen implementations are also
+#    handled correctly with cu_seqlens (required when SP pads cu_seqlens
+#    with an extra entry for the padding chunk).
+# ================================================================
+def qwen3_omni_moe_vision_attention_forward(
+    self: hf_qwen3_omni_moe.Qwen3OmniMoeVisionAttention,
+    hidden_states: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    rotary_pos_emb: Optional[torch.Tensor] = None,
+    position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
+    **kwargs,
+) -> torch.Tensor:
+    seq_length = hidden_states.shape[0]
+    query_states, key_states, value_states = (
+        self.qkv(hidden_states).reshape(seq_length, 3, self.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
+    )
+    cos, sin = position_embeddings
+    query_states, key_states = hf_qwen3_omni_moe.apply_rotary_pos_emb_vision(query_states, key_states, cos, sin)
+
+    query_states = query_states.transpose(0, 1).unsqueeze(0)
+    key_states = key_states.transpose(0, 1).unsqueeze(0)
+    value_states = value_states.transpose(0, 1).unsqueeze(0)
+
+    attention_interface: Callable = hf_qwen3_omni_moe.eager_attention_forward
+    if self.config._attn_implementation != "eager":
+        attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+    # [SP] Use VARLEN_ATTENTION_TYPES to support flash_attention_3 and other varlen implementations.
+    # The varlen path passes cu_seqlens directly to the kernel; the else-branch splits by full-sequence
+    # lengths which causes a size mismatch when SP pads cu_seqlens with an extra entry.
+    if self.config._attn_implementation in VARLEN_ATTENTION_TYPES:
+        max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
+        attn_output, _ = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask=None,
+            scaling=self.scaling,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            cu_seq_lens_q=cu_seqlens,
+            cu_seq_lens_k=cu_seqlens,
+            max_length_q=max_seqlen,
+            max_length_k=max_seqlen,
+            is_causal=False,
+            **kwargs,
+        )
+    else:
+        lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+        splits = [torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)]
+        attn_outputs = [
+            attention_interface(
+                self,
+                q,
+                k,
+                v,
+                attention_mask=None,
+                scaling=self.scaling,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                is_causal=False,
+                **kwargs,
+            )[0]
+            for q, k, v in zip(*splits)
+        ]
+        attn_output = torch.cat(attn_outputs, dim=1)
+
+    attn_output = attn_output.reshape(seq_length, -1).contiguous()
+    attn_output = self.proj(attn_output)
+    return attn_output
+
+
+# ================================================================
 # PATCH: Qwen3OmniMoeVisionEncoder.forward
-# 1. Support SP for position embeddings (slice pos_embeds with sp_pad_and_slice)
-# 2. Support SP for rotary position embeddings
-# 3. Pad cu_seqlens when using SP to match padded hidden_states
+# 1. [SP] Slice pos_embeds and rotary position embeddings to match the SP-sharded hidden_states
+# 2. [SP] Extend cu_seqlens with a padding entry when the total seq length is not divisible by sp_size
 # ================================================================
 def qwen3_omni_moe_vision_encoder_forward(
     self: hf_qwen3_omni_moe.Qwen3OmniMoeVisionEncoder,
@@ -83,13 +152,12 @@ def qwen3_omni_moe_vision_encoder_forward(
 
     pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
 
-    # --- Patch.1 ---
-    # Modification: slice pos embedding if using sp to let sharded hidden_states get its corresponding pos embedding
     sp_group = get_parallel_state().sp_group if get_parallel_state().sp_enabled else None
+
+    # [SP] Slice pos embedding so each SP rank's hidden_states shard gets the matching pos embedding.
+    # pad_scale=4 matches the padding applied to hidden_states.
     if sp_group is not None:
-        # We need to do padding here because of hidden_states did padding with pad_scale=4
         pos_embeds = sp_pad_and_slice(pos_embeds, dim=0, pad_value=0, pad_scale=4)
-    # --- Patch.1 ---
     hidden_states = hidden_states + pos_embeds
 
     cu_seqlens = torch.repeat_interleave(grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]).cumsum(
@@ -103,9 +171,7 @@ def qwen3_omni_moe_vision_encoder_forward(
     cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
 
     rotary_pos_emb = self.rot_pos_emb(grid_thw)
-    # --- Patch.2 ---
-    # Modification: Get before-sliced full seq from cu_seqlens
-    # total_seq_len should equal to seq_len when not using SP
+    # [SP] Capture total_seq_len from cu_seqlens before any SP slicing; equals seq_len when SP is off.
     total_seq_len = cu_seqlens[-1]
     seq_len, _ = hidden_states.size()
     hidden_states = hidden_states.reshape(seq_len, -1)
@@ -113,24 +179,21 @@ def qwen3_omni_moe_vision_encoder_forward(
     emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
     position_embeddings = (emb.cos(), emb.sin())
 
-    # Modification: slice pos embedding when using sp to let sp-sliced hidden_states get its corresponding pos embedding
+    # [SP] Slice rotary position embeddings to match the SP-sharded hidden_states.
     if sp_group is not None:
         cos, sin = position_embeddings
         cos = sp_pad_and_slice(cos, dim=0, pad_value=0, pad_scale=4)
         sin = sp_pad_and_slice(sin, dim=0, pad_value=0, pad_scale=4)
         position_embeddings = (cos, sin)
 
-    # Modification: pad cu_seqlens when using SP to match the padded hidden_states
+    # [SP] Append a padding entry to cu_seqlens to cover the padded tail on the last rank.
     if sp_group is not None:
         ps = get_parallel_state()
         sp_size = getattr(ps, "sp_size", 1)
-        # Calculate the last one padding seq_len : seq_len*sp_size - total_seq_len
         pad_seq_len = seq_len * sp_size - total_seq_len.item()
         if pad_seq_len > 0:
-            # Add this extra sequence to cu_seqlens with the padding length
             new_cumsum = cu_seqlens[-1] + pad_seq_len
             cu_seqlens = torch.cat([cu_seqlens, new_cumsum.unsqueeze(0)], dim=0)
-    # --- Patch.2 ---
 
     deepstack_feature_lists = []
     for layer_num, blk in enumerate(self.blocks):
@@ -152,9 +215,9 @@ def qwen3_omni_moe_vision_encoder_forward(
 
 
 # ================================================================
-# PATCH: Qwen3OmniMoeVisionEncoder.dummy_forward (NEW)
-# Prevent FSDP reduce-scatter hang when some ranks get None pixel_values
-# while others get valid pixel_values
+# NEW: Qwen3OmniMoeVisionEncoder.dummy_forward
+# [FSDP] Prevent reduce-scatter hang when some ranks receive None pixel_values
+# while others receive valid pixel_values.
 # ================================================================
 def qwen3_omni_moe_vision_encoder_dummy_forward(
     self: hf_qwen3_omni_moe.Qwen3OmniMoeVisionEncoder,
@@ -173,8 +236,120 @@ def qwen3_omni_moe_vision_encoder_dummy_forward(
 
 
 # ================================================================
+# PATCH: Qwen3OmniMoeAudioEncoder.forward
+# 1. [SP] Gather input_features along the time dim and strip SP padding before chunking
+# 2. [SP] Slice hidden_states before encoder layers; extend cu_seqlens for the padded tail
+# ================================================================
+def qwen3_omni_moe_audio_encoder_forward(
+    self: hf_qwen3_omni_moe.Qwen3OmniMoeAudioEncoder,
+    input_features,
+    feature_lens=None,
+    aftercnn_lens=None,
+):
+    aftercnn_lens = hf_qwen3_omni_moe._get_feat_extract_output_lengths(feature_lens)
+    chunk_num = torch.ceil(feature_lens / (self.n_window * 2)).long()
+
+    chunk_lengths = torch.tensor(
+        [self.n_window * 2] * chunk_num.sum(),
+        dtype=torch.long,
+        device=feature_lens.device,
+    )
+    tail_chunk_index = F.pad(chunk_num, (1, 0), value=-1).cumsum(0)[1:]
+    chunk_lengths[tail_chunk_index] = feature_lens % (self.n_window * 2)
+    chunk_lengths[chunk_lengths == 0] = self.n_window * 2
+
+    # [SP] input_features is (num_mel_bins, total_len); gather along the time dimension (dim=1)
+    # and strip any SP padding before chunking.
+    if get_parallel_state().sp_enabled:
+        unpadded_input_len = torch.sum(chunk_lengths)
+        input_features = gather_outputs(input_features, gather_dim=1, group=get_parallel_state().sp_group)
+        sp_input_padding = input_features.size(1) - unpadded_input_len
+        if sp_input_padding > 0:
+            input_features = unpad_tensor(input_features, dim=1, padding_size=sp_input_padding)
+
+    chunk_list = input_features.T.split(chunk_lengths.tolist(), dim=0)
+    padded_feature = nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
+    feature_lens_after_cnn = hf_qwen3_omni_moe._get_feat_extract_output_lengths(chunk_lengths)
+    padded_mask_after_cnn = nn.utils.rnn.pad_sequence(
+        [torch.ones(length, dtype=torch.bool, device=padded_feature.device) for length in feature_lens_after_cnn],
+        batch_first=True,
+    )
+    padded_feature = padded_feature.unsqueeze(1)
+    # Split to chunk to avoid OOM during convolution
+    padded_embeds = []
+    for chunk in padded_feature.split(self.conv_chunksize, dim=0):
+        padded_embed = F.gelu(self.conv2d1(chunk))
+        padded_embed = F.gelu(self.conv2d2(padded_embed))
+        padded_embed = F.gelu(self.conv2d3(padded_embed))
+        padded_embeds.append(padded_embed)
+    padded_embed = torch.cat(padded_embeds, dim=0)
+    b, c, f, t = padded_embed.size()
+    padded_embed = self.conv_out(padded_embed.permute(0, 3, 1, 2).contiguous().view(b, t, c * f))
+
+    positional_embedding = (
+        self.positional_embedding.positional_embedding[: padded_embed.shape[1], :].unsqueeze(0).to(padded_embed.dtype)
+    )
+    padded_embed = padded_embed + positional_embedding
+    hidden_states = padded_embed[padded_mask_after_cnn]
+    cu_chunk_lens = [0]
+    window_aftercnn = padded_mask_after_cnn.shape[-1] * (self.n_window_infer // (self.n_window * 2))
+    for cnn_len in aftercnn_lens:
+        cu_chunk_lens += [window_aftercnn] * (cnn_len // window_aftercnn)
+        remainder = cnn_len % window_aftercnn
+        if remainder != 0:
+            cu_chunk_lens += [remainder]
+    cu_seqlens = torch.tensor(cu_chunk_lens, device=aftercnn_lens.device).cumsum(-1, dtype=torch.int32)
+
+    # [SP] Slice hidden_states along the seq dim (dim=0) before encoder layers.
+    # Extend cu_seqlens to cover the padded tail on the last rank if needed.
+    if get_parallel_state().sp_enabled:
+        unpadded_hidden_len = cu_seqlens[-1]
+        hidden_states = slice_input_tensor(hidden_states, dim=0, group=get_parallel_state().sp_group)
+        pad_seq_len = hidden_states.size(0) * get_parallel_state().sp_size - unpadded_hidden_len
+        if pad_seq_len > 0:
+            cu_seqlens = torch.cat([cu_seqlens, (cu_seqlens[-1] + pad_seq_len).unsqueeze(0)], dim=0)
+
+    for encoder_layer in self.layers:
+        layer_outputs = encoder_layer(
+            hidden_states,
+            cu_seqlens,
+        )
+        hidden_states = layer_outputs[0]
+
+    hidden_states = self.ln_post(hidden_states)
+    hidden_states = self.proj1(hidden_states)
+    hidden_states = self.act(hidden_states)
+    hidden_states = self.proj2(hidden_states)
+    return BaseModelOutput(last_hidden_state=hidden_states)
+
+
+# ================================================================
+# NEW: Qwen3OmniMoeAudioEncoder.dummy_forward
+# [FSDP] Prevent reduce-scatter hang when some ranks have no audio data
+# while others receive valid audio data.
+# ================================================================
+def qwen3_omni_moe_audio_encoder_dummy_forward(
+    self: hf_qwen3_omni_moe.Qwen3OmniMoeAudioEncoder,
+):
+    """
+    Dummy forward to avoid FSDP reduce-scatter hang when some ranks have no audio data.
+    input_features shape is (num_mel_bins, total_len), feature_lens is (num_audios,).
+    """
+    if getattr(self, "_dummy_data", None) is None:
+        # Minimal valid input: one audio clip of length n_window*2 (smallest non-zero chunk)
+        min_len = self.n_window * 2
+        input_features = torch.zeros((self.num_mel_bins, min_len), dtype=self.dtype, device=self.device)
+        feature_lens = torch.tensor([min_len], dtype=torch.long, device=self.device)
+        self._dummy_data = {
+            "input_features": input_features,
+            "feature_lens": feature_lens,
+        }
+    return self(**self._dummy_data)
+
+
+# ================================================================
 # PATCH: Qwen3OmniMoeThinkerTextModel.forward
-# 1. Support SP for position embeddings via slice_position_embedding
+# 1. [SP] Slice rotary position embeddings to match the SP-sharded hidden_states
 # ================================================================
 def qwen3_omni_moe_thinker_text_model_forward(
     self: hf_qwen3_omni_moe.Qwen3OmniMoeThinkerTextModel,
@@ -240,12 +415,11 @@ def qwen3_omni_moe_thinker_text_model_forward(
     # create position embeddings to be shared across the decoder layers
     position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-    # --- Patch.1 ---
-    # Modification: slice pos embedding when using sp to let sp-sliced hidden_states get its corresponding pos_embedding
+    # [SP] Slice rotary position embeddings so each SP rank's hidden_states shard gets the
+    # matching positional encoding.
     sp_group = get_parallel_state().sp_group if get_parallel_state().sp_enabled else None
     if sp_group is not None:
         position_embeddings = slice_position_embedding(position_embeddings, dim=1, sp_group=sp_group)
-    # --- Patch.1 ---
 
     # decoder layers
     for layer_idx, decoder_layer in enumerate(self.layers):
@@ -278,9 +452,10 @@ def qwen3_omni_moe_thinker_text_model_forward(
 
 # ================================================================
 # PATCH: Qwen3OmniMoeThinkerTextModel._deepstack_process
-# 1. Handle None visual_pos_masks for FSDP hang prevention
-#    (add 0.0 to hidden_states to keep FSDP backward reduce scatter working)
-# 2. Mask format changed: visual_pos_masks is now pre-computed without extra dim
+# 1. [FSDP] Handle None visual_pos_masks: add 0.0 to hidden_states to keep
+#    FSDP backward reduce-scatter working even when no visual tokens are present
+# 2. [Mask] visual_pos_masks is now pre-computed without an extra trailing dim;
+#    squeeze any residual (bsz, seq_len, 1) shape for compatibility
 # ================================================================
 def qwen3_omni_moe_thinker_text_model_deepstack_process(
     self: hf_qwen3_omni_moe.Qwen3OmniMoeThinkerTextModel,
@@ -288,22 +463,17 @@ def qwen3_omni_moe_thinker_text_model_deepstack_process(
     visual_pos_masks,
     visual_embeds,
 ):
-    # --- Patch.1 ---
-    # Modification: Handle case when visual_pos_masks is None (both image and video pixel_values are None)
-    # Still call this operation but just add 0.0 to hidden_states to avoid FSDP reduce scatter stuck
+    # [FSDP] visual_pos_masks is None when both pixel_values and pixel_values_videos are None.
+    # Still touch visual_embeds so FSDP reduce-scatter stays in sync across ranks.
     if visual_pos_masks is None:
         visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
         hidden_states = hidden_states + visual_embeds.mean() * 0.0
         return hidden_states
-    # --- Patch.1 ---
 
-    # --- Patch.2 ---
-    # Modification: removed visual_pos_masks[..., 0] since mask is now pre-computed in correct format
-    # Also handle 3D masks (bsz, seq_len, 1) by squeezing the trailing dim
+    # [Mask] Mask is pre-computed in the correct 2D format; squeeze trailing dim if still 3D.
     visual_pos_masks = visual_pos_masks.to(hidden_states.device)
     if visual_pos_masks.ndim == 3:
         visual_pos_masks = visual_pos_masks[..., 0]
-    # --- Patch.2 ---
     visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
     local_this = hidden_states[visual_pos_masks, :].clone() + visual_embeds
     hidden_states[visual_pos_masks, :] = local_this
@@ -312,8 +482,8 @@ def qwen3_omni_moe_thinker_text_model_deepstack_process(
 
 # ================================================================
 # PATCH: Qwen3OmniMoeThinkerForConditionalGeneration.__init__
-# 1. Use VeOmni data constants (IMAGE_INPUT_INDEX, VIDEO_INPUT_INDEX, AUDIO_INPUT_INDEX)
-#    for token indices instead of config token_id values
+# 1. [Constants] Use VeOmni data constants (IMAGE_INPUT_INDEX, VIDEO_INPUT_INDEX,
+#    AUDIO_INPUT_INDEX) for multimodal token indices instead of config token_id values
 # ================================================================
 def qwen3_omni_moe_thinker_init(
     self: hf_qwen3_omni_moe.Qwen3OmniMoeThinkerForConditionalGeneration,
@@ -333,12 +503,10 @@ def qwen3_omni_moe_thinker_init(
     self.num_experts = config.text_config.num_experts
     self.num_experts_per_tok = config.text_config.num_experts_per_tok
 
-    # --- Patch.1 ---
-    # Modification: Use VeOmni data constants for multimodal token indices
+    # [Constants] Use VeOmni data constants for multimodal token indices.
     self.image_token_index = IMAGE_INPUT_INDEX
     self.video_token_index = VIDEO_INPUT_INDEX
     self.audio_token_index = AUDIO_INPUT_INDEX
-    # --- Patch.1 ---
     self.post_init()
 
 
@@ -383,8 +551,8 @@ def get_position_id(main_func, self, **kwargs):
 
 
 # ================================================================
-# PATCH: Qwen3OmniMoeThinkerForConditionalGeneration.get_position_id_func (NEW)
-# Provides a serializable function for multiprocessing data preprocessing
+# NEW: Qwen3OmniMoeThinkerForConditionalGeneration.get_position_id_func
+# Provides a picklable partial function for multiprocessing data preprocessing
 # ================================================================
 def qwen3_omni_moe_thinker_get_position_id_func(
     self: hf_qwen3_omni_moe.Qwen3OmniMoeThinkerForConditionalGeneration,
@@ -411,7 +579,9 @@ def qwen3_omni_moe_thinker_get_position_id_func(
 
 # ================================================================
 # PATCH: Qwen3OmniMoeThinkerForConditionalGeneration.get_audio_features
-# 1. Raise NotImplementedError when SP is enabled (audio SP not yet supported)
+# 1. Remove NotImplementedError for SP (audio SP is now handled inside audio_tower)
+# 2. Unpack feature_attention_mask into flat (num_mel_bins, total_len) format expected by audio_tower
+# 3. Handle pre-processed 2D input (total_len, num_mel_bins) without a mask
 # ================================================================
 def qwen3_omni_moe_thinker_get_audio_features(
     self: hf_qwen3_omni_moe.Qwen3OmniMoeThinkerForConditionalGeneration,
@@ -430,14 +600,19 @@ def qwen3_omni_moe_thinker_get_audio_features(
         audio_feature_lengths (`torch.LongTensor` of shape `(num_audios)`, *optional*):
             The length of feature shape of each audio in LLM.
     """
-    # TODO audio sp support
-    if get_parallel_state().sp_enabled:
-        raise NotImplementedError("audio sp is not supported yet.")
     if feature_attention_mask is not None:
+        # Unpack into flat (num_mel_bins, total_len) format expected by audio_tower; SP is handled inside.
         audio_feature_lengths = torch.sum(feature_attention_mask, dim=1)
         input_features = input_features.permute(0, 2, 1)[feature_attention_mask.bool()].permute(1, 0)
+    else:
+        # Compatibility: handle pre-processed (total_len, num_mel_bins) input without mask.
+        if input_features.ndim == 2 and input_features.size(-1) == self.audio_tower.num_mel_bins:
+            input_features = input_features.transpose(0, 1)  # -> (num_mel_bins, total_len)
 
-    feature_lens = audio_feature_lengths if audio_feature_lengths is not None else feature_attention_mask.sum(-1)
+    if audio_feature_lengths is not None:
+        feature_lens = audio_feature_lengths
+    else:
+        feature_lens = torch.tensor([input_features.size(1)], dtype=torch.long, device=input_features.device)
     audio_outputs = self.audio_tower(
         input_features,
         feature_lens=feature_lens,
@@ -449,14 +624,20 @@ def qwen3_omni_moe_thinker_get_audio_features(
 
 # ================================================================
 # PATCH: Qwen3OmniMoeThinkerForConditionalGeneration.forward
-# 1. Use pre-computed image_mask/video_mask from kwargs (avoid all-gather for complete mask in SP)
-# 2. Pop flash attention kwargs for ViT (ViT computes its own cu_seqlens from grid_thw)
-# 3. SP: gather_seq_scatter_heads for input/image/video embeddings
-# 4. Dummy ViT forward for FSDP when pixel_values is None
-# 5. SP: gather_heads_scatter_seq after multimodal merging
-# 6. SP: all_gather deepstack embeddings + rank-specific slicing
-# 7. FSDP: fake_deepstack handling when both pixel_values and pixel_values_videos are None
-# 8. Custom loss computation with Liger kernel + SP loss reduction
+# 1. [Mask]    Use pre-computed image_mask/video_mask/audio_mask from kwargs to avoid
+#              all-gather for a complete mask when using SP
+# 2. [ViT]    Pop flash-attention kwargs before ViT forward; ViT computes its own
+#              cu_seqlens from grid_thw and must not receive LLM-level seqlen kwargs
+# 3. [SP]     gather_seq_scatter_heads on input/image/video/audio embeddings before
+#              multimodal token fill-back
+# 4. [FSDP]   Dummy ViT/audio forward when pixel_values/input_features is None to keep
+#              reduce-scatter in sync across ranks
+# 5. [SP]     gather_heads_scatter_seq after multimodal merging to restore seq-parallel layout
+# 6. [SP]     all_gather deepstack embeddings then select the per-rank visual token slice
+# 7. [FSDP]   Pass fake_deepstack to _deepstack_process when no visual input is present
+# 8. [Loss]   Delegate loss computation to ForCausalLMLoss (handles label shifting,
+#              Liger/fused kernel, and SP loss reduction)
+# 9. [PosIDs] Transpose pre-computed position_ids from (bs, 3, L) to (3, bs, L)
 # ================================================================
 def qwen3_omni_moe_thinker_forward(
     self: hf_qwen3_omni_moe.Qwen3OmniMoeThinkerForConditionalGeneration,
@@ -512,33 +693,30 @@ def qwen3_omni_moe_thinker_forward(
         # 1. Extract the input embeddings
         inputs_embeds = self.get_input_embeddings()(input_ids)
 
-    # Modification: we use the pre-computed image, video and audio mask to support ulysses
+    # [Mask] Use pre-computed masks to avoid all-gather for complete mask info when using SP.
     assert "image_mask" in kwargs, "image_mask should have already been computed in process_sample"
     assert "video_mask" in kwargs, "video_mask should have already been computed in process_sample"
     assert "audio_mask" in kwargs, "audio_mask should have already been computed in process_sample"
-    image_mask = kwargs["image_mask"]
-    video_mask = kwargs["video_mask"]
-    audio_mask = kwargs["audio_mask"]
+    image_mask = kwargs.pop("image_mask")
+    video_mask = kwargs.pop("video_mask")
+    audio_mask = kwargs.pop("audio_mask")
 
-    # --- Patch.2 ---
-    # Modification: Pop flash attention kwargs for ViT, they should only be used for language model
-    # Qwen3L ViT input images seq lens should be computed during ViT forward using grid_thw
+    # [ViT] Pop flash-attention kwargs before ViT forward. ViT computes its own cu_seqlens from
+    # grid_thw and must not receive the LLM-level seqlen kwargs:
     # https://github.com/huggingface/transformers/blob/94df0e65602922be2831b3faa457a2bde78b936b/src/transformers/modeling_flash_attention_utils.py#L432-L450
     flash_attn_kwargs = {}
     for key in ["cu_seq_lens_q", "cu_seq_lens_k", "max_length_q", "max_length_k"]:
         if key in kwargs:
             flash_attn_kwargs[key] = kwargs.pop(key)
-    # --- Patch.2 ---
 
-    # --- Patch.3 ---
+    # [SP] Gather seq and scatter heads on inputs_embeds so multimodal fill-back operates on the
+    # full sequence: (batch_size, seq_len // sp_size, hidden_size) -> (batch_size, seq_len, hidden_size // sp_size)
     if self.training and get_parallel_state().sp_enabled:
-        # (batch_size, seq_len // sp_size, hidden_size) to  (batch_size, seq_len, hidden_size // sp_size)
         inputs_embeds = gather_seq_scatter_heads(
             inputs_embeds, seq_dim=1, head_dim=2, group=get_parallel_state().sp_group
         )
-    # --- Patch.3 ---
 
-    # 2. Merge text , audios , image and video
+    # 2. Merge text, audios, image and video
     if input_features is not None:
         audio_features = self.get_audio_features(
             input_features,
@@ -546,8 +724,23 @@ def qwen3_omni_moe_thinker_forward(
             audio_feature_lengths=audio_feature_lengths,
         )
         audio_features = audio_features.to(inputs_embeds.device, inputs_embeds.dtype)
-        audio_mask = audio_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device, non_blocking=True)
-        inputs_embeds = inputs_embeds.masked_scatter(audio_mask, audio_features)
+        # [SP] audio_tower returns seq-sliced features; gather seq and scatter heads to match
+        # inputs_embeds layout before fill-back.
+        if self.training and get_parallel_state().sp_enabled:
+            audio_features = gather_seq_scatter_heads(
+                audio_features, seq_dim=0, head_dim=1, group=get_parallel_state().sp_group
+            )
+        # Drop any padding tokens beyond the actual audio placeholder count.
+        n_audio_tokens = audio_mask.sum().long().item()
+        audio_features = audio_features[:n_audio_tokens]
+        audio_mask_expanded = audio_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
+        inputs_embeds = inputs_embeds.masked_scatter(audio_mask_expanded, audio_features)
+    elif get_parallel_state().fsdp_enabled:
+        # [FSDP] Dummy audio tower forward to keep reduce-scatter in sync when some ranks
+        # have no audio data while others do.
+        fake_audio = self.audio_tower.dummy_forward().last_hidden_state.mean() * 0.0
+        fake_audio = fake_audio.to(inputs_embeds.device, inputs_embeds.dtype)
+        inputs_embeds = inputs_embeds + fake_audio
 
     # Initialize fake_deepstack to None
     fake_deepstack = None
@@ -555,31 +748,25 @@ def qwen3_omni_moe_thinker_forward(
     if pixel_values is not None:
         image_embeds, deepstack_image_embeds = self.get_image_features(pixel_values, image_grid_thw)
         image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
-        # --- Patch.3 ---
-        # Modification: sp patch
+        # [SP] Gather seq and scatter heads on image_embeds:
+        # (seq_len // sp_size, hidden_size) -> (seq_len, hidden_size // sp_size)
         if self.training and get_parallel_state().sp_enabled:
-            # (seq_len // sp_size, hidden_size) to  (seq_len, hidden_size // sp_size)
             image_embeds = gather_seq_scatter_heads(
                 image_embeds, seq_dim=0, head_dim=-1, group=get_parallel_state().sp_group
             )
-        # --- Patch.3 ---
-        # Original: We calculated the special_image_mask in the forward pass,
-        # but now we pre-compute it and pass it in as image_mask to avoid
-        # all-gather to get complete image_mask info when using sequence parallel
+        # [Mask] Use pre-computed image_mask instead of calling get_placeholder_mask to avoid
+        # all-gather for complete mask info when using SP:
         # image_mask, _, _ = self.get_placeholder_mask(
         #     input_ids, inputs_embeds=inputs_embeds, image_features=image_embeds
         # )
 
-        # --- Patch.4 ---
-        # Modification: Get the num of image tokens from the pre-computed image_mask
-        # And reshape the masks to match the shape of inputs_embeds
+        # [Mask] Get token count from pre-computed mask and expand to inputs_embeds shape.
         n_image_tokens = image_mask.sum().long().item()
         image_mask = image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device, non_blocking=True)
 
-        # Modification: Slice tensor to drop any padded image tokens
+        # Drop any padded image tokens beyond the actual placeholder count.
         image_embeds = image_embeds[:n_image_tokens]
         deepstack_image_embeds = [embed[:n_image_tokens] for embed in deepstack_image_embeds]
-        # --- Patch.4 ---
         n_image_features = image_embeds.shape[0]
         if n_image_tokens != n_image_features:
             raise ValueError(
@@ -588,42 +775,36 @@ def qwen3_omni_moe_thinker_forward(
 
         inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
     elif get_parallel_state().fsdp_enabled:
-        # --- Patch.5 ---
-        # Modification: add dummy ViT forward to avoid FSDP reduce-scatter hang
-        # when some ranks get None pixel_values while others get valid pixel_values
+        # [FSDP] Dummy ViT forward to keep reduce-scatter in sync when some ranks receive
+        # None pixel_values while others receive valid pixel_values.
         fake_embeds, fake_deepstack = self.visual.dummy_forward()
         fake_embeds = fake_embeds.mean() * 0.0
         fake_embeds = fake_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
         inputs_embeds = inputs_embeds + fake_embeds
-        # --- Patch.5 ---
 
     if pixel_values_videos is not None:
         video_embeds, video_embeds_multiscale = self.get_video_features(pixel_values_videos, video_grid_thw)
 
         video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
-        # --- Patch.3 ---
-        # Modification: sequence parallel patch for video embeds
+        # [SP] Gather seq and scatter heads on video_embeds:
+        # (seq_len // sp_size, hidden_size) -> (seq_len, hidden_size // sp_size)
         if self.training and get_parallel_state().sp_enabled:
-            # (seq_len // sp_size, hidden_size) to  (seq_len, hidden_size // sp_size)
             video_embeds = gather_seq_scatter_heads(
                 video_embeds, seq_dim=0, head_dim=-1, group=get_parallel_state().sp_group
             )
-        # --- Patch.3 ---
+        # [Mask] Use pre-computed video_mask instead of calling get_placeholder_mask:
         # _, video_mask, _ = self.get_placeholder_mask(
         #     input_ids, inputs_embeds=inputs_embeds, video_features=video_embeds
         # )
 
-        # --- Patch.4 ---
-        # Modification: Get the num of video tokens from the pre-computed video_mask
-        # And reshape the masks to match the shape of inputs_embeds
+        # [Mask] Get token count from pre-computed mask and expand to inputs_embeds shape.
         n_video_tokens = video_mask.sum().long().item()
         video_mask = video_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device, non_blocking=True)
 
-        # Modification: Slice tensor to drop any padded video tokens
+        # Drop any padded video tokens beyond the actual placeholder count.
         video_embeds = video_embeds[:n_video_tokens]
         deepstack_video_embeds = video_embeds_multiscale
         deepstack_video_embeds = [embed[:n_video_tokens] for embed in deepstack_video_embeds]
-        # --- Patch.4 ---
         n_video_features = video_embeds.shape[0]
         if n_video_tokens != n_video_features:
             raise ValueError(
@@ -634,97 +815,72 @@ def qwen3_omni_moe_thinker_forward(
         inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
 
     elif get_parallel_state().fsdp_enabled:
-        # --- Patch.5 ---
-        # Modification: add dummy ViT forward to avoid FSDP reduce-scatter hang
-        # when some ranks get None pixel_values_videos while others get valid pixel_values_videos
+        # [FSDP] Dummy ViT forward to keep reduce-scatter in sync when some ranks receive
+        # None pixel_values_videos while others receive valid pixel_values_videos.
         fake_embeds, fake_deepstack = self.visual.dummy_forward()
         fake_embeds = fake_embeds.mean() * 0.0
         fake_embeds = fake_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
         inputs_embeds = inputs_embeds + fake_embeds
-        # --- Patch.5 ---
 
-    # Prepare sliced masks for deepstack use
+    # Prepare rank-local masks for deepstack use (set after SP scatter below).
     rank_image_mask = None
     rank_video_mask = None
 
-    # --- Patch.6 ---
-    # Modification: sequence parallel patch
+    # [SP] Restore seq-parallel layout after fill-back:
+    # (batch_size, seq_len, hidden_size // sp_size) -> (batch_size, seq_len // sp_size, hidden_size)
     if self.training and get_parallel_state().sp_enabled:
-        # (batch_size, seq_len, hidden_size // sp_size) back to (batch_size, seq_len // sp_size, hidden_size)
         inputs_embeds = gather_heads_scatter_seq(
             inputs_embeds, head_dim=2, seq_dim=1, group=get_parallel_state().sp_group
         )
 
-        # After sequence is scattered, do all_gather on deepstack embeddings
-        # and use masks to select the corresponding visual tokens for this rank
+        # [SP] all_gather deepstack embeddings and select the per-rank visual token slice
+        # using the full-sequence mask.
         sp_size = get_parallel_state().sp_size
         sp_rank = get_parallel_state().sp_rank
 
         if pixel_values is not None:
-            # Do all_gather on deepstack_image_embeds
-            # (seq_len // sp_size, hidden_size) -> (seq_len, hidden_size)
+            # all_gather: (seq_len // sp_size, hidden_size) -> (seq_len, hidden_size)
             deepstack_image_embeds = [
                 _Gather.apply(get_parallel_state().sp_group, embed, 0, False) for embed in deepstack_image_embeds
             ]
 
-            # Now use image_mask to select visual tokens for this rank's sequence slice
-            # image_mask is (batch_size, seq_len, hidden_size // sp_size) before gather_heads_scatter_seq
+            # image_mask is (batch_size, seq_len, hidden_size // sp_size) at this point.
             image_mask_1d = image_mask[..., 0]  # (batch_size, seq_len)
-
-            # Determine which sequence positions belong to this rank
             seq_len = image_mask_1d.shape[1]
             seq_per_rank = seq_len // sp_size
             rank_start = sp_rank * seq_per_rank
             rank_end = rank_start + seq_per_rank
 
-            # Get the mask for this rank's sequence slice and save it for later
             rank_image_mask = image_mask_1d[:, rank_start:rank_end]  # (batch_size, seq_len // sp_size)
-            # Count how many visual tokens are before this rank's slice
-            before_rank_mask = image_mask_1d[:, :rank_start]
-            offset = before_rank_mask.sum().item()
-            # Count how many visual tokens are in this rank's slice
+            offset = image_mask_1d[:, :rank_start].sum().item()
             num_visual_tokens = rank_image_mask.sum().item()
-            # Slice the all-gathered deepstack embeddings
             deepstack_image_embeds = [embed[offset : offset + num_visual_tokens] for embed in deepstack_image_embeds]
 
         if pixel_values_videos is not None:
-            # Do all_gather on deepstack_video_embeds
-            # (seq_len // sp_size, hidden_size) -> (seq_len, hidden_size)
+            # all_gather: (seq_len // sp_size, hidden_size) -> (seq_len, hidden_size)
             deepstack_video_embeds = [
                 _Gather.apply(get_parallel_state().sp_group, embed, 0, False) for embed in deepstack_video_embeds
             ]
 
-            # Same logic for video embeddings
             video_mask_1d = video_mask[..., 0]  # (batch_size, seq_len)
             seq_len = video_mask_1d.shape[1]
             seq_per_rank = seq_len // sp_size
             rank_start = sp_rank * seq_per_rank
             rank_end = rank_start + seq_per_rank
 
-            # Get the mask for this rank's sequence slice and save it for later
             rank_video_mask = video_mask_1d[:, rank_start:rank_end]
-            before_rank_mask = video_mask_1d[:, :rank_start]
-            offset = before_rank_mask.sum().item()
+            offset = video_mask_1d[:, :rank_start].sum().item()
             num_visual_tokens = rank_video_mask.sum().item()
             deepstack_video_embeds = [embed[offset : offset + num_visual_tokens] for embed in deepstack_video_embeds]
-    # --- Patch.6 ---
 
     visual_pos_masks = None
     deepstack_visual_embeds = None
 
-    # --- Patch.7 ---
-    # Modification: use pixel_values and pixel_values_videos instead of masks
     if pixel_values is not None and pixel_values_videos is not None:
-        # aggregate visual_pos_masks and deepstack_visual_embeds
-        # reuse the sliced masks if SP is enabled
-        if rank_image_mask is not None:
-            image_mask = rank_image_mask
-        else:
-            image_mask = image_mask[..., 0]
-        if rank_video_mask is not None:
-            video_mask = rank_video_mask
-        else:
-            video_mask = video_mask[..., 0]
+        # Both image and video: merge masks and interleave deepstack embeddings.
+        # Reuse the rank-local sliced masks when SP is active.
+        image_mask = rank_image_mask if rank_image_mask is not None else image_mask[..., 0]
+        video_mask = rank_video_mask if rank_video_mask is not None else video_mask[..., 0]
         visual_pos_masks = image_mask | video_mask
         deepstack_visual_embeds = []
         image_mask_joint = image_mask[visual_pos_masks]
@@ -735,31 +891,18 @@ def qwen3_omni_moe_thinker_forward(
             embed_joint[video_mask_joint, :] = vid_embed
             deepstack_visual_embeds.append(embed_joint)
     elif pixel_values is not None:
-        # Modification: Reuse the sliced mask if SP is enabled
-        if rank_image_mask is not None:
-            image_mask = rank_image_mask
-        else:
-            image_mask = image_mask[..., 0]
+        image_mask = rank_image_mask if rank_image_mask is not None else image_mask[..., 0]
         visual_pos_masks = image_mask
         deepstack_visual_embeds = deepstack_image_embeds
     elif pixel_values_videos is not None:
-        # Modification: Reuse the sliced mask if SP is enabled
-        if rank_video_mask is not None:
-            video_mask = rank_video_mask
-        else:
-            video_mask = video_mask[..., 0]
+        video_mask = rank_video_mask if rank_video_mask is not None else video_mask[..., 0]
         visual_pos_masks = video_mask
         deepstack_visual_embeds = deepstack_video_embeds
     else:
-        # Both pixel_values and pixel_values_videos are None
-        # still pass fake_deepstack to language_model to trigger _deepstack_process
-        # to avoid FSDP backward reduce scatter stuck
-        # visual_pos_masks remains None, so _deepstack_process will just add 0.0
+        # [FSDP] No visual input: still pass fake_deepstack so _deepstack_process is called on all
+        # ranks (visual_pos_masks=None makes it a no-op that keeps reduce-scatter in sync).
         if fake_deepstack is not None:
             deepstack_visual_embeds = fake_deepstack
-        else:
-            deepstack_visual_embeds = None
-    # --- Patch.7 ---
 
     if feature_attention_mask is not None:
         audio_feature_lengths = torch.sum(feature_attention_mask, dim=1)
@@ -791,11 +934,14 @@ def qwen3_omni_moe_thinker_forward(
             position_ids = position_ids.view(1, -1).expand(batch_size, -1)
             position_ids = position_ids.add(delta)
             position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+    elif position_ids is not None:
+        # [PosIDs] During training with rmpad_with_pos_ids, position_ids are computed per sample as
+        # (3, L) and collated to (bs, 3, L). Transpose to (3, bs, L) as the model expects.
+        if position_ids.ndim == 3 and position_ids.shape[1] == 3:
+            position_ids = position_ids.transpose(0, 1).contiguous()  # (bs, 3, L) -> (3, bs, L)
 
-    # --- Patch.2 ---
-    # Modification: Restore flash attention kwargs for language model to avoid CPU-GPU sync
+    # [ViT] Restore flash-attention kwargs for the language model forward.
     kwargs.update(flash_attn_kwargs)
-    # --- Patch.2 ---
 
     outputs = self.model(
         attention_mask=attention_mask,
@@ -811,38 +957,22 @@ def qwen3_omni_moe_thinker_forward(
     )
 
     hidden_states = outputs[0]
-    # --- Patch.8 ---
-    # Modification: sp patch: custom loss computation with Liger kernel and SP loss reduction
+    # [Loss] Delegate to ForCausalLMLoss which handles label shifting (non-SP), Liger/fused kernel
+    # selection, and SP loss reduction.
+    # NOTE: ForCausalLMLoss pads labels to (S+1) then slices [..., 1:] back to length S, so
+    # shift_labels stays at length S — matching the full, unsliced hidden_states. Do NOT
+    # pre-slice hidden_states[..., :-1, :] here or the shapes will mismatch.
     if labels is not None:
-        if not get_parallel_state().sp_enabled:
-            labels = labels[..., 1:].contiguous()  # shift labels
-
-        labels = labels.view(-1)  # flatten labels
-
-        if is_liger_kernel_available():
-            loss_fct = LigerFusedLinearCrossEntropyLoss(reduction="mean")
-            if not get_parallel_state().sp_enabled:
-                hidden_states = hidden_states[..., :-1, :].contiguous()  # shift hidden states
-
-            hidden_states = hidden_states.view(-1, self.config.text_config.hidden_size)  # flatten hidden states
-            loss = loss_fct(self.lm_head.weight, hidden_states, labels)
-            logits = None
-        else:
-            loss_fct = CrossEntropyLoss(reduction="mean")
-            logits = self.lm_head(hidden_states)
-            if not get_parallel_state().sp_enabled:
-                logits = logits[..., :-1, :].contiguous()  # shift logits
-
-            logits = logits.float().view(-1, self.config.text_config.vocab_size)  # flatten logits
-            loss = loss_fct(logits, labels)
-
-        if get_parallel_state().sp_enabled:
-            num_valid_tokens = (labels != IGNORE_INDEX).sum()
-            loss = reduce_sequence_parallel_loss(loss, num_valid_tokens)
+        loss, logits = ForCausalLMLoss(
+            labels=labels,
+            vocab_size=self.config.text_config.vocab_size,
+            hidden_states=hidden_states,
+            weights=self.lm_head.weight,
+            ignore_index=IGNORE_INDEX,
+        )
     else:
         logits = self.lm_head(hidden_states)
         loss = None
-    # --- Patch.8 ---
 
     aux_loss = None
     if output_router_logits:
@@ -882,6 +1012,159 @@ def qwen3_omni_moe_for_conditional_generation_forward(
 
 
 # ================================================================
+# PATCH: Qwen3OmniMoeForConditionalGeneration.__init__
+# 1. [MoE] Propagate _moe_implementation from top-level config down to thinker_config
+#    and text_config before the thinker model is built
+# ================================================================
+def qwen3_omni_moe_for_conditional_generation_init(
+    self: hf_qwen3_omni_moe.Qwen3OmniMoeForConditionalGeneration,
+    config,
+):
+    # [MoE] Propagate _moe_implementation so SparseMoeBlock picks up the correct mode.
+    moe_implementation = getattr(config, "_moe_implementation", "eager")
+    config.thinker_config._moe_implementation = moe_implementation
+    config.thinker_config.text_config._moe_implementation = moe_implementation
+    super(hf_qwen3_omni_moe.Qwen3OmniMoeForConditionalGeneration, self).__init__(config)
+
+    self.thinker = hf_qwen3_omni_moe.Qwen3OmniMoeThinkerForConditionalGeneration._from_config(config.thinker_config)
+    self.has_talker = config.enable_audio_output
+    if self.has_talker:
+        self.enable_talker()
+    self.post_init()
+
+
+# ================================================================
+# NEW: Qwen3OmniMoeThinkerExperts
+# Stacked expert weights for fused MoE forward in Qwen3-Omni-MoE thinker layers.
+# Used when _moe_implementation == "fused".
+# ================================================================
+class Qwen3OmniMoeThinkerExperts(nn.Module):
+    """Stacked expert weights for fused MoE forward in Qwen3-Omni-MoE thinker layers.
+
+    Stores all expert weights as 3-D tensors (num_experts, out, in) so that
+    the fused MoE kernel and Expert Parallelism can operate on them directly.
+    The parameter names match the merged-checkpoint convention:
+      *.mlp.experts.gate_proj, *.mlp.experts.up_proj, *.mlp.experts.down_proj
+    """
+
+    def __init__(self, config) -> None:
+        super().__init__()
+        from transformers.activations import ACT2FN
+
+        num_experts = config.num_experts
+        intermediate_size = config.moe_intermediate_size
+        hidden_size = config.hidden_size
+        # Shape convention (same as fused_moe_forward expectation):
+        #   gate_proj / up_proj : (num_experts, intermediate_size, hidden_size)
+        #   down_proj            : (num_experts, hidden_size,       intermediate_size)
+        self.gate_proj = nn.Parameter(torch.empty(num_experts, intermediate_size, hidden_size))
+        self.up_proj = nn.Parameter(torch.empty(num_experts, intermediate_size, hidden_size))
+        self.down_proj = nn.Parameter(torch.empty(num_experts, hidden_size, intermediate_size))
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        routing_weights: torch.Tensor,
+        selected_experts: torch.Tensor,
+        num_experts: int,
+    ) -> torch.Tensor:
+        return fused_moe_forward(
+            module=self,
+            num_experts=num_experts,
+            routing_weights=routing_weights,
+            selected_experts=selected_experts,
+            hidden_states=hidden_states,
+            fc1_1_weight=self.gate_proj,  # (num_experts, intermediate_size, hidden_size)
+            fc1_2_weight=self.up_proj,  # (num_experts, intermediate_size, hidden_size)
+            fc2_weight=self.down_proj,  # (num_experts, hidden_size,       intermediate_size)
+        )
+
+
+# ================================================================
+# PATCH: Qwen3OmniMoeThinkerTextSparseMoeBlock.__init__ and forward
+# 1. [MoE/eager]  Original nn.ModuleList experts; raises error if EP is enabled
+# 2. [MoE/fused]  Qwen3OmniMoeThinkerExperts with stacked weights for fused MoE kernel and EP
+# ================================================================
+def qwen3_omni_moe_thinker_sparse_moe_block_init(
+    self: hf_qwen3_omni_moe.Qwen3OmniMoeThinkerTextSparseMoeBlock,
+    config,
+) -> None:
+    # Call grandparent (nn.Module) init to avoid re-running the original __init__
+    nn.Module.__init__(self)
+    self.num_experts = config.num_experts
+    self.top_k = config.num_experts_per_tok
+    self.norm_topk_prob = config.norm_topk_prob
+    self._moe_implementation = getattr(config, "_moe_implementation", "eager")
+
+    self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
+
+    if self._moe_implementation == "fused":
+        # experts sub-module holds stacked weights; its name "experts" ensures
+        # parameter FQNs align with the merged checkpoint and parallel_plan.
+        self.experts = Qwen3OmniMoeThinkerExperts(config)
+    elif self._moe_implementation == "eager":
+        self.experts = nn.ModuleList(
+            [
+                hf_qwen3_omni_moe.Qwen3OmniMoeThinkerTextMLP(config, intermediate_size=config.moe_intermediate_size)
+                for _ in range(self.num_experts)
+            ]
+        )
+    else:
+        raise ValueError(f"Invalid _moe_implementation: {self._moe_implementation!r}. Expected 'eager' or 'fused'.")
+
+
+def qwen3_omni_moe_thinker_sparse_moe_block_forward(
+    self: hf_qwen3_omni_moe.Qwen3OmniMoeThinkerTextSparseMoeBlock,
+    hidden_states: torch.Tensor,
+) -> torch.Tensor:
+    batch_size, sequence_length, hidden_dim = hidden_states.shape
+    hidden_states = hidden_states.view(-1, hidden_dim)
+    # router_logits: (batch * sequence_length, n_experts)
+    router_logits = self.gate(hidden_states)
+
+    routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+    routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+    if self.norm_topk_prob:
+        routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+    routing_weights = routing_weights.to(hidden_states.dtype)
+
+    if self._moe_implementation == "eager":
+        ps = get_parallel_state()
+        if ps.ep_enabled:
+            raise NotImplementedError(
+                "eager MoE does not support Expert Parallelism (EP). Set _moe_implementation='fused' to use EP."
+            )
+        final_hidden_states = torch.zeros(
+            (batch_size * sequence_length, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
+        )
+        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+        expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+        for expert_idx in expert_hit:
+            expert_layer = self.experts[expert_idx]
+            idx, top_x = torch.where(expert_mask[expert_idx].squeeze(0))
+            current_state = hidden_states[None, top_x].reshape(-1, hidden_dim)
+            current_hidden_states = expert_layer(current_state) * routing_weights[top_x, idx, None]
+            final_hidden_states.index_add_(0, top_x, current_hidden_states.to(hidden_states.dtype))
+    else:
+        # fused: delegate entirely to Qwen3OmniMoeThinkerExperts
+        final_hidden_states = self.experts(hidden_states, routing_weights, selected_experts, self.num_experts)
+
+    final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+    return final_hidden_states, router_logits
+
+
+# ================================================================
+# NEW: _get_parallel_plan
+# Provides the parallel execution plan for FSDP/SP/EP coordination
+# ================================================================
+def _get_parallel_plan(self):
+    from .parallel_plan import get_parallel_plan
+
+    return get_parallel_plan()
+
+
+# ================================================================
 # apply_veomni_qwen3_omni_moe_patch
 # Central entry point to apply all VeOmni patches to HF Qwen3OmniMoe classes
 # ================================================================
@@ -894,15 +1177,29 @@ def apply_veomni_qwen3_omni_moe_patch():
         "Qwen3OmniMoeVisionBlock",
     ]
 
+    # Patch parallel plan support
+    hf_qwen3_omni_moe.Qwen3OmniMoePreTrainedModel.get_parallel_plan = _get_parallel_plan
+
+    # Patch VisionAttention
+    hf_qwen3_omni_moe.Qwen3OmniMoeVisionAttention.forward = qwen3_omni_moe_vision_attention_forward
+
     # Patch VisionEncoder
     hf_qwen3_omni_moe.Qwen3OmniMoeVisionEncoder.forward = qwen3_omni_moe_vision_encoder_forward
     hf_qwen3_omni_moe.Qwen3OmniMoeVisionEncoder.dummy_forward = qwen3_omni_moe_vision_encoder_dummy_forward
+
+    # Patch AudioEncoder
+    hf_qwen3_omni_moe.Qwen3OmniMoeAudioEncoder.forward = qwen3_omni_moe_audio_encoder_forward
+    hf_qwen3_omni_moe.Qwen3OmniMoeAudioEncoder.dummy_forward = qwen3_omni_moe_audio_encoder_dummy_forward
 
     # Patch ThinkerTextModel
     hf_qwen3_omni_moe.Qwen3OmniMoeThinkerTextModel.forward = qwen3_omni_moe_thinker_text_model_forward
     hf_qwen3_omni_moe.Qwen3OmniMoeThinkerTextModel._deepstack_process = (
         qwen3_omni_moe_thinker_text_model_deepstack_process
     )
+
+    # Patch MoE block (eager/fused modes, EP support)
+    hf_qwen3_omni_moe.Qwen3OmniMoeThinkerTextSparseMoeBlock.__init__ = qwen3_omni_moe_thinker_sparse_moe_block_init
+    hf_qwen3_omni_moe.Qwen3OmniMoeThinkerTextSparseMoeBlock.forward = qwen3_omni_moe_thinker_sparse_moe_block_forward
 
     # Patch ThinkerForConditionalGeneration
     hf_qwen3_omni_moe.Qwen3OmniMoeThinkerForConditionalGeneration.__init__ = qwen3_omni_moe_thinker_init
@@ -914,15 +1211,6 @@ def apply_veomni_qwen3_omni_moe_patch():
     )
     hf_qwen3_omni_moe.Qwen3OmniMoeThinkerForConditionalGeneration.forward = qwen3_omni_moe_thinker_forward
 
-    # Patch ForConditionalGeneration (training-only simplified forward)
+    # Patch ForConditionalGeneration
+    hf_qwen3_omni_moe.Qwen3OmniMoeForConditionalGeneration.__init__ = qwen3_omni_moe_for_conditional_generation_init
     hf_qwen3_omni_moe.Qwen3OmniMoeForConditionalGeneration.forward = qwen3_omni_moe_for_conditional_generation_forward
-
-
-__all__ = [
-    "Qwen3OmniMoeForConditionalGeneration",
-    "Qwen3OmniMoeThinkerTextModel",
-    "Qwen3OmniMoeThinkerForConditionalGeneration",
-    "Qwen3OmniMoeTalkerForConditionalGeneration",
-    "Qwen3OmniMoeTalkerModel",
-    "apply_veomni_qwen3_omni_moe_patch",
-]


### PR DESCRIPTION
## What does this PR do?

> Remove redundant per-expert weight merging code in `scripts/moe_ckpt_merge/moe_merge.py` that was left behind after refactoring to support Qwen3-Omni models.
>
> The script previously had two merge passes: a new generic path (`_detect_moe_groups` + `_merge_experts_for_group`) that correctly handles flat MoE, thinker, and talker components, followed by old hardcoded logic that only handled `model.layers.*`. The old code was never cleaned up, causing:
> - **Omni models** (`Qwen3-Omni-30B`): `RuntimeError` because top-level config has no `num_experts`
> - **Flat MoE models** (`Qwen3-30B-A3B`): `KeyError` because the first pass already `pop`-ed the expert weights

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}`

### Test

> Verified that the new generic path correctly handles both `Qwen3-Omni-30B-A3B-Instruct` (thinker + talker MoE) and `Qwen3-30B-A3B-Instruct` (flat MoE) by dry-running config detection.

### Design & Code Changes

- Deleted the 34-line hardcoded expert merge loop in `main()` (lines 147–179 of the original file)
- All merge logic is now routed through `_detect_moe_groups()` + `_merge_experts_for_group()`, which handles flat, thinker, and talker MoE groups uniformly

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: script-level change, not feasible to test in CI without large model weights.