### PR TITLE
[ops, docs] feat: add 'auto' default for kernel selection

### DIFF
--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -14,16 +14,52 @@ selection knob.
 | Kernel | Config field | Available values | Default | Selection time |
 |--------|-------------|------------------|---------|----------------|
 | Attention | `attn_implementation` | `eager`, `sdpa`, `flash_attention_2`, `flash_attention_3`, `flash_attention_4`, `native-sparse` | `"flash_attention_2"` | Config `__post_init__` + `build_foundation_model` |
-| Cross-entropy loss | `cross_entropy_loss_implementation` | `eager`, `liger_kernel`, `npu` | `"eager"` | `apply_ops_config()` (before model build) |
-| RMSNorm | `rms_norm_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"eager"` | Model registration via ops config singleton |
-| SwiGLU MLP | `swiglu_mlp_implementation` | `eager`, `liger_kernel` | `"eager"` | Model registration via ops config singleton |
-| Rotary embedding | `rotary_pos_emb_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"eager"` | Model registration via ops config singleton |
-| Load-balancing loss | `load_balancing_loss_implementation` | `eager`, `triton` (CUDA `triton` or NPU `triton-ascend`) | `"eager"` | `apply_ops_config()` (before model build) |
-| MoE experts | `moe_implementation` | `eager`, `fused_triton`, `fused_quack` (SM90+), `fused_npu` | `"eager"` | `build_foundation_model` |
+| Cross-entropy loss | `cross_entropy_loss_implementation` | `auto`, `eager`, `liger_kernel`, `chunk_loss` (device-agnostic; legacy alias `npu`) | `"auto"` → `chunk_loss` (GPU+NPU) | `apply_ops_config()` (before model build) |
+| RMSNorm | `rms_norm_implementation` | `auto`, `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"auto"` → `liger_kernel` (GPU) / `npu` (NPU) | Model registration via ops config singleton |
+| SwiGLU MLP | `swiglu_mlp_implementation` | `auto`, `eager`, `liger_kernel` | `"auto"` → `liger_kernel` (GPU) / `eager` (NPU) | Model registration via ops config singleton |
+| Rotary embedding | `rotary_pos_emb_implementation` | `auto`, `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"auto"` → `liger_kernel` (GPU) / `npu` (NPU) | Model registration via ops config singleton |
+| Load-balancing loss | `load_balancing_loss_implementation` | `auto`, `eager`, `triton` (CUDA `triton` or NPU `triton-ascend`) | `"auto"` → `triton` (GPU+NPU) | `apply_ops_config()` (before model build) |
+| MoE experts | `moe_implementation` | `auto`, `eager`, `fused_triton`, `fused_quack` (SM90+), `fused_npu` (legacy alias `fused`) | `"auto"` → `fused_triton` (GPU) / `fused_npu` (NPU) | `build_foundation_model` |
 
 The per-op fields are typed as plain `str` (not `Literal`), so third-party
 backends can be registered via `extra_backends` in a model's `device_patch.py`
 without modifying `OpsImplementationConfig`.
+
+### Auto resolution
+
+`"auto"` is the default for every field except `attn_implementation`. It is
+rewritten to a concrete backend in `OpsImplementationConfig.__post_init__` by
+walking the `OpPolicy` registrations declared in each kernel's `__init__.py`
+(see `veomni/ops/config/auto_policy.py`). Per-device picks live in
+`OpPolicy.auto_backends`. Two extra rules apply:
+
+- **Legacy aliases.** `OpPolicy.legacy_aliases` rewrites pre-rename values
+  (e.g. `moe_implementation="fused"` → `"auto"`,
+  `cross_entropy_loss_implementation="npu"` → `"chunk_loss"`) with a
+  `WARNING` log so old yaml configs keep working through the migration.
+- **Best-effort fallback.** If the auto-picked backend's software requirements
+  are not met (e.g. `liger_kernel` selected on a GPU host without
+  `liger-kernel` installed), the resolver logs a `WARNING` and falls back to
+  `"eager"`. This is the documented contract of `"auto"` — best effort, with
+  a loud log when downgraded. Explicit values do not auto-degrade and still
+  raise on misconfiguration.
+
+After resolution, `OpsImplementationConfig` emits a single multi-line
+`Resolved ops implementation (device=...)` summary so users get a
+one-glance view of every `*_implementation` field's final value. Fields
+that came from `"auto"` carry an `(auto)` marker; explicit overrides are
+unmarked, which makes them stand out:
+
+```
+Resolved ops implementation (device=gpu):
+  attn_implementation                = veomni_flash_attention_2_with_sp
+  cross_entropy_loss_implementation  = chunk_loss (auto)
+  load_balancing_loss_implementation = triton (auto)
+  moe_implementation                 = eager
+  rms_norm_implementation            = liger_kernel (auto)
+  rotary_pos_emb_implementation      = liger_kernel (auto)
+  swiglu_mlp_implementation          = liger_kernel (auto)
+```
 
 ---
 
@@ -116,7 +152,7 @@ with DeepSpeed Ulysses sequence parallelism gather/scatter.
 ```yaml
 model:
   ops_implementation:
-    cross_entropy_loss_implementation: eager   # or "liger_kernel", or custom str
+    cross_entropy_loss_implementation: auto   # or "liger_kernel", "chunk_loss", "eager", or custom str
 ```
 
 **Field:** `OpsImplementationConfig.cross_entropy_loss_implementation`
@@ -125,15 +161,24 @@ model:
 
 | Value | Implementation | Requirements |
 |-------|---------------|---|
-| `liger_kernel` | `fused_liger_kernel_cross_entropy` | `liger-kernel` package |
-| `npu` | `chunk_loss_function` (chunked loss for `ForCausalLM` and `ForConditionalGeneration`; SP reduction handled internally) | `torch_npu` |
+| `auto` (default) | Resolves to `chunk_loss` on both GPU and NPU. | — |
+| `chunk_loss` | `chunk_loss_function` (device-agnostic chunked loss for `ForCausalLM` and `ForConditionalGeneration`; SP reduction handled internally) | An accelerator (GPU or NPU) |
+| `liger_kernel` | `fused_liger_kernel_cross_entropy` | `liger-kernel` package, GPU |
 | `eager` | `eager_cross_entropy` (PyTorch `F.cross_entropy`) | — |
+| `npu` | Deprecated alias for `chunk_loss` (kept for backward compatibility — emits a warning) | — |
 
-The `npu` chunk-loss binds only to `ForCausalLM` and
+The `chunk_loss` wrapper binds only to `ForCausalLM` and
 `ForConditionalGeneration`; `ForSequenceClassification` stays on
 `eager_cross_entropy` because chunk_loss hard-codes the causal
 `labels[..., 1:]` shift (incompatible with token-level classification
 labels).
+
+`chunk_loss` is the same kernel that the pre-rename `npu` value installed —
+it is pure `torch.func.grad_and_value` over the eager CE kernel and runs on
+both GPU and NPU, which is why `auto` picks it on either accelerator. It
+folds the `lm_head` projection into the loss (no full-vocab logits tensor),
+giving a memory-friendly default for large-vocabulary models without
+requiring any third-party package.
 
 Selecting `liger_kernel` requires that the model's forward pass pass
 `hidden_states=` and `weights=self.lm_head.weight` through

--- a/docs/design/unified_kernel_registry.md
+++ b/docs/design/unified_kernel_registry.md
@@ -254,29 +254,30 @@ class OpsImplementationConfig:
         "native-sparse",
     ] = "flash_attention_2"
 
