### PR TITLE
[ci] fix: disable pin_memory in multisource dataset test for NPU

### DIFF
--- a/tests/data/test_multisource_dataset.py
+++ b/tests/data/test_multisource_dataset.py
@@ -1,6 +1,7 @@
 import argparse
 import copy
 import dataclasses
+import gc
 import os
 import subprocess
 import sys
@@ -393,6 +394,13 @@ def _main_distributed_test():
         trainer.train()
         assert trainer.args.train.checkpoint.load_path is not None
         trainer.resume_train()
+        # Drop trainer and force GC so DataLoader workers / pin_memory thread
+        # exit before we tear down the process group. NPU/HCCL aborts if the
+        # ProcessGroup is destroyed while those threads are still alive.
+        del trainer
+        gc.collect()
+    if dist.is_initialized():
+        dist.destroy_process_group()
 
 
 def _make_simple_dataset(

--- a/tests/data/test_multisource_dataset.py
+++ b/tests/data/test_multisource_dataset.py
@@ -1,7 +1,6 @@
 import argparse
 import copy
 import dataclasses
-import gc
 import os
 import subprocess
 import sys
@@ -188,7 +187,11 @@ class TrainerTest(BaseTrainer):
             dyn_bsz_dataset_save_by_idx=False,
             num_workers=1,
             drop_last=args.data.dataloader.drop_last,
-            pin_memory=args.data.dataloader.pin_memory,
+            # Force pin_memory=False: on NPU the pin_memory background thread
+            # races with HCCL teardown (triggered inside destroy_distributed)
+            # and aborts the process with SIGABRT. The test uses DummyDataset
+            # so pin_memory provides no benefit anyway.
+            pin_memory=False,
             prefetch_factor=args.data.dataloader.prefetch_factor,
         )
 
@@ -394,13 +397,6 @@ def _main_distributed_test():
         trainer.train()
         assert trainer.args.train.checkpoint.load_path is not None
         trainer.resume_train()
-        # Drop trainer and force GC so DataLoader workers / pin_memory thread
-        # exit before we tear down the process group. NPU/HCCL aborts if the
-        # ProcessGroup is destroyed while those threads are still alive.
-        del trainer
-        gc.collect()
-    if dist.is_initialized():
-        dist.destroy_process_group()
 
 
 def _make_simple_dataset(


### PR DESCRIPTION

### What does this PR do?

> Fix NPU CI failure in `tests/data/test_multisource_dataset.py`. Test logic (checkpoint save/load + multi-source dataset resume comparison) passes on both GPU and NPU, but on NPU the `torchrun` worker aborts with SIGABRT after the final assertion:
>
> ```
> [INFO] dataset_a: 89 dataset_b: 78          # assertions passed
> terminate called without an active exception
> Exception in thread Thread-21 (_pin_memory_loop)
> ring is NULL / path string is NULL [ERROR] ... ERR99999
> exitcode: -6 (SIGABRT)
> ```
>
> https://github.com/ByteDance-Seed/VeOmni/actions/runs/24210625573/job/70678107433
>
> **Root cause**: `terminate called without an active exception` is raised when a joinable C++ `std::thread` is destroyed — here, the DataLoader's pin_memory worker. Flow:
>
> 1. `BaseTrainer.train()` ends with `self.destroy_distributed()` (`veomni/trainer/base.py:589`) which calls `dist.destroy_process_group()`.
> 2. On NPU, tearing down `ProcessGroupHCCL` invalidates torch_npu global state (`ring` / `path` become NULL) that the pin_memory thread is using to pin host tensors to the NPU device.
> 3. The pin_memory thread crashes on its next pin operation → `Exception in thread Thread-21 (_pin_memory_loop)`.
> 4. At interpreter shutdown, the underlying `std::thread` is still joinable → `std::terminate()` → SIGABRT.
>
> GPU/NCCL does not couple pinned-memory allocation with the ProcessGroup lifetime, so the same ordering is harmless there.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A
- PR title follows `[{modules}] {type}: {description}` format

### Test

> Cannot reproduce locally without Ascend hardware — relies on NPU CI for validation. GPU CI continues to pass (pin_memory has no effect on the DummyDataset test data, so there is no behavioral change on GPU).

### API and Usage Example

> N/A

### Design & Code Changes

> - `tests/data/test_multisource_dataset.py`: force `pin_memory=False` in `TrainerTest._build_dataloader()`. This eliminates the pin_memory background thread entirely, removing the HCCL-teardown / pin_memory race at the source. The test uses `DummyDataset` so pin_memory provides no benefit anyway.
> - Alternatives considered and rejected:
>   - Deferring `dist.destroy_process_group()` until after `del trainer` + `gc.collect()` in `_main_distributed_test` (initial attempt, commit `f9909a1`): this was a no-op because `BaseTrainer.train()` already destroys the process group internally before returning, so the explicit call at the end was short-circuited by `dist.is_initialized()` being `False`. Reverted in this PR.
>   - Overriding `TrainerTest.destroy_distributed` to defer PG destruction (Gemini review suggestion): would also work, but requires coordinated changes across two places and relies on `gc.collect()` synchronously joining the pin_memory thread. Disabling pin_memory at the source is simpler and strictly safer.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [ ] Applied pre-commit checks
- [ ] Added/updated documentation
- [ ] Added tests to CI workflow (or explained why not feasible)
