### PR TITLE
[model] feat: guard unmigrated models against transformers v5

### DIFF
--- a/veomni/models/loader.py
+++ b/veomni/models/loader.py
@@ -59,6 +59,20 @@ MODEL_PROCESSOR_REGISTRY = Registry("ModelProcessor")
 logger = logging.get_logger(__name__)
 
 
+def raise_if_not_migrated_to_v5(model_name: str) -> None:
+    # Gate for models whose VeOmni path is a v4-style monkey-patch and has NOT been ported
+    # to the patchgen/generated flow. `get_model_class` in this module short-circuits when
+    # MODELING_BACKEND=hf, so this function is only reached when the caller wants VeOmni's
+    # patched classes — under transformers>=5.0.0 those patches are almost certainly broken
+    # against v5's rewritten modeling layer, so fail loudly instead of silently corrupting.
+    if is_transformers_version_greater_or_equal_to("5.0.0"):
+        raise RuntimeError(
+            f"{model_name} has not been migrated to transformers v5 in VeOmni. "
+            f"Set MODELING_BACKEND=hf to bypass VeOmni patches and load upstream "
+            f"HuggingFace classes directly, or pin transformers<5.0.0."
+        )
+
+
 def get_model_config(config_path: str, **kwargs):
     modeling_backend = get_env("MODELING_BACKEND")
     if modeling_backend == "hf":

--- a/veomni/models/transformers/deepseek_v3/__init__.py
+++ b/veomni/models/transformers/deepseek_v3/__init__.py
@@ -11,11 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...loader import MODELING_REGISTRY
+from ...loader import MODELING_REGISTRY, raise_if_not_migrated_to_v5
 
 
 @MODELING_REGISTRY.register("deepseek_v3")
 def register_deepseek_v3_modeling(architecture: str):
