### PR TITLE
[ops, model] feat: log post-build kernel selection summary

### DIFF
--- a/tests/ops/test_kernel_selection_summary.py
+++ b/tests/ops/test_kernel_selection_summary.py
@@ -1,0 +1,106 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke tests for ``format_kernel_selection_summary``.
+
+These cover the formatter's branching, not the underlying kernel selection
+itself: the three ``_attn_implementation`` shapes (flat / HF v5 dict / per
+sub-config) and the OpSlot section's labelling for unbound / eager / kernel
+states.
+"""
+
+from types import ModuleType, SimpleNamespace
+
+from veomni.ops import format_kernel_selection_summary
+from veomni.ops.dispatch import OpSlot
+
+
+def _model(**cfg_kwargs):
+    return SimpleNamespace(config=SimpleNamespace(**cfg_kwargs))
+
+
+def test_no_args_emits_header_footer_and_core_rows():
+    out = format_kernel_selection_summary()
+    assert "============= Kernel selection summary =============" in out
+    assert out.rstrip().endswith("=====================================================")
+    # GLOBAL ops + cross-entropy are always present
+    for alias in ("cross_entropy", "_fused_moe_forward", "_flash_attention_forward", "_load_balancing_loss"):
+        assert alias in out
+    # No model section / OpSlot section when called without args
+    assert "model " not in out
+    assert "OpSlot bindings" not in out
+
+
+def test_flat_attn_implementation_and_model_label():
+    out = format_kernel_selection_summary(model=_model(model_type="qwen3", _attn_implementation="flash_attention_2"))
+    assert "(model_type=qwen3)" in out
+    # Single attn line with the flat string (no [sub_config] suffix).
+    attn_lines = [line for line in out.splitlines() if "attn_implementation" in line]
+    assert len(attn_lines) == 1
+    assert "[" not in attn_lines[0]
+    assert "flash_attention_2" in attn_lines[0]
+
+
+def test_dict_form_attn_implementation_expands_per_key():
+    out = format_kernel_selection_summary(
+        model=_model(_attn_implementation={"text_config": "flash_attention_2", "vision_config": "sdpa"})
+    )
+    assert "attn_implementation[text_config]" in out
+    assert "flash_attention_2" in out
+    assert "attn_implementation[vision_config]" in out
+    assert "sdpa" in out
+
+
+def test_sub_config_attn_implementation_collected():
+    out = format_kernel_selection_summary(
+        model=SimpleNamespace(
+            config=SimpleNamespace(
+                text_config=SimpleNamespace(_attn_implementation="sdpa"),
+                vision_config=SimpleNamespace(_attn_implementation="eager"),
+            )
+        )
+    )
+    assert "attn_implementation[text_config]" in out
+    assert "attn_implementation[vision_config]" in out
+
+
+def test_opslot_bindings_section_sorted_with_state_labels():
+    mod = ModuleType("fake_modeling")
+
+    unbound = OpSlot("rms_norm", "standard")  # never bound
+
+    eager = OpSlot("rms_norm", "standard")  # bound, but resolved to eager (kernel=None)
+    eager._impl_name = "eager"
+
+    def my_kernel(x):
+        return x
+
+    bound = OpSlot("rms_norm", "standard")
+    bound._impl_name = "my_impl"
+    bound._kernel = my_kernel
+
+    # Names chosen so alphabetical sort != insertion order, to verify sorting.
+    mod.veomni_z_unbound = unbound
+    mod.veomni_a_eager = eager
+    mod.veomni_m_bound = bound
+    mod.not_a_slot = "ignored"  # non-OpSlot attrs must be filtered out
+
+    out = format_kernel_selection_summary(modeling_module=mod)
+
+    assert "-- OpSlot bindings (fake_modeling) --" in out
+    assert out.index("veomni_a_eager") < out.index("veomni_m_bound") < out.index("veomni_z_unbound")
+    assert "<unbound> -> eager" in out
+    assert "eager -> eager" in out
+    assert "my_impl -> my_kernel" in out
+    assert "not_a_slot" not in out

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -225,6 +225,15 @@ def build_foundation_model(
         if _bind_veomni_ops(modeling_module, get_ops_config()):
             logger.info_rank0("OpSlot-based kernel dispatch active.")
 
+    # Final summary of which kernel won the dispatch for each op.  Emitted
+    # post-build so it reflects the *resolved* state (attn_implementation on
+    # model.config, GLOBAL pointers bound by apply_global_ops /
+    # apply_veomni_fused_moe_patch, and per-OpSlot bindings on the modeling
+    # module).
+    from ..ops import format_kernel_selection_summary
+
+    logger.info_rank0(format_kernel_selection_summary(model, modeling_module))
+
     if is_torch_npu_available():
         # We override the forward method (on NPU devices) instead of passing CPU FA kwargs directly to the model in the trainer,
         # due to the behavior in https://github.com/pytorch/pytorch/blob/134179474539648ba7dee1317959529fbd0e7f89/torch/distributed/fsdp/_fully_shard/_fsdp_state.py#L130

--- a/veomni/ops/__init__.py
+++ b/veomni/ops/__init__.py
@@ -121,86 +121,83 @@ def format_kernel_functions() -> str:
     return "\n".join(lines)
 
 
+_ATTN_SUB_CONFIGS = ("text_config", "vision_config", "audio_config", "thinker_config", "talker_config")
+
+
 def format_kernel_selection_summary(model=None, modeling_module=None) -> str:
     """Final kernel-selection summary, intended to be logged after model build.
 
     Unlike :func:`format_kernel_functions` (which runs at ``apply_ops_config``
-    time and only sees GLOBAL pointers), this summary includes:
-
-    - the attention implementation actually wired onto ``model.config``,
-    - the cross-entropy kernel installed into ``LOSS_MAPPING``,
-    - all GLOBAL function pointers (``_fused_moe_forward``,
-      ``_flash_attention_forward``, ``_load_balancing_loss``) — bound by
-      ``apply_ops_config`` and ``_bind_veomni_ops``,
-    - every :class:`OpSlot` declared on the model's generated modeling module
-      (RMSNorm / RoPE / SwiGLU / MoE experts / per-task loss slots).
+    time and only sees GLOBAL pointers), this includes the attn implementation
+    wired onto ``model.config``, the cross-entropy installed into
+    ``LOSS_MAPPING``, every GLOBAL ops pointer, and every :class:`OpSlot`
+    declared on the model's generated modeling module.
     """
-    lines = ["", "============= Kernel selection summary ============="]
-
+    rows: list[tuple[str, str]] = []
     if model is not None:
-        cfg = getattr(model, "config", None)
-        cls = model.__class__
-        model_type = getattr(cfg, "model_type", None) if cfg is not None else None
-        model_label = f"{cls.__module__}.{cls.__name__}"
-        if model_type:
-            model_label = f"{model_label} (model_type={model_type})"
-        lines.append(f"  model                     = {model_label}")
-        for attn_label, attn_value in _collect_attn_implementations(cfg):
-            lines.append(f"  {attn_label:<25} = {attn_value}")
+        rows.append(("model", _model_label(model)))
+        rows.extend(_collect_attn_implementations(getattr(model, "config", None)))
+    rows.append(("cross_entropy", _current_cross_entropy_name()))
+    rows.extend((alias, _kernel_name(func, none="None (eager / unbound)")) for alias, func in build_ALL_OPS())
 
-    lines.append(f"  cross_entropy             = {_current_cross_entropy_name()}")
-
-    for alias, func in build_ALL_OPS():
-        impl = getattr(func, "__name__", repr(func)) if func is not None else "None (eager / unbound)"
-        lines.append(f"  {alias:<25} = {impl}")
-
-    if modeling_module is not None:
-        slot_entries: list[tuple[str, OpSlot]] = []
-        for attr_name in dir(modeling_module):
-            obj = getattr(modeling_module, attr_name, None)
-            if isinstance(obj, OpSlot):
-                slot_entries.append((attr_name, obj))
-        if slot_entries:
-            module_label = modeling_module.__name__.rsplit(".", 1)[-1]
-            lines.append(f"  -- OpSlot bindings ({module_label}) --")
-            for attr_name, slot in sorted(slot_entries):
-                impl_label = slot.impl_name if slot.impl_name is not None else "<unbound>"
-                kernel_label = (
-                    getattr(slot.kernel, "__name__", repr(slot.kernel)) if slot.kernel is not None else "eager"
-                )
-                lines.append(f"  {attr_name:<35} = {impl_label} -> {kernel_label}")
-
+    lines = ["", "============= Kernel selection summary ============="]
+    lines.extend(f"  {k:<25} = {v}" for k, v in rows)
+    lines.extend(_format_opslot_bindings(modeling_module))
     lines.append("=====================================================")
     return "\n".join(lines)
+
+
+def _model_label(model) -> str:
+    cls = model.__class__
+    label = f"{cls.__module__}.{cls.__name__}"
+    model_type = getattr(getattr(model, "config", None), "model_type", None)
+    return f"{label} (model_type={model_type})" if model_type else label
+
+
+def _format_opslot_bindings(modeling_module) -> list[str]:
+    if modeling_module is None:
+        return []
+    slots = sorted(
+        (name, obj) for name in dir(modeling_module) if isinstance(obj := getattr(modeling_module, name, None), OpSlot)
+    )
+    if not slots:
+        return []
+    module_label = modeling_module.__name__.rsplit(".", 1)[-1]
+    out = [f"  -- OpSlot bindings ({module_label}) --"]
+    for name, slot in slots:
+        impl = slot.impl_name or "<unbound>"
+        kernel = _kernel_name(slot.kernel, none="eager")
+        out.append(f"  {name:<35} = {impl} -> {kernel}")
+    return out
+
+
+def _kernel_name(obj, none: str = "None") -> str:
+    """Render a callable for the summary: ``__name__`` if available, else ``repr``."""
+    if obj is None:
+        return none
+    return getattr(obj, "__name__", repr(obj))
 
 
 def _collect_attn_implementations(cfg) -> list[tuple[str, str]]:
     """Return ``[(label, value), ...]`` for every attn impl reachable from ``cfg``.
 
