### PR TITLE
[model, ckpt] feat: runtime checkpoint tensor converter for transformers v4 MoE

### DIFF
--- a/docs/transformers_v5/transformers_v5_moe_weight_loading.md
+++ b/docs/transformers_v5/transformers_v5_moe_weight_loading.md
@@ -95,11 +95,28 @@ VeOmni keeps split expert tensors in patched modeling:
 This differs from native Transformers v5 `gate_up_proj` layout.
 
 Checkpoint loading behavior:
-- VeOmni does not do runtime remapping from legacy per-expert keys;
-- HuggingFace safetensor checkpoints commonly store expert weights in per-expert form.
+- HuggingFace safetensor checkpoints store expert weights in per-expert form
+  (`experts.{j}.gate_proj.weight`, etc.).
+- A runtime `CheckpointTensorConverter` is now registered on each v4 MoE model
+  class (`qwen3_moe`, `deepseek_v3`, and `qwen3_omni_moe` in fused mode), so
+  HF checkpoints load directly into VeOmni's three stacked nn.Parameters
+  without offline preprocessing. The shared converter lives at
+  `veomni/models/transformers/_moe_v4_converter.py`; per-model factories sit
+  alongside their v5 counterparts as `checkpoint_tensor_converter_v4.py`.
+- Output keys mirror what the offline merge script produces:
+  - `experts.gate_proj` `[E, I, H]`
+  - `experts.up_proj` `[E, I, H]`
+  - `experts.down_proj` `[E, H, I]`
+  Unlike the v5 converter, the v4 converter does **not** cat gate+up — v4
+  modeling holds them as separate parameters.
+- For Qwen3-Omni-MoE the converter only fires for the **thinker** tower and
+  only when `_moe_implementation == "fused"`. The talker tower (and the
+  thinker in eager mode) keep `nn.ModuleList` experts and load HF per-expert
+  keys natively.
 
-To avoid loading/mapping issues, merge weights offline before training:
-- `scripts/moe_ckpt_merge/moe_merge.py`
+The offline `scripts/moe_ckpt_merge/moe_merge.py` script is **deprecated** but
+retained for cases where you want to amortize the stacking cost across many
+runs (e.g. very large checkpoints).
 
 ### Transformers v5 (`transformers>=5.0.0`)
 
@@ -187,6 +204,6 @@ Expected tensor interface:
 
 | Checkpoint Format | v4 VeOmni Load | v5 VeOmni Load | HF `from_pretrained()` | vLLM/SGLang |
 |---|---|---|---|---|
-| HF per-expert (original) | needs `moe_merge.py` | runtime converter | direct | direct |
+| HF per-expert (original) | runtime converter | runtime converter | direct | direct |
 | v4 merged (gate/up/down separate) | direct | needs re-merge with v5 format | needs `moe_split.py` | needs `moe_split.py` |
 | v5 fused (gate_up_proj) | incompatible | direct | needs `moe_split.py` | needs `moe_split.py` |

--- a/scripts/moe_ckpt_merge/moe_merge.py
+++ b/scripts/moe_ckpt_merge/moe_merge.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import warnings
 from argparse import ArgumentParser
 from dataclasses import dataclass
 from glob import glob
@@ -11,6 +12,15 @@ from tqdm import tqdm
 from transformers import AutoConfig
 
 from veomni.models import save_model_weights
+
+
+_DEPRECATION_MESSAGE = (
+    "scripts/moe_ckpt_merge/moe_merge.py is deprecated: VeOmni now stacks per-expert "
+    "weights on-the-fly at model load time for both transformers v4 and v5, so you can "
+    "pass the original HuggingFace checkpoint directly to training. This script will be "
+    "removed in a future release. Pre-merging is still useful for very large checkpoints "
+    "(e.g. Qwen3-235B) when you want to amortize the stacking cost across many runs."
+)
 
 
 @dataclass
@@ -147,6 +157,8 @@ def _copy_non_weight_files(src_dir: str, dst_dir: str):
 
 
 def main(raw_hf_path, merge_hf_path):
+    warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
+    print(f"DeprecationWarning: {_DEPRECATION_MESSAGE}")
     torch.set_default_dtype(torch.bfloat16)
     os.makedirs(merge_hf_path, exist_ok=True)
 

--- a/tests/models/hf_unpatch.py
+++ b/tests/models/hf_unpatch.py
@@ -1,0 +1,122 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Pristine HuggingFace class snapshots + restoration helpers.
+
+Tests that build both an HF and a VeOmni model in the same process need to
+run the HF build *before* anything triggers ``apply_veomni_*_patch``, since
+those functions monkey-patch HF module classes process-wide. When pytest
+runs multiple cases in the same process this is hard to guarantee, so
+``apply_veomni_hf_unpatch()`` restores the pristine class attributes
+captured at this module's import time.
+
+This module deliberately avoids importing from ``veomni.data`` so test
+files that only need the unpatch helper don't pull in heavyweight optional
+dependencies (``av``, ``torchcodec``, ...). Keep the imports here narrow.
+"""
+
+import transformers.models.deepseek_v3.modeling_deepseek_v3 as _hf_ds3
+import transformers.models.qwen3.modeling_qwen3 as _hf_qwen3
+import transformers.models.qwen3_moe.modeling_qwen3_moe as _hf_qwen3_moe
+
+
+# Cover every patch site reachable from apply_veomni_*_patch() + the Liger
+# and Triton branches of apply_veomni_*_gpu_patch(). We capture:
+# - forward methods (undo in-class forward replacement, used by both the
+#   always-on patch and the Triton branch's _patch_rms_norm / RoPE forward)
+# - whole classes (undo module-level class swap done by the Liger branch
+#   and by DeepseekV3MoE / Qwen3MoeSparseMoeBlock replacements)
+# - module-level functions (apply_rotary_pos_emb is replaced by Liger)
+#
+# Restore order matters: we first reset in-class attributes on the pristine
+# class objects, then restore the module-level names. That way, even if a
+# prior test mutated `Class.forward` and then swapped in a Liger class at
+# the module level, both layers are reverted.
+_PRISTINE_HF = {
+    # qwen3
+    "qwen3.CausalLM.forward": _hf_qwen3.Qwen3ForCausalLM.forward,
+    "qwen3.SeqCls.forward": _hf_qwen3.Qwen3ForSequenceClassification.forward,
+    "qwen3.apply_rotary_pos_emb": _hf_qwen3.apply_rotary_pos_emb,
+    "qwen3.RMSNorm.cls": _hf_qwen3.Qwen3RMSNorm,
+    "qwen3.RMSNorm.forward": _hf_qwen3.Qwen3RMSNorm.forward,
+    "qwen3.MLP.cls": _hf_qwen3.Qwen3MLP,
+    # qwen3_moe
+    "qwen3_moe.CausalLM.forward": _hf_qwen3_moe.Qwen3MoeForCausalLM.forward,
+    "qwen3_moe.MoeBlock.cls": _hf_qwen3_moe.Qwen3MoeSparseMoeBlock,
+    "qwen3_moe.PreTrained.init_weights": _hf_qwen3_moe.Qwen3MoePreTrainedModel._init_weights,
+    "qwen3_moe.apply_rotary_pos_emb": _hf_qwen3_moe.apply_rotary_pos_emb,
+    "qwen3_moe.RMSNorm.cls": _hf_qwen3_moe.Qwen3MoeRMSNorm,
+    "qwen3_moe.RMSNorm.forward": _hf_qwen3_moe.Qwen3MoeRMSNorm.forward,
+    "qwen3_moe.MLP.cls": _hf_qwen3_moe.Qwen3MoeMLP,
+    # deepseek_v3
+    "ds3.Attention.forward": _hf_ds3.DeepseekV3Attention.forward,
+    "ds3.CausalLM.forward": _hf_ds3.DeepseekV3ForCausalLM.forward,
+    "ds3.MoE.cls": _hf_ds3.DeepseekV3MoE,
+    "ds3.PreTrained.init_weights": _hf_ds3.DeepseekV3PreTrainedModel._init_weights,
+    "ds3.apply_rotary_pos_emb": _hf_ds3.apply_rotary_pos_emb,
+    "ds3.RotaryEmb.cls": _hf_ds3.DeepseekV3RotaryEmbedding,
+    "ds3.RotaryEmb.forward": _hf_ds3.DeepseekV3RotaryEmbedding.forward,
+    "ds3.RMSNorm.cls": _hf_ds3.DeepseekV3RMSNorm,
+    "ds3.RMSNorm.forward": _hf_ds3.DeepseekV3RMSNorm.forward,
+    "ds3.MLP.cls": _hf_ds3.DeepseekV3MLP,
+}
+
+
+def apply_veomni_hf_unpatch():
+    """Undo in-place veomni monkey-patches on HF model modules.
+
+    `apply_veomni_*_patch()` in each of `qwen3/`, `qwen3_moe/`, `deepseek_v3/`
+    mutates the HF model modules directly (forward swaps, class swaps, new
+    `get_parallel_plan` methods). Without this restore, the first parametrize
+    case to build a veomni model leaks its patches into every subsequent HF
+    build in the same test session.
+    """
+    # Step 1: restore in-class forward methods on pristine class objects.
+    # This handles both the always-on forward swaps and the Triton branch's
+    # in-class mutations (DeepseekV3RotaryEmbedding.forward / DeepseekV3RMSNorm.forward).
+    _PRISTINE_HF["qwen3.RMSNorm.cls"].forward = _PRISTINE_HF["qwen3.RMSNorm.forward"]
+    _PRISTINE_HF["qwen3_moe.RMSNorm.cls"].forward = _PRISTINE_HF["qwen3_moe.RMSNorm.forward"]
+    _PRISTINE_HF["ds3.RotaryEmb.cls"].forward = _PRISTINE_HF["ds3.RotaryEmb.forward"]
+    _PRISTINE_HF["ds3.RMSNorm.cls"].forward = _PRISTINE_HF["ds3.RMSNorm.forward"]
+
+    _hf_qwen3.Qwen3ForCausalLM.forward = _PRISTINE_HF["qwen3.CausalLM.forward"]
+    _hf_qwen3.Qwen3ForSequenceClassification.forward = _PRISTINE_HF["qwen3.SeqCls.forward"]
+    _hf_qwen3_moe.Qwen3MoeForCausalLM.forward = _PRISTINE_HF["qwen3_moe.CausalLM.forward"]
+    _hf_qwen3_moe.Qwen3MoePreTrainedModel._init_weights = _PRISTINE_HF["qwen3_moe.PreTrained.init_weights"]
+    _hf_ds3.DeepseekV3Attention.forward = _PRISTINE_HF["ds3.Attention.forward"]
+    _hf_ds3.DeepseekV3ForCausalLM.forward = _PRISTINE_HF["ds3.CausalLM.forward"]
+    _hf_ds3.DeepseekV3PreTrainedModel._init_weights = _PRISTINE_HF["ds3.PreTrained.init_weights"]
+
+    # Step 2: restore module-level names for classes / functions that the
+    # Liger branch swaps out wholesale, plus the class swaps done by the
+    # always-on patch (Qwen3MoeSparseMoeBlock, DeepseekV3MoE).
+    _hf_qwen3.apply_rotary_pos_emb = _PRISTINE_HF["qwen3.apply_rotary_pos_emb"]
+    _hf_qwen3.Qwen3RMSNorm = _PRISTINE_HF["qwen3.RMSNorm.cls"]
+    _hf_qwen3.Qwen3MLP = _PRISTINE_HF["qwen3.MLP.cls"]
+    _hf_qwen3_moe.Qwen3MoeSparseMoeBlock = _PRISTINE_HF["qwen3_moe.MoeBlock.cls"]
+    _hf_qwen3_moe.apply_rotary_pos_emb = _PRISTINE_HF["qwen3_moe.apply_rotary_pos_emb"]
+    _hf_qwen3_moe.Qwen3MoeRMSNorm = _PRISTINE_HF["qwen3_moe.RMSNorm.cls"]
+    _hf_qwen3_moe.Qwen3MoeMLP = _PRISTINE_HF["qwen3_moe.MLP.cls"]
+    _hf_ds3.DeepseekV3MoE = _PRISTINE_HF["ds3.MoE.cls"]
+    _hf_ds3.apply_rotary_pos_emb = _PRISTINE_HF["ds3.apply_rotary_pos_emb"]
+    _hf_ds3.DeepseekV3RotaryEmbedding = _PRISTINE_HF["ds3.RotaryEmb.cls"]
+    _hf_ds3.DeepseekV3RMSNorm = _PRISTINE_HF["ds3.RMSNorm.cls"]
+    _hf_ds3.DeepseekV3MLP = _PRISTINE_HF["ds3.MLP.cls"]
+
+    # Step 3: remove `get_parallel_plan` methods injected onto HF causal-LM
+    # classes by apply_veomni_*_patch.
+    for cls in (_hf_qwen3_moe.Qwen3MoeForCausalLM, _hf_ds3.DeepseekV3ForCausalLM):
+        if "get_parallel_plan" in cls.__dict__:
+            delattr(cls, "get_parallel_plan")

--- a/tests/models/test_models_logits_equal.py
+++ b/tests/models/test_models_logits_equal.py
@@ -247,14 +247,57 @@ def _build_veomni_model_via_runtime_converter(case: Case, hf_state_dict, hf_buff
     directly, let the v4 converter stack per-expert keys at load time. No manual
     sync adapter, no offline merge.
 
-    HF's non-persistent buffers (e.g. `model.rotary_emb.inv_freq`) are not in the
-    state dict and so do not round-trip through safetensors. The
-    ``init_empty_weights() + to_empty(cuda)`` path used here computes them with a
-    different floating-point op order than HF's direct `with torch.device('cuda')`
-    construction (CPU vs CUDA, ULP-level fp32 difference). To keep the smoke test
-    a true bitwise check on the converter's *parameter* loading rather than a
-    fight with init-time fp jitter, we copy HF's non-persistent buffers in after
-    load. The converter's correctness on stacked expert params is unchanged.
+    Why we patch non-persistent buffers below
+    -----------------------------------------
+
+    The HF rotary `inv_freq` buffer is registered with ``persistent=False`` in
+    upstream transformers, so it is **not** in ``model.state_dict()`` and therefore
+    does not round-trip through safetensors. Whatever values end up in
+    ``model.rotary_emb.inv_freq`` after load come entirely from VeOmni's loader
+    init flow, not from the checkpoint.
+
+    VeOmni's loader has two construction paths in
+    ``CustomizedModelingLoader.load_model``:
+
+    1. ``weights_path is None`` (random-init build, used by the sibling
+       ``test_logits_bitwise_equal``): the model is constructed under
+       ``with torch.device(init_device)``. The rotary embedding's
+       ``inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float() / dim))``
+       executes directly on CUDA, bit-matching the HF reference build which
+       does the same.
+
+    2. ``weights_path != None`` (every real training run, including offline-
+       merged MoE checkpoints from the pre-PR world): the model is
+       constructed under ``init_empty_weights() + no_init_weights()``. Note
+       that accelerate's ``init_empty_weights()`` patches ``register_parameter``
+       to use the meta device, but by default does **not** patch
+       ``register_buffer`` — so the rotary embedding's ``inv_freq`` math runs
+       as a regular **CPU** tensor during ``__init__``. ``load_model_weights``
+       then snapshots ``buffer_dict = {n: b.clone() for n, b in named_buffers()}``
+       (CPU values), runs ``model.to_empty(device=init_device)`` (which wipes
+       buffer storage to uninitialized memory on CUDA), and finally
+       ``post_process_after_weight_loading`` calls ``_dispatch_buffer`` which
+       does ``buf.to(device, dtype)`` — a bit-exact CPU→CUDA copy. So
+       ``inv_freq`` ends up as **CPU-computed** ``1.0 / (base ** ...)`` moved
+       to CUDA, which differs from CUDA-computed ``1.0 / (base ** ...)`` by
+       one ULP per element.
+
+    That 1-ULP gap propagates through attention into a small but non-zero
+    logits delta — enough to fail ``torch.equal`` (we observed ~1e-6 for
+    qwen3_moe and ~3e-3 for deepseek_v3). It is a **pre-existing property of
+    path 2**, not something this PR's converter introduced: every offline-
+    merged MoE checkpoint loaded through ``weights_path=<merged_dir>`` had
+    the same CPU→CUDA ``inv_freq`` move. The sibling test simply never tripped
+    on it because it uses path 1.
+
+    To keep this smoke test a true bitwise check on the converter's
+    *parameter* loading — and not a regression test for a separate loader-
+    level fp jitter that would belong in its own fix — we copy HF's
+    non-persistent buffers into the model after load.
+
+    A proper loader-level fix would be to call ``init_empty_weights(
+    include_buffers=True)`` and recompute buffers on ``init_device`` after
+    ``to_empty``. That is out of scope here; tracked separately.
     """
     from veomni.models.auto import build_foundation_model
 
