### PR TITLE
[model, ops] refactor: keep moe implementation at model build

### DIFF
--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -19,11 +19,11 @@ selection knob.
 | SwiGLU MLP | `swiglu_mlp_implementation` | `eager`, `liger_kernel` | `"eager"` | Model registration via ops config singleton |
 | Rotary embedding | `rotary_pos_emb_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"eager"` | Model registration via ops config singleton |
 | Load-balancing loss | `load_balancing_loss_implementation` | `eager`, `triton` (CUDA `triton` or NPU `triton-ascend`) | `"eager"` | `apply_ops_config()` (before model build) |
-| MoE experts | `moe_implementation` | `eager`, `fused_triton`, `fused_quack` (SM90+), `fused_npu` | `"eager"` | `build_foundation_model` |
+| MoE experts | `moe_implementation` | `eager`, `fused`, `fused_triton`, `fused_quack` (SM90+), `fused_npu` | `"fused"` | `build_foundation_model` |
 
-The per-op fields are typed as plain `str` (not `Literal`), so third-party
-backends can be registered via `extra_backends` in a model's `device_patch.py`
-without modifying `OpsImplementationConfig`.
+The per-op fields are typed as plain `str` (not `Literal`) so validation can
+live at each dispatch boundary. Some per-model ops still support third-party
+or model-local backends through `extra_backends` in a model's `device_patch.py`.
 
 ---
 
@@ -269,21 +269,30 @@ selected backend automatically — no per-model patching needed.
 ```yaml
 model:
   ops_implementation:
-    moe_implementation: fused_triton   # Triton group-gemm (GPU, SM70+)
+    moe_implementation: fused          # Auto: NPU -> fused_npu, SM100+ -> fused_quack, other GPUs -> fused_triton
+    # moe_implementation: fused_triton # Triton group-gemm (GPU, SM70+)
     # moe_implementation: fused_quack  # Quack CUTLASS/CuTe (GPU, SM90+)
     # moe_implementation: fused_npu    # NPU group-gemm (Ascend)
     # moe_implementation: eager        # Reference PyTorch loop (very slow, debug only)
 ```
 
 **Field:** `OpsImplementationConfig.moe_implementation`
-**Default:** `"eager"`
+**Default:** `"fused"`
 
-The mode and kernel backend are expressed as a single field. Mismatches raise
-at ``apply_veomni_fused_moe_patch`` time — no silent hardware fallback.
+The mode and kernel backend are expressed as a single field. ``fused`` resolves
+to one concrete backend before model construction. Mismatches raise at
+``apply_veomni_fused_moe_patch`` / OpSlot bind time — no silent hardware
+fallback.
+
+Transformers v4 MoE models always use the legacy ``_moe_implementation`` +
+global ``fused_moe_forward`` path. Transformers v5 MoE models use OpSlot only
+when their generated modeling module declares ``OpSlot("moe_experts", ...)``;
+otherwise they remain on the same legacy global-pointer path.
 
 | Value | Kernel | Hardware | EP support |
 |-------|--------|----------|:----------:|
 | `eager` | PyTorch expert loop | Any | No |
+| `fused` | Auto: NPU, Quack on SM100+, otherwise Triton | NPU or CUDA GPU | Backend-dependent |
 | `fused_triton` | Triton group-gemm | GPU, SM70+ (V100+) | Yes |
 | `fused_quack` | Quack CUTLASS/CuTe | GPU, SM90+ (H100+) | No |
 | `fused_npu` | NPU group-gemm | Ascend NPU | Yes |
@@ -368,7 +377,7 @@ All four are defined in `transformers.integrations`:
 | | VeOmni | Transformers v5 |
 |---|--------|----------------|
 | **Mechanism** | `apply_veomni_fused_moe_patch()` replaces the global `fused_moe_forward` function pointer. Internally `config._moe_implementation ∈ {"eager", "fused"}` flags whether the patched experts should call the pointer at all; the actual kernel (Triton / Quack / NPU) is selected by `OpsImplementationConfig.moe_implementation`. | `@use_experts_implementation` decorator on `Qwen3MoeExperts` class; at forward time dispatches via `ALL_EXPERTS_FUNCTIONS.get_interface(config._experts_implementation, original_forward)`. Built-in implementations: `"batched_mm"` (BMM-based), `"grouped_mm"` (PyTorch `torch.nn.functional.grouped_mm`, requires PT 2.9+). |
