### PR TITLE
[ckpt] fix: Add missing broadcast_model_weights_from_rank0 option for build_parallelize_model()

### DIFF
--- a/docs/usage/support_new_models/guide_and_checklist.md
+++ b/docs/usage/support_new_models/guide_and_checklist.md
@@ -3,7 +3,7 @@
 **TLDR:** VeOmni patches HuggingFace models at runtime to add FSDP, Sequence Parallelism (SP), Expert Parallelism (EP), and fused kernels. This guide walks you through the integration steps with checklists per model type. For worked examples, see:
 - [qwen3_vl_example.md](./qwen3_vl_example.md) — VLM + MoE (image/video, deepstack, EP)
 - [qwen3_omni_moe_example.md](./qwen3_omni_moe_example.md) — Omni-modal MoE (image/video/audio, talker)
- 
+
 > **Scope note:** This guide currently targets the **transformers v4** integration/patchgen flow.
 > **TODO:** Add a dedicated **transformers v5** section, since modeling code patchgen requires a slightly different approach.
 

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -467,6 +467,13 @@ class TrainingArguments:
         )
         if acc.fsdp_config.fsdp_mode == "fsdp2":
             assert self.init_device == "meta", "Please use init_device: meta for FSDP2 training"
+        else:
+            if self.broadcast_model_weights_from_rank0:
+                logger.warning_rank0(
+                    "Ignoring train.broadcast_model_weights_from_rank0=True because it is only "
+                    "used with train.accelerator.fsdp_config.fsdp_mode='fsdp2'. "
+                    f"Received fsdp_mode={acc.fsdp_config.fsdp_mode!r}. Disable this flag or switch to fsdp2.",
+                )
 
     def _derive_batch_config(self):
         acc = self.accelerator

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -325,6 +325,7 @@ class BaseTrainer(Stateful, ABC):
             ),
             enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
             enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
+            broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
         )
         self.model.train()
 


### PR DESCRIPTION
### What does this PR do?

Add missing broadcast_model_weights_from_rank0 option for build_parallelize_model(). This argument is used for fsdp2 setup only. This is the updated version of PR https://github.com/ByteDance-Seed/VeOmni/pull/545, after the refactoring.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: Argument was added in https://github.com/ByteDance-Seed/VeOmni/pull/123.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`
  - If this PR involves multiple modules, separate them with `,` like `[ci, data, model]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][parallel, model] feat: dynamic batching`

### API and Usage Example

No API changes. This PR enables the `broadcast_model_weights_from_rank0` functionality and thus the `train:broadcast_model_weights_from_rank0` field in yaml config.

### Design & Code Changes

In `/veomni/VeOmni/veomni/trainer/base.py` L327, add the argument to `build_parallelize_model()`.
```
broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
```  
If not passed, the argument will be None, and the broadcasting from rank0 will not be used regardless of the `train:broadcast_model_weights_from_rank0` config field.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md?plain=1#L22): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/ByteDance-Seed/VeOmni/blob/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/ByteDance-Seed/VeOmni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