@@ -269,7 +312,8 @@ def _build_veomni_model_via_runtime_converter(case: Case, hf_state_dict, hf_buff
     )
 
     # Restore non-persistent buffers (e.g. rotary inv_freq) that aren't in the
-    # state dict. Walking by FQN keeps this independent of how nested they are.
+    # state dict. See the docstring above for the full background. Walking by
+    # FQN keeps this independent of how nested they are.
     persistent_keys = set(hf_state_dict.keys())
     for name, buf in hf_buffers.items():
         if name in persistent_keys:
@@ -288,13 +332,20 @@ def _build_veomni_model_via_runtime_converter(case: Case, hf_state_dict, hf_buff
 def test_logits_bitwise_equal_via_runtime_converter(case: Case):
     """Smoke test: per-expert HF checkpoint -> on-the-fly converter -> bitwise-equal forward.
 
-    Complements ``test_logits_bitwise_equal``: that one syncs HF weights into the
-    VeOmni model via the manual adapter in ``weight_sync_adapters.py``. This one
-    saves the HF state dict to disk as a real HF checkpoint and routes loading
-    through ``load_model_weights`` -> ``MoEV4StackingConverter``, exercising the
-    same code path users hit when pointing training at a vanilla HF model dir.
-    Bitwise-equal logits prove the runtime converter produces the exact same
-    stacked tensors the manual adapter does.
+    Complements ``test_logits_bitwise_equal``: that one syncs HF weights into
+    the VeOmni model via the manual adapter in ``weight_sync_adapters.py``.
+    This one saves the HF state dict to disk as a real HF checkpoint and
+    routes loading through ``load_model_weights`` -> ``MoEV4StackingConverter``,
+    exercising the same code path users hit when pointing training at a vanilla
+    HF model dir. Bitwise-equal logits prove the runtime converter produces
+    the exact same stacked parameter tensors the manual adapter does.
+
+    Note on non-persistent buffers: ``_build_veomni_model_via_runtime_converter``
+    copies HF's ``inv_freq`` (and any other ``persistent=False`` buffers) into
+    the loaded model before the forward. That step works around a separate,
+    pre-existing loader quirk on the ``weights_path != None`` path that has
+    nothing to do with this PR's converter — see the helper's docstring for
+    the full explanation.
     """
     from transformers import AutoConfig
 

--- a/tests/models/test_models_logits_equal.py
+++ b/tests/models/test_models_logits_equal.py
@@ -12,12 +12,12 @@ import torch
 
 from veomni.utils.device import IS_CUDA_AVAILABLE, empty_cache, get_device_type, get_torch_device
 
-# Importing `utils` now captures pristine HF class attributes (in its
-# `_PRISTINE_HF_CLASSES` snapshot) before any veomni import has a chance to
-# monkey-patch them. `apply_veomni_hf_unpatch()` restores them; we call it
-# before every HF build so leaks from the previous test do not poison the
-# current one.
-from .utils import apply_veomni_hf_unpatch  # noqa: E402
+# Importing `hf_unpatch` here (rather than from `utils`) captures pristine HF
+# class attributes before any veomni import has a chance to monkey-patch them,
+# without dragging in the heavy `veomni.data` import chain (av/torchcodec).
+# `apply_veomni_hf_unpatch()` restores them; we call it before every HF build
+# so leaks from the previous test do not poison the current one.
+from .hf_unpatch import apply_veomni_hf_unpatch  # noqa: E402
 
 
 # Must be set before `import veomni` so GPU kernel patches remain gated off.

--- a/tests/models/test_models_logits_equal.py
+++ b/tests/models/test_models_logits_equal.py
@@ -240,12 +240,21 @@ def _save_hf_checkpoint(state_dict: dict, config, dst_dir: str) -> None:
     )
 
 
-def _build_veomni_model_via_runtime_converter(case: Case, hf_state_dict, config, weights_dir: str):
+def _build_veomni_model_via_runtime_converter(case: Case, hf_state_dict, hf_buffers, config, weights_dir: str):
     """Build VeOmni model by going through `build_foundation_model(weights_path=...)`.
 
     This is the path real users hit after this PR: pass the original HF checkpoint
     directly, let the v4 converter stack per-expert keys at load time. No manual
     sync adapter, no offline merge.
+
+    HF's non-persistent buffers (e.g. `model.rotary_emb.inv_freq`) are not in the
+    state dict and so do not round-trip through safetensors. The
+    ``init_empty_weights() + to_empty(cuda)`` path used here computes them with a
+    different floating-point op order than HF's direct `with torch.device('cuda')`
+    construction (CPU vs CUDA, ULP-level fp32 difference). To keep the smoke test
+    a true bitwise check on the converter's *parameter* loading rather than a
+    fight with init-time fp jitter, we copy HF's non-persistent buffers in after
+    load. The converter's correctness on stacked expert params is unchanged.
     """
     from veomni.models.auto import build_foundation_model
 
@@ -258,6 +267,20 @@ def _build_veomni_model_via_runtime_converter(case: Case, hf_state_dict, config,
         attn_implementation=case.attn_implementation,
         init_device=get_device_type(),
     )
+
+    # Restore non-persistent buffers (e.g. rotary inv_freq) that aren't in the
+    # state dict. Walking by FQN keeps this independent of how nested they are.
+    persistent_keys = set(hf_state_dict.keys())
+    for name, buf in hf_buffers.items():
+        if name in persistent_keys:
+            continue
+        parts = name.split(".")
+        target_module = model
+        for p in parts[:-1]:
+            target_module = getattr(target_module, p)
+        target = target_module._buffers[parts[-1]]
+        target.copy_(buf.to(target.device, dtype=target.dtype))
+
     return model.eval()
 
 
@@ -295,6 +318,7 @@ def test_logits_bitwise_equal_via_runtime_converter(case: Case):
     with torch.no_grad():
         logits_hf = model_hf(input_ids=input_ids, use_cache=False).logits.detach().clone()
     hf_state_dict = copy.deepcopy(model_hf.state_dict())