-    Handles three shapes:
-    - flat ``cfg._attn_implementation`` (string),
-    - HF v5 dict form ``cfg._attn_implementation = {"text_config": ..., ...}``,
-    - composite multimodal configs whose sub-configs (``text_config``,
-      ``vision_config``, ``audio_config``) each carry their own
-      ``_attn_implementation``.
+    Handles flat ``cfg._attn_implementation`` (string), HF v5 dict form
+    (``{"text_config": ..., ...}``), and composite multimodal configs whose
+    sub-configs each carry their own ``_attn_implementation``.
     """
     if cfg is None:
         return []
-
-    out: list[tuple[str, str]] = []
     top = getattr(cfg, "_attn_implementation", None)
     if isinstance(top, dict):
-        for k, v in top.items():
-            out.append((f"attn_implementation[{k}]", str(v)))
+        out = [(f"attn_implementation[{k}]", str(v)) for k, v in top.items()]
     elif top is not None:
-        out.append(("attn_implementation", str(top)))
-
-    for sub_attr in ("text_config", "vision_config", "audio_config", "thinker_config", "talker_config"):
-        sub = getattr(cfg, sub_attr, None)
-        sub_attn = getattr(sub, "_attn_implementation", None) if sub is not None else None
+        out = [("attn_implementation", str(top))]
+    else:
+        out = []
+    for sub_attr in _ATTN_SUB_CONFIGS:
+        sub_attn = getattr(getattr(cfg, sub_attr, None), "_attn_implementation", None)
         if sub_attn is not None and not isinstance(sub_attn, dict):
             out.append((f"attn_implementation[{sub_attr}]", str(sub_attn)))
-
     return out
 
 

--- a/veomni/ops/__init__.py
+++ b/veomni/ops/__init__.py
@@ -37,6 +37,8 @@ __all__ = [
     "fused_moe_forward",
     "OpSlot",
     "load_balancing_loss_func",
+    "format_kernel_functions",
+    "format_kernel_selection_summary",
 ]
 
 logger = logging.get_logger(__name__)
@@ -117,6 +119,87 @@ def format_kernel_functions() -> str:
 
     lines.append("==============================")
     return "\n".join(lines)
+
+
+def format_kernel_selection_summary(model=None, modeling_module=None) -> str:
+    """Final kernel-selection summary, intended to be logged after model build.
+
+    Unlike :func:`format_kernel_functions` (which runs at ``apply_ops_config``
+    time and only sees GLOBAL pointers), this summary includes:
+
+    - the attention implementation actually wired onto ``model.config``,
+    - the cross-entropy kernel installed into ``LOSS_MAPPING``,
+    - all GLOBAL function pointers (``_fused_moe_forward``,
+      ``_flash_attention_forward``, ``_load_balancing_loss``) — bound by
+      ``apply_ops_config`` and ``_bind_veomni_ops``,
+    - every :class:`OpSlot` declared on the model's generated modeling module
+      (RMSNorm / RoPE / SwiGLU / MoE experts / per-task loss slots).
+    """
+    lines = ["", "============= Kernel selection summary ============="]
+
+    if model is not None:
+        cfg = getattr(model, "config", None)
+        cls = model.__class__
+        model_type = getattr(cfg, "model_type", None) if cfg is not None else None
+        model_label = f"{cls.__module__}.{cls.__name__}"
+        if model_type:
+            model_label = f"{model_label} (model_type={model_type})"
+        lines.append(f"  model                     = {model_label}")
+        for attn_label, attn_value in _collect_attn_implementations(cfg):
+            lines.append(f"  {attn_label:<25} = {attn_value}")
+
+    lines.append(f"  cross_entropy             = {_current_cross_entropy_name()}")
+
+    for alias, func in build_ALL_OPS():
+        impl = func.__name__ if func is not None else "None (eager / unbound)"
+        lines.append(f"  {alias:<25} = {impl}")
+
+    if modeling_module is not None:
+        slot_entries: list[tuple[str, OpSlot]] = []
+        for attr_name in dir(modeling_module):
+            obj = getattr(modeling_module, attr_name, None)
+            if isinstance(obj, OpSlot):
+                slot_entries.append((attr_name, obj))
+        if slot_entries:
+            module_label = modeling_module.__name__.rsplit(".", 1)[-1]
+            lines.append(f"  -- OpSlot bindings ({module_label}) --")
+            for attr_name, slot in sorted(slot_entries):
+                impl_label = slot.impl_name if slot.impl_name is not None else "<unbound>"
+                kernel_label = slot.kernel.__name__ if slot.kernel is not None else "eager"
+                lines.append(f"  {attr_name:<35} = {impl_label} -> {kernel_label}")
+
+    lines.append("=====================================================")
+    return "\n".join(lines)
+
+
+def _collect_attn_implementations(cfg) -> list[tuple[str, str]]:
+    """Return ``[(label, value), ...]`` for every attn impl reachable from ``cfg``.
+
+    Handles three shapes:
+    - flat ``cfg._attn_implementation`` (string),
+    - HF v5 dict form ``cfg._attn_implementation = {"text_config": ..., ...}``,
+    - composite multimodal configs whose sub-configs (``text_config``,
+      ``vision_config``, ``audio_config``) each carry their own
+      ``_attn_implementation``.
+    """
+    if cfg is None:
+        return []
+
+    out: list[tuple[str, str]] = []
+    top = getattr(cfg, "_attn_implementation", None)
+    if isinstance(top, dict):
+        for k, v in top.items():
+            out.append((f"attn_implementation[{k}]", str(v)))
+    elif top is not None:
+        out.append(("attn_implementation", str(top)))
+
+    for sub_attr in ("text_config", "vision_config", "audio_config", "thinker_config", "talker_config"):
+        sub = getattr(cfg, sub_attr, None)
+        sub_attn = getattr(sub, "_attn_implementation", None) if sub is not None else None
+        if sub_attn is not None and not isinstance(sub_attn, dict):
+            out.append((f"attn_implementation[{sub_attr}]", str(sub_attn)))
+
+    return out
 
 
 def _current_cross_entropy_name() -> str:

--- a/veomni/ops/__init__.py
+++ b/veomni/ops/__init__.py
@@ -151,7 +151,7 @@ def format_kernel_selection_summary(model=None, modeling_module=None) -> str:
     lines.append(f"  cross_entropy             = {_current_cross_entropy_name()}")
 
     for alias, func in build_ALL_OPS():
-        impl = func.__name__ if func is not None else "None (eager / unbound)"
+        impl = getattr(func, "__name__", repr(func)) if func is not None else "None (eager / unbound)"
         lines.append(f"  {alias:<25} = {impl}")
 
     if modeling_module is not None:
@@ -165,7 +165,9 @@ def format_kernel_selection_summary(model=None, modeling_module=None) -> str:
             lines.append(f"  -- OpSlot bindings ({module_label}) --")
             for attr_name, slot in sorted(slot_entries):
                 impl_label = slot.impl_name if slot.impl_name is not None else "<unbound>"
-                kernel_label = slot.kernel.__name__ if slot.kernel is not None else "eager"
+                kernel_label = (
+                    getattr(slot.kernel, "__name__", repr(slot.kernel)) if slot.kernel is not None else "eager"
+                )
                 lines.append(f"  {attr_name:<35} = {impl_label} -> {kernel_label}")
 
     lines.append("=====================================================")

--- a/veomni/ops/dispatch.py
+++ b/veomni/ops/dispatch.py
@@ -73,6 +73,16 @@ class OpSlot:
         """
         return self._kernel is not None
 