-| **Config** | `OpsImplementationConfig.moe_implementation` (`"eager"` / `"fused_triton"` / `"fused_quack"` / `"fused_npu"`) | `config._experts_implementation` (`"eager"` / `"batched_mm"` / `"grouped_mm"`) |
+| **Config** | `OpsImplementationConfig.moe_implementation` (`"eager"` / `"fused"` / `"fused_triton"` / `"fused_quack"` / `"fused_npu"`) | `config._experts_implementation` (`"eager"` / `"batched_mm"` / `"grouped_mm"`) |
 | **EP support** | `fused_triton` and `fused_npu` paths support Expert Parallelism via VeOmni's EP sharding | `batched_mm` handles invalid expert IDs (sentinel `>= num_experts`) for EP compatibility |
 | **When** | Deferred to `build_foundation_model()` | Decorator at class definition time; dispatch at forward time |
 

--- a/docs/design/unified_kernel_registry.md
+++ b/docs/design/unified_kernel_registry.md
@@ -254,13 +254,13 @@ class OpsImplementationConfig:
         "native-sparse",
     ] = "flash_attention_2"
 
-    # Per-op implementation selection (all default to "eager" = original HF code)
+    # Per-op implementation selection.
     rms_norm_implementation: str = "eager"
     rms_norm_gated_implementation: str = "eager"   # (proposed — not yet shipped)
     rotary_pos_emb_implementation: str = "eager"
     swiglu_mlp_implementation: str = "eager"
     # MoE: single-field backend selection — no silent hardware fallback.
-    moe_implementation: Literal["eager", "fused_triton", "fused_quack", "fused_npu"] = "eager"
+    moe_implementation: str = "fused"
     cross_entropy_loss_implementation: str = "eager"
     load_balancing_loss_implementation: str = "eager"
 ```
@@ -274,7 +274,7 @@ PR — see `veomni/arguments/arguments_types.py`):
 | `rms_norm_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | |
 | `rotary_pos_emb_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | |
 | `swiglu_mlp_implementation` | `eager`, `liger_kernel` | |
-| `moe_implementation` | `eager`, `fused_triton`, `fused_quack`, `fused_npu` | Single field; mismatches (e.g. `fused_triton` on NPU) raise in `apply_veomni_fused_moe_patch` rather than silently falling back |
+| `moe_implementation` | `eager`, `fused`, `fused_triton`, `fused_quack`, `fused_npu` | Single field; `fused` resolves to `fused_npu` on NPU, `fused_quack` on SM100+ GPUs, and `fused_triton` on other GPUs. Mismatches raise in `apply_veomni_fused_moe_patch` / OpSlot bind rather than silently falling back |
 | `cross_entropy_loss_implementation` | `eager`, `liger_kernel`, `npu` | |
 | `load_balancing_loss_implementation` | `eager`, `triton` | `triton` backend works on CUDA (`triton`) and NPU (`triton-ascend`); introduced in #651 and kept through this refactor |
 
@@ -346,8 +346,8 @@ User YAML                    OpsImplementationConfig              OpSlot.bind()
 ─────────                    ───────────────────────              ─────────────
 model:                       @dataclass
   ops_implementation:  ───→  class OpsImplementationConfig:
-    moe_implementation:          moe_implementation: Literal[...]
-      fused_triton                         │
+    moe_implementation:          moe_implementation: str
+      fused                               │
                                            ▼
                              build_foundation_model(config)
                                ├─ import patched_modeling_qwen3_5_moe_gpu
@@ -357,10 +357,11 @@ model:                       @dataclass
                                │         veomni_load_balancing_loss   = OpSlot(...)
                                │    (all start with _kernel = None)
                                │
-                               ├─ _bind_veomni_ops(module, ops_config):
-                               │    for name, obj in vars(module).items():
-                               │        if isinstance(obj, OpSlot):
-                               │            impl = getattr(ops_config, f"{obj.op_name}_implementation", "eager")
+                              ├─ resolve fused -> concrete backend
+                              ├─ _bind_veomni_ops(module, ops_config, moe_implementation):
+                              │    for name, obj in vars(module).items():
+                              │        if isinstance(obj, OpSlot):
+                              │            impl = getattr(ops_config, f"{obj.op_name}_implementation", "eager")
                                │            obj.bind(impl)     ← resolves via KERNEL_REGISTRY
                                │
                                └─ model init + weight loading
@@ -374,18 +375,15 @@ module-global lookup does the work.
 ```python
 # veomni/models/auto.py
 
-def _bind_veomni_ops(modeling_module, ops_config: OpsImplementationConfig):
+def _bind_veomni_ops(modeling_module, ops_config: OpsImplementationConfig, moe_implementation: str):
     """Find all OpSlot instances in the module and bind them."""
     for name, obj in vars(modeling_module).items():
         if isinstance(obj, OpSlot):
             # `moe_experts` is the one op whose config field is `moe_implementation`
