### PR TITLE
[model, ci] test: bitwise-equal HF vs veomni logits; fix bf16 MoE dtype divergences

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -94,6 +94,7 @@ jobs:
           uv run --frozen pytest -s -x tests/models/test_model_registry.py
           uv run --frozen pytest -s -x tests/models/test_models_patch.py
           uv run --frozen pytest -s -x tests/models/test_padded_packed_loss.py
+          uv run --frozen pytest -s -x tests/models/test_models_logits_equal.py
       - name: Run fsdp2/extra_parallel+fsdp2 (e.g. ep+fsdp2, mb+fsdp2, ep+emb+fsdp2) clip grad norm test
         run: |
           uv run --frozen pytest -s -x tests/utils/test_extra_parallel_clip_grad_norm.py

--- a/tests/models/test_models_logits_equal.py
+++ b/tests/models/test_models_logits_equal.py
@@ -8,6 +8,8 @@ from typing import Optional
 import pytest
 import torch
 
+from veomni.utils.device import IS_CUDA_AVAILABLE, empty_cache, get_device_type, get_torch_device
+
 # Importing `utils` now captures pristine HF class attributes (in its
 # `_PRISTINE_HF_CLASSES` snapshot) before any veomni import has a chance to
 # monkey-patch them. `apply_veomni_hf_unpatch()` restores them; we call it
