### PR TITLE
[ci] chore: drop v4 tests for models already migrated to v5

### DIFF
--- a/tests/distributed/test_dummy_forward.py
+++ b/tests/distributed/test_dummy_forward.py
@@ -202,28 +202,8 @@ def _asymmetric_forward_worker(model_type, config_path, batch_fn):
 # VLM test cases
 # ---------------------------------------------------------------------------
 
+# qwen2_vl / qwen2_5_vl / qwen3_vl / qwen3_vl_moe are migrated — only v5 params remain.
 _vlm_cases = [
-    pytest.param(
-        "qwen3_vl",
-        "./tests/toy_config/qwen3vl_toy",
-        partial(_vlm_batch, patch_size=16),
-        id="qwen3_vl",
-        marks=_v4_only,
-    ),
-    pytest.param(
-        "qwen2_vl",
-        "./tests/toy_config/qwen2vl_toy",
-        partial(_vlm_batch, patch_size=14),
-        id="qwen2_vl",
-        marks=_v4_only,
-    ),
-    pytest.param(
-        "qwen2_5_vl",
-        "./tests/toy_config/qwen25vl_toy",
-        partial(_vlm_batch, patch_size=14),
-        id="qwen2_5_vl",
-        marks=_v4_only,
-    ),
     pytest.param(
         "qwen2_5_vl",
         "./tests/toy_config/qwen25vl_toy",
@@ -263,19 +243,14 @@ def test_asymmetric_forward_vlm(model_type: str, config_path: str, batch_fn):
 # Omni test cases (vision + audio encoders)
 # ---------------------------------------------------------------------------
 
+# qwen2_5_omni is not migrated (out of scope, guarded under v5) — keep v4 entry.
+# qwen3_omni_moe is migrated — only the v5 param remains.
 _omni_cases = [
     pytest.param(
         "qwen2_5_omni",
         "./tests/toy_config/qwen25omni_toy",
         partial(_omni_batch, patch_size=14, is_qwen3_omni=False),
         id="qwen2_5_omni",
-        marks=_v4_only,
-    ),
-    pytest.param(
-        "qwen3_omni_moe",
-        "./tests/toy_config/qwen3omni_toy",
-        partial(_omni_batch, patch_size=16, is_qwen3_omni=True),
-        id="qwen3_omni_moe",
         marks=_v4_only,
     ),
     pytest.param(

--- a/tests/distributed/test_fsdp_equivalence.py
+++ b/tests/distributed/test_fsdp_equivalence.py
@@ -177,25 +177,9 @@ def _run_fsdp_equivalence(
 
 # --- Text model test cases ---
 
+# qwen3 / qwen3_moe are migrated — their v5 variants cover this test.
+# llama3.1 is out of scope (guarded under v5), so it stays under _v4_only.
 _text_test_cases_v4 = [
-    pytest.param(
-        "qwen3",
-        "./tests/toy_config/qwen3_toy",
-        False,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        id="qwen3",
-        marks=_v4_only,
-    ),
-    pytest.param(
-        "qwen3_moe",
-        "./tests/toy_config/qwen3_moe_toy",
-        True,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        id="qwen3_moe",
-        marks=_v4_only,
-    ),
     pytest.param(
         "llama3.1",
         "./tests/toy_config/llama31_toy",

--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -93,6 +93,9 @@ def main(
 _DEFAULT_RTOL = 1e-1
 _DEFAULT_ATOL = 1e-1
 
+# Migrated models (qwen2 / qwen3 / qwen3_moe) no longer carry _v4_only entries —
+# their v5 variants are the canonical coverage. Non-migrated/guarded models
+# (llama3.1, seed_oss, deepseek_v3) stay under _v4_only.
 text_test_cases = [
     pytest.param(
         "llama3.1",
@@ -111,33 +114,6 @@ text_test_cases = [
         _DEFAULT_ATOL,
         None,  # max_sp_size
         marks=_v5_only,
-    ),
-    pytest.param(
-        "qwen2.5",
-        "./tests/toy_config/qwen25_toy",
-        False,  # is_moe
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        None,  # max_sp_size
-        marks=_v4_only,
-    ),
-    pytest.param(
-        "qwen3",
-        "./tests/toy_config/qwen3_toy",
-        False,  # is_moe
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        None,  # max_sp_size
-        marks=_v4_only,
-    ),
-    pytest.param(
-        "qwen3_moe",
-        "./tests/toy_config/qwen3_moe_toy",
-        True,  # is_moe
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        None,  # max_sp_size
-        marks=_v4_only,
     ),
     pytest.param(
         "qwen3_moe",
@@ -169,6 +145,7 @@ text_test_cases = [
     ),
 ]
 
+# qwen2vl / qwen2_5_vl are migrated — only the v5 params remain.
 qwen2vl_test_cases = [
     pytest.param(
         "qwen2vl",
@@ -176,23 +153,7 @@ qwen2vl_test_cases = [
         False,
         _DEFAULT_RTOL,
         _DEFAULT_ATOL,
-        marks=_v4_only,
-    ),
-    pytest.param(
-        "qwen2vl",
-        "./tests/toy_config/qwen2vl_toy",
-        False,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
         marks=_v5_only,
-    ),
-    pytest.param(
-        "qwen25vl",
-        "./tests/toy_config/qwen25vl_toy",
-        False,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        marks=_v4_only,
     ),
     pytest.param(
         "qwen25vl",
@@ -204,6 +165,7 @@ qwen2vl_test_cases = [
     ),
 ]
 
+# qwen3_vl / qwen3_vl_moe are migrated — only the v5 params remain.
 qwen3vl_test_cases = [
     pytest.param(
         "qwen3vl",
@@ -212,25 +174,7 @@ qwen3vl_test_cases = [
         _DEFAULT_RTOL,
         _DEFAULT_ATOL,
         None,  # max_sp_size
-        marks=_v4_only,
-    ),
-    pytest.param(
-        "qwen3vl",
-        "./tests/toy_config/qwen3vl_toy",
-        False,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        None,  # max_sp_size
         marks=_v5_only,
-    ),
-    pytest.param(
-        "qwen3vlmoe",
-        "./tests/toy_config/qwen3vlmoe_toy",
-        True,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        None,  # max_sp_size
-        marks=_v4_only,
     ),
     pytest.param(
         "qwen3vlmoe",
@@ -272,15 +216,8 @@ qwen2omni_test_cases = [
     ),
 ]
 
+# qwen3_omni_moe is migrated — only the v5 param remains.
 qwen3omni_test_cases = [
-    pytest.param(
-        "qwen3_omni_moe",
-        "./tests/toy_config/qwen3omni_toy",
-        True,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        marks=_v4_only,
-    ),
     pytest.param(
         "qwen3_omni_moe",
         "./tests/toy_config/qwen3omni_toy",

--- a/tests/models/test_models_patch.py
+++ b/tests/models/test_models_patch.py
@@ -161,6 +161,9 @@ class TrainerTest(BaseTrainer):
 _DEFAULT_RTOL = 1e-2
 _DEFAULT_ATOL = 1e-2
 
+# Only non-migrated or out-of-scope models remain under v4; migrated models
+# (qwen2/qwen2_vl/qwen2_5_vl/qwen3/qwen3_moe/qwen3_vl/qwen3_vl_moe/qwen3_omni_moe)
+# are exercised by the v5 list below.
 _TEST_CASES_TRANSFORMERS_V4 = [
     pytest.param(
         "./tests/toy_config/llama31_toy",
@@ -168,27 +171,6 @@ _TEST_CASES_TRANSFORMERS_V4 = [
         _DEFAULT_RTOL,
         _DEFAULT_ATOL,
         id="llama3.1",
-    ),
-    pytest.param(
-        "./tests/toy_config/qwen25_toy",
-        False,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        id="qwen2.5",
-    ),
-    pytest.param(
-        "./tests/toy_config/qwen3_toy",
-        False,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        id="qwen3",
-    ),
-    pytest.param(
-        "./tests/toy_config/qwen3_moe_toy",
-        True,
-        0.5,
-        0.02,
-        id="qwen3_moe",
     ),
     pytest.param(
         "./tests/toy_config/seed_oss_toy",
@@ -205,46 +187,11 @@ _TEST_CASES_TRANSFORMERS_V4 = [
         id="deepseek_v3",
     ),
     pytest.param(
-        "./tests/toy_config/qwen2vl_toy",
-        False,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        id="qwen2_vl",
-    ),
-    pytest.param(
-        "./tests/toy_config/qwen25vl_toy",
-        False,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        id="qwen2_5_vl",
-    ),
-    pytest.param(
-        "./tests/toy_config/qwen3vl_toy",
-        False,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        id="qwen3_vl",
-    ),
-    pytest.param(
         "./tests/toy_config/qwen25omni_toy",
         False,
         _DEFAULT_RTOL,
         _DEFAULT_ATOL,
         id="qwen2_5_omni",
-    ),
-    pytest.param(
-        "./tests/toy_config/qwen3vlmoe_toy",
-        True,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        id="qwen3_vl_moe",
-    ),
-    pytest.param(
-        "./tests/toy_config/qwen3omni_toy",
-        False,
-        _DEFAULT_RTOL,
-        _DEFAULT_ATOL,
-        id="qwen3_omni_moe",
     ),
 ]
 

--- a/tests/models/test_vlm_trainer.py
+++ b/tests/models/test_vlm_trainer.py
@@ -13,25 +13,20 @@ from veomni.trainer.vlm_trainer import (
 from veomni.utils.import_utils import is_transformers_version_greater_or_equal_to
 
 
-_FREEZE_VIT_VLM_CASES_TRANSFORMERS_V4 = [
-    pytest.param("./tests/toy_config/qwen2vl_toy", id="qwen2_vl"),
-    pytest.param("./tests/toy_config/qwen25vl_toy", id="qwen2_5_vl"),
-    pytest.param("./tests/toy_config/qwen3vl_toy", id="qwen3_vl"),
-]
+# All VLMs that would be exercised here (qwen2_vl, qwen2_5_vl, qwen3_vl, qwen3_vl_moe,
+# qwen3_5, qwen3_5_moe) are migrated to v5, so the whole module is v5-only now.
+pytestmark = pytest.mark.skipif(
+    not is_transformers_version_greater_or_equal_to("5.0.0"),
+    reason="All covered VLMs are migrated to transformers v5",
+)
 
-_FREEZE_VIT_VLM_CASES_TRANSFORMERS_V5 = [
+_FREEZE_VIT_VLM_CASES = [
     pytest.param("./tests/toy_config/qwen3_5_toy/config.json", id="qwen3_5"),
     pytest.param("./tests/toy_config/qwen3_5_moe_toy/config.json", id="qwen3_5_moe"),
     pytest.param("./tests/toy_config/qwen25vl_toy/config.json", id="qwen2_5_vl"),
     pytest.param("./tests/toy_config/qwen3vl_toy/config.json", id="qwen3_vl"),
     pytest.param("./tests/toy_config/qwen3vlmoe_toy/config.json", id="qwen3_vl_moe"),
 ]
-
-_FREEZE_VIT_VLM_CASES = (
-    _FREEZE_VIT_VLM_CASES_TRANSFORMERS_V5
-    if is_transformers_version_greater_or_equal_to("5.0.0")
-    else _FREEZE_VIT_VLM_CASES_TRANSFORMERS_V4
-)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

> Trim redundant transformers-v4 CI test parametrizations for models that
> have already been migrated to the transformers-v5 patchgen path, as
> tracked in `tingyang/transformer_v5/STATUS.md`. For each migrated model
> the v5 variant is the canonical coverage, so the duplicated v4 params
> were just spending CI minutes without adding signal.

### Checklist Before Starting

- Search for relative PRs/issues and link here: follow-up to the v5
  migration series (qwen3_vl, qwen3_vl_moe, qwen3_omni_moe, …).
- PR title follows `[{modules}] {type}: {description}` format

### Test

> `make quality` passes.
>
> `pytest --collect-only` resolves as expected under both envs:
> - transformers 4.57.3 → 36 tests across the 5 edited files
> - transformers 5.2.0  → 40 tests across the 5 edited files
>
> Non-migrated / out-of-scope models keep their v4 coverage:
> `llama3.1`, `seed_oss`, `deepseek_v3`, `qwen2_5_omni`.

### API and Usage Example

> N/A — test-only cleanup.

### Design & Code Changes

> - `tests/models/test_models_patch.py`: drop 8 migrated entries from
>   `_TEST_CASES_TRANSFORMERS_V4` (qwen2.5, qwen3, qwen3_moe, qwen2_vl,
>   qwen2_5_vl, qwen3_vl, qwen3_vl_moe, qwen3_omni_moe).
> - `tests/e2e/test_e2e_parallel.py`: drop `_v4_only` params for
>   qwen2.5 / qwen3 / qwen3_moe (text), qwen2vl / qwen25vl,
>   qwen3vl / qwen3vlmoe, and qwen3_omni_moe.
> - `tests/distributed/test_dummy_forward.py`: drop `_v4_only` params
>   for qwen2_vl, qwen2_5_vl, qwen3_vl, and qwen3_omni_moe.
> - `tests/models/test_vlm_trainer.py`: all former v4 VLMs are migrated;
>   collapse to the v5 list and add a module-level `pytestmark` that
>   skips the file under transformers < 5.0.0.
> - `tests/distributed/test_fsdp_equivalence.py`: drop qwen3 and
>   qwen3_moe from `_text_test_cases_v4`; keep llama3.1.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [ ] Added/updated documentation — N/A, test-only cleanup
- [x] Added tests to CI workflow (or explained why not feasible) — this
      PR only removes redundant test params; all removed coverage is
      exercised by the corresponding v5 variant
