### PR TITLE
[ci] fix: Fix the count_flops CI for transformers v5.

### DIFF
--- a/.github/workflows/gpu_e2e_test.yml
+++ b/.github/workflows/gpu_e2e_test.yml
@@ -79,6 +79,8 @@ jobs:
         run: |
           uv sync --frozen --no-group transformers-stable --extra transformers5-exp --extra gpu --extra audio --group dev
       - name: Run models tests [transformers-v5]
+        # TODO: Run the following tests with proper `--no-group transformers-stable --extra transformers5-exp` to enable transformers v5.
+        # Currently those tests are effectively skipped (but it's not straightforward to enable due to L20 OOM).
         run: |
           uv run --frozen pytest -s -x tests/e2e/test_e2e_training.py
           uv run --frozen pytest -s -x tests/e2e/test_e2e_parallel.py

--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -110,6 +110,8 @@ jobs:
         run: |
           uv sync --frozen --no-group transformers-stable --extra transformers5-exp --extra gpu --extra audio --group dev
       - name: Run models tests [transformers-v5]
+        # TODO: Run the following tests with proper `--no-group transformers-stable --extra transformers5-exp` to enable transformers v5.
+        # Currently those tests are effectively skipped (but it's not straightforward to enable due to L20 OOM).
         run: |
           uv run  --frozen pytest -s -x tests/models/test_model_registry.py
           uv run --frozen pytest -s -x tests/models/test_models_patch.py
@@ -121,7 +123,7 @@ jobs:
         # TODO: run all tests under tests/utils/ once all util tests are verified
         run: |
           # Need v5 to support newer models like Qwen3.5 count flops tests.
-          uv run --frozen pytest -s -x tests/utils/test_count_flops.py
+          uv run --frozen --no-group transformers-stable --extra transformers5-exp pytest -s -x tests/utils/test_count_flops.py
       # TODO: Run other tests in transformers v5 env as well.
 
   cleanup:


### PR DESCRIPTION
Fix the CI problem introduced in https://github.com/ByteDance-Seed/VeOmni/pull/561

ALSO NOTE THAT we have the same bug in other v5 tests for now. To keep the change minimal, we will enable those tests later after solving the L20 OOM issue.