+    hf_buffers = {n: b.detach().clone() for n, b in model_hf.named_buffers()}
     hf_config = AutoConfig.from_pretrained(case.path)
     del model_hf
     _release()
@@ -302,7 +326,7 @@ def test_logits_bitwise_equal_via_runtime_converter(case: Case):
     # --- veomni phase: load the HF checkpoint through build_foundation_model ---
     tmp_dir = tempfile.mkdtemp(prefix="veomni_v4_converter_test_")
     try:
-        model_ve = _build_veomni_model_via_runtime_converter(case, hf_state_dict, hf_config, tmp_dir)
+        model_ve = _build_veomni_model_via_runtime_converter(case, hf_state_dict, hf_buffers, hf_config, tmp_dir)
         with torch.no_grad():
             logits_ve = model_ve(input_ids=input_ids, use_cache=False).logits.detach().clone()
         del model_ve

--- a/tests/models/test_models_logits_equal.py
+++ b/tests/models/test_models_logits_equal.py
@@ -2,6 +2,8 @@ import copy
 import gc
 import importlib.util
 import os
+import shutil
+import tempfile
 from dataclasses import dataclass
 from typing import Optional
 
@@ -212,6 +214,117 @@ def test_logits_bitwise_equal(case: Case):
         first_idx = torch.nonzero(ne, as_tuple=False)[:5].tolist()
         raise AssertionError(
             f"[{case.case_id}] logits not bitwise equal: "
+            f"{n_mis}/{total} mismatched, max_abs_diff={max_abs:.3e}, "
+            f"first_mismatch_indices={first_idx}"
+        )
+
+
+# Subset of CASES exercised through the runtime converter — only the MoE
+# models, since the converter only fires for them. Eager + fp32 only: this
+# test is about the converter's correctness on the load path, not about
+# attention-kernel parity (already covered by the case above).
+_RUNTIME_CONVERTER_CASES = [
+    Case("qwen3_moe-toy-runtime-converter", _toy("qwen3_moe_toy"), sync_weight_key="qwen3_moe"),
+    Case("deepseek_v3-toy-runtime-converter", _toy("deepseek_v3_toy"), sync_weight_key="deepseek_v3"),
+]
+
+
+def _save_hf_checkpoint(state_dict: dict, config, dst_dir: str) -> None:
+    """Write an HF-format per-expert checkpoint that build_foundation_model can read."""
+    from safetensors.torch import save_file
+
+    config.save_pretrained(dst_dir)
+    save_file(
+        {k: v.detach().contiguous().cpu() for k, v in state_dict.items()},
+        os.path.join(dst_dir, "model.safetensors"),
+    )
+
+
+def _build_veomni_model_via_runtime_converter(case: Case, hf_state_dict, config, weights_dir: str):
+    """Build VeOmni model by going through `build_foundation_model(weights_path=...)`.
+
+    This is the path real users hit after this PR: pass the original HF checkpoint
+    directly, let the v4 converter stack per-expert keys at load time. No manual
+    sync adapter, no offline merge.
+    """
+    from veomni.models.auto import build_foundation_model
+
+    _save_hf_checkpoint(hf_state_dict, config, weights_dir)
+
+    model = build_foundation_model(
+        config_path=weights_dir,
+        weights_path=weights_dir,
+        torch_dtype=case.dtype,
+        attn_implementation=case.attn_implementation,
+        init_device=get_device_type(),
+    )
+    return model.eval()
+
+
+@pytest.mark.parametrize("case", _RUNTIME_CONVERTER_CASES, ids=[c.case_id for c in _RUNTIME_CONVERTER_CASES])
+def test_logits_bitwise_equal_via_runtime_converter(case: Case):
+    """Smoke test: per-expert HF checkpoint -> on-the-fly converter -> bitwise-equal forward.
+
+    Complements ``test_logits_bitwise_equal``: that one syncs HF weights into the
+    VeOmni model via the manual adapter in ``weight_sync_adapters.py``. This one
+    saves the HF state dict to disk as a real HF checkpoint and routes loading
+    through ``load_model_weights`` -> ``MoEV4StackingConverter``, exercising the
+    same code path users hit when pointing training at a vanilla HF model dir.
+    Bitwise-equal logits prove the runtime converter produces the exact same
+    stacked tensors the manual adapter does.
+    """
+    from transformers import AutoConfig
+
+    from veomni.utils.import_utils import is_transformers_version_greater_or_equal_to
+
+    if is_transformers_version_greater_or_equal_to("5.0.0"):
+        pytest.skip("Scope is transformers v4 model definition only.")
+    if not IS_CUDA_AVAILABLE:
+        pytest.skip("CUDA required.")
+    if not os.path.isdir(case.path):
+        pytest.skip(f"Path not found: {case.path}")
+
+    _apply_determinism()
+
+    device_type = get_device_type()
+    gen = torch.Generator(device=device_type).manual_seed(0)
+    input_ids = torch.randint(0, 32000, (1, 32), device=device_type, dtype=torch.long, generator=gen)
+
+    # --- HF phase (must precede any veomni model build, same as the sibling test) ---
+    model_hf = _build_hf_model(case)
+    with torch.no_grad():
+        logits_hf = model_hf(input_ids=input_ids, use_cache=False).logits.detach().clone()
+    hf_state_dict = copy.deepcopy(model_hf.state_dict())
+    hf_config = AutoConfig.from_pretrained(case.path)
+    del model_hf
+    _release()
+
+    # --- veomni phase: load the HF checkpoint through build_foundation_model ---
+    tmp_dir = tempfile.mkdtemp(prefix="veomni_v4_converter_test_")
+    try:
+        model_ve = _build_veomni_model_via_runtime_converter(case, hf_state_dict, hf_config, tmp_dir)
+        with torch.no_grad():
+            logits_ve = model_ve(input_ids=input_ids, use_cache=False).logits.detach().clone()
+        del model_ve
+        _release()
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        del hf_state_dict
+        _release()
+
+    assert logits_hf.shape == logits_ve.shape, (
+        f"[{case.case_id}] shape mismatch: hf={tuple(logits_hf.shape)} ve={tuple(logits_ve.shape)}"
+    )
+
+    if not torch.equal(logits_hf, logits_ve):
+        diff = (logits_hf.float() - logits_ve.float()).abs()
+        ne = logits_hf != logits_ve
+        n_mis = int(ne.sum().item())
+        total = logits_hf.numel()
+        max_abs = float(diff.max().item())
+        first_idx = torch.nonzero(ne, as_tuple=False)[:5].tolist()
+        raise AssertionError(
+            f"[{case.case_id}] logits not bitwise equal via runtime converter: "
             f"{n_mis}/{total} mismatched, max_abs_diff={max_abs:.3e}, "
             f"first_mismatch_indices={first_idx}"
         )

--- a/tests/models/test_models_logits_equal.py
+++ b/tests/models/test_models_logits_equal.py
@@ -220,12 +220,26 @@ def test_logits_bitwise_equal(case: Case):
 
 
 # Subset of CASES exercised through the runtime converter — only the MoE
-# models, since the converter only fires for them. Eager + fp32 only: this
-# test is about the converter's correctness on the load path, not about
-# attention-kernel parity (already covered by the case above).
+# models, since the converter only fires for them. Mirrors the eager+fp32
+# and fa2+bf16 split of CASES so the converter path gets exercised against
+# both the attention kernels and the dtypes that real users hit.
 _RUNTIME_CONVERTER_CASES = [
     Case("qwen3_moe-toy-runtime-converter", _toy("qwen3_moe_toy"), sync_weight_key="qwen3_moe"),
     Case("deepseek_v3-toy-runtime-converter", _toy("deepseek_v3_toy"), sync_weight_key="deepseek_v3"),
+    Case(
+        "qwen3_moe-toy-runtime-converter-fa2",
+        _toy("qwen3_moe_toy"),
+        sync_weight_key="qwen3_moe",
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+    Case(
+        "deepseek_v3-toy-runtime-converter-fa2",
+        _toy("deepseek_v3_toy"),
+        sync_weight_key="deepseek_v3",
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
 ]
 
 
@@ -357,6 +371,8 @@ def test_logits_bitwise_equal_via_runtime_converter(case: Case):
         pytest.skip("CUDA required.")
     if not os.path.isdir(case.path):
         pytest.skip(f"Path not found: {case.path}")
+    if case.attn_implementation == "flash_attention_2" and importlib.util.find_spec("flash_attn") is None:
+        pytest.skip("flash_attn package not installed.")
 
     _apply_determinism()
 

--- a/tests/models/test_moe_v4_runtime_merge.py
+++ b/tests/models/test_moe_v4_runtime_merge.py
@@ -344,13 +344,30 @@ class TestDeepseekV3V4Factory:
 # ---------------------------------------------------------------------------
 
 
-class TestQwen3OmniMoeV4Factory:
+def _omni_top_level_model(moe_implementation: str = "fused"):
+    """SimpleNamespace mimicking Qwen3OmniMoeForConditionalGeneration's config shape."""
+    text_config = SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation=moe_implementation)
+    thinker_config = SimpleNamespace(text_config=text_config)
+    return SimpleNamespace(
+        config=SimpleNamespace(thinker_config=thinker_config, _moe_implementation=moe_implementation)
+    )
+
+
+def _omni_thinker_standalone_model(moe_implementation: str = "fused"):
+    """SimpleNamespace mimicking Qwen3OmniMoeThinkerForConditionalGeneration's config shape."""
+    text_config = SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation=moe_implementation)
+    return SimpleNamespace(config=SimpleNamespace(text_config=text_config, _moe_implementation=moe_implementation))
+
+
+def _omni_text_model_standalone(moe_implementation: str = "fused"):
+    """SimpleNamespace mimicking Qwen3OmniMoeThinkerTextModel's config shape."""
+    return SimpleNamespace(config=SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation=moe_implementation))
+
+
+class TestQwen3OmniMoeV4FactoryFusedGate:
     def test_returns_none_in_eager_mode(self):
         """In eager mode the thinker uses nn.ModuleList and HF per-expert keys map directly."""
-        text_config = SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation="eager")
-        thinker_config = SimpleNamespace(text_config=text_config)
-        model = SimpleNamespace(config=SimpleNamespace(thinker_config=thinker_config, _moe_implementation="eager"))
-        assert create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model) is None
+        assert create_qwen3_omni_moe_v4_checkpoint_tensor_converter(_omni_top_level_model("eager")) is None
 
     def test_returns_none_when_implementation_unset(self):
         """No `_moe_implementation` set → fallback is eager (per modeling code)."""
@@ -360,42 +377,93 @@ class TestQwen3OmniMoeV4Factory:
         assert create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model) is None
 
     def test_returns_converter_in_fused_mode(self):
-        text_config = SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation="fused")
-        thinker_config = SimpleNamespace(text_config=text_config)
-        model = SimpleNamespace(config=SimpleNamespace(thinker_config=thinker_config, _moe_implementation="fused"))
-        converter = create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model)
-        assert isinstance(converter, MoEV4StackingConverter)
+        assert isinstance(
+            create_qwen3_omni_moe_v4_checkpoint_tensor_converter(_omni_top_level_model("fused")),
+            MoEV4StackingConverter,
+        )
 
-    def test_fused_converter_handles_thinker_prefix(self):
-        text_config = SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation="fused")
-        thinker_config = SimpleNamespace(text_config=text_config)
-        model = SimpleNamespace(config=SimpleNamespace(thinker_config=thinker_config, _moe_implementation="fused"))
-        converter = create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model)
 