-            # (not `moe_experts_implementation`) and whose values carry a `fused_`
-            # prefix that registry entries don't — translate here.
+            # (not `moe_experts_implementation`) and whose values may be auto
+            # mode (`fused`) or carry a `fused_` prefix — resolve/translate here.
             if obj.op_name == "moe_experts":
-                impl_name = (
-                    "eager" if ops_config.moe_implementation == "eager"
-                    else ops_config.moe_implementation.removeprefix("fused_")
-                )
+                impl_name = _select_moe_kernel_by_device(moe_implementation).kernel_name or "eager"
             else:
                 impl_name = getattr(ops_config, f"{obj.op_name}_implementation", "eager")
             obj.bind(impl_name)  # validates variant + hardware
@@ -738,9 +736,9 @@ build_foundation_model(config)                     # (4) model build time
   │         veomni_causal_lm_loss        = OpSlot("cross_entropy_loss", "causal")
   │         (all start with _kernel = None)
   │
-  ├─ _bind_veomni_ops(module, ops_config):          #     bind from config
+  ├─ _bind_veomni_ops(module, ops_config, moe_implementation):
   │    for each OpSlot in vars(module):
-  │        impl = ops_config.moe_implementation.removeprefix("fused_")   # if moe_experts
+  │        impl = resolved_moe.kernel_name or "eager"      # if moe_experts
   │              or getattr(ops_config, f"{slot.op_name}_implementation", "eager")
   │        slot.bind(impl)                                    # KERNEL_REGISTRY.resolve()
   │
@@ -770,7 +768,7 @@ model.forward()                                    # (5) runtime
 | `gpu_patch.py` monkey-patching | patchgen + `OpSlot` guards | Remove `gpu_patch.py` files |
 | `apply_veomni_loss_patch()` at import | `cross_entropy_loss_implementation` + `OpSlot` | Remove import-time patch |
 | `apply_veomni_fused_moe_patch()` | `OpSlot("moe_experts", ...)` | Kept for legacy-dispatch models (qwen3_moe etc.) until they adopt OpSlot |
-| `moe_implementation: fused` (auto-picks Triton on GPU / NPU group-gemm on NPU) | `moe_implementation: fused_triton` or `fused_npu` | Breaking change — `"fused"` renamed to `"fused_triton"` and the silent NPU auto-pick replaced by explicit `"fused_npu"`. `fused_quack` is unchanged. |
+| `moe_implementation: fused` | shared resolver in `build_foundation_model` | Auto-picks `fused_npu` on NPU, `fused_quack` on SM100+ GPUs, and `fused_triton` on other GPUs. Explicit `fused_triton` / `fused_quack` / `fused_npu` pins a backend. |
 
 ---
 
@@ -781,9 +779,9 @@ model.forward()                                    # (5) runtime
 2. **Attention:** Keep in `ALL_ATTENTION_FUNCTIONS` (shared with HF) or unify
    under `KERNEL_REGISTRY`?
 3. ~~**NPU auto-selection:** Should NPU be an explicit `npu_group_gemm`
-   implementation name, or remain automatic?~~ **Resolved:** NPU is now opted
-   into explicitly via `moe_implementation: fused_npu`; the previous silent
-   auto-pick was removed so mismatched selections raise at patch/bind time.
+   implementation name, or remain automatic?~~ **Resolved:** `fused` remains
+   the portable auto mode, while explicit `fused_npu` / `fused_triton` /
+   `fused_quack` pin a backend and raise on hardware mismatch.
 4. **Multi-model processes:** Each generated module has its own `OpSlot`
    instances, so different models work independently. But two instances of the
    same model with different ops configs share the same `OpSlot` objects.

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -130,13 +130,13 @@ Root config — assembles `model`, `data`, and `train`.
 `model.ops_implementation.*` — Attention, MoE, and fused kernel implementation.
 
 Each `*_implementation` field selects the kernel backend for that operation.
