### PR TITLE
[ops, model] refactor: relax moe_implementation Literal to str for extensibility

### DIFF
--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -652,15 +652,20 @@ class OpsImplementationConfig:
         default="flash_attention_2",
         metadata={"help": "Attention implementation to use."},
     )
-    moe_implementation: Literal["eager", "fused_triton", "fused_quack", "fused_npu"] = field(
+    moe_implementation: str = field(
         default="eager",
         metadata={
             "help": "MoE experts forward implementation. "
-            "'fused_triton' uses the Triton group-gemm kernel (GPU, SM70+). "
-            "'fused_quack' uses the Quack CUTLASS/CuTe kernel (GPU, SM90+). "
-            "'fused_npu' uses the NPU group-gemm kernel (requires torch_npu). "
-            "'eager' (default) runs the reference loop. "
-            "The backend must match the hardware — no silent fallback."
+            "OSS backends: 'fused_triton' (Triton group-gemm, GPU, SM70+), "
+            "'fused_quack' (Quack CUTLASS/CuTe, GPU, SM90+), "
+            "'fused_npu' (NPU group-gemm, requires torch_npu), "
+            "'eager' (default, reference loop). "
+            "The backend must match the hardware — no silent fallback. "
+            "Typed as plain str (not Literal) so third-party backends can be "
+            "plugged in via `apply_veomni_fused_moe_patch` (legacy-dispatch "
+            "models) or `KERNEL_REGISTRY.register(op_name='moe_experts', ...)` "
+            "(OpSlot-dispatch models), matching the extensibility of the "
+            "other *_implementation fields."
         },
     )
     cross_entropy_loss_implementation: str = field(

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -78,7 +78,10 @@ def apply_moe_patch_transformers_v4(config, moe_implementation: str):
     if not moe_implementation.startswith("fused_"):
         raise ValueError(
             f"Invalid moe_implementation: {moe_implementation!r}. "
-            "Expected one of: 'eager', 'fused_triton', 'fused_quack', 'fused_npu'."
+            "Expected 'eager' or a 'fused_<kernel>' name. OSS kernels: "
+            "'fused_triton', 'fused_quack', 'fused_npu'. Third-party backends "
+            "may register additional 'fused_<name>' values; if you set one, "
+            "make sure the corresponding kernel is installed and registered."
         )
 
     fused_moe_kernel = moe_implementation.removeprefix("fused_")
@@ -146,7 +149,7 @@ def build_foundation_model(
             "native-sparse",
         ]
     ] = "veomni_flash_attention_2_with_sp",
-    moe_implementation: Optional[Literal["eager", "fused_triton", "fused_quack", "fused_npu"]] = None,
+    moe_implementation: Optional[str] = None,
     init_device: Literal["cpu", "cuda", "npu", "meta"] = "cuda",
     config_kwargs: Optional[Dict[str, Any]] = None,
     encoder_data_balance: Optional[bool] = False,

--- a/veomni/ops/kernels/moe/__init__.py
+++ b/veomni/ops/kernels/moe/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Literal
-
 import torch
 
 from ....utils import logging
@@ -61,18 +59,22 @@ def fused_moe_forward(
     )
 
 
-def apply_veomni_fused_moe_patch(
-    fused_moe_kernel: Literal["triton", "quack", "npu"] = "triton",
-):
+def apply_veomni_fused_moe_patch(fused_moe_kernel: str = "triton") -> None:
     """Bind the global ``_fused_moe_forward`` function pointer.
 
     Args:
-        fused_moe_kernel: Which fused MoE kernel to activate.
-            ``"triton"`` uses the Triton group-gemm kernels (GPU, SM70+).
-            ``"quack"`` uses the Quack CUTLASS/CuTe kernels (GPU, SM90+).
-            ``"npu"`` uses the NPU group-gemm kernel (requires torch_npu).
+        fused_moe_kernel: Which fused MoE kernel to activate. OSS values:
+            ``"triton"`` (Triton group-gemm, GPU, SM70+),
+            ``"quack"`` (Quack CUTLASS/CuTe, GPU, SM90+),
+            ``"npu"`` (NPU group-gemm, requires torch_npu).
             The kernel must match the hardware; mismatches raise here rather
             than silently falling back to a different backend.
+
+            Typed as plain ``str`` (not ``Literal``) so third-party backends
+            (e.g. seed-kernels) can monkey-patch this function to intercept
+            their own name and delegate unknown names to the OSS dispatch
+            below. Unknown names that reach the OSS dispatch raise
+            ``ValueError``.
     """
     global _fused_moe_forward
     if fused_moe_kernel == "npu":


### PR DESCRIPTION
### What does this PR do?

> Relax the `moe_implementation` type from `Literal["eager", "fused_triton", "fused_quack", "fused_npu"]` to plain `str` so third-party MoE kernels (e.g. seed-kernels) can be plugged in without widening the Literal on every backend. The OSS dispatch still validates names and raises on unknown values — no silent fallback. This brings `moe_implementation` in line with the other `*_implementation` fields (e.g. `cross_entropy_loss_implementation`), which are already typed as `str` for the same reason.
>
> Follows up on #678 (registration-based kernel replacement framework).

### Checklist Before Starting

- Search for relative PRs/issues and link here: #678
- PR title follows `[{modules}] {type}: {description}` format

### Test

> Pure typing / docstring refactor — runtime behavior for OSS backends (`eager`, `fused_triton`, `fused_quack`, `fused_npu`) is unchanged. The `ValueError` path in `apply_moe_patch_transformers_v4` still rejects names that don't start with `fused_`, and `apply_veomni_fused_moe_patch` still raises on unknown `fused_<name>` values. Existing MoE tests cover these paths.

### API and Usage Example

> **Before** — adding a third-party backend required widening the Literal in three places.
>
> **After** — third-party backends can plug in via either dispatch path without core changes:
>
> ```python
> # Legacy-dispatch models: monkey-patch apply_veomni_fused_moe_patch to intercept your name
> # and delegate unknown names to the OSS dispatch.
>
> # OpSlot-dispatch models:
> KERNEL_REGISTRY.register(op_name="moe_experts", backend="fused_myvendor", fn=...)
> ```
>
> No change to existing user configs.

### Design & Code Changes

> - `veomni/arguments/arguments_types.py`: `OpsImplementationConfig.moe_implementation` typed as `str`; help text documents both the OSS backends and the third-party extension mechanism.
> - `veomni/models/auto.py`: `build_foundation_model(moe_implementation=...)` typed as `Optional[str]`; `apply_moe_patch_transformers_v4` error message mentions that `fused_<name>` values may come from third-party backends.
> - `veomni/ops/kernels/moe/__init__.py`: `apply_veomni_fused_moe_patch(fused_moe_kernel: str)`; drop unused `Literal` import; docstring explains why it is plain `str`.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [ ] Applied pre-commit checks
- [ ] Added/updated documentation
- [ ] Added tests to CI workflow (or explained why not feasible)