+class TestQwen3OmniMoeV4FactoryTopLevel:
+    """Top-level Qwen3OmniMoeForConditionalGeneration: thinker prefix only, talker keys pass through."""
+
+    def setup_method(self):
+        self.converter = create_qwen3_omni_moe_v4_checkpoint_tensor_converter(_omni_top_level_model("fused"))
+
+    def test_handles_thinker_prefix(self):
+        assert self.converter.can_handle("thinker.model.layers.0.mlp.experts.0.gate_proj.weight")
         last = None
         for e in range(NUM_EXPERTS):
-            last = converter.convert(
+            last = self.converter.convert(
                 f"thinker.model.layers.0.mlp.experts.{e}.gate_proj.weight",
                 _hf_expert_tensor("gate_proj", e),
             )
         assert last is not None
         assert last.name == "thinker.model.layers.0.mlp.experts.gate_proj"
 
-    def test_fused_converter_does_not_match_talker_prefix(self):
+    def test_does_not_match_talker_prefix(self):
         """Talker tower runs in eager (nn.ModuleList) on v4; converter must leave its keys alone."""
-        text_config = SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation="fused")
-        thinker_config = SimpleNamespace(text_config=text_config)
-        model = SimpleNamespace(config=SimpleNamespace(thinker_config=thinker_config, _moe_implementation="fused"))
-        converter = create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model)
-
         talker_key = "talker.model.layers.0.mlp.experts.0.gate_proj.weight"
-        assert not converter.can_handle(talker_key)
+        assert not self.converter.can_handle(talker_key)
 
         # Pass-through via maybe_convert_checkpoint_tensor:
         t = torch.randn(INTERMEDIATE_DIM, HIDDEN_DIM)
-        result = maybe_convert_checkpoint_tensor(talker_key, t, converter)
+        result = maybe_convert_checkpoint_tensor(talker_key, t, self.converter)
         assert result is not None and result.name == talker_key
         assert torch.equal(result.tensor, t)
