### PR TITLE
[ci] fix: fix ci port select error

### DIFF
--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -10,7 +10,7 @@ from veomni.models.auto import build_foundation_model
 from veomni.utils.device import get_device_type
 from veomni.utils.import_utils import is_diffusers_available, is_transformers_version_greater_or_equal_to
 
-from ..tools import DummyDataset, compare_metrics, print_comparison_table
+from ..tools import DummyDataset, build_torchrun_cmd, compare_metrics, print_comparison_table
 from .utils import prepare_exec_cmd
 
 
@@ -71,8 +71,9 @@ def main(
     )
     res = {}
     log_keys = []
-    for task_name, cmd in command_list:
+    for task_name, cmd_kwargs in command_list:
         print(f"{'-' * 10} {task_name} {'-' * 10}")
+        cmd = build_torchrun_cmd(**cmd_kwargs)
         subprocess.run(cmd, check=True)
         with open(os.path.join(test_path, f"{task_name}/log_dict.json")) as f:
             output = json.load(f)

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from ..tools import DummyDataset as DummyDataset
-from ..tools import ParallelConfig, build_torchrun_cmd
+from ..tools import ParallelConfig
 
 
 def parse_training_log(log_content) -> pd.DataFrame:
@@ -103,8 +103,12 @@ def prepare_exec_cmd(
     output_dir: str,
     is_moe: bool,
     max_sp_size: int | None = None,
-) -> list[tuple[str, list[str]]]:
-    """Build torchrun commands for every (task, parallel-mode) combination.
+) -> list[tuple[str, dict]]:
+    """Prepare torchrun command kwargs for every (task, parallel-mode) combination.
+
+    Port allocation is deferred to execution time to avoid TOCTOU races —
+    the caller must pass each dict to ``build_torchrun_cmd(**kwargs)`` right
+    before ``subprocess.run()``.
 
     Args:
         test_tasks: Script basenames under tests/train_scripts/ to run (e.g. ["train_text_test"]).
@@ -118,8 +122,8 @@ def prepare_exec_cmd(
             Use 1 to skip sp=2 when the model does not support sequence parallelism yet.
 
     Returns:
-        List of (task_name, command) tuples, where command is a list of strings
-        suitable for subprocess.run.
+        List of (task_name, cmd_kwargs) tuples, where cmd_kwargs is a dict of
+        keyword arguments for :func:`build_torchrun_cmd`.
     """
     model_modes: list[ParallelMode] = _base_model_modes() if not is_moe else _moe_model_modes()
     if max_sp_size is not None:
@@ -129,16 +133,15 @@ def prepare_exec_cmd(
     for task in test_tasks:
         for mode in model_modes:
             task_name = f"{model_name}_{task}_{mode}"
-            parallel_config = ParallelConfig(sp_size=mode.sp_size, ep_size=mode.ep_size, fsdp_mode="fsdp2")
-            command = build_torchrun_cmd(
+            cmd_kwargs = dict(
                 script=f"tests/train_scripts/{task}.py",
                 config_path=config_path,
                 model_path=model_path,
                 train_path=train_path,
                 output_dir=os.path.join(output_dir, task_name),
-                parallel_config=parallel_config,
+                parallel_config=ParallelConfig(sp_size=mode.sp_size, ep_size=mode.ep_size, fsdp_mode="fsdp2"),
                 nproc=mode.sp_size * 4,
             )
-            command_list.append((task_name, command))
+            command_list.append((task_name, cmd_kwargs))
 
     return command_list


### PR DESCRIPTION
### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

Commit did not select port on runtime https://github.com/ByteDance-Seed/VeOmni/commit/3af1776e, may get CI error like https://github.com/ByteDance-Seed/VeOmni/actions/runs/24335749677/job/71066806601?pr=644. Fix to finding free port before torchrun.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