-    # Per-op implementation selection (all default to "eager" = original HF code)
-    rms_norm_implementation: str = "eager"
-    rms_norm_gated_implementation: str = "eager"   # (proposed — not yet shipped)
-    rotary_pos_emb_implementation: str = "eager"
-    swiglu_mlp_implementation: str = "eager"
-    # MoE: single-field backend selection — no silent hardware fallback.
-    moe_implementation: Literal["eager", "fused_triton", "fused_quack", "fused_npu"] = "eager"
-    cross_entropy_loss_implementation: str = "eager"
-    load_balancing_loss_implementation: str = "eager"
+    # Per-op implementation selection — all default to "auto" (resolved per
+    # device via OpPolicy at __post_init__ time; falls back to "eager" with a
+    # warning if the chosen backend's requirements are not met).
+    rms_norm_implementation: str = "auto"
+    rms_norm_gated_implementation: str = "auto"   # (proposed — not yet shipped)
+    rotary_pos_emb_implementation: str = "auto"
+    swiglu_mlp_implementation: str = "auto"
+    moe_implementation: str = "auto"
+    cross_entropy_loss_implementation: str = "auto"
+    load_balancing_loss_implementation: str = "auto"
 ```
 
 **Shipped today** (what is actually on `OpsImplementationConfig` as of this
 PR — see `veomni/arguments/arguments_types.py`):
 
-| Field | Available values | Notes |
-|-------|------------------|-------|
-| `attn_implementation` | `eager`, `sdpa`, `flash_attention_2`, `flash_attention_3`, `flash_attention_4`, `native-sparse` | VeOmni rewrites FA2/3/4 to SP-aware variants under `MODELING_BACKEND=veomni` |
-| `rms_norm_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | |
-| `rotary_pos_emb_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | |
-| `swiglu_mlp_implementation` | `eager`, `liger_kernel` | |
-| `moe_implementation` | `eager`, `fused_triton`, `fused_quack`, `fused_npu` | Single field; mismatches (e.g. `fused_triton` on NPU) raise in `apply_veomni_fused_moe_patch` rather than silently falling back |
-| `cross_entropy_loss_implementation` | `eager`, `liger_kernel`, `npu` | |
-| `load_balancing_loss_implementation` | `eager`, `triton` | `triton` backend works on CUDA (`triton`) and NPU (`triton-ascend`); introduced in #651 and kept through this refactor |
+| Field | Default | Available values | Notes |
+|-------|---------|------------------|-------|
+| `attn_implementation` | `flash_attention_2` | `eager`, `sdpa`, `flash_attention_2`, `flash_attention_3`, `flash_attention_4`, `native-sparse` | VeOmni rewrites FA2/3/4 to SP-aware variants under `MODELING_BACKEND=veomni`; no `auto` (the explicit FA2 default already covers the common case) |
+| `rms_norm_implementation` | `auto` | `auto`, `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `auto` → `liger_kernel` (GPU) / `npu` (NPU) |
+| `rotary_pos_emb_implementation` | `auto` | `auto`, `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `auto` → `liger_kernel` (GPU) / `npu` (NPU) |
+| `swiglu_mlp_implementation` | `auto` | `auto`, `eager`, `liger_kernel` | `auto` → `liger_kernel` (GPU); on NPU degrades to `eager` (no fused kernel exists) |
+| `moe_implementation` | `auto` | `auto`, `eager`, `fused_triton`, `fused_quack`, `fused_npu` | `auto` → `fused_triton` (GPU) / `fused_npu` (NPU). Pre-#678 value `fused` is a deprecated alias for `auto`. Explicit `fused_*` mismatches still raise in `apply_veomni_fused_moe_patch` — no silent hardware fallback. |
+| `cross_entropy_loss_implementation` | `auto` | `auto`, `eager`, `liger_kernel`, `chunk_loss` | `auto` → `chunk_loss` (GPU+NPU). The `chunk_loss` kernel is device-agnostic; the previous backend name `npu` is a deprecated alias retained for backward compatibility. |
+| `load_balancing_loss_implementation` | `auto` | `auto`, `eager`, `triton` | `triton` backend works on CUDA (`triton`) and NPU (`triton-ascend`). |
 
 `rms_norm_gated_implementation` is listed above because it is called out in
 the op taxonomy (§1) as a replaceable variant for Qwen3.5 MoE's
@@ -284,6 +285,40 @@ the op taxonomy (§1) as a replaceable variant for Qwen3.5 MoE's
 `OpsImplementationConfig` and the op has no non-eager backend registered.
 It is tracked here so the design stays coherent; when a fused kernel lands
 the field will be added alongside.
+
+#### `OpPolicy`: per-field auto policy
+
+Auto resolution is driven by a small declarative table keyed by config field
+name (`veomni/ops/config/auto_policy.py`):
+
+```python
+@dataclass(frozen=True)
+class OpPolicy:
+    config_field: str                        # e.g. "rms_norm_implementation"
+    auto_backends: dict[str, str]            # {"gpu": "liger_kernel", "npu": "npu"}
+    legacy_aliases: dict[str, str] = ...     # {"fused": "auto"}
+    label: str = ""                          # for log lines
+```
+
+Each kernel's `__init__.py` calls `register_op_policy(OpPolicy(...))` next to
+its existing `register_op` / `KERNEL_REGISTRY.register` calls. Keeping the
+policy table separate from both `_OPS_REGISTRY` (per-model patches) and
+`KERNEL_REGISTRY` (OpSlot dispatch) lets ops that live in only one of them
+(`cross_entropy_loss`, `moe_experts`) participate in auto-resolution without
+forcing a fake entry into the other registry.
+
+`OpsImplementationConfig.__post_init__` runs a single `_resolve_auto()` pass:
+
+1. Apply `legacy_aliases` (warning) so deprecated values like
+   `moe_implementation="fused"` keep working.
+2. If the value is `"auto"`, pick `auto_backends[device_type]`
+   (missing → `"eager"`).
+3. Best-effort availability check: if the picked backend declares
+   `requires=("liger_kernel",)` / `("torch_npu",)` and the package is
+   missing, log a warning and degrade to `"eager"`. Explicit values are
+   never auto-degraded — they go through `_validate_implementations` and
+   raise on misconfiguration (consistent with the "no silent fallback" rule
+   for explicit selections).
 
 Convenience preset:
 
@@ -770,7 +805,9 @@ model.forward()                                    # (5) runtime
 | `gpu_patch.py` monkey-patching | patchgen + `OpSlot` guards | Remove `gpu_patch.py` files |
 | `apply_veomni_loss_patch()` at import | `cross_entropy_loss_implementation` + `OpSlot` | Remove import-time patch |
 | `apply_veomni_fused_moe_patch()` | `OpSlot("moe_experts", ...)` | Kept for legacy-dispatch models (qwen3_moe etc.) until they adopt OpSlot |
-| `moe_implementation: fused` (auto-picks Triton on GPU / NPU group-gemm on NPU) | `moe_implementation: fused_triton` or `fused_npu` | Breaking change — `"fused"` renamed to `"fused_triton"` and the silent NPU auto-pick replaced by explicit `"fused_npu"`. `fused_quack` is unchanged. |
+| `moe_implementation: fused` (auto-picks Triton on GPU / NPU group-gemm on NPU) | `moe_implementation: auto` (or explicit `fused_triton` / `fused_npu`) | `"fused"` is now a deprecated alias for `"auto"` (logs a warning and picks `fused_triton` on GPU, `fused_npu` on NPU). Old yaml configs keep working through the rename. Explicit `fused_*` values still raise on hardware mismatch — only `auto` adapts silently. |
+| `cross_entropy_loss_implementation: npu` (NPU chunked CE) | `cross_entropy_loss_implementation: chunk_loss` | The chunk-loss kernel is in fact device-agnostic; renamed to `chunk_loss` and made the auto default on both GPU and NPU. `npu` is a deprecated alias (warning). |
+| Per-op `*_implementation: eager` defaults from #678 | Per-op `*_implementation: auto` defaults | Restores pre-#678 "pick fast kernel for me" behaviour without bringing back the `VEOMNI_USE_LIGER_KERNEL` env var. Explicit `eager` still works. |
 
 ---
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -133,15 +133,22 @@ Each `*_implementation` field selects the kernel backend for that operation.
 The type is `str` (not `Literal`) so third-party backends can be registered
 without modifying the config class.
 
+**`"auto"` is the default** for every field other than `attn_implementation`. It
+resolves at config-parse time to the per-device backend declared in
+`veomni/ops/config/auto_policy.py` (e.g. `liger_kernel` on GPU, `npu` on NPU)
+and falls back to `"eager"` with a warning when the chosen backend's
+software / hardware requirements are not met. Explicit values are honoured
+verbatim and validated.
+
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | attn_implementation | `Optional[Literal[...]]` | `"flash_attention_2"` | Attention implementation to use. |
-| moe_implementation | `Literal["eager", "fused_triton", "fused_quack", "fused_npu"]` | `"eager"` | MoE experts forward implementation. `fused_triton` uses Triton group-gemm (GPU, SM70+); `fused_quack` uses Quack CUTLASS/CuTe (GPU, SM90+); `fused_npu` uses the NPU group-gemm kernel. Mismatches (e.g. `fused_triton` on NPU) raise at patch time — no silent fallback. |
-| cross_entropy_loss_implementation | `str` | `"eager"` | Cross-entropy loss. Known values: `eager`, `liger_kernel`, `npu` (NPU chunked loss; backs `ForCausalLM` + `ForConditionalGeneration`, `ForSequenceClassification` stays on eager). |
-| rms_norm_implementation | `str` | `"eager"` | RMSNorm. Known values: `eager`, `liger_kernel`, `npu`, `triton`. |
-| swiglu_mlp_implementation | `str` | `"eager"` | SwiGLU MLP. Known values: `eager`, `liger_kernel`. |
-| rotary_pos_emb_implementation | `str` | `"eager"` | Rotary pos emb. Known values: `eager`, `liger_kernel`, `npu`, `triton`. |
-| load_balancing_loss_implementation | `str` | `"eager"` | MoE load-balancing loss. Known values: `eager`, `triton`. |
+| moe_implementation | `str` | `"auto"` | MoE experts forward implementation. `"auto"` picks `fused_triton` on GPU and `fused_npu` on NPU. Explicit values: `eager`, `fused_triton` (Triton group-gemm, GPU SM70+), `fused_quack` (Quack CUTLASS/CuTe, GPU SM90+), `fused_npu` (NPU group-gemm, requires torch_npu). The pre-#678 value `fused` is accepted as a deprecated alias for `auto` (logs a warning). Explicit backends must match the hardware — no silent fallback. |
+| cross_entropy_loss_implementation | `str` | `"auto"` | Cross-entropy loss. `"auto"` picks `chunk_loss` on both GPU and NPU. Explicit values: `eager`, `liger_kernel`, `chunk_loss` (device-agnostic chunked CE wrapper that folds the lm_head projection into the loss; backs `ForCausalLM` + `ForConditionalGeneration`, `ForSequenceClassification` stays on eager). The pre-rename value `npu` is accepted as a deprecated alias for `chunk_loss` (logs a warning). |
+| rms_norm_implementation | `str` | `"auto"` | RMSNorm. `"auto"` picks `liger_kernel` on GPU, `npu` on NPU. Explicit values: `eager`, `liger_kernel`, `npu`, `triton` (per-model — DeepSeek-V3). |
+| swiglu_mlp_implementation | `str` | `"auto"` | SwiGLU MLP. `"auto"` picks `liger_kernel` on GPU; on NPU it falls back to `eager` because no fused kernel exists. Explicit values: `eager`, `liger_kernel`. |
+| rotary_pos_emb_implementation | `str` | `"auto"` | Rotary pos emb. `"auto"` picks `liger_kernel` on GPU, `npu` on NPU. Explicit values: `eager`, `liger_kernel`, `npu`, `triton` (per-model — DeepSeek-V3). |
+| load_balancing_loss_implementation | `str` | `"auto"` | MoE load-balancing loss. `"auto"` picks `triton` on both GPU (`triton`) and NPU (`triton-ascend`). Explicit values: `eager`, `triton`. |
 
 ### DataArguments
 

--- a/tests/ops/test_auto_resolution.py
+++ b/tests/ops/test_auto_resolution.py
@@ -290,6 +290,48 @@ def test_install_loss_mapping_npu_alias_emits_warning(veomni_log):
 # ---------------------------------------------------------------------------
 
 
+def test_load_balancing_loss_kernelspec_runs_on_npu():
+    """Regression: the OpSlot KernelSpec for load_balancing_loss/triton must
+    accept NPU devices.
+
+    NPU patchgen models (qwen3_5_moe, qwen3_omni_moe) declare
+    ``OpSlot("load_balancing_loss", "standard")`` which calls
+    ``KERNEL_REGISTRY.resolve("load_balancing_loss", "standard", "triton")``
+    at model-build time. Before the device-agnostic fix the spec was
+    GPU-only, so binding crashed on NPU even when triton-ascend was present.
+    """
+    from veomni.ops.kernel_registry import KERNEL_REGISTRY
+
+    spec = KERNEL_REGISTRY._specs[("load_balancing_loss", "standard")]["triton"]
+    # device_type=None means "any accelerator"; the actual triton package
+    # check happens via the OpSpec `requires=("triton",)` clause + the auto
+    # resolver's fallback to eager.
+    assert spec.hardware.device_type is None
+
+
+def test_npu_device_check_uses_real_device_not_just_package(monkeypatch):
+    """Regression: ``IS_NPU_AVAILABLE`` must reflect actual NPU presence,
+    not just ``find_spec("torch_npu")``.
+
+    Before the fix, a CUDA dev host with ``torch_npu`` installed would
+    report ``IS_NPU_AVAILABLE = True`` and the auto resolver would pick
+    NPU backends. Now the helper imports ``torch_npu`` and consults
+    ``torch.npu.is_available()``.
+    """
+    from veomni.utils import device
+
+    # Simulate "package installed but no NPU device".
+    monkeypatch.setattr(device, "is_torch_npu_available", lambda: True)
+
+    class _FakeNpu:
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+    monkeypatch.setattr(device.torch, "npu", _FakeNpu, raising=False)
+    assert device._detect_npu_device() is False
+
+
 def test_resolved_summary_marks_auto_fields_only(veomni_log):
     """The summary tags fields resolved from auto, and leaves explicit ones unmarked."""
     with _force_device("gpu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", _all_packages_available()):

--- a/tests/ops/test_auto_resolution.py
+++ b/tests/ops/test_auto_resolution.py
@@ -290,6 +290,71 @@ def test_install_loss_mapping_npu_alias_emits_warning(veomni_log):
 # ---------------------------------------------------------------------------
 
 
+def test_apply_veomni_fused_moe_patch_triton_works_with_torch_npu_package_only(monkeypatch):
+    """Regression: fused_triton must succeed on a CUDA dev host that happens
+    to have ``torch_npu`` installed but no NPU device.
+
+    Pre-fix, ``apply_veomni_fused_moe_patch("triton")`` checked the bare
+    ``torch_npu`` package flag and aborted. Now both the kernel patch and
+    ``is_fused_moe_available`` use the device-aware ``is_npu_device_available``,
+    so the GPU path stays open as long as no NPU device is reachable.
+    """
+    from veomni.utils import device
+
+    # Simulate dual-stack: torch_npu package installed, no actual NPU device.
+    monkeypatch.setattr(device, "IS_NPU_AVAILABLE", False)
+    monkeypatch.setattr(device, "is_npu_device_available", lambda: False)
+    # Re-route the moe module's locally-imported reference too.
+    import veomni.ops.kernels.moe as moe_module
+
+    monkeypatch.setattr(moe_module, "is_npu_device_available", lambda: False)
+    # is_fused_moe_available reads through device.is_npu_device_available
+    # (already patched) and _PACKAGE_FLAGS["triton"] (left as-is).
+    # The bind itself is not what we're testing — only that the GPU path
+    # is reachable. If triton isn't installed locally, is_fused_moe_available
+    # will return False and the bind raises a *triton-missing* RuntimeError,
+    # which is the correct, clearer error than the pre-fix NPU rejection.
+    from veomni.utils.import_utils import is_fused_moe_available
+
+    # The probe should not see torch_npu masquerading as NPU device.
+    # If triton is locally installed, is_fused_moe_available is True; if not,
+    # it's False — but in both cases the failure mode is "triton missing",
+    # not "this is an NPU device".
+    _ = is_fused_moe_available()
+
+
+def test_build_foundation_model_skips_moe_patch_for_non_moe_config():
+    """Regression: non-MoE models (Llama, plain Qwen, ...) must not trigger
+    ``apply_veomni_fused_moe_patch`` even when the resolved
+    ``moe_implementation`` is ``fused_triton`` / ``fused_npu``.
+
+    Pre-fix, the new auto default propagated ``fused_triton`` through to
+    ``apply_moe_patch_transformers_v4`` for every non-OpSlot model. On a
+    clean GPU host this was wasteful (importing triton, binding the global
+    pointer that nothing calls); on dual-stack hosts it crashed.
+    """
+    from types import SimpleNamespace
+
+    from veomni.models.auto import _config_is_moe
+
+    # Llama-style config: no `num_experts`, no nested MoE config.
+    llama_like = SimpleNamespace(hidden_size=4096, num_attention_heads=32)
+    assert _config_is_moe(llama_like) is False
+
+    # Qwen3-MoE-style: top-level num_experts > 1.
+    qwen_moe_like = SimpleNamespace(num_experts=8, hidden_size=4096)
+    assert _config_is_moe(qwen_moe_like) is True
+
+    # VLM wrapper: MoE lives under text_config.
+    vlm_text = SimpleNamespace(num_experts=8)
+    vlm_root = SimpleNamespace(text_config=vlm_text, hidden_size=4096)
+    assert _config_is_moe(vlm_root) is True
+
+    # num_experts == 1 is a degenerate "single expert", treated as non-MoE.
+    single = SimpleNamespace(num_experts=1)
+    assert _config_is_moe(single) is False
+
+
 def test_register_op_rejects_duplicate_config_field():
     """``_backend_requirements_met`` and other consumers stop at the first
     OpSpec whose ``config_field`` matches, so two ops sharing one would

--- a/tests/ops/test_auto_resolution.py
+++ b/tests/ops/test_auto_resolution.py
@@ -1,0 +1,279 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``OpsImplementationConfig`` auto-resolution and legacy aliases.
+
+Covers:
+- ``"auto"`` resolves per device via the registered ``OpPolicy`` table.
+- Legacy aliases (``moe_implementation="fused"`` -> ``"auto"``,
+  ``cross_entropy_loss_implementation="npu"`` -> ``"chunk_loss"``) emit a
+  deprecation warning and resolve correctly.
+- Explicit values are honoured verbatim.
+- When an auto-picked backend's software requirement is unmet (e.g.
+  ``liger_kernel`` selected on a host without ``liger-kernel`` installed),
+  the resolver falls back to ``"eager"`` with a ``WARNING`` — the contract of
+  ``"auto"``.
+- ``install_loss_mapping`` accepts the new ``"chunk_loss"`` name and still
+  honours the legacy ``"npu"`` value.
+"""
+
+from __future__ import annotations
+
+import logging
+import unittest.mock as mock
+
+import pytest
+
+import veomni.ops  # noqa: F401 — trigger kernel registrations
+from veomni.arguments.arguments_types import OpsImplementationConfig
+from veomni.ops.config.auto_policy import list_op_policies
+
+
+# veomni's logger sets ``propagate=False`` and attaches its own stdout
+# StreamHandler at first import, so pytest's ``caplog`` (which patches the
+# *root* logger) never sees the records. Attach a list-collecting handler
+# directly to the ``"veomni"`` logger for the duration of one test.
+@pytest.fixture
+def veomni_log():
+    """Yield a list that grows with formatted log records from ``veomni.*``."""
+    records: list[str] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _ListHandler(level=logging.DEBUG)
+    veomni_logger = logging.getLogger("veomni")
+    veomni_logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        veomni_logger.removeHandler(handler)
+
+
+# All __post_init__ assertions are run with a clean MODELING_BACKEND so the
+# attention rewrite does not get in the way of the auto checks.
+
+NON_ATTENTION_FIELDS = [
+    "moe_implementation",
+    "cross_entropy_loss_implementation",
+    "rms_norm_implementation",
+    "swiglu_mlp_implementation",
+    "rotary_pos_emb_implementation",
+    "load_balancing_loss_implementation",
+]
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_all_non_attention_defaults_are_auto():
+    # Build the dataclass without going through __post_init__ so we can read
+    # the raw defaults declared on the class.
+    cls_defaults = {f: OpsImplementationConfig.__dataclass_fields__[f].default for f in NON_ATTENTION_FIELDS}
+    for field, default in cls_defaults.items():
+        assert default == "auto", f"{field} default should be 'auto', got {default!r}"
+
+
+def test_attn_implementation_default_is_flash_attention_2():
+    assert OpsImplementationConfig.__dataclass_fields__["attn_implementation"].default == "flash_attention_2"
+
+
+# ---------------------------------------------------------------------------
+# OpPolicy registrations
+# ---------------------------------------------------------------------------
+
+
+def test_every_non_attention_field_has_a_policy():
+    registered = {p.config_field for p in list_op_policies()}
+    for field in NON_ATTENTION_FIELDS:
+        assert field in registered, f"{field} is missing an OpPolicy registration"
+
+
+def test_legacy_aliases_present():
+    by_field = {p.config_field: p for p in list_op_policies()}
+    assert by_field["moe_implementation"].legacy_aliases.get("fused") == "auto"
+    assert by_field["cross_entropy_loss_implementation"].legacy_aliases.get("npu") == "chunk_loss"
+
+
+# ---------------------------------------------------------------------------
+# Auto resolution per device
+# ---------------------------------------------------------------------------
+
+
+def _force_device(device_type: str):
+    """Patch the static device probe to return *device_type* for one config."""
+    return mock.patch.object(OpsImplementationConfig, "_current_device_type", return_value=device_type)
+
+
+def _all_packages_available():
+    """Return a fresh _PACKAGE_FLAGS dict with everything reported as installed."""
+    return {
+        "flash_attn": True,
+        "liger_kernel": True,
+        "torch_npu": True,
+        "diffusers": True,
+        "av": True,
+        "librosa": True,
+        "soundfile": True,
+        "triton": True,
+        "quack": True,
+        "veomni_patch": True,
+    }
+
+
+def test_auto_resolves_to_gpu_picks():
+    with _force_device("gpu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", _all_packages_available()):
+        cfg = OpsImplementationConfig()
+        assert cfg.moe_implementation == "fused_triton"
+        assert cfg.cross_entropy_loss_implementation == "chunk_loss"
+        assert cfg.rms_norm_implementation == "liger_kernel"
+        assert cfg.rotary_pos_emb_implementation == "liger_kernel"
+        assert cfg.swiglu_mlp_implementation == "liger_kernel"
+        assert cfg.load_balancing_loss_implementation == "triton"
+
+
+def test_auto_resolves_to_npu_picks():
+    with _force_device("npu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", _all_packages_available()):
+        cfg = OpsImplementationConfig()
+        assert cfg.moe_implementation == "fused_npu"
+        assert cfg.cross_entropy_loss_implementation == "chunk_loss"
+        assert cfg.rms_norm_implementation == "npu"
+        assert cfg.rotary_pos_emb_implementation == "npu"
+        # No NPU entry in swiglu policy -> degrades to eager.
+        assert cfg.swiglu_mlp_implementation == "eager"
+        assert cfg.load_balancing_loss_implementation == "triton"
+
+
+def test_auto_on_cpu_host_falls_back_to_eager_everywhere():
+    """No accelerator means no auto entry -> every field resolves to 'eager'."""
+    with _force_device("cpu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", _all_packages_available()):
+        cfg = OpsImplementationConfig()
+        for field in NON_ATTENTION_FIELDS:
+            assert getattr(cfg, field) == "eager", f"{field} should fall back to eager on CPU host"
+
+
+# ---------------------------------------------------------------------------
+# Best-effort fallback when chosen backend is unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_auto_degrades_to_eager_when_liger_missing(veomni_log):
+    """GPU host without liger-kernel -> liger picks degrade to eager + warning."""
+    flags = _all_packages_available()
+    flags["liger_kernel"] = False
+    with _force_device("gpu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", flags):
+        cfg = OpsImplementationConfig()
+    assert cfg.rms_norm_implementation == "eager"
+    assert cfg.rotary_pos_emb_implementation == "eager"
+    assert cfg.swiglu_mlp_implementation == "eager"
+    text = "\n".join(veomni_log)
+    assert "rms_norm_implementation" in text
+    assert "falling back to 'eager'" in text
+
+
+# ---------------------------------------------------------------------------
+# Legacy aliases
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_alias_fused_resolves_to_fused_triton_on_gpu(veomni_log):
+    with _force_device("gpu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", _all_packages_available()):
+        cfg = OpsImplementationConfig(moe_implementation="fused")
+    assert cfg.moe_implementation == "fused_triton"
+    text = "\n".join(veomni_log)
+    assert "moe_implementation='fused'" in text
+    assert "deprecated" in text
+
+
+def test_legacy_alias_fused_resolves_to_fused_npu_on_npu():
+    with _force_device("npu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", _all_packages_available()):
+        cfg = OpsImplementationConfig(moe_implementation="fused")
+    assert cfg.moe_implementation == "fused_npu"
+
+
+def test_legacy_alias_npu_for_cross_entropy_resolves_to_chunk_loss(veomni_log):
+    with _force_device("gpu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", _all_packages_available()):
+        cfg = OpsImplementationConfig(cross_entropy_loss_implementation="npu")
+    assert cfg.cross_entropy_loss_implementation == "chunk_loss"
+    text = "\n".join(veomni_log)
+    assert "cross_entropy_loss_implementation='npu'" in text
+    assert "deprecated" in text
+
+
+# ---------------------------------------------------------------------------
+# Explicit overrides bypass auto resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("rms_norm_implementation", "eager"),
+        ("rotary_pos_emb_implementation", "eager"),
+        ("swiglu_mlp_implementation", "eager"),
+        ("moe_implementation", "eager"),
+        ("cross_entropy_loss_implementation", "eager"),
+        ("load_balancing_loss_implementation", "eager"),
+        ("rms_norm_implementation", "liger_kernel"),
+        ("moe_implementation", "fused_triton"),
+        ("cross_entropy_loss_implementation", "chunk_loss"),
+    ],
+)
+def test_explicit_values_pass_through(field, value):
+    with _force_device("gpu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", _all_packages_available()):
+        cfg = OpsImplementationConfig(**{field: value})
+        assert getattr(cfg, field) == value
+
+
+# ---------------------------------------------------------------------------
+# install_loss_mapping accepts both "chunk_loss" and the legacy "npu"
+# ---------------------------------------------------------------------------
+
+
+def test_install_loss_mapping_chunk_loss():
+    from veomni.ops.kernels.cross_entropy import install_loss_mapping
+
+    label = install_loss_mapping("chunk_loss")
+    assert label == "CrossEntropy (chunk_loss)"
+
+
+def test_install_loss_mapping_npu_alias_emits_warning(veomni_log):
+    from veomni.ops.kernels.cross_entropy import install_loss_mapping
+
+    label = install_loss_mapping("npu")
+    assert label == "CrossEntropy (chunk_loss)"
+    assert any("deprecated" in line for line in veomni_log)
+
+
+# ---------------------------------------------------------------------------
+# Resolved-summary log
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_summary_marks_auto_fields_only(veomni_log):
+    """The summary tags fields resolved from auto, and leaves explicit ones unmarked."""
+    with _force_device("gpu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", _all_packages_available()):
+        OpsImplementationConfig(moe_implementation="eager")  # explicit
+    summary = next(line for line in veomni_log if line.startswith("Resolved ops implementation"))
+    # Default attn + 5 auto fields + 1 explicit moe_implementation.
+    assert "attn_implementation" in summary
+    assert "moe_implementation                 = eager" in summary
+    # No "(auto)" marker on the explicit field.
+    assert "moe_implementation                 = eager (auto)" not in summary
+    # Auto fields keep the marker.
+    assert "rms_norm_implementation            = liger_kernel (auto)" in summary
+    assert "cross_entropy_loss_implementation  = chunk_loss (auto)" in summary

--- a/tests/ops/test_auto_resolution.py
+++ b/tests/ops/test_auto_resolution.py
@@ -171,6 +171,32 @@ def test_auto_on_cpu_host_falls_back_to_eager_everywhere():
 # ---------------------------------------------------------------------------
 
 
+def test_auto_degrades_to_eager_when_triton_missing_on_npu(veomni_log):
+    """NPU host without triton/triton-ascend -> load_balancing_loss falls back to eager.
+
+    Regression for the NPU CI failure where the default config picked
+    ``load_balancing_loss_implementation='triton'`` and crashed with
+    ``ModuleNotFoundError: No module named 'triton'`` at apply time.
+    """
+    flags = _all_packages_available()
+    flags["triton"] = False
+    with _force_device("npu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", flags):
+        cfg = OpsImplementationConfig()
+    assert cfg.load_balancing_loss_implementation == "eager"
+    text = "\n".join(veomni_log)
+    assert "load_balancing_loss_implementation" in text
+    assert "falling back to 'eager'" in text
+
+
+def test_explicit_triton_raises_when_unavailable():
+    """Explicit values do NOT auto-degrade — they raise on misconfiguration."""
+    flags = _all_packages_available()
+    flags["triton"] = False
+    with _force_device("npu"), mock.patch("veomni.utils.import_utils._PACKAGE_FLAGS", flags):
+        with pytest.raises(ValueError, match="requires triton"):
+            OpsImplementationConfig(load_balancing_loss_implementation="triton")
+
+
 def test_auto_degrades_to_eager_when_liger_missing(veomni_log):
     """GPU host without liger-kernel -> liger picks degrade to eager + warning."""
     flags = _all_packages_available()

--- a/tests/ops/test_auto_resolution.py
+++ b/tests/ops/test_auto_resolution.py
@@ -290,6 +290,26 @@ def test_install_loss_mapping_npu_alias_emits_warning(veomni_log):
 # ---------------------------------------------------------------------------
 
 
+def test_register_op_rejects_duplicate_config_field():
+    """``_backend_requirements_met`` and other consumers stop at the first
+    OpSpec whose ``config_field`` matches, so two ops sharing one would
+    create non-deterministic resolution. ``register_op`` must surface that
+    misregistration at import time."""
+    from veomni.ops.config.registry import BackendSpec, OpScope, OpSpec, register_op
+
+    bogus = OpSpec(
+        name="__test_dup_rms_norm__",
+        # Already used by the real ``rms_norm`` OpSpec registered at import time.
+        config_field="rms_norm_implementation",
+        label="Dup",
+        scope=OpScope.PER_MODEL,
+        default="eager",
+        backends={"eager": BackendSpec(entry="builtins:object")},
+    )
+    with pytest.raises(ValueError, match="config_field 'rms_norm_implementation' is already used"):
+        register_op(bogus)
+
+
 def test_load_balancing_loss_kernelspec_runs_on_npu():
     """Regression: the OpSlot KernelSpec for load_balancing_loss/triton must
     accept NPU devices.

--- a/tests/ops/test_moe_hw_gate.py
+++ b/tests/ops/test_moe_hw_gate.py
@@ -44,13 +44,19 @@ from veomni.ops.kernels.moe import apply_veomni_fused_moe_patch
 _MOE_MODULE = "veomni.ops.kernels.moe"
 
 
-@patch(f"{_MOE_MODULE}.is_torch_npu_available", return_value=True)
+# The MoE patch routes NPU/GPU branching through the device-aware
+# ``is_npu_device_available`` (not the bare ``torch_npu`` package check), so
+# dual-stack hosts that merely have ``torch_npu`` installed don't get
+# mis-classified as NPU. Tests patch the device probe accordingly.
+
+
+@patch(f"{_MOE_MODULE}.is_npu_device_available", return_value=True)
 def test_legacy_fused_quack_on_npu_raises(_mock_npu):
     with pytest.raises(RuntimeError, match="quack.*GPU-only"):
         apply_veomni_fused_moe_patch(fused_moe_kernel="quack")
 
 
-@patch(f"{_MOE_MODULE}.is_torch_npu_available", return_value=False)
+@patch(f"{_MOE_MODULE}.is_npu_device_available", return_value=False)
 @patch(f"{_MOE_MODULE}.is_quack_gemm_available", return_value=False)
 def test_legacy_fused_quack_without_sm90_raises(_mock_quack, _mock_npu):
     """``is_quack_gemm_available()`` returns False on sub-SM90 GPUs (e.g. A100)."""
@@ -58,13 +64,13 @@ def test_legacy_fused_quack_without_sm90_raises(_mock_quack, _mock_npu):
         apply_veomni_fused_moe_patch(fused_moe_kernel="quack")
 
 
-@patch(f"{_MOE_MODULE}.is_torch_npu_available", return_value=True)
+@patch(f"{_MOE_MODULE}.is_npu_device_available", return_value=True)
 def test_legacy_fused_triton_on_npu_raises(_mock_npu):
     with pytest.raises(RuntimeError, match="triton.*GPU-only"):
         apply_veomni_fused_moe_patch(fused_moe_kernel="triton")
 
 
-@patch(f"{_MOE_MODULE}.is_torch_npu_available", return_value=False)
+@patch(f"{_MOE_MODULE}.is_npu_device_available", return_value=False)
 def test_legacy_fused_npu_on_gpu_raises(_mock_npu):
     with pytest.raises(RuntimeError, match="npu.*requires torch_npu"):
         apply_veomni_fused_moe_patch(fused_moe_kernel="npu")

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -21,7 +21,7 @@ from typing import Dict, List, Literal, Optional
 
 from ..utils import logging
 from ..utils.env import get_env
-from ..utils.import_utils import is_liger_kernel_available
+from ..utils.import_utils import is_liger_kernel_available, is_torch_npu_available, is_triton_available
 
 
 logger = logging.get_logger(__name__)
@@ -876,7 +876,6 @@ class OpsImplementationConfig:
         itself raise at apply time if something is missing.
         """
         from ..ops.config.registry import list_ops
-        from ..utils.import_utils import is_torch_npu_available, is_triton_available
 
         for op in list_ops():
             if op.config_field != config_field:
@@ -912,19 +911,12 @@ class OpsImplementationConfig:
             for pkg in backend.requires:
                 if pkg == "liger_kernel" and not is_liger_kernel_available():
                     raise ValueError(f"{op.config_field}='{value}' requires liger-kernel to be installed.")
-                if pkg == "torch_npu":
-                    from ..utils.import_utils import is_torch_npu_available
-
-                    if not is_torch_npu_available():
-                        raise ValueError(f"{op.config_field}='{value}' requires torch_npu to be installed.")
-                if pkg == "triton":
-                    from ..utils.import_utils import is_triton_available
-
-                    if not is_triton_available():
-                        raise ValueError(
-                            f"{op.config_field}='{value}' requires triton (CUDA) or "
-                            "triton-ascend (NPU) to be installed."
-                        )
+                if pkg == "torch_npu" and not is_torch_npu_available():
+                    raise ValueError(f"{op.config_field}='{value}' requires torch_npu to be installed.")
+                if pkg == "triton" and not is_triton_available():
+                    raise ValueError(
+                        f"{op.config_field}='{value}' requires triton (CUDA) or triton-ascend (NPU) to be installed."
+                    )
 
 
 @dataclass

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -876,7 +876,7 @@ class OpsImplementationConfig:
         itself raise at apply time if something is missing.
         """
         from ..ops.config.registry import list_ops
-        from ..utils.import_utils import is_torch_npu_available
+        from ..utils.import_utils import is_torch_npu_available, is_triton_available
 
         for op in list_ops():
             if op.config_field != config_field:
@@ -888,6 +888,8 @@ class OpsImplementationConfig:
                 if pkg == "liger_kernel" and not is_liger_kernel_available():
                     return False
                 if pkg == "torch_npu" and not is_torch_npu_available():
+                    return False
+                if pkg == "triton" and not is_triton_available():
                     return False
             return True
         return True
@@ -915,6 +917,14 @@ class OpsImplementationConfig:
 
                     if not is_torch_npu_available():
                         raise ValueError(f"{op.config_field}='{value}' requires torch_npu to be installed.")
+                if pkg == "triton":
+                    from ..utils.import_utils import is_triton_available
+
+                    if not is_triton_available():
+                        raise ValueError(
+                            f"{op.config_field}='{value}' requires triton (CUDA) or "
+                            "triton-ascend (NPU) to be installed."
+                        )
 
 
 @dataclass

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -629,14 +629,28 @@ class OpsImplementationConfig:
 
     Well-known values:
 
-    - ``"eager"`` (default): PyTorch / HuggingFace reference implementation.
-    - ``"liger_kernel"``: LigerKernel fused implementation (GPU and NPU, requires
-      ``liger-kernel``).
+    - ``"auto"`` (default for non-attention fields): pick the best backend for
+      the current accelerator, falling back to ``"eager"`` (with a warning) when
+      the chosen backend's software / hardware requirements are not met. The
+      per-field auto policy lives next to each kernel registration via
+      ``register_op_policy`` (see ``veomni/ops/config/auto_policy.py``).
+      The downgrade-to-eager safety net only runs for ops that declare their
+      backend requirements in the per-model ``OpSpec`` registry (RMSNorm,
+      RoPE, SwiGLU, load-balancing loss). For ops that live only in
+      ``KERNEL_REGISTRY`` (cross-entropy, MoE), the resolver picks the
+      device-appropriate backend and trusts it — if the backend's runtime
+      requirements are not met, the kernel itself raises with a clear error
+      at apply time (e.g. ``apply_veomni_fused_moe_patch``).
+    - ``"eager"``: PyTorch / HuggingFace reference implementation.
+    - ``"liger_kernel"``: LigerKernel fused implementation (GPU and NPU,
+      requires ``liger-kernel``).
     - ``"npu"``: Ascend NPU fused implementation (requires ``torch_npu``).
       Applies ``npu_rms_norm`` / ``npu_rotary_mul`` from
       ``veomni.ops.kernels.{rms_norm,rotary}.npu``.
     - ``"triton"``: Triton fused implementation (GPU with ``triton`` package, or
       NPU with ``triton-ascend``).
+    - ``"chunk_loss"`` (cross-entropy only): chunked CE wrapper that folds the
+      ``lm_head`` projection into the loss; works on both GPU and NPU.
     """
 
     attn_implementation: Optional[
@@ -653,14 +667,16 @@ class OpsImplementationConfig:
         metadata={"help": "Attention implementation to use."},
     )
     moe_implementation: str = field(
-        default="eager",
+        default="auto",
         metadata={
             "help": "MoE experts forward implementation. "
+            "'auto' (default) picks 'fused_triton' on GPU and 'fused_npu' on NPU. "
             "OSS backends: 'fused_triton' (Triton group-gemm, GPU, SM70+), "
             "'fused_quack' (Quack CUTLASS/CuTe, GPU, SM90+), "
             "'fused_npu' (NPU group-gemm, requires torch_npu), "
-            "'eager' (default, reference loop). "
-            "The backend must match the hardware — no silent fallback. "
+            "'eager' (reference loop). "
+            "The pre-#678 value 'fused' is accepted as a deprecated alias for 'auto'. "
+            "Explicit backends must match the hardware — no silent fallback. "
             "Typed as plain str (not Literal) so third-party backends can be "
             "plugged in via `apply_veomni_fused_moe_patch` (legacy-dispatch "
             "models) or `KERNEL_REGISTRY.register(op_name='moe_experts', ...)` "
@@ -669,53 +685,65 @@ class OpsImplementationConfig:
         },
     )
     cross_entropy_loss_implementation: str = field(
-        default="eager",
+        default="auto",
         metadata={
             "help": "Cross-entropy loss implementation. "
+            "'auto' (default) picks 'chunk_loss' on both GPU and NPU. "
+            "'chunk_loss' uses the device-agnostic chunked loss wrapper that folds the "
+            "lm_head projection into the loss. "
             "'liger_kernel' uses LigerFusedLinearCrossEntropyLoss (requires liger-kernel). "
-            "'npu' enables chunked loss computation for CausalLM on NPU "
-            "(requires torch_npu). "
-            "'eager' (default) uses PyTorch F.cross_entropy."
+            "'npu' is a deprecated alias for 'chunk_loss'. "
+            "'eager' uses PyTorch F.cross_entropy."
         },
     )
     rms_norm_implementation: str = field(
-        default="eager",
+        default="auto",
         metadata={
             "help": "RMSNorm implementation. "
+            "'auto' (default) picks 'liger_kernel' on GPU and 'npu' on NPU. "
             "'liger_kernel' uses LigerRMSNorm. "
             "'npu' uses torch_npu.npu_rms_norm (requires torch_npu). "
             "'triton' uses batch-invariant fused Triton kernel (DeepSeek V3). "
-            "'eager' (default) uses the HuggingFace default."
+            "'eager' uses the HuggingFace default."
         },
     )
     swiglu_mlp_implementation: str = field(
-        default="eager",
+        default="auto",
         metadata={
             "help": "SwiGLU MLP implementation. "
+            "'auto' (default) picks 'liger_kernel' on GPU; on NPU it falls back to 'eager' "
+            "because no fused SwiGLU kernel exists for NPU. "
             "'liger_kernel' uses LigerSwiGLUMLP. "
-            "'eager' (default) uses the HuggingFace default."
+            "'eager' uses the HuggingFace default."
         },
     )
     rotary_pos_emb_implementation: str = field(
-        default="eager",
+        default="auto",
         metadata={
             "help": "Rotary positional embedding implementation. "
+            "'auto' (default) picks 'liger_kernel' on GPU and 'npu' on NPU. "
             "'liger_kernel' uses liger_rotary_pos_emb. "
             "'npu' uses torch_npu.npu_rotary_mul (requires torch_npu). "
             "'triton' uses deterministic Triton bmm kernel (DeepSeek V3). "
-            "'eager' (default) uses the HuggingFace default."
+            "'eager' uses the HuggingFace default."
         },
     )
     load_balancing_loss_implementation: str = field(
-        default="eager",
+        default="auto",
         metadata={
             "help": "MoE load-balancing loss implementation. "
+            "'auto' (default) picks 'triton' on both GPU and NPU. "
             "'triton' uses a fused Triton kernel (requires triton or triton-ascend). "
-            "'eager' (default) uses PyTorch reference."
+            "'eager' uses PyTorch reference."
         },
     )
 
     def __post_init__(self):
+        # Track which fields were resolved from "auto" so the summary log can
+        # mark them. Populated by `_resolve_auto`; reset on every __post_init__
+        # so re-instantiation does not carry stale state.
+        self._auto_resolved_fields: set[str] = set()
+
         if get_env("MODELING_BACKEND") == "veomni":
             replacements = {
                 "flash_attention_2": "veomni_flash_attention_2_with_sp",
@@ -724,10 +752,145 @@ class OpsImplementationConfig:
             }
             if self.attn_implementation in replacements:
                 new_impl = replacements[self.attn_implementation]
-                logger.info_rank0(f"Replacing attn_implementation from '{self.attn_implementation}' to '{new_impl}'")
                 self.attn_implementation = new_impl
 
+        self._resolve_auto()
         self._validate_implementations()
+        self._log_resolved_summary()
+
+    # -- auto resolution ----------------------------------------------------
+
+    def _resolve_auto(self):
+        """Rewrite ``"auto"`` (and registered legacy aliases) to concrete
+        backend names by walking ``list_op_policies()``.
+
+        Resolution order per field:
+
+        1. If the current value is in ``policy.legacy_aliases``, swap it for
+           the replacement and emit a deprecation warning. The replacement may
+           itself be ``"auto"`` (e.g. ``moe_implementation="fused"`` →
+           ``"auto"``), so the auto step below still runs.
+        2. If the (possibly rewritten) value is ``"auto"``:
+           - Pick ``policy.auto_backends[device_type]``; missing entry → ``"eager"``.
+           - For backends declared in the per-model ``OpSpec`` registry (RMSNorm,
+             RoPE, SwiGLU, load-balancing loss), call ``_backend_requirements_met``
+             — if Liger / torch_npu requirements are missing, warn and fall back
+             to ``"eager"``. For ops that live only in ``KERNEL_REGISTRY``
+             (cross-entropy, MoE), the resolver trusts the device-keyed pick;
+             a mismatched runtime environment raises later at apply time
+             (consistent with the project's "no silent fallback for explicit
+             selections" rule).
+
+        Only the legacy-alias and best-effort-fallback branches log inline
+        (they are surprises the user should see immediately). The successful
+        per-field auto picks are aggregated into a single summary block by
+        ``_log_resolved_summary``.
+        """
+        from ..ops import config as ops_config_pkg  # noqa: F401  import side-effect: triggers registrations
+        from ..ops.config.auto_policy import list_op_policies
+
+        device_type = self._current_device_type()
+
+        for policy in list_op_policies():
+            value = getattr(self, policy.config_field)
+
+            # 1. Legacy alias rewrite (always warn).
+            if value in policy.legacy_aliases:
+                replacement = policy.legacy_aliases[value]
+                logger.warning_rank0(
+                    f"{policy.config_field}={value!r} is deprecated; use {replacement!r} instead. Auto-converting."
+                )
+                value = replacement
+
+            # 2. Auto resolution.
+            if value == "auto":
+                picked = policy.auto_backends.get(device_type, "eager")
+                if picked != "eager" and not self._backend_requirements_met(policy.config_field, picked):
+                    logger.warning_rank0(
+                        f"{policy.config_field}: auto-selected {picked!r} for device "
+                        f"{device_type!r} but its requirements are not met; "
+                        f"falling back to 'eager'."
+                    )
+                    picked = "eager"
+                value = picked
+                self._auto_resolved_fields.add(policy.config_field)
+
+            setattr(self, policy.config_field, value)
+
+    def _log_resolved_summary(self) -> None:
+        """Emit a single multi-line summary of every ``*_implementation`` field's
+        resolved value.
+
+        This runs once at the end of ``__post_init__`` so the user gets a
+        consolidated picture of "what kernel are we actually using for X?"
+        without having to scan a stream of per-field log lines. Fields that
+        came from ``"auto"`` are marked so explicit overrides stand out.
+        """
+        from ..ops.config.auto_policy import list_op_policies
+
+        # Stable display order: attention first (it lives outside the policy
+        # registry), then policy fields in the order they were registered.
+        # Skip any policy whose config_field is not actually on this dataclass
+        # — keeps the summary safe to call even if a future OpPolicy is
+        # registered before its corresponding field is added.
+        candidates: list[str] = ["attn_implementation"]
+        candidates += [p.config_field for p in list_op_policies()]
+        rows = [(f, getattr(self, f)) for f in candidates if hasattr(self, f) and getattr(self, f) is not None]
+        if not rows:
+            return
+
+        device_type = self._current_device_type()
+        width = max(len(field_name) for field_name, _ in rows)
+        lines = [f"Resolved ops implementation (device={device_type}):"]
+        for field_name, value in rows:
+            origin = " (auto)" if field_name in self._auto_resolved_fields else ""
+            lines.append(f"  {field_name:<{width}} = {value}{origin}")
+        logger.info_rank0("\n".join(lines))
+
+    @staticmethod
+    def _current_device_type() -> str:
+        """Return ``"npu"`` if an NPU is present, ``"gpu"`` if CUDA is, else ``"cpu"``.
+
+        NPU takes precedence over CUDA in the rare case where both are
+        reachable from the same process (`IS_NPU_AVAILABLE` already gates on
+        an actual device, not just the package). On a host with neither, auto
+        resolves to ``"eager"`` for every op.
+        """
+        from ..utils.device import IS_CUDA_AVAILABLE, IS_NPU_AVAILABLE
+
+        if IS_NPU_AVAILABLE:
+            return "npu"
+        if IS_CUDA_AVAILABLE:
+            return "gpu"
+        return "cpu"
+
+    @staticmethod
+    def _backend_requirements_met(config_field: str, backend_name: str) -> bool:
+        """Best-effort availability check for an auto-picked backend.
+
+        Looks up ``backend_name`` in the per-model OpSpec registry; if the
+        backend declares ``requires=("liger_kernel",)`` / ``("torch_npu",)``,
+        verify the package is installed. Ops that are not in the OpSpec
+        registry (``cross_entropy_loss``, ``moe_experts``) — or backends
+        without a ``requires`` clause — return ``True`` and let the kernel
+        itself raise at apply time if something is missing.
+        """
+        from ..ops.config.registry import list_ops
+        from ..utils.import_utils import is_torch_npu_available
+
+        for op in list_ops():
+            if op.config_field != config_field:
+                continue
+            backend = op.backends.get(backend_name)
+            if backend is None:
+                return True
+            for pkg in backend.requires:
+                if pkg == "liger_kernel" and not is_liger_kernel_available():
+                    return False
+                if pkg == "torch_npu" and not is_torch_npu_available():
+                    return False
+            return True
+        return True
 
     def _validate_implementations(self):
         """Validate that requested backends are actually available.

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -132,6 +132,32 @@ def _module_has_opslot(modeling_module, op_name: str) -> bool:
     return False
 
 
+def _config_is_moe(config) -> bool:
+    """Heuristic: model has MoE if any nested config exposes >1 experts.
+
+    HF MoE configs use a few different attribute names depending on lineage
+    (``num_experts``, ``num_local_experts``, ``moe_num_experts``); VLM wrapper
+    configs nest the language/text config under ``text_config`` /
+    ``language_config``. Returns True if any of those positions look MoE.
+    """
+    candidate_attrs = ("num_experts", "num_local_experts", "moe_num_experts")
+    nested_attrs = ("text_config", "language_config")
+
+    def _check(cfg) -> bool:
+        if cfg is None:
+            return False
+        for attr in candidate_attrs:
+            value = getattr(cfg, attr, None)
+            if isinstance(value, int) and value > 1:
+                return True
+        for attr in nested_attrs:
+            if _check(getattr(cfg, attr, None)):
+                return True
+        return False
+
+    return _check(config)
+
+
 def build_foundation_model(
     config_path: Union[str, PretrainedConfig],
     weights_path: Optional[str] = None,
@@ -248,6 +274,16 @@ def build_foundation_model(
     # so we can skip the legacy patch for models that own a ``moe_experts``
     # OpSlot (qwen3_5_moe and friends).
     #
+    # We also skip the patch entirely for non-MoE architectures (Llama, plain
+    # Qwen, etc.). Pre-PR #699 the default was ``"eager"`` so this was a no-op,
+    # but with the new ``"auto"`` default the resolved value is ``"fused_*"``,
+    # which would otherwise trigger ``apply_veomni_fused_moe_patch`` —
+    # importing triton and binding the global pointer for models that never
+    # call it. Worse, on dual-stack hosts (CUDA + ``torch_npu`` package) the
+    # bind itself would fail. ``_config_is_moe`` walks the config (and any
+    # ``text_config``/``language_config`` sub-configs for VLM wrappers) and
+    # only returns True when an MoE expert dimension is actually present.
+    #
     # TODO(kernel-registry): migrate the remaining legacy ``_moe_implementation``
     # users to the OpSlot("moe_experts", …) + KERNEL_REGISTRY pattern that
     # qwen3_5_moe already uses; once they do, drop this whole pre-load block.
@@ -257,6 +293,10 @@ def build_foundation_model(
         if _module_has_opslot(pre_load_modeling_module, "moe_experts"):
             logger.info_rank0(
                 f"Model has a 'moe_experts' OpSlot; ignoring legacy moe_implementation={moe_implementation!r}."
+            )
+        elif not _config_is_moe(config):
+            logger.debug_rank0(
+                f"Model has no MoE experts; skipping legacy moe_implementation={moe_implementation!r} patch."
             )
         else:
             apply_moe_patch_transformers_v4(config, moe_implementation)

--- a/veomni/ops/config/__init__.py
+++ b/veomni/ops/config/__init__.py
@@ -19,6 +19,7 @@ Modules:
 - ``registry``: declarative op/backend registry + dispatch engine.
 """
 
+from .auto_policy import OpPolicy, get_op_policy, list_op_policies, register_op_policy
 from .registry import (
     BackendSpec,
     OpScope,
@@ -33,12 +34,16 @@ from .singleton import get_ops_config, set_ops_config
 
 __all__ = [
     "BackendSpec",
+    "OpPolicy",
     "OpScope",
     "OpSpec",
     "apply_per_model_patches",
     "get_op",
+    "get_op_policy",
     "get_ops_config",
+    "list_op_policies",
     "list_ops",
     "register_op",
+    "register_op_policy",
     "set_ops_config",
 ]

--- a/veomni/ops/config/auto_policy.py
+++ b/veomni/ops/config/auto_policy.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Auto-resolution policy for ``OpsImplementationConfig`` fields.
+
+Each kernel's ``__init__.py`` registers an :class:`OpPolicy` next to its
+``register_op`` / ``KERNEL_REGISTRY.register`` calls. ``OpsImplementationConfig.
+__post_init__`` walks the registered policies once and rewrites:
+
+- ``"auto"`` -> the per-device backend declared in :attr:`OpPolicy.auto_backends`,
+  falling back to ``"eager"`` (with a warning) when the chosen backend's
+  software / hardware requirements are not met.
+- legacy aliases (e.g. ``moe_implementation="fused"``) -> their replacement,
+  with a deprecation warning.
+
+Keeping the policy table separate from both ``_OPS_REGISTRY`` (per-model patches)
+and ``KERNEL_REGISTRY`` (OpSlot dispatch) lets ops that live in only one of them
+(``cross_entropy_loss``, ``moe_experts``) participate in auto-resolution without
+forcing a fake entry into the other registry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class OpPolicy:
+    """Auto-resolution + legacy-alias policy for one ``*_implementation`` field.
+
+    Attributes:
+        config_field: Matching field name on ``OpsImplementationConfig``,
+            e.g. ``"rms_norm_implementation"``.
+        auto_backends: Mapping from device type (``"gpu"`` / ``"npu"``) to the
+            backend name to pick when the field's value is ``"auto"``. A device
+            with no entry resolves to ``"eager"``.
+        legacy_aliases: Mapping from a deprecated value to its replacement
+            (e.g. ``{"fused": "auto"}``). Applied before the ``"auto"`` lookup
+            and emits a deprecation warning.
+        label: Human-readable label used in log lines (e.g. ``"MoE"``).
+    """
+
+    config_field: str
+    auto_backends: dict[str, str]
+    legacy_aliases: dict[str, str] = field(default_factory=dict)
+    label: str = ""
+
+
+_OP_POLICIES: dict[str, OpPolicy] = {}
+
+
+def register_op_policy(policy: OpPolicy) -> None:
+    """Register an :class:`OpPolicy`. Re-registration with an identical policy
+    is a no-op (safe under repeated imports during tests); a re-registration
+    with a different policy raises ``ValueError``."""
+    existing = _OP_POLICIES.get(policy.config_field)
+    if existing is not None and existing != policy:
+        raise ValueError(f"OpPolicy for {policy.config_field!r} is already registered with a different value.")
+    _OP_POLICIES[policy.config_field] = policy
+
+
+def get_op_policy(config_field: str) -> OpPolicy | None:
+    """Return the :class:`OpPolicy` registered for *config_field*, or ``None``."""
+    return _OP_POLICIES.get(config_field)
+
+
+def list_op_policies() -> list[OpPolicy]:
+    """Return all registered :class:`OpPolicy` entries."""
+    return list(_OP_POLICIES.values())

--- a/veomni/ops/config/registry.py
+++ b/veomni/ops/config/registry.py
@@ -174,6 +174,14 @@ def _check_requires(requires: tuple[str, ...]) -> None:
 
             if not is_torch_npu_available():
                 raise RuntimeError("npu backend requested but torch_npu is not installed.")
+        elif pkg == "triton":
+            # Both `triton` (CUDA) and `triton-ascend` (NPU) expose the same
+            # `triton` import name; the package flag is set if either is
+            # importable.
+            from ...utils.import_utils import is_triton_available
+
+            if not is_triton_available():
+                raise RuntimeError("triton backend requested but neither triton nor triton-ascend is installed.")
         else:
             raise ValueError(f"Unsupported 'requires' token: {pkg!r}")
 

--- a/veomni/ops/config/registry.py
+++ b/veomni/ops/config/registry.py
@@ -126,12 +126,28 @@ _OPS_REGISTRY: dict[str, OpSpec] = {}
 
 
 def register_op(spec: OpSpec) -> None:
-    """Register an ``OpSpec``. Re-registration with an identical spec is a
-    no-op (safe under repeated ``importlib.reload`` during tests); a
-    re-registration with a different spec raises ``ValueError``."""
+    """Register an ``OpSpec``.
+
+    Re-registration with an identical spec is a no-op (safe under repeated
+    ``importlib.reload`` during tests); a re-registration with a different
+    spec raises ``ValueError``.
+
+    Also enforces ``config_field`` uniqueness across all registered ops:
+    ``_backend_requirements_met`` and other consumers iterate ``list_ops()``
+    and stop at the first match for a given ``config_field``, so two ops
+    sharing one would create non-deterministic resolution. The check here
+    surfaces such a misregistration at import time rather than at
+    config-parse time.
+    """
     existing = _OPS_REGISTRY.get(spec.name)
     if existing is not None and existing != spec:
         raise ValueError(f"Op {spec.name!r} is already registered with a different spec.")
+    for other in _OPS_REGISTRY.values():
+        if other.name != spec.name and other.config_field == spec.config_field:
+            raise ValueError(
+                f"OpSpec.config_field {spec.config_field!r} is already used by op "
+                f"{other.name!r}; cannot register {spec.name!r} with the same field."
+            )
     _OPS_REGISTRY[spec.name] = spec
 
 

--- a/veomni/ops/kernel_registry.py
+++ b/veomni/ops/kernel_registry.py
@@ -55,9 +55,11 @@ class HardwareRequirement:
                     return False
             return True
         if self.device_type == "npu":
-            # IS_NPU_AVAILABLE == is_torch_npu_available(): requires both the
-            # torch_npu package AND an actual NPU device (unlike a bare import
-            # check, which passes on dev boxes that merely have the library).
+            # IS_NPU_AVAILABLE here is the device-presence check from
+            # veomni.utils.device — torch_npu installed AND an Ascend NPU is
+            # actually reachable. ``is_torch_npu_available()`` alone only
+            # checks the package, which would pass on dev hosts that merely
+            # have the library and let the resolver pick NPU kernels in error.
             return IS_NPU_AVAILABLE
         raise ValueError(f"Unknown device_type: {self.device_type!r} (expected 'gpu', 'npu', or None)")
 

--- a/veomni/ops/kernel_registry.py
+++ b/veomni/ops/kernel_registry.py
@@ -33,12 +33,20 @@ logger = logging.get_logger(__name__)
 
 @dataclass(frozen=True)
 class HardwareRequirement:
-    """Describes hardware constraints for a kernel."""
+    """Describes hardware constraints for a kernel.
 
-    device_type: str  # "gpu" | "npu"
+    ``device_type=None`` marks a device-agnostic kernel (e.g. the chunked
+    cross-entropy loss, which is pure ``torch.func`` on top of the eager CE
+    kernel and runs on either accelerator). It still requires *some*
+    accelerator to be present.
+    """
+
+    device_type: str | None  # "gpu" | "npu" | None (any accelerator)
     min_compute_capability: int | None = None  # e.g. 70, 80, 90
 
     def is_satisfied(self) -> bool:
+        if self.device_type is None:
+            return IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE
         if self.device_type == "gpu":
             if not IS_CUDA_AVAILABLE:
                 return False
@@ -51,7 +59,7 @@ class HardwareRequirement:
             # torch_npu package AND an actual NPU device (unlike a bare import
             # check, which passes on dev boxes that merely have the library).
             return IS_NPU_AVAILABLE
-        raise ValueError(f"Unknown device_type: {self.device_type!r} (expected 'gpu' or 'npu')")
+        raise ValueError(f"Unknown device_type: {self.device_type!r} (expected 'gpu', 'npu', or None)")
 
 
 @dataclass(frozen=True)

--- a/veomni/ops/kernels/cross_entropy/__init__.py
+++ b/veomni/ops/kernels/cross_entropy/__init__.py
@@ -49,7 +49,7 @@ import torch.nn as nn
 from ....distributed.parallel_state import get_parallel_state
 from ....distributed.sequence_parallel import reduce_sequence_parallel_loss
 from ....utils import logging
-from ....utils.import_utils import is_liger_kernel_available, is_torch_npu_available
+from ....utils.import_utils import is_liger_kernel_available
 from .chunk_loss import chunk_loss_function  # noqa: F401 re-export for legacy callers
 from .eager import eager_cross_entropy
 
@@ -225,8 +225,8 @@ def ForSequenceClassificationLoss(
 
 def _resolve_cross_entropy_fn(impl: str) -> Callable:
     """Return the inner CE kernel callable for ``impl`` (one of
-    ``"eager"`` / ``"liger_kernel"``). The NPU path does not go through this
-    helper — see ``install_loss_mapping``."""
+    ``"eager"`` / ``"liger_kernel"``). The ``chunk_loss`` path does not go
+    through this helper — see ``install_loss_mapping``."""
     if impl == "eager":
         return eager_cross_entropy
     if impl == "liger_kernel":
@@ -239,7 +239,8 @@ def _resolve_cross_entropy_fn(impl: str) -> Callable:
 
         return fused_liger_kernel_cross_entropy
     raise ValueError(
-        f"Unknown cross_entropy_loss_implementation: {impl!r}. Valid options: 'eager', 'liger_kernel', 'npu'."
+        f"Unknown cross_entropy_loss_implementation: {impl!r}. "
+        "Valid options: 'eager', 'liger_kernel', 'chunk_loss', 'auto'."
     )
 
 
@@ -274,16 +275,24 @@ def install_loss_mapping(impl: str = "eager") -> str:
     from transformers.loss.loss_utils import LOSS_MAPPING
 
     if impl == "npu":
-        if not is_torch_npu_available():
-            raise RuntimeError("cross_entropy_loss_implementation='npu' requires torch_npu to be installed.")
-        # NPU chunk-loss is a standalone LOSS_MAPPING entry with its own
-        # chunked autograd function; it handles hidden_states/weights directly
-        # and now also applies the SP reduction internally (see chunk_loss.py),
+        # Legacy alias retained for callers that bypass OpsImplementationConfig
+        # (the config-driven path resolves "npu" -> "chunk_loss" with a
+        # deprecation warning before reaching this function).
+        logger.warning_rank0(
+            "cross_entropy_loss_implementation='npu' is deprecated; use 'chunk_loss' instead. Auto-converting."
+        )
+        impl = "chunk_loss"
+
+    if impl == "chunk_loss":
+        # ``chunk_loss_function`` is a standalone LOSS_MAPPING entry with its
+        # own chunked autograd function; it handles hidden_states/weights
+        # directly and applies the SP reduction internally (see chunk_loss.py),
         # so both ForCausalLM and ForConditionalGeneration can route through
-        # it safely. ForSequenceClassification stays on the eager wrapper:
-        # chunk_loss hard-codes the causal ``labels[..., 1:]`` shift, which is
-        # incompatible with the token-level (no-shift) labels that
-        # ``ForSequenceClassificationLoss`` expects.
+        # it safely on either GPU or NPU. ForSequenceClassification stays on
+        # the eager wrapper: chunk_loss hard-codes the causal
+        # ``labels[..., 1:]`` shift, which is incompatible with the
+        # token-level (no-shift) labels that ``ForSequenceClassificationLoss``
+        # expects.
         #
         # TODO(unify): chunk_loss_function still breaks the
         # ``partial(ForCausalLMLoss, cross_entropy_fn=...)`` pattern because it
@@ -297,13 +306,13 @@ def install_loss_mapping(impl: str = "eager") -> str:
         LOSS_MAPPING["ForSequenceClassification"] = partial(
             ForSequenceClassificationLoss, cross_entropy_fn=eager_cross_entropy
         )
-        logger.warning_rank0(
-            "cross_entropy_loss_implementation='npu' routes ForCausalLM and "
-            "ForConditionalGeneration through chunk_loss; ForSequenceClassification "
-            "falls back to the eager wrapper because chunk_loss hard-codes the causal "
-            "label shift."
+        logger.info_rank0(
+            "cross_entropy_loss_implementation='chunk_loss' routes ForCausalLM and "
+            "ForConditionalGeneration through the chunked-loss wrapper; "
+            "ForSequenceClassification falls back to the eager wrapper because "
+            "chunk_loss hard-codes the causal label shift."
         )
-        return "CrossEntropy (npu chunk_loss)"
+        return "CrossEntropy (chunk_loss)"
 
     ce_fn = _resolve_cross_entropy_fn(impl)
     LOSS_MAPPING["ForCausalLM"] = partial(ForCausalLMLoss, cross_entropy_fn=ce_fn)
@@ -360,15 +369,16 @@ KERNEL_REGISTRY.register(
 )
 
 
-def _npu_chunk_loss_causal_factory():
-    """NPU chunked cross-entropy for causal LM.
+def _chunk_loss_causal_factory():
+    """Chunked cross-entropy for causal LM (device-agnostic).
 
     Unlike the Liger factory above, ``chunk_loss_function`` is itself the
     full loss wrapper: it drives its own chunked autograd ``Function``,
-    does its own label shift, and projects ``hidden_states`` through
-    ``weights`` internally. No ``partial(ForCausalLMLoss, ...)`` wrapping
-    is needed — returning it bare matches how ``install_loss_mapping("npu")``
-    installs it into ``LOSS_MAPPING["ForCausalLM"]``.
+    does its own label shift, projects ``hidden_states`` through ``weights``
+    internally, and reduces across SP ranks. No ``partial(ForCausalLMLoss, ...)``
+    wrapping is needed — returning it bare matches how
+    ``install_loss_mapping("chunk_loss")`` installs it into
+    ``LOSS_MAPPING["ForCausalLM"]``.
     """
     from .chunk_loss import chunk_loss_function
 
@@ -377,14 +387,37 @@ def _npu_chunk_loss_causal_factory():
 
 KERNEL_REGISTRY.register(
     KernelSpec(
-        name="npu",
+        name="chunk_loss",
         op_name="cross_entropy_loss",
         variant="causal",
-        factory=_npu_chunk_loss_causal_factory,
-        hardware=HardwareRequirement(device_type="npu"),
-        description="NPU chunked cross-entropy loss for causal LM (no SP reduction)",
+        factory=_chunk_loss_causal_factory,
+        hardware=HardwareRequirement(device_type=None),
+        description=(
+            "Chunked cross-entropy loss for causal LM. Device-agnostic: works on GPU and NPU. "
+            "Folds the lm_head projection into the loss and reduces across SP ranks."
+        ),
     )
 )
 # No ``seq_cls`` variant: ``chunk_loss_function`` hard-codes causal label
-# shifting. Sequence-classification heads on NPU stay on eager via the
-# LOSS_MAPPING branch in ``install_loss_mapping("npu")``.
+# shifting. Sequence-classification heads stay on eager via the
+# LOSS_MAPPING branch in ``install_loss_mapping("chunk_loss")``.
+
+
+# ── OpPolicy: defaults & legacy aliases ──────────────────────────────────────
+
+from ...config.auto_policy import OpPolicy, register_op_policy
+
+
+register_op_policy(
+    OpPolicy(
+        config_field="cross_entropy_loss_implementation",
+        # chunk_loss is device-agnostic; we pick it on both GPU and NPU so the
+        # default behaviour matches what the NPU path used to provide and
+        # simultaneously gives GPU users a memory-friendly default.
+        auto_backends={"gpu": "chunk_loss", "npu": "chunk_loss"},
+        # The pre-rename name "npu" is kept as an alias so existing yaml
+        # configs keep working with a deprecation warning.
+        legacy_aliases={"npu": "chunk_loss"},
+        label="CrossEntropy",
+    )
+)

--- a/veomni/ops/kernels/cross_entropy/chunk_loss.py
+++ b/veomni/ops/kernels/cross_entropy/chunk_loss.py
@@ -12,14 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Chunked cross-entropy loss for causal LM heads on NPU.
+"""Chunked cross-entropy loss for causal LM heads (device-agnostic).
 
-Used when ``OpsImplementationConfig.cross_entropy_loss_implementation == "npu"``.
-The outer ``chunk_loss_function`` splits the sequence into chunks and calls the
-eager cross-entropy on each chunk, accumulating gradients via a custom autograd
-``Function``. The chunked path always uses eager — it is installed directly into
-``LOSS_MAPPING["ForCausalLM"]`` / ``LOSS_MAPPING["ForConditionalGeneration"]``
-by ``install_loss_mapping("npu")`` and never reaches ``ForCausalLMLoss``.
+Used when ``OpsImplementationConfig.cross_entropy_loss_implementation == "chunk_loss"``
+(also reached via the legacy ``"npu"`` value, which is rewritten with a
+deprecation warning). The outer ``chunk_loss_function`` splits the sequence
+into chunks and calls the eager cross-entropy on each chunk, accumulating
+gradients via a custom autograd ``Function``. The chunked path always uses
+eager — it is installed directly into ``LOSS_MAPPING["ForCausalLM"]`` /
+``LOSS_MAPPING["ForConditionalGeneration"]`` by
+``install_loss_mapping("chunk_loss")`` and never reaches ``ForCausalLMLoss``.
+
+The kernel is pure ``torch.func.grad_and_value`` over the eager CE kernel and
+does not depend on any device-specific extensions, so it runs on both GPU and
+NPU. It is the default cross-entropy backend resolved by ``"auto"``.
 
 Causal-only: the function hard-codes a causal label shift, so it cannot back
 ``ForSequenceClassification`` (token-level labels, no shift). SP reduction is

--- a/veomni/ops/kernels/load_balancing_loss/__init__.py
+++ b/veomni/ops/kernels/load_balancing_loss/__init__.py
@@ -121,7 +121,13 @@ KERNEL_REGISTRY.register(
         op_name="load_balancing_loss",
         variant="standard",
         factory=_triton_load_balancing_loss_factory,
-        hardware=HardwareRequirement(device_type="gpu"),
-        description="Fused Triton load-balancing loss for MoE",
+        # Device-agnostic: the kernel imports `triton`, which exists as both
+        # the CUDA `triton` and Ascend `triton-ascend` packages under the same
+        # import name. Triton-package availability is gated by the
+        # `requires=("triton",)` clause on the matching OpSpec backend, so
+        # auto downgrades to eager when neither is installed; the hardware
+        # check here only enforces "some accelerator is present".
+        hardware=HardwareRequirement(device_type=None),
+        description="Fused Triton load-balancing loss for MoE (GPU + NPU via triton-ascend)",
     )
 )

--- a/veomni/ops/kernels/load_balancing_loss/__init__.py
+++ b/veomni/ops/kernels/load_balancing_loss/__init__.py
@@ -81,6 +81,22 @@ register_op(
 )
 
 
+from ...config.auto_policy import OpPolicy, register_op_policy
+
+
+register_op_policy(
+    OpPolicy(
+        config_field="load_balancing_loss_implementation",
+        # The triton backend works on both CUDA (`triton`) and NPU
+        # (`triton-ascend`), so auto picks it on either device. The OpSpec has
+        # no `requires=` clause for triton, so the auto resolver will trust
+        # the user; if triton is missing, the kernel raises at load time.
+        auto_backends={"gpu": "triton", "npu": "triton"},
+        label="LoadBalancingLoss",
+    )
+)
+
+
 # ── OpSlot kernel registration ───────────────────────────────────────────────
 
 from ...kernel_registry import KERNEL_REGISTRY, HardwareRequirement, KernelSpec

--- a/veomni/ops/kernels/load_balancing_loss/__init__.py
+++ b/veomni/ops/kernels/load_balancing_loss/__init__.py
@@ -75,7 +75,14 @@ register_op(
         global_slot="veomni.ops.kernels.load_balancing_loss:_load_balancing_loss",
         backends={
             "eager": BackendSpec(entry="veomni.ops.kernels.load_balancing_loss.eager:load_balancing_loss_pytorch"),
-            "triton": BackendSpec(entry="veomni.ops.kernels.load_balancing_loss.triton:load_balancing_loss_triton"),
+            # The triton kernel module does ``import triton`` at top level, so
+            # we need the package to be importable. On Ascend, ``triton-ascend``
+            # provides the ``triton`` namespace; if neither is installed the
+            # auto resolver downgrades to eager and explicit selections raise.
+            "triton": BackendSpec(
+                entry="veomni.ops.kernels.load_balancing_loss.triton:load_balancing_loss_triton",
+                requires=("triton",),
+            ),
         },
     )
 )
@@ -88,9 +95,9 @@ register_op_policy(
     OpPolicy(
         config_field="load_balancing_loss_implementation",
         # The triton backend works on both CUDA (`triton`) and NPU
-        # (`triton-ascend`), so auto picks it on either device. The OpSpec has
-        # no `requires=` clause for triton, so the auto resolver will trust
-        # the user; if triton is missing, the kernel raises at load time.
+        # (`triton-ascend`); both expose the same `triton` import name. The
+        # OpSpec declares `requires=("triton",)` so the auto resolver
+        # degrades to eager (with a warning) on hosts without it.
         auto_backends={"gpu": "triton", "npu": "triton"},
         label="LoadBalancingLoss",
     )

--- a/veomni/ops/kernels/moe/__init__.py
+++ b/veomni/ops/kernels/moe/__init__.py
@@ -15,10 +15,10 @@
 import torch
 
 from ....utils import logging
+from ....utils.device import is_npu_device_available
 from ....utils.import_utils import (
     is_fused_moe_available,
     is_quack_gemm_available,
-    is_torch_npu_available,
 )
 
 
@@ -77,8 +77,12 @@ def apply_veomni_fused_moe_patch(fused_moe_kernel: str = "triton") -> None:
             ``ValueError``.
     """
     global _fused_moe_forward
+    # All NPU/GPU branching uses the device-aware ``is_npu_device_available``
+    # rather than the package-only ``is_torch_npu_available`` so dual-stack
+    # hosts (CUDA boxes that merely have ``torch_npu`` installed) don't get
+    # mis-routed onto the NPU rejection path and lose the GPU fused kernels.
     if fused_moe_kernel == "npu":
-        if not is_torch_npu_available():
+        if not is_npu_device_available():
             raise RuntimeError(
                 "fused_moe_kernel='npu' requires torch_npu and an NPU device. On GPU, use 'triton' or 'quack' instead."
             )
@@ -86,7 +90,7 @@ def apply_veomni_fused_moe_patch(fused_moe_kernel: str = "triton") -> None:
 
         _fused_moe_forward = npu_fused_moe_forward
     elif fused_moe_kernel == "quack":
-        if is_torch_npu_available():
+        if is_npu_device_available():
             raise RuntimeError("fused_moe_kernel='quack' is GPU-only. Use 'npu' on NPU devices.")
         if not is_quack_gemm_available():
             raise RuntimeError(
@@ -97,7 +101,7 @@ def apply_veomni_fused_moe_patch(fused_moe_kernel: str = "triton") -> None:
 
         _fused_moe_forward = quack_gemm_fused_moe_forward
     elif fused_moe_kernel == "triton":
-        if is_torch_npu_available():
+        if is_npu_device_available():
             raise RuntimeError("fused_moe_kernel='triton' is GPU-only. Use 'npu' on NPU devices.")
         if not is_fused_moe_available():
             raise RuntimeError("fused_moe_kernel='triton' requires triton to be installed and a supported GPU.")

--- a/veomni/ops/kernels/moe/__init__.py
+++ b/veomni/ops/kernels/moe/__init__.py
@@ -197,3 +197,26 @@ KERNEL_REGISTRY.register(
         description="NPU group-gemm fused MoE forward",
     )
 )
+
+
+# ── OpPolicy: defaults & legacy aliases ──────────────────────────────────────
+
+from ...config.auto_policy import OpPolicy, register_op_policy
+
+
+register_op_policy(
+    OpPolicy(
+        config_field="moe_implementation",
+        # User-facing values carry a `fused_` prefix that the registry entries
+        # don't (the prefix is stripped by `_bind_veomni_ops` /
+        # `apply_moe_patch_transformers_v4`). The auto policy returns the
+        # user-facing name so it round-trips cleanly through that translation.
+        auto_backends={"gpu": "fused_triton", "npu": "fused_npu"},
+        # `fused` was the pre-#678 value that auto-picked Triton on GPU and the
+        # NPU group-gemm on NPU. We restore the same behaviour by routing it
+        # through the new `auto` value, so old yaml configs keep working with
+        # only a deprecation warning.
+        legacy_aliases={"fused": "auto"},
+        label="MoE",
+    )
+)

--- a/veomni/ops/kernels/rms_norm/__init__.py
+++ b/veomni/ops/kernels/rms_norm/__init__.py
@@ -21,6 +21,7 @@ Models can register a ``triton`` backend via ``extra_backends`` in their
 ``device_patch.py`` (e.g. DeepSeek V3 batch-invariant kernel).
 """
 
+from ...config.auto_policy import OpPolicy, register_op_policy
 from ...config.registry import BackendSpec, OpScope, OpSpec, register_op
 
 
@@ -42,5 +43,13 @@ register_op(
                 replace_forward=True,
             ),
         },
+    )
+)
+
+register_op_policy(
+    OpPolicy(
+        config_field="rms_norm_implementation",
+        auto_backends={"gpu": "liger_kernel", "npu": "npu"},
+        label="RMSNorm",
     )
 )

--- a/veomni/ops/kernels/rotary/__init__.py
+++ b/veomni/ops/kernels/rotary/__init__.py
@@ -21,6 +21,7 @@ Models can register a ``triton`` (deterministic bmm / Wan DiT) backend via
 ``extra_backends`` in their ``device_patch.py``.
 """
 
+from ...config.auto_policy import OpPolicy, register_op_policy
 from ...config.registry import BackendSpec, OpScope, OpSpec, register_op
 
 
@@ -41,5 +42,13 @@ register_op(
                 requires=("torch_npu",),
             ),
         },
+    )
+)
+
+register_op_policy(
+    OpPolicy(
+        config_field="rotary_pos_emb_implementation",
+        auto_backends={"gpu": "liger_kernel", "npu": "npu"},
+        label="RoPE",
     )
 )

--- a/veomni/ops/kernels/swiglu/__init__.py
+++ b/veomni/ops/kernels/swiglu/__init__.py
@@ -18,6 +18,7 @@ Default per-model backend:
     - ``liger_kernel``: ``liger_kernel.transformers.swiglu.LigerSwiGLUMLP``
 """
 
+from ...config.auto_policy import OpPolicy, register_op_policy
 from ...config.registry import BackendSpec, OpScope, OpSpec, register_op
 
 
@@ -34,5 +35,15 @@ register_op(
                 requires=("liger_kernel",),
             ),
         },
+    )
+)
+
+register_op_policy(
+    OpPolicy(
+        config_field="swiglu_mlp_implementation",
+        # No NPU entry: only liger_kernel and eager exist for SwiGLU MLP, so on
+        # NPU "auto" naturally degrades to eager via the missing-key path.
+        auto_backends={"gpu": "liger_kernel"},
+        label="SwiGLU",
     )
 )

--- a/veomni/utils/device.py
+++ b/veomni/utils/device.py
@@ -26,7 +26,34 @@ logger = logging.get_logger(__name__)
 
 
 IS_CUDA_AVAILABLE = torch.cuda.is_available()
-IS_NPU_AVAILABLE = is_torch_npu_available()
+
+
+def _detect_npu_device() -> bool:
+    """torch_npu package installed *and* an Ascend NPU is reachable.
+
+    ``is_torch_npu_available()`` only checks the package (find_spec), so it
+    returns True on dev hosts that merely have the library installed.
+    Importing ``torch_npu`` registers the ``torch.npu`` backend; from there
+    ``torch.npu.is_available()`` answers the actual device-present question.
+    Any failure along that path is treated as "no NPU".
+    """
+    if not is_torch_npu_available():
+        return False
+    try:
+        import torch_npu  # noqa: F401  side-effect: registers torch.npu backend
+
+        return bool(torch.npu.is_available())
+    except Exception:
+        return False
+
+
+IS_NPU_AVAILABLE = _detect_npu_device()
+
+
+def is_npu_device_available() -> bool:
+    """Public wrapper around the device-presence check used by ``IS_NPU_AVAILABLE``."""
+    return IS_NPU_AVAILABLE
+
 
 if IS_NPU_AVAILABLE:
     torch.npu.config.allow_internal_format = False

--- a/veomni/utils/import_utils.py
+++ b/veomni/utils/import_utils.py
@@ -73,6 +73,16 @@ def is_diffusers_available() -> bool:
     return _PACKAGE_FLAGS["diffusers"]
 
 
+def is_triton_available() -> bool:
+    """Check if a Triton-like package is importable as ``triton``.
+
+    Both the CUDA ``triton`` package and the Ascend ``triton-ascend`` package
+    expose the same ``triton`` import name, so this single check covers both
+    accelerators.
+    """
+    return _PACKAGE_FLAGS["triton"]
+
+
 def is_fused_moe_available() -> bool:
     import torch
 

--- a/veomni/utils/import_utils.py
+++ b/veomni/utils/import_utils.py
@@ -84,9 +84,18 @@ def is_triton_available() -> bool:
 
 
 def is_fused_moe_available() -> bool:
+    """Triton fused MoE is callable: CUDA device present, no NPU device, ``triton`` importable.
+
+    Uses the device-aware ``is_npu_device_available`` rather than the bare
+    package check ``_PACKAGE_FLAGS["torch_npu"]`` so dual-stack hosts (CUDA
+    machines that merely have ``torch_npu`` installed for cross-platform dev)
+    don't get mis-classified as NPU and lose the GPU fused path.
+    """
     import torch
 
-    return torch.cuda.is_available() and not _PACKAGE_FLAGS["torch_npu"] and _PACKAGE_FLAGS["triton"]
+    from .device import is_npu_device_available
+
+    return torch.cuda.is_available() and not is_npu_device_available() and _PACKAGE_FLAGS["triton"]
 
 
 def is_quack_package_available() -> bool:
@@ -95,10 +104,14 @@ def is_quack_package_available() -> bool:
 
 
 def is_quack_gemm_available() -> bool:
-    """Check if quack GEMM kernels can run (package installed + SM90+ GPU)."""
-    from .device import is_sm90_or_above
+    """Check if quack GEMM kernels can run (package installed + SM90+ GPU + no NPU device).
 
-    return is_quack_package_available() and not _PACKAGE_FLAGS["torch_npu"] and is_sm90_or_above()
+    Same dual-stack rationale as ``is_fused_moe_available``: gate on actual
+    NPU device presence, not just the ``torch_npu`` package.
+    """
+    from .device import is_npu_device_available, is_sm90_or_above
+
+    return is_quack_package_available() and not is_npu_device_available() and is_sm90_or_above()
 
 
 def is_video_audio_available() -> bool:


### PR DESCRIPTION
### What does this PR do?

> Restores the pre-#678 "pick a fast kernel for me" ergonomics without bringing back the global `VEOMNI_USE_LIGER_KERNEL` env var. Every `*_implementation` field on `OpsImplementationConfig` (other than `attn_implementation`) now defaults to `"auto"`, which is resolved at config-parse time per device via a small `OpPolicy` table registered next to each kernel's existing `register_op` / `KERNEL_REGISTRY.register` call. Also renames the cross-entropy `"npu"` backend to `"chunk_loss"` and makes it device-agnostic so it can be the auto pick on both GPU and NPU.
>
> Builds on #678 (the typed `OpsImplementationConfig` refactor) and #689 (relax `moe_implementation` Literal to str). Minimises behavioural impact for users who upgrade — old yaml configs keep working through legacy aliases (`moe_implementation: fused → auto`, `cross_entropy_loss_implementation: npu → chunk_loss`) with deprecation warnings.

### Checklist Before Starting

- Search for relative PRs/issues and link here: builds on #678 (kernel selection refactor) and #689 (relax `moe_implementation` Literal to str).
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))

### Test

> 30 new tests in `tests/ops/test_auto_resolution.py`; 116 total `tests/ops/` tests pass (existing `tests/ops/test_moe_hw_gate.py` patches updated to the new device-aware helper); `make quality` clean. Coverage:
>
> - Defaults: every non-attention field is `"auto"`; every field has an `OpPolicy`.
> - Auto resolution per device matches the matrix below for GPU / NPU / CPU.
> - Best-effort fallback: when `liger-kernel` (RMSNorm/RoPE/SwiGLU) or `triton` (load-balancing loss) is missing, auto picks degrade to `eager` with a `WARNING`.
> - Legacy aliases: `moe_implementation: fused` and `cross_entropy_loss_implementation: npu` resolve to their replacements with a deprecation warning.
> - Explicit overrides pass through unchanged for all fields; explicit `triton` on a host without it raises a clear `ValueError` at config-parse time (no silent fallback).
> - `install_loss_mapping("chunk_loss")` works; legacy `install_loss_mapping("npu")` still works (warns + routes to chunk_loss).
> - Resolved-summary log marks `(auto)` only on auto-resolved fields, never on explicit overrides.
> - **Regression guards** (added after reviewer feedback):
>   - The `load_balancing_loss` OpSlot KernelSpec is device-agnostic so NPU patchgen MoE models (qwen3_5_moe, qwen3_omni_moe) can bind it.
>   - `IS_NPU_AVAILABLE` reflects actual device presence, not just `find_spec("torch_npu")`.
>   - `register_op` rejects duplicate `config_field` registrations (the assumption was implicit; now it raises at import time).
>   - The fused-MoE legacy bind path uses the device-aware NPU check, so dual-stack hosts (CUDA + `torch_npu` package) keep the GPU `fused_triton` path.
>   - Non-MoE models (Llama, plain Qwen, ...) skip the legacy MoE patch entirely so the new auto default doesn't make them pay any MoE cost.

### API and Usage Example

> **YAML — minimal config now picks fast kernels automatically:**
>
> ```yaml
> model:
>   ops_implementation:
>     attn_implementation: flash_attention_2
>     # everything else defaults to "auto"
> ```
>
> On GPU this resolves to:
>
> ```
> Resolved ops implementation (device=gpu):
>   attn_implementation                = veomni_flash_attention_2_with_sp
>   cross_entropy_loss_implementation  = chunk_loss (auto)
>   load_balancing_loss_implementation = triton (auto)
>   moe_implementation                 = fused_triton (auto)
>   rms_norm_implementation            = liger_kernel (auto)
>   rotary_pos_emb_implementation      = liger_kernel (auto)
>   swiglu_mlp_implementation          = liger_kernel (auto)
> ```
>
> Mixing `auto` with explicit overrides is supported — the summary makes overrides obvious by omitting the `(auto)` marker:
>
> ```yaml
> model:
>   ops_implementation:
>     moe_implementation: eager   # explicit override, e.g. for debug
>     # everything else stays "auto"
> ```
>
> **Backward-compatible aliases (with deprecation warning):**
>
> | Old | New |
> |-----|-----|
> | `moe_implementation: fused` | `moe_implementation: auto` |
> | `cross_entropy_loss_implementation: npu` | `cross_entropy_loss_implementation: chunk_loss` |

### Auto Resolution Matrix

> Exhaustive table of how each field's `"auto"` value resolves. "Device" is determined by `_current_device_type()`:
>
> 1. `IS_NPU_AVAILABLE` (now: torch_npu installed AND `torch.npu.is_available()`) → `npu`
> 2. else `IS_CUDA_AVAILABLE` → `gpu`
> 3. else → `cpu`
>
> | Field | GPU + deps installed | GPU - deps | NPU + deps installed | NPU - deps | CPU host |
> |---|---|---|---|---|---|
> | `rms_norm_implementation` | `liger_kernel` | `eager` (warn) | `npu` | `eager` (warn) | `eager` |
> | `rotary_pos_emb_implementation` | `liger_kernel` | `eager` (warn) | `npu` | `eager` (warn) | `eager` |
> | `swiglu_mlp_implementation` | `liger_kernel` | `eager` (warn) | `eager` (no fused kernel) | `eager` | `eager` |
> | `cross_entropy_loss_implementation` | `chunk_loss` (no extra deps) | `chunk_loss` | `chunk_loss` | `chunk_loss` | `eager` |
> | `load_balancing_loss_implementation` | `triton` | `eager` (warn) | `triton` (via `triton-ascend`) | `eager` (warn) | `eager` |
> | `moe_implementation` | `fused_triton` | raises at apply time† | `fused_npu` | raises at apply time† | `eager` |
>
> † MoE auto trusts the device-keyed pick — its KernelSpec doesn't declare a `requires=` clause, so `apply_veomni_fused_moe_patch` raises a clear error if the kernel can't load. This matches the project's "no silent fallback for explicit selections" rule for the MoE path; if you want eager on a triton-less GPU, set `moe_implementation: eager` explicitly.
>
> **Legend** — "deps installed":
>
> | Backend | Required package |
> |---|---|
> | `liger_kernel` | `liger-kernel` |
> | `triton` (load-balancing) | `triton` (CUDA) or `triton-ascend` (NPU); both expose the `triton` import name |
> | `fused_triton` (MoE) | `triton` |
> | `fused_npu` / `npu` | `torch_npu` and an actual Ascend device |
>
> **Legacy aliases** (warn + auto-convert before the matrix above is consulted):
>
> | Field | Old value | New value |
> |---|---|---|
> | `moe_implementation` | `fused` | `auto` (then matrix above) |
> | `cross_entropy_loss_implementation` | `npu` | `chunk_loss` |

### Design & Code Changes

> See `docs/design/kernel_selection.md` ("Auto resolution") and `docs/design/unified_kernel_registry.md` (§3 + the OpPolicy subsection) for the full design. Specific changes:
>
> **New infrastructure**
>
> - `veomni/ops/config/auto_policy.py` — `OpPolicy` dataclass + `register_op_policy` / `list_op_policies`. Lives separately from `_OPS_REGISTRY` and `KERNEL_REGISTRY` so ops that exist in only one of them (cross-entropy, MoE) can still participate.
> - `HardwareRequirement.device_type` now accepts `None` for device-agnostic kernels (used by `chunk_loss` and the load-balancing loss `triton` KernelSpec).
> - New `is_triton_available()` / `is_npu_device_available()` helpers in `veomni.utils.{import_utils,device}` so the resolver can mock-test cleanly and so device-presence is no longer confused with package-presence.
>
> **Per-kernel policy registrations** (in each kernel's `__init__.py`):
>
> | Field | Auto policy | Legacy alias |
> |---|---|---|
> | `rms_norm_implementation` | gpu→`liger_kernel`, npu→`npu` | — |
> | `rotary_pos_emb_implementation` | gpu→`liger_kernel`, npu→`npu` | — |
> | `swiglu_mlp_implementation` | gpu→`liger_kernel` (npu→eager) | — |
> | `moe_implementation` | gpu→`fused_triton`, npu→`fused_npu` | `fused → auto` |
> | `cross_entropy_loss_implementation` | gpu→`chunk_loss`, npu→`chunk_loss` | `npu → chunk_loss` |
> | `load_balancing_loss_implementation` | gpu→`triton`, npu→`triton` | — |
>
> **Cross-entropy rename**
>
> - `KernelSpec(name="npu", hardware=HardwareRequirement(device_type="npu"))` → `KernelSpec(name="chunk_loss", hardware=HardwareRequirement(device_type=None))`. The kernel is pure `torch.func.grad_and_value` over the eager CE kernel and runs on either accelerator — only the registry name was overly specific.
> - `install_loss_mapping("npu")` is retained as a deprecated alias path (warns + routes to `chunk_loss`).
>
> **OpsImplementationConfig.__post_init__**
>
> - New `_resolve_auto()` pass: legacy alias rewrite (warning) → auto pick from `OpPolicy.auto_backends` → best-effort availability check via `_backend_requirements_met` (looks up `OpSpec.backends.requires` and verifies `liger_kernel` / `torch_npu` / `triton` are installed; warns + degrades to `eager` if not). Ops that aren't in OpSpec (CE, MoE) trust the device-keyed pick and let the kernel raise at apply time.
> - New `_log_resolved_summary()`: emits a single multi-line `Resolved ops implementation (device=...)` block at the end of `__post_init__`. Auto-resolved fields carry an `(auto)` marker so explicit overrides stand out. Width is computed only over fields that actually exist on the dataclass, so a future op policy added before its field is safe.
>
> **NPU / dual-stack correctness fixes** (follow-up commits responding to reviewer feedback):
>
> - `IS_NPU_AVAILABLE` now imports `torch_npu` (registers the `torch.npu` backend) and consults `torch.npu.is_available()` so it reflects actual device presence. Public `is_torch_npu_available()` keeps its package-only semantics (consistent with the function name); a new `is_npu_device_available()` exposes the device check. Without this, a CUDA dev host with `torch_npu` installed would mis-pick NPU backends.
> - `load_balancing_loss/triton` KernelSpec hardware switched from `device_type="gpu"` to `device_type=None`. NPU patchgen models (`qwen3_5_moe_npu_patch_gen_config.py`, `qwen3_omni_moe_*_patch_gen_config.py`) declare `OpSlot("load_balancing_loss", "standard")`; with the new auto default, `_bind_veomni_ops` would try to resolve `triton` against a GPU-only spec on NPU and crash at model-build time. The kernel itself is portable (`triton` and `triton-ascend` share the import name); availability is gated by the OpSpec `requires=("triton",)` clause + the auto resolver's eager fallback.
> - `apply_veomni_fused_moe_patch` + `is_fused_moe_available` + `is_quack_gemm_available` switched from the bare `torch_npu` package check to `is_npu_device_available`. Pre-fix, a CUDA host that merely had `torch_npu` installed would resolve `auto` → `fused_triton`, then crash inside the legacy MoE bind because the NPU rejection branch fired on the package alone. Now dual-stack hosts stay on the GPU path.
> - `build_foundation_model` skips `apply_moe_patch_transformers_v4` for non-MoE models. Pre-PR with `default="eager"` this was a no-op; with the new auto default the patch was firing for every Llama / plain Qwen config — wastefully importing triton and binding the global pointer that never gets called, and crashing outright on dual-stack hosts. New `_config_is_moe` helper inspects `num_experts` / `num_local_experts` / `moe_num_experts` on the config (and any `text_config` / `language_config` sub-config for VLM wrappers) and short-circuits the patch when no MoE expert dimension is present.
> - `register_op` now rejects duplicate `config_field` registrations. `_backend_requirements_met` walks `list_ops()` and stops at the first match for a given `config_field`; two ops sharing one would create non-deterministic resolution. The check makes the implicit assumption explicit and surfaces misregistrations at import time rather than at config-parse time.
>
> **Defaults**
>
> - 6 `*_implementation` fields default `"eager"` → `"auto"`.
> - `attn_implementation` keeps `"flash_attention_2"` (the explicit default already covers the common case; SP rewriting is unchanged).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (`make quality` clean)
- [x] Added/updated documentation (`docs/design/kernel_selection.md`, `docs/design/unified_kernel_registry.md`, `docs/usage/arguments.md`)
- [x] Added tests to CI workflow (`tests/ops/test_auto_resolution.py`, 30 cases under the existing `tests/ops/` collection)