+
+    def test_does_not_match_unprefixed_keys(self):
+        """When loading the top-level container, expert keys without `thinker.` prefix
+        are unexpected — pass them through so the dispatcher can flag them."""
+        assert not self.converter.can_handle("model.layers.0.mlp.experts.0.gate_proj.weight")
+
+
+class TestQwen3OmniMoeV4FactoryThinkerStandalone:
+    """Standalone Qwen3OmniMoeThinkerForConditionalGeneration: experts under `model.layers.*`."""
+
+    def setup_method(self):
+        self.converter = create_qwen3_omni_moe_v4_checkpoint_tensor_converter(_omni_thinker_standalone_model("fused"))
+
+    def test_handles_model_prefix(self):
+        # The standalone thinker class wraps a `.model = Qwen3OmniMoeThinkerTextModel`,
+        # so its parameter FQNs (and the matching HF checkpoint keys) start with `model.`.
+        assert self.converter.can_handle("model.layers.0.mlp.experts.0.gate_proj.weight")
+
+        last = None
+        for e in range(NUM_EXPERTS):
+            last = self.converter.convert(
+                f"model.layers.0.mlp.experts.{e}.gate_proj.weight",
+                _hf_expert_tensor("gate_proj", e),
+            )
+        assert last is not None
+        assert last.name == "model.layers.0.mlp.experts.gate_proj"
+
+    def test_does_not_match_thinker_or_talker_prefixes(self):
+        # The standalone thinker never sees `thinker.*` or `talker.*` keys.
+        assert not self.converter.can_handle("thinker.model.layers.0.mlp.experts.0.gate_proj.weight")
+        assert not self.converter.can_handle("talker.model.layers.0.mlp.experts.0.gate_proj.weight")
+
+
+class TestQwen3OmniMoeV4FactoryTextModelStandalone:
+    """Standalone Qwen3OmniMoeThinkerTextModel: experts under `layers.*` (the model class IS the root)."""
+
+    def setup_method(self):
+        self.converter = create_qwen3_omni_moe_v4_checkpoint_tensor_converter(_omni_text_model_standalone("fused"))
+
+    def test_handles_bare_layers_prefix(self):
+        assert self.converter.can_handle("layers.0.mlp.experts.0.gate_proj.weight")
+
+        last = None
+        for e in range(NUM_EXPERTS):
+            last = self.converter.convert(
+                f"layers.0.mlp.experts.{e}.gate_proj.weight",
+                _hf_expert_tensor("gate_proj", e),
+            )
+        assert last is not None
+        assert last.name == "layers.0.mlp.experts.gate_proj"
+
+    def test_does_not_match_wrapped_prefixes(self):
+        assert not self.converter.can_handle("model.layers.0.mlp.experts.0.gate_proj.weight")
+        assert not self.converter.can_handle("thinker.model.layers.0.mlp.experts.0.gate_proj.weight")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/test_moe_v4_runtime_merge.py
+++ b/tests/models/test_moe_v4_runtime_merge.py
@@ -1,0 +1,488 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for transformers v4 on-the-fly MoE expert weight stacking converters.
+
+The v4 patches for `qwen3_moe`, `deepseek_v3`, and `qwen3_omni_moe` (in fused
+mode) store experts as three separate stacked nn.Parameters. The converters
+in this test file fold the per-expert HF checkpoint format into that layout
+at load time so users can pass vanilla HF checkpoints directly.
+"""
+
+import os
+import re
+import shutil
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from transformers import AutoConfig
+
+from veomni.models.checkpoint_tensor_loading import maybe_convert_checkpoint_tensor
+from veomni.models.loader import get_model_class
+from veomni.models.module_utils import init_empty_weights, load_model_weights
+from veomni.models.transformers._moe_v4_converter import MoEV4StackingConverter
+from veomni.models.transformers.deepseek_v3.checkpoint_tensor_converter_v4 import (
+    create_deepseek_v3_v4_checkpoint_tensor_converter,
+)
+from veomni.models.transformers.qwen3_moe.checkpoint_tensor_converter_v4 import (
+    create_qwen3_moe_v4_checkpoint_tensor_converter,
+)
+from veomni.models.transformers.qwen3_omni_moe.checkpoint_tensor_converter_v4 import (
+    create_qwen3_omni_moe_v4_checkpoint_tensor_converter,
+)
+from veomni.utils.import_utils import is_transformers_version_greater_or_equal_to
+
+
+try:
+    from transformers.initialization import no_init_weights
+except ImportError:
+    from transformers.modeling_utils import no_init_weights
+
+
+NUM_EXPERTS = 4
+HIDDEN_DIM = 8
+INTERMEDIATE_DIM = 6
+
+
+def _hf_expert_key(prefix: str, expert: int, proj: str) -> str:
+    return f"{prefix}.experts.{expert}.{proj}.weight"
+
+
+def _hf_expert_tensor(proj: str, expert_id: int) -> torch.Tensor:
+    """Deterministic per-expert tensor in HF layout.
+
+    gate_proj/up_proj: [I, H]; down_proj: [H, I]. Filled with `expert_id + offset`
+    so we can assert the post-stack tensor has the right value at each index.
+    """
+    if proj == "down_proj":
+        shape = (HIDDEN_DIM, INTERMEDIATE_DIM)
+    else:
+        shape = (INTERMEDIATE_DIM, HIDDEN_DIM)
+    offset = {"gate_proj": 0.0, "up_proj": 0.1, "down_proj": 0.2}[proj]
+    return torch.full(shape, float(expert_id) + offset)
+
+
+# Same regex used by the qwen3_moe / deepseek_v3 / qwen3_omni_moe v4 factories.
+_PATTERN = re.compile(r"^(.+\.mlp)\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$")
+
+
+# ---------------------------------------------------------------------------
+# MoEV4StackingConverter unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMoEV4StackingConverterCanHandle:
+    def setup_method(self):
+        self.converter = MoEV4StackingConverter(_PATTERN, num_experts_for=lambda _: NUM_EXPERTS)
+
+    def test_matches_per_expert_keys(self):
+        assert self.converter.can_handle("model.layers.0.mlp.experts.0.gate_proj.weight")
+        assert self.converter.can_handle("model.layers.7.mlp.experts.31.up_proj.weight")
+        assert self.converter.can_handle("model.layers.2.mlp.experts.1.down_proj.weight")
+
+    def test_rejects_non_expert_keys(self):
+        # Already-stacked keys (e.g. from a pre-merged checkpoint) MUST pass through unchanged.
+        assert not self.converter.can_handle("model.layers.0.mlp.experts.gate_proj")
+        assert not self.converter.can_handle("model.layers.0.mlp.experts.up_proj")
+        assert not self.converter.can_handle("model.layers.0.mlp.experts.down_proj")
+        # Other parameters.
+        assert not self.converter.can_handle("model.layers.0.self_attn.q_proj.weight")
+        assert not self.converter.can_handle("model.layers.0.mlp.gate.weight")
+        assert not self.converter.can_handle("model.embed_tokens.weight")
+
+
+class TestMoEV4StackingConverterStacks:
+    def setup_method(self):
+        self.converter = MoEV4StackingConverter(_PATTERN, num_experts_for=lambda _: NUM_EXPERTS)
+
+    def _feed_all(self, prefix: str, proj: str):
+        results = []
+        for e in range(NUM_EXPERTS):
+            key = _hf_expert_key(prefix, e, proj)
+            results.append(self.converter.convert(key, _hf_expert_tensor(proj, e)))
+        return results
+
+    def test_buffers_until_complete(self):
+        # First N-1 experts return None.
+        for e in range(NUM_EXPERTS - 1):
+            key = _hf_expert_key("model.layers.0.mlp", e, "gate_proj")
+            assert self.converter.convert(key, _hf_expert_tensor("gate_proj", e)) is None
+
+    def test_emits_three_separate_keys(self):
+        """v4 emits three keys (gate/up/down), unlike v5 which merges gate+up."""
+        emitted = {}
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            for r in self._feed_all("model.layers.0.mlp", proj):
+                if r is not None:
+                    emitted[r.name] = r.tensor
+
+        # Three separate stacked tensors — not a single fused gate_up_proj.
+        assert "model.layers.0.mlp.experts.gate_proj" in emitted
+        assert "model.layers.0.mlp.experts.up_proj" in emitted
+        assert "model.layers.0.mlp.experts.down_proj" in emitted
+        assert "model.layers.0.mlp.experts.gate_up_proj" not in emitted
+
+        # Shapes match the v4 modeling layout.
+        assert emitted["model.layers.0.mlp.experts.gate_proj"].shape == (
+            NUM_EXPERTS,
+            INTERMEDIATE_DIM,
+            HIDDEN_DIM,
+        )
+        assert emitted["model.layers.0.mlp.experts.up_proj"].shape == (
+            NUM_EXPERTS,
+            INTERMEDIATE_DIM,
+            HIDDEN_DIM,
+        )
+        assert emitted["model.layers.0.mlp.experts.down_proj"].shape == (
+            NUM_EXPERTS,
+            HIDDEN_DIM,
+            INTERMEDIATE_DIM,
+        )
+
+        # Verify per-expert content survived the stack.
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            stacked = emitted[f"model.layers.0.mlp.experts.{proj}"]
+            for e in range(NUM_EXPERTS):
+                assert torch.equal(stacked[e], _hf_expert_tensor(proj, e))
+
+    def test_experts_out_of_order(self):
+        """Safetensors shards may yield experts in any order; stacking must still index by expert id."""
+        for e in [3, 0, 2, 1]:
+            key = _hf_expert_key("model.layers.0.mlp", e, "down_proj")
+            self.converter.convert(key, _hf_expert_tensor("down_proj", e))
+
+        # Trigger the emit on the last expert. We re-feed expert 1 with the
+        # same tensor, but actually the previous loop already fed all 4, so
+        # the last `convert` call returned the stacked result. Fetch it via
+        # a fresh independent converter run for clarity:
+        converter = MoEV4StackingConverter(_PATTERN, num_experts_for=lambda _: NUM_EXPERTS)
+        last = None
+        for e in [2, 0, 3, 1]:
+            last = converter.convert(
+                _hf_expert_key("model.layers.0.mlp", e, "down_proj"),
+                _hf_expert_tensor("down_proj", e),
+            )
+        assert last is not None
+        for e in range(NUM_EXPERTS):
+            assert torch.equal(last.tensor[e], _hf_expert_tensor("down_proj", e))
+
+    def test_independent_layers(self):
+        """Different layers buffer independently."""
+        for e in range(NUM_EXPERTS):
+            r0 = self.converter.convert(
+                _hf_expert_key("model.layers.0.mlp", e, "down_proj"),
+                _hf_expert_tensor("down_proj", e),
+            )
+            r1 = self.converter.convert(
+                _hf_expert_key("model.layers.1.mlp", e, "down_proj"),
+                _hf_expert_tensor("down_proj", e),
+            )
+            if e < NUM_EXPERTS - 1:
+                assert r0 is None and r1 is None
+            else:
+                assert r0 is not None and r0.name == "model.layers.0.mlp.experts.down_proj"
+                assert r1 is not None and r1.name == "model.layers.1.mlp.experts.down_proj"
+
+
+class TestMoEV4StackingConverterFinalize:
+    def test_noop_when_all_flushed(self):
+        converter = MoEV4StackingConverter(_PATTERN, num_experts_for=lambda _: NUM_EXPERTS)
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            for e in range(NUM_EXPERTS):
+                converter.convert(_hf_expert_key("model.layers.0.mlp", e, proj), _hf_expert_tensor(proj, e))
+        assert converter.finalize() == []
+
+    def test_raises_with_helpful_diagnostic_on_incomplete(self):
+        converter = MoEV4StackingConverter(_PATTERN, num_experts_for=lambda _: NUM_EXPERTS)
+        # Drop expert 3 from gate_proj (simulates a corrupted checkpoint).
+        for e in range(NUM_EXPERTS - 1):
+            converter.convert(_hf_expert_key("model.layers.0.mlp", e, "gate_proj"), _hf_expert_tensor("gate_proj", e))
+        with pytest.raises(RuntimeError, match="incomplete checkpoint detected"):
+            converter.finalize()
+
+    def test_finalize_lists_collected_expert_ids(self):
+        converter = MoEV4StackingConverter(_PATTERN, num_experts_for=lambda _: NUM_EXPERTS)
+        for e in (0, 2):
+            converter.convert(_hf_expert_key("model.layers.5.mlp", e, "up_proj"), _hf_expert_tensor("up_proj", e))
+        with pytest.raises(RuntimeError) as exc:
+            converter.finalize()
+        # The diagnostic should name the buffered key and the collected expert ids
+        # so users can see which expert is actually missing.
+        assert "model.layers.5.mlp.experts.up_proj" in str(exc.value)
+        assert "[0, 2]" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Multi-tower variant (Qwen3-Omni-MoE) — per-prefix expert counts
+# ---------------------------------------------------------------------------
+
+
+class TestMoEV4StackingConverterMultiPrefix:
+    def test_per_prefix_expert_counts(self):
+        """num_experts_for can vary by prefix — covers thinker/talker towers with different sizes."""
+        thinker_n, talker_n = 3, 5
+
+        def num_experts_for(prefix: str) -> int:
+            if prefix.startswith("thinker."):
+                return thinker_n
+            return talker_n
+
+        pattern = re.compile(
+            r"^((?:thinker|talker)\.model\.layers\.\d+\.mlp)\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
+        )
+        converter = MoEV4StackingConverter(pattern, num_experts_for=num_experts_for)
+
+        # Feed thinker_n experts under thinker prefix → emits at the thinker_n-th call.
+        thinker_emit = None
+        for e in range(thinker_n):
+            thinker_emit = converter.convert(
+                f"thinker.model.layers.0.mlp.experts.{e}.gate_proj.weight",
+                torch.full((INTERMEDIATE_DIM, HIDDEN_DIM), float(e)),
+            )
+        assert thinker_emit is not None
+        assert thinker_emit.name == "thinker.model.layers.0.mlp.experts.gate_proj"
+        assert thinker_emit.tensor.shape == (thinker_n, INTERMEDIATE_DIM, HIDDEN_DIM)
+
+        # Feed talker_n experts under talker prefix → emits at the talker_n-th call.
+        talker_emit = None
+        for e in range(talker_n):
+            talker_emit = converter.convert(
+                f"talker.model.layers.0.mlp.experts.{e}.gate_proj.weight",
+                torch.full((INTERMEDIATE_DIM, HIDDEN_DIM), float(e)),
+            )
+        assert talker_emit is not None
+        assert talker_emit.name == "talker.model.layers.0.mlp.experts.gate_proj"
+        assert talker_emit.tensor.shape == (talker_n, INTERMEDIATE_DIM, HIDDEN_DIM)
+
+
+# ---------------------------------------------------------------------------
+# qwen3_moe v4 factory
+# ---------------------------------------------------------------------------
+
+
+class TestQwen3MoeV4Factory:
+    def test_factory_creates_converter(self):
+        model = SimpleNamespace(config=SimpleNamespace(num_experts=NUM_EXPERTS))
+        converter = create_qwen3_moe_v4_checkpoint_tensor_converter(model)
+        assert isinstance(converter, MoEV4StackingConverter)
+        assert converter.can_handle("model.layers.0.mlp.experts.0.gate_proj.weight")
+
+    def test_full_conversion_emits_three_keys(self):
+        model = SimpleNamespace(config=SimpleNamespace(num_experts=NUM_EXPERTS))
+        converter = create_qwen3_moe_v4_checkpoint_tensor_converter(model)
+        emitted = {}
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            for e in range(NUM_EXPERTS):
+                r = maybe_convert_checkpoint_tensor(
+                    _hf_expert_key("model.layers.0.mlp", e, proj),
+                    _hf_expert_tensor(proj, e),
+                    converter,
+                )
+                if r is not None:
+                    emitted[r.name] = r.tensor
+        assert converter.finalize() == []
+        assert set(emitted.keys()) == {
+            "model.layers.0.mlp.experts.gate_proj",
+            "model.layers.0.mlp.experts.up_proj",
+            "model.layers.0.mlp.experts.down_proj",
+        }
+
+
+# ---------------------------------------------------------------------------
+# deepseek_v3 v4 factory
+# ---------------------------------------------------------------------------
+
+
+class TestDeepseekV3V4Factory:
+    def test_factory_uses_n_routed_experts(self):
+        # DeepSeek V3 config exposes `n_routed_experts`, NOT `num_experts`.
+        model = SimpleNamespace(config=SimpleNamespace(n_routed_experts=NUM_EXPERTS))
+        converter = create_deepseek_v3_v4_checkpoint_tensor_converter(model)
+        assert isinstance(converter, MoEV4StackingConverter)
+
+        # Stack one full set; emit happens on the N-th expert.
+        last = None
+        for e in range(NUM_EXPERTS):
+            last = converter.convert(
+                _hf_expert_key("model.layers.5.mlp", e, "down_proj"),
+                _hf_expert_tensor("down_proj", e),
+            )
+        assert last is not None
+        assert last.name == "model.layers.5.mlp.experts.down_proj"
+
+    def test_dense_layers_pass_through(self):
+        """Dense MLP layers (< first_k_dense_replace) have no `experts.*` keys; the
+        regex should never match those keys, so they pass through untouched."""
+        model = SimpleNamespace(config=SimpleNamespace(n_routed_experts=NUM_EXPERTS))
+        converter = create_deepseek_v3_v4_checkpoint_tensor_converter(model)
+        # Dense layer: standard MLP weight key, no experts in path.
+        dense_key = "model.layers.0.mlp.gate_proj.weight"
+        dense_t = torch.randn(INTERMEDIATE_DIM, HIDDEN_DIM)
+        result = maybe_convert_checkpoint_tensor(dense_key, dense_t, converter)
+        assert result is not None
+        assert result.name == dense_key
+        assert torch.equal(result.tensor, dense_t)
+
+
+# ---------------------------------------------------------------------------
+# qwen3_omni_moe v4 factory — conditional on _moe_implementation
+# ---------------------------------------------------------------------------
+
+
+class TestQwen3OmniMoeV4Factory:
+    def test_returns_none_in_eager_mode(self):
+        """In eager mode the thinker uses nn.ModuleList and HF per-expert keys map directly."""
+        text_config = SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation="eager")
+        thinker_config = SimpleNamespace(text_config=text_config)
+        model = SimpleNamespace(config=SimpleNamespace(thinker_config=thinker_config, _moe_implementation="eager"))
+        assert create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model) is None
+
+    def test_returns_none_when_implementation_unset(self):
+        """No `_moe_implementation` set → fallback is eager (per modeling code)."""
+        text_config = SimpleNamespace(num_experts=NUM_EXPERTS)
+        thinker_config = SimpleNamespace(text_config=text_config)
+        model = SimpleNamespace(config=SimpleNamespace(thinker_config=thinker_config))
+        assert create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model) is None
+
+    def test_returns_converter_in_fused_mode(self):
+        text_config = SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation="fused")
+        thinker_config = SimpleNamespace(text_config=text_config)
+        model = SimpleNamespace(config=SimpleNamespace(thinker_config=thinker_config, _moe_implementation="fused"))
+        converter = create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model)
+        assert isinstance(converter, MoEV4StackingConverter)
+
+    def test_fused_converter_handles_thinker_prefix(self):
+        text_config = SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation="fused")
+        thinker_config = SimpleNamespace(text_config=text_config)
+        model = SimpleNamespace(config=SimpleNamespace(thinker_config=thinker_config, _moe_implementation="fused"))
+        converter = create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model)
+
+        last = None
+        for e in range(NUM_EXPERTS):
+            last = converter.convert(
+                f"thinker.model.layers.0.mlp.experts.{e}.gate_proj.weight",
+                _hf_expert_tensor("gate_proj", e),
+            )
+        assert last is not None
+        assert last.name == "thinker.model.layers.0.mlp.experts.gate_proj"
+
+    def test_fused_converter_does_not_match_talker_prefix(self):
+        """Talker tower runs in eager (nn.ModuleList) on v4; converter must leave its keys alone."""
+        text_config = SimpleNamespace(num_experts=NUM_EXPERTS, _moe_implementation="fused")
+        thinker_config = SimpleNamespace(text_config=text_config)
+        model = SimpleNamespace(config=SimpleNamespace(thinker_config=thinker_config, _moe_implementation="fused"))
+        converter = create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model)
+
+        talker_key = "talker.model.layers.0.mlp.experts.0.gate_proj.weight"
+        assert not converter.can_handle(talker_key)
+
+        # Pass-through via maybe_convert_checkpoint_tensor:
+        t = torch.randn(INTERMEDIATE_DIM, HIDDEN_DIM)
+        result = maybe_convert_checkpoint_tensor(talker_key, t, converter)
+        assert result is not None and result.name == talker_key
+        assert torch.equal(result.tensor, t)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration: build a tiny v4 patched model, write per-expert
+# safetensors, run load_model_weights, and verify the resulting stacked
+# parameters reproduce torch.stack of the per-expert inputs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    is_transformers_version_greater_or_equal_to("5.0.0"),
+    reason="v4 converter only fires under transformers<5; on v5 the v5 converter handles loading.",
+)
+class TestQwen3MoeV4LoadIntegration:
+    """End-to-end check that load_model_weights pipes per-expert HF keys through the converter
+    into the v4 patched model's stacked nn.Parameters."""
+
+    def _make_tiny_state_dict(self, cfg) -> dict:
+        sd = {}
+        rng = torch.Generator().manual_seed(0)
+        L, E, H, I = cfg.num_hidden_layers, cfg.num_experts, cfg.hidden_size, cfg.moe_intermediate_size
+        head = cfg.head_dim
+        for layer in range(L):
+            for e in range(E):
+                sd[f"model.layers.{layer}.mlp.experts.{e}.gate_proj.weight"] = torch.randn(
+                    I, H, generator=rng
+                ).bfloat16()
+                sd[f"model.layers.{layer}.mlp.experts.{e}.up_proj.weight"] = torch.randn(
+                    I, H, generator=rng
+                ).bfloat16()
+                sd[f"model.layers.{layer}.mlp.experts.{e}.down_proj.weight"] = torch.randn(
+                    H, I, generator=rng
+                ).bfloat16()
+            sd[f"model.layers.{layer}.mlp.gate.weight"] = torch.randn(E, H, generator=rng).bfloat16()
+            sd[f"model.layers.{layer}.input_layernorm.weight"] = torch.randn(H, generator=rng).bfloat16()
+            sd[f"model.layers.{layer}.post_attention_layernorm.weight"] = torch.randn(H, generator=rng).bfloat16()
+            sd[f"model.layers.{layer}.self_attn.q_proj.weight"] = torch.randn(2 * head, H, generator=rng).bfloat16()
+            sd[f"model.layers.{layer}.self_attn.k_proj.weight"] = torch.randn(head, H, generator=rng).bfloat16()
+            sd[f"model.layers.{layer}.self_attn.v_proj.weight"] = torch.randn(head, H, generator=rng).bfloat16()
+            sd[f"model.layers.{layer}.self_attn.o_proj.weight"] = torch.randn(H, 2 * head, generator=rng).bfloat16()
+            sd[f"model.layers.{layer}.self_attn.q_norm.weight"] = torch.randn(head, generator=rng).bfloat16()
+            sd[f"model.layers.{layer}.self_attn.k_norm.weight"] = torch.randn(head, generator=rng).bfloat16()
+        sd["model.embed_tokens.weight"] = torch.randn(cfg.vocab_size, H, generator=rng).bfloat16()
+        sd["model.norm.weight"] = torch.randn(H, generator=rng).bfloat16()
+        sd["lm_head.weight"] = torch.randn(cfg.vocab_size, H, generator=rng).bfloat16()
+        return sd
+
+    def test_per_expert_hf_checkpoint_loads_into_stacked_params(self):
+        toy_cfg_dir = os.path.join(os.path.dirname(__file__), "..", "toy_config", "qwen3_moe_toy")
+        with tempfile.TemporaryDirectory() as tmp:
+            shutil.copy(os.path.join(toy_cfg_dir, "config.json"), os.path.join(tmp, "config.json"))
+            cfg = AutoConfig.from_pretrained(tmp)
+            cfg.hidden_size = 16
+            cfg.intermediate_size = 32
+            cfg.moe_intermediate_size = 12
+            cfg.num_experts = NUM_EXPERTS
+            cfg.num_attention_heads = 2
+            cfg.num_key_value_heads = 1
+            cfg.head_dim = 8
+            cfg.num_hidden_layers = 1
+            cfg.vocab_size = 32
+
+            # The v4 expert layout is shared by eager and fused modes; loading test
+            # only depends on the parameter shapes, so eager keeps this test
+            # CPU-only (no triton kernel needed).
+            cfg._moe_implementation = "eager"
+            cfg.torch_dtype = torch.bfloat16
+
+            sd = self._make_tiny_state_dict(cfg)
+            save_file(sd, os.path.join(tmp, "model.safetensors"))
+
+            # Trigger registration; attaches our v4 converter staticmethod to the HF class.
+            cls = get_model_class(cfg)
+            assert hasattr(cls, "_create_checkpoint_tensor_converter"), (
+                "v4 init branch should attach _create_checkpoint_tensor_converter"
+            )
+
+            with init_empty_weights(), no_init_weights():
+                model = cls._from_config(cfg, torch_dtype=torch.bfloat16, attn_implementation="eager")
+
+            load_model_weights(model, tmp, init_device="cpu")
+
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                param = getattr(model.model.layers[0].mlp.experts, proj)
+                expected = torch.stack(
+                    [sd[f"model.layers.0.mlp.experts.{e}.{proj}.weight"] for e in range(NUM_EXPERTS)]
+                )
+                assert not param.is_meta, f"{proj} still on meta after load"
+                assert param.shape == expected.shape
+                assert torch.equal(param.detach().cpu(), expected), f"value mismatch for {proj}"

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -248,106 +248,11 @@ def compare_multi_items(outputs_dict: Dict, rtol=0.01, atol=0.01):
                 raise AssertionError(f"{key} not match") from e
 
 
