### PR TITLE
[model] fix: qwen3_vl vision dummy_forward sp shape mismatch

### DIFF
--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.diff
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.diff
@@ -712,7 +712,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -812,11 +1075,60 @@
+@@ -812,11 +1075,77 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -729,10 +729,15 @@
 +    # 1. add dummy_forward so ranks without pixel_values can still run the
 +    #    visual encoder under FSDP — otherwise reduce-scatter hangs when
 +    #    some ranks get None pixel_values while others have real images
-+    # 2. SP-aware shape: grid_thw height is scaled by sp_size so the dummy
-+    #    batch stays a clean multiple after sequence slicing. Shapes are
-+    #    derived from the vision config (patch_size / temporal_patch_size /
-+    #    in_channels / spatial_merge_size) so model variants don't break
++    # 2. SP-aware shape: grid_thw is built at the FULL un-sliced size (height
++    #    scaled by sp_size) and pixel_values are then SP-pre-sliced with
++    #    pad_scale=4, mirroring what MainCollator does for real pixel_values
++    #    via DataCollateInfo(0, True, 0, 4). This keeps hidden_states (after
++    #    patch_embed) and pos_embeds (which fast_pos_embed_interpolate computes
++    #    from the FULL grid_thw and forward.sp_pad_and_slice's down to per-rank)
++    #    at the same dim-0 size for the `hidden_states + pos_embeds` add. Shapes
++    #    are derived from the vision config (patch_size / temporal_patch_size /
++    #    in_channels / spatial_merge_size) so model variants don't break.
 +    # ================================================================
 +    def dummy_forward(self):
 +        # --- Patch.1 ---
@@ -762,6 +767,18 @@
 +        pixel_row_size = in_channels * temporal_patch_size * patch_size * patch_size
 +        pixel_values = torch.zeros((num_patches, pixel_row_size), dtype=self.dtype, device=self.device)
 +        grid_thw = torch.tensor([[t, h, w]], dtype=torch.int32, device=self.device)
++
++        # --- Patch.3 ---
++        # Match MainCollator's per-rank slicing of `pixel_values` (DataCollateInfo
++        # pack_dim=0, sp_slice=True, sp_pad_value=0, sp_pad_scale=4) so that the
++        # synthesized batch enters forward at the same per-rank size the real
++        # data path produces. Otherwise hidden_states keeps the full size while
++        # pos_embeds gets sp_pad_and_slice'd inside forward, and
++        # `hidden_states + pos_embeds` mismatches at dim 0 by sp_size.
++        if get_parallel_state().sp_enabled:
++            pixel_values = sp_pad_and_slice(pixel_values, dim=0, pad_value=0, pad_scale=4)
++        # --- Patch.3 ---
++
 +        return self(hidden_states=pixel_values, grid_thw=grid_thw)
 +        # --- Patch.1 ---
 +
@@ -773,7 +790,7 @@
 
 
  @auto_docstring(
-@@ -940,15 +1252,35 @@
+@@ -940,15 +1269,35 @@
              past_key_values=past_key_values,
          )
 
@@ -809,7 +826,7 @@
 
 
  @auto_docstring