@@ -93,7 +95,6 @@ CASES = [
 
 
 def _apply_determinism():
-    torch.backends.cuda.matmul.allow_tf32 = False
     torch.backends.cudnn.allow_tf32 = False
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
@@ -102,22 +103,22 @@ def _apply_determinism():
 
 def _release():
     gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+    if IS_CUDA_AVAILABLE:
+        empty_cache()
 
 
 def _build_hf_model(case: Case):
-    """Return a CUDA, eval-mode HF model randomly initialised from config."""
+    """Return a device-resident, eval-mode HF model randomly initialised from config."""
     from transformers import AutoConfig, AutoModelForCausalLM
 
     apply_veomni_hf_unpatch()
     config = AutoConfig.from_pretrained(case.path)
     torch.manual_seed(0)
-    torch.cuda.manual_seed_all(0)
-    # Init directly on CUDA so init-time buffers (e.g. rotary `inv_freq`) use
-    # the same arithmetic path as the veomni build, which allocates under
-    # `torch.device("cuda")` via its CustomizedModelingLoader.
-    with torch.device("cuda"):
+    get_torch_device().manual_seed_all(0)
+    # Init directly on device so init-time buffers (e.g. rotary `inv_freq`)
+    # use the same arithmetic path as the veomni build, which allocates under
+    # `torch.device(get_device_type())` via its CustomizedModelingLoader.
+    with torch.device(get_device_type()):
         model_hf = AutoModelForCausalLM.from_config(
             config,
             torch_dtype=_DTYPE_MAP[case.dtype],
@@ -127,7 +128,7 @@ def _build_hf_model(case: Case):
 
 
 def _build_veomni_model(case: Case, hf_state_dict):
-    """Return a CUDA, eval-mode veomni model with HF weights loaded."""
+    """Return a device-resident, eval-mode veomni model with HF weights loaded."""
     from veomni.models.auto import build_foundation_model
 
     model = build_foundation_model(
@@ -135,7 +136,7 @@ def _build_veomni_model(case: Case, hf_state_dict):
         weights_path=None,
         torch_dtype=case.dtype,
         attn_implementation=case.attn_implementation,
-        init_device="cuda",
+        init_device=get_device_type(),
     )
 
     if case.sync_weight_key is not None:
@@ -168,7 +169,7 @@ def test_logits_bitwise_equal(case: Case):
 
     if is_transformers_version_greater_or_equal_to("5.0.0"):
         pytest.skip("Scope is transformers v4 model definition only.")
-    if not torch.cuda.is_available():
+    if not IS_CUDA_AVAILABLE:
         pytest.skip("CUDA required.")
     if not os.path.isdir(case.path):
         pytest.skip(f"Path not found: {case.path}")
@@ -177,10 +178,11 @@ def test_logits_bitwise_equal(case: Case):
 
     _apply_determinism()
 
-    gen = torch.Generator(device="cuda").manual_seed(0)
+    device_type = get_device_type()
+    gen = torch.Generator(device=device_type).manual_seed(0)
     # Vocab floor of 32000 dodges special tokens across Qwen3 (151936),
     # Qwen3MoE (151936), and DeepseekV3 (129280).
-    input_ids = torch.randint(0, 32000, (1, 32), device="cuda", dtype=torch.long, generator=gen)
+    input_ids = torch.randint(0, 32000, (1, 32), device=device_type, dtype=torch.long, generator=gen)
 
     # --- HF phase (must precede any veomni model build) ---
     model_hf = _build_hf_model(case)

--- a/tests/models/test_models_logits_equal.py
+++ b/tests/models/test_models_logits_equal.py
@@ -1,0 +1,215 @@
+import copy
+import gc
+import importlib.util
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+import torch
+
+# Importing `utils` now captures pristine HF class attributes (in its
+# `_PRISTINE_HF_CLASSES` snapshot) before any veomni import has a chance to
+# monkey-patch them. `apply_veomni_hf_unpatch()` restores them; we call it
+# before every HF build so leaks from the previous test do not poison the
+# current one.
+from .utils import apply_veomni_hf_unpatch  # noqa: E402
+
+
+# Must be set before `import veomni` so GPU kernel patches remain gated off.
+# VEOMNI_USE_LIGER_KERNEL=0 disables Liger substitutions in qwen3 / qwen3_moe
+# / deepseek_v3 gpu_patch.py. VEOMNI_USE_FUSED_KERNELS=0 additionally disables
+# the deepseek_v3 Triton RoPE + batch-invariant RMSNorm path, which is the
+# default when Liger is off.
+os.environ.setdefault("VEOMNI_USE_LIGER_KERNEL", "0")
+os.environ.setdefault("VEOMNI_USE_FUSED_KERNELS", "0")
+os.environ.setdefault("RANK", "0")
+os.environ.setdefault("LOCAL_RANK", "0")
+os.environ.setdefault("WORLD_SIZE", "1")
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "12355")
+# Required by torch.use_deterministic_algorithms for cuBLAS.
+os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_DTYPE_MAP = {"float32": torch.float32, "bfloat16": torch.bfloat16}
+
+
+@dataclass(frozen=True)
+class Case:
+    """A test case pairing an HF model config with a veomni build.
+
+    HF is random-initialised from the toy config; its state dict is then
+    copied into the veomni model. `sync_weight_key` selects a layout
+    adapter from `tests/models/weight_sync_adapters.py`; needed for MoE
+    models whose veomni layout stacks experts into a single tensor.
+
+    `attn_implementation` is passed through to both HF and veomni. For
+    `"flash_attention_2"` the dtype must be bf16/fp16 (FA2 requirement),
+    so each case pairs an attention backend with the appropriate dtype.
+    """
+
+    case_id: str
+    path: str
+    sync_weight_key: Optional[str]
+    attn_implementation: str = "eager"
+    dtype: str = "float32"
+
+
+def _toy(name: str) -> str:
+    return os.path.join(REPO_ROOT, "tests", "toy_config", name)
+
+
+CASES = [
+    # eager + fp32
+    Case("qwen3-toy-eager", _toy("qwen3_toy"), sync_weight_key=None),
+    Case("qwen3_moe-toy-eager", _toy("qwen3_moe_toy"), sync_weight_key="qwen3_moe"),
+    Case("deepseek_v3-toy-eager", _toy("deepseek_v3_toy"), sync_weight_key="deepseek_v3"),
+    # flash_attention_2 + bf16 (FA2 does not support fp32)
+    Case(
+        "qwen3-toy-fa2",
+        _toy("qwen3_toy"),
+        sync_weight_key=None,
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+    Case(
+        "qwen3_moe-toy-fa2",
+        _toy("qwen3_moe_toy"),
+        sync_weight_key="qwen3_moe",
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+    Case(
+        "deepseek_v3-toy-fa2",
+        _toy("deepseek_v3_toy"),
+        sync_weight_key="deepseek_v3",
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+]
+
+
+def _apply_determinism():
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    torch.use_deterministic_algorithms(True, warn_only=True)
+
+
+def _release():
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def _build_hf_model(case: Case):
+    """Return a CUDA, eval-mode HF model randomly initialised from config."""
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    apply_veomni_hf_unpatch()
+    config = AutoConfig.from_pretrained(case.path)
+    torch.manual_seed(0)
+    torch.cuda.manual_seed_all(0)
+    # Init directly on CUDA so init-time buffers (e.g. rotary `inv_freq`) use
+    # the same arithmetic path as the veomni build, which allocates under
+    # `torch.device("cuda")` via its CustomizedModelingLoader.
+    with torch.device("cuda"):
+        model_hf = AutoModelForCausalLM.from_config(
+            config,
+            torch_dtype=_DTYPE_MAP[case.dtype],
+            attn_implementation=case.attn_implementation,
+        )
+    return model_hf.eval()
+
+
+def _build_veomni_model(case: Case, hf_state_dict):
+    """Return a CUDA, eval-mode veomni model with HF weights loaded."""
+    from veomni.models.auto import build_foundation_model
+
+    model = build_foundation_model(
+        config_path=case.path,
+        weights_path=None,
+        torch_dtype=case.dtype,
+        attn_implementation=case.attn_implementation,
+        init_device="cuda",
+    )
+
+    if case.sync_weight_key is not None:
+        from .weight_sync_adapters import get_sync_weight_func
+
+        sync_func = get_sync_weight_func(case.sync_weight_key)
+        assert sync_func is not None, f"no sync func for {case.sync_weight_key}"
+        sync_func(model.config, hf_state_dict, model)
+    else:
+        model.load_state_dict(hf_state_dict)
+
+    return model.eval()
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.case_id for c in CASES])
+def test_logits_bitwise_equal(case: Case):
+    """Verify veomni forward logits are bitwise identical to native HF.
+
+    Scope: transformers v4 model definition, single sequence, single GPU,
+    no GPU kernel patching (Liger + Triton fused kernels both disabled).
+    HF is random-initialised from the toy config; its state dict is synced
+    to veomni via the layout adapters.
+
+    Execution order is mandatory: the HF forward must run BEFORE any
+    veomni model build, because `build_foundation_model` triggers
+    `apply_veomni_*_patch` which monkey-patches HF module classes
+    process-wide.
+    """
+    from veomni.utils.import_utils import is_transformers_version_greater_or_equal_to
+
+    if is_transformers_version_greater_or_equal_to("5.0.0"):
+        pytest.skip("Scope is transformers v4 model definition only.")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required.")
+    if not os.path.isdir(case.path):
+        pytest.skip(f"Path not found: {case.path}")
+    if case.attn_implementation == "flash_attention_2" and importlib.util.find_spec("flash_attn") is None:
+        pytest.skip("flash_attn package not installed.")
+
+    _apply_determinism()
+
+    gen = torch.Generator(device="cuda").manual_seed(0)
+    # Vocab floor of 32000 dodges special tokens across Qwen3 (151936),
+    # Qwen3MoE (151936), and DeepseekV3 (129280).
+    input_ids = torch.randint(0, 32000, (1, 32), device="cuda", dtype=torch.long, generator=gen)
+
+    # --- HF phase (must precede any veomni model build) ---
+    model_hf = _build_hf_model(case)
+    with torch.no_grad():
+        logits_hf = model_hf(input_ids=input_ids, use_cache=False).logits.detach().clone()
+    hf_state_dict = copy.deepcopy(model_hf.state_dict())
+    del model_hf
+    _release()
+
+    # --- veomni phase ---
+    model_ve = _build_veomni_model(case, hf_state_dict)
+    with torch.no_grad():
+        logits_ve = model_ve(input_ids=input_ids, use_cache=False).logits.detach().clone()
+    del model_ve, hf_state_dict
+    _release()
+
+    assert logits_hf.shape == logits_ve.shape, (
+        f"[{case.case_id}] shape mismatch: hf={tuple(logits_hf.shape)} ve={tuple(logits_ve.shape)}"
+    )
+
+    if not torch.equal(logits_hf, logits_ve):
+        diff = (logits_hf.float() - logits_ve.float()).abs()
+        ne = logits_hf != logits_ve
+        n_mis = int(ne.sum().item())
+        total = logits_hf.numel()
+        max_abs = float(diff.max().item())
+        first_idx = torch.nonzero(ne, as_tuple=False)[:5].tolist()
+        raise AssertionError(
+            f"[{case.case_id}] logits not bitwise equal: "
+            f"{n_mis}/{total} mismatched, max_abs_diff={max_abs:.3e}, "
+            f"first_mismatch_indices={first_idx}"
+        )

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -240,17 +240,45 @@ import transformers.models.qwen3.modeling_qwen3 as _hf_qwen3  # noqa: E402
 import transformers.models.qwen3_moe.modeling_qwen3_moe as _hf_qwen3_moe  # noqa: E402
 
 
-_PRISTINE_HF_CLASSES = {
-    "qwen3.forward": _hf_qwen3.Qwen3ForCausalLM.forward,
-    "qwen3_moe.forward": _hf_qwen3_moe.Qwen3MoeForCausalLM.forward,
-    "qwen3_moe.MoeBlock": _hf_qwen3_moe.Qwen3MoeSparseMoeBlock,
-    "qwen3_moe.init_weights": _hf_qwen3_moe.Qwen3MoePreTrainedModel._init_weights,
-    "ds3.attn_fwd": _hf_ds3.DeepseekV3Attention.forward,
-    "ds3.lm_fwd": _hf_ds3.DeepseekV3ForCausalLM.forward,
-    "ds3.MoE": _hf_ds3.DeepseekV3MoE,
-    "ds3.init_weights": _hf_ds3.DeepseekV3PreTrainedModel._init_weights,
-    "ds3.rope_fwd": _hf_ds3.DeepseekV3RotaryEmbedding.forward,
-    "ds3.rmsnorm_fwd": _hf_ds3.DeepseekV3RMSNorm.forward,
+# Cover every patch site reachable from apply_veomni_*_patch() + the Liger
+# and Triton branches of apply_veomni_*_gpu_patch(). We capture:
+# - forward methods (undo in-class forward replacement, used by both the
+#   always-on patch and the Triton branch's _patch_rms_norm / RoPE forward)
+# - whole classes (undo module-level class swap done by the Liger branch
+#   and by DeepseekV3MoE / Qwen3MoeSparseMoeBlock replacements)
+# - module-level functions (apply_rotary_pos_emb is replaced by Liger)
+#
+# Restore order matters: we first reset in-class attributes on the pristine
+# class objects, then restore the module-level names. That way, even if a
+# prior test mutated `Class.forward` and then swapped in a Liger class at
+# the module level, both layers are reverted.
+_PRISTINE_HF = {
+    # qwen3
+    "qwen3.CausalLM.forward": _hf_qwen3.Qwen3ForCausalLM.forward,
+    "qwen3.SeqCls.forward": _hf_qwen3.Qwen3ForSequenceClassification.forward,
+    "qwen3.apply_rotary_pos_emb": _hf_qwen3.apply_rotary_pos_emb,
+    "qwen3.RMSNorm.cls": _hf_qwen3.Qwen3RMSNorm,
+    "qwen3.RMSNorm.forward": _hf_qwen3.Qwen3RMSNorm.forward,
+    "qwen3.MLP.cls": _hf_qwen3.Qwen3MLP,
+    # qwen3_moe
+    "qwen3_moe.CausalLM.forward": _hf_qwen3_moe.Qwen3MoeForCausalLM.forward,
+    "qwen3_moe.MoeBlock.cls": _hf_qwen3_moe.Qwen3MoeSparseMoeBlock,
+    "qwen3_moe.PreTrained.init_weights": _hf_qwen3_moe.Qwen3MoePreTrainedModel._init_weights,
+    "qwen3_moe.apply_rotary_pos_emb": _hf_qwen3_moe.apply_rotary_pos_emb,
+    "qwen3_moe.RMSNorm.cls": _hf_qwen3_moe.Qwen3MoeRMSNorm,
+    "qwen3_moe.RMSNorm.forward": _hf_qwen3_moe.Qwen3MoeRMSNorm.forward,
+    "qwen3_moe.MLP.cls": _hf_qwen3_moe.Qwen3MoeMLP,
+    # deepseek_v3
+    "ds3.Attention.forward": _hf_ds3.DeepseekV3Attention.forward,
+    "ds3.CausalLM.forward": _hf_ds3.DeepseekV3ForCausalLM.forward,
+    "ds3.MoE.cls": _hf_ds3.DeepseekV3MoE,
+    "ds3.PreTrained.init_weights": _hf_ds3.DeepseekV3PreTrainedModel._init_weights,
+    "ds3.apply_rotary_pos_emb": _hf_ds3.apply_rotary_pos_emb,
+    "ds3.RotaryEmb.cls": _hf_ds3.DeepseekV3RotaryEmbedding,
+    "ds3.RotaryEmb.forward": _hf_ds3.DeepseekV3RotaryEmbedding.forward,
+    "ds3.RMSNorm.cls": _hf_ds3.DeepseekV3RMSNorm,
+    "ds3.RMSNorm.forward": _hf_ds3.DeepseekV3RMSNorm.forward,
+    "ds3.MLP.cls": _hf_ds3.DeepseekV3MLP,
 }
 
 
@@ -258,20 +286,48 @@ def apply_veomni_hf_unpatch():
     """Undo in-place veomni monkey-patches on HF model modules.
 
     `apply_veomni_*_patch()` in each of `qwen3/`, `qwen3_moe/`, `deepseek_v3/`
-    mutates the HF model modules directly (e.g. swaps in PatchQwen3MoeSparseMoeBlock).
-    Without this restore, the first parametrize case to build a veomni model
-    leaks its patches into every subsequent HF build in the same test session.
+    mutates the HF model modules directly (forward swaps, class swaps, new
+    `get_parallel_plan` methods). Without this restore, the first parametrize
+    case to build a veomni model leaks its patches into every subsequent HF
+    build in the same test session.
     """
-    _hf_qwen3.Qwen3ForCausalLM.forward = _PRISTINE_HF_CLASSES["qwen3.forward"]
-    _hf_qwen3_moe.Qwen3MoeForCausalLM.forward = _PRISTINE_HF_CLASSES["qwen3_moe.forward"]
-    _hf_qwen3_moe.Qwen3MoeSparseMoeBlock = _PRISTINE_HF_CLASSES["qwen3_moe.MoeBlock"]
-    _hf_qwen3_moe.Qwen3MoePreTrainedModel._init_weights = _PRISTINE_HF_CLASSES["qwen3_moe.init_weights"]
-    _hf_ds3.DeepseekV3Attention.forward = _PRISTINE_HF_CLASSES["ds3.attn_fwd"]
-    _hf_ds3.DeepseekV3ForCausalLM.forward = _PRISTINE_HF_CLASSES["ds3.lm_fwd"]
-    _hf_ds3.DeepseekV3MoE = _PRISTINE_HF_CLASSES["ds3.MoE"]
-    _hf_ds3.DeepseekV3PreTrainedModel._init_weights = _PRISTINE_HF_CLASSES["ds3.init_weights"]
-    _hf_ds3.DeepseekV3RotaryEmbedding.forward = _PRISTINE_HF_CLASSES["ds3.rope_fwd"]
-    _hf_ds3.DeepseekV3RMSNorm.forward = _PRISTINE_HF_CLASSES["ds3.rmsnorm_fwd"]
+    # Step 1: restore in-class forward methods on pristine class objects.
+    # This handles both the always-on forward swaps and the Triton branch's
+    # in-class mutations (DeepseekV3RotaryEmbedding.forward / DeepseekV3RMSNorm.forward).
+    _PRISTINE_HF["qwen3.RMSNorm.cls"].forward = _PRISTINE_HF["qwen3.RMSNorm.forward"]
+    _PRISTINE_HF["qwen3_moe.RMSNorm.cls"].forward = _PRISTINE_HF["qwen3_moe.RMSNorm.forward"]
+    _PRISTINE_HF["ds3.RotaryEmb.cls"].forward = _PRISTINE_HF["ds3.RotaryEmb.forward"]
+    _PRISTINE_HF["ds3.RMSNorm.cls"].forward = _PRISTINE_HF["ds3.RMSNorm.forward"]
+
+    _hf_qwen3.Qwen3ForCausalLM.forward = _PRISTINE_HF["qwen3.CausalLM.forward"]
+    _hf_qwen3.Qwen3ForSequenceClassification.forward = _PRISTINE_HF["qwen3.SeqCls.forward"]
+    _hf_qwen3_moe.Qwen3MoeForCausalLM.forward = _PRISTINE_HF["qwen3_moe.CausalLM.forward"]
+    _hf_qwen3_moe.Qwen3MoePreTrainedModel._init_weights = _PRISTINE_HF["qwen3_moe.PreTrained.init_weights"]
+    _hf_ds3.DeepseekV3Attention.forward = _PRISTINE_HF["ds3.Attention.forward"]
+    _hf_ds3.DeepseekV3ForCausalLM.forward = _PRISTINE_HF["ds3.CausalLM.forward"]
+    _hf_ds3.DeepseekV3PreTrainedModel._init_weights = _PRISTINE_HF["ds3.PreTrained.init_weights"]
+
+    # Step 2: restore module-level names for classes / functions that the
+    # Liger branch swaps out wholesale, plus the class swaps done by the
+    # always-on patch (Qwen3MoeSparseMoeBlock, DeepseekV3MoE).
+    _hf_qwen3.apply_rotary_pos_emb = _PRISTINE_HF["qwen3.apply_rotary_pos_emb"]
+    _hf_qwen3.Qwen3RMSNorm = _PRISTINE_HF["qwen3.RMSNorm.cls"]
+    _hf_qwen3.Qwen3MLP = _PRISTINE_HF["qwen3.MLP.cls"]
+    _hf_qwen3_moe.Qwen3MoeSparseMoeBlock = _PRISTINE_HF["qwen3_moe.MoeBlock.cls"]
+    _hf_qwen3_moe.apply_rotary_pos_emb = _PRISTINE_HF["qwen3_moe.apply_rotary_pos_emb"]
+    _hf_qwen3_moe.Qwen3MoeRMSNorm = _PRISTINE_HF["qwen3_moe.RMSNorm.cls"]
+    _hf_qwen3_moe.Qwen3MoeMLP = _PRISTINE_HF["qwen3_moe.MLP.cls"]
+    _hf_ds3.DeepseekV3MoE = _PRISTINE_HF["ds3.MoE.cls"]
+    _hf_ds3.apply_rotary_pos_emb = _PRISTINE_HF["ds3.apply_rotary_pos_emb"]
+    _hf_ds3.DeepseekV3RotaryEmbedding = _PRISTINE_HF["ds3.RotaryEmb.cls"]
+    _hf_ds3.DeepseekV3RMSNorm = _PRISTINE_HF["ds3.RMSNorm.cls"]
+    _hf_ds3.DeepseekV3MLP = _PRISTINE_HF["ds3.MLP.cls"]
+
+    # Step 3: remove `get_parallel_plan` methods injected onto HF causal-LM
+    # classes by apply_veomni_*_patch.
+    for cls in (_hf_qwen3_moe.Qwen3MoeForCausalLM, _hf_ds3.DeepseekV3ForCausalLM):
+        if "get_parallel_plan" in cls.__dict__:
+            delattr(cls, "get_parallel_plan")
 
 
 def apply_veomni_loss_unpatch():

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -7,7 +7,6 @@ from rich.console import Console
 from rich.table import Table
 from transformers import set_seed
 
-from veomni.data.dummy_dataset import build_dummy_dataset
 from veomni.utils.import_utils import is_torch_npu_available
 
 
@@ -162,6 +161,8 @@ def prepare_data(model_name: str, max_seq_len: int, model_config):
     Build a DummyDataLoader that yields raw features (list of 2 dicts).
     MainCollator packing + cu_seqlens precompute is done in the trainer (TrainerTest).
     """
+    from veomni.data.dummy_dataset import build_dummy_dataset
+
     dataset_name = MODEL_TO_DATASET.get(model_name, "text")
     dataset = build_dummy_dataset(dataset_name, 2, max_seq_len)
 
@@ -225,6 +226,52 @@ def compare_multi_items(outputs_dict: Dict, rtol=0.01, atol=0.01):
             except AssertionError as e:
                 print_all_values(outputs_dict, key)
                 raise AssertionError(f"{key} not match") from e
+
+
+# ---------------------------------------------------------------------------
+# Pristine snapshots of HF model classes taken at module import — before any
+# veomni import has a chance to monkey-patch them. `apply_veomni_hf_unpatch`
+# restores them so a second test in the same process can build an HF model
+# that is genuinely un-patched. Keep the module imports inside this block
+# so that util users who never need them are not forced to pay the cost.
+# ---------------------------------------------------------------------------
+import transformers.models.deepseek_v3.modeling_deepseek_v3 as _hf_ds3  # noqa: E402
+import transformers.models.qwen3.modeling_qwen3 as _hf_qwen3  # noqa: E402
+import transformers.models.qwen3_moe.modeling_qwen3_moe as _hf_qwen3_moe  # noqa: E402
+
+
+_PRISTINE_HF_CLASSES = {
+    "qwen3.forward": _hf_qwen3.Qwen3ForCausalLM.forward,
+    "qwen3_moe.forward": _hf_qwen3_moe.Qwen3MoeForCausalLM.forward,
+    "qwen3_moe.MoeBlock": _hf_qwen3_moe.Qwen3MoeSparseMoeBlock,
+    "qwen3_moe.init_weights": _hf_qwen3_moe.Qwen3MoePreTrainedModel._init_weights,
+    "ds3.attn_fwd": _hf_ds3.DeepseekV3Attention.forward,
+    "ds3.lm_fwd": _hf_ds3.DeepseekV3ForCausalLM.forward,
+    "ds3.MoE": _hf_ds3.DeepseekV3MoE,
+    "ds3.init_weights": _hf_ds3.DeepseekV3PreTrainedModel._init_weights,
+    "ds3.rope_fwd": _hf_ds3.DeepseekV3RotaryEmbedding.forward,
+    "ds3.rmsnorm_fwd": _hf_ds3.DeepseekV3RMSNorm.forward,
+}
+
+
+def apply_veomni_hf_unpatch():
+    """Undo in-place veomni monkey-patches on HF model modules.
+
+    `apply_veomni_*_patch()` in each of `qwen3/`, `qwen3_moe/`, `deepseek_v3/`
+    mutates the HF model modules directly (e.g. swaps in PatchQwen3MoeSparseMoeBlock).
+    Without this restore, the first parametrize case to build a veomni model
+    leaks its patches into every subsequent HF build in the same test session.
+    """
+    _hf_qwen3.Qwen3ForCausalLM.forward = _PRISTINE_HF_CLASSES["qwen3.forward"]
+    _hf_qwen3_moe.Qwen3MoeForCausalLM.forward = _PRISTINE_HF_CLASSES["qwen3_moe.forward"]
+    _hf_qwen3_moe.Qwen3MoeSparseMoeBlock = _PRISTINE_HF_CLASSES["qwen3_moe.MoeBlock"]
+    _hf_qwen3_moe.Qwen3MoePreTrainedModel._init_weights = _PRISTINE_HF_CLASSES["qwen3_moe.init_weights"]
+    _hf_ds3.DeepseekV3Attention.forward = _PRISTINE_HF_CLASSES["ds3.attn_fwd"]
+    _hf_ds3.DeepseekV3ForCausalLM.forward = _PRISTINE_HF_CLASSES["ds3.lm_fwd"]
+    _hf_ds3.DeepseekV3MoE = _PRISTINE_HF_CLASSES["ds3.MoE"]
+    _hf_ds3.DeepseekV3PreTrainedModel._init_weights = _PRISTINE_HF_CLASSES["ds3.init_weights"]
+    _hf_ds3.DeepseekV3RotaryEmbedding.forward = _PRISTINE_HF_CLASSES["ds3.rope_fwd"]
+    _hf_ds3.DeepseekV3RMSNorm.forward = _PRISTINE_HF_CLASSES["ds3.rmsnorm_fwd"]
 
 
 def apply_veomni_loss_unpatch():

--- a/veomni/models/transformers/deepseek_v3/gpu_patch.py
+++ b/veomni/models/transformers/deepseek_v3/gpu_patch.py
@@ -68,6 +68,9 @@ def _patch_rms_norm():
 
 
 def apply_veomni_deepseek_v3_gpu_patch():
+    if get_env("VEOMNI_USE_FUSED_KERNELS") == "0":
+        logger.info_rank0("Skip GPU kernel patch for deepseek_v3 (VEOMNI_USE_FUSED_KERNELS=0).")
+        return
     if is_liger_kernel_available() and get_env("VEOMNI_USE_LIGER_KERNEL") == "1":
         from liger_kernel.transformers.rms_norm import LigerRMSNorm
         from liger_kernel.transformers.rope import liger_rotary_pos_emb

--- a/veomni/models/transformers/deepseek_v3/modeling_deepseek_v3.py
+++ b/veomni/models/transformers/deepseek_v3/modeling_deepseek_v3.py
@@ -99,9 +99,13 @@ class PatchDeepseekV3NaiveMoe(nn.Module):
         top_k_index: torch.Tensor,
         top_k_weights: torch.Tensor,
     ) -> torch.Tensor:
-        final_hidden_states = torch.zeros_like(hidden_states)
-
         if self._moe_implementation == "eager":
+            # Accumulate in top_k_weights dtype (fp32) to match HF's
+            # DeepseekV3MoE.moe, which allocates final_hidden_states with
+            # `dtype=topk_weights.dtype` and casts to input dtype only at
+            # return. Accumulating in bf16 per-expert introduces extra
+            # rounding that breaks bitwise parity with HF.
+            final_hidden_states = torch.zeros_like(hidden_states, dtype=top_k_weights.dtype)
             with torch.no_grad():
                 expert_mask = torch.nn.functional.one_hot(top_k_index, num_classes=self.num_experts)
                 expert_mask = expert_mask.permute(2, 1, 0)
@@ -118,8 +122,10 @@ class PatchDeepseekV3NaiveMoe(nn.Module):
                 current_hidden_states = self.act_fn(gate) * up
                 current_hidden_states = nn.functional.linear(current_hidden_states, self.down_proj[expert_idx])
                 current_hidden_states = current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
-                final_hidden_states.index_add_(0, token_idx, current_hidden_states.to(final_hidden_states.dtype))
+                final_hidden_states.index_add_(0, token_idx, current_hidden_states)
+            final_hidden_states = final_hidden_states.to(hidden_states.dtype)
         elif self._moe_implementation == "fused":
+            final_hidden_states = torch.zeros_like(hidden_states)
             # cast top_k_weights to dtype of final_hidden_states
             top_k_weights = top_k_weights.to(final_hidden_states.dtype)
 

--- a/veomni/models/transformers/deepseek_v3/modeling_deepseek_v3.py
+++ b/veomni/models/transformers/deepseek_v3/modeling_deepseek_v3.py
@@ -125,9 +125,9 @@ class PatchDeepseekV3NaiveMoe(nn.Module):
                 final_hidden_states.index_add_(0, token_idx, current_hidden_states)
             final_hidden_states = final_hidden_states.to(hidden_states.dtype)
         elif self._moe_implementation == "fused":
-            final_hidden_states = torch.zeros_like(hidden_states)
-            # cast top_k_weights to dtype of final_hidden_states
-            top_k_weights = top_k_weights.to(final_hidden_states.dtype)
+            # cast top_k_weights to dtype of hidden_states to satisfy the
+            # fused MoE kernel's half-precision requirement
+            top_k_weights = top_k_weights.to(hidden_states.dtype)
 
             final_hidden_states = fused_moe_forward(
                 num_experts=self.num_experts,

--- a/veomni/models/transformers/qwen3_moe/modeling_qwen3_moe.py
+++ b/veomni/models/transformers/qwen3_moe/modeling_qwen3_moe.py
@@ -129,13 +129,17 @@ class PatchQwen3MoeTopKRouter(nn.Module):
         self.register_forward_hook(router_forward_hook)
 
     def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
         hidden_states = hidden_states.reshape(-1, self.hidden_dim)
         router_logits = F.linear(hidden_states, self.weight)  # (seq_len, num_experts)
         router_logits = torch.nn.functional.softmax(router_logits, dtype=torch.float, dim=-1)
         router_top_value, router_indices = torch.topk(router_logits, self.top_k, dim=-1)  # (seq_len, top_k)
         if self.norm_topk_prob:
             router_top_value /= router_top_value.sum(dim=-1, keepdim=True)
-        router_top_value = router_top_value.to(router_logits.dtype)
+        # Cast back to input dtype — matches HF's Qwen3MoeSparseMoeBlock semantics
+        # so the expert multiplication `expert_output * routing_weights` is done
+        # in input dtype rather than promoted to fp32 (which drops bf16 rounding).
+        router_top_value = router_top_value.to(input_dtype)
         router_scores = router_top_value
         return router_logits, router_scores, router_indices
 

--- a/veomni/utils/env.py
+++ b/veomni/utils/env.py
@@ -23,6 +23,7 @@ logger = logging.get_logger(__name__)
 ENV_DEFAULTS = {
     "MODELING_BACKEND": "veomni",
     "VEOMNI_USE_LIGER_KERNEL": "1",
+    "VEOMNI_USE_FUSED_KERNELS": "1",
     "USE_GROUP_GEMM": "1",
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds a pytest suite that asserts veomni's forward logits are **bitwise identical** (via `torch.equal`) to native HuggingFace across qwen3 / qwen3_moe / deepseek_v3 toy configs, in both `eager`+fp32 and `flash_attention_2`+bf16 configurations. Fixes three production bugs that the test surfaced in veomni's MoE bf16 dtype handling and deepseek_v3's unconditional GPU kernel patching.

### Checklist Before Starting

- Related PRs/issues: none
- PR title follows `[{modules}] {type}: {description}` format — modules `model, ci`, type `test`.

### Test

All 6 cases pass bitwise:

| case | attn_implementation | dtype | result |
|---|---|---|---|
| qwen3-toy | eager | fp32 | PASS |
| qwen3_moe-toy | eager | fp32 | PASS |
| deepseek_v3-toy | eager | fp32 | PASS |
| qwen3-toy | flash_attention_2 | bf16 | PASS |
| qwen3_moe-toy | flash_attention_2 | bf16 | PASS |
| deepseek_v3-toy | flash_attention_2 | bf16 | PASS |

```
============================== 6 passed in 32.92s ==============================
```

Test command:

```bash
VEOMNI_USE_LIGER_KERNEL=0 VEOMNI_USE_FUSED_KERNELS=0 \
  pytest -v tests/models/test_models_logits_equal.py
```

### API and Usage Example

New env var **`VEOMNI_USE_FUSED_KERNELS`** (default `"1"`, preserves current production behavior). Setting `"0"` causes `apply_veomni_deepseek_v3_gpu_patch` to early-return, leaving HF's native RoPE + RMSNorm in place. Previously the Triton RoPE bmm + batch-invariant RMSNorm substitution was unconditional in the `else` branch of the Liger gate, with no way to opt out — this made bitwise parity with HF impossible to achieve for deepseek_v3.

### Design & Code Changes

**Test (`tests/models/test_models_logits_equal.py`)**
- Single parametrized test `test_logits_bitwise_equal(case)` over 6 `Case`s (3 models × 2 attn/dtype combinations). HF is random-initialised from the toy config; its state dict is copied to veomni via the existing `weight_sync_adapters` for MoE layout conversion.
- Execution order within each test is mandatory: HF forward before any veomni model build, because `build_foundation_model` triggers `apply_veomni_*_patch()` which monkey-patches HF module classes process-wide.
- HF model is built under `torch.device(""cuda"")` so init-time buffers (rotary `inv_freq` under YaRN) use the same arithmetic path as veomni's `CustomizedModelingLoader`.
- Determinism: TF32 off (matmul + cudnn), cudnn deterministic, `use_deterministic_algorithms(warn_only=True)`, `CUBLAS_WORKSPACE_CONFIG=:4096:8`.

**Test isolation helper (`tests/models/utils.py`)**
- `apply_veomni_hf_unpatch()` restores pristine HF class attributes. Snapshots are captured at `utils.py` import time, before veomni's lazy per-model patches can fire. Called before every HF build so patches leaked by an earlier veomni build in the same pytest session do not poison subsequent HF models.
- Made `from veomni.data.dummy_dataset import build_dummy_dataset` lazy (moved into `prepare_data`) so importers that only need the unpatch helpers don't pay the torchcodec/ffmpeg import cost.

**Production fix 1: `veomni/utils/env.py` + `veomni/models/transformers/deepseek_v3/gpu_patch.py`**
- Register `VEOMNI_USE_FUSED_KERNELS` in `ENV_DEFAULTS` (default `""1""`).
- `apply_veomni_deepseek_v3_gpu_patch()` now early-returns when the env var is `""0""`, skipping both the Liger branch and the Triton RoPE + batch-invariant RMSNorm branch. Current production behavior is preserved by the default.

**Production fix 2: `veomni/models/transformers/qwen3_moe/modeling_qwen3_moe.py`**
- `PatchQwen3MoeTopKRouter.forward` now casts `router_top_value` to the **input** dtype rather than `router_logits.dtype`. After `softmax(dtype=torch.float)`, `router_logits` is fp32, so the existing cast was a no-op; the intent (matching HF's `routing_weights.to(hidden_states.dtype)`) was lost.
- In fp32 both casts are no-ops so the bug was invisible. In bf16, keeping router weights in fp32 promoted the expert multiplication `expert_output(bf16) * routing_weights(fp32)` to fp32 → cast back to bf16, which rounded differently from HF's bf16×bf16=bf16.

**Production fix 3: `veomni/models/transformers/deepseek_v3/modeling_deepseek_v3.py`**
- `PatchDeepseekV3NaiveMoe.forward` eager branch now allocates `final_hidden_states` in `top_k_weights.dtype` (fp32) and casts to input dtype once at return, matching HF's `DeepseekV3MoE.moe` which uses `dtype=topk_weights.dtype`.
- Previously it allocated in `hidden_states.dtype` (bf16) and cast each expert contribution to bf16 before `index_add_`, rounding per-expert rather than once at the end. Again invisible in fp32; visible in bf16.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (`make style` + `make quality` clean)
- [ ] Added/updated documentation — no docs impact; the new env var's default preserves prior behavior
- [ ] If `tasks/` training scripts were moved or renamed — N/A
- [ ] Added tests to CI workflow — the new test file is standalone and self-skipping (skips on non-CUDA, on transformers >= 5); wiring into nightly/presubmit GPU CI can be done in a follow-up