### PR TITLE
[data] chore: add modal mask into keys_to_pad 

### DIFF
--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -207,7 +207,11 @@ class PackingCollator(DataCollator):
         if pad_len == 0:
             return batch
 
-        keys_to_pad = ["input_ids", "attention_mask", "labels", "position_ids"]
+        keys_to_pad = []
+        for key in self.collate_infos.keys():
+            if self.collate_infos[key].pack_dim == -1:
+                keys_to_pad.append(key)
+
         for key in keys_to_pad:
             if key in batch:
                 batch[key] = self.pad_feature_to_length(


### PR DESCRIPTION
### What does this PR do?

In PR https://github.com/ByteDance-Seed/VeOmni/pull/410, some keys will pad to length. This PR adds modal mask, such as image_mask and video_mask, into keys_to_pad in PackingCollator.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
