### PR TITLE
[docs] fix: list allowed modules and types in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,9 @@
 ### Checklist Before Starting
 
 - Search for relative PRs/issues and link here: ...
-- PR title follows `[{modules}] {type}: {description}` format (see [check_pr_title.yml](.github/workflows/check_pr_title.yml) for the full list of allowed modules and types)
+- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
+  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
+  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
   - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`
 
 ### Test


### PR DESCRIPTION
## Summary

- List the allowed modules and types directly in the PR template so contributors don't have to open `check_pr_title.yml` to find them.

## Test plan

- Visual inspection of the rendered PR template.

Made with [Cursor](https://cursor.com)