### PR TITLE
[BREAKING][ops] feat: switch *_implementation defaults to GPU-reasonable values

### DIFF
--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -174,6 +174,7 @@ jobs:
         run: |
           uv run --frozen pytest -v -s -x tests/ops/test_comp.py
           uv run --frozen pytest -v -s -x tests/ops/test_moe_hw_gate.py
+          uv run --frozen pytest -v -s -x tests/ops/test_ops_config_defaults.py
       - name: Sync dependencies [transformers-v5]
         run: |
           uv sync --frozen --python 3.11 --no-group transformers-stable --extra transformers5-exp --extra npu --extra audio --group dev

--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -18,7 +18,7 @@ selection knob.
 | RMSNorm | `rms_norm_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"liger_kernel"` | Model registration via ops config singleton |
 | SwiGLU MLP | `swiglu_mlp_implementation` | `eager`, `liger_kernel` | `"liger_kernel"` | Model registration via ops config singleton |
 | Rotary embedding | `rotary_pos_emb_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"liger_kernel"` | Model registration via ops config singleton |
-| Load-balancing loss | `load_balancing_loss_implementation` | `eager`, `triton` (CUDA `triton` or NPU `triton-ascend`) | `"triton"` | `apply_ops_config()` (before model build) |
+| Load-balancing loss | `load_balancing_loss_implementation` | `eager`, `triton` (CUDA `triton` or NPU `triton-ascend`) | `"eager"` | `apply_ops_config()` (before model build) |
 | MoE experts | `moe_implementation` | `eager`, `fused_triton`, `fused_quack` (SM90+), `fused_npu` | `"fused_triton"` | `build_foundation_model` |
 
 The per-op fields are typed as plain `str` (not `Literal`), so third-party
@@ -31,11 +31,17 @@ kernel that runs out of the box on a GPU host with the standard
 fields whose default has no NPU implementation raise a clear error in
 `OpsImplementationConfig.__post_init__` pointing the user at the suggested
 NPU value (`npu` / `fused_npu` / `eager`) — there is no silent hardware
-fallback. NPU users must opt in explicitly per field; the only
-universal-on-NPU default is `load_balancing_loss_implementation: triton`,
-which works on NPU via `triton-ascend`. To get a portable, no-deps config
-in code (e.g. tests, standalone scripts), use
+fallback. NPU users must opt in explicitly per field. To get a portable,
+no-deps config in code (e.g. tests, standalone scripts), use
 `OpsImplementationConfig.eager_defaults()`.
+
+**Exception:** `load_balancing_loss_implementation` defaults to `"eager"`,
+not `"triton"`. The op is GLOBAL-scoped — `apply_ops_config` resolves it
+eagerly for every model, including dense models that never call the loss —
+so a fused default would force every dense run on every host to depend on
+triton (or triton-ascend on NPU, which is not in the standard `--extra npu`
+install). MoE configs that want the speedup opt in explicitly with
+`load_balancing_loss_implementation: triton`.
 
 **Backwards compatibility.** `moe_implementation: fused` (the pre-#678
 auto-pick value) is rewritten to `fused_triton` with a deprecation warning,

--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -28,20 +28,30 @@ without modifying `OpsImplementationConfig`.
 **Defaults are GPU-reasonable.** Every default targets a fast, well-tested
 kernel that runs out of the box on a GPU host with the standard
 `--extra gpu` install (Liger fused ops + Triton MoE + FA2). On Ascend NPU,
-fields whose default has no NPU implementation raise a clear error in
-`OpsImplementationConfig.__post_init__` pointing the user at the suggested
-NPU value (`npu` / `fused_npu` / `eager`) — there is no silent hardware
-fallback. NPU users must opt in explicitly per field. To get a portable,
-no-deps config in code (e.g. tests, standalone scripts), use
-`OpsImplementationConfig.eager_defaults()`.
+the kernel-registry fields whose default has no NPU implementation raise a
+clear error in `OpsImplementationConfig.__post_init__` pointing the user at
+the suggested NPU value (`npu` / `fused_npu` / `eager`) — there is no
+silent hardware fallback. NPU users must opt in explicitly for those
+fields. To get a portable, no-deps config in code (e.g. tests, standalone
+scripts), use `OpsImplementationConfig.eager_defaults()`.
 
-**Exception:** `load_balancing_loss_implementation` defaults to `"eager"`,
-not `"triton"`. The op is GLOBAL-scoped — `apply_ops_config` resolves it
-eagerly for every model, including dense models that never call the loss —
-so a fused default would force every dense run on every host to depend on
-triton (or triton-ascend on NPU, which is not in the standard `--extra npu`
-install). MoE configs that want the speedup opt in explicitly with
-`load_balancing_loss_implementation: triton`.
+**Two exceptions** to the kernel-registry NPU validation:
+
+1. `attn_implementation` is **not** validated here. Attention is
+   dispatched via transformers' pluggable `ALL_ATTENTION_FUNCTIONS`
+   registry (see §5.2), so third-party backends can register kernels for
+   any name (including FA2/FA3/FA4 on Ascend) at runtime. A pre-flight
+   check at config-parse time can't see those registrations, so we leave
+   attention compatibility to the FA-import site, which raises a clear
+   `ImportError` when the requested backend is not available.
+
+2. `load_balancing_loss_implementation` defaults to `"eager"`, not
+   `"triton"`. The op is GLOBAL-scoped — `apply_ops_config` resolves it
+   eagerly for every model, including dense models that never call the
+   loss — so a fused default would force every dense run on every host to
+   depend on triton (or triton-ascend on NPU, which is not in the standard
+   `--extra npu` install). MoE configs that want the speedup opt in
+   explicitly with `load_balancing_loss_implementation: triton`.
 
 **Backwards compatibility.** `moe_implementation: fused` (the pre-#678
 auto-pick value) is rewritten to `fused_triton` with a deprecation warning,

--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -14,16 +14,32 @@ selection knob.
 | Kernel | Config field | Available values | Default | Selection time |
 |--------|-------------|------------------|---------|----------------|
 | Attention | `attn_implementation` | `eager`, `sdpa`, `flash_attention_2`, `flash_attention_3`, `flash_attention_4`, `native-sparse` | `"flash_attention_2"` | Config `__post_init__` + `build_foundation_model` |
-| Cross-entropy loss | `cross_entropy_loss_implementation` | `eager`, `liger_kernel`, `npu` | `"eager"` | `apply_ops_config()` (before model build) |
-| RMSNorm | `rms_norm_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"eager"` | Model registration via ops config singleton |
-| SwiGLU MLP | `swiglu_mlp_implementation` | `eager`, `liger_kernel` | `"eager"` | Model registration via ops config singleton |
-| Rotary embedding | `rotary_pos_emb_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"eager"` | Model registration via ops config singleton |
-| Load-balancing loss | `load_balancing_loss_implementation` | `eager`, `triton` (CUDA `triton` or NPU `triton-ascend`) | `"eager"` | `apply_ops_config()` (before model build) |
-| MoE experts | `moe_implementation` | `eager`, `fused_triton`, `fused_quack` (SM90+), `fused_npu` | `"eager"` | `build_foundation_model` |
+| Cross-entropy loss | `cross_entropy_loss_implementation` | `eager`, `liger_kernel`, `npu` | `"liger_kernel"` | `apply_ops_config()` (before model build) |
+| RMSNorm | `rms_norm_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"liger_kernel"` | Model registration via ops config singleton |
+| SwiGLU MLP | `swiglu_mlp_implementation` | `eager`, `liger_kernel` | `"liger_kernel"` | Model registration via ops config singleton |
+| Rotary embedding | `rotary_pos_emb_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"liger_kernel"` | Model registration via ops config singleton |
+| Load-balancing loss | `load_balancing_loss_implementation` | `eager`, `triton` (CUDA `triton` or NPU `triton-ascend`) | `"triton"` | `apply_ops_config()` (before model build) |
+| MoE experts | `moe_implementation` | `eager`, `fused_triton`, `fused_quack` (SM90+), `fused_npu` | `"fused_triton"` | `build_foundation_model` |
 
 The per-op fields are typed as plain `str` (not `Literal`), so third-party
 backends can be registered via `extra_backends` in a model's `device_patch.py`
 without modifying `OpsImplementationConfig`.
+
+**Defaults are GPU-reasonable.** Every default targets a fast, well-tested
+kernel that runs out of the box on a GPU host with the standard
+`--extra gpu` install (Liger fused ops + Triton MoE + FA2). On Ascend NPU,
+fields whose default has no NPU implementation raise a clear error in
+`OpsImplementationConfig.__post_init__` pointing the user at the suggested
+NPU value (`npu` / `fused_npu` / `eager`) — there is no silent hardware
+fallback. NPU users must opt in explicitly per field; the only
+universal-on-NPU default is `load_balancing_loss_implementation: triton`,
+which works on NPU via `triton-ascend`. To get a portable, no-deps config
+in code (e.g. tests, standalone scripts), use
+`OpsImplementationConfig.eager_defaults()`.
+
+**Backwards compatibility.** `moe_implementation: fused` (the pre-#678
+auto-pick value) is rewritten to `fused_triton` with a deprecation warning,
+so old YAML configs keep working. Update configs to the explicit value.
 
 ---
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -133,15 +133,25 @@ Each `*_implementation` field selects the kernel backend for that operation.
 The type is `str` (not `Literal`) so third-party backends can be registered
 without modifying the config class.
 
+**Defaults are GPU-reasonable.** Every default below targets a fast kernel
+that runs on a GPU host with the standard `--extra gpu` install. On Ascend
+NPU, fields whose default has no NPU implementation raise a clear error in
+`__post_init__` pointing at the suggested NPU value (`npu` / `fused_npu` /
+`eager`) — there is no silent hardware fallback. NPU users must override
+per field explicitly; the only universal-on-NPU default is
+`load_balancing_loss_implementation: triton` (works on NPU via
+`triton-ascend`). For a portable, no-deps config in code, call
+`OpsImplementationConfig.eager_defaults()`.
+
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | attn_implementation | `Optional[Literal[...]]` | `"flash_attention_2"` | Attention implementation to use. |
-| moe_implementation | `Literal["eager", "fused_triton", "fused_quack", "fused_npu"]` | `"eager"` | MoE experts forward implementation. `fused_triton` uses Triton group-gemm (GPU, SM70+); `fused_quack` uses Quack CUTLASS/CuTe (GPU, SM90+); `fused_npu` uses the NPU group-gemm kernel. Mismatches (e.g. `fused_triton` on NPU) raise at patch time — no silent fallback. |
-| cross_entropy_loss_implementation | `str` | `"eager"` | Cross-entropy loss. Known values: `eager`, `liger_kernel`, `npu` (NPU chunked loss; backs `ForCausalLM` + `ForConditionalGeneration`, `ForSequenceClassification` stays on eager). |
-| rms_norm_implementation | `str` | `"eager"` | RMSNorm. Known values: `eager`, `liger_kernel`, `npu`, `triton`. |
-| swiglu_mlp_implementation | `str` | `"eager"` | SwiGLU MLP. Known values: `eager`, `liger_kernel`. |
-| rotary_pos_emb_implementation | `str` | `"eager"` | Rotary pos emb. Known values: `eager`, `liger_kernel`, `npu`, `triton`. |
-| load_balancing_loss_implementation | `str` | `"eager"` | MoE load-balancing loss. Known values: `eager`, `triton`. |
+| moe_implementation | `str` | `"fused_triton"` | MoE experts forward implementation. `fused_triton` uses Triton group-gemm (GPU, SM70+); `fused_quack` uses Quack CUTLASS/CuTe (GPU, SM90+); `fused_npu` uses the NPU group-gemm kernel; `eager` is a debug-only reference loop. Legacy `fused` is rewritten to `fused_triton` with a deprecation warning. Mismatches (e.g. `fused_triton` on NPU) raise at config-parse / patch time — no silent fallback. |
+| cross_entropy_loss_implementation | `str` | `"liger_kernel"` | Cross-entropy loss. Known values: `eager`, `liger_kernel`, `npu` (NPU chunked loss; backs `ForCausalLM` + `ForConditionalGeneration`, `ForSequenceClassification` stays on eager). |
+| rms_norm_implementation | `str` | `"liger_kernel"` | RMSNorm. Known values: `eager`, `liger_kernel`, `npu`, `triton` (per-model). |
+| swiglu_mlp_implementation | `str` | `"liger_kernel"` | SwiGLU MLP. Known values: `eager`, `liger_kernel`. No NPU fused kernel; NPU users must set `eager`. |
+| rotary_pos_emb_implementation | `str` | `"liger_kernel"` | Rotary pos emb. Known values: `eager`, `liger_kernel`, `npu`, `triton` (per-model). |
+| load_balancing_loss_implementation | `str` | `"triton"` | MoE load-balancing loss. Known values: `eager`, `triton`. The `triton` backend is universal: `triton` (GPU) or `triton-ascend` (NPU). |
 
 ### DataArguments
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -138,10 +138,12 @@ that runs on a GPU host with the standard `--extra gpu` install. On Ascend
 NPU, fields whose default has no NPU implementation raise a clear error in
 `__post_init__` pointing at the suggested NPU value (`npu` / `fused_npu` /
 `eager`) — there is no silent hardware fallback. NPU users must override