-# ---------------------------------------------------------------------------
-# Pristine snapshots of HF model classes taken at module import — before any
-# veomni import has a chance to monkey-patch them. `apply_veomni_hf_unpatch`
-# restores them so a second test in the same process can build an HF model
-# that is genuinely un-patched. Keep the module imports inside this block
-# so that util users who never need them are not forced to pay the cost.
-# ---------------------------------------------------------------------------
-import transformers.models.deepseek_v3.modeling_deepseek_v3 as _hf_ds3  # noqa: E402
-import transformers.models.qwen3.modeling_qwen3 as _hf_qwen3  # noqa: E402
-import transformers.models.qwen3_moe.modeling_qwen3_moe as _hf_qwen3_moe  # noqa: E402
-
-
-# Cover every patch site reachable from apply_veomni_*_patch() + the Liger
-# and Triton branches of apply_veomni_*_gpu_patch(). We capture:
-# - forward methods (undo in-class forward replacement, used by both the
-#   always-on patch and the Triton branch's _patch_rms_norm / RoPE forward)
-# - whole classes (undo module-level class swap done by the Liger branch
-#   and by DeepseekV3MoE / Qwen3MoeSparseMoeBlock replacements)
-# - module-level functions (apply_rotary_pos_emb is replaced by Liger)
-#
-# Restore order matters: we first reset in-class attributes on the pristine
-# class objects, then restore the module-level names. That way, even if a
-# prior test mutated `Class.forward` and then swapped in a Liger class at
-# the module level, both layers are reverted.
-_PRISTINE_HF = {
-    # qwen3
-    "qwen3.CausalLM.forward": _hf_qwen3.Qwen3ForCausalLM.forward,
-    "qwen3.SeqCls.forward": _hf_qwen3.Qwen3ForSequenceClassification.forward,
-    "qwen3.apply_rotary_pos_emb": _hf_qwen3.apply_rotary_pos_emb,
-    "qwen3.RMSNorm.cls": _hf_qwen3.Qwen3RMSNorm,
-    "qwen3.RMSNorm.forward": _hf_qwen3.Qwen3RMSNorm.forward,
-    "qwen3.MLP.cls": _hf_qwen3.Qwen3MLP,
-    # qwen3_moe
-    "qwen3_moe.CausalLM.forward": _hf_qwen3_moe.Qwen3MoeForCausalLM.forward,
-    "qwen3_moe.MoeBlock.cls": _hf_qwen3_moe.Qwen3MoeSparseMoeBlock,
-    "qwen3_moe.PreTrained.init_weights": _hf_qwen3_moe.Qwen3MoePreTrainedModel._init_weights,
-    "qwen3_moe.apply_rotary_pos_emb": _hf_qwen3_moe.apply_rotary_pos_emb,
-    "qwen3_moe.RMSNorm.cls": _hf_qwen3_moe.Qwen3MoeRMSNorm,
-    "qwen3_moe.RMSNorm.forward": _hf_qwen3_moe.Qwen3MoeRMSNorm.forward,
-    "qwen3_moe.MLP.cls": _hf_qwen3_moe.Qwen3MoeMLP,
-    # deepseek_v3
-    "ds3.Attention.forward": _hf_ds3.DeepseekV3Attention.forward,
-    "ds3.CausalLM.forward": _hf_ds3.DeepseekV3ForCausalLM.forward,
-    "ds3.MoE.cls": _hf_ds3.DeepseekV3MoE,
-    "ds3.PreTrained.init_weights": _hf_ds3.DeepseekV3PreTrainedModel._init_weights,
-    "ds3.apply_rotary_pos_emb": _hf_ds3.apply_rotary_pos_emb,
-    "ds3.RotaryEmb.cls": _hf_ds3.DeepseekV3RotaryEmbedding,
-    "ds3.RotaryEmb.forward": _hf_ds3.DeepseekV3RotaryEmbedding.forward,
-    "ds3.RMSNorm.cls": _hf_ds3.DeepseekV3RMSNorm,
-    "ds3.RMSNorm.forward": _hf_ds3.DeepseekV3RMSNorm.forward,
-    "ds3.MLP.cls": _hf_ds3.DeepseekV3MLP,
-}
-
-
-def apply_veomni_hf_unpatch():
-    """Undo in-place veomni monkey-patches on HF model modules.
-
-    `apply_veomni_*_patch()` in each of `qwen3/`, `qwen3_moe/`, `deepseek_v3/`
-    mutates the HF model modules directly (forward swaps, class swaps, new
-    `get_parallel_plan` methods). Without this restore, the first parametrize
-    case to build a veomni model leaks its patches into every subsequent HF
-    build in the same test session.
-    """
-    # Step 1: restore in-class forward methods on pristine class objects.
-    # This handles both the always-on forward swaps and the Triton branch's
-    # in-class mutations (DeepseekV3RotaryEmbedding.forward / DeepseekV3RMSNorm.forward).
-    _PRISTINE_HF["qwen3.RMSNorm.cls"].forward = _PRISTINE_HF["qwen3.RMSNorm.forward"]
-    _PRISTINE_HF["qwen3_moe.RMSNorm.cls"].forward = _PRISTINE_HF["qwen3_moe.RMSNorm.forward"]
-    _PRISTINE_HF["ds3.RotaryEmb.cls"].forward = _PRISTINE_HF["ds3.RotaryEmb.forward"]
-    _PRISTINE_HF["ds3.RMSNorm.cls"].forward = _PRISTINE_HF["ds3.RMSNorm.forward"]
-
-    _hf_qwen3.Qwen3ForCausalLM.forward = _PRISTINE_HF["qwen3.CausalLM.forward"]
-    _hf_qwen3.Qwen3ForSequenceClassification.forward = _PRISTINE_HF["qwen3.SeqCls.forward"]
-    _hf_qwen3_moe.Qwen3MoeForCausalLM.forward = _PRISTINE_HF["qwen3_moe.CausalLM.forward"]
-    _hf_qwen3_moe.Qwen3MoePreTrainedModel._init_weights = _PRISTINE_HF["qwen3_moe.PreTrained.init_weights"]
-    _hf_ds3.DeepseekV3Attention.forward = _PRISTINE_HF["ds3.Attention.forward"]
-    _hf_ds3.DeepseekV3ForCausalLM.forward = _PRISTINE_HF["ds3.CausalLM.forward"]
-    _hf_ds3.DeepseekV3PreTrainedModel._init_weights = _PRISTINE_HF["ds3.PreTrained.init_weights"]
-
-    # Step 2: restore module-level names for classes / functions that the
-    # Liger branch swaps out wholesale, plus the class swaps done by the
-    # always-on patch (Qwen3MoeSparseMoeBlock, DeepseekV3MoE).
-    _hf_qwen3.apply_rotary_pos_emb = _PRISTINE_HF["qwen3.apply_rotary_pos_emb"]
-    _hf_qwen3.Qwen3RMSNorm = _PRISTINE_HF["qwen3.RMSNorm.cls"]
-    _hf_qwen3.Qwen3MLP = _PRISTINE_HF["qwen3.MLP.cls"]
-    _hf_qwen3_moe.Qwen3MoeSparseMoeBlock = _PRISTINE_HF["qwen3_moe.MoeBlock.cls"]
-    _hf_qwen3_moe.apply_rotary_pos_emb = _PRISTINE_HF["qwen3_moe.apply_rotary_pos_emb"]
-    _hf_qwen3_moe.Qwen3MoeRMSNorm = _PRISTINE_HF["qwen3_moe.RMSNorm.cls"]
-    _hf_qwen3_moe.Qwen3MoeMLP = _PRISTINE_HF["qwen3_moe.MLP.cls"]
-    _hf_ds3.DeepseekV3MoE = _PRISTINE_HF["ds3.MoE.cls"]
-    _hf_ds3.apply_rotary_pos_emb = _PRISTINE_HF["ds3.apply_rotary_pos_emb"]
-    _hf_ds3.DeepseekV3RotaryEmbedding = _PRISTINE_HF["ds3.RotaryEmb.cls"]
-    _hf_ds3.DeepseekV3RMSNorm = _PRISTINE_HF["ds3.RMSNorm.cls"]
-    _hf_ds3.DeepseekV3MLP = _PRISTINE_HF["ds3.MLP.cls"]
-
-    # Step 3: remove `get_parallel_plan` methods injected onto HF causal-LM
-    # classes by apply_veomni_*_patch.
-    for cls in (_hf_qwen3_moe.Qwen3MoeForCausalLM, _hf_ds3.DeepseekV3ForCausalLM):
-        if "get_parallel_plan" in cls.__dict__:
-            delattr(cls, "get_parallel_plan")
+# `apply_veomni_hf_unpatch` lives in a sibling module that does not import
+# ``veomni.data`` so test files that only need it (e.g. the converter logits
+# smoke test) don't pull in optional video/audio dependencies. Re-exported
+# here for backwards compatibility with existing call sites.
+from .hf_unpatch import apply_veomni_hf_unpatch  # noqa: F401, E402
 
 
 def apply_veomni_loss_unpatch():