+    @property
+    def impl_name(self) -> str | None:
+        """Implementation name passed to :meth:`bind`, or ``None`` if unbound."""
+        return self._impl_name
+
+    @property
+    def kernel(self) -> Callable | None:
+        """The bound kernel callable, or ``None`` for eager / unbound."""
+        return self._kernel
+
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         if self._kernel is None:
             raise RuntimeError(


### PR DESCRIPTION
### What does this PR do?

> Adds a single, consolidated log line emitted at the end of `build_foundation_model` that shows — per built model — which kernel actually won the dispatch for every replaceable op.
>
> Previously, kernel-selection information was split across:
> - `apply_ops_config` log (incomplete: `_fused_moe_forward` is still `None` at that point);
> - per-`OpSlot` info traces inside `_bind_veomni_ops`;
> - per-model `device_patch.py` "Apply ops patches to ..." lines.
>
> None of those gave a single end-of-build view, and the `apply_ops_config` summary was misleading because it ran before MoE binding.

### Checklist Before Starting

- PR title follows `[{modules}] {type}: {description}` format

### Test

> - `make quality` — pass.
> - `pytest tests/ops/` — 91 passed, 14 skipped (5 new cases in `test_kernel_selection_summary.py`).
> - New unit tests cover: header/footer + core rows, the three `_attn_implementation` shapes (flat / HF v5 dict / per-sub-config), and the OpSlot section's three states (`<unbound>` / bound-to-eager / bound-to-kernel) including alphabetical sort and non-`OpSlot` attr filtering.
> - Manual smoke (flat config, HF v5 dict-form `_attn_implementation`, multimodal sub-configs).

### API and Usage Example

> No config or YAML changes. The new summary is logged at `info_rank0` once per `build_foundation_model` call. Example output:
>
> ```
> ============= Kernel selection summary =============
>   model                     = veomni.models.transformers.qwen3_moe.generated.patched_modeling_qwen3_moe_gpu.Qwen3MoeForCausalLM (model_type=qwen3_moe)
>   attn_implementation       = veomni_flash_attention_2_with_sp
>   cross_entropy             = ForCausalLMLoss
>   _fused_moe_forward        = group_gemm_fused_moe_forward
>   _flash_attention_forward  = veomni_flash_attention_forward
>   _load_balancing_loss      = load_balancing_loss_pytorch
>   -- OpSlot bindings (patched_modeling_qwen3_moe_gpu) --
>   veomni_causal_lm_loss               = eager -> eager
>   veomni_load_balancing_loss          = eager -> eager
>   veomni_moe_experts_forward          = triton_group_gemm -> group_gemm_fused_moe_forward
> =====================================================
> ```
>
> For multimodal models (e.g. Qwen3-VL) the attention line expands per sub-config:
>
> ```
>   attn_implementation[text_config]   = flash_attention_2
>   attn_implementation[vision_config] = sdpa
> ```
>
> Public additions to `veomni.ops`:
> - `format_kernel_selection_summary(model, modeling_module)` — the helper itself, in case callers (e.g. tests) want to log it.
> - `OpSlot.impl_name` / `OpSlot.kernel` — read-only properties so the summary can introspect bindings without touching private attrs.

### Design & Code Changes

> - `veomni/ops/__init__.py`: add `format_kernel_selection_summary` plus three small private helpers — `_model_label`, `_format_opslot_bindings`, `_kernel_name` (folds in the `__name__`/`repr` fallback) — and `_collect_attn_implementations` (flat string / HF v5 dict / per-sub-config). Main function builds a `[(label, value), ...]` row list once and formats uniformly, keeping the body to ~12 lines. Export `format_kernel_functions` and `format_kernel_selection_summary` in `__all__`.
> - `veomni/ops/dispatch.py`: add `OpSlot.impl_name` and `OpSlot.kernel` read-only properties so the summary can introspect bindings without touching private attrs.
> - `veomni/models/auto.py`: emit the summary at the end of `build_foundation_model`, after `_bind_veomni_ops`, so it reflects the resolved state (FA SP rewrite applied, MoE pointer bound, every OpSlot bound).
> - `tests/ops/test_kernel_selection_summary.py`: new file with 5 CPU-only smoke tests covering the formatter's branching. Auto-picked up by `gpu_unit_tests.yml` (which already runs `pytest tests/ops`); no workflow edit needed. Skipped for NPU CI since the test is device-agnostic and the NPU lane only cherry-picks device-specific ops tests.
>
> Additive change — existing logs (`apply_ops_config`, per-`OpSlot` traces, per-model `device_patch.py` lines) are left untouched.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [ ] Added/updated documentation (logging-only change; no config/API surface changes that warrant docs updates)
- [x] Added tests to CI workflow (`tests/ops/test_kernel_selection_summary.py`, auto-included via `gpu_unit_tests.yml`'s `pytest tests/ops` step)