-per field explicitly; the only universal-on-NPU default is
-`load_balancing_loss_implementation: triton` (works on NPU via
-`triton-ascend`). For a portable, no-deps config in code, call
-`OpsImplementationConfig.eager_defaults()`.
+per field explicitly. The one exception is
+`load_balancing_loss_implementation`, which keeps an eager default because
+it is GLOBAL-scoped and resolved eagerly for every model — a fused default
+would force every dense run to depend on triton (or triton-ascend on NPU,
+which is not in the standard `--extra npu` install). For a portable,
+no-deps config in code, call `OpsImplementationConfig.eager_defaults()`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -151,7 +153,7 @@ per field explicitly; the only universal-on-NPU default is
 | rms_norm_implementation | `str` | `"liger_kernel"` | RMSNorm. Known values: `eager`, `liger_kernel`, `npu`, `triton` (per-model). |
 | swiglu_mlp_implementation | `str` | `"liger_kernel"` | SwiGLU MLP. Known values: `eager`, `liger_kernel`. No NPU fused kernel; NPU users must set `eager`. |
 | rotary_pos_emb_implementation | `str` | `"liger_kernel"` | Rotary pos emb. Known values: `eager`, `liger_kernel`, `npu`, `triton` (per-model). |
-| load_balancing_loss_implementation | `str` | `"triton"` | MoE load-balancing loss. Known values: `eager`, `triton`. The `triton` backend is universal: `triton` (GPU) or `triton-ascend` (NPU). |
+| load_balancing_loss_implementation | `str` | `"eager"` | MoE load-balancing loss. Known values: `eager`, `triton` (CUDA `triton` or NPU `triton-ascend`). Default stays eager because this op is GLOBAL-scoped and would otherwise force every dense run to depend on the triton package; MoE configs that want the speedup set `triton` explicitly. |
 
 ### DataArguments
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -135,19 +135,23 @@ without modifying the config class.
 
 **Defaults are GPU-reasonable.** Every default below targets a fast kernel
 that runs on a GPU host with the standard `--extra gpu` install. On Ascend
-NPU, fields whose default has no NPU implementation raise a clear error in
-`__post_init__` pointing at the suggested NPU value (`npu` / `fused_npu` /
-`eager`) — there is no silent hardware fallback. NPU users must override
-per field explicitly. The one exception is
-`load_balancing_loss_implementation`, which keeps an eager default because
-it is GLOBAL-scoped and resolved eagerly for every model — a fused default
-would force every dense run to depend on triton (or triton-ascend on NPU,
-which is not in the standard `--extra npu` install). For a portable,
-no-deps config in code, call `OpsImplementationConfig.eager_defaults()`.
+NPU, the kernel-registry fields whose default has no NPU implementation
+raise a clear error in `__post_init__` pointing at the suggested NPU value
+(`npu` / `fused_npu` / `eager`) — there is no silent hardware fallback. NPU
+users must override those fields explicitly. Two exceptions:
+`attn_implementation` is dispatched via transformers' pluggable
+`ALL_ATTENTION_FUNCTIONS` registry (any backend that registers an FA
+kernel works on any device, so device-availability is gated at the FA
+import site rather than at config-parse time); and
+`load_balancing_loss_implementation` keeps an eager default because it is
+GLOBAL-scoped and resolved eagerly for every model — a fused default would
+force every dense run to depend on triton (or triton-ascend on NPU, which
+is not in the standard `--extra npu` install). For a portable, no-deps
+config in code, call `OpsImplementationConfig.eager_defaults()`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| attn_implementation | `Optional[Literal[...]]` | `"flash_attention_2"` | Attention implementation to use. |
+| attn_implementation | `Optional[Literal[...]]` | `"flash_attention_2"` | Attention implementation. Dispatched via `ALL_ATTENTION_FUNCTIONS` (pluggable), so device-availability is checked at the FA-import site rather than in `__post_init__`. |
 | moe_implementation | `str` | `"fused_triton"` | MoE experts forward implementation. `fused_triton` uses Triton group-gemm (GPU, SM70+); `fused_quack` uses Quack CUTLASS/CuTe (GPU, SM90+); `fused_npu` uses the NPU group-gemm kernel; `eager` is a debug-only reference loop. Legacy `fused` is rewritten to `fused_triton` with a deprecation warning. Mismatches (e.g. `fused_triton` on NPU) raise at config-parse / patch time — no silent fallback. |
 | cross_entropy_loss_implementation | `str` | `"liger_kernel"` | Cross-entropy loss. Known values: `eager`, `liger_kernel`, `npu` (NPU chunked loss; backs `ForCausalLM` + `ForConditionalGeneration`, `ForSequenceClassification` stays on eager). |
 | rms_norm_implementation | `str` | `"liger_kernel"` | RMSNorm. Known values: `eager`, `liger_kernel`, `npu`, `triton` (per-model). |

--- a/tests/checkpoints/utils.py
+++ b/tests/checkpoints/utils.py
@@ -9,13 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from tools import hf_local_or_remote
 from tools.launch_utils import find_free_port
