### PR TITLE
[model] fix: correct audio projection layer for Qwen3-Omni-MoE in VLM trainer

### DIFF
--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -145,7 +145,11 @@ class VLMTrainer:
 
         if args.train.freeze_audio_tower and model_config.model_type in ("qwen2_5_omni", "qwen3_omni_moe"):
             self.base.model.thinker.audio_tower.requires_grad_(False)
-            self.base.model.thinker.audio_tower.proj.requires_grad_(True)
+            # Qwen2.5-Omni uses audio_tower.proj; Qwen3-Omni-MoE uses audio_tower.proj1.
+            audio_proj = (
+                getattr(self.base.model.thinker.audio_tower, "proj1", None) or self.base.model.thinker.audio_tower.proj
+            )
+            audio_proj.requires_grad_(True)
 
         pretty_print_trainable_parameters(self.base.model)
         helper.print_device_mem_info("VRAM usage after building model")


### PR DESCRIPTION
### What does this PR do?

> Fix the `freeze_audio_tower` logic in `VLMTrainer` to support Qwen3-Omni-MoE, which uses `audio_tower.proj1` instead of `audio_tower.proj` (used by Qwen2.5-Omni). Previously, training Qwen3-Omni-MoE with `freeze_audio_tower=True` would fail with an `AttributeError` because the model does not have `audio_tower.proj`.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] PR title follows `[{modules}] {type}: {description}` format

### Test

> Verified that Qwen3-Omni-MoE training with `freeze_audio_tower=True` no longer raises an `AttributeError` and correctly unfreezes `audio_tower.proj1`.

### API and Usage Example

> No API changes. Existing configs work as before.

### Design & Code Changes

> In `veomni/trainer/vlm_trainer.py`, the audio projection layer is now resolved dynamically:
> - Try `audio_tower.proj1` first (Qwen3-Omni-MoE)
> - Fall back to `audio_tower.proj` (Qwen2.5-Omni)
>
> This ensures `requires_grad_(True)` is applied to the correct projection layer regardless of model variant.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [ ] Applied pre-commit checks
- [ ] Added/updated documentation
- [ ] Added tests to CI workflow (or explained why not feasible)
