### PR TITLE
[parallel, ci] feat: support loading large tensor for fsdp2

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -98,9 +98,12 @@ jobs:
           uv run --frozen pytest -s -x tests/models/test_model_registry.py
           uv run --frozen pytest -s -x tests/models/test_models_patch.py
           uv run --frozen pytest -s -x tests/models/test_padded_packed_loss.py
-      - name: Run utils tests
+      - name: Run fsdp2/extra_parallel+fsdp2 (e.g. ep+fsdp2, emb+fsdp2, ep+emb+fsdp2) clip grad norm test
         run: |
-          uv run --frozen pytest -s -x tests/utils
+          uv run --frozen pytest -s -x tests/utils/test_extra_parallel_clip_grad_norm.py
+      - name: Run fsdp2 all ranks or rank0 load model weights
+        run: |
+          uv run --frozen pytest -s -x tests/utils/test_rank0_load_and_broadcast_weights.py
       - name: Run checkpoint callback unit tests
         run: |
           uv run --frozen pytest -s -x tests/checkpoints/test_checkpoint_callback.py

--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -98,10 +98,9 @@ jobs:
           uv run --frozen pytest -s -x tests/models/test_model_registry.py
           uv run --frozen pytest -s -x tests/models/test_models_patch.py
           uv run --frozen pytest -s -x tests/models/test_padded_packed_loss.py
-          uv run --frozen pytest -s -x tests/models/test_models_logits_equal.py
-      - name: Run fsdp2/extra_parallel+fsdp2 (e.g. ep+fsdp2, mb+fsdp2, ep+emb+fsdp2) clip grad norm test
+      - name: Run utils tests
         run: |
-          uv run --frozen pytest -s -x tests/utils/test_extra_parallel_clip_grad_norm.py
+          uv run --frozen pytest -s -x tests/utils
       - name: Run checkpoint callback unit tests
         run: |
           uv run --frozen pytest -s -x tests/checkpoints/test_checkpoint_callback.py

--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -98,6 +98,7 @@ jobs:
           uv run --frozen pytest -s -x tests/models/test_model_registry.py
           uv run --frozen pytest -s -x tests/models/test_models_patch.py
           uv run --frozen pytest -s -x tests/models/test_padded_packed_loss.py
+          uv run --frozen pytest -s -x tests/models/test_models_logits_equal.py
       - name: Run fsdp2/extra_parallel+fsdp2 (e.g. ep+fsdp2, emb+fsdp2, ep+emb+fsdp2) clip grad norm test
         run: |
           uv run --frozen pytest -s -x tests/utils/test_extra_parallel_clip_grad_norm.py

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -292,7 +292,7 @@ without modifying the config class.
 | full_shard | `bool` | `True` | Enable full sharding — equivalent to ZeRO-3. |
 | forward_prefetch | `bool` | `True` | Enable forward prefetch. |
 | offload | `bool` | `False` | Enable CPU offload (FSDP1 only). |
-| max_load_broadcast_size | `float` | `20.0` | Maximum load broadcast size (FSDP2). |
+| max_load_broadcast_size | `float` | `20.0` | Maximum size (in GB) of parameters broadcasted from rank 0 during loading weights (FSDP2). Parameters exceeding this threshold will be chunked according to the parallel plan before broadcasting. |
 | mixed_precision | `MixedPrecisionConfig` | — | Mixed precision configuration. |
 
 ### MixedPrecisionConfig

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -292,6 +292,7 @@ without modifying the config class.
 | full_shard | `bool` | `True` | Enable full sharding — equivalent to ZeRO-3. |
 | forward_prefetch | `bool` | `True` | Enable forward prefetch. |
 | offload | `bool` | `False` | Enable CPU offload (FSDP1 only). |