-The type is `str` (not `Literal`) so third-party backends can be registered
-without modifying the config class.
+The fields are typed as `str` so backend validation can live at the dispatch
+boundary instead of in the dataclass.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | attn_implementation | `Optional[Literal[...]]` | `"flash_attention_2"` | Attention implementation to use. |
-| moe_implementation | `Literal["eager", "fused_triton", "fused_quack", "fused_npu"]` | `"eager"` | MoE experts forward implementation. `fused_triton` uses Triton group-gemm (GPU, SM70+); `fused_quack` uses Quack CUTLASS/CuTe (GPU, SM90+); `fused_npu` uses the NPU group-gemm kernel. Mismatches (e.g. `fused_triton` on NPU) raise at patch time — no silent fallback. |
+| moe_implementation | `str` | `"fused"` | MoE experts forward implementation. `fused` auto-selects `fused_npu` on NPU, `fused_quack` on SM100+ GPUs, and `fused_triton` on other GPUs. Explicit values are `eager`, `fused_triton`, `fused_quack`, and `fused_npu`. Mismatches raise at patch time; there is no silent fallback. |
 | cross_entropy_loss_implementation | `str` | `"eager"` | Cross-entropy loss. Known values: `eager`, `liger_kernel`, `npu` (NPU chunked loss; backs `ForCausalLM` + `ForConditionalGeneration`, `ForSequenceClassification` stays on eager). |
 | rms_norm_implementation | `str` | `"eager"` | RMSNorm. Known values: `eager`, `liger_kernel`, `npu`, `triton`. |
 | swiglu_mlp_implementation | `str` | `"eager"` | SwiGLU MLP. Known values: `eager`, `liger_kernel`. |

--- a/tests/ops/test_moe_hw_gate.py
+++ b/tests/ops/test_moe_hw_gate.py
@@ -22,6 +22,8 @@ rather than silently falling back to another backend.
 Two paths:
 1. Legacy: ``apply_veomni_fused_moe_patch`` (qwen3_moe, deepseek_v3, etc.)
 2. OpSlot: ``KERNEL_REGISTRY.resolve`` via ``HardwareRequirement`` (qwen3_5_moe)
+3. Auto: ``moe_implementation='fused'`` resolves to the accelerator-specific
+   concrete fused backend before either path binds a kernel.
 
 We mock the hardware-detection helpers so the same test suite runs on any
 CI host.
@@ -138,7 +140,7 @@ def test_opslot_unknown_kernel_name_raises():
 @patch(f"{_REGISTRY_MODULE}.IS_CUDA_AVAILABLE", True)
 @patch(f"{_REGISTRY_MODULE}.IS_NPU_AVAILABLE", False)
 @patch(f"{_REGISTRY_MODULE}.get_gpu_compute_capability", return_value=80)
-def test_bind_veomni_ops_translates_moe_implementation_and_checks_hw(_mock_cc):
+def test_bind_veomni_ops_translates_moe_kernel_and_checks_hw(_mock_cc):
     """Reproducer for the silent-fallback regression:
 
     User sets ``moe_implementation='fused_quack'`` on an A100. The binding
@@ -156,6 +158,73 @@ def test_bind_veomni_ops_translates_moe_implementation_and_checks_hw(_mock_cc):
 
     with pytest.raises(RuntimeError, match="compute_capability>=90"):
         _bind_veomni_ops(fake_module, ops_config)
+
+
+@patch("veomni.models.auto.IS_NPU_AVAILABLE", True)
+@patch("veomni.models.auto.IS_CUDA_AVAILABLE", False)
+def test_select_moe_kernel_fused_auto_selects_npu():
+    from veomni.models.auto import _select_moe_kernel_by_device
+
+    resolved = _select_moe_kernel_by_device("fused")
+    assert resolved.config_value == "fused"
+    assert resolved.kernel_name == "npu"
+
+
+@patch("veomni.models.auto.IS_NPU_AVAILABLE", False)
+@patch("veomni.models.auto.IS_CUDA_AVAILABLE", True)
+@patch("veomni.models.auto.get_gpu_compute_capability", return_value=100)
+def test_select_moe_kernel_fused_auto_selects_quack_on_sm100(_mock_cc):
+    from veomni.models.auto import _select_moe_kernel_by_device
+
+    resolved = _select_moe_kernel_by_device("fused")
+    assert resolved.kernel_name == "quack"
+
+
+@patch("veomni.models.auto.IS_NPU_AVAILABLE", False)
+@patch("veomni.models.auto.IS_CUDA_AVAILABLE", True)
+@patch("veomni.models.auto.get_gpu_compute_capability", return_value=90)
+def test_select_moe_kernel_fused_auto_selects_triton_below_sm100(_mock_cc):
+    from veomni.models.auto import _select_moe_kernel_by_device
+
+    resolved = _select_moe_kernel_by_device("fused")
+    assert resolved.kernel_name == "triton"
+
+
+@patch("veomni.models.auto.IS_NPU_AVAILABLE", False)
+@patch("veomni.models.auto.IS_CUDA_AVAILABLE", False)
+def test_select_moe_kernel_fused_auto_requires_accelerator():
+    from veomni.models.auto import _select_moe_kernel_by_device
+
+    with pytest.raises(RuntimeError, match="requires a CUDA GPU or NPU"):
+        _select_moe_kernel_by_device("fused")
+
+
+def test_select_moe_kernel_rejects_unknown_fused_backend():
+    from veomni.models.auto import _select_moe_kernel_by_device
+
+    with pytest.raises(ValueError, match="Expected one of"):
+        _select_moe_kernel_by_device("fused_unit_test_custom")
+
+
+@patch("veomni.models.auto.is_transformers_version_greater_or_equal_to", return_value=False)
+def test_opslot_moe_dispatch_ignores_transformers_v4(_mock_tf_version):
+    from types import SimpleNamespace
+
+    from veomni.models.auto import _module_uses_opslot_moe_dispatch
+
+    fake_module = SimpleNamespace(veomni_moe_experts_forward=OpSlot("moe_experts", "standard"))
+    assert not _module_uses_opslot_moe_dispatch(fake_module)
+
+
+@patch("veomni.models.auto.is_transformers_version_greater_or_equal_to", return_value=True)
+def test_opslot_moe_dispatch_requires_moe_experts_slot(_mock_tf_version):
+    from types import SimpleNamespace
+
+    from veomni.models.auto import _module_uses_opslot_moe_dispatch
+
+    assert not _module_uses_opslot_moe_dispatch(SimpleNamespace())
+    fake_module = SimpleNamespace(veomni_moe_experts_forward=OpSlot("moe_experts", "standard"))
+    assert _module_uses_opslot_moe_dispatch(fake_module)
 
 
 # KERNEL_REGISTRY is a module-level singleton. Assert the registrations the

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -624,8 +624,8 @@ class OpsImplementationConfig:
     """model.ops_implementation.* — Attention, MoE, and fused kernel implementation.
 
     Each ``*_implementation`` field selects the kernel backend for that operation.