--- a/veomni/models/transformers/_moe_v4_converter.py
+++ b/veomni/models/transformers/_moe_v4_converter.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Shared on-the-fly checkpoint tensor converter for transformers v4 MoE models.
+
+The transformers-v4 VeOmni patches for `qwen3_moe`, `deepseek_v3`, and
+`qwen3_omni_moe` (in fused mode) store expert weights as three separate stacked
+nn.Parameters (`gate_proj`, `up_proj`, `down_proj`) shaped `[E, ...]`. Vanilla
+HuggingFace checkpoints store the same data per-expert under nn.ModuleList.
+This module bridges that gap at load time so users can pass HF checkpoints
+directly without running the offline `scripts/moe_ckpt_merge/moe_merge.py`.
+
+Output keys match what the offline merge script produces (see
+`_merge_experts_for_group` in moe_merge.py):
+
+    {prefix}.experts.gate_proj  [E, I, H]
+    {prefix}.experts.up_proj    [E, I, H]
+    {prefix}.experts.down_proj  [E, H, I]
+
+The v5 converters (e.g. `qwen3_moe/checkpoint_tensor_converter.py`) cat gate+up
+into a single `gate_up_proj` because v5 modeling uses one fused parameter; v4
+modeling keeps them separate, so we stack each projection independently.
+"""
+
+from typing import Callable, Dict, List, Optional, Pattern, Tuple
+
+import torch
+
+from ..checkpoint_tensor_loading import ConvertedCheckpointTensor
+
+
+class MoEV4StackingConverter:
+    """Buffer per-expert tensors and emit one stacked tensor per (prefix, projection).
+
+    Args:
+        pattern: Compiled regex with three capture groups:
+            (1) layer prefix up to and including ``.mlp`` (e.g.
+                ``"model.layers.3.mlp"``), used as the emit-key prefix and as
+                the bucket key.
+            (2) expert id (decimal integer).
+            (3) projection name — one of ``gate_proj``, ``up_proj``, ``down_proj``.
+        num_experts_for: Callable mapping a prefix to the expected number of
+            experts at that prefix. For flat single-tower models pass
+            ``lambda _: N``; for multi-tower omni models, dispatch on the
+            tower component of the prefix.
+    """
+
+    def __init__(self, pattern: Pattern[str], num_experts_for: Callable[[str], int]):
+        self._pattern = pattern
+        self._num_experts_for = num_experts_for
+        # {(prefix, proj_name): {expert_id: tensor}}
+        self._buffer: Dict[Tuple[str, str], Dict[int, torch.Tensor]] = {}
+
+    def can_handle(self, name: str) -> bool:
+        return bool(self._pattern.match(name))
+
+    def convert(self, name: str, tensor: "torch.Tensor") -> Optional[ConvertedCheckpointTensor]:
+        match = self._pattern.match(name)
+        if not match:
+            return None
+
+        prefix, expert_id_str, proj_name = match.group(1), match.group(2), match.group(3)
+        expert_id = int(expert_id_str)
+        bucket = self._buffer.setdefault((prefix, proj_name), {})
+        bucket[expert_id] = tensor
+
+        num_experts = self._num_experts_for(prefix)
+        if len(bucket) < num_experts:
+            return None
+
+        stacked = torch.stack([bucket[i] for i in range(num_experts)])
+        del self._buffer[(prefix, proj_name)]
+        return ConvertedCheckpointTensor(name=f"{prefix}.experts.{proj_name}", tensor=stacked)
+
+    def finalize(self) -> List[ConvertedCheckpointTensor]:
+        if not self._buffer:
+            return []
+        unflushed = {f"{p}.experts.{proj}": sorted(b.keys()) for (p, proj), b in self._buffer.items()}
+        raise RuntimeError(
+            "MoE v4 checkpoint converter: incomplete checkpoint detected. "
+            f"Unflushed per-expert buffers (collected expert ids per key): {unflushed}"
+        )

--- a/veomni/models/transformers/deepseek_v3/__init__.py
+++ b/veomni/models/transformers/deepseek_v3/__init__.py
@@ -24,9 +24,16 @@ def register_deepseek_v3_modeling(architecture: str):
         DeepseekV3Model,
     )
 
+    from .checkpoint_tensor_converter_v4 import create_deepseek_v3_v4_checkpoint_tensor_converter
     from .modeling_deepseek_v3 import apply_veomni_deepseek_v3_patch
 
     apply_veomni_deepseek_v3_patch()
+
+    # Stack per-expert HF weights into v4's three 3-D nn.Parameters at load time
+    # (PatchDeepseekV3NaiveMoe.gate_proj/up_proj/down_proj). Skips the first
+    # `first_k_dense_replace` layers automatically (regex won't match dense layers).
+    for model_cls in (DeepseekV3ForCausalLM, DeepseekV3ForSequenceClassification, DeepseekV3Model):
+        model_cls._create_checkpoint_tensor_converter = staticmethod(create_deepseek_v3_v4_checkpoint_tensor_converter)
 
     if "ForCausalLM" in architecture:
         return DeepseekV3ForCausalLM

--- a/veomni/models/transformers/deepseek_v3/checkpoint_tensor_converter_v4.py
+++ b/veomni/models/transformers/deepseek_v3/checkpoint_tensor_converter_v4.py
@@ -1,0 +1,40 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Runtime per-expert -> stacked converter for transformers v4 DeepSeek V3.
+
+The v4 patch (`PatchDeepseekV3NaiveMoe`) stores expert weights as three 3-D
+nn.Parameters; HF ships per-expert keys. DeepSeek V3 differs from Qwen3-MoE
+in two ways:
+- Number of experts is `config.n_routed_experts` (not `num_experts`).
+- The first `config.first_k_dense_replace` layers are dense MLPs with no
+  `experts.*` keys; the regex naturally won't match those layers.
+"""
+
+import re
+
+from .._moe_v4_converter import MoEV4StackingConverter
+
+
+_EXPERT_PATTERN = re.compile(r"^(.+\.mlp)\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$")
+
+
+def create_deepseek_v3_v4_checkpoint_tensor_converter(model):
+    """Factory registered on v4 DeepSeek V3 model classes via `_create_checkpoint_tensor_converter`."""
+    num_experts = model.config.n_routed_experts
+    return MoEV4StackingConverter(
+        pattern=_EXPERT_PATTERN,
+        num_experts_for=lambda _prefix: num_experts,
+    )

--- a/veomni/models/transformers/qwen3_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_moe/__init__.py
@@ -37,9 +37,18 @@ def register_qwen3_moe_modeling(architecture: str):
             Qwen3MoeModel,
         )
 
+        from .checkpoint_tensor_converter_v4 import create_qwen3_moe_v4_checkpoint_tensor_converter
         from .modeling_qwen3_moe import apply_veomni_qwen3_moe_patch
 
         apply_veomni_qwen3_moe_patch()
+
+        # Stack per-expert HF weights into v4's three 3-D nn.Parameters at load time
+        # (PatchQwen3MoeExperts.gate_proj/up_proj/down_proj). Without this, users had
+        # to pre-merge with scripts/moe_ckpt_merge/moe_merge.py before training.
+        for model_cls in (Qwen3MoeForCausalLM, Qwen3MoeForQuestionAnswering, Qwen3MoeModel):
+            model_cls._create_checkpoint_tensor_converter = staticmethod(
+                create_qwen3_moe_v4_checkpoint_tensor_converter
+            )
 
     if "ForCausalLM" in architecture:
         return Qwen3MoeForCausalLM