+| max_load_broadcast_size | `float` | `20.0` | Maximum load broadcast size (FSDP2). |
 | mixed_precision | `MixedPrecisionConfig` | — | Mixed precision configuration. |
 
 ### MixedPrecisionConfig

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -364,6 +364,8 @@ model = build_parallelize_model(
     basic_modules=list(set(getattr(model, "_no_split_modules", None) or []) | set(args.model.basic_modules)), # FSDP basic modules
     enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
     enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
+    broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0, # load model weights
+    max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size, # max load broadcast size
 )
 ```
 

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -249,6 +249,10 @@ def main():
         dist.barrier()
         return
 
+    cpu_load_param_name = None
+    if hasattr(model, "get_parallel_plan"):
+        cpu_load_param_name = getattr(model.get_parallel_plan(), "cpu_load_param_name", None)
+
     model = build_parallelize_model(
         model,
         weights_path=args.model.model_path,
@@ -262,6 +266,9 @@ def main():
         basic_modules=model._no_split_modules,
         enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
         enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
+        broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
+        cpu_load_param_name=cpu_load_param_name,
+        max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
     )
     optimizer = build_optimizer(
         model,

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -138,6 +138,8 @@ def main():
         basic_modules=[],
         enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
         enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
+        broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
+        max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
     )
 
     from veomni.distributed.parallel_state import get_parallel_state

--- a/tests/utils/test_rank0_load_and_broadcast_weights.py
+++ b/tests/utils/test_rank0_load_and_broadcast_weights.py
@@ -262,7 +262,7 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
             init_device=args.train.init_device,
             mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
             enable_gradient_checkpointing=False,
-            basic_modules=rank0_load_model._no_split_modules,
+            basic_modules=[],
             broadcast_model_weights_from_rank0=True,
         )
 

--- a/tests/utils/test_rank0_load_and_broadcast_weights.py
+++ b/tests/utils/test_rank0_load_and_broadcast_weights.py
@@ -11,6 +11,7 @@ from torch import distributed as dist
 from torch import nn
 
 from veomni.arguments import DataArguments, ModelArguments, TrainingArguments, parse_args
+from veomni.distributed.parallel_plan import ParallelPlan
 from veomni.distributed.parallel_state import init_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models.module_utils import load_model_weights, rank0_load_and_broadcast_weights
@@ -19,7 +20,7 @@ from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torc
 
 
 try:
-    from torch.distributed.tensor import DTensor, Replicate, distribute_tensor
+    from torch.distributed.tensor import DTensor, Replicate, Shard, distribute_tensor
 except ImportError:  # pragma: no cover - torch < 2.2 fallback
     DTensor = None  # type: ignore[assignment]
     Replicate = None  # type: ignore[assignment]
@@ -45,52 +46,144 @@ class Arguments:
     test: "BroadcastTestArguments" = field(default_factory=BroadcastTestArguments)
 
 
-class TinyEmbedding(nn.Module):
+class ToyEmbed(torch.nn.Module):
     def __init__(self, num_embeddings: int, embed_dim: int) -> None:
         super().__init__()
-        self.weight = nn.Parameter(torch.empty(num_embeddings, embed_dim))
+        self.weight = nn.Parameter(torch.empty(num_embeddings, embed_dim), requires_grad=True)
         if self.weight.device.type != "meta":
             self.reset_parameters()
+
+    def forward(self) -> torch.Tensor:
+        return self.weight.sum()
 
     def reset_parameters(self) -> None:
         nn.init.normal_(self.weight)
 
 
-class TinyModel(nn.Module):
-    def __init__(self) -> None:
+class ToyMoeAndEmbedDecoderLayer(torch.nn.Module):
+    def __init__(self):
         super().__init__()
-        self.input_embeddings = TinyEmbedding(7, 4)
-        self.output_embeddings = TinyEmbedding(7, 4)
-        if self.output_embeddings.weight.device.type != "meta":
-            self.output_embeddings.weight.data.copy_(self.input_embeddings.weight.data)
+        self.extra_embed_tokens = ToyEmbed(64, 16)
+        self.regular_mlp = torch.nn.Parameter(torch.ones(64, 16), requires_grad=True)
+        self.moe = ToyMoeExperts()
+
+    def forward(self) -> torch.Tensor:
+        return self.extra_embed_tokens() + self.regular_mlp.sum() + self.moe()
+
+
+class ToyMoeExperts(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.experts = torch.nn.Parameter(torch.ones(64, 16, 32), requires_grad=True)
+
+    def forward(self) -> torch.Tensor:
+        return self.experts.sum()
+
+
+class ToyMoeAndEmbedModel(torch.nn.Module):
+    _no_split_modules = ["ToyMoeAndEmbedDecoderLayer", "ToyEmbed"]
+
+    def __init__(self):
+        super().__init__()
+        self.input_embed_tokens = ToyEmbed(7, 4)
+        self.output_embed_tokens = ToyEmbed(7, 4)
+        if self.output_embed_tokens.weight.device.type != "meta":
+            self.output_embed_tokens.weight.data.copy_(self.input_embed_tokens.weight.data)
+
         self.linear1 = nn.Linear(4, 3, bias=True)
         self.linear2 = nn.Linear(3, 2, bias=False)
+        self.linear3 = nn.Linear(2, 1, bias=True)
+
         self.register_buffer("buffer", torch.arange(2, dtype=torch.float32))
+
+        self.extra_embed_tokens = ToyEmbed(64, 16)
+        self.bias = torch.nn.Parameter(torch.ones(16), requires_grad=True)
+        self.decoder = ToyMoeAndEmbedDecoderLayer()
+
         self.config = SimpleNamespace(tie_word_embeddings=True)
-        self._no_split_modules: list[str] = []
 
     def get_input_embeddings(self) -> nn.Module:
-        return self.input_embeddings
+        return self.input_embed_tokens
 
     def get_output_embeddings(self) -> nn.Module:
-        return self.output_embeddings
+        return self.output_embed_tokens
 
-    def init_weights(self) -> None:
-        self.input_embeddings.reset_parameters()
-        self.output_embeddings.weight.data.copy_(self.input_embeddings.weight.data)
+    def init_weights(self):
+        self.input_embed_tokens.reset_parameters()
+        self.output_embed_tokens.weight.data.copy_(self.input_embed_tokens.weight.data)
         nn.init.xavier_uniform_(self.linear1.weight)
-        nn.init.zeros_(self.linear1.bias)
+        self.linear1.bias.data.fill_(1.0)
         nn.init.xavier_uniform_(self.linear2.weight)
+        nn.init.xavier_uniform_(self.linear3.weight)
+        self.linear3.bias.data.fill_(2.0)
+        nn.init.xavier_uniform_(self.extra_embed_tokens.weight)
+        nn.init.xavier_uniform_(self.decoder.extra_embed_tokens.weight)
+        self.bias.data.fill_(3.0)
+        nn.init.xavier_uniform_(self.decoder.regular_mlp)
+        nn.init.xavier_uniform_(self.decoder.moe.experts)
+
+    def get_parallel_plan(self):
+        ep_plan = {"decoder.moe.experts": Shard(0)}
+        emb_plan = {"extra_embed_tokens.weight": Shard(0), "decoder.extra_embed_tokens.weight": Shard(0)}
+        parallel_plan = ParallelPlan(
+            extra_parallel_plan={
+                "ep": ep_plan,
+                "emb": emb_plan,
+            }
+        )
+        parallel_plan.extra_parallel_fsdp_no_shard_module = {
+            "ep": {"decoder.moe"},
+            "emb": {"extra_embed_tokens", "decoder.extra_embed_tokens"},
+        }
+        parallel_plan.cpu_load_param_name = ["linear3.bias", "decoder.extra_embed_tokens.weight"]
+
+        return parallel_plan
 
 
-def _write_checkpoint(checkpoint_dir: Path) -> str:
+class ToyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.input_embed_tokens = ToyEmbed(7, 4)
+        self.output_embed_tokens = ToyEmbed(7, 4)
+        if self.output_embed_tokens.weight.device.type != "meta":
+            self.output_embed_tokens.weight.data.copy_(self.input_embed_tokens.weight.data)
+
+        self.linear1 = nn.Linear(4, 3, bias=True)
+        self.linear2 = nn.Linear(3, 2, bias=False)
+        self.linear3 = nn.Linear(2, 1, bias=True)
+
+        self.register_buffer("buffer", torch.arange(2, dtype=torch.float32))
+
+        self.config = SimpleNamespace(tie_word_embeddings=True)
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.input_embed_tokens
+
+    def get_output_embeddings(self) -> nn.Module:
+        return self.output_embed_tokens
+
+    def init_weights(self):
+        self.input_embed_tokens.reset_parameters()
+        self.output_embed_tokens.weight.data.copy_(self.input_embed_tokens.weight.data)
+        nn.init.xavier_uniform_(self.linear1.weight)
+        self.linear1.bias.data.fill_(1.0)
+        nn.init.xavier_uniform_(self.linear2.weight)
+        nn.init.xavier_uniform_(self.linear3.weight)
+        self.linear3.bias.data.fill_(2.0)
+
+
+def _write_checkpoint(checkpoint_dir: Path, is_parallel: bool) -> str:
     torch.manual_seed(0)
-    model = TinyModel().cpu()
+    if is_parallel:
+        model = ToyMoeAndEmbedModel().cpu()
+    else:
+        model = ToyModel()
     model.init_weights()
-    model.output_embeddings.weight = model.input_embeddings.weight  # tie before saving
+    model.output_embed_tokens.weight = model.input_embed_tokens.weight  # tie before saving
     model.buffer.uniform_(-0.5, 0.5)
     state_dict = {name: tensor.detach().clone().cpu() for name, tensor in model.state_dict().items()}
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Saving checkpoint to {checkpoint_dir}")
     save_file(state_dict, str(checkpoint_dir / "model.safetensors"))
     return str(checkpoint_dir)
 
@@ -125,71 +218,156 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
         dp_mode=args.train.accelerator.fsdp_config.fsdp_mode,
     )
 
+    dtensor_factory = distribute_tensor if distribute_tensor is not None else None
+    if dtensor_factory is None:
+        raise RuntimeError("torch.distributed.tensor.distribute_tensor is required for fsdp2 weight loading test")
+
     try:
-        base_model = TinyModel()
-        fsdp_model = build_parallelize_model(
-            base_model,
+        rank0_load_model = ToyMoeAndEmbedModel()
+        all_rank_load_model = ToyMoeAndEmbedModel()
+        """
+        model before parallelize:
+        ToyMoeAndEmbedModel(
+            (input_embed_tokens): ToyEmbed()
+            (output_embed_tokens): ToyEmbed()
+            (linear1): Linear(in_features=4, out_features=3, bias=True)
+            (linear2): Linear(in_features=3, out_features=2, bias=False)
+            (linear3): Linear(in_features=2, out_features=1, bias=True)
+            (extra_embed_tokens): ToyEmbed()
+            (decoder): ToyMoeAndEmbedDecoderLayer(
+                (extra_embed_tokens): ToyEmbed()
+                (moe): ToyMoeExperts()
+            )
+        )
+
+        model after parallelize:
+        FSDPToyMoeAndEmbedModel(
+            (input_embed_tokens): FSDPToyEmbed()
+            (output_embed_tokens): FSDPToyEmbed()
+            (linear1): Linear(in_features=4, out_features=3, bias=True)
+            (linear2): Linear(in_features=3, out_features=2, bias=False)
+            (linear3): Linear(in_features=2, out_features=1, bias=True)
+            (extra_embed_tokens): FSDPToyEmbed()
+            (decoder): FSDPToyMoeAndEmbedDecoderLayer(
+                (extra_embed_tokens): FSDPToyEmbed()
+                (moe): FSDPToyMoeExperts()
+            )
+        )
+        """
+
+        # 1.1 rank0_load_model init with no weights_path
+        rank0_load_model = build_parallelize_model(
+            rank0_load_model,
+            weights_path=None,
+            init_device=args.train.init_device,
+            mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
+            enable_gradient_checkpointing=False,
+            basic_modules=rank0_load_model._no_split_modules,
+            broadcast_model_weights_from_rank0=True,
+        )
+
+        cpu_load_param_name = None
+        if hasattr(rank0_load_model, "get_parallel_plan"):
+            cpu_load_param_name = getattr(rank0_load_model.get_parallel_plan(), "cpu_load_param_name", None)
+
+        # 1.2 rank0_load_model load from weights_path
+        rank0_load_and_broadcast_weights(
+            rank0_load_model,
+            str(weights_path),
+            init_device=get_device_type(),
+            dtensor_factory=dtensor_factory,
+            cpu_load_param_name=cpu_load_param_name,
+            max_load_broadcast_size=0.0,
+        )
+
+        # 2.1 all_rank_load_model init with no weights_path
+        all_rank_load_model = build_parallelize_model(
+            all_rank_load_model,
             weights_path=None,
             init_device=args.train.init_device,
             mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
             enable_gradient_checkpointing=False,
             basic_modules=[],
-            broadcast_model_weights_from_rank0=True,
+            broadcast_model_weights_from_rank0=False,
         )
 
-        dtensor_factory = distribute_tensor if distribute_tensor is not None else None
-        if dtensor_factory is None:
-            raise RuntimeError("torch.distributed.tensor.distribute_tensor is required for fsdp2 weight loading test")
+        # 2.2 all_rank_load_model load from weights_path
+        load_model_weights(
+            all_rank_load_model,
+            str(weights_path),
+            init_device=get_device_type(),
+            dtensor_factory=dtensor_factory,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.get_input_embeddings().weight,
+            all_rank_load_model.get_input_embeddings().weight,
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.get_output_embeddings().weight,
+            all_rank_load_model.get_output_embeddings().weight,
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.linear1.weight,
+            all_rank_load_model.linear1.weight,
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.linear1.bias,
+            all_rank_load_model.linear1.bias,
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.linear2.weight,
+            all_rank_load_model.linear2.weight,
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.buffer,
+            all_rank_load_model.buffer,
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.linear3.weight,
+            all_rank_load_model.linear3.weight,
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.linear3.bias,
+            all_rank_load_model.linear3.bias,
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.extra_embed_tokens.weight,
+            all_rank_load_model.extra_embed_tokens.weight,
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.decoder.moe.experts,
+            all_rank_load_model.decoder.moe.experts,
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            rank0_load_model.decoder.extra_embed_tokens.weight,
+            all_rank_load_model.decoder.extra_embed_tokens.weight,
+            atol=0.0,
+            rtol=0.0,
+        )
 
-        rank0_load_and_broadcast_weights(
-            fsdp_model, str(weights_path), init_device=get_device_type(), dtensor_factory=dtensor_factory
-        )
-
-        reference_model = TinyModel().to(get_device_type())
-        load_model_weights(reference_model, str(weights_path), init_device=get_device_type())
-        reference_model = reference_model.cpu()
-
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.get_input_embeddings().weight),
-            reference_model.get_input_embeddings().weight.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.get_output_embeddings().weight),
-            reference_model.get_output_embeddings().weight.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.linear1.weight),
-            reference_model.linear1.weight.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.linear1.bias),
-            reference_model.linear1.bias.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.linear2.weight),
-            reference_model.linear2.weight.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.buffer),
-            reference_model.buffer.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-
-        assert fsdp_model.get_input_embeddings().weight is fsdp_model.get_output_embeddings().weight
         assert (
-            reference_model.get_input_embeddings().weight.data_ptr()
-            == reference_model.get_output_embeddings().weight.data_ptr()
+            all_rank_load_model.get_input_embeddings().weight.data_ptr()
+            == all_rank_load_model.get_output_embeddings().weight.data_ptr()
         )
 
         dist.barrier()
@@ -203,9 +381,9 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
 @pytest.mark.skipif(not dist.is_available(), reason="torch.distributed required")
 def test_load_dist_model_weights_matches_standard(tmp_path: Path) -> None:
     checkpoint_dir = tmp_path / "ckpt"
-    weights_path = _write_checkpoint(checkpoint_dir)
+    weights_path = _write_checkpoint(checkpoint_dir, is_parallel=True)
 
-    world_size = 2
+    world_size = 4
     port = 12345 + random.randint(0, 100)
     command = [
         "torchrun",
@@ -220,6 +398,11 @@ def test_load_dist_model_weights_matches_standard(tmp_path: Path) -> None:
         "--train.accelerator.fsdp_config.mixed_precision.enable=False",
         "--train.gradient_checkpointing.enable=False",
         "--train.broadcast_model_weights_from_rank0=True",
+        "--train.accelerator.ep_size=2",
+        "--train.accelerator.ep_outside=False",
+        "--train.accelerator.extra_parallel_sizes=2",
+        "--train.accelerator.extra_parallel_placement_innermost=False",
+        "--train.accelerator.extra_parallel_names=emb",
         f"--test.weights_path={weights_path}",
         f"--test.device_type={get_device_type()}",
         f"--test.backend={get_dist_comm_backend()}",
@@ -264,15 +447,35 @@ def run_load_weights_test(args: Arguments) -> None:
         # build_parallelize_model with weights_path triggers load_model_weights
         # (the every-rank-reads-from-disk path, fixed in issue #637).
         fsdp_model = build_parallelize_model(
-            TinyModel(),
+            ToyModel(),
             weights_path=str(weights_path),
             init_device=args.train.init_device,
             mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
             enable_gradient_checkpointing=False,
             basic_modules=[],
         )
+        """
+        fsdp_model:
+        FSDPToyModel(
+            (input_embed_tokens): ToyEmbed()
+            (output_embed_tokens): ToyEmbed()
+            (linear1): Linear(in_features=4, out_features=3, bias=True)
+            (linear2): Linear(in_features=3, out_features=2, bias=False)
+            (linear3): Linear(in_features=2, out_features=1, bias=True)
+        )
 
-        reference_model = TinyModel().to(get_device_type())
+        reference_model:
+        ToyModel(
+            (input_embed_tokens): ToyEmbed()
+            (output_embed_tokens): ToyEmbed()
+            (linear1): Linear(in_features=4, out_features=3, bias=True)
+            (linear2): Linear(in_features=3, out_features=2, bias=False)
+            (linear3): Linear(in_features=2, out_features=1, bias=True)
+        )
+
+        """
+
+        reference_model = ToyModel().to(get_device_type())
         load_model_weights(reference_model, str(weights_path), init_device=get_device_type())
         reference_model = reference_model.cpu()
 
@@ -306,10 +509,21 @@ def run_load_weights_test(args: Arguments) -> None:
             atol=0.0,
             rtol=0.0,
         )
-
         torch.testing.assert_close(
             _clone_to_cpu(fsdp_model.buffer),
             reference_model.buffer.detach().cpu(),
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            _clone_to_cpu(fsdp_model.linear3.weight),
+            reference_model.linear3.weight.detach().cpu(),
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            _clone_to_cpu(fsdp_model.linear3.bias),
+            reference_model.linear3.bias.detach().cpu(),
             atol=0.0,
             rtol=0.0,
         )
@@ -335,9 +549,9 @@ def test_load_weights_no_scatter(tmp_path: Path) -> None:
     test_load_dist_model_weights_matches_standard.
     """
     checkpoint_dir = tmp_path / "ckpt"
-    weights_path = _write_checkpoint(checkpoint_dir)
+    weights_path = _write_checkpoint(checkpoint_dir, is_parallel=False)
 
-    world_size = 2
+    world_size = 4
     port = 12345 + random.randint(0, 100)
     command = [
         "torchrun",
@@ -351,6 +565,7 @@ def test_load_weights_no_scatter(tmp_path: Path) -> None:
         "--train.init_device=meta",
         "--train.accelerator.fsdp_config.mixed_precision.enable=False",
         "--train.gradient_checkpointing.enable=False",
+        "--train.broadcast_model_weights_from_rank0=False",
         f"--test.weights_path={weights_path}",
         f"--test.device_type={get_device_type()}",
         f"--test.backend={get_dist_comm_backend()}",

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -249,7 +249,9 @@ class FSDPConfig:
     )
     max_load_broadcast_size: float = field(
         default=20.0,
-        metadata={"help": "Max parameter load and broadcast size (GB) for FSDP2."},
+        metadata={
+            "help": "Maximum size (in GB) of parameters broadcasted from rank 0 during loading weights (FSDP2). Parameters exceeding this threshold will be chunked according to the parallel plan before broadcasting."
+        },
     )
     mixed_precision: MixedPrecisionConfig = field(default_factory=MixedPrecisionConfig)
 

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -247,6 +247,10 @@ class FSDPConfig:
         default=False,
         metadata={"help": "Enable CPU offload for FSDP1."},
     )
+    max_load_broadcast_size: float = field(
+        default=20.0,
+        metadata={"help": "Max parameter load and broadcast size (GB) for FSDP2."},
+    )
     mixed_precision: MixedPrecisionConfig = field(default_factory=MixedPrecisionConfig)
 
 

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -565,7 +565,14 @@ def parallelize_model_fsdp2(
         logger.info_rank0("starting to load model weights...")
         if kwargs.get("broadcast_model_weights_from_rank0"):
             logger.info_rank0("Loading model weights from disk on rank0 then broadcasting to other ranks...")
-            rank0_load_and_broadcast_weights(model, weights_path, get_device_type(), dtensor_factory=distribute_tensor)
+            rank0_load_and_broadcast_weights(
+                model,
+                weights_path,
+                get_device_type(),
+                dtensor_factory=distribute_tensor,
+                cpu_load_param_name=kwargs.get("cpu_load_param_name", None),
+                max_load_broadcast_size=kwargs.get("max_load_broadcast_size", 20.0),
+            )
         else:
             logger.info_rank0("Every rank would read weights from disk and expect this to be slow!")
             load_model_weights(model, weights_path, get_device_type(), dtensor_factory=distribute_tensor)

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -339,7 +339,7 @@ def rank0_load_and_broadcast_weights(
     weights_path: str,
     init_device: Literal["cpu", "cuda", "npu"] = "cuda",
     dtensor_factory: Optional[Callable[["torch.Tensor", Any, Any], "torch.Tensor"]] = None,
-    cpu_load_param_name: list[str] = None,
+    cpu_load_param_name: List[str] = None,
     max_load_broadcast_size: float = 20.0,  # in GB
 ):
     """
@@ -629,11 +629,11 @@ def rank0_load_and_broadcast_weights(
                 raise RuntimeError("Received incomplete broadcast metadata.")
             if (
                 (
-                    (cpu_load_param_name and name in cpu_load_param_name)
+                    (cpu_load_param_name is not None and name in cpu_load_param_name)
                     or _param_larger_than(shape, dtype, max_load_broadcast_size=max_load_broadcast_size)
                 )
                 and name in parameter_names_to_load
-                and parallel_plan._get_shard_parameter_groupname(name) is not None
+                and (parallel_plan is not None and parallel_plan._get_shard_parameter_groupname(name) is not None)
             ):
                 _chunk_and_broadcast_and_dispatch(name, shape, dtype, tensor)
             else:

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 
+import itertools
 import json
+import math
 import os
 import re
 import time
@@ -270,6 +272,16 @@ def _convert_weight_key(key: str, model: "PreTrainedModel") -> str:
     return key
 
 
+def _param_larger_than(shape: Tuple[int, ...], dtype: torch.dtype, max_load_broadcast_size: float = 20.0) -> bool:
+    """
+    Check if a parameter is large enough to be sharded.
+    """
+    num_elem = math.prod(shape)
+    elem_size = torch.finfo(dtype).bits // 8 if dtype.is_floating_point else torch.iinfo(dtype).bits // 8
+    param_size = num_elem * elem_size
+    return param_size >= max_load_broadcast_size * (1024**3)
+
+
 @torch.no_grad()
 def load_model_weights(
     model: Union["nn.Module", "PreTrainedModel"],
@@ -327,6 +339,8 @@ def rank0_load_and_broadcast_weights(
     weights_path: str,
     init_device: Literal["cpu", "cuda", "npu"] = "cuda",
     dtensor_factory: Optional[Callable[["torch.Tensor", Any, Any], "torch.Tensor"]] = None,
+    cpu_load_param_name: list[str] = None,
+    max_load_broadcast_size: float = 20.0,  # in GB
 ):
     """
     This functions serves as the same purpose as `load_model_weights`
@@ -372,6 +386,175 @@ def rank0_load_and_broadcast_weights(
         else:
             if global_rank == 0:
                 logger.info_rank0(f"Unexpected key in state dict: {name}.")
+        del tensor
+
+    # P2P chunk transfer parameter
+    extra_parallel_shard_dst_cache: Dict[str, List[List[int]]] = {}
+    p2p_chunk_tag_counter = 0
+
+    def _next_chunk_p2p_tag() -> int:
+        nonlocal p2p_chunk_tag_counter
+        p2p_chunk_tag_counter += 1
+        return p2p_chunk_tag_counter
+
+    def _get_extra_parallel_shard_dst_ranks(
+        parallel_state: Any,
+        para_group_name: str,
+        para_size: int,
+        device: torch.device,
+    ) -> List[List[int]]:
+        """
+        Build chunk_id -> [global ranks] table via one all_gather (cached for this load).
+
+        Each global rank reports its extra_parallel_rank for `para_group_name`; ranks whose
+        rank is in [0, para_size) are grouped by shard index.
+        """
+        if para_group_name in extra_parallel_shard_dst_cache:
+            return extra_parallel_shard_dst_cache[para_group_name]
+        if not dist.is_initialized():
+            raise RuntimeError("_get_extra_parallel_shard_dst_ranks requires initialized process group")
+        world_size = dist.get_world_size()
+        mine = torch.tensor(
+            [parallel_state.extra_parallel_rank(para_group_name)],
+            dtype=torch.long,
+            device=device,
+        )
+
+        gathered = [torch.empty_like(mine) for _ in range(world_size)]
+        dist.all_gather(gathered, mine)
+        table: List[List[int]] = [[] for _ in range(para_size)]
+        for r in range(world_size):
+            epr = int(gathered[r].item())
+            assert 0 <= epr < para_size, (
+                f"Global rank {r} reports extra_parallel_rank {epr} for parallel group {para_group_name}, which is out of range [0, {para_size})."
+            )
+            table[epr].append(r)
+        extra_parallel_shard_dst_cache[para_group_name] = table
+        return table
+
+    def _chunk_and_broadcast_and_dispatch(name, shape, dtype, tensor):
+        """Broadcast a single (name, tensor) from rank0 and dispatch it."""
+        logger.info_rank0(f"rank0_load_and_broadcast_weights: chunking and broadcasting {name=}")
+
+        assert name not in buffer_dict, f"Buffer {name} should not be chunked."
+        assert name in parameter_names_to_load, f"Unexpected key in state dict: {name}."
+
+        if global_rank == 0:
+            assert tensor.device == torch.device("cpu"), "Large parameter should be loaded to CPU first."
+
+        start_time = time.perf_counter()
+
+        para_group_name = parallel_plan._get_shard_parameter_groupname(name)
+        assert para_group_name is not None, (
+            f"Parameter {name} can not be chunked as it is not part of any parallel group."
+        )
+
+        parallel_state = get_parallel_state()
+        assert parallel_state.extra_parallel_enabled(para_group_name), (
+            f"Parallel group {para_group_name} is not enabled for extra parallel."
+        )
+
+        module, local_name = _find_submodule(model, name)
+        shard_tensor = module._parameters[local_name].data
+        target_shape = shard_tensor.shape
+
+        para_size = parallel_state.extra_parallel_sizes[para_group_name]
+        assert len(shape) >= 1, f"Original parameter {name} to be chunked has shape {shape}, which is 0-dim."
+        assert len(target_shape) >= 1, f"Shard parameter {name} to get chunk has shape {target_shape}, which is 0-dim."
+
+        if global_rank == 0:
+            if shape[0] % para_size != 0:
+                logger.info_rank0(
+                    f"Parallel group {para_group_name} size {para_size} does not divide original parameter shape {shape} at dim 0."
+                )
+
+                target_size = list(shard_tensor.size())
+                target_size[0] *= para_size
+                target_size = torch.Size(target_size)
+                loaded_size = tensor.size()
+                pad_size = tuple(
+                    (0, target_dim - loaded_dim) for target_dim, loaded_dim in zip(target_size, loaded_size)
+                )
+                pad_size = tuple(itertools.chain(*(pad_size[::-1])))
+
+                logger.info_rank0(
+                    f"Shard parameter shape = {target_shape}, Loaded parameter shape = {tensor.shape}, pad_size = {pad_size}"
+                )
+
+                tensor = torch.nn.functional.pad(tensor, pad_size, value=0.0)
+
+            assert tensor.shape[0] // para_size == target_shape[0], (
+                f"Parallel {para_group_name}: padded shape {shape} at dim 0 // {para_size} == {tensor.shape[0] // para_size}, not equal to {target_shape[0]}"
+            )
+
+            chunk_loaded_data = list(tensor.chunk(para_size, dim=0))
+
+        assert shard_tensor.is_cuda, "Shard parameter should be on CUDA."
+        is_shard_tensor_dtensor = hasattr(shard_tensor, "device_mesh")
+        if is_shard_tensor_dtensor:
+            device_mesh = shard_tensor.device_mesh
+            placements = shard_tensor.placements
+        else:
+            device_mesh = None
+            placements = None
+
+        broadcast_buffer = torch.empty(
+            shard_tensor.shape,
+            dtype=shard_tensor.dtype,
+            device=shard_tensor.device,
+        )
+        shard_dst_ranks = _get_extra_parallel_shard_dst_ranks(
+            parallel_state, para_group_name, para_size, shard_tensor.device
+        )
+        for chunk_id in range(para_size):
+            # For example:
+            #   if we have two params, ranks = [0, 1, 2, 3, 4, 5, 6, 7], then
+            #   at extra_parallel_1 with para_size = 2,
+            #     when chunk_id = 0, send_seq = [2, 4, 6], p2p tag = [1, 1, 1]
+            #     when chunk_id = 1, send_seq = [1, 3, 5, 7], p2p tag = [2, 2, 2, 2]
+            #   at extra_parallel_2 with para_size = 4,
+            #     when chunk_id = 0, send_seq = [4], p2p tag = [3]
+            #     when chunk_id = 1, send_seq = [1, 5], p2p tag = [4, 4]
+            #     when chunk_id = 2, send_seq = [2, 6], p2p tag = [5, 5]
+            #     when chunk_id = 3, send_seq = [3, 7], p2p tag = [6, 6]
+
+            if dist.get_rank() == 0:
+                broadcast_buffer.copy_(chunk_loaded_data[chunk_id].contiguous())
+            dst_ranks = sorted(shard_dst_ranks[chunk_id])
+            # One tag increment per chunk_id on every rank so the counter stays aligned.
+            tag = _next_chunk_p2p_tag()
+            send_seq = [d for d in dst_ranks if d != 0]
+            extra_para_local_rank = parallel_state.extra_parallel_rank(para_group_name)
+
+            if global_rank == 0:
+                for dst in send_seq:
+                    dist.send(broadcast_buffer, dst=dst, tag=tag)
+
+                if global_rank in dst_ranks:
+                    if is_shard_tensor_dtensor:
+                        shard_tensor.copy_(dtensor_factory(broadcast_buffer, device_mesh, placements).contiguous())
+                    else:
+                        shard_tensor.copy_(broadcast_buffer.contiguous())
+
+            elif global_rank in send_seq:
+                if is_shard_tensor_dtensor:
+                    assert device_mesh.mesh.tolist() == dst_ranks, (
+                        f"Device mesh {device_mesh.mesh.tolist()} does not match dst ranks {dst_ranks}."
+                    )
+
+                assert extra_para_local_rank == chunk_id, f"Rank {global_rank} is not the shard {chunk_id} rank."
+                dist.recv(broadcast_buffer, src=0, tag=tag)
+
+                if is_shard_tensor_dtensor:
+                    shard_tensor.copy_(dtensor_factory(broadcast_buffer, device_mesh, placements).contiguous())
+                else:
+                    shard_tensor.copy_(broadcast_buffer.contiguous())
+
+        logger.info_rank0(
+            f"{name=}, {shape=}, {dtype=}, chunk and broadcast time (ms) spent: {1000 * (time.perf_counter() - start_time)}"
+        )
+
+        parameter_names_to_load.discard(name)
         del tensor
 
     # --- Broadcast shard count ---
@@ -441,9 +624,20 @@ def rank0_load_and_broadcast_weights(
             name = metadata.name
             shape = metadata.shape
             dtype = metadata.dtype
+
             if name is None or shape is None or dtype is None:
                 raise RuntimeError("Received incomplete broadcast metadata.")
-            _broadcast_and_dispatch(name, shape, dtype, tensor)
+            if (
+                (
+                    (cpu_load_param_name and name in cpu_load_param_name)
+                    or _param_larger_than(shape, dtype, max_load_broadcast_size=max_load_broadcast_size)
+                )
+                and name in parameter_names_to_load
+                and parallel_plan._get_shard_parameter_groupname(name) is not None
+            ):
+                _chunk_and_broadcast_and_dispatch(name, shape, dtype, tensor)
+            else:
+                _broadcast_and_dispatch(name, shape, dtype, tensor)
 
         if global_rank == 0:
             del state_dict_iterator

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -315,6 +315,10 @@ class BaseTrainer(Stateful, ABC):
     def _build_parallelized_model(self):
         args: VeOmniArguments = self.args
 
+        cpu_load_param_name = None
+        if hasattr(self.model, "get_parallel_plan"):
+            cpu_load_param_name = getattr(self.model.get_parallel_plan(), "cpu_load_param_name", None)
+
         # Parallelize model
         self.model = build_parallelize_model(
             self.model,
@@ -331,6 +335,8 @@ class BaseTrainer(Stateful, ABC):
             enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
             enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
             broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
+            cpu_load_param_name=cpu_load_param_name,
+            max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
         )
         self.model.train()
 

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -146,6 +146,10 @@ class TextDPOTrainer:
 
         self.reference_model.requires_grad_(False)
 
+        cpu_load_param_name = None
+        if hasattr(self.model, "get_parallel_plan"):
+            cpu_load_param_name = getattr(self.model.get_parallel_plan(), "cpu_load_param_name", None)
+
         self.reference_model = build_parallelize_model(
             self.reference_model,
             init_device=args.train.init_device,
@@ -160,6 +164,9 @@ class TextDPOTrainer:
             ),
             enable_reentrant=False,
             enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
+            broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
+            cpu_load_param_name=cpu_load_param_name,
+            max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
         )
         self.reference_model.eval()
         helper.print_device_mem_info("VRAM usage after building reference model")


### PR DESCRIPTION
### What does this PR do?

1. Support loading large tensor for `fsdp2` by `_chunk_and_broadcast_and_dispatch` at the shard dim of `extra parallel`.

The process is as follows:
(1) rank0 loads safetensors from disk to cpu
(2) according to the parallel plan of `extra parallel`, rank0 chunks the loaded tensor at the shard dim
(3) rank0 and other ranks use P2P comm, including `dist.send` and `dist.recv`, to exchange params

This is controlled by `cpu_load_param_name` defined in the `parallel_plan` of specific model. Users can define which parameters are too large that should be loaded from CPU.

Besides, we also provide `max_load_broadcast_size` argument to control the max size of loaded parameters. Parameters larger than this threshold will also use `_chunk_and_broadcast_and_dispatch`.
 
2. Add CI for loading model weights
    1. `load_model_weights`: all ranks load model weights.
    2. `rank0_load_and_broadcast_weights`: rank0 loads and broadcast
    3. The CI uses a toy model with parallel plan of `extra parallel` and `cpu_load_param_name` to test all kind of cases.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
