### PR TITLE
[misc] fix: remove duplicate expert merge logic in moe_merge.py

### DIFF
--- a/scripts/moe_ckpt_merge/moe_merge.py
+++ b/scripts/moe_ckpt_merge/moe_merge.py
@@ -144,40 +144,6 @@ def main(raw_hf_path, merge_hf_path):
     for group in moe_groups:
         _merge_experts_for_group(new_state_dict, group)
 
-    if hasattr(config, "num_experts"):
-        # qwen3moe
-        num_experts = config.num_experts
-    elif hasattr(config, "n_routed_experts"):
-        # deepseek
-        num_experts = config.n_routed_experts
-    else:
-        raise RuntimeError("could not find how many experts to assign")
-    num_hidden_layers = config.num_hidden_layers
-
-    if hasattr(config, "first_k_dense_replace"):
-        # deepseek first k dense layer
-        moe_layer_start_idx = config.first_k_dense_replace
-    else:
-        # moe layer only in the model
-        moe_layer_start_idx = 0
-
-    for i in range(moe_layer_start_idx, num_hidden_layers):
-        gate_proj = []
-        for j in range(num_experts):
-            gate_proj.append(new_state_dict.pop(f"model.layers.{i}.mlp.experts.{j}.gate_proj.weight"))
-
-        new_state_dict[f"model.layers.{i}.mlp.experts.gate_proj"] = torch.stack(gate_proj)
-        up_proj = []
-        for j in range(num_experts):
-            up_proj.append(new_state_dict.pop(f"model.layers.{i}.mlp.experts.{j}.up_proj.weight"))
-
-        new_state_dict[f"model.layers.{i}.mlp.experts.up_proj"] = torch.stack(up_proj)
-        down_proj = []
-        for j in range(num_experts):
-            down_proj.append(new_state_dict.pop(f"model.layers.{i}.mlp.experts.{j}.down_proj.weight"))
-
-        new_state_dict[f"model.layers.{i}.mlp.experts.down_proj"] = torch.stack(down_proj)
-
     model_assets = [config, tokenizer]
     save_model_weights(merge_hf_path, new_state_dict, model_assets=model_assets)
 


### PR DESCRIPTION
### What does this PR do?

> Remove redundant per-expert weight merging code in `scripts/moe_ckpt_merge/moe_merge.py` that was left behind after refactoring to support Qwen3-Omni models.
>
> The script previously had two merge passes: a new generic path (`_detect_moe_groups` + `_merge_experts_for_group`) that correctly handles flat MoE, thinker, and talker components, followed by old hardcoded logic that only handled `model.layers.*`. The old code was never cleaned up, causing:
> - **Omni models** (`Qwen3-Omni-30B`): `RuntimeError` because top-level config has no `num_experts`
> - **Flat MoE models** (`Qwen3-30B-A3B`): `KeyError` because the first pass already `pop`-ed the expert weights

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}`

### Test

> Verified that the new generic path correctly handles both `Qwen3-Omni-30B-A3B-Instruct` (thinker + talker MoE) and `Qwen3-30B-A3B-Instruct` (flat MoE) by dry-running config detection.

### Design & Code Changes

- Deleted the 34-line hardcoded expert merge loop in `main()` (lines 147–179 of the original file)
- All merge logic is now routed through `_detect_moe_groups()` + `_merge_experts_for_group()`, which handles flat, thinker, and talker MoE groups uniformly

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: script-level change, not feasible to test in CI without large model weights.