+    raise_if_not_migrated_to_v5("deepseek_v3")
+
     from transformers import (
         DeepseekV3ForCausalLM,
         DeepseekV3ForSequenceClassification,

--- a/veomni/models/transformers/janus/__init__.py
+++ b/veomni/models/transformers/janus/__init__.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...loader import MODEL_CONFIG_REGISTRY, MODEL_PROCESSOR_REGISTRY, MODELING_REGISTRY
+from ...loader import MODEL_CONFIG_REGISTRY, MODEL_PROCESSOR_REGISTRY, MODELING_REGISTRY, raise_if_not_migrated_to_v5
 
 
 @MODEL_CONFIG_REGISTRY.register("janus")
@@ -24,6 +24,8 @@ def register_janus_config():
 
 @MODELING_REGISTRY.register("janus")
 def register_janus_modeling(architecture: str):
+    raise_if_not_migrated_to_v5("janus")
+
     from .modeling_janus import Janus
 
     return Janus

--- a/veomni/models/transformers/llama/__init__.py
+++ b/veomni/models/transformers/llama/__init__.py
@@ -11,11 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...loader import MODELING_REGISTRY
+from ...loader import MODELING_REGISTRY, raise_if_not_migrated_to_v5
 
 
 @MODELING_REGISTRY.register("llama")
 def register_llama_modeling(architecture: str):
+    raise_if_not_migrated_to_v5("llama")
+
     from transformers import LlamaForCausalLM, LlamaForSequenceClassification, LlamaModel
 
     from .modeling_llama import apply_veomni_llama_patch

--- a/veomni/models/transformers/qwen2_5_omni/__init__.py
+++ b/veomni/models/transformers/qwen2_5_omni/__init__.py
@@ -16,6 +16,8 @@ from ...loader import MODEL_CONFIG_REGISTRY, MODEL_PROCESSOR_REGISTRY, MODELING_
 
 @MODEL_CONFIG_REGISTRY.register("qwen2_5_omni")
 def register_qwen2_5_omni_config():
+    raise_if_not_migrated_to_v5("qwen2_5_omni")
+
     from .configuration_qwen2_5_omni import Qwen2_5OmniConfig, apply_veomni_qwen25_omni_patch
 
     apply_veomni_qwen25_omni_patch()
@@ -43,6 +45,8 @@ def register_qwen2_5_omni_modeling(architecture: str):
 
 @MODEL_PROCESSOR_REGISTRY.register("Qwen2_5OmniProcessor")
 def register_qwen2_5_omni_processor():
+    raise_if_not_migrated_to_v5("qwen2_5_omni")
+
     from .processing_qwen2_5_omni import Qwen2_5OmniProcessor, apply_veomni_qwen25_omni_patch
 
     apply_veomni_qwen25_omni_patch()

--- a/veomni/models/transformers/qwen2_5_omni/__init__.py
+++ b/veomni/models/transformers/qwen2_5_omni/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...loader import MODEL_CONFIG_REGISTRY, MODEL_PROCESSOR_REGISTRY, MODELING_REGISTRY
+from ...loader import MODEL_CONFIG_REGISTRY, MODEL_PROCESSOR_REGISTRY, MODELING_REGISTRY, raise_if_not_migrated_to_v5
 
 
 @MODEL_CONFIG_REGISTRY.register("qwen2_5_omni")
@@ -25,6 +25,8 @@ def register_qwen2_5_omni_config():
 
 @MODELING_REGISTRY.register("qwen2_5_omni")
 def register_qwen2_5_omni_modeling(architecture: str):
+    raise_if_not_migrated_to_v5("qwen2_5_omni")
+
     from .modeling_qwen2_5_omni import (
         Qwen2_5OmniForConditionalGeneration,
         Qwen2_5OmniThinkerForConditionalGeneration,

--- a/veomni/models/transformers/seed_oss/__init__.py
+++ b/veomni/models/transformers/seed_oss/__init__.py
@@ -11,11 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...loader import MODELING_REGISTRY
+from ...loader import MODELING_REGISTRY, raise_if_not_migrated_to_v5
 
 
 @MODELING_REGISTRY.register("seed_oss")
 def register_seed_oss_modeling(architecture: str):
+    raise_if_not_migrated_to_v5("seed_oss")
+
     from transformers import (
         SeedOssForCausalLM,
         SeedOssForQuestionAnswering,


### PR DESCRIPTION
### What does this PR do?

> Adds a runtime guard `raise_if_not_migrated_to_v5` in `veomni/models/loader.py` and wires it into the model-registry entry points of the VeOmni models that are still on the v4-style monkey-patch path (`deepseek_v3`, `janus`, `llama`, `qwen2_5_omni`, `seed_oss`). Under `transformers>=5.0.0` these patches are almost certainly broken against v5's rewritten modeling layer, so the guard fails loudly with an actionable message (pin `transformers<5.0.0` or set `MODELING_BACKEND=hf`) instead of silently producing a corrupted model.
>
> Follow-up to #668 (qwen3_omni_moe v5 migration).

### Checklist Before Starting

- Search for relative PRs/issues and link here: #668
- PR title follows `[{modules}] {type}: {description}` format

### Test

> N/A — guard only fires under `transformers>=5.0.0` for models that have not been migrated. Manually verified the error message path by importing `raise_if_not_migrated_to_v5` under a v5 env. On the default `transformers==4.57.3` setup, `is_transformers_version_greater_or_equal_to("5.0.0")` returns `False` so behavior is unchanged.

### API and Usage Example

> New public helper in `veomni.models.loader`:
>
> ```python
> from veomni.models.loader import raise_if_not_migrated_to_v5
>
> raise_if_not_migrated_to_v5("llama")
> # Under transformers>=5.0.0:
> # RuntimeError: llama has not been migrated to transformers v5 in VeOmni.
> # Set MODELING_BACKEND=hf to bypass VeOmni patches and load upstream
> # HuggingFace classes directly, or pin transformers<5.0.0.
> ```

### Design & Code Changes

> - `veomni/models/loader.py`: add `raise_if_not_migrated_to_v5(model_name)` that checks the installed transformers version and raises a `RuntimeError` with a fix suggestion.
> - `veomni/models/transformers/{deepseek_v3,janus,llama,qwen2_5_omni,seed_oss}/__init__.py`: call the guard at the top of each `register_*_modeling` entry point so the error surfaces before any v4 monkey-patch runs.
> - Already-migrated models (qwen3 / qwen3_moe / qwen3_5* / glm_moe_dsa / qwen3_vl_moe / qwen3_omni_moe) are unaffected — the guard is only added to the remaining v4-only models.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [ ] Added/updated documentation
- [ ] Added tests to CI workflow (or explained why not feasible)
