### PR TITLE
[docs] fix: fix images not rendering on GitHub in ulysses.md

### DIFF
--- a/docs/key_features/ulysses.md
+++ b/docs/key_features/ulysses.md
@@ -45,20 +45,12 @@ Sequence Parallel (SP) serves as a prevalent strategy to handle long sequences t
 
 Suppose we have P GPUs and a sequence whose shape is [S, H], where N denotes the sequence length and d represents the hidden size (head num \* head dim). Each GPU initially holds the sequence's [S/P, H] partition. After performing an all_to_all communication, each GPU will get a head-splitting sequence whose shape is [S, H/P]. An illustration figure when P = 4 is as follows:
 
-```{image} ../assets/all_2_all.jpg
-:alt: all_to_all communication
-:width: 75%
-:align: center
-```
+![all_to_all communication](../assets/all_2_all.jpg)
 
 ### DeepSpeed-Ulysses
 We use the all_to_all based sequence parallelism which is proposed by DeepSpeed, named DeepSpeed-Ulysses.
 
-```{image} ../assets/ulysses.png
-:alt: DeepSpeed-Ulysses
-:width: 75%
-:align: center
-```
+![DeepSpeed-Ulysses](../assets/ulysses.png)
 
 (Image source: [DeepSpeed Ulysses: System Optimizations for Enabling Training of Extreme Long Sequence Transformer Models](https://arxiv.org/abs/2309.14509))
 


### PR DESCRIPTION
### What does this PR do?

> Fix two images in `docs/key_features/ulysses.md` that were not rendering on GitHub. The images used Sphinx/MyST `{image}` directive syntax which is not supported by GitHub's Markdown renderer. Replace them with standard Markdown `![]()` syntax.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: https://github.com/ByteDance-Seed/VeOmni/pulls?q=docs+image
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

Images now render correctly on GitHub after switching from Sphinx-style directives to standard Markdown image syntax.

### API and Usage Example

N/A

### Design & Code Changes

- `docs/key_features/ulysses.md`: Replace two `` ```{image} ``` `` Sphinx directives with standard Markdown `![]()` image syntax for GitHub compatibility.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: docs-only change, no code to test.