-    The type is ``str`` (not ``Literal``) so that third-party backends can be
-    registered without modifying this class.
+    The fields are typed as ``str`` (not ``Literal``) so backend validation can
+    live at the dispatch boundary instead of in the dataclass.
 
     Well-known values:
 
@@ -653,19 +653,18 @@ class OpsImplementationConfig:
         metadata={"help": "Attention implementation to use."},
     )
     moe_implementation: str = field(
-        default="eager",
+        default="fused",
         metadata={
             "help": "MoE experts forward implementation. "
+            "'fused' auto-selects 'fused_npu' on NPU, 'fused_quack' on SM100+ GPUs, "
+            "and 'fused_triton' on other GPUs. "
             "OSS backends: 'fused_triton' (Triton group-gemm, GPU, SM70+), "
             "'fused_quack' (Quack CUTLASS/CuTe, GPU, SM90+), "
             "'fused_npu' (NPU group-gemm, requires torch_npu), "
-            "'eager' (default, reference loop). "
+            "'eager' (reference loop). "
             "The backend must match the hardware — no silent fallback. "
-            "Typed as plain str (not Literal) so third-party backends can be "
-            "plugged in via `apply_veomni_fused_moe_patch` (legacy-dispatch "
-            "models) or `KERNEL_REGISTRY.register(op_name='moe_experts', ...)` "
-            "(OpSlot-dispatch models), matching the extensibility of the "
-            "other *_implementation fields."
+            "Typed as plain str so the CLI/dataclass layer stays simple; "
+            "validation and auto-resolution happen in build_foundation_model."
         },
     )
     cross_entropy_loss_implementation: str = field(

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -15,6 +15,7 @@
 
 import functools
 import sys
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Union
 
 import torch
@@ -28,7 +29,7 @@ from ..arguments.arguments_types import OpsImplementationConfig
 from ..distributed.parallel_state import get_parallel_state
 from ..ops.dispatch import OpSlot
 from ..utils import logging
-from ..utils.device import is_torch_npu_available
+from ..utils.device import IS_CUDA_AVAILABLE, IS_NPU_AVAILABLE, get_gpu_compute_capability, is_torch_npu_available
 from ..utils.import_utils import is_transformers_version_greater_or_equal_to
 from .loader import BaseModelLoader, get_loader, get_model_class, get_model_config, get_model_processor
 
@@ -37,6 +38,45 @@ if TYPE_CHECKING:
     from transformers import PreTrainedTokenizer, ProcessorMixin
 
 logger = logging.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class _ResolvedMoeImplementation:
+    config_value: Literal["eager", "fused"]
+    kernel_name: Optional[str]
+
+
+def _select_moe_kernel_by_device(moe_implementation: str) -> _ResolvedMoeImplementation:
+    """Select the concrete MoE kernel for the user-facing implementation value."""
+    if moe_implementation == "eager":
+        return _ResolvedMoeImplementation(
+            config_value="eager",
+            kernel_name=None,
+        )
+
+    if moe_implementation == "fused":
+        if IS_NPU_AVAILABLE:
+            kernel_name = "npu"
+        elif IS_CUDA_AVAILABLE:
+            kernel_name = "quack" if get_gpu_compute_capability() >= 100 else "triton"
+        else:
+            raise RuntimeError("moe_implementation='fused' requires a CUDA GPU or NPU device.")
+    elif moe_implementation == "fused_triton":
+        kernel_name = "triton"
+    elif moe_implementation == "fused_quack":
+        kernel_name = "quack"
+    elif moe_implementation == "fused_npu":
+        kernel_name = "npu"
+    else:
+        raise ValueError(
+            f"Invalid moe_implementation: {moe_implementation!r}. "
+            "Expected one of: 'eager', 'fused', 'fused_triton', 'fused_quack', 'fused_npu'."
+        )
+
+    return _ResolvedMoeImplementation(
+        config_value="fused",
+        kernel_name=kernel_name,
+    )
 
 
 def build_tokenizer(tokenizer_path: str) -> "PreTrainedTokenizer":
@@ -64,27 +104,21 @@ def build_config(config_path: str, **config_kwargs) -> "PretrainedConfig":
 def apply_moe_patch_transformers_v4(config, moe_implementation: str):
     """Legacy MoE dispatch path for models that don't use OpSlot.
 
-    User-facing ``moe_implementation`` is a single field with values
-    ``"eager"``/``"fused_triton"``/``"fused_quack"``. Legacy modeling code
-    (qwen3_moe, deepseek_v3, etc.) only checks ``config._moe_implementation``
-    for the coarse ``"eager"``/``"fused"`` distinction, so we split the user
-    value into (mode, kernel) here and bind the fused kernel separately.
+    User-facing ``moe_implementation`` is a single field with values like
+    ``"eager"``/``"fused"``/``"fused_triton"``/``"fused_quack"``. Legacy
+    modeling code (qwen3_moe, deepseek_v3, etc.) only checks
+    ``config._moe_implementation`` for the coarse ``"eager"``/``"fused"``
+    distinction, so we split the user value into (mode, kernel) here and bind
+    the fused kernel separately.
     """
-    if moe_implementation == "eager":
+    resolved = _select_moe_kernel_by_device(moe_implementation)
+    if resolved.config_value == "eager":
         logger.warning_rank0("You are using eager moe implementation, expect this to be VERY SLOW!")
         config._moe_implementation = "eager"
         return
 
-    if not moe_implementation.startswith("fused_"):
-        raise ValueError(
-            f"Invalid moe_implementation: {moe_implementation!r}. "
-            "Expected 'eager' or a 'fused_<kernel>' name. OSS kernels: "
-            "'fused_triton', 'fused_quack', 'fused_npu'. Third-party backends "
-            "may register additional 'fused_<name>' values; if you set one, "
-            "make sure the corresponding kernel is installed and registered."
-        )
-
-    fused_moe_kernel = moe_implementation.removeprefix("fused_")
+    fused_moe_kernel = resolved.kernel_name
+    assert fused_moe_kernel is not None
     logger.info_rank0(f"MoE implementation: fused (kernel={fused_moe_kernel})")
     config._moe_implementation = "fused"
 
@@ -93,26 +127,27 @@ def apply_moe_patch_transformers_v4(config, moe_implementation: str):
     apply_veomni_fused_moe_patch(fused_moe_kernel=fused_moe_kernel)
 
 
-def _bind_veomni_ops(modeling_module, ops_config: OpsImplementationConfig) -> bool:
+def _bind_veomni_ops(
+    modeling_module,
+    ops_config: OpsImplementationConfig,
+    moe_implementation: Optional[str] = None,
+) -> bool:
     """Bind all OpSlot instances found in *modeling_module*.
 
     Returns ``True`` if at least one OpSlot was found (and bound).
     """
     found = False
+    resolved_moe: Optional[_ResolvedMoeImplementation] = None
     for name in dir(modeling_module):
         obj = getattr(modeling_module, name, None)
         if isinstance(obj, OpSlot):
             # `moe_experts` is the one op whose user-facing config field is not
-            # `moe_experts_implementation` but `moe_implementation`, and its
-            # values carry a `fused_` prefix (e.g. `fused_triton`) that the
-            # KERNEL_REGISTRY entries don't. Translate here so the registry
-            # lookup finds the kernel and the HardwareRequirement check fires.
+            # `moe_experts_implementation` but `moe_implementation`. Resolve
+            # auto/explicit user values into the registry's concrete kernel names.
             if obj.op_name == "moe_experts":
-                impl_name = (
-                    "eager"
-                    if ops_config.moe_implementation == "eager"
-                    else ops_config.moe_implementation.removeprefix("fused_")
-                )
+                if resolved_moe is None:
+                    resolved_moe = _select_moe_kernel_by_device(moe_implementation or ops_config.moe_implementation)
+                impl_name = resolved_moe.kernel_name or "eager"
             else:
                 impl_name = getattr(ops_config, f"{obj.op_name}_implementation", "eager")
             obj.bind(impl_name)
@@ -132,6 +167,16 @@ def _module_has_opslot(modeling_module, op_name: str) -> bool:
     return False
 
 
+def _module_imports_global_fused_moe(modeling_module) -> bool:
+    """Return True if *modeling_module* imports the global fused_moe_forward."""
+    return modeling_module is not None and hasattr(modeling_module, "fused_moe_forward")
+
+
+def _module_uses_opslot_moe_dispatch(modeling_module) -> bool:
+    """Return True when MoE experts should be driven by an OpSlot."""
+    return is_transformers_version_greater_or_equal_to("5.0.0") and _module_has_opslot(modeling_module, "moe_experts")
+
+
 def build_foundation_model(
     config_path: Union[str, PretrainedConfig],
     weights_path: Optional[str] = None,
@@ -149,7 +194,7 @@ def build_foundation_model(
             "native-sparse",
         ]
     ] = "veomni_flash_attention_2_with_sp",
-    moe_implementation: Optional[str] = None,
+    moe_implementation: Optional[str] = "fused",
     init_device: Literal["cpu", "cuda", "npu", "meta"] = "cuda",
     config_kwargs: Optional[Dict[str, Any]] = None,
     encoder_data_balance: Optional[bool] = False,
@@ -244,22 +289,24 @@ def build_foundation_model(
     # Models like qwen3_moe capture ``config._moe_implementation`` inside
     # ``PatchQwen3MoeExperts.__init__``, so the legacy patch has to land on
     # *config* before ``loader.load_model`` instantiates the experts.
-    # We look up the modeling module via ``get_model_class`` (config → class)
-    # so we can skip the legacy patch for models that own a ``moe_experts``
-    # OpSlot (qwen3_5_moe and friends).
+    # Transformers v4 monkey patches stay on the legacy path. Transformers v5
+    # models use OpSlot only when the generated module declares a ``moe_experts``
+    # slot; v5 models still using ``_moe_implementation`` remain on the legacy
+    # global-pointer path.
     #
     # TODO(kernel-registry): migrate the remaining legacy ``_moe_implementation``
     # users to the OpSlot("moe_experts", …) + KERNEL_REGISTRY pattern that
     # qwen3_5_moe already uses; once they do, drop this whole pre-load block.
     # Current holdouts: qwen3_moe, qwen3_vl_moe, qwen3_omni_moe, deepseek_v3.
-    if moe_implementation is not None:
-        pre_load_modeling_module = sys.modules.get(get_model_class(config).__module__)
-        if _module_has_opslot(pre_load_modeling_module, "moe_experts"):
+    effective_moe_implementation = moe_implementation or get_ops_config().moe_implementation
+    pre_load_modeling_module = sys.modules.get(get_model_class(config).__module__)
+    if _module_imports_global_fused_moe(pre_load_modeling_module):
+        if _module_uses_opslot_moe_dispatch(pre_load_modeling_module):
             logger.info_rank0(
-                f"Model has a 'moe_experts' OpSlot; ignoring legacy moe_implementation={moe_implementation!r}."
+                f"Model has a 'moe_experts' OpSlot; using OpSlot MoE dispatch for {effective_moe_implementation!r}."
             )
         else:
-            apply_moe_patch_transformers_v4(config, moe_implementation)
+            apply_moe_patch_transformers_v4(config, effective_moe_implementation)
 
     model = loader.load_model(
         init_kwargs=init_kwargs,
@@ -275,7 +322,7 @@ def build_foundation_model(
     # model class).
     modeling_module = sys.modules.get(model.__class__.__module__)
     if modeling_module is not None:
-        if _bind_veomni_ops(modeling_module, get_ops_config()):
+        if _bind_veomni_ops(modeling_module, get_ops_config(), moe_implementation=effective_moe_implementation):
             logger.info_rank0("OpSlot-based kernel dispatch active.")
 
     if is_torch_npu_available():

--- a/veomni/ops/README.md
+++ b/veomni/ops/README.md
@@ -51,7 +51,7 @@ depending on when and where the kernel is bound:
 | RMSNorm | `rms_norm_implementation` | PER_MODEL | `eager` | `liger_kernel`, `npu`, `triton`\* |
 | Rotary pos emb | `rotary_pos_emb_implementation` | PER_MODEL | `eager` | `liger_kernel`, `npu`, `triton`\* |
 | SwiGLU MLP | `swiglu_mlp_implementation` | PER_MODEL | `eager` | `liger_kernel` |
-| Fused MoE | `moe_implementation` | build-time | `eager` | `eager`, `fused_triton` (group-gemm, SM70+), `fused_quack` (CUTLASS/CuTe, SM90+), `fused_npu` (Ascend). Mismatches raise instead of falling back. |
+| Fused MoE | `moe_implementation` | build-time | `fused` | `eager`, `fused` (auto), `fused_triton` (group-gemm, SM70+), `fused_quack` (CUTLASS/CuTe, SM90+), `fused_npu` (Ascend). Mismatches raise instead of falling back. |
 
 \* The `triton` backend is registered per-model via `extra_backends`: DeepSeek
 V3 exposes a batch-invariant RMSNorm + deterministic RoPE, and Wan exposes its
@@ -69,6 +69,7 @@ own Triton RMSNorm/rotary. See the per-model table below.
 | `moe_implementation=fused_triton` | Triton, SM70+ | `is_fused_moe_available()` |
 | `moe_implementation=fused_quack` | `quack` package, SM90+ | `is_quack_gemm_available()` |
 | `moe_implementation=fused_npu` | `torch_npu` + Ascend NPU | `is_torch_npu_available()` |
+| `moe_implementation=fused` | NPU, or CUDA GPU | auto-resolves to `fused_npu`, `fused_quack` on SM100+, otherwise `fused_triton` |
 
 ### Per-model PER_MODEL coverage
 

--- a/veomni/ops/__init__.py
+++ b/veomni/ops/__init__.py
@@ -82,8 +82,8 @@ def apply_ops_config(ops_config: OpsImplementationConfig) -> None:
        ``OpSlot.bind`` can read the user's selections.
 
     MoE dispatch is applied in ``build_foundation_model`` (via
-    ``moe_implementation`` ∈ {``eager``, ``fused_triton``, ``fused_quack``,
-    ``fused_npu``}); per-model kernels are applied by each model's
+    ``moe_implementation`` ∈ {``eager``, ``fused``, ``fused_triton``,
+    ``fused_quack``, ``fused_npu``}); per-model kernels are applied by each model's
     ``device_patch.py``.
     """
     set_ops_config(ops_config)


### PR DESCRIPTION
### What does this PR do?

This PR keeps `moe_implementation` as an explicit `build_foundation_model()` input while adding a small shared resolver for MoE kernel selection.

Motivation:

- `build_foundation_model()` is the common model-construction boundary for both Transformers v4 monkey-patched models and Transformers v5 generated models.
- Routing MoE selection only through `OpSlot` makes v4 behavior harder to reason about, because v4 model classes can still live in upstream Transformers modules even when VeOmni monkey-patches their internals.
- Existing v4 MoE models should not be affected by `OpSlot`; they should continue to use `_moe_implementation` plus the global `fused_moe_forward` pointer.
- v5 models should use `OpSlot` only when the generated modeling module actually declares `OpSlot("moe_experts", ...)`.

### Checklist Before Starting

- Search for relative PRs/issues and link here: follows up the design concerns from #705.
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

- `make quality`

`pytest tests/ops/test_moe_hw_gate.py` was not run locally because this venv does not have `torch` installed, so test collection fails before reaching the test cases.

### API and Usage Example

`OpsImplementationConfig.moe_implementation` now defaults to:

```yaml
model:
  ops_implementation:
    moe_implementation: fused
```

`fused` is resolved at model build time:

- NPU -> `fused_npu`
- CUDA SM100+ -> `fused_quack`
- other CUDA GPUs -> `fused_triton`

Explicit values remain available:

- `eager`
- `fused_triton`
- `fused_quack`
- `fused_npu`

### Design & Code Changes

- Keep `moe_implementation` in `build_foundation_model()` so model construction remains the shared v4/v5 dispatch boundary.
- Add `_select_moe_kernel_by_device()` to map the user-facing value to:
  - `config_value`: `eager` or `fused`, used by legacy `_moe_implementation` model code.
  - `kernel_name`: `triton`, `quack`, `npu`, or `None`, used by either the legacy global pointer or OpSlot registry binding.
- Preserve v4 behavior:
  - v4 MoE models keep using `config._moe_implementation` plus `apply_veomni_fused_moe_patch()`.
  - v4 models are not switched to `OpSlot`.
- Use OpSlot for MoE only when both are true:
  - Transformers version is v5+.
  - The modeling module declares `OpSlot("moe_experts", ...)`.
- Update MoE hardware-gate tests for auto selection and the v4/v5 OpSlot decision rule.
- Update docs for the new `fused` default and dispatch design.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
