### PR TITLE
[ops] fix: use reshape for non-contiguous chunks in chunk_loss

### DIFF
--- a/veomni/ops/kernels/cross_entropy/chunk_loss.py
+++ b/veomni/ops/kernels/cross_entropy/chunk_loss.py
@@ -107,8 +107,11 @@ def chunk_loss_function(
         hidden_states = hidden_states[..., :-1, :].contiguous()
 
     def ce_loss_func(hidden_states, weight, bias, labels, num_items_in_batch, ignore_index=-100, **kwargs):
-        labels = labels.view(-1)
-        hidden_states = hidden_states.view(-1, hidden_states.size(-1))
+        # Use ``reshape`` instead of ``view`` because the per-chunk tensors come
+        # from ``torch.split(..., dim=1)`` on contiguous parents, which yields
+        # non-contiguous views (parent stride is preserved on dim 0).
+        labels = labels.reshape(-1)
+        hidden_states = hidden_states.reshape(-1, hidden_states.size(-1))
         logits = F.linear(hidden_states, weight).float()
         loss, logits = eager_cross_entropy(
             logits,


### PR DESCRIPTION
### What does this PR do?

> Fix a `RuntimeError: view size is not compatible with input tensor's size and stride` that fires inside `chunk_loss_function` when the cross-entropy chunks come from `torch.split(..., dim=1)`. Splitting along `dim=1` on a contiguous parent yields non-contiguous views (parent stride is preserved on `dim=0`), so the subsequent `Tensor.view(-1, ...)` flatten fails. Switching to `Tensor.reshape(-1, ...)` falls back to a copy when needed and keeps the fast path when the chunk happens to be contiguous.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A
- PR title follows `[{modules}] {type}: {description}` format

### Test

> Reproduced the original failure on a long-sequence run that hits the chunked CE path; with the fix the loss matches the non-chunked reference within numerical tolerance and training proceeds without the view error.

### API and Usage Example

> N/A — internal kernel fix, no API change.

### Design & Code Changes

> - `veomni/ops/kernels/cross_entropy/chunk_loss.py`: replace `labels.view(-1)` / `hidden_states.view(-1, ...)` inside `ce_loss_func` with `reshape`, and add a comment explaining why (chunks come from `torch.split` on `dim=1`, which produces non-contiguous views).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added/updated documentation (N/A — internal fix)
- [ ] Added tests to CI workflow (existing chunk_loss tests cover the path; the bug only triggers when the parent tensor layout makes the split non-contiguous)
