### PR TITLE
[task, model] fix: update import in train_qwen3_omni to use VeOmni subclass

### DIFF
--- a/tasks/omni/train_qwen3_omni.py
+++ b/tasks/omni/train_qwen3_omni.py
@@ -27,7 +27,7 @@ from veomni.distributed.parallel_state import get_parallel_state, init_parallel_
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models import build_foundation_model, build_processor, save_model_assets
 from veomni.models.transformers.qwen3_omni_moe.modeling_qwen3_omni_moe import (
-    Qwen3OmniMoePreTrainedModelForConditionalGeneration,
+    Qwen3OmniMoeForConditionalGeneration,
 )
 from veomni.optim import build_lr_scheduler, build_optimizer
 from veomni.utils import helper
@@ -94,7 +94,7 @@ def main():
     )
 
     logger.info_rank0("Prepare model")
-    model: Qwen3OmniMoePreTrainedModelForConditionalGeneration = build_foundation_model(
+    model: Qwen3OmniMoeForConditionalGeneration = build_foundation_model(
         config_path=args.model.config_path,
         weights_path=args.model.model_path,
         init_device=args.train.init_device,


### PR DESCRIPTION
### What does this PR do?

> Fix incorrect import in `tasks/omni/train_qwen3_omni.py`: replace `Qwen3OmniMoePreTrainedModelForConditionalGeneration` (which is not defined in VeOmni's modeling file) with the correct VeOmni subclass `Qwen3OmniMoeForConditionalGeneration`.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `core`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, torch, liger-kernals,fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, torch, liger-kernals] feat: dynamic batching`

### Test

> Import fix only; no behavioral change. Verified by checking that `Qwen3OmniMoeForConditionalGeneration` is exported from `veomni/models/transformers/qwen3_omni_moe/modeling_qwen3_omni_moe.py`.

### API and Usage Example

No API change.

### Design & Code Changes

- `tasks/omni/train_qwen3_omni.py`: replace import and type annotation from `Qwen3OmniMoePreTrainedModelForConditionalGeneration` → `Qwen3OmniMoeForConditionalGeneration`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: import-only fix, no logic change.
