### PR TITLE
[dist] fix: use src_data_rank=None in load_model_weights to eliminate…

### DIFF
--- a/tests/utils/test_rank0_load_and_broadcast_weights.py
+++ b/tests/utils/test_rank0_load_and_broadcast_weights.py
@@ -34,6 +34,7 @@ class BroadcastTestArguments:
     weights_path: str = ""
     device_type: str = get_device_type()
     backend: str = get_dist_comm_backend()
+    mode: str = "broadcast"  # "broadcast" | "load_weights"
 
 
 @dataclass
@@ -122,7 +123,6 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
         extra_parallel_placement_innermost=args.train.accelerator.extra_parallel_placement_innermost,
         extra_parallel_names=args.train.accelerator.extra_parallel_names,
         dp_mode=args.train.accelerator.fsdp_config.fsdp_mode,
-        ep_outside=args.train.accelerator.ep_outside,
     )
 
     try:
@@ -229,6 +229,140 @@ def test_load_dist_model_weights_matches_standard(tmp_path: Path) -> None:
     assert result.returncode == 0
 
 
+def run_load_weights_test(args: Arguments) -> None:
+    """
+    Worker entrypoint for test_load_weights_no_scatter.
+
+    Verifies that load_model_weights (which now passes src_data_rank=None to
+    distribute_tensor) produces bit-for-bit identical parameters to a reference
+    single-rank load. This is the code path fixed in:
+    https://github.com/ByteDance-Seed/VeOmni/issues/637
+    """
+    weights_path = Path(args.test.weights_path)
+    if not weights_path.exists():
+        raise ValueError("`--test.weights_path` must point to an existing directory.")
+
+    get_torch_device().set_device(args.train.local_rank)
+    dist.init_process_group(backend=args.test.backend)
+
+    init_parallel_state(
+        dp_size=args.train.accelerator.dp_size,
+        dp_replicate_size=args.train.accelerator.dp_replicate_size,
+        dp_shard_size=args.train.accelerator.dp_shard_size,
+        tp_size=args.train.accelerator.tp_size,
+        pp_size=args.train.accelerator.pp_size,
+        cp_size=args.train.accelerator.cp_size,
+        ulysses_size=args.train.accelerator.ulysses_size,
+        extra_parallel_sizes=args.train.accelerator.extra_parallel_sizes,
+        extra_parallel_placement_innermost=args.train.accelerator.extra_parallel_placement_innermost,
+        extra_parallel_names=args.train.accelerator.extra_parallel_names,
+        dp_mode=args.train.accelerator.fsdp_config.fsdp_mode,
+    )
+
+    try:
+        # build_parallelize_model with weights_path triggers load_model_weights
+        # (the every-rank-reads-from-disk path, fixed in issue #637).
+        fsdp_model = build_parallelize_model(
+            TinyModel(),
+            weights_path=str(weights_path),
+            init_device=args.train.init_device,
+            mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
+            enable_gradient_checkpointing=False,
+            basic_modules=[],
+        )
+
+        reference_model = TinyModel().to(get_device_type())
+        load_model_weights(reference_model, str(weights_path), init_device=get_device_type())
+        reference_model = reference_model.cpu()
+
+        torch.testing.assert_close(
+            _clone_to_cpu(fsdp_model.get_input_embeddings().weight),
+            reference_model.get_input_embeddings().weight.detach().cpu(),
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            _clone_to_cpu(fsdp_model.get_output_embeddings().weight),
+            reference_model.get_output_embeddings().weight.detach().cpu(),
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            _clone_to_cpu(fsdp_model.linear1.weight),
+            reference_model.linear1.weight.detach().cpu(),
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            _clone_to_cpu(fsdp_model.linear1.bias),
+            reference_model.linear1.bias.detach().cpu(),
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            _clone_to_cpu(fsdp_model.linear2.weight),
+            reference_model.linear2.weight.detach().cpu(),
+            atol=0.0,
+            rtol=0.0,
+        )
+
+        torch.testing.assert_close(
+            _clone_to_cpu(fsdp_model.buffer),
+            reference_model.buffer.detach().cpu(),
+            atol=0.0,
+            rtol=0.0,
+        )
+
+        assert fsdp_model.get_input_embeddings().weight is fsdp_model.get_output_embeddings().weight
+
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+        from veomni.distributed import parallel_state as _ps
+
+        _ps._PARALLEL_STATE = None
+
+
+@pytest.mark.skipif(not dist.is_available(), reason="torch.distributed required")
+def test_load_weights_no_scatter(tmp_path: Path) -> None:
+    """
+    Regression test for https://github.com/ByteDance-Seed/VeOmni/issues/637.
+
+    Ensures load_model_weights with src_data_rank=None (all-ranks-read path)
+    loads bit-for-bit correct parameters into an FSDP2 model.
+    The rank0_load_and_broadcast_weights path is tested separately in
+    test_load_dist_model_weights_matches_standard.
+    """
+    checkpoint_dir = tmp_path / "ckpt"
+    weights_path = _write_checkpoint(checkpoint_dir)
+
+    world_size = 2
+    port = 12345 + random.randint(0, 100)
+    command = [
+        "torchrun",
+        f"--nproc_per_node={world_size}",
+        f"--master_port={port}",
+        "tests/utils/test_rank0_load_and_broadcast_weights.py",
+        "--model.config_path=test",
+        "--data.train_path=tests",
+        "--train.checkpoint.output_dir=.tests/cache",
+        "--train.accelerator.fsdp_config.fsdp_mode=fsdp2",
+        "--train.init_device=meta",
+        "--train.accelerator.fsdp_config.mixed_precision.enable=False",
+        "--train.gradient_checkpointing.enable=False",
+        f"--test.weights_path={weights_path}",
+        f"--test.device_type={get_device_type()}",
+        f"--test.backend={get_dist_comm_backend()}",
+        "--test.mode=load_weights",
+    ]
+
+    result = subprocess.run(command, check=True)
+    assert result.returncode == 0
+
+
 if __name__ == "__main__":
     args = parse_args(Arguments)
