### PR TITLE
[docs] fix: add install datasets==2.21.0 to ascend doc

### DIFF
--- a/docs/get_started/installation/install_ascend_arm.md
+++ b/docs/get_started/installation/install_ascend_arm.md
@@ -21,6 +21,7 @@ cd VeOmni
 # Choose one of the following installation options based on your needs:
 # Option 1: Stable version (transformers < 5.0)
 pip install -e .[npu_aarch64,transformers-stable]
+pip install datasets==2.21.0
 
 # Option 2: Experimental version for new models (transformers ≥ 5.0)
 # Note: This uses the transformers5-exp extra which includes transformers 5.0+ support

--- a/docs/get_started/installation/install_ascend_x86.md
+++ b/docs/get_started/installation/install_ascend_x86.md
@@ -54,6 +54,7 @@ cd VeOmni
 # Choose one of the following installation options based on your needs:
 # Option 1: Stable version (transformers < 5.0)
 pip install -e .[npu,transformers-stable]
+pip install datasets==2.21.0
 
 # Option 2: Experimental version for new models (transformers ≥ 5.0)
 # Note: This uses the transformers5-exp extra which includes transformers 5.0+ support


### PR DESCRIPTION
### What does this PR do?

There is a version issue with the datasets in the current pyproject, which needs to be fixed.
issue：https://github.com/ByteDance-Seed/VeOmni/issues/690

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
