### PR TITLE
[ci] fix: add -v for npu ut e2e test

### DIFF
--- a/.github/workflows/npu_e2e_test.yml
+++ b/.github/workflows/npu_e2e_test.yml
@@ -95,16 +95,16 @@ jobs:
           uv pip list
       - name: Run e2e training test
         run: |
-          uv run --frozen pytest -s -x tests/e2e/test_e2e_parallel.py
+          uv run --frozen pytest -v -s -x tests/e2e/test_e2e_parallel.py
       - name: Run FSDP equivalence tests
         run: |
-          uv run --frozen pytest -s -x tests/distributed/test_fsdp_equivalence.py
+          uv run --frozen pytest -v -s -x tests/distributed/test_fsdp_equivalence.py
       - name: Sync dependencies [transformers-v5]
         run: |
           uv sync --frozen --no-group transformers-stable --extra transformers5-exp --extra npu --extra audio --group dev
       - name: Run e2e tests [transformers-v5]
         run: |
-          uv run --frozen pytest -s -x tests/e2e/test_e2e_parallel.py
+          uv run --frozen pytest -v -s -x tests/e2e/test_e2e_parallel.py
       - name: Run FSDP equivalence tests [transformers-v5]
         run: |
-          uv run --frozen pytest -s -x tests/distributed/test_fsdp_equivalence.py
+          uv run --frozen pytest -v -s -x tests/distributed/test_fsdp_equivalence.py

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -93,47 +93,47 @@ jobs:
           uv pip list
       - name: Run parallel tests
         run: |
-          uv run --frozen pytest -s -x tests/parallel/ulysses/test_ulysses.py
-          uv run --frozen pytest -s -x tests/parallel/ulysses/test_all_gather.py
-          uv run --frozen pytest -s -x tests/parallel/ulysses/test_slice_input_tensor.py
-          uv run --frozen pytest -s -x tests/parallel/encoder_data_balance/test_balance_reverse.py
-          uv run --frozen pytest -s -x tests/parallel/encoder_data_balance/test_balance_sorting_algo.py
+          uv run --frozen pytest -v -s -x tests/parallel/ulysses/test_ulysses.py
+          uv run --frozen pytest -v -s -x tests/parallel/ulysses/test_all_gather.py
+          uv run --frozen pytest -v -s -x tests/parallel/ulysses/test_slice_input_tensor.py
+          uv run --frozen pytest -v -s -x tests/parallel/encoder_data_balance/test_balance_reverse.py
+          uv run --frozen pytest -v -s -x tests/parallel/encoder_data_balance/test_balance_sorting_algo.py
       - name: Run models tests
         run: |
-          uv run --frozen pytest -s -x tests/models/test_model_registry.py
-          uv run --frozen pytest -s -x tests/models/test_models_patch.py
-          uv run --frozen pytest -s -x tests/models/test_padded_packed_loss.py
+          uv run --frozen pytest -v -s -x tests/models/test_model_registry.py
+          uv run --frozen pytest -v -s -x tests/models/test_models_patch.py
+          uv run --frozen pytest -v -s -x tests/models/test_padded_packed_loss.py
       - name: Run fsdp2/extra_parallel+fsdp2 (e.g. ep+fsdp2, mb+fsdp2, ep+emb+fsdp2) clip grad norm test
         run: |
-          uv run --frozen pytest -s -x tests/utils/test_extra_parallel_clip_grad_norm.py
+          uv run --frozen pytest -v -s -x tests/utils/test_extra_parallel_clip_grad_norm.py
       - name: Run checkpoint callback unit tests
         run: |
-          uv run --frozen pytest -s -x tests/checkpoints/test_checkpoint_callback.py
+          uv run --frozen pytest -v -s -x tests/checkpoints/test_checkpoint_callback.py
       - name: Run e2e dcp save and load test
         run: |
-          uv run --frozen pytest -s -x tests/checkpoints/test_trainer_saveload.py
+          uv run --frozen pytest -v -s -x tests/checkpoints/test_trainer_saveload.py
       - name: Run distributed tests (dummy_forward)
         run: |
-          uv run --frozen pytest -s -x tests/distributed/test_dummy_forward.py
+          uv run --frozen pytest -v -s -x tests/distributed/test_dummy_forward.py
       - name: Run data tests
         run: |
-          uv run --frozen pytest -s -x tests/data
+          uv run --frozen pytest -v -s -x tests/data
       - name: Run ops tests
         run: |
-          uv run --frozen pytest -s -x tests/ops/test_comp.py
+          uv run --frozen pytest -v -s -x tests/ops/test_comp.py
       - name: Sync dependencies [transformers-v5]
         run: |
           uv sync --frozen --no-group transformers-stable --extra transformers5-exp --extra npu --extra audio --group dev
       - name: Run models tests [transformers-v5]
         run: |
-          uv run  --frozen pytest -s -x tests/models/test_model_registry.py
-          uv run --frozen pytest -s -x tests/models/test_models_patch.py
-          uv run --frozen pytest -s -x tests/models/test_vlm_trainer.py
+          uv run  --frozen pytest -v -s -x tests/models/test_model_registry.py
+          uv run --frozen pytest -v -s -x tests/models/test_models_patch.py
+          uv run --frozen pytest -v -s -x tests/models/test_vlm_trainer.py
       - name: Run Qwen3.5 GatedDeltaNet Ulysses SP tests [transformers-v5]
         if: steps.changes.outputs.qwen3_5_ulysses == 'true'
         run: |
-          uv run --frozen pytest -s -x tests/parallel/ulysses/test_qwen3_5_gated_deltanet_ulysses.py
+          uv run --frozen pytest -v -s -x tests/parallel/ulysses/test_qwen3_5_gated_deltanet_ulysses.py
       - name: Run utils tests [transformers-v5]
         run: |
           # Need v5 to support newer models like Qwen3.5 count flops tests.
-          uv run --frozen --no-group transformers-stable --extra transformers5-exp pytest -s -x tests/utils/test_count_flops.py
+          uv run --frozen --no-group transformers-stable --extra transformers5-exp pytest -v -s -x tests/utils/test_count_flops.py


### PR DESCRIPTION
### What does this PR do?

Add - v to the test cases of ut and e2e to display some details.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
