### PR TITLE
[misc] chore: check if ckpt.load_path starts with ckpt.output_dir in post_init

### DIFF
--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -16,6 +16,7 @@ import json
 import math
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Dict, List, Literal, Optional
 
 from ..utils import logging
@@ -529,6 +530,15 @@ class TrainingArguments:
                 is_local_rank0=self.local_rank == 0,
                 ckpt_manager=ckpt.manager,
             )
+
+        if ckpt.load_path:
+            load_path = Path(os.path.normpath(os.path.abspath(ckpt.load_path)))
+            output_dir = Path(os.path.normpath(os.path.abspath(ckpt.output_dir)))
+
+            try:
+                load_path.relative_to(output_dir)
+            except ValueError:
+                logger.warning("load_checkpoint_path should be under output_dir.")
 
         # output_dir/
         # ├── checkpoints/          # DCP training checkpoints (model + optimizer + extra_state)


### PR DESCRIPTION
In class TrainingArguments, check if "load_checkpoint_path" starts with "output_dir", forcing VeOmni to load checkpoints from output_dir (previous saved checkpoint).