### PR TITLE
[parallel] fix: NPU Hang/Deadlock during DTensor parameter loading in FSDP2

### DIFF
--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -229,7 +229,12 @@ def _dispatch_parameter(
                 
         else:
             # Default execution path for GPUs or non-EP scenarios
-            tensor =
+            tensor = tensor.to(orig_tensor)
+            module._parameters[local_name].data.copy_(dtensor_factory(tensor, device_mesh, placements))
+            
+    else:  # not dtensor
+        tensor = tensor.to(device=orig_tensor.device, dtype=orig_tensor.dtype)
+        module._parameters[local_name].data.copy_(tensor.contiguous())
 
 
 def _dispatch_buffer(

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -194,13 +194,13 @@ def _dispatch_parameter(
 
         device_mesh = orig_tensor.device_mesh
         placements = orig_tensor.placements
-        
-        # Workaround for Ascend NPU: Implicit DTensor redistribute collective sync 
+
+        # Workaround for Ascend NPU: Implicit DTensor redistribute collective sync
         # triggers critical HCCL deadlocks during FSDP initialization.
         apply_npu_patch = False
         if orig_tensor.device.type == "npu" and parallel_plan is not None:
             apply_npu_patch = True
-        
+
         if apply_npu_patch:
             # Step 1: Perform manual mathematical chunking on CPU first.
             # This prevents NPU Out-Of-Memory (OOM) errors when dealing with large MoE parameters.
@@ -209,11 +209,13 @@ def _dispatch_parameter(
                     shard_dim = p.dim
                     my_mesh_rank = device_mesh.get_coordinate()[mesh_dim]
                     world_size = device_mesh.size(mesh_dim)
-                    
+
                     # Defensive check: ensure tensor size is sufficient for the requested world_size
                     if tensor.size(shard_dim) < world_size:
-                        raise ValueError(f"Tensor size {tensor.size(shard_dim)} on dim {shard_dim} is too small for world_size {world_size} on mesh dimension {mesh_dim} for parameter {full_param_name}")
-                    
+                        raise ValueError(
+                            f"Tensor size {tensor.size(shard_dim)} on dim {shard_dim} is too small for world_size {world_size} on mesh dimension {mesh_dim} for parameter {full_param_name}"
+                        )
+
                     shards = tensor.chunk(world_size, dim=shard_dim)
                     tensor = shards[my_mesh_rank]
 
@@ -226,12 +228,12 @@ def _dispatch_parameter(
                 target_local.copy_(tensor)
             else:
                 target_local.copy_(tensor.reshape(target_local.shape))
-                
+
         else:
             # Default execution path for GPUs or non-EP scenarios
             tensor = tensor.to(orig_tensor)
             module._parameters[local_name].data.copy_(dtensor_factory(tensor, device_mesh, placements))
-            
+
     else:  # not dtensor
         tensor = tensor.to(device=orig_tensor.device, dtype=orig_tensor.dtype)
         module._parameters[local_name].data.copy_(tensor.contiguous())

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -188,16 +188,44 @@ def _dispatch_parameter(
     if parallel_plan is not None:
         tensor = parallel_plan.shard_tensor(tensor, full_param_name, orig_tensor.shape)
 
-    tensor = tensor.to(orig_tensor)
     if hasattr(orig_tensor, "device_mesh"):  # dtensor
         if orig_tensor.device.type == "cpu":
             raise ValueError("Cannot load dtensor on CPU.")
 
         device_mesh = orig_tensor.device_mesh
         placements = orig_tensor.placements
-        module._parameters[local_name].data.copy_(dtensor_factory(tensor, device_mesh, placements))
+        apply_npu_patch = False
+
+        if orig_tensor.device.type == "npu":
+            if parallel_plan is not None:
+                apply_npu_patch = True
+        
+        if apply_npu_patch:
+            local_device = orig_tensor.device
+            tensor = tensor.to(device=local_device, dtype=orig_tensor.dtype)
+            target_local = orig_tensor.to_local()
+            
+            for mesh_dim, p in enumerate(placements):
+                if p.__class__.__name__ == "Shard":
+                    shard_dim = p.dim
+                    my_mesh_rank = device_mesh.get_coordinate()[mesh_dim]
+                    world_size = device_mesh.size(mesh_dim)
+                    
+                    shards = tensor.chunk(world_size, dim=shard_dim)
+                    tensor = shards[my_mesh_rank].contiguous()
+
+            if target_local.shape == tensor.shape:
+                target_local.copy_(tensor)
+            else:
+                target_local.copy_(tensor.reshape(target_local.shape))
+                
+        else:
+            tensor = tensor.to(orig_tensor)
+            module._parameters[local_name].data.copy_(dtensor_factory(tensor, device_mesh, placements))
+            
     else:  # not dtensor
-        module._parameters[local_name].data.copy_(tensor)
+        tensor = tensor.to(device=orig_tensor.device, dtype=orig_tensor.dtype)
+        module._parameters[local_name].data.copy_(tensor.contiguous())
 
 
 def _dispatch_buffer(

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -194,25 +194,33 @@ def _dispatch_parameter(
 
         device_mesh = orig_tensor.device_mesh
         placements = orig_tensor.placements
+        
+        # Workaround for Ascend NPU: Implicit DTensor redistribute collective sync 
+        # triggers critical HCCL deadlocks during FSDP initialization.
         apply_npu_patch = False
-
-        if orig_tensor.device.type == "npu":
-            if parallel_plan is not None:
-                apply_npu_patch = True
+        if orig_tensor.device.type == "npu" and parallel_plan is not None:
+            apply_npu_patch = True
         
         if apply_npu_patch:
-            local_device = orig_tensor.device
-            tensor = tensor.to(device=local_device, dtype=orig_tensor.dtype)
-            target_local = orig_tensor.to_local()
-            
+            # Step 1: Perform manual mathematical chunking on CPU first.
+            # This prevents NPU Out-Of-Memory (OOM) errors when dealing with large MoE parameters.
             for mesh_dim, p in enumerate(placements):
                 if p.__class__.__name__ == "Shard":
                     shard_dim = p.dim
                     my_mesh_rank = device_mesh.get_coordinate()[mesh_dim]
                     world_size = device_mesh.size(mesh_dim)
                     
+                    # Defensive check: ensure tensor size is sufficient for the requested world_size
+                    if tensor.size(shard_dim) < world_size:
+                        raise ValueError(f"Tensor size {tensor.size(shard_dim)} on dim {shard_dim} is too small for world_size {world_size} on mesh dimension {mesh_dim} for parameter {full_param_name}")
+                    
                     shards = tensor.chunk(world_size, dim=shard_dim)
-                    tensor = shards[my_mesh_rank].contiguous()
+                    tensor = shards[my_mesh_rank]
+
+            # Step 2: Safely move the sharded local chunk to the NPU physical device
+            # and perform a pure local copy to bypass dtensor_factory.
+            tensor = tensor.to(device=orig_tensor.device, dtype=orig_tensor.dtype).contiguous()
+            target_local = orig_tensor.to_local()
 
             if target_local.shape == tensor.shape:
                 target_local.copy_(tensor)
@@ -220,12 +228,8 @@ def _dispatch_parameter(
                 target_local.copy_(tensor.reshape(target_local.shape))
                 
         else:
-            tensor = tensor.to(orig_tensor)
-            module._parameters[local_name].data.copy_(dtensor_factory(tensor, device_mesh, placements))
-            
-    else:  # not dtensor
-        tensor = tensor.to(device=orig_tensor.device, dtype=orig_tensor.dtype)
-        module._parameters[local_name].data.copy_(tensor.contiguous())
+            # Default execution path for GPUs or non-EP scenarios
+            tensor =
 
 
 def _dispatch_buffer(


### PR DESCRIPTION
**Describe the bug**
When training VLM/MoE models on certain hardware backends (especially Ascend NPUs with HCCL), the program frequently hangs indefinitely during the weight loading phase. 

**Root Cause**
The original `_dispatch_parameter` uses `dtensor_factory` and then calls `.copy_()` on a flat parameter. When assigning a DTensor view to a flat parameter, PyTorch's `__torch_dispatch__` implicitly triggers a `Redistribute` collective communication. This uncoordinated implicit network communication disrupts the backend streams on NPU, causing permanent deadlocks.

**Proposed Solution**
This PR adds a defensive feature toggle for NPU environments to bypass implicit DTensor network communications:
* Extracts the local physical tensor using `.to_local()`.
* Manually parses the `placements` to perform pure mathematical `.chunk()`, assigning the correct shard based on the local mesh coordinate.
* Performs a pure local physical `.copy_()`.

This "physical bypass" effectively decouples the weight assignment from the distributed communication graph, completely resolving the deadlock while leaving the default GPU execution path untouched.