-
-from veomni.utils.import_utils import is_torch_npu_available
-
-
-# Pick the fused-MoE backend that matches the test hardware. On NPU the NPU
-# kernel is the only option; on GPU default to Triton (SM70+).
-_FUSED_MOE_IMPL = "fused_npu" if is_torch_npu_available() else "fused_triton"
+from tools.training_utils import host_appropriate_ops_cli_args
 
 
 MODEL_CONFIGS = {
@@ -63,8 +57,10 @@ def get_checkpoint_test_command(
         "tests/checkpoints/test_trainer_saveload.py",
         f"--model.config_path {config_path}",
         f"--model.tokenizer_path {tokenizer_path}",
-        f"--model.ops_implementation.moe_implementation {_FUSED_MOE_IMPL}",
-        "--model.ops_implementation.attn_implementation flash_attention_2",
+        # ``--key value`` separator (space) — different from torchrun-builder's
+        # ``--key=value`` form because this command is later joined by " \\\n"
+        # and shell-parsed; the helper accepts both separators.
+        *host_appropriate_ops_cli_args(separator=" "),
         "--data.train_path dummy",
         "--data.max_seq_len 128",
         f"--train.checkpoint.output_dir {output_dir}",

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -217,6 +217,14 @@ if __name__ == "__main__":
 def build_command(dataset_type: str, dyn_bsz: bool, data_path: str):
     port = 12345 + random.randint(0, 100)
 
+    # The new GPU-reasonable defaults on ``OpsImplementationConfig`` would
+    # trip the NPU device-compatibility validator inside the subprocess'd
+    # ``parse_args(VeOmniArguments)`` call. These tests don't exercise any
+    # kernel — just the data pipeline — so force every kernel field to
+    # ``eager`` (universal, zero runtime deps). Imported lazily so the
+    # subprocess script itself doesn't need ``tests.tools`` on its sys.path.
+    from tests.tools.training_utils import host_appropriate_ops_cli_args
+
     command = [
         "torchrun",
         "--nnodes=1",
@@ -224,6 +232,7 @@ def build_command(dataset_type: str, dyn_bsz: bool, data_path: str):
         f"--master_port={port}",
         "tests/data/test_datasets.py",
         "--model.config_path=test",
+        *host_appropriate_ops_cli_args(eager_only=True),
         f"--data.train_path={data_path}",
         "--data.train_size=1000",
         "--data.train_sample=4",  # iterable & not dyn_bsz

--- a/tests/data/test_dynamic_batching_dataset.py
+++ b/tests/data/test_dynamic_batching_dataset.py
@@ -391,6 +391,10 @@ def build_command(shuffle=True, save_by_idx=True, multi_sample_per_iteration=Fal
     Returns:
         list: Command arguments for subprocess.run().
     """
+    # See note in tests/data/test_datasets.py — kernel fields forced to eager
+    # so the subprocess'd parse_args doesn't trip the NPU validator.
+    from tests.tools.training_utils import host_appropriate_ops_cli_args
+
     port = find_free_port()
 
     command = [
@@ -400,6 +404,7 @@ def build_command(shuffle=True, save_by_idx=True, multi_sample_per_iteration=Fal
         f"--master_port={port}",
         "tests/data/test_dynamic_batching_dataset.py",
         "--model.config_path=test",
+        *host_appropriate_ops_cli_args(eager_only=True),
         "--data.train_path=None",
         "--data.train_size=2000",
         f"--data.dyn_bsz_buffer_size={READY_FOR_MICRO_BATCH_THRESHOLD}",

--- a/tests/data/test_multisource_dataset.py
+++ b/tests/data/test_multisource_dataset.py
@@ -828,6 +828,10 @@ class TestLoadStateDictBoundary:
 
 
 def build_command():
+    # See note in tests/data/test_datasets.py — kernel fields forced to eager
+    # so the subprocess'd parse_args doesn't trip the NPU validator.
+    from tests.tools.training_utils import host_appropriate_ops_cli_args
+
     port = find_free_port()
     command = [
         "torchrun",
@@ -836,6 +840,7 @@ def build_command():
         f"--master_port={port}",
         "tests/data/test_multisource_dataset.py",
         "--model.config_path=test",
+        *host_appropriate_ops_cli_args(eager_only=True),
         "--data.train_path=None",
         "--data.train_size=1000",
         "--data.max_seq_len=32",

--- a/tests/models/test_models_patch.py
+++ b/tests/models/test_models_patch.py
@@ -15,6 +15,7 @@ from veomni.arguments import (
     FSDPConfig,
     MixedPrecisionConfig,
     ModelArguments,
+    OpsImplementationConfig,
     TrainingArguments,
 )
 from veomni.data.data_collator import MainCollator
@@ -386,7 +387,15 @@ def test_models_patch_fwd_bwd(
             mode for mode in veomni_model_modes if mode.attn_implementation != "veomni_flash_attention_3_with_sp"
         ]
 
-    model_config = ModelArguments(config_path=config_path)
+    # Per-mode ops are installed via ``set_environ_param(mode)`` inside the
+    # mode loop below, so the placeholder ops_implementation here just needs
+    # to construct cleanly on every device. ``eager_defaults()`` is portable;
+    # without it, the new GPU-reasonable defaults would trip the NPU
+    # device-compatibility validator on Ascend hosts.
+    model_config = ModelArguments(
+        config_path=config_path,
+        ops_implementation=OpsImplementationConfig.eager_defaults(),
+    )
     data_config = DataArguments(train_path="")
     training_config = TrainingArguments(
         checkpoint=CheckpointConfig(output_dir="./test_models_patch"),

--- a/tests/models/test_padded_packed_loss.py
+++ b/tests/models/test_padded_packed_loss.py
@@ -20,7 +20,7 @@ def _skip_if_no_flash_attn():
 @pytest.mark.parametrize("pad_to_length", [16])
 def test_qwen3_loss_match_with_padded_packed_input(monkeypatch, pad_to_length):
     _skip_if_no_flash_attn()
-    apply_ops_config(OpsImplementationConfig())
+    apply_ops_config(OpsImplementationConfig.eager_defaults())
     monkeypatch.setattr(
         "veomni.data.data_collator.get_parallel_state",
         lambda: type("PS", (), {"sp_enabled": False, "sp_size": 1, "sp_rank": 0})(),

--- a/tests/models/test_vlm_trainer.py
+++ b/tests/models/test_vlm_trainer.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from veomni.arguments import OpsImplementationConfig
 from veomni.models import build_foundation_model
 from veomni.trainer.vlm_trainer import (
     VeOmniVLMArguments,
@@ -53,8 +54,15 @@ def test_freeze_vit_on_vlm_model(config_path, freeze_vit):
     visual = _get_vlm_visual_module(model)
     assert visual is not None
 
+    # ``eager_defaults()`` keeps the placeholder ops_implementation portable
+    # — without it the new GPU-reasonable defaults trip the NPU
+    # device-compatibility validator on Ascend hosts. This test never
+    # exercises kernel selection (it only checks the freeze-ViT plumbing).
     args = VeOmniVLMArguments(
-        model=VLMMModelArguments(config_path=config_path),
+        model=VLMMModelArguments(
+            config_path=config_path,
+            ops_implementation=OpsImplementationConfig.eager_defaults(),
+        ),
         data=VLMMDataArguments(train_path="dummy"),
     )
     args.train.freeze_vit = freeze_vit

--- a/tests/ops/test_moe_hw_gate.py
+++ b/tests/ops/test_moe_hw_gate.py
@@ -150,7 +150,10 @@ def test_bind_veomni_ops_translates_moe_implementation_and_checks_hw(_mock_cc):
     from veomni.arguments.arguments_types import OpsImplementationConfig
     from veomni.models.auto import _bind_veomni_ops
 
-    ops_config = OpsImplementationConfig(moe_implementation="fused_quack")
+    # Build the config from ``eager_defaults`` so non-MoE fields don't pull
+    # liger-kernel into the test (the test only exercises the MoE bind path).
+    ops_config = OpsImplementationConfig.eager_defaults()
+    ops_config.moe_implementation = "fused_quack"
     # Simulate a patchgen'd modeling module with a moe_experts OpSlot.
     fake_module = SimpleNamespace(veomni_moe_experts_forward=OpSlot("moe_experts", "standard"))
 

--- a/tests/ops/test_ops_config_defaults.py
+++ b/tests/ops/test_ops_config_defaults.py
@@ -1,0 +1,272 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for OpsImplementationConfig defaults and device-compatibility validation.
+
+Defaults are GPU-reasonable. Three things to lock down:
+
+1. Each ``*_implementation`` field has the documented GPU default — a future
+   accidental rename of ``"fused_triton"`` to ``"triton"`` etc. should fail
+   here, not silently skip kernels.
+2. ``moe_implementation: 'fused'`` (the pre-#678 alias that used to silently
+   auto-pick by hardware) is rewritten to ``'fused_triton'`` with a
+   deprecation warning, so old YAML keeps working.
+3. On Ascend NPU, instantiating with default ``OpsImplementationConfig()``
+   raises ``ValueError`` with a clear message and a suggested NPU value —
+   we never silently fall back to a kernel that won't run on NPU.
+
+The NPU branch is tested by mocking ``IS_NPU_AVAILABLE`` so the suite runs
+on any CI host (mainline GPU CI, NPU CI, or a dev box).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+# Default per-field GPU-reasonable values. Kept as a single source of truth so
+# adding a field to ``OpsImplementationConfig`` only needs one update here.
+_EXPECTED_DEFAULTS = {
+    "attn_implementation": "flash_attention_2",
+    "moe_implementation": "fused_triton",
+    "cross_entropy_loss_implementation": "liger_kernel",
+    "rms_norm_implementation": "liger_kernel",
+    "swiglu_mlp_implementation": "liger_kernel",
+    "rotary_pos_emb_implementation": "liger_kernel",
+    "load_balancing_loss_implementation": "triton",
+}
+
+
+def _make_config_no_validation(**overrides):
+    """Construct an ``OpsImplementationConfig`` while bypassing ``__post_init__``.
+
+    Used by tests that only want to inspect the dataclass-level defaults
+    without triggering the device / package availability checks (those are
+    covered by their own dedicated tests below).
+    """
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    with patch.object(OpsImplementationConfig, "__post_init__", lambda self: None):
+        return OpsImplementationConfig(**overrides)
+
+
+# ---------------------------------------------------------------------------
+# 1. Defaults are GPU-reasonable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field_name,expected", list(_EXPECTED_DEFAULTS.items()))
+def test_default_value_is_gpu_reasonable(field_name, expected):
+    cfg = _make_config_no_validation()
+    assert getattr(cfg, field_name) == expected, (
+        f"{field_name} default changed; update _EXPECTED_DEFAULTS or the dataclass."
+    )
+
+
+def test_eager_defaults_classmethod_returns_eager_everywhere():
+    """``eager_defaults()`` is the explicit-portable escape hatch.
+
+    Used by the ``build_foundation_model`` standalone-script fallback and by
+    tests that don't care about kernel selection — must keep every kernel
+    field set to ``"eager"`` so it works on hosts without liger / triton."""
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    cfg = OpsImplementationConfig.eager_defaults()
+    assert cfg.moe_implementation == "eager"
+    assert cfg.cross_entropy_loss_implementation == "eager"
+    assert cfg.rms_norm_implementation == "eager"
+    assert cfg.swiglu_mlp_implementation == "eager"
+    assert cfg.rotary_pos_emb_implementation == "eager"
+    assert cfg.load_balancing_loss_implementation == "eager"
+
+
+# ---------------------------------------------------------------------------
+# 2. Legacy alias rewrite for moe_implementation: 'fused' → 'fused_triton'
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_moe_fused_alias_is_rewritten():
+    """``veomni.utils.logging`` configures a non-propagating root logger that
+    writes via a stdout handler captured at import time, so neither
+    ``caplog`` nor ``capsys`` see the warning. We attach our own handler to
+    the ``veomni`` logger to capture the warning emitted by
+    ``_rewrite_legacy_aliases``."""
+    import logging as stdlib_logging
+
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    records: list[stdlib_logging.LogRecord] = []
+
+    class _ListHandler(stdlib_logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    veomni_logger = stdlib_logging.getLogger("veomni")
+    handler = _ListHandler(level=stdlib_logging.WARNING)
+    veomni_logger.addHandler(handler)
+    try:
+        # Force GPU branch so device validation doesn't preempt the alias rewrite.
+        with patch("veomni.utils.device.IS_NPU_AVAILABLE", False):
+            cfg = OpsImplementationConfig.eager_defaults()
+            # eager_defaults sets moe_implementation='eager'; flip back to the
+            # legacy value to exercise the alias rewrite. Re-running __post_init__
+            # so the warning fires.
+            cfg.moe_implementation = "fused"
+            cfg.__post_init__()
+    finally:
+        veomni_logger.removeHandler(handler)
+
+    assert cfg.moe_implementation == "fused_triton"
+    deprecation_warnings = [r for r in records if "deprecated" in r.getMessage() and "fused" in r.getMessage()]
+    assert deprecation_warnings, f"Expected a deprecation warning; got records: {[r.getMessage() for r in records]}"
+
+
+# ---------------------------------------------------------------------------
+# 3. NPU device-compatibility validation
+# ---------------------------------------------------------------------------
+
+
+# (field, GPU-only value, expected suggestion in the error message)
+_NPU_INCOMPATIBLE_CASES = [
+    ("attn_implementation", "flash_attention_2", "sdpa"),
+    ("attn_implementation", "flash_attention_3", "sdpa"),
+    ("attn_implementation", "veomni_flash_attention_2_with_sp", "sdpa"),
+    ("moe_implementation", "fused_triton", "fused_npu"),
+    ("moe_implementation", "fused_quack", "fused_npu"),
+    ("cross_entropy_loss_implementation", "liger_kernel", "npu"),
+    ("rms_norm_implementation", "liger_kernel", "npu"),
+    ("rms_norm_implementation", "triton", "npu"),
+    ("rotary_pos_emb_implementation", "liger_kernel", "npu"),
+    ("rotary_pos_emb_implementation", "triton", "npu"),
+    ("swiglu_mlp_implementation", "liger_kernel", "eager"),
+]
+
+
+@pytest.mark.parametrize("field_name,gpu_value,suggested", _NPU_INCOMPATIBLE_CASES)
+def test_npu_default_raises_with_clear_suggestion(field_name, gpu_value, suggested):
+    """On NPU, every GPU-only default value raises with a suggestion.
+
+    The error message must:
+    - name the offending field and value,
+    - state that the current device is NPU,
+    - include the suggested replacement value verbatim, so a user can copy
+      it into their config without further guessing.
+    """
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    # Start every field on a NPU-friendly value so the parametrized field is
+    # the only one that can trip the validator. ``attn_implementation`` is
+    # also in ``_NPU_INCOMPATIBLE`` (default ``flash_attention_2`` is GPU-only)
+    # so it has to be explicitly set to a portable value here too.
+    overrides = dict.fromkeys(_EXPECTED_DEFAULTS, "eager")
+    overrides["attn_implementation"] = "sdpa"
+    overrides[field_name] = gpu_value
+
+    with patch("veomni.utils.device.IS_NPU_AVAILABLE", True):
+        with pytest.raises(ValueError) as excinfo:
+            OpsImplementationConfig(**overrides)
+
+    message = str(excinfo.value)
+    assert field_name in message
+    assert gpu_value in message
+    assert "NPU" in message
+    assert suggested in message
+
+
+def test_npu_default_constructor_raises_on_first_incompatible_field():
+    """``OpsImplementationConfig()`` on NPU raises before any kernel is bound.
+
+    The exact field that trips first depends on dict iteration order in
+    ``_NPU_INCOMPATIBLE``; we just assert that *some* GPU-only default fires
+    a ``ValueError`` (i.e. the user gets an early, actionable error rather
+    than a runtime crash inside the kernel).
+    """
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    with patch("veomni.utils.device.IS_NPU_AVAILABLE", True):
+        with pytest.raises(ValueError, match="GPU-only"):
+            OpsImplementationConfig()
+
+
+def test_npu_with_explicit_npu_values_constructs_cleanly():
+    """A correctly-overridden NPU config validates without raising.
+
+    This is the path NPU users are pushed onto by the validator: explicit
+    ``npu`` / ``fused_npu`` / ``eager`` per field.
+    """
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    with patch("veomni.utils.device.IS_NPU_AVAILABLE", True):
+        # ``_validate_implementations`` on NPU still checks ``torch_npu``
+        # availability; mock the package check so the test runs on a dev box
+        # that doesn't have torch_npu installed.
+        with patch("veomni.utils.import_utils.is_torch_npu_available", return_value=True):
+            cfg = OpsImplementationConfig(
+                attn_implementation="eager",
+                moe_implementation="fused_npu",
+                cross_entropy_loss_implementation="npu",
+                rms_norm_implementation="npu",
+                swiglu_mlp_implementation="eager",
+                rotary_pos_emb_implementation="npu",
+                load_balancing_loss_implementation="triton",
+            )
+    assert cfg.moe_implementation == "fused_npu"
+
+
+def test_load_balancing_triton_is_universal_on_npu():
+    """``load_balancing_loss: triton`` works on NPU via ``triton-ascend``.
+
+    This is the one field whose GPU default is *also* the NPU pick — the
+    package name ``triton`` is shared by both stacks. The validator must
+    not raise on NPU for this value; otherwise NPU users would have to
+    override a default that already does the right thing.
+    """
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    with patch("veomni.utils.device.IS_NPU_AVAILABLE", True):
+        with patch("veomni.utils.import_utils.is_torch_npu_available", return_value=True):
+            cfg = OpsImplementationConfig(
+                attn_implementation="eager",
+                moe_implementation="eager",
+                cross_entropy_loss_implementation="eager",
+                rms_norm_implementation="eager",
+                swiglu_mlp_implementation="eager",
+                rotary_pos_emb_implementation="eager",
+                load_balancing_loss_implementation="triton",  # universal
+            )
+    assert cfg.load_balancing_loss_implementation == "triton"
+
+
+def test_gpu_host_skips_npu_validation():
+    """``_validate_device_compatibility`` is a no-op on a GPU host.
+
+    Default GPU values must construct cleanly — this is the happy path that
+    GPU users hit out of the box."""
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    with patch("veomni.utils.device.IS_NPU_AVAILABLE", False):
+        # ``_validate_implementations`` calls ``is_liger_kernel_available`` via
+        # the local re-export bound at module import time
+        # (``from ..utils.import_utils import is_liger_kernel_available``).
+        # Patch the local name on ``arguments_types`` so the mock is visible to
+        # the validator on hosts without liger-kernel installed.
+        with patch("veomni.arguments.arguments_types.is_liger_kernel_available", return_value=True):
+            cfg = OpsImplementationConfig()
+    # All GPU-reasonable defaults preserved.
+    assert cfg.moe_implementation == "fused_triton"
+    assert cfg.cross_entropy_loss_implementation == "liger_kernel"
+    assert cfg.rms_norm_implementation == "liger_kernel"
+    assert cfg.rotary_pos_emb_implementation == "liger_kernel"
+    assert cfg.swiglu_mlp_implementation == "liger_kernel"
+    assert cfg.load_balancing_loss_implementation == "triton"

--- a/tests/ops/test_ops_config_defaults.py
+++ b/tests/ops/test_ops_config_defaults.py
@@ -98,12 +98,12 @@ def test_eager_defaults_classmethod_returns_eager_everywhere():
 def test_eager_defaults_classmethod_constructs_cleanly_on_npu():
     """``eager_defaults()`` must not raise on an NPU host.
 
-    Regression test for the bug Gemini flagged in PR review: previously the
-    classmethod inherited the dataclass default ``attn_implementation =
-    "flash_attention_2"``, which (after the SP rewrite) is in
-    ``_NPU_INCOMPATIBLE`` and would make ``__post_init__`` raise on NPU.
-    The whole point of ``eager_defaults()`` is to be a portable escape
-    hatch, so this path must construct without error on every device."""
+    The classmethod is the documented portable / no-deps escape hatch
+    (used by the ``build_foundation_model`` standalone-script fallback and
+    by tests that don't need fused kernels), so it has to construct on
+    every device without raising. Setting every field explicitly to
+    ``"eager"`` — including ``attn_implementation`` — also avoids the FA
+    import path on hosts that don't have ``flash_attn`` installed."""
     from veomni.arguments.arguments_types import OpsImplementationConfig
 
     with patch("veomni.utils.device.IS_NPU_AVAILABLE", True):
@@ -157,11 +157,14 @@ def test_legacy_moe_fused_alias_is_rewritten():
 # ---------------------------------------------------------------------------
 
 
-# (field, GPU-only value, expected suggestion in the error message)
+# (field, GPU-only value, expected suggestion in the error message).
+#
+# ``attn_implementation`` is intentionally absent — attention is dispatched
+# via transformers' pluggable ``ALL_ATTENTION_FUNCTIONS`` registry, so
+# device-availability for the attention backend is gated at the FA import
+# site rather than at config-parse time. See the comment on
+# ``_NPU_INCOMPATIBLE`` in ``veomni/arguments/arguments_types.py``.
 _NPU_INCOMPATIBLE_CASES = [
-    ("attn_implementation", "flash_attention_2", "sdpa"),
-    ("attn_implementation", "flash_attention_3", "sdpa"),
-    ("attn_implementation", "veomni_flash_attention_2_with_sp", "sdpa"),
     ("moe_implementation", "fused_triton", "fused_npu"),
     ("moe_implementation", "fused_quack", "fused_npu"),
     ("cross_entropy_loss_implementation", "liger_kernel", "npu"),
@@ -185,12 +188,9 @@ def test_npu_default_raises_with_clear_suggestion(field_name, gpu_value, suggest
     """
     from veomni.arguments.arguments_types import OpsImplementationConfig
 
-    # Start every field on a NPU-friendly value so the parametrized field is
-    # the only one that can trip the validator. ``attn_implementation`` is
-    # also in ``_NPU_INCOMPATIBLE`` (default ``flash_attention_2`` is GPU-only)
-    # so it has to be explicitly set to a portable value here too.
+    # Start every field on an NPU-compatible value so the parametrized
+    # field is the only one that can trip the validator.
     overrides = dict.fromkeys(_EXPECTED_DEFAULTS, "eager")
-    overrides["attn_implementation"] = "sdpa"
     overrides[field_name] = gpu_value
 
     with patch("veomni.utils.device.IS_NPU_AVAILABLE", True):

--- a/tests/ops/test_ops_config_defaults.py
+++ b/tests/ops/test_ops_config_defaults.py
@@ -44,7 +44,10 @@ _EXPECTED_DEFAULTS = {
     "rms_norm_implementation": "liger_kernel",
     "swiglu_mlp_implementation": "liger_kernel",
     "rotary_pos_emb_implementation": "liger_kernel",
-    "load_balancing_loss_implementation": "triton",
+    # Stays eager — see the dataclass docstring. ``apply_ops_config`` resolves
+    # GLOBAL ops eagerly for every model, so a triton default would force
+    # every dense run to depend on triton.
+    "load_balancing_loss_implementation": "eager",
 }
 
 
@@ -310,4 +313,5 @@ def test_gpu_host_skips_npu_validation():
     assert cfg.rms_norm_implementation == "liger_kernel"
     assert cfg.rotary_pos_emb_implementation == "liger_kernel"
     assert cfg.swiglu_mlp_implementation == "liger_kernel"
-    assert cfg.load_balancing_loss_implementation == "triton"
+    # load_balancing_loss stays eager — see the dataclass docstring.
+    assert cfg.load_balancing_loss_implementation == "eager"

--- a/tests/ops/test_ops_config_defaults.py
+++ b/tests/ops/test_ops_config_defaults.py
@@ -83,12 +83,29 @@ def test_eager_defaults_classmethod_returns_eager_everywhere():
     from veomni.arguments.arguments_types import OpsImplementationConfig
 
     cfg = OpsImplementationConfig.eager_defaults()
+    assert cfg.attn_implementation == "eager"
     assert cfg.moe_implementation == "eager"
     assert cfg.cross_entropy_loss_implementation == "eager"
     assert cfg.rms_norm_implementation == "eager"
     assert cfg.swiglu_mlp_implementation == "eager"
     assert cfg.rotary_pos_emb_implementation == "eager"
     assert cfg.load_balancing_loss_implementation == "eager"
+
+
+def test_eager_defaults_classmethod_constructs_cleanly_on_npu():
+    """``eager_defaults()`` must not raise on an NPU host.
+
+    Regression test for the bug Gemini flagged in PR review: previously the
+    classmethod inherited the dataclass default ``attn_implementation =
+    "flash_attention_2"``, which (after the SP rewrite) is in
+    ``_NPU_INCOMPATIBLE`` and would make ``__post_init__`` raise on NPU.
+    The whole point of ``eager_defaults()`` is to be a portable escape
+    hatch, so this path must construct without error on every device."""
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    with patch("veomni.utils.device.IS_NPU_AVAILABLE", True):
+        cfg = OpsImplementationConfig.eager_defaults()
+    assert cfg.attn_implementation == "eager"
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +263,30 @@ def test_load_balancing_triton_is_universal_on_npu():
                 load_balancing_loss_implementation="triton",  # universal
             )
     assert cfg.load_balancing_loss_implementation == "triton"
+
+
+def test_load_balancing_loss_triton_default_requires_triton_package():
+    """``load_balancing_loss_implementation: triton`` is the new default.
+
+    ``apply_global_ops`` resolves GLOBAL ops eagerly for *every* model
+    (including dense models that never call this loss), so the backend
+    declares ``requires=("triton",)``. On a host without triton (or
+    triton-ascend), the validator must raise at config-parse time with a
+    clear message — not crash later inside ``apply_global_ops`` when it
+    imports the kernel module.
+
+    Regression test for the second issue Codex flagged in PR review.
+    """
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    # GPU host so the device-compatibility check is skipped.
+    with patch("veomni.utils.device.IS_NPU_AVAILABLE", False):
+        with patch("veomni.utils.import_utils.is_package_available", return_value=False):
+            with pytest.raises(ValueError, match="triton.*triton-ascend"):
+                # Have to bypass the liger validator too, otherwise the test
+                # would fail there first on hosts without liger-kernel.
+                with patch("veomni.arguments.arguments_types.is_liger_kernel_available", return_value=True):
+                    OpsImplementationConfig(load_balancing_loss_implementation="triton")
 
 
 def test_gpu_host_skips_npu_validation():

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -11,6 +11,7 @@ from .launch_utils import find_free_port, torchrun
 from .training_utils import (
     ParallelConfig,
     build_torchrun_cmd,
+    host_appropriate_ops_cli_args,
     materialize_weights,
     release_device_memory,
     run_training_config,

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -16,39 +16,45 @@ from veomni.utils.import_utils import is_liger_kernel_available, is_package_avai
 from .launch_utils import find_free_port
 
 
-# Pick host-appropriate ops_implementation values. NPU users must opt in
-# explicitly for every GPU-only kernel; without these, the e2e tests would
-# trip ``OpsImplementationConfig._validate_device_compatibility`` (added in
-# the kernel-defaults refactor). Hosts without ``liger-kernel`` installed
-# (e.g. NPU CI) need ``eager`` for the Liger fields too.
-_IS_NPU = is_torch_npu_available()
-_HAS_LIGER = is_liger_kernel_available()
-# ``triton`` (CUDA) and ``triton-ascend`` (NPU) both expose the same import
-# name. Treat ``triton`` as available iff we can import it, regardless of
-# device — the load-balancing-loss kernel works on both stacks but the
-# standard ``--extra npu`` install does NOT ship triton-ascend.
-_HAS_TRITON = is_package_available("triton")
-_FUSED_MOE_IMPL = "fused_npu" if _IS_NPU else "fused_triton"
-# Attention: keep ``flash_attention_2`` on both GPU and NPU. The Ulysses-SP
-# rewrite in ``OpsImplementationConfig.__post_init__`` only kicks in for
-# ``flash_attention_*`` names → ``veomni_flash_attention_*_with_sp`` (which
-# does the cross-rank Q/K/V gather/scatter). ``sdpa`` is not in the rewrite
-# map, so picking it on NPU with ``ulysses_size>1`` enables SP in
-# ``parallel_state`` but leaves attention running locally per rank — the
-# sp1/sp2 e2e alignment test (``test_text_parallel_align``) catches that
-# regression. NPU + FA2 is supported by the OSS NPU CI image and by
-# downstream third-party FA-on-Ascend providers.
-_ATTN_IMPL = "flash_attention_2"
-# RMSNorm / RoPE: NPU has its own fused kernel; GPU uses Liger if available.
-_RMS_NORM_IMPL = "npu" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
-_ROTARY_IMPL = "npu" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
-# SwiGLU has no NPU fused kernel; CE on NPU goes through chunk_loss.
-_SWIGLU_IMPL = "eager" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
-_CE_IMPL = "npu" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
-# Load-balancing-loss: triton-ascend is not in the standard ``--extra npu``
-# install, so we can't unconditionally pick triton on NPU. Fall back to
-# eager whenever the triton import would fail.
-_LB_LOSS_IMPL = "triton" if _HAS_TRITON else "eager"
+# Per-host ops_implementation values for tests that subprocess into a
+# training script. The new GPU-reasonable defaults raise on NPU for any
+# GPU-only field, so we spell each one out explicitly.
+_OPS_FIELDS = (
+    "attn_implementation",
+    "moe_implementation",
+    "rms_norm_implementation",
+    "rotary_pos_emb_implementation",
+    "swiglu_mlp_implementation",
+    "cross_entropy_loss_implementation",
+    "load_balancing_loss_implementation",
+)
+
+
+def _host_appropriate_impls() -> Dict[str, str]:
+    # triton-ascend is not in the standard --extra npu install, so the
+    # load-balancing-loss triton kernel must be gated on import availability
+    # regardless of device.
+    lb_loss = "triton" if is_package_available("triton") else "eager"
+    if is_torch_npu_available():
+        return {
+            "attn_implementation": "flash_attention_2",
+            "moe_implementation": "fused_npu",
+            "rms_norm_implementation": "npu",
+            "rotary_pos_emb_implementation": "npu",
+            "swiglu_mlp_implementation": "eager",  # no NPU fused SwiGLU
+            "cross_entropy_loss_implementation": "npu",
+            "load_balancing_loss_implementation": lb_loss,
+        }
+    liger = "liger_kernel" if is_liger_kernel_available() else "eager"
+    return {
+        "attn_implementation": "flash_attention_2",
+        "moe_implementation": "fused_triton",
+        "rms_norm_implementation": liger,
+        "rotary_pos_emb_implementation": liger,
+        "swiglu_mlp_implementation": liger,
+        "cross_entropy_loss_implementation": liger,
+        "load_balancing_loss_implementation": lb_loss,
+    }
 
 
 def host_appropriate_ops_cli_args(
@@ -59,50 +65,21 @@ def host_appropriate_ops_cli_args(
 ) -> List[str]:
     """Return ``--model.ops_implementation.*`` CLI args that work on this host.
 
-    The new GPU-reasonable defaults on ``OpsImplementationConfig`` raise on
-    NPU for any field whose default is GPU-only (Liger / fused_triton /
-    flash_attention_2). Tests that subprocess into a training script via
-    torchrun therefore need to spell out the per-host values explicitly so
-    ``OpsImplementationConfig.__post_init__`` does not blow up inside the
-    child process.
-
     Args:
         separator: ``"="`` for ``--key=value`` form (used by build_torchrun_cmd /
             most train scripts), or ``" "`` for the ``--key value`` form used
             by ``tests/checkpoints/utils.py``.
         attn_implementation: Override for the attention impl. When ``None``
-            (default) the helper picks a host-appropriate value (``sdpa`` on
-            NPU, ``flash_attention_2`` on GPU). Pass an explicit value to
-            keep the existing-test behaviour where attention mode is
-            chosen by the test.
-        eager_only: If True, every kernel field is set to ``"eager"`` —
-            universal and has zero runtime dependencies. Suitable for tests
-            that don't actually exercise model kernels (data-pipeline tests,
-            arg-parsing tests). Equivalent to passing
-            ``OpsImplementationConfig.eager_defaults()`` via CLI.
+            the helper picks a host-appropriate value.
+        eager_only: If True, every kernel field is set to ``"eager"`` (zero
+            runtime dependencies — for tests that don't exercise kernels).
+            Equivalent to passing ``OpsImplementationConfig.eager_defaults()``
+            via CLI.
     """
-    if eager_only:
-        attn = attn_implementation if attn_implementation is not None else "eager"
-        return [
-            f"--model.ops_implementation.attn_implementation{separator}{attn}",
-            f"--model.ops_implementation.moe_implementation{separator}eager",
-            f"--model.ops_implementation.rms_norm_implementation{separator}eager",
-            f"--model.ops_implementation.rotary_pos_emb_implementation{separator}eager",
-            f"--model.ops_implementation.swiglu_mlp_implementation{separator}eager",
-            f"--model.ops_implementation.cross_entropy_loss_implementation{separator}eager",
-            f"--model.ops_implementation.load_balancing_loss_implementation{separator}eager",
-        ]
-
-    attn = attn_implementation if attn_implementation is not None else _ATTN_IMPL
-    return [
-        f"--model.ops_implementation.attn_implementation{separator}{attn}",
-        f"--model.ops_implementation.moe_implementation{separator}{_FUSED_MOE_IMPL}",
-        f"--model.ops_implementation.rms_norm_implementation{separator}{_RMS_NORM_IMPL}",
-        f"--model.ops_implementation.rotary_pos_emb_implementation{separator}{_ROTARY_IMPL}",
-        f"--model.ops_implementation.swiglu_mlp_implementation{separator}{_SWIGLU_IMPL}",
-        f"--model.ops_implementation.cross_entropy_loss_implementation{separator}{_CE_IMPL}",
-        f"--model.ops_implementation.load_balancing_loss_implementation{separator}{_LB_LOSS_IMPL}",
-    ]
+    impls = dict.fromkeys(_OPS_FIELDS, "eager") if eager_only else _host_appropriate_impls()
+    if attn_implementation is not None:
+        impls["attn_implementation"] = attn_implementation
+    return [f"--model.ops_implementation.{k}{separator}{v}" for k, v in impls.items()]
 
 
 def release_device_memory():

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -11,7 +11,7 @@ import subprocess
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from veomni.utils.import_utils import is_liger_kernel_available, is_torch_npu_available
+from veomni.utils.import_utils import is_liger_kernel_available, is_package_available, is_torch_npu_available
 
 from .launch_utils import find_free_port
 
@@ -23,6 +23,11 @@ from .launch_utils import find_free_port
 # (e.g. NPU CI) need ``eager`` for the Liger fields too.
 _IS_NPU = is_torch_npu_available()
 _HAS_LIGER = is_liger_kernel_available()
+# ``triton`` (CUDA) and ``triton-ascend`` (NPU) both expose the same import
+# name. Treat ``triton`` as available iff we can import it, regardless of
+# device — the load-balancing-loss kernel works on both stacks but the
+# standard ``--extra npu`` install does NOT ship triton-ascend.
+_HAS_TRITON = is_package_available("triton")
 _FUSED_MOE_IMPL = "fused_npu" if _IS_NPU else "fused_triton"
 _ATTN_IMPL = "sdpa" if _IS_NPU else "flash_attention_2"
 # RMSNorm / RoPE: NPU has its own fused kernel; GPU uses Liger if available.
@@ -31,8 +36,10 @@ _ROTARY_IMPL = "npu" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
 # SwiGLU has no NPU fused kernel; CE on NPU goes through chunk_loss.
 _SWIGLU_IMPL = "eager" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
 _CE_IMPL = "npu" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
-# Load-balancing-loss ``triton`` is universal (works on NPU via triton-ascend).
-_LB_LOSS_IMPL = "triton"
+# Load-balancing-loss: triton-ascend is not in the standard ``--extra npu``
+# install, so we can't unconditionally pick triton on NPU. Fall back to
+# eager whenever the triton import would fail.
+_LB_LOSS_IMPL = "triton" if _HAS_TRITON else "eager"
 
 
 def host_appropriate_ops_cli_args(

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -11,14 +11,82 @@ import subprocess
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from veomni.utils.import_utils import is_torch_npu_available
+from veomni.utils.import_utils import is_liger_kernel_available, is_torch_npu_available
 
 from .launch_utils import find_free_port
 
 
-# Pick the fused-MoE backend that matches the test hardware. On NPU the NPU
-# kernel is the only option; on GPU default to Triton (SM70+).
-_FUSED_MOE_IMPL = "fused_npu" if is_torch_npu_available() else "fused_triton"
+# Pick host-appropriate ops_implementation values. NPU users must opt in
+# explicitly for every GPU-only kernel; without these, the e2e tests would
+# trip ``OpsImplementationConfig._validate_device_compatibility`` (added in
+# the kernel-defaults refactor). Hosts without ``liger-kernel`` installed
+# (e.g. NPU CI) need ``eager`` for the Liger fields too.
+_IS_NPU = is_torch_npu_available()
+_HAS_LIGER = is_liger_kernel_available()
+_FUSED_MOE_IMPL = "fused_npu" if _IS_NPU else "fused_triton"
+_ATTN_IMPL = "sdpa" if _IS_NPU else "flash_attention_2"
+# RMSNorm / RoPE: NPU has its own fused kernel; GPU uses Liger if available.
+_RMS_NORM_IMPL = "npu" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
+_ROTARY_IMPL = "npu" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
+# SwiGLU has no NPU fused kernel; CE on NPU goes through chunk_loss.
+_SWIGLU_IMPL = "eager" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
+_CE_IMPL = "npu" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
+# Load-balancing-loss ``triton`` is universal (works on NPU via triton-ascend).
+_LB_LOSS_IMPL = "triton"
+
+
+def host_appropriate_ops_cli_args(
+    *,
+    separator: str = "=",
+    attn_implementation: Optional[str] = None,
+    eager_only: bool = False,
+) -> List[str]:
+    """Return ``--model.ops_implementation.*`` CLI args that work on this host.
+
+    The new GPU-reasonable defaults on ``OpsImplementationConfig`` raise on
+    NPU for any field whose default is GPU-only (Liger / fused_triton /
+    flash_attention_2). Tests that subprocess into a training script via
+    torchrun therefore need to spell out the per-host values explicitly so
+    ``OpsImplementationConfig.__post_init__`` does not blow up inside the
+    child process.
+
+    Args:
+        separator: ``"="`` for ``--key=value`` form (used by build_torchrun_cmd /
+            most train scripts), or ``" "`` for the ``--key value`` form used
+            by ``tests/checkpoints/utils.py``.
+        attn_implementation: Override for the attention impl. When ``None``
+            (default) the helper picks a host-appropriate value (``sdpa`` on
+            NPU, ``flash_attention_2`` on GPU). Pass an explicit value to
+            keep the existing-test behaviour where attention mode is
+            chosen by the test.
+        eager_only: If True, every kernel field is set to ``"eager"`` —
+            universal and has zero runtime dependencies. Suitable for tests
+            that don't actually exercise model kernels (data-pipeline tests,
+            arg-parsing tests). Equivalent to passing
+            ``OpsImplementationConfig.eager_defaults()`` via CLI.
+    """
+    if eager_only:
+        attn = attn_implementation if attn_implementation is not None else "eager"
+        return [
+            f"--model.ops_implementation.attn_implementation{separator}{attn}",
+            f"--model.ops_implementation.moe_implementation{separator}eager",
+            f"--model.ops_implementation.rms_norm_implementation{separator}eager",
+            f"--model.ops_implementation.rotary_pos_emb_implementation{separator}eager",
+            f"--model.ops_implementation.swiglu_mlp_implementation{separator}eager",
+            f"--model.ops_implementation.cross_entropy_loss_implementation{separator}eager",
+            f"--model.ops_implementation.load_balancing_loss_implementation{separator}eager",
+        ]
+
+    attn = attn_implementation if attn_implementation is not None else _ATTN_IMPL
+    return [
+        f"--model.ops_implementation.attn_implementation{separator}{attn}",
+        f"--model.ops_implementation.moe_implementation{separator}{_FUSED_MOE_IMPL}",
+        f"--model.ops_implementation.rms_norm_implementation{separator}{_RMS_NORM_IMPL}",
+        f"--model.ops_implementation.rotary_pos_emb_implementation{separator}{_ROTARY_IMPL}",
+        f"--model.ops_implementation.swiglu_mlp_implementation{separator}{_SWIGLU_IMPL}",
+        f"--model.ops_implementation.cross_entropy_loss_implementation{separator}{_CE_IMPL}",
+        f"--model.ops_implementation.load_balancing_loss_implementation{separator}{_LB_LOSS_IMPL}",
+    ]
 
 
 def release_device_memory():
@@ -85,8 +153,7 @@ def build_torchrun_cmd(
         "--data.dyn_bsz_buffer_size=1",
         "--train.global_batch_size=16",
         "--train.micro_batch_size=1",
-        "--model.ops_implementation.attn_implementation=flash_attention_2",
-        f"--model.ops_implementation.moe_implementation={_FUSED_MOE_IMPL}",
+        *host_appropriate_ops_cli_args(),
         f"--train.init_device={init_device}",
         "--train.bsz_warmup_ratio=0",
         "--train.num_train_epochs=1",

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -29,7 +29,16 @@ _HAS_LIGER = is_liger_kernel_available()
 # standard ``--extra npu`` install does NOT ship triton-ascend.
 _HAS_TRITON = is_package_available("triton")
 _FUSED_MOE_IMPL = "fused_npu" if _IS_NPU else "fused_triton"
-_ATTN_IMPL = "sdpa" if _IS_NPU else "flash_attention_2"
+# Attention: keep ``flash_attention_2`` on both GPU and NPU. The Ulysses-SP
+# rewrite in ``OpsImplementationConfig.__post_init__`` only kicks in for
+# ``flash_attention_*`` names → ``veomni_flash_attention_*_with_sp`` (which
+# does the cross-rank Q/K/V gather/scatter). ``sdpa`` is not in the rewrite
+# map, so picking it on NPU with ``ulysses_size>1`` enables SP in
+# ``parallel_state`` but leaves attention running locally per rank — the
+# sp1/sp2 e2e alignment test (``test_text_parallel_align``) catches that
+# regression. NPU + FA2 is supported by the OSS NPU CI image and by
+# downstream third-party FA-on-Ascend providers.
+_ATTN_IMPL = "flash_attention_2"
 # RMSNorm / RoPE: NPU has its own fused kernel; GPU uses Liger if available.
 _RMS_NORM_IMPL = "npu" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")
 _ROTARY_IMPL = "npu" if _IS_NPU else ("liger_kernel" if _HAS_LIGER else "eager")

--- a/tests/utils/test_helper.py
+++ b/tests/utils/test_helper.py
@@ -74,12 +74,17 @@ def run_environ_meter(args):
 def test_environ_meter():
     port = 12345 + random.randint(0, 100)
 
+    # See note in tests/data/test_datasets.py — kernel fields forced to eager
+    # so the subprocess'd parse_args doesn't trip the NPU validator.
+    from tests.tools.training_utils import host_appropriate_ops_cli_args
+
     command = [
         "torchrun",
         "--nproc_per_node=8",
         f"--master_port={port}",
         "tests/utils/test_helper.py",
         "--model.config_path=test",
+        *host_appropriate_ops_cli_args(eager_only=True),
         "--data.train_path=tests",
         "--train.checkpoint.output_dir=.tests/cache",
     ]

--- a/tests/utils/test_model_loader.py
+++ b/tests/utils/test_model_loader.py
@@ -67,6 +67,10 @@ def run_environ_meter(args: Arguments):
     ],
 )
 def test_model_loader(model_path):
+    # See note in tests/data/test_datasets.py — kernel fields forced to eager
+    # so the subprocess'd parse_args doesn't trip the NPU validator.
+    from tests.tools.training_utils import host_appropriate_ops_cli_args
+
     port = 12345 + random.randint(0, 100)
 
     command = [
@@ -75,6 +79,7 @@ def test_model_loader(model_path):
         f"--master_port={port}",
         "tests/utils/test_model_loader.py",
         f"--model.config_path={model_path}",
+        *host_appropriate_ops_cli_args(eager_only=True),
         "--data.train_path=tests",
         "--train.checkpoint.output_dir=.tests/cache",
         f"--train.init_device={get_device_type()}",

--- a/tests/utils/test_rank0_load_and_broadcast_weights.py
+++ b/tests/utils/test_rank0_load_and_broadcast_weights.py
@@ -29,6 +29,17 @@ except ImportError:  # pragma: no cover - torch < 2.2 fallback
 logger = helper.create_logger(__name__)
 
 
+def _ops_eager_cli_args():
+    """Force every kernel field to ``eager`` for the subprocess'd parse_args.
+
+    See note in tests/data/test_datasets.py — without this the new
+    GPU-reasonable defaults trip the NPU device-compatibility validator.
+    Tiny-model tests don't exercise any kernel anyway."""
+    from tests.tools.training_utils import host_appropriate_ops_cli_args
+
+    return host_appropriate_ops_cli_args(eager_only=True)
+
+
 @dataclass
 class BroadcastTestArguments:
     weights_path: str = ""
@@ -213,6 +224,7 @@ def test_load_dist_model_weights_matches_standard(tmp_path: Path) -> None:
         f"--master_port={port}",
         "tests/utils/test_rank0_load_and_broadcast_weights.py",
         "--model.config_path=test",
+        *_ops_eager_cli_args(),
         "--data.train_path=tests",
         "--train.checkpoint.output_dir=.tests/cache",
         "--train.accelerator.fsdp_config.fsdp_mode=fsdp2",
@@ -345,6 +357,7 @@ def test_load_weights_no_scatter(tmp_path: Path) -> None:
         f"--master_port={port}",
         "tests/utils/test_rank0_load_and_broadcast_weights.py",
         "--model.config_path=test",
+        *_ops_eager_cli_args(),
         "--data.train_path=tests",
         "--train.checkpoint.output_dir=.tests/cache",
         "--train.accelerator.fsdp_config.fsdp_mode=fsdp2",

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -661,25 +661,18 @@ _LEGACY_ALIASES: Dict[str, Dict[str, str]] = {
 #     (same import name), and the package availability gate lives in
 #     ``_validate_implementations`` via the BackendSpec ``requires=("triton",)``
 #     declaration — not here.
-#   - ``attn_implementation`` is the one field validated *after* the SP
-#     rewrite, so its entry has to list both the user-facing names
-#     (``flash_attention_2``) and the rewritten ones
-#     (``veomni_flash_attention_2_with_sp``); both forms reach this
-#     validator depending on whether the user already passed the
-#     pre-rewrite or post-rewrite value.
+#   - ``attn_implementation`` is intentionally NOT validated here. Attention
+#     is dispatched via transformers' ``ALL_ATTENTION_FUNCTIONS`` registry
+#     (see ``kernel_selection.md`` §5.2), which is pluggable: third-party
+#     backends can register kernels for any name (including FA2/FA3/FA4 on
+#     Ascend) at runtime. A pre-flight check at config-parse time cannot
+#     know which providers will be installed, so we leave attention
+#     compatibility to runtime: the FA imports in
+#     ``veomni/ops/kernels/attention/__init__.py`` raise a clear
+#     ``ImportError`` when the requested backend is not available, and
+#     ``ALL_ATTENTION_FUNCTIONS`` falls through to whichever provider is
+#     registered.
 _NPU_INCOMPATIBLE: Dict[str, Dict[str, str]] = {
-    # ``attn_implementation`` is checked after the SP rewrite, so both the
-    # user-facing names and the rewritten ``veomni_flash_attention_*_with_sp``
-    # names need to be listed here. Suggested NPU equivalent is ``sdpa``,
-    # which is what NPU users typically pick.
-    "attn_implementation": {
-        "flash_attention_2": "sdpa",
-        "flash_attention_3": "sdpa",
-        "flash_attention_4": "sdpa",
-        "veomni_flash_attention_2_with_sp": "sdpa",
-        "veomni_flash_attention_3_with_sp": "sdpa",
-        "veomni_flash_attention_4_with_sp": "sdpa",
-    },
     "moe_implementation": {
         "fused_triton": "fused_npu",
         "fused_quack": "fused_npu",
@@ -745,7 +738,12 @@ class OpsImplementationConfig:
         ]
     ] = field(
         default="flash_attention_2",
-        metadata={"help": "Attention implementation to use. Default targets GPU; NPU users must override."},
+        metadata={
+            "help": "Attention implementation to use. Dispatched via "
+            "``ALL_ATTENTION_FUNCTIONS`` (transformers' registry) and is "
+            "pluggable, so device-availability is checked at the FA-import "
+            "site rather than here."
+        },
     )
     moe_implementation: str = field(
         default="fused_triton",

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -790,10 +790,14 @@ class OpsImplementationConfig:
 
         Used by fallback paths (``build_foundation_model`` standalone-script
         warning, tests that only care about the loss-mapping plumbing) where
-        GPU dependencies cannot be assumed. Equivalent to passing every
-        ``*_implementation`` field explicitly as ``"eager"``.
+        GPU dependencies cannot be assumed. Every ``*_implementation`` field
+        — including ``attn_implementation`` — is set explicitly to
+        ``"eager"``; this matters on NPU, where the dataclass default
+        ``"flash_attention_2"`` is in ``_NPU_INCOMPATIBLE`` and would
+        otherwise make this constructor raise.
         """
         return cls(
+            attn_implementation="eager",
             moe_implementation="eager",
             cross_entropy_loss_implementation="eager",
             rms_norm_implementation="eager",
@@ -891,6 +895,17 @@ class OpsImplementationConfig:
 
                     if not is_torch_npu_available():
                         raise ValueError(f"{op.config_field}='{value}' requires torch_npu to be installed.")
+                if pkg == "triton":
+                    from ..utils.import_utils import is_package_available
+
+                    if not is_package_available("triton"):
+                        # ``triton-ascend`` exposes the ``triton`` import name on NPU,
+                        # so a single check covers both stacks; mention both in the hint
+                        # so the user knows which package to install for their device.
+                        raise ValueError(
+                            f"{op.config_field}='{value}' requires triton (GPU) or "
+                            f"triton-ascend (NPU) to be installed."
+                        )
 
 
 @dataclass

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -619,24 +619,91 @@ class TrainingArguments:
 #
 
 
+# Legacy values that have been renamed; rewritten in ``__post_init__`` with a
+# deprecation warning so old YAML configs keep working for one release.
+_LEGACY_ALIASES: Dict[str, Dict[str, str]] = {
+    "moe_implementation": {
+        # Removed in #678 in favour of explicit ``fused_triton`` (GPU) and
+        # ``fused_npu`` (NPU). The pre-#678 ``fused`` value silently auto-picked
+        # by hardware; we collapse it to the GPU pick here so old configs do not
+        # silently change behaviour on NPU — NPU users now have to opt in to
+        # ``fused_npu`` explicitly.
+        "fused": "fused_triton",
+    },
+}
+
+# Values that are GPU-only (the GPU-reasonable defaults below) but have a
+# direct NPU equivalent. Used by ``_validate_device_compatibility`` to give a
+# clear, actionable error on NPU when a GPU value would otherwise reach
+# bind-time and fail with a less helpful message.
+#
+# ``"eager"`` and load-balancing-loss ``"triton"`` (which works on NPU via
+# ``triton-ascend``) are universal — not listed here.
+_NPU_INCOMPATIBLE: Dict[str, Dict[str, str]] = {
+    # ``attn_implementation`` is checked after the SP rewrite, so both the
+    # user-facing names and the rewritten ``veomni_flash_attention_*_with_sp``
+    # names need to be listed here. Suggested NPU equivalent is ``sdpa``,
+    # which is what NPU users typically pick.
+    "attn_implementation": {
+        "flash_attention_2": "sdpa",
+        "flash_attention_3": "sdpa",
+        "flash_attention_4": "sdpa",
+        "veomni_flash_attention_2_with_sp": "sdpa",
+        "veomni_flash_attention_3_with_sp": "sdpa",
+        "veomni_flash_attention_4_with_sp": "sdpa",
+    },
+    "moe_implementation": {
+        "fused_triton": "fused_npu",
+        "fused_quack": "fused_npu",
+    },
+    "cross_entropy_loss_implementation": {
+        "liger_kernel": "npu",
+    },
+    "rms_norm_implementation": {
+        "liger_kernel": "npu",
+        # Per-model triton (DeepSeek-V3 batch-invariant) is GPU-only.
+        "triton": "npu",
+    },
+    "rotary_pos_emb_implementation": {
+        "liger_kernel": "npu",
+        "triton": "npu",
+    },
+    "swiglu_mlp_implementation": {
+        # No NPU fused SwiGLU exists; NPU users must explicitly fall back.
+        "liger_kernel": "eager",
+    },
+}
+
+
 @dataclass
 class OpsImplementationConfig:
     """model.ops_implementation.* — Attention, MoE, and fused kernel implementation.
 
-    Each ``*_implementation`` field selects the kernel backend for that operation.
-    The type is ``str`` (not ``Literal``) so that third-party backends can be
-    registered without modifying this class.
+    Each ``*_implementation`` field selects the kernel backend for that
+    operation. The type is ``str`` (not ``Literal``) so third-party backends
+    can be registered without modifying this class.
+
+    **Defaults are GPU-reasonable.** Every field defaults to a fast,
+    well-tested kernel that runs on GPU with the standard ``--extra gpu``
+    install (``liger_kernel`` / ``triton`` / ``fused_triton`` / FA2). On
+    Ascend NPU, fields whose default has no NPU implementation raise a clear
+    error in ``__post_init__`` pointing the user at the suggested NPU value
+    (``npu`` / ``fused_npu`` / ``eager``) — there is no silent hardware
+    fallback. Switch a field to ``"eager"`` for portable behaviour on hosts
+    without the GPU dependency.
 
     Well-known values:
 
-    - ``"eager"`` (default): PyTorch / HuggingFace reference implementation.
-    - ``"liger_kernel"``: LigerKernel fused implementation (GPU and NPU, requires
+    - ``"eager"``: PyTorch / HuggingFace reference implementation. Universal
+      (runs on any device).
+    - ``"liger_kernel"``: LigerKernel fused implementation (GPU only, requires
       ``liger-kernel``).
     - ``"npu"``: Ascend NPU fused implementation (requires ``torch_npu``).
       Applies ``npu_rms_norm`` / ``npu_rotary_mul`` from
-      ``veomni.ops.kernels.{rms_norm,rotary}.npu``.
-    - ``"triton"``: Triton fused implementation (GPU with ``triton`` package, or
-      NPU with ``triton-ascend``).
+      ``veomni.ops.kernels.{rms_norm,rotary}.npu``, or the chunked loss for
+      cross-entropy.
+    - ``"triton"``: Triton fused implementation (GPU with ``triton`` package,
+      or NPU with ``triton-ascend`` for the load-balancing loss).
     """
 
     attn_implementation: Optional[
@@ -650,72 +717,94 @@ class OpsImplementationConfig:
         ]
     ] = field(
         default="flash_attention_2",
-        metadata={"help": "Attention implementation to use."},
+        metadata={"help": "Attention implementation to use. Default targets GPU; NPU users must override."},
     )
     moe_implementation: str = field(
-        default="eager",
+        default="fused_triton",
         metadata={
             "help": "MoE experts forward implementation. "
-            "OSS backends: 'fused_triton' (Triton group-gemm, GPU, SM70+), "
+            "OSS backends: 'fused_triton' (default, Triton group-gemm, GPU, SM70+), "
             "'fused_quack' (Quack CUTLASS/CuTe, GPU, SM90+), "
             "'fused_npu' (NPU group-gemm, requires torch_npu), "
-            "'eager' (default, reference loop). "
+            "'eager' (reference loop). "
             "The backend must match the hardware — no silent fallback. "
-            "Typed as plain str (not Literal) so third-party backends can be "
-            "plugged in via `apply_veomni_fused_moe_patch` (legacy-dispatch "
+            "Legacy 'fused' is rewritten to 'fused_triton' with a deprecation "
+            "warning. Typed as plain str (not Literal) so third-party backends "
+            "can be plugged in via `apply_veomni_fused_moe_patch` (legacy-dispatch "
             "models) or `KERNEL_REGISTRY.register(op_name='moe_experts', ...)` "
             "(OpSlot-dispatch models), matching the extensibility of the "
             "other *_implementation fields."
         },
     )
     cross_entropy_loss_implementation: str = field(
-        default="eager",
+        default="liger_kernel",
         metadata={
             "help": "Cross-entropy loss implementation. "
-            "'liger_kernel' uses LigerFusedLinearCrossEntropyLoss (requires liger-kernel). "
-            "'npu' enables chunked loss computation for CausalLM on NPU "
-            "(requires torch_npu). "
-            "'eager' (default) uses PyTorch F.cross_entropy."
+            "'liger_kernel' (default) uses LigerFusedLinearCrossEntropyLoss (requires liger-kernel; GPU). "
+            "'npu' enables chunked loss computation for CausalLM on NPU (requires torch_npu). "
+            "'eager' uses PyTorch F.cross_entropy."
         },
     )
     rms_norm_implementation: str = field(
-        default="eager",
+        default="liger_kernel",
         metadata={
             "help": "RMSNorm implementation. "
-            "'liger_kernel' uses LigerRMSNorm. "
+            "'liger_kernel' (default) uses LigerRMSNorm (GPU). "
             "'npu' uses torch_npu.npu_rms_norm (requires torch_npu). "
             "'triton' uses batch-invariant fused Triton kernel (DeepSeek V3). "
-            "'eager' (default) uses the HuggingFace default."
+            "'eager' uses the HuggingFace default."
         },
     )
     swiglu_mlp_implementation: str = field(
-        default="eager",
+        default="liger_kernel",
         metadata={
             "help": "SwiGLU MLP implementation. "
-            "'liger_kernel' uses LigerSwiGLUMLP. "
-            "'eager' (default) uses the HuggingFace default."
+            "'liger_kernel' (default) uses LigerSwiGLUMLP (GPU). "
+            "'eager' uses the HuggingFace default. No NPU fused kernel exists; "
+            "NPU users must set this to 'eager' explicitly."
         },
     )
     rotary_pos_emb_implementation: str = field(
-        default="eager",
+        default="liger_kernel",
         metadata={
             "help": "Rotary positional embedding implementation. "
-            "'liger_kernel' uses liger_rotary_pos_emb. "
+            "'liger_kernel' (default) uses liger_rotary_pos_emb (GPU). "
             "'npu' uses torch_npu.npu_rotary_mul (requires torch_npu). "
             "'triton' uses deterministic Triton bmm kernel (DeepSeek V3). "
-            "'eager' (default) uses the HuggingFace default."
+            "'eager' uses the HuggingFace default."
         },
     )
     load_balancing_loss_implementation: str = field(
-        default="eager",
+        default="triton",
         metadata={
             "help": "MoE load-balancing loss implementation. "
-            "'triton' uses a fused Triton kernel (requires triton or triton-ascend). "
-            "'eager' (default) uses PyTorch reference."
+            "'triton' (default) uses a fused Triton kernel — works on GPU "
+            "(``triton``) and on NPU (``triton-ascend``). "
+            "'eager' uses PyTorch reference."
         },
     )
 
+    @classmethod
+    def eager_defaults(cls) -> "OpsImplementationConfig":
+        """Return an instance with every kernel field set to ``"eager"``.
+
+        Used by fallback paths (``build_foundation_model`` standalone-script
+        warning, tests that only care about the loss-mapping plumbing) where
+        GPU dependencies cannot be assumed. Equivalent to passing every
+        ``*_implementation`` field explicitly as ``"eager"``.
+        """
+        return cls(
+            moe_implementation="eager",
+            cross_entropy_loss_implementation="eager",
+            rms_norm_implementation="eager",
+            swiglu_mlp_implementation="eager",
+            rotary_pos_emb_implementation="eager",
+            load_balancing_loss_implementation="eager",
+        )
+
     def __post_init__(self):
+        self._rewrite_legacy_aliases()
+
         if get_env("MODELING_BACKEND") == "veomni":
             replacements = {
                 "flash_attention_2": "veomni_flash_attention_2_with_sp",
@@ -727,7 +816,57 @@ class OpsImplementationConfig:
                 logger.info_rank0(f"Replacing attn_implementation from '{self.attn_implementation}' to '{new_impl}'")
                 self.attn_implementation = new_impl
 
+        self._validate_device_compatibility()
         self._validate_implementations()
+
+    def _rewrite_legacy_aliases(self):
+        """Rewrite deprecated values to their current equivalents with a warning.
+
+        The mapping lives in the module-level ``_LEGACY_ALIASES`` table so new
+        renames can be added without touching this method.
+        """
+        for field_name, mapping in _LEGACY_ALIASES.items():
+            value = getattr(self, field_name)
+            if value in mapping:
+                replacement = mapping[value]
+                logger.warning_rank0(
+                    f"{field_name}='{value}' is deprecated; auto-converting to '{replacement}'. "
+                    f"Update your config to use the new value explicitly."
+                )
+                setattr(self, field_name, replacement)
+
+    def _validate_device_compatibility(self):
+        """Raise on (field, value) combinations that don't run on the current device.
+
+        Defaults are picked for GPU. On Ascend NPU, a value that has no NPU
+        implementation raises here so the user is told to override
+        explicitly. The error includes the suggested NPU equivalent for that
+        field. No GPU-side check is needed: GPU-only kernels live in the
+        existing package/hardware checks (Liger requires ``liger_kernel``;
+        ``apply_veomni_fused_moe_patch`` rejects ``fused_npu`` on GPU; etc.).
+        """
+        from ..utils.device import IS_NPU_AVAILABLE
+
+        if not IS_NPU_AVAILABLE:
+            return
+
+        for field_name, mapping in _NPU_INCOMPATIBLE.items():
+            value = getattr(self, field_name)
+            if value in mapping:
+                suggested = mapping[value]
+                # When ``suggested == "eager"`` the trailing "(or 'eager')" hint
+                # would be a tautology, so drop it.
+                hint = (
+                    f"Set {field_name}='{suggested}' explicitly"
+                    if suggested == "eager"
+                    else f"Set {field_name}='{suggested}' (or 'eager') in your config explicitly"
+                )
+                raise ValueError(
+                    f"{field_name}='{value}' is GPU-only but the current device is NPU. "
+                    f"{hint}. "
+                    f"Defaults in OpsImplementationConfig target GPU; on NPU every kernel "
+                    f"that does not have a portable implementation must be opted into."
+                )
 
     def _validate_implementations(self):
         """Validate that requested backends are actually available.

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -632,13 +632,41 @@ _LEGACY_ALIASES: Dict[str, Dict[str, str]] = {
     },
 }
 
-# Values that are GPU-only (the GPU-reasonable defaults below) but have a
-# direct NPU equivalent. Used by ``_validate_device_compatibility`` to give a
-# clear, actionable error on NPU when a GPU value would otherwise reach
-# bind-time and fail with a less helpful message.
+# Active validation rule (NOT just documentation). Read by
+# ``_validate_device_compatibility`` at ``__post_init__`` time:
+# when ``IS_NPU_AVAILABLE`` is true, the validator iterates this table and
+# RAISES ``ValueError`` for any field whose current value is listed here.
 #
-# ``"eager"`` and load-balancing-loss ``"triton"`` (which works on NPU via
-# ``triton-ascend``) are universal — not listed here.
+# Schema:
+#     {
+#       <ops_implementation field name>: {
+#         <gpu-only value that is NOT supported on NPU>: <suggested NPU replacement>,
+#         ...
+#       },
+#       ...
+#     }
+#
+# The inner mapping serves two roles at once:
+#   1. **Membership check** — `value in mapping` is the gate that triggers
+#      the error.  Adding a new (field, value) entry is what *makes* it
+#      forbidden on NPU; removing the entry makes it allowed.
+#   2. **Error-message hint** — the inner value is interpolated into the
+#      raised message so the user sees a concrete copy-pasteable
+#      replacement (``Set rms_norm_implementation='npu' (or 'eager')``).
+#
+# Anything *not* listed here is implicitly allowed on NPU. In particular:
+#   - ``"eager"`` is universal across every field, so it never appears here.
+#   - ``load_balancing_loss_implementation`` has no entry: its ``triton``
+#     value is portable across CUDA ``triton`` and NPU ``triton-ascend``
+#     (same import name), and the package availability gate lives in
+#     ``_validate_implementations`` via the BackendSpec ``requires=("triton",)``
+#     declaration — not here.
+#   - ``attn_implementation`` is the one field validated *after* the SP
+#     rewrite, so its entry has to list both the user-facing names
+#     (``flash_attention_2``) and the rewritten ones
+#     (``veomni_flash_attention_2_with_sp``); both forms reach this
+#     validator depending on whether the user already passed the
+#     pre-rewrite or post-rewrite value.
 _NPU_INCOMPATIBLE: Dict[str, Dict[str, str]] = {
     # ``attn_implementation`` is checked after the SP rewrite, so both the
     # user-facing names and the rewritten ``veomni_flash_attention_*_with_sp``
@@ -775,12 +803,20 @@ class OpsImplementationConfig:
         },
     )
     load_balancing_loss_implementation: str = field(
-        default="triton",
+        default="eager",
         metadata={
             "help": "MoE load-balancing loss implementation. "
-            "'triton' (default) uses a fused Triton kernel — works on GPU "
-            "(``triton``) and on NPU (``triton-ascend``). "
-            "'eager' uses PyTorch reference."
+            "'eager' (default) uses the PyTorch reference. The default stays "
+            "eager (not GPU-reasonable) because this op is GLOBAL-scoped: "
+            "``apply_ops_config`` resolves it eagerly for *every* model — "
+            "including dense models that never call this loss — so a "
+            "non-eager default would force every dense run to depend on the "
+            "fused kernel package, even on hosts (e.g. the standard "
+            "``--extra npu`` install) that don't ship triton-ascend. "
+            "MoE configs that want the speedup can opt in to "
+            "``load_balancing_loss_implementation: triton`` explicitly. "
+            "The triton kernel is portable across CUDA ``triton`` and NPU "
+            "``triton-ascend`` (both expose the same import name)."
         },
     )
 

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -175,12 +175,13 @@ def build_foundation_model(
         logger.warning_rank0(
             "build_foundation_model was called before apply_ops_config. VeOmni "
             "assumes training goes through BaseTrainer, which installs the ops "
-            "config for you. Installing OpsImplementationConfig() defaults now "
-            "so self.loss_function() does not trip on missing kwargs. If you "
-            "are running a standalone script, call apply_ops_config(...) "
+            "config for you. Installing OpsImplementationConfig.eager_defaults() "
+            "now so self.loss_function() does not trip on missing kwargs and "
+            "the build does not require liger-kernel / triton / fused MoE. If "
+            "you are running a standalone script, call apply_ops_config(...) "
             "yourself before build_foundation_model to pick kernel backends."
         )
-        apply_ops_config(OpsImplementationConfig())
+        apply_ops_config(OpsImplementationConfig.eager_defaults())
 
     if config_kwargs is None:
         config_kwargs = {}

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -61,6 +61,44 @@ def build_config(config_path: str, **config_kwargs) -> "PretrainedConfig":
     return get_model_config(config_path, trust_remote_code=trust_remote_code, **config_kwargs)
 
 
+_MOE_EXPERT_COUNT_FIELDS = (
+    # Names used by HF MoE configs for the routed-experts dimension. Any one
+    # of these being present (and > 0) means the model has MoE experts.
+    "num_experts",
+    "num_local_experts",
+    "moe_num_experts",
+    "n_routed_experts",
+)
+
+
+def _config_is_moe(config) -> bool:
+    """Return True if *config* declares any MoE expert dimension.
+
+    The legacy MoE patch (``apply_moe_patch_transformers_v4``) binds a fused
+    MoE kernel via ``apply_veomni_fused_moe_patch``. With the GPU-reasonable
+    ``moe_implementation`` default flipped from ``"eager"`` to
+    ``"fused_triton"``, that patch would otherwise fire for *every* model
+    (Llama / plain Qwen / etc.) and crash on hosts without triton (or NPU
+    where ``fused_triton`` is GPU-only). We short-circuit it for non-MoE
+    configs so dense models pay no cost from the new default.
+
+    Walks the top-level config plus any ``text_config`` / ``language_config``
+    sub-config (used by VLM wrappers like Qwen2-VL / Qwen3-VL) since those
+    place the MoE fields on the language sub-config rather than the wrapper.
+    """
+    candidates = [config]
+    for sub_attr in ("text_config", "language_config"):
+        sub = getattr(config, sub_attr, None)
+        if sub is not None:
+            candidates.append(sub)
+    for cand in candidates:
+        for field_name in _MOE_EXPERT_COUNT_FIELDS:
+            value = getattr(cand, field_name, None)
+            if value is not None and value > 0:
+                return True
+    return False
+
+
 def apply_moe_patch_transformers_v4(config, moe_implementation: str):
     """Legacy MoE dispatch path for models that don't use OpSlot.
 
@@ -258,6 +296,17 @@ def build_foundation_model(
         if _module_has_opslot(pre_load_modeling_module, "moe_experts"):
             logger.info_rank0(
                 f"Model has a 'moe_experts' OpSlot; ignoring legacy moe_implementation={moe_implementation!r}."
+            )
+        elif not _config_is_moe(config):
+            # Dense models (Llama, plain Qwen, etc.) don't have experts. With
+            # the new ``moe_implementation`` default of ``"fused_triton"``,
+            # falling through to the legacy patch would import / bind a fused
+            # MoE kernel that the model never uses, and would outright crash on
+            # hosts without triton (or on NPU where ``fused_triton`` is
+            # GPU-only). Skip the patch so dense models pay zero cost from the
+            # new default.
+            logger.info_rank0(
+                f"Config has no MoE expert dimension; skipping legacy MoE patch (moe_implementation={moe_implementation!r})."
             )
         else:
             apply_moe_patch_transformers_v4(config, moe_implementation)

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -71,6 +71,15 @@ _MOE_EXPERT_COUNT_FIELDS = (
 )
 
 
+# Sub-config attribute names that may contain (or themselves contain) the
+# MoE expert dimension. Walked recursively by ``_config_is_moe`` so models
+# with nested config layouts are picked up. The inclusion of
+# ``thinker_config`` covers the Qwen Omni family
+# (``Qwen3OmniMoeConfig.thinker_config.text_config.num_experts``); the
+# others cover VLM wrappers that place language-model fields on a sub-config.
+_MOE_NESTED_CONFIG_ATTRS = ("text_config", "language_config", "thinker_config")
+
+
 def _config_is_moe(config) -> bool:
     """Return True if *config* declares any MoE expert dimension.
 
@@ -82,21 +91,30 @@ def _config_is_moe(config) -> bool:
     where ``fused_triton`` is GPU-only). We short-circuit it for non-MoE
     configs so dense models pay no cost from the new default.
 
-    Walks the top-level config plus any ``text_config`` / ``language_config``
-    sub-config (used by VLM wrappers like Qwen2-VL / Qwen3-VL) since those
-    place the MoE fields on the language sub-config rather than the wrapper.
+    Walks the top-level config plus any sub-config in ``_MOE_NESTED_CONFIG_ATTRS``
+    *recursively*, so deeply nested layouts are covered too — notably
+    ``Qwen3OmniMoeConfig.thinker_config.text_config.num_experts``.
     """
-    candidates = [config]
-    for sub_attr in ("text_config", "language_config"):
-        sub = getattr(config, sub_attr, None)
-        if sub is not None:
-            candidates.append(sub)
-    for cand in candidates:
+    seen: set[int] = set()
+
+    def _walk(cand) -> bool:
+        if cand is None or id(cand) in seen:
+            return False
+        seen.add(id(cand))
+
         for field_name in _MOE_EXPERT_COUNT_FIELDS:
             value = getattr(cand, field_name, None)
             if value is not None and value > 0:
                 return True
-    return False
+
+        for sub_attr in _MOE_NESTED_CONFIG_ATTRS:
+            sub = getattr(cand, sub_attr, None)
+            if sub is not None and _walk(sub):
+                return True
+
+        return False
+
+    return _walk(config)
 
 
 def apply_moe_patch_transformers_v4(config, moe_implementation: str):

--- a/veomni/ops/config/registry.py
+++ b/veomni/ops/config/registry.py
@@ -69,7 +69,9 @@ class BackendSpec:
     Attributes:
         entry: ``"module:attr"`` - lazily imported to resolve the replacement.
         requires: Package names that must be available, checked before
-            resolution. Supported values: ``"liger_kernel"``, ``"torch_npu"``.
+            resolution. Supported values: ``"liger_kernel"``, ``"torch_npu"``,
+            ``"triton"`` (covers both CUDA ``triton`` and NPU ``triton-ascend``
+            since both expose the same import name).
         side_effect: GLOBAL ops only. ``"module:callable"`` invoked after
             ``entry`` is bound to ``global_slot`` (e.g. installing additional
             ``LOSS_MAPPING`` entries).
@@ -174,6 +176,14 @@ def _check_requires(requires: tuple[str, ...]) -> None:
 
             if not is_torch_npu_available():
                 raise RuntimeError("npu backend requested but torch_npu is not installed.")
+        elif pkg == "triton":
+            # ``triton`` (CUDA) and ``triton-ascend`` (NPU) both expose the
+            # same ``triton`` import name, so a single package check covers
+            # both stacks.
+            from ...utils.import_utils import is_package_available
+
+            if not is_package_available("triton"):
+                raise RuntimeError("triton backend requested but neither triton nor triton-ascend is installed.")
         else:
             raise ValueError(f"Unsupported 'requires' token: {pkg!r}")
 

--- a/veomni/ops/kernels/load_balancing_loss/__init__.py
+++ b/veomni/ops/kernels/load_balancing_loss/__init__.py
@@ -71,7 +71,7 @@ register_op(
         config_field="load_balancing_loss_implementation",
         label="LoadBalancingLoss",
         scope=OpScope.GLOBAL,
-        default="eager",
+        default="triton",
         global_slot="veomni.ops.kernels.load_balancing_loss:_load_balancing_loss",
         backends={
             "eager": BackendSpec(entry="veomni.ops.kernels.load_balancing_loss.eager:load_balancing_loss_pytorch"),

--- a/veomni/ops/kernels/load_balancing_loss/__init__.py
+++ b/veomni/ops/kernels/load_balancing_loss/__init__.py
@@ -75,7 +75,17 @@ register_op(
         global_slot="veomni.ops.kernels.load_balancing_loss:_load_balancing_loss",
         backends={
             "eager": BackendSpec(entry="veomni.ops.kernels.load_balancing_loss.eager:load_balancing_loss_pytorch"),
-            "triton": BackendSpec(entry="veomni.ops.kernels.load_balancing_loss.triton:load_balancing_loss_triton"),
+            # ``apply_global_ops`` resolves GLOBAL ops eagerly for every model
+            # — including dense models that never call this loss. Declare the
+            # triton dependency on the BackendSpec so the availability check
+            # fires at ``__post_init__`` time with an actionable error rather
+            # than crashing later when ``apply_global_ops`` imports the
+            # ``triton`` kernel module on a host that doesn't have triton /
+            # triton-ascend installed.
+            "triton": BackendSpec(
+                entry="veomni.ops.kernels.load_balancing_loss.triton:load_balancing_loss_triton",
+                requires=("triton",),
+            ),
         },
     )
 )

--- a/veomni/ops/kernels/load_balancing_loss/__init__.py
+++ b/veomni/ops/kernels/load_balancing_loss/__init__.py
@@ -71,7 +71,13 @@ register_op(
         config_field="load_balancing_loss_implementation",
         label="LoadBalancingLoss",
         scope=OpScope.GLOBAL,
-        default="triton",
+        # Default kept at ``eager`` (not GPU-reasonable like the other ops)
+        # because this op is GLOBAL-scoped: ``apply_ops_config`` resolves it
+        # eagerly for every model, including dense models that never call
+        # this loss. A non-eager default would force every dense run to
+        # depend on the fused kernel package — see the ``help`` string on
+        # ``OpsImplementationConfig.load_balancing_loss_implementation``.
+        default="eager",
         global_slot="veomni.ops.kernels.load_balancing_loss:_load_balancing_loss",
         backends={
             "eager": BackendSpec(entry="veomni.ops.kernels.load_balancing_loss.eager:load_balancing_loss_pytorch"),

--- a/veomni/ops/kernels/rms_norm/__init__.py
+++ b/veomni/ops/kernels/rms_norm/__init__.py
@@ -30,7 +30,7 @@ register_op(
         config_field="rms_norm_implementation",
         label="RMSNorm",
         scope=OpScope.PER_MODEL,
-        default="eager",
+        default="liger_kernel",
         backends={
             "liger_kernel": BackendSpec(
                 entry="liger_kernel.transformers.rms_norm:LigerRMSNorm",

--- a/veomni/ops/kernels/rotary/__init__.py
+++ b/veomni/ops/kernels/rotary/__init__.py
@@ -30,7 +30,7 @@ register_op(
         config_field="rotary_pos_emb_implementation",
         label="RoPE",
         scope=OpScope.PER_MODEL,
-        default="eager",
+        default="liger_kernel",
         backends={
             "liger_kernel": BackendSpec(
                 entry="liger_kernel.transformers.rope:liger_rotary_pos_emb",

--- a/veomni/ops/kernels/swiglu/__init__.py
+++ b/veomni/ops/kernels/swiglu/__init__.py
@@ -27,7 +27,7 @@ register_op(
         config_field="swiglu_mlp_implementation",
         label="SwiGLU",
         scope=OpScope.PER_MODEL,
-        default="eager",
+        default="liger_kernel",
         backends={
             "liger_kernel": BackendSpec(
                 entry="liger_kernel.transformers.swiglu:LigerSwiGLUMLP",


### PR DESCRIPTION
### What does this PR do?

> Defaults on `OpsImplementationConfig` flip from `"eager"` to **GPU-reasonable values** so the standard `--extra gpu` install gets the fused kernels out of the box. On Ascend NPU, kernel-registry defaults that have no NPU implementation now raise in `__post_init__` with an actionable suggestion — no silent hardware fallback, no late failure inside a kernel. New `OpsImplementationConfig.eager_defaults()` is the explicit portable escape hatch (used by the `build_foundation_model` standalone-script fallback). Builds on #678 and #696; supersedes the abandoned `auto`-resolution proposal in #699.

### Checklist Before Starting

- Builds on #678 (kernel registry refactor) and #696 (runtime ckpt converter); supersedes #699.
- PR title follows `[BREAKING][{modules}] {type}: {description}`.

### ⚠️ Breaking Changes

> Default values changed for 5 kernel-registry fields. Existing GPU YAMLs that didn't override these fields will now use fused kernels (different numerics from eager). Existing NPU YAMLs that didn't override them will now fail at config-parse time with a clear "set this field to '<npu_value>' (or 'eager')" error.
>
> | Field | Old | New |
> |---|---|---|
> | `attn_implementation` | `flash_attention_2` | `flash_attention_2` (unchanged) |
> | `moe_implementation` | `eager` | `fused_triton` |
> | `cross_entropy_loss_implementation` | `eager` | `liger_kernel` |
> | `rms_norm_implementation` | `eager` | `liger_kernel` |
> | `swiglu_mlp_implementation` | `eager` | `liger_kernel` |
> | `rotary_pos_emb_implementation` | `eager` | `liger_kernel` |
> | `load_balancing_loss_implementation` | `eager` | `eager` (unchanged — see below) |
>
> Backwards-compatible alias: `moe_implementation: 'fused'` (pre-#678 auto-pick) is rewritten to `'fused_triton'` with a deprecation warning.

### Test

> 23 tests in `tests/ops/test_ops_config_defaults.py` cover: every field's default value; the legacy `'fused'` alias rewrite; the NPU validator matrix (per-field GPU-only-value → suggested-replacement); `eager_defaults()` portability on NPU; the `triton` package gate for `load_balancing_loss`; GPU host is a no-op for the validator.
>
> All 109 tests in `tests/ops/` pass; `tests/models/test_models_patch.py` (116 tests) and `tests/models/test_padded_packed_loss.py` pass after switching two test sites to `eager_defaults()`. GPU CI runs `tests/ops` directory-wide, so the new file is auto-included; NPU CI gets an explicit entry in `npu_unit_tests.yml`.

### API and Usage Example

> **GPU YAML — minimal config now picks fast kernels automatically:**
>
> ```yaml
> model:
>   ops_implementation:
>     attn_implementation: flash_attention_2
>     # everything else uses GPU-reasonable defaults — fused_triton MoE,
>     # Liger RMSNorm/RoPE/SwiGLU/CE. Set load_balancing_loss_implementation:
>     # triton explicitly to opt into the fused load-balancing loss kernel.
> ```
>
> **NPU YAML — override the kernel-registry fields:**
>
> ```yaml
> model:
>   ops_implementation:
>     moe_implementation: fused_npu
>     cross_entropy_loss_implementation: npu
>     rms_norm_implementation: npu
>     rotary_pos_emb_implementation: npu
>     swiglu_mlp_implementation: eager      # no NPU fused SwiGLU
>     # attn_implementation: pluggable via ALL_ATTENTION_FUNCTIONS — keep
>     # flash_attention_2 if your FA-on-NPU provider is installed; else
>     # set sdpa or eager.
> ```
>
> **Python — explicit eager fallback** (standalone scripts / tests):
>
> ```python
> from veomni.arguments.arguments_types import OpsImplementationConfig
> from veomni.ops import apply_ops_config
>
> apply_ops_config(OpsImplementationConfig.eager_defaults())
> ```

### Design & Code Changes

> **Defaults flipped** — 5 kernel-registry fields default to GPU-reasonable values; help text updated.
>
> **NPU validator** (`_NPU_INCOMPATIBLE` table + `_validate_device_compatibility` in `veomni/arguments/arguments_types.py`) — table-driven membership check that raises `ValueError` with a copy-pasteable suggestion when a GPU-only value reaches an NPU host. Covers MoE, Liger fields, and per-model `triton` RMSNorm/RoPE.
>
> **Two exceptions** to the GPU-reasonable rule, both deliberate:
>
> 1. **`attn_implementation`** is *not* in the validator. Attention is dispatched via transformers' `ALL_ATTENTION_FUNCTIONS` registry, which is genuinely pluggable — third-party backends register kernels for any name (including FA2/3/4 on Ascend) at runtime. A pre-flight check at config-parse time can't see those registrations, so a hard rule would reject legitimate setups. Compatibility is gated at the FA-import site instead, which raises a clear `ImportError` when the requested backend is unavailable.
>
> 2. **`load_balancing_loss_implementation`** keeps an `eager` default. The op is GLOBAL-scoped — `apply_ops_config` resolves it eagerly for *every* model, including dense models that never call this loss — so a fused default would make every dense run on every host depend on the triton package (or `triton-ascend` on NPU, which is **not** in the standard `--extra npu` install). MoE configs that want the speedup opt in explicitly with `load_balancing_loss_implementation: triton`. This is the one place we trade "fast by default for the common GPU MoE case" for "no spurious dependency on dense runs."
>
> **`OpsImplementationConfig.eager_defaults()` classmethod** sets every kernel field — including `attn_implementation` — to `"eager"`. Used by the `build_foundation_model` standalone-script fallback so the build doesn't transitively require liger-kernel / triton / fused MoE. Hardcoded field-by-field on purpose: each addition forces a deliberate decision about the new field's NPU behavior.
>
> **Triton package gate** — new `requires=("triton",)` token in `BackendSpec`, recognized by `_check_requires` and `_validate_implementations`. Single check covers CUDA `triton` and NPU `triton-ascend` (same import name). Declared on the `load_balancing_loss` triton BackendSpec so explicit opt-in raises at config-parse time on hosts without triton, before `apply_global_ops` would crash inside the kernel module import.
>
> **Dense-model MoE-patch skip** (`_config_is_moe` in `veomni/models/auto.py`) — recursive walk over `(text_config, language_config, thinker_config)` sub-configs (with cycle protection) checking for `num_experts` / `num_local_experts` / `moe_num_experts` / `n_routed_experts`. When none are present, `build_foundation_model` short-circuits the legacy `apply_moe_patch_transformers_v4` call. Without this, the new `fused_triton` default would make every dense config (Llama, plain Qwen) try to bind a fused MoE kernel that the model never calls — a no-op pre-PR with `default="eager"`, but a hard crash with the new default. The `thinker_config` walk specifically covers `Qwen3OmniMoeConfig.thinker_config.text_config.num_experts`.
>
> **Test plumbing** (`tests/tools/training_utils.py`) — extended the existing `_FUSED_MOE_IMPL` per-host pattern to all kernel fields. New `host_appropriate_ops_cli_args(*, separator=, attn_implementation=, eager_only=)` returns the `--model.ops_implementation.*` CLI args needed to keep subprocess'd `parse_args(VeOmniArguments)` from tripping the new NPU validator. `eager_only=True` forces everything to `"eager"` for tests that don't exercise kernels (data-pipeline, tiny-model, checkpoint save/load). `tests/models/test_{models_patch,vlm_trainer}.py` pass `ops_implementation=OpsImplementationConfig.eager_defaults()` on the in-process `ModelArguments(...)` so the placeholder constructs cleanly on every device; per-mode kernel selection still happens later via `set_environ_param`.
>
> **Docs** — `docs/design/kernel_selection.md` Quick Reference defaults updated, with a "Defaults are GPU-reasonable" callout plus a "Two exceptions" subsection (`attn_implementation` pluggability + `load_balancing_loss` GLOBAL-scope rationale). `docs/usage/arguments.md` mirrors the same guidance on the per-field table.

### Tradeoffs

> - **NPU friction.** NPU users now have to override 4–5 kernel fields where pre-PR they got away with overriding 0–2. Accepted in exchange for "GPU users get fast kernels by default" and "no silent fallback when an opt-in fails." The validator's error message is copy-pasteable so the migration is one-shot, not exploratory.
> - **`load_balancing_loss` exception.** Could keep the rule "every default is GPU-reasonable" by making the load-balancing dispatch lazy (only resolve the kernel when the loss is actually called). Decided against it as out-of-scope — `apply_global_ops` is GLOBAL-eager by design (#678), and an opt-in default for one MoE-only kernel is a much smaller surface than touching the global-ops resolution path.
> - **`attn_implementation` exception.** Could keep the rule "every NPU-incompatible default raises" by hard-coding `flash_attention_2 → sdpa` on NPU. Decided against it because attention dispatch is genuinely pluggable (third-party FA-on-Ascend backends register at runtime) and a pre-flight check would reject those legitimate setups. The FA-import-site `ImportError` is a cleaner failure point.
> - **Dense-model MoE-patch skip.** Could leave dense models running through `apply_veomni_fused_moe_patch("triton")` and rely on the kernel never being called. Decided against it because the patch path itself crashes on hosts without triton (or NPU), so the "never called" property is too fragile to depend on.
> - **`_NPU_INCOMPATIBLE` and `eager_defaults` are hardcoded** rather than introspected. Hardcoding catches accidental default changes (regression-guard semantics) and forces a deliberate per-field decision when a new `*_implementation` is added. Auto-introspection would silently pick up new fields, which is exactly the wrong default for a config that drives device-specific dispatch.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (`make quality` clean)
- [x] Added/updated documentation (`docs/design/kernel_selection.md`, `docs/usage/arguments.md`)
- [x] Added tests to CI workflow (`tests/ops/test_ops_config_defaults.py`; auto-included in GPU CI's `tests/ops` directory run; explicit entry added to NPU CI workflow)
