### PR TITLE
[misc] fix: save processor in MoE checkpoint merge script

### DIFF
--- a/scripts/moe_ckpt_merge/moe_merge.py
+++ b/scripts/moe_ckpt_merge/moe_merge.py
@@ -128,7 +128,10 @@ def main(raw_hf_path, merge_hf_path):
 
     config = AutoConfig.from_pretrained(raw_hf_path)
     tokenizer = build_tokenizer(raw_hf_path)
-    processor = build_processor(raw_hf_path)
+    try:
+        processor = build_processor(raw_hf_path)
+    except Exception:
+        processor = None
 
     safetensor_files = list(glob(os.path.join(raw_hf_path, "*.safetensors")))
     safetensor_files.sort()
@@ -145,7 +148,7 @@ def main(raw_hf_path, merge_hf_path):
     for group in moe_groups:
         _merge_experts_for_group(new_state_dict, group)
 
-    model_assets = [config, tokenizer, processor]
+    model_assets = [asset for asset in [config, tokenizer, processor] if asset is not None]
     save_model_weights(merge_hf_path, new_state_dict, model_assets=model_assets)
 
 


### PR DESCRIPTION
### What does this PR do?

Fix `scripts/moe_ckpt_merge/moe_merge.py` missing processor save. Previously only `config` and `tokenizer` were included in `model_assets`, causing `preprocessor_config.json` and related processor files to be absent from the merged checkpoint output.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `core`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, torch, liger-kernals,fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, torch, liger-kernals] feat: dynamic batching`

### Test

Verified the merged checkpoint directory now contains `preprocessor_config.json` and all processor-related files after running the script on a Qwen3-Omni-MoE checkpoint.

### API and Usage Example

No API changes. Script usage unchanged:

```bash
python scripts/moe_ckpt_merge/moe_merge.py \
    --raw_hf_path /path/to/raw_checkpoint \
    --merge_hf_path /path/to/merged_checkpoint
```

### Design & Code Changes

- Import `build_processor` from `veomni.models`
- Load `processor = build_processor(raw_hf_path)` alongside config and tokenizer
- Add `processor` to `model_assets` so `save_model_weights` calls `processor.save_pretrained(output_dir)`

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
