### PR TITLE
[misc] feat: add ep_size property to ParallelState

### DIFF
--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -339,6 +339,10 @@ class ParallelState:
         return self.extra_parallel_enabled("ep")
 
     @property
+    def ep_size(self) -> int:
+        return self.extra_parallel_sizes["ep"]
+
+    @property
     def ep_rank(self) -> int:
         return self.extra_parallel_rank("ep")
 


### PR DESCRIPTION
### What does this PR do?

This PR adds ep_size as a dedicated property alongside existing EP-related accessors such as ep_enabled, ep_rank, and ep_fsdp_size.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