--- a/veomni/models/transformers/qwen3_moe/checkpoint_tensor_converter_v4.py
+++ b/veomni/models/transformers/qwen3_moe/checkpoint_tensor_converter_v4.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Runtime per-expert -> stacked converter for transformers v4 Qwen3-MoE.
+
+The v4 patch (`PatchQwen3MoeExperts` in modeling_qwen3_moe.py) stores expert
+weights as three separate 3-D nn.Parameters in both eager and fused modes;
+HuggingFace ships per-expert keys. This converter stacks them at load time.
+Mirrors v5's `Qwen3MoeCheckpointTensorConverter` minus the gate/up cat step.
+"""
+
+import re
+
+from .._moe_v4_converter import MoEV4StackingConverter
+
+
+_EXPERT_PATTERN = re.compile(r"^(.+\.mlp)\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$")
+
+
+def create_qwen3_moe_v4_checkpoint_tensor_converter(model):
+    """Factory registered on v4 Qwen3-MoE model classes via `_create_checkpoint_tensor_converter`."""
+    num_experts = model.config.num_experts
+    return MoEV4StackingConverter(
+        pattern=_EXPERT_PATTERN,
+        num_experts_for=lambda _prefix: num_experts,
+    )

--- a/veomni/models/transformers/qwen3_omni_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_omni_moe/__init__.py
@@ -64,6 +64,7 @@ def register_qwen3_omni_moe_modeling(architecture: str):
             Qwen3OmniMoeTalkerModel,
         )
 
+        from .checkpoint_tensor_converter_v4 import create_qwen3_omni_moe_v4_checkpoint_tensor_converter
         from .modeling_qwen3_omni_moe import (
             Qwen3OmniMoeForConditionalGeneration,
             Qwen3OmniMoeThinkerForConditionalGeneration,
@@ -72,6 +73,19 @@ def register_qwen3_omni_moe_modeling(architecture: str):
         )
 
         apply_veomni_qwen3_omni_moe_patch()
+
+        # Stack per-expert HF weights into the thinker's three 3-D nn.Parameters at
+        # load time (Qwen3OmniMoeThinkerExperts.gate_proj/up_proj/down_proj). The
+        # factory returns None when `_moe_implementation != "fused"`, so eager-mode
+        # loads (which use nn.ModuleList for the thinker too) are unaffected.
+        for model_cls in (
+            Qwen3OmniMoeForConditionalGeneration,
+            Qwen3OmniMoeThinkerForConditionalGeneration,
+            Qwen3OmniMoeThinkerTextModel,
+        ):
+            model_cls._create_checkpoint_tensor_converter = staticmethod(
+                create_qwen3_omni_moe_v4_checkpoint_tensor_converter
+            )
 
     if "ThinkerTextModel" in architecture:
         return Qwen3OmniMoeThinkerTextModel

--- a/veomni/models/transformers/qwen3_omni_moe/checkpoint_tensor_converter_v4.py
+++ b/veomni/models/transformers/qwen3_omni_moe/checkpoint_tensor_converter_v4.py
@@ -15,11 +15,21 @@
 """
 Runtime per-expert -> stacked converter for transformers v4 Qwen3-Omni-MoE.
 
-Only fired for the thinker tower's experts. The talker tower in v4 always runs
-in eager mode (`nn.ModuleList`) and consumes per-expert HF keys natively, so
-the converter intentionally does not match talker prefixes. The converter is
-also a no-op when `_moe_implementation != "fused"` because eager mode also
-uses `nn.ModuleList` for the thinker; the factory returns `None` in that case.
+The converter is registered on three classes that can each be the load entry,
+and they expose different parameter prefixes:
+
+    Qwen3OmniMoeForConditionalGeneration          → ``thinker.model.layers.*``
+    Qwen3OmniMoeThinkerForConditionalGeneration   → ``model.layers.*``
+    Qwen3OmniMoeThinkerTextModel                  → ``layers.*``
+
+We pick the pattern at factory time from config introspection so each load
+target only matches its own keys. The top-level pattern intentionally excludes
+the talker tower: in v4 the talker keeps ``nn.ModuleList`` experts and consumes
+HF per-expert keys natively, so passing them through unchanged is required.
+
+The converter is also a no-op when ``_moe_implementation != "fused"`` because
+the thinker uses ``nn.ModuleList`` in eager mode too — the factory returns
+``None`` in that case.
 """
 
 import re
@@ -27,10 +37,14 @@ import re
 from .._moe_v4_converter import MoEV4StackingConverter
 
 
-# Match thinker-tower per-expert keys only; talker stays in nn.ModuleList format on v4.
-_EXPERT_PATTERN = re.compile(
-    r"^(thinker\.model\.layers\.\d+\.mlp)\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
-)
+_PROJ_SUFFIX = r"\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
+
+# Top-level Qwen3OmniMoeForConditionalGeneration: thinker only, talker is nn.ModuleList in v4.
+_TOP_LEVEL_PATTERN = re.compile(r"^(thinker\.model\.layers\.\d+\.mlp)" + _PROJ_SUFFIX)
+# Standalone Qwen3OmniMoeThinkerForConditionalGeneration: experts under `model.*`.
+_THINKER_PATTERN = re.compile(r"^(model\.layers\.\d+\.mlp)" + _PROJ_SUFFIX)
+# Standalone Qwen3OmniMoeThinkerTextModel: experts under `layers.*` (the model class IS the root).
+_TEXT_MODEL_PATTERN = re.compile(r"^(layers\.\d+\.mlp)" + _PROJ_SUFFIX)
 
 
 def create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model):
@@ -40,15 +54,20 @@ def create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model):
     ``nn.ModuleList`` whose per-expert FQNs already match the HF checkpoint.
     """
     config = model.config
-    # The factory may be attached to either the top-level conditional-generation class
-    # or to the inner thinker text model loaded standalone. Resolve the text config that
-    # carries `num_experts` accordingly.
+    # Resolve text config and the matching key-prefix pattern from whichever
+    # config shape the model carries.
     if hasattr(config, "thinker_config"):
+        # Top-level Qwen3OmniMoeConfig.
         text_config = config.thinker_config.text_config
+        pattern = _TOP_LEVEL_PATTERN
     elif hasattr(config, "text_config"):
+        # Qwen3OmniMoeThinkerConfig — standalone thinker.
         text_config = config.text_config
+        pattern = _THINKER_PATTERN
     else:
+        # Qwen3OmniMoeThinkerTextConfig — text model is the root.
         text_config = config
+        pattern = _TEXT_MODEL_PATTERN
 
     moe_implementation = getattr(text_config, "_moe_implementation", None) or getattr(
         config, "_moe_implementation", "eager"
@@ -58,6 +77,6 @@ def create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model):
 
     num_experts = text_config.num_experts
     return MoEV4StackingConverter(
-        pattern=_EXPERT_PATTERN,
+        pattern=pattern,
         num_experts_for=lambda _prefix: num_experts,
     )

--- a/veomni/models/transformers/qwen3_omni_moe/checkpoint_tensor_converter_v4.py
+++ b/veomni/models/transformers/qwen3_omni_moe/checkpoint_tensor_converter_v4.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Runtime per-expert -> stacked converter for transformers v4 Qwen3-Omni-MoE.
+
+Only fired for the thinker tower's experts. The talker tower in v4 always runs
+in eager mode (`nn.ModuleList`) and consumes per-expert HF keys natively, so
+the converter intentionally does not match talker prefixes. The converter is
+also a no-op when `_moe_implementation != "fused"` because eager mode also
+uses `nn.ModuleList` for the thinker; the factory returns `None` in that case.
+"""
+
+import re
+
+from .._moe_v4_converter import MoEV4StackingConverter
+
+
+# Match thinker-tower per-expert keys only; talker stays in nn.ModuleList format on v4.
+_EXPERT_PATTERN = re.compile(
+    r"^(thinker\.model\.layers\.\d+\.mlp)\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
+)
+
+
+def create_qwen3_omni_moe_v4_checkpoint_tensor_converter(model):
+    """Factory registered on v4 Qwen3-Omni-MoE classes via `_create_checkpoint_tensor_converter`.
+
+    Returns ``None`` outside fused mode: in eager mode the thinker uses
+    ``nn.ModuleList`` whose per-expert FQNs already match the HF checkpoint.
+    """
+    config = model.config
+    # The factory may be attached to either the top-level conditional-generation class
+    # or to the inner thinker text model loaded standalone. Resolve the text config that
+    # carries `num_experts` accordingly.
+    if hasattr(config, "thinker_config"):
+        text_config = config.thinker_config.text_config
+    elif hasattr(config, "text_config"):
+        text_config = config.text_config
+    else:
+        text_config = config
+
+    moe_implementation = getattr(text_config, "_moe_implementation", None) or getattr(
+        config, "_moe_implementation", "eager"
+    )
+    if moe_implementation != "fused":
+        return None
+
+    num_experts = text_config.num_experts
+    return MoEV4StackingConverter(
+        pattern=_EXPERT_PATTERN,
+        num_experts_for=lambda _prefix: num_experts,
+    )


### PR DESCRIPTION
## Summary

- Adds a shared `MoEV4StackingConverter` and per-model v4 factories for `qwen3_moe`, `deepseek_v3`, and `qwen3_omni_moe` (thinker, fused mode) so vanilla HuggingFace MoE checkpoints load directly into VeOmni's three stacked `nn.Parameter`s at runtime — no more offline `scripts/moe_ckpt_merge/moe_merge.py` step before training on transformers 4.57.3.
- Mirrors the v5 converter introduced in #589 but emits three separate stacked tensors (`gate_proj`, `up_proj`, `down_proj`) instead of the v5 fused `gate_up_proj`, matching what `PatchQwen3MoeExperts` / `PatchDeepseekV3NaiveMoe` / `Qwen3OmniMoeThinkerExperts` actually allocate.
- The offline merge script gets a `DeprecationWarning` but is kept for users who want to amortize the stacking cost across many runs on very large checkpoints (e.g. Qwen3-235B).

## Why

Today, transformers v4 users have to run the offline merge script on every fresh HF checkpoint — extra disk I/O, extra storage, easy to forget. v5 users already get this for free via the converter protocol added in #589. The infrastructure (`module_utils.py`'s `get_checkpoint_tensor_converter` / `maybe_convert_checkpoint_tensor` / `converter.finalize` calls) is version-agnostic; only the per-model staticmethod attachment was missing for v4.

A prior attempt at this same problem — closed PR #67 *"qwen3-moe-a3b load"* — predated the converter protocol and shipped a custom load hook inside the model patch. This PR routes through the shared protocol instead.

## Scope

| Model | v4 path | Action |
|-------|---------|--------|
| `qwen3_moe` | `PatchQwen3MoeExperts` always uses stacked params | Always-on converter |
| `deepseek_v3` | `PatchDeepseekV3NaiveMoe` always uses stacked params; reads `n_routed_experts`; first `first_k_dense_replace` layers are dense | Always-on converter (regex misses dense layers naturally) |
| `qwen3_omni_moe` | Thinker uses stacked in fused mode, `nn.ModuleList` in eager; talker always `nn.ModuleList` | Converter only when `_moe_implementation == "fused"`, thinker prefix only |
| `qwen3_vl_moe` | Inherits HF's class with native `gate_up_proj [E, H, 2*I]` and transposes at runtime | **No converter needed** |
| `qwen3_5_moe`, `glm_moe_dsa` | Registered only on transformers ≥ 5.2.0 | N/A on v4 |

## Test plan

- [x] `pytest tests/models/test_moe_v4_runtime_merge.py -v` — 20 tests covering the shared base, per-model factories, multi-prefix dispatch, and an end-to-end `load_model_weights` integration that builds a tiny qwen3_moe model, writes per-expert HF safetensors, and verifies post-load `experts.{gate,up,down}_proj` exactly equals `torch.stack` of the inputs.
- [x] `pytest tests/models/test_checkpoint_tensor_converter.py` — 51 existing v5 converter tests pass unchanged (no protocol changes).
- [x] `pytest tests/models/test_model_registry.py` — registration regression check passes.
- [x] `make quality` — ruff check + format clean.
- [x] Offline `moe_merge.py` still runs and emits a `DeprecationWarning` on entry.
- [ ] Suggested follow-up: round-trip equivalence on a real `/mnt/hdfs/models/Qwen3-30B-A3B` checkpoint comparing direct load vs. pre-merged load.
- [ ] Suggested follow-up: 1-step training smoke run on a tiny MoE fixture.

## Risk notes

- Memory: the converter buffers up to `num_experts` per `(prefix, projection)` before stacking — same shape as the existing v5 converter that has been in production since #589.
- Broadcast load path (`module_utils.py:405-430`) already handles `None`-returns from buffered converters, so no extra work there.
- Safetensors key order across shards is not assumed; the converter is keyed by `(prefix, expert_id, projection)`.