### PR TITLE
[docker] fix: datasets version fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 
 dependencies = [
   "blobfile>=3.0.0",
-  "datasets>=2.16.0,<=2.21.0",
+  "datasets>=2.20.0,<=2.21.0",
   "packaging>=23.0,<26.0",
   "torchdata>=0.8.0,<1.0",
   "tiktoken>=0.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3829,7 +3829,7 @@ requires-dist = [
     { name = "av", marker = "python_full_version == '3.12.*' and extra == 'video'", url = "https://files.pythonhosted.org/packages/ed/e8/cf60f3fcde3d0eedee3e9ff66b674a9b85bffc907dccebbc56fb5ac4a954/av-14.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
     { name = "blobfile", specifier = ">=3.0.0" },
     { name = "cuda-python", marker = "extra == 'gpu'", specifier = "==12.9.1" },
-    { name = "datasets", specifier = ">=2.16.0,<=2.21.0" },
+    { name = "datasets", specifier = ">=2.20.0,<=2.21.0" },
     { name = "decorator", marker = "extra == 'npu'", specifier = ">=5.2.1" },
     { name = "decorator", marker = "extra == 'npu-aarch64'", specifier = ">=5.2.1" },
     { name = "diffusers", marker = "extra == 'dit'", specifier = "==0.36.0" },


### PR DESCRIPTION
### What does this PR do?

The current pyproject dataset has a version issue and needs to be fixed.
issue：https://github.com/ByteDance-Seed/VeOmni/issues/690

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
