### PR TITLE
[data] fix: fallback to "source" key when "source_name" is missing in data transform

### DIFF
--- a/veomni/data/data_transform.py
+++ b/veomni/data/data_transform.py
@@ -211,7 +211,7 @@ def process_sample_qwen2_5_vl(
     from .multimodal.image_utils import fetch_images
     from .multimodal.video_utils import fetch_videos
 
-    source = kwargs.get("source_name") or sample.get("source_name") or sample.get("source")
+    source = sample.get("source") or sample.get("source_name") or kwargs.get("source_name")
 
     if "conversations" in sample and sample["conversations"] is not None and len(sample["conversations"]) > 0:
         conversations = sample["conversations"]
@@ -273,7 +273,7 @@ def process_sample_qwen3_vl(
     from .multimodal.image_utils import fetch_images
     from .multimodal.video_utils import fetch_videos_metadata
 
-    source = kwargs.get("source_name") or sample.get("source_name") or sample.get("source")
+    source = sample.get("source") or sample.get("source_name") or kwargs.get("source_name")
 
     if "conversations" in sample and sample["conversations"] is not None and len(sample["conversations"]) > 0:
         conversations = sample["conversations"]
@@ -371,7 +371,7 @@ def process_sample_qwen_omni(
 
     image_token_id, video_token_id, audio_token_id = get_omni_token_ids(processor)
 
-    source = kwargs.get("source_name") or sample.get("source_name") or sample.get("source")
+    source = sample.get("source") or sample.get("source_name") or kwargs.get("source_name")
     conversations = (
         sample["conversations"] if ("conversations" in sample and len(sample["conversations"]) > 0) else sample
     )


### PR DESCRIPTION
### What does this PR do?

> Fix `KeyError` in `process_sample_qwen2_5_vl`, `process_sample_qwen3_vl`, and `process_sample_qwen_omni` when the input sample has neither `kwargs["source_name"]` nor `sample["source_name"]`. The source name lookup now gracefully falls back to `sample["source"]`.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [x] PR title follows `[{modules}] {type}: {description}` format

### Test

> Existing data transform tests should pass. This change only adds a fallback path for the `source` field lookup.

### Design & Code Changes

- Changed 3 occurrences in `veomni/data/data_transform.py` (lines 214, 276, 374):
  - **Before:** `source = kwargs["source_name"] if "source_name" in kwargs else sample["source_name"]`
  - **After:** `source = sample.get("source") or sample.get("source_name") or kwargs.get("source_name")`
- Priority: `sample["source"]` > `sample["source_name"]` > `kwargs["source_name"]`

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [ ] Applied pre-commit checks
- [ ] Added/updated documentation
- [ ] Added tests to CI workflow (or explained why not feasible)