### PR TITLE
[data] fix: defer DataCollatorWithPositionIDs instantiation to avoid import-time error

### DIFF
--- a/veomni/data/dynamic_batching.py
+++ b/veomni/data/dynamic_batching.py
@@ -67,7 +67,7 @@ class DynamicBatchingSizeDataset(IterableDataset):
         dataset: IterableDataset,
         micro_batch_seq_length: int,
         ready_for_micro_batch_threshold: int,
-        dynamic_batching_collate_fn: Optional[Callable] = DataCollatorWithPositionIDs(),
+        dynamic_batching_collate_fn: Optional[Callable] = None,
         save_by_idx: bool = True,
         get_length_fn: Optional[Callable] = len,
         force_generate_long_sequence: bool = False,
@@ -95,6 +95,8 @@ class DynamicBatchingSizeDataset(IterableDataset):
                 reconstruct the buffer from indices on resume.
         """
         self.dataset = dataset
+        if dynamic_batching_collate_fn is None:
+            dynamic_batching_collate_fn = DataCollatorWithPositionIDs()
         self.dynamic_batching_collate_fn = dynamic_batching_collate_fn
         self.ready_for_micro_batch_threshold = ready_for_micro_batch_threshold
         self.micro_batch_seq_length = micro_batch_seq_length


### PR DESCRIPTION
### What does this PR do?

Fix a crash that occurs when importing `veomni` before the distributed process group is initialized. `DynamicBatchingSizeDataset` had `DataCollatorWithPositionIDs()` as a default argument value, which Python evaluates at **class definition time** (i.e., at import time). `DataCollatorWithPositionIDs.__post_init__` calls `get_parallel_state()`, which requires the distributed environment to be set up — causing the following error when the module is imported before `dist.init_process_group`:

```
ValueError: The product of parallel sizes should be equal to the world size.
```

Fix: change the default to `None` and instantiate `DataCollatorWithPositionIDs()` lazily inside `__init__`.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}`

### Test

Reproducer: import `veomni` (or any module that transitively imports `dynamic_batching`) in a process where `dist.init_process_group` has not yet been called. Before this fix the import raises `ValueError`; after this fix it succeeds.

### API and Usage Example

No API change. The default collator remains `DataCollatorWithPositionIDs()`, but it is now instantiated per-object inside `__init__` instead of at class definition time.

### Design & Code Changes

- [veomni/data/dynamic_batching.py](veomni/data/dynamic_batching.py):
  - Change default of `dynamic_batching_collate_fn` from `DataCollatorWithPositionIDs()` → `None`.
  - Instantiate `DataCollatorWithPositionIDs()` inside `__init__` when the argument is `None`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `make commit && make style && make quality`
- [ ] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: the fix prevents an import-time crash; existing CI import/initialization order covers this.

