### PR TITLE
[ci] fix: disable pin_memory in test_datasets multisource tests for NPU

### DIFF
--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -237,6 +237,12 @@ def build_command(dataset_type: str, dyn_bsz: bool, data_path: str):
         "--train.accelerator.ulysses_size=2",
         "--train.bsz_warmup_ratio=0",
         "--data.dataloader.num_workers=1",
+        # Force pin_memory=False: on NPU the pin_memory background thread
+        # races with HCCL teardown (triggered inside destroy_distributed) and
+        # aborts the process with SIGABRT. The tests use DummyDataset so
+        # pin_memory provides no benefit anyway. Mirrors the fix in #639 for
+        # tests/data/test_multisource_dataset.py.
+        "--data.dataloader.pin_memory=False",
         "--train.num_train_epochs=5",
         "--train.checkpoint.output_dir=.tests/cache",
     ]


### PR DESCRIPTION
### What does this PR do?

> Follow-up to #639. Applies the same `pin_memory=False` fix to `tests/data/test_datasets.py`, which was missed by #639 and still suffers the same flaky SIGABRT on NPU CI.

Observed failures (all show the identical `terminate called without an active exception` → `SIGABRT` teardown crash):

- PR #651 CI: https://github.com/ByteDance-Seed/VeOmni/actions/runs/24599839122/job/71937456779 — `test_multisource_dataset[True-mapping]`
- `main` run `24379970711` (merge commit of #639 itself): `test_multisource_dataset[False-iterable]`

### Root cause (identical to #639)

1. `BaseTrainer.train()` ends with `self.destroy_distributed()` → `dist.destroy_process_group()`.
2. On NPU, tearing down `ProcessGroupHCCL` invalidates `torch_npu` global state used by the DataLoader's `pin_memory` background thread to pin host tensors to the NPU device.
3. The `pin_memory` thread crashes on its next pin op → `Exception in thread Thread-N (_pin_memory_loop)`.
4. At interpreter shutdown the underlying C++ `std::thread` is still joinable → `std::terminate()` → `SIGABRT` (`exitcode: -6`).

GPU/NCCL does not couple pinned-memory allocation with `ProcessGroup` lifetime, so the ordering is harmless on GPU.

### Why #639 didn't cover this file

#639 fixed `tests/data/test_multisource_dataset.py` by overriding `pin_memory` inside `TrainerTest._build_dataloader()`. But `tests/data/test_datasets.py` uses a different `TrainerTest` that inherits `_build_dataloader` unchanged from `BaseTrainer`, so the fix never took effect there.

### Checklist Before Starting

- Search for relative PRs/issues and link here: follow-up to #639; unblocks #651 (CI only — #651's logic change is unrelated to this crash)
- PR title follows `[{modules}] {type}: {description}` format

### Test

> Cannot reproduce locally without Ascend hardware — relies on NPU CI for validation. GPU CI unaffected: `DummyDataset` in CPU memory means `pin_memory=True` vs `False` is behaviorally neutral on GPU too.

### API and Usage Example

> N/A — test-only change.

### Design & Code Changes

- `tests/data/test_datasets.py`: add `--data.dataloader.pin_memory=False` to `build_command()`, which is consumed by `args.data.dataloader.pin_memory` inside `BaseTrainer._build_dataloader`. This removes the pin_memory background thread at the source, eliminating the HCCL-teardown race for every `test_multisource_dataset[*]` and `test_native_dataset[*]` parametrization.
- Alternative considered and rejected: overriding `_build_dataloader` in `TrainerTest` (as #639 did for the other file). Would also work but duplicates a lot of `BaseTrainer` wiring; passing a CLI flag keeps the test in sync with the base class for free.

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] Applied pre-commit checks (`make quality` passes)
- [x] Added/updated documentation (N/A — internal test-only fix)
- [x] Added tests to CI workflow (fix IS in a test file, exercised by existing NPU unit tests workflow)

Made with [Cursor](https://cursor.com)