### PR TITLE
[data] fix: prioritize kwargs source_name over sample fields in data transform

### DIFF
--- a/veomni/data/data_transform.py
+++ b/veomni/data/data_transform.py
@@ -211,7 +211,7 @@ def process_sample_qwen2_5_vl(
     from .multimodal.image_utils import fetch_images
     from .multimodal.video_utils import fetch_videos
 
-    source = sample.get("source") or sample.get("source_name") or kwargs.get("source_name")
+    source = kwargs.get("source_name") or sample.get("source") or sample.get("source_name")
 
     if "conversations" in sample and sample["conversations"] is not None and len(sample["conversations"]) > 0:
         conversations = sample["conversations"]
@@ -273,7 +273,7 @@ def process_sample_qwen3_vl(
     from .multimodal.image_utils import fetch_images
     from .multimodal.video_utils import fetch_videos_metadata
 
-    source = sample.get("source") or sample.get("source_name") or kwargs.get("source_name")
+    source = kwargs.get("source_name") or sample.get("source") or sample.get("source_name")
 
     if "conversations" in sample and sample["conversations"] is not None and len(sample["conversations"]) > 0:
         conversations = sample["conversations"]
@@ -371,7 +371,7 @@ def process_sample_qwen_omni(
 
     image_token_id, video_token_id, audio_token_id = get_omni_token_ids(processor)
 
-    source = sample.get("source") or sample.get("source_name") or kwargs.get("source_name")
+    source = kwargs.get("source_name") or sample.get("source") or sample.get("source_name")
     conversations = (
         sample["conversations"] if ("conversations" in sample and len(sample["conversations"]) > 0) else sample
     )


### PR DESCRIPTION
### What does this PR do?

> Fix source name resolution in `process_sample_qwen2_5_vl`, `process_sample_qwen3_vl`, and `process_sample_qwen_omni` for multi-source datasets. In PR #553, the fallback order was `sample["source"]` > `sample["source_name"]` > `kwargs["source_name"]`, which caused incorrect source assignment when mixing multiple datasets — the sample-level field could shadow the dataset-level `kwargs["source_name"]`. This PR corrects the priority to `kwargs["source_name"]` > `sample["source"]` > `sample["source_name"]`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: #553
- [x] PR title follows `[{modules}] {type}: {description}` format

### Test

> Existing data transform tests should pass. This change only reorders the fallback priority for the `source` field lookup.

### Design & Code Changes

- Changed 3 occurrences in `veomni/data/data_transform.py` (lines 214, 276, 374):
  - **Before:** `source = sample.get("source") or sample.get("source_name") or kwargs.get("source_name")`
  - **After:** `source = kwargs.get("source_name") or sample.get("source") or sample.get("source_name")`
- New priority: `kwargs["source_name"]` > `sample["source"]` > `sample["source_name"]`
- This ensures the dataset-level source name (passed via `kwargs`) takes precedence over per-sample fields, which is the correct behavior for multi-source dataset configurations.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [ ] Applied pre-commit checks
- [ ] Added/updated documentation
- [ ] Added tests to CI workflow (or explained why not feasible)