### PR TITLE
[ci] chore: trigger gpu/npu ci only when lint check pass

### DIFF
--- a/.github/workflows/check_pr_lint.yml
+++ b/.github/workflows/check_pr_lint.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 permissions:
   contents: read
+
+env:
+  RUFF_VERSION: "0.13.2"
 
 jobs:
   check_pr_lint:
@@ -16,16 +20,26 @@ jobs:
       matrix:
         python-version: ["3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: .
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install ruff
-        run: pip install ruff
+        run: pip install ruff==${{ env.RUFF_VERSION }}
 
-      - name: Run ruff format and check
+      - name: Run ruff lint and format check
         run: |
-          pwd && ls -la
-          ruff check tasks tests veomni docs
-          ruff format --check tasks tests veomni docs
+          failed=0
+          ruff check tasks tests veomni docs || failed=1
+          ruff format --check tasks tests veomni docs || failed=1
+          if [ "$failed" -eq 1 ]; then
+            echo ""
+            echo "=========================================="
+            echo "  Fix: run 'make style && make quality'"
+            echo "  Ruff version: ${{ env.RUFF_VERSION }}"
+            echo "=========================================="
+            exit 1
+          fi

--- a/.github/workflows/gpu_e2e_test.yml
+++ b/.github/workflows/gpu_e2e_test.yml
@@ -38,7 +38,11 @@ env:
   NCCL_DEBUG: "WARN"
 
 jobs:
+  lint:
+    uses: ./.github/workflows/check_pr_lint.yml
+
   setup:
+    needs: lint
     if: github.repository_owner == 'ByteDance-Seed'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -38,7 +38,11 @@ env:
   NCCL_DEBUG: "WARN"
 
 jobs:
+  lint:
+    uses: ./.github/workflows/check_pr_lint.yml
+
   setup:
+    needs: lint
     if: github.repository_owner == 'ByteDance-Seed'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/npu_e2e_test.yml
+++ b/.github/workflows/npu_e2e_test.yml
@@ -33,7 +33,11 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    uses: ./.github/workflows/check_pr_lint.yml
+
   npu_e2e_tests:
+    needs: lint
     if: github.repository_owner == 'ByteDance-Seed'
     name: VeOmni Ascend test (self-host)
     runs-on: [self-hosted, npu-0]

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -33,7 +33,11 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    uses: ./.github/workflows/check_pr_lint.yml
+
   npu_unit_tests:
+    needs: lint
     if: github.repository_owner == 'ByteDance-Seed'
     name: VeOmni Ascend test (self-host)
     runs-on: [self-hosted, npu-0]


### PR DESCRIPTION
### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

trigger gpu/npu ci only when lint check pass

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