-    run_rank0_broadcast_test(args)
+    if getattr(args.test, "mode", "broadcast") == "load_weights":
+        run_load_weights_test(args)
+    else:
+        run_rank0_broadcast_test(args)

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -344,12 +344,10 @@ def parallelize_model_fsdp2(
     #        Apply embed parallelism (slice embed tensors [64,H] -> [16,H])
     if parallel_state.any_extra_parallel_enabled:
         parallel_plan = model.get_parallel_plan()
-        assert parallel_plan is not None, (
-            "ExtraParallel needs parallel plan defined in the model! \
+        assert parallel_plan is not None, "ExtraParallel needs parallel plan defined in the model! \
             Please see veomni/models/transformers/qwen3_moe/parallel_plan.py for example of expert parallelism. \
             Please see tests/utils/test_extra_parallel_clip_grad_norm.py::test_clip_grad_norm_fsdp2_ep2_emb4 \
             for example of expert parallelism + embed parallelism."
-        )
         # Add SpecInfo to extra_parallel modules,
         #   e.g. embed_tokens.weight, decoder.regular_mlp, decoder.embed_tokens.weight, and decoder.moe.experts
         fqn2spec_info = parallel_plan.apply(model, parallel_state.extra_parallel_fsdp_device_mesh)
@@ -431,9 +429,9 @@ def parallelize_model_fsdp2(
         modules_to_ignore_in_mixed_precision = None
 
     if modules_to_ignore_in_mixed_precision:
-        assert isinstance(modules_to_ignore_in_mixed_precision, tuple), (
-            "modules_to_ignore_in_mixed_precision needs to be a tuple!"
-        )
+        assert isinstance(
+            modules_to_ignore_in_mixed_precision, tuple
+        ), "modules_to_ignore_in_mixed_precision needs to be a tuple!"
         mp_ignored_classes = modules_to_ignore_in_mixed_precision
         fsdp_kwargs_without_mp = dict(fsdp_kwargs)
         fsdp_kwargs_without_mp.pop("mp_policy", None)
@@ -566,7 +564,11 @@ def parallelize_model_fsdp2(
             rank0_load_and_broadcast_weights(model, weights_path, get_device_type(), dtensor_factory=distribute_tensor)
         else:
             logger.info_rank0("Every rank would read weights from disk and expect this to be slow!")
-            load_model_weights(model, weights_path, get_device_type(), dtensor_factory=distribute_tensor)
+            # Every rank independently reads the full checkpoint from disk, so dist.scatter() from
+            # rank 0 is redundant. src_data_rank=None performs a local tensor split with zero
+            # collective communication. See: https://github.com/ByteDance-Seed/VeOmni/issues/637
+            _dt_local_split = partial(distribute_tensor, src_data_rank=None)
+            load_model_weights(model, weights_path, get_device_type(), dtensor_factory=_dt_local_split)
 
     # Register grad norm clipping method for FSDP2
     from .fsdp2 import clip_grad_norm as clip_grad_norm_fn


### PR DESCRIPTION
… redundant scatter

Every rank already reads the full checkpoint from disk in the load_model_weights path. Passing src_data_rank=0 (the PyTorch default) triggers distribute_tensor → Shard._shard_tensor → mesh_scatter(), which sends chunks from rank 0 to ranks that already have identical data.

Fix: pass src_data_rank=None so PyTorch performs a local tensor split with zero collective communication, which is the correct API for the 'every rank holds the full tensor' case (available since PyTorch 2.1).

Scope: only the load_model_weights (all-ranks-read) path is changed. The rank0_load_and_broadcast_weights path legitimately needs src_data_rank=0 since only rank 0 reads the checkpoint there.

Impact:
- Startup time: -10% to -23% across 0.5B–14B models (A100 PCIe, 2-GPU)
- Fixes hard hang on backends without P2P IPC support (e.g. XCCL on PCIe)
- Bit-for-bit identical losses verified on 5 models (Qwen2/Qwen3/MoE)

Also:
- Adds test_load_weights_no_scatter regression test (PASSED, 2x A100)
- Fixes pre-existing ep_outside kwarg bug in test_rank0_load_and_broadcast_weights (ep_outside is not a param of init_parallel_state; base.py never passed it)

support log :
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.0.2

tests/utils/test_rank0_load_and_broadcast_weights.py::test_load_dist_model_weights_matches_standard PASSED [ 50%]
tests/utils/test_rank0_load_and_broadcast_weights.py::test_load_weights_no_scatter PASSED [100%]

======================== 2 passed, 1 warning in 18.97s =========================

Closes: https://github.com/ByteDance-Seed/VeOmni/issues/637

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