-@@ -1081,6 +1413,13 @@
+@@ -1081,6 +1430,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -823,7 +840,7 @@
      @can_return_tuple
      @auto_docstring
      def get_image_features(
-@@ -1088,63 +1427,36 @@
+@@ -1088,63 +1444,36 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -905,7 +922,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1184,6 +1496,24 @@
+@@ -1184,6 +1513,24 @@
              position_ids = None
          return position_ids
 
@@ -930,7 +947,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1200,20 +1530,40 @@
+@@ -1200,20 +1547,40 @@
          cache_position: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLModelOutputWithPast:
@@ -979,7 +996,7 @@
 
          if pixel_values is not None:
              image_outputs: BaseModelOutputWithDeepstackFeatures = self.get_image_features(
-@@ -1221,11 +1571,51 @@
+@@ -1221,11 +1588,51 @@
              )
              image_embeds = image_outputs.pooler_output
              deepstack_image_embeds = image_outputs.deepstack_features
@@ -1035,7 +1052,7 @@
 
          if pixel_values_videos is not None:
              video_outputs: BaseModelOutputWithDeepstackFeatures = self.get_video_features(
-@@ -1233,18 +1623,63 @@
+@@ -1233,18 +1640,63 @@
              )
              video_embeds = video_outputs.pooler_output
              deepstack_video_embeds = video_outputs.deepstack_features
@@ -1107,7 +1124,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1254,24 +1689,56 @@
+@@ -1254,24 +1706,56 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1169,7 +1186,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1286,7 +1753,10 @@
+@@ -1286,7 +1770,10 @@
          )
 
          return Qwen3VLModelOutputWithPast(
@@ -1181,7 +1198,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1318,6 +1788,12 @@
+@@ -1318,6 +1805,12 @@
      hidden_states: tuple[torch.FloatTensor] | None = None
      attentions: tuple[torch.FloatTensor] | None = None
      rope_deltas: torch.LongTensor | None = None
@@ -1194,7 +1211,7 @@
 
 
  class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
-@@ -1372,6 +1848,16 @@
+@@ -1372,6 +1865,16 @@
          """
          return self.model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw, **kwargs)
 
@@ -1211,7 +1228,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1389,53 +1875,6 @@
+@@ -1389,53 +1892,6 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLCausalLMOutputWithPast:
@@ -1265,7 +1282,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1451,14 +1890,31 @@
+@@ -1451,14 +1907,31 @@
          )
 
          hidden_states = outputs[0]
@@ -1302,7 +1319,7 @@
 
          return Qwen3VLCausalLMOutputWithPast(
              loss=loss,
-@@ -1693,6 +2149,25 @@
+@@ -1693,6 +2166,25 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.py
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.py
@@ -1088,10 +1088,15 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
     # 1. add dummy_forward so ranks without pixel_values can still run the
     #    visual encoder under FSDP — otherwise reduce-scatter hangs when
     #    some ranks get None pixel_values while others have real images
-    # 2. SP-aware shape: grid_thw height is scaled by sp_size so the dummy
-    #    batch stays a clean multiple after sequence slicing. Shapes are
-    #    derived from the vision config (patch_size / temporal_patch_size /
-    #    in_channels / spatial_merge_size) so model variants don't break
+    # 2. SP-aware shape: grid_thw is built at the FULL un-sliced size (height
+    #    scaled by sp_size) and pixel_values are then SP-pre-sliced with
+    #    pad_scale=4, mirroring what MainCollator does for real pixel_values
+    #    via DataCollateInfo(0, True, 0, 4). This keeps hidden_states (after
+    #    patch_embed) and pos_embeds (which fast_pos_embed_interpolate computes
+    #    from the FULL grid_thw and forward.sp_pad_and_slice's down to per-rank)
+    #    at the same dim-0 size for the `hidden_states + pos_embeds` add. Shapes
+    #    are derived from the vision config (patch_size / temporal_patch_size /
+    #    in_channels / spatial_merge_size) so model variants don't break.
     # ================================================================
     def dummy_forward(self):
         # --- Patch.1 ---
@@ -1121,6 +1126,18 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         pixel_row_size = in_channels * temporal_patch_size * patch_size * patch_size
         pixel_values = torch.zeros((num_patches, pixel_row_size), dtype=self.dtype, device=self.device)
         grid_thw = torch.tensor([[t, h, w]], dtype=torch.int32, device=self.device)
+
+        # --- Patch.3 ---
+        # Match MainCollator's per-rank slicing of `pixel_values` (DataCollateInfo
+        # pack_dim=0, sp_slice=True, sp_pad_value=0, sp_pad_scale=4) so that the
+        # synthesized batch enters forward at the same per-rank size the real
+        # data path produces. Otherwise hidden_states keeps the full size while
+        # pos_embeds gets sp_pad_and_slice'd inside forward, and
+        # `hidden_states + pos_embeds` mismatches at dim 0 by sp_size.
+        if get_parallel_state().sp_enabled:
+            pixel_values = sp_pad_and_slice(pixel_values, dim=0, pad_value=0, pad_scale=4)
+        # --- Patch.3 ---
+
         return self(hidden_states=pixel_values, grid_thw=grid_thw)
         # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.diff
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.diff
@@ -836,7 +836,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -812,11 +1103,60 @@
+@@ -812,11 +1103,77 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -853,10 +853,15 @@
 +    # 1. add dummy_forward so ranks without pixel_values can still run the
 +    #    visual encoder under FSDP — otherwise reduce-scatter hangs when
 +    #    some ranks get None pixel_values while others have real images
-+    # 2. SP-aware shape: grid_thw height is scaled by sp_size so the dummy
-+    #    batch stays a clean multiple after sequence slicing. Shapes are
-+    #    derived from the vision config (patch_size / temporal_patch_size /
-+    #    in_channels / spatial_merge_size) so model variants don't break
++    # 2. SP-aware shape: grid_thw is built at the FULL un-sliced size (height
++    #    scaled by sp_size) and pixel_values are then SP-pre-sliced with
++    #    pad_scale=4, mirroring what MainCollator does for real pixel_values
++    #    via DataCollateInfo(0, True, 0, 4). This keeps hidden_states (after
++    #    patch_embed) and pos_embeds (which fast_pos_embed_interpolate computes
++    #    from the FULL grid_thw and forward.sp_pad_and_slice's down to per-rank)
++    #    at the same dim-0 size for the `hidden_states + pos_embeds` add. Shapes
++    #    are derived from the vision config (patch_size / temporal_patch_size /
++    #    in_channels / spatial_merge_size) so model variants don't break.
 +    # ================================================================
 +    def dummy_forward(self):
 +        # --- Patch.1 ---
@@ -886,6 +891,18 @@
 +        pixel_row_size = in_channels * temporal_patch_size * patch_size * patch_size
 +        pixel_values = torch.zeros((num_patches, pixel_row_size), dtype=self.dtype, device=self.device)
 +        grid_thw = torch.tensor([[t, h, w]], dtype=torch.int32, device=self.device)
++
++        # --- Patch.3 ---
++        # Match MainCollator's per-rank slicing of `pixel_values` (DataCollateInfo
++        # pack_dim=0, sp_slice=True, sp_pad_value=0, sp_pad_scale=4) so that the
++        # synthesized batch enters forward at the same per-rank size the real
++        # data path produces. Otherwise hidden_states keeps the full size while
++        # pos_embeds gets sp_pad_and_slice'd inside forward, and
++        # `hidden_states + pos_embeds` mismatches at dim 0 by sp_size.
++        if get_parallel_state().sp_enabled:
++            pixel_values = sp_pad_and_slice(pixel_values, dim=0, pad_value=0, pad_scale=4)
++        # --- Patch.3 ---
++
 +        return self(hidden_states=pixel_values, grid_thw=grid_thw)
 +        # --- Patch.1 ---
 +
@@ -897,7 +914,7 @@
 
 
  @auto_docstring(
-@@ -940,15 +1280,35 @@
+@@ -940,15 +1297,35 @@
              past_key_values=past_key_values,
          )
 
@@ -933,7 +950,7 @@
 
 
  @auto_docstring
-@@ -1081,6 +1441,13 @@
+@@ -1081,6 +1458,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -947,7 +964,7 @@
      @can_return_tuple
      @auto_docstring
      def get_image_features(
-@@ -1088,63 +1455,36 @@
+@@ -1088,63 +1472,36 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1029,7 +1046,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1184,6 +1524,24 @@
+@@ -1184,6 +1541,24 @@
              position_ids = None
          return position_ids
 
@@ -1054,7 +1071,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1200,20 +1558,40 @@
+@@ -1200,20 +1575,40 @@
          cache_position: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLModelOutputWithPast:
@@ -1103,7 +1120,7 @@
 
          if pixel_values is not None:
              image_outputs: BaseModelOutputWithDeepstackFeatures = self.get_image_features(
-@@ -1221,11 +1599,51 @@
+@@ -1221,11 +1616,51 @@
              )
              image_embeds = image_outputs.pooler_output
              deepstack_image_embeds = image_outputs.deepstack_features
@@ -1159,7 +1176,7 @@
 
          if pixel_values_videos is not None:
              video_outputs: BaseModelOutputWithDeepstackFeatures = self.get_video_features(
-@@ -1233,18 +1651,63 @@
+@@ -1233,18 +1668,63 @@
              )
              video_embeds = video_outputs.pooler_output
              deepstack_video_embeds = video_outputs.deepstack_features
@@ -1231,7 +1248,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1254,24 +1717,56 @@
+@@ -1254,24 +1734,56 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1293,7 +1310,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1286,7 +1781,10 @@
+@@ -1286,7 +1798,10 @@
          )
 
          return Qwen3VLModelOutputWithPast(
@@ -1305,7 +1322,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1318,6 +1816,12 @@
+@@ -1318,6 +1833,12 @@
      hidden_states: tuple[torch.FloatTensor] | None = None
      attentions: tuple[torch.FloatTensor] | None = None
      rope_deltas: torch.LongTensor | None = None
@@ -1318,7 +1335,7 @@
 
 
  class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
-@@ -1372,6 +1876,16 @@
+@@ -1372,6 +1893,16 @@
          """
          return self.model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw, **kwargs)
 
@@ -1335,7 +1352,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1389,53 +1903,6 @@
+@@ -1389,53 +1920,6 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLCausalLMOutputWithPast:
@@ -1389,7 +1406,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1451,14 +1918,31 @@
+@@ -1451,14 +1935,31 @@
          )
 
          hidden_states = outputs[0]
@@ -1426,7 +1443,7 @@
 
          return Qwen3VLCausalLMOutputWithPast(
              loss=loss,
-@@ -1693,6 +2177,25 @@
+@@ -1693,6 +2194,25 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.py
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.py
@@ -1116,10 +1116,15 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
     # 1. add dummy_forward so ranks without pixel_values can still run the
     #    visual encoder under FSDP — otherwise reduce-scatter hangs when
     #    some ranks get None pixel_values while others have real images
-    # 2. SP-aware shape: grid_thw height is scaled by sp_size so the dummy
-    #    batch stays a clean multiple after sequence slicing. Shapes are
-    #    derived from the vision config (patch_size / temporal_patch_size /
-    #    in_channels / spatial_merge_size) so model variants don't break
+    # 2. SP-aware shape: grid_thw is built at the FULL un-sliced size (height
+    #    scaled by sp_size) and pixel_values are then SP-pre-sliced with
+    #    pad_scale=4, mirroring what MainCollator does for real pixel_values
+    #    via DataCollateInfo(0, True, 0, 4). This keeps hidden_states (after
+    #    patch_embed) and pos_embeds (which fast_pos_embed_interpolate computes
+    #    from the FULL grid_thw and forward.sp_pad_and_slice's down to per-rank)
+    #    at the same dim-0 size for the `hidden_states + pos_embeds` add. Shapes
+    #    are derived from the vision config (patch_size / temporal_patch_size /
+    #    in_channels / spatial_merge_size) so model variants don't break.
     # ================================================================
     def dummy_forward(self):
         # --- Patch.1 ---
@@ -1149,6 +1154,18 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         pixel_row_size = in_channels * temporal_patch_size * patch_size * patch_size
         pixel_values = torch.zeros((num_patches, pixel_row_size), dtype=self.dtype, device=self.device)
         grid_thw = torch.tensor([[t, h, w]], dtype=torch.int32, device=self.device)
+
+        # --- Patch.3 ---
+        # Match MainCollator's per-rank slicing of `pixel_values` (DataCollateInfo
+        # pack_dim=0, sp_slice=True, sp_pad_value=0, sp_pad_scale=4) so that the
+        # synthesized batch enters forward at the same per-rank size the real
+        # data path produces. Otherwise hidden_states keeps the full size while
+        # pos_embeds gets sp_pad_and_slice'd inside forward, and
+        # `hidden_states + pos_embeds` mismatches at dim 0 by sp_size.
+        if get_parallel_state().sp_enabled:
+            pixel_values = sp_pad_and_slice(pixel_values, dim=0, pad_value=0, pad_scale=4)
+        # --- Patch.3 ---
+
         return self(hidden_states=pixel_values, grid_thw=grid_thw)
         # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_vl/qwen3_vl_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_vl/qwen3_vl_gpu_patch_gen_config.py
@@ -558,10 +558,15 @@ def qwen3_vl_vision_forward_patched(
 # 1. add dummy_forward so ranks without pixel_values can still run the
 #    visual encoder under FSDP — otherwise reduce-scatter hangs when
 #    some ranks get None pixel_values while others have real images
-# 2. SP-aware shape: grid_thw height is scaled by sp_size so the dummy
-#    batch stays a clean multiple after sequence slicing. Shapes are
-#    derived from the vision config (patch_size / temporal_patch_size /
-#    in_channels / spatial_merge_size) so model variants don't break
+# 2. SP-aware shape: grid_thw is built at the FULL un-sliced size (height
+#    scaled by sp_size) and pixel_values are then SP-pre-sliced with
+#    pad_scale=4, mirroring what MainCollator does for real pixel_values
+#    via DataCollateInfo(0, True, 0, 4). This keeps hidden_states (after
+#    patch_embed) and pos_embeds (which fast_pos_embed_interpolate computes
+#    from the FULL grid_thw and forward.sp_pad_and_slice's down to per-rank)
+#    at the same dim-0 size for the `hidden_states + pos_embeds` add. Shapes
+#    are derived from the vision config (patch_size / temporal_patch_size /
+#    in_channels / spatial_merge_size) so model variants don't break.
 # ================================================================
 @config.override_method(
     "Qwen3VLVisionModel.dummy_forward",
@@ -595,6 +600,18 @@ def qwen3_vl_vision_dummy_forward_patched(self):
     pixel_row_size = in_channels * temporal_patch_size * patch_size * patch_size
     pixel_values = torch.zeros((num_patches, pixel_row_size), dtype=self.dtype, device=self.device)
     grid_thw = torch.tensor([[t, h, w]], dtype=torch.int32, device=self.device)
+
+    # --- Patch.3 ---
+    # Match MainCollator's per-rank slicing of `pixel_values` (DataCollateInfo
+    # pack_dim=0, sp_slice=True, sp_pad_value=0, sp_pad_scale=4) so that the
+    # synthesized batch enters forward at the same per-rank size the real
+    # data path produces. Otherwise hidden_states keeps the full size while
+    # pos_embeds gets sp_pad_and_slice'd inside forward, and
+    # `hidden_states + pos_embeds` mismatches at dim 0 by sp_size.
+    if get_parallel_state().sp_enabled:
+        pixel_values = sp_pad_and_slice(pixel_values, dim=0, pad_value=0, pad_scale=4)
+    # --- Patch.3 ---
+
     return self(hidden_states=pixel_values, grid_thw=grid_thw)
     # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.diff
@@ -843,7 +843,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -802,11 +1125,54 @@
+@@ -802,11 +1125,71 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -860,10 +860,15 @@
 +    # 1. add dummy_forward so ranks without pixel_values can still run the
 +    #    visual encoder under FSDP — otherwise reduce-scatter hangs when
 +    #    some ranks get None pixel_values while others have real images
-+    # 2. SP-aware shape: grid_thw height is scaled by sp_size so the dummy
-+    #    batch stays a clean multiple after sequence slicing. Shapes are
-+    #    derived from the vision config (patch_size / temporal_patch_size /
-+    #    in_channels / spatial_merge_size) so model variants don't break
++    # 2. SP-aware shape: grid_thw is built at the FULL un-sliced size (height
++    #    scaled by sp_size) and pixel_values are then SP-pre-sliced with
++    #    pad_scale=4, mirroring what MainCollator does for real pixel_values
++    #    via DataCollateInfo(0, True, 0, 4). This keeps hidden_states (after
++    #    patch_embed) and pos_embeds (which fast_pos_embed_interpolate computes
++    #    from the FULL grid_thw and forward.sp_pad_and_slice's down to per-rank)
++    #    at the same dim-0 size for the `hidden_states + pos_embeds` add. Shapes
++    #    are derived from the vision config (patch_size / temporal_patch_size /
++    #    in_channels / spatial_merge_size) so model variants don't break.
 +    # ================================================================
 +    def dummy_forward(self):
 +        # --- Patch.1 ---
@@ -893,12 +898,24 @@
 +        pixel_row_size = in_channels * temporal_patch_size * patch_size * patch_size
 +        pixel_values = torch.zeros((num_patches, pixel_row_size), dtype=self.dtype, device=self.device)
 +        grid_thw = torch.tensor([[t, h, w]], dtype=torch.int32, device=self.device)
++
++        # --- Patch.3 ---
++        # Match MainCollator's per-rank slicing of `pixel_values` (DataCollateInfo
++        # pack_dim=0, sp_slice=True, sp_pad_value=0, sp_pad_scale=4) so that the
++        # synthesized batch enters forward at the same per-rank size the real
++        # data path produces. Otherwise hidden_states keeps the full size while
++        # pos_embeds gets sp_pad_and_slice'd inside forward, and
++        # `hidden_states + pos_embeds` mismatches at dim 0 by sp_size.
++        if get_parallel_state().sp_enabled:
++            pixel_values = sp_pad_and_slice(pixel_values, dim=0, pad_value=0, pad_scale=4)
++        # --- Patch.3 ---
++
 +        return self(hidden_states=pixel_values, grid_thw=grid_thw)
 +        # --- Patch.1 ---
 
 
  class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
-@@ -896,6 +1262,12 @@
+@@ -896,6 +1279,12 @@
              idx = slice(offset, length, 3)
              freqs_t[..., idx] = freqs[dim, ..., idx]
          return freqs_t
@@ -911,7 +928,7 @@
 
 
  @auto_docstring(
-@@ -1019,9 +1391,23 @@
+@@ -1019,9 +1408,23 @@
              past_key_values=past_key_values,
          )
 
@@ -935,7 +952,7 @@
          visual_pos_masks = visual_pos_masks.to(hidden_states.device)
          visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
          hidden_states = hidden_states.clone()
-@@ -1086,6 +1472,12 @@
+@@ -1086,6 +1489,12 @@
      aux_loss: torch.FloatTensor | None = None
 
 
@@ -948,7 +965,7 @@
  @auto_docstring
  class Qwen3VLMoeModel(Qwen3VLMoePreTrainedModel):
      base_model_prefix = "model"
-@@ -1095,7 +1487,19 @@
+@@ -1095,7 +1504,19 @@
      config: Qwen3VLMoeConfig
      _no_split_modules = ["Qwen3VLMoeTextDecoderLayer", "Qwen3VLMoeVisionBlock"]
 
@@ -968,7 +985,7 @@
          super().__init__(config)
          self.visual = Qwen3VLMoeVisionModel._from_config(config.vision_config)
          self.language_model = Qwen3VLMoeTextModel._from_config(config.text_config)
-@@ -1216,6 +1620,13 @@
+@@ -1216,6 +1637,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -982,7 +999,7 @@
      @can_return_tuple
      @auto_docstring
      def get_image_features(
-@@ -1223,63 +1634,36 @@
+@@ -1223,63 +1651,36 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1064,7 +1081,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1319,6 +1703,16 @@
+@@ -1319,6 +1720,16 @@
              position_ids = None
          return position_ids
 
@@ -1081,7 +1098,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1335,20 +1729,40 @@
+@@ -1335,20 +1746,40 @@
          cache_position: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLMoeModelOutputWithPast:
@@ -1130,7 +1147,7 @@
 
          if pixel_values is not None:
              image_outputs: BaseModelOutputWithDeepstackFeatures = self.get_image_features(
-@@ -1356,11 +1770,51 @@
+@@ -1356,11 +1787,51 @@
              )
              image_embeds = image_outputs.pooler_output
              deepstack_image_embeds = image_outputs.deepstack_features
@@ -1186,7 +1203,7 @@
 
          if pixel_values_videos is not None:
              video_outputs: BaseModelOutputWithDeepstackFeatures = self.get_video_features(
-@@ -1368,18 +1822,63 @@
+@@ -1368,18 +1839,63 @@
              )
              video_embeds = video_outputs.pooler_output
              deepstack_video_embeds = video_outputs.deepstack_features
@@ -1258,7 +1275,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1389,24 +1888,48 @@
+@@ -1389,24 +1905,48 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1312,7 +1329,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1421,7 +1944,11 @@
+@@ -1421,7 +1961,11 @@
          )
 
          return Qwen3VLMoeModelOutputWithPast(
@@ -1325,7 +1342,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1506,6 +2033,12 @@
+@@ -1506,6 +2050,12 @@
 
      overall_loss = torch.sum(tokens_per_expert * router_prob_per_expert.unsqueeze(0))
      return overall_loss * num_experts
@@ -1338,7 +1355,7 @@
 
 
  class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMixin):
-@@ -1560,6 +2093,14 @@
+@@ -1560,6 +2110,14 @@
          """
          return self.model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw, **kwargs)
 
@@ -1353,7 +1370,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1577,58 +2118,6 @@
+@@ -1577,58 +2135,6 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLMoeCausalLMOutputWithPast:
@@ -1412,7 +1429,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1644,27 +2133,55 @@
+@@ -1644,27 +2150,55 @@
          )
 
          hidden_states = outputs[0]
@@ -1484,7 +1501,7 @@
 
          return Qwen3VLMoeCausalLMOutputWithPast(
              loss=loss,
-@@ -1674,7 +2191,7 @@
+@@ -1674,7 +2208,7 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
@@ -1493,7 +1510,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1901,6 +2418,37 @@
+@@ -1901,6 +2435,37 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.py
@@ -1138,10 +1138,15 @@ class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
     # 1. add dummy_forward so ranks without pixel_values can still run the
     #    visual encoder under FSDP — otherwise reduce-scatter hangs when
     #    some ranks get None pixel_values while others have real images
-    # 2. SP-aware shape: grid_thw height is scaled by sp_size so the dummy
-    #    batch stays a clean multiple after sequence slicing. Shapes are
-    #    derived from the vision config (patch_size / temporal_patch_size /
-    #    in_channels / spatial_merge_size) so model variants don't break
+    # 2. SP-aware shape: grid_thw is built at the FULL un-sliced size (height
+    #    scaled by sp_size) and pixel_values are then SP-pre-sliced with
+    #    pad_scale=4, mirroring what MainCollator does for real pixel_values
+    #    via DataCollateInfo(0, True, 0, 4). This keeps hidden_states (after
+    #    patch_embed) and pos_embeds (which fast_pos_embed_interpolate computes
+    #    from the FULL grid_thw and forward.sp_pad_and_slice's down to per-rank)
+    #    at the same dim-0 size for the `hidden_states + pos_embeds` add. Shapes
+    #    are derived from the vision config (patch_size / temporal_patch_size /
+    #    in_channels / spatial_merge_size) so model variants don't break.
     # ================================================================
     def dummy_forward(self):
         # --- Patch.1 ---
@@ -1171,6 +1176,18 @@ class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
         pixel_row_size = in_channels * temporal_patch_size * patch_size * patch_size
         pixel_values = torch.zeros((num_patches, pixel_row_size), dtype=self.dtype, device=self.device)
         grid_thw = torch.tensor([[t, h, w]], dtype=torch.int32, device=self.device)
+
+        # --- Patch.3 ---
+        # Match MainCollator's per-rank slicing of `pixel_values` (DataCollateInfo
+        # pack_dim=0, sp_slice=True, sp_pad_value=0, sp_pad_scale=4) so that the
+        # synthesized batch enters forward at the same per-rank size the real
+        # data path produces. Otherwise hidden_states keeps the full size while
+        # pos_embeds gets sp_pad_and_slice'd inside forward, and
+        # `hidden_states + pos_embeds` mismatches at dim 0 by sp_size.
+        if get_parallel_state().sp_enabled:
+            pixel_values = sp_pad_and_slice(pixel_values, dim=0, pad_value=0, pad_scale=4)
+        # --- Patch.3 ---
+
         return self(hidden_states=pixel_values, grid_thw=grid_thw)
         # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.diff
@@ -952,7 +952,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -802,11 +1150,54 @@
+@@ -802,11 +1150,71 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -969,10 +969,15 @@
 +    # 1. add dummy_forward so ranks without pixel_values can still run the
 +    #    visual encoder under FSDP — otherwise reduce-scatter hangs when
 +    #    some ranks get None pixel_values while others have real images
-+    # 2. SP-aware shape: grid_thw height is scaled by sp_size so the dummy
-+    #    batch stays a clean multiple after sequence slicing. Shapes are
-+    #    derived from the vision config (patch_size / temporal_patch_size /
-+    #    in_channels / spatial_merge_size) so model variants don't break
++    # 2. SP-aware shape: grid_thw is built at the FULL un-sliced size (height
++    #    scaled by sp_size) and pixel_values are then SP-pre-sliced with
++    #    pad_scale=4, mirroring what MainCollator does for real pixel_values
++    #    via DataCollateInfo(0, True, 0, 4). This keeps hidden_states (after
++    #    patch_embed) and pos_embeds (which fast_pos_embed_interpolate computes
++    #    from the FULL grid_thw and forward.sp_pad_and_slice's down to per-rank)
++    #    at the same dim-0 size for the `hidden_states + pos_embeds` add. Shapes
++    #    are derived from the vision config (patch_size / temporal_patch_size /
++    #    in_channels / spatial_merge_size) so model variants don't break.
 +    # ================================================================
 +    def dummy_forward(self):
 +        # --- Patch.1 ---
@@ -1002,12 +1007,24 @@
 +        pixel_row_size = in_channels * temporal_patch_size * patch_size * patch_size
 +        pixel_values = torch.zeros((num_patches, pixel_row_size), dtype=self.dtype, device=self.device)
 +        grid_thw = torch.tensor([[t, h, w]], dtype=torch.int32, device=self.device)
++
++        # --- Patch.3 ---
++        # Match MainCollator's per-rank slicing of `pixel_values` (DataCollateInfo
++        # pack_dim=0, sp_slice=True, sp_pad_value=0, sp_pad_scale=4) so that the
++        # synthesized batch enters forward at the same per-rank size the real
++        # data path produces. Otherwise hidden_states keeps the full size while
++        # pos_embeds gets sp_pad_and_slice'd inside forward, and
++        # `hidden_states + pos_embeds` mismatches at dim 0 by sp_size.
++        if get_parallel_state().sp_enabled:
++            pixel_values = sp_pad_and_slice(pixel_values, dim=0, pad_value=0, pad_scale=4)
++        # --- Patch.3 ---
++
 +        return self(hidden_states=pixel_values, grid_thw=grid_thw)
 +        # --- Patch.1 ---
 
 
  class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
-@@ -896,6 +1287,12 @@
+@@ -896,6 +1304,12 @@
              idx = slice(offset, length, 3)
              freqs_t[..., idx] = freqs[dim, ..., idx]
          return freqs_t
@@ -1020,7 +1037,7 @@
 
 
  @auto_docstring(
-@@ -1019,9 +1416,23 @@
+@@ -1019,9 +1433,23 @@
              past_key_values=past_key_values,
          )
 
@@ -1044,7 +1061,7 @@
          visual_pos_masks = visual_pos_masks.to(hidden_states.device)
          visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
          hidden_states = hidden_states.clone()
-@@ -1086,6 +1497,12 @@
+@@ -1086,6 +1514,12 @@
      aux_loss: torch.FloatTensor | None = None
 
 
@@ -1057,7 +1074,7 @@
  @auto_docstring
  class Qwen3VLMoeModel(Qwen3VLMoePreTrainedModel):
      base_model_prefix = "model"
-@@ -1095,7 +1512,19 @@
+@@ -1095,7 +1529,19 @@
      config: Qwen3VLMoeConfig
      _no_split_modules = ["Qwen3VLMoeTextDecoderLayer", "Qwen3VLMoeVisionBlock"]
 
@@ -1077,7 +1094,7 @@
          super().__init__(config)
          self.visual = Qwen3VLMoeVisionModel._from_config(config.vision_config)
          self.language_model = Qwen3VLMoeTextModel._from_config(config.text_config)
-@@ -1216,6 +1645,13 @@
+@@ -1216,6 +1662,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -1091,7 +1108,7 @@
      @can_return_tuple
      @auto_docstring
      def get_image_features(
-@@ -1223,63 +1659,36 @@
+@@ -1223,63 +1676,36 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1173,7 +1190,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1319,6 +1728,16 @@
+@@ -1319,6 +1745,16 @@
              position_ids = None
          return position_ids
 
@@ -1190,7 +1207,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1335,20 +1754,40 @@
+@@ -1335,20 +1771,40 @@
          cache_position: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLMoeModelOutputWithPast:
@@ -1239,7 +1256,7 @@
 
          if pixel_values is not None:
              image_outputs: BaseModelOutputWithDeepstackFeatures = self.get_image_features(
-@@ -1356,11 +1795,51 @@
+@@ -1356,11 +1812,51 @@
              )
              image_embeds = image_outputs.pooler_output
              deepstack_image_embeds = image_outputs.deepstack_features
@@ -1295,7 +1312,7 @@
 
          if pixel_values_videos is not None:
              video_outputs: BaseModelOutputWithDeepstackFeatures = self.get_video_features(
-@@ -1368,18 +1847,63 @@
+@@ -1368,18 +1864,63 @@
              )
              video_embeds = video_outputs.pooler_output
              deepstack_video_embeds = video_outputs.deepstack_features
@@ -1367,7 +1384,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1389,24 +1913,48 @@
+@@ -1389,24 +1930,48 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1421,7 +1438,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1421,7 +1969,11 @@
+@@ -1421,7 +1986,11 @@
          )
 
          return Qwen3VLMoeModelOutputWithPast(
@@ -1434,7 +1451,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1506,6 +2058,12 @@
+@@ -1506,6 +2075,12 @@
 
      overall_loss = torch.sum(tokens_per_expert * router_prob_per_expert.unsqueeze(0))
      return overall_loss * num_experts
@@ -1447,7 +1464,7 @@
 
 
  class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMixin):
-@@ -1560,6 +2118,14 @@
+@@ -1560,6 +2135,14 @@
          """
          return self.model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw, **kwargs)
 
@@ -1462,7 +1479,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1577,58 +2143,6 @@
+@@ -1577,58 +2160,6 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLMoeCausalLMOutputWithPast:
@@ -1521,7 +1538,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1644,27 +2158,55 @@
+@@ -1644,27 +2175,55 @@
          )
 
          hidden_states = outputs[0]
@@ -1593,7 +1610,7 @@
 
          return Qwen3VLMoeCausalLMOutputWithPast(
              loss=loss,
-@@ -1674,7 +2216,7 @@
+@@ -1674,7 +2233,7 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
@@ -1602,7 +1619,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1901,6 +2443,37 @@
+@@ -1901,6 +2460,37 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.py
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.py
@@ -1163,10 +1163,15 @@ class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
     # 1. add dummy_forward so ranks without pixel_values can still run the
     #    visual encoder under FSDP — otherwise reduce-scatter hangs when
     #    some ranks get None pixel_values while others have real images
-    # 2. SP-aware shape: grid_thw height is scaled by sp_size so the dummy
-    #    batch stays a clean multiple after sequence slicing. Shapes are
-    #    derived from the vision config (patch_size / temporal_patch_size /
-    #    in_channels / spatial_merge_size) so model variants don't break
+    # 2. SP-aware shape: grid_thw is built at the FULL un-sliced size (height
+    #    scaled by sp_size) and pixel_values are then SP-pre-sliced with
+    #    pad_scale=4, mirroring what MainCollator does for real pixel_values
+    #    via DataCollateInfo(0, True, 0, 4). This keeps hidden_states (after
+    #    patch_embed) and pos_embeds (which fast_pos_embed_interpolate computes
+    #    from the FULL grid_thw and forward.sp_pad_and_slice's down to per-rank)
+    #    at the same dim-0 size for the `hidden_states + pos_embeds` add. Shapes
+    #    are derived from the vision config (patch_size / temporal_patch_size /
+    #    in_channels / spatial_merge_size) so model variants don't break.
     # ================================================================
     def dummy_forward(self):
         # --- Patch.1 ---
@@ -1196,6 +1201,18 @@ class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
         pixel_row_size = in_channels * temporal_patch_size * patch_size * patch_size
         pixel_values = torch.zeros((num_patches, pixel_row_size), dtype=self.dtype, device=self.device)
         grid_thw = torch.tensor([[t, h, w]], dtype=torch.int32, device=self.device)
+
+        # --- Patch.3 ---
+        # Match MainCollator's per-rank slicing of `pixel_values` (DataCollateInfo
+        # pack_dim=0, sp_slice=True, sp_pad_value=0, sp_pad_scale=4) so that the
+        # synthesized batch enters forward at the same per-rank size the real
+        # data path produces. Otherwise hidden_states keeps the full size while
+        # pos_embeds gets sp_pad_and_slice'd inside forward, and
+        # `hidden_states + pos_embeds` mismatches at dim 0 by sp_size.
+        if get_parallel_state().sp_enabled:
+            pixel_values = sp_pad_and_slice(pixel_values, dim=0, pad_value=0, pad_scale=4)
+        # --- Patch.3 ---
+
         return self(hidden_states=pixel_values, grid_thw=grid_thw)
         # --- Patch.1 ---
 


### PR DESCRIPTION
### What does this PR do?

> Fix `Qwen3VLVisionModel.dummy_forward` (and its `qwen3_vl_moe` counterpart) so the synthesized empty-batch path enters vision forward at the same per-rank shape as real data under sequence parallelism (SP).
>
> Without this fix, on ranks without `pixel_values` the dummy `hidden_states` enters `forward()` at full size, while `pos_embeds` (computed inside `forward` via `fast_pos_embed_interpolate` from the full `grid_thw`) gets `sp_pad_and_slice`'d down to per-rank size. The subsequent `hidden_states + pos_embeds` add then mismatches at dim 0 by `sp_size`.

### Checklist Before Starting

- Search for relative PRs/issues and link here: regression surfaces under SP after the kernel-registry refactor (#678) once `dummy_forward` started running on real configs again
- PR title follows `[{modules}] {type}: {description}` format

### Test

> Re-run `qwen3_vl_8b` dense and `qwen3_vl_30b_a3b` MoE training under SP. Verify:
>
> - `hidden_states + pos_embeds` dim-0 mismatch in `dummy_forward` no longer raises on ranks without pixel_values
> - `make patchgen` is a no-op on a clean tree (generated files match the patch-gen config)
> - GPU and NPU generated outputs both reflect the new SP branch

### API and Usage Example

> N/A — internal patch on `Qwen3VLVisionModel.dummy_forward`; no public API change.

### Design & Code Changes

> - `veomni/models/transformers/qwen3_vl/qwen3_vl_gpu_patch_gen_config.py`: in `qwen3_vl_vision_dummy_forward_patched`, add an SP branch that pre-slices `pixel_values` with `sp_pad_and_slice(..., dim=0, pad_value=0, pad_scale=4)` when `get_parallel_state().sp_enabled`. This mirrors what the data collator does for real `pixel_values` (`DataCollateInfo(pack_dim=0, sp_slice=True, sp_pad_value=0, sp_pad_scale=4)`), so the synthesized batch enters `forward()` at the per-rank size the real data path produces.
> - Update the inline rationale block above `dummy_forward` to document the SP slicing rule and why `grid_thw` stays at the full un-sliced size.
> - Regenerate the 8 published mirror files via `make patchgen`:
>   - `qwen3_vl/generated/patched_modeling_qwen3_vl_{gpu,npu}.{py,diff}`
>   - `qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_{gpu,npu}.{py,diff}`
>
> Files under `*/generated/` are not hand-edited — they are the `make patchgen` output of the patch-gen config.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [ ] Added/updated documentation (N/A — internal patch, no public API change)
- [ ] Added tests to CI workflow (validated via nightly SP training runs; unit-testing `dummy_forward` requires a multi-rank SP harness not present in CI)
