### PR TITLE
[trainer] feat: add sub-step lifecycle hooks for callbacks

### DIFF
--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -456,16 +456,16 @@ class BaseTrainer(Stateful, ABC):
     def on_data_load_end(self, micro_batches=None):
         pass
 
-    def on_forward_begin(self):
+    def on_forward_begin(self, micro_batch=None):
         pass
 
-    def on_forward_end(self):
+    def on_forward_end(self, micro_batch=None):
         pass
 
-    def on_backward_begin(self):
+    def on_backward_begin(self, micro_batch=None):
         pass
 
-    def on_backward_end(self):
+    def on_backward_end(self, micro_batch=None):
         pass
 
     def on_optimizer_step_begin(self):
@@ -500,20 +500,20 @@ class BaseTrainer(Stateful, ABC):
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         micro_batch = self.preforward(micro_batch)
 
-        self.on_forward_begin()
+        self.on_forward_begin(micro_batch=micro_batch)
         with self.model_fwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
             outputs: ModelOutput = self.model(**micro_batch, use_cache=False)
 
         loss: torch.Tensor
         loss_dict: Dict[str, torch.Tensor]
         loss, loss_dict = self.postforward(outputs, micro_batch)
-        self.on_forward_end()
+        self.on_forward_end(micro_batch=micro_batch)
 
         # Backward pass
-        self.on_backward_begin()
+        self.on_backward_begin(micro_batch=micro_batch)
         with self.model_bwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
             loss.backward()
-        self.on_backward_end()
+        self.on_backward_end(micro_batch=micro_batch)
 
         del micro_batch
         return loss, loss_dict

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -415,6 +415,7 @@ class BaseTrainer(Stateful, ABC):
         self.checkpointer_callback.on_epoch_begin(self.state)
         self.hf_ckpt_callback.on_epoch_begin(self.state)
         self.evaluate_callback.on_epoch_begin(self.state)
+        self.moe_monitor_callback.on_epoch_begin(self.state)
 
     def on_epoch_end(self):
         self.environ_meter_callback.on_epoch_end(self.state)
@@ -424,6 +425,7 @@ class BaseTrainer(Stateful, ABC):
         self.checkpointer_callback.on_epoch_end(self.state)
         self.hf_ckpt_callback.on_epoch_end(self.state)
         self.evaluate_callback.on_epoch_end(self.state)
+        self.moe_monitor_callback.on_epoch_end(self.state)
 
     def on_step_begin(self, micro_batches=None):
         self.environ_meter_callback.on_step_begin(self.state, micro_batches=micro_batches)
@@ -433,6 +435,7 @@ class BaseTrainer(Stateful, ABC):
         self.checkpointer_callback.on_step_begin(self.state, micro_batches=micro_batches)
         self.hf_ckpt_callback.on_step_begin(self.state, micro_batches=micro_batches)
         self.evaluate_callback.on_step_begin(self.state, micro_batches=micro_batches)
+        self.moe_monitor_callback.on_step_begin(self.state, micro_batches=micro_batches)
 
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
         self.environ_meter_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -444,6 +444,36 @@ class BaseTrainer(Stateful, ABC):
         self.evaluate_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
         self.moe_monitor_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
 
+    # Sub-step lifecycle hooks. Defaults are no-ops — built-in callbacks don't
+    # subscribe yet, so there's nothing to dispatch. Trainer subclasses override
+    # these to wire in their own callbacks (e.g. modelchef DiagnosticsCallback).
+    # When a built-in callback eventually overrides one of the matching hooks
+    # on Callback, add the hand-listed dispatch body here (mirroring on_step_*).
+
+    def on_data_load_begin(self):
+        pass
+
+    def on_data_load_end(self, micro_batches=None):
+        pass
+
+    def on_forward_begin(self):
+        pass
+
+    def on_forward_end(self):
+        pass
+
+    def on_backward_begin(self):
+        pass
+
+    def on_backward_end(self):
+        pass
+
+    def on_optimizer_step_begin(self):
+        pass
+
+    def on_optimizer_step_end(self, grad_norm=None):
+        pass
+
     def preforward(self, micro_batch: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Preprocess micro batches before forward pass."""
         micro_batch = {
@@ -470,16 +500,20 @@ class BaseTrainer(Stateful, ABC):
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         micro_batch = self.preforward(micro_batch)
 
+        self.on_forward_begin()
         with self.model_fwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
             outputs: ModelOutput = self.model(**micro_batch, use_cache=False)
 
         loss: torch.Tensor
         loss_dict: Dict[str, torch.Tensor]
         loss, loss_dict = self.postforward(outputs, micro_batch)
+        self.on_forward_end()
 
         # Backward pass
+        self.on_backward_begin()
         with self.model_bwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
             loss.backward()
+        self.on_backward_end()
 
         del micro_batch
         return loss, loss_dict
@@ -504,7 +538,9 @@ class BaseTrainer(Stateful, ABC):
         args = self.args
         self.state.global_step += 1
 
+        self.on_data_load_begin()
         micro_batches: List[Dict[str, Any]] = next(data_iterator)
+        self.on_data_load_end(micro_batches=micro_batches)
 
         self.on_step_begin(micro_batches=micro_batches)
 
@@ -530,6 +566,7 @@ class BaseTrainer(Stateful, ABC):
             for k, v in loss_dict.items():
                 total_loss_dict[k] += v.item()
 
+        self.on_optimizer_step_begin()
         # Gradient clipping
         grad_norm = veomni_clip_grad_norm(self.model, args.train.optimizer.max_grad_norm)
 
@@ -537,6 +574,7 @@ class BaseTrainer(Stateful, ABC):
         self.optimizer.step()
         self.lr_scheduler.step()
         self.optimizer.zero_grad()
+        self.on_optimizer_step_end(grad_norm=grad_norm)
 
         self.on_step_end(loss=total_loss, loss_dict=total_loss_dict, grad_norm=grad_norm)
 

--- a/veomni/trainer/callbacks/base.py
+++ b/veomni/trainer/callbacks/base.py
@@ -49,3 +49,30 @@ class Callback:
 
     def on_train_end(self, state: TrainerState, **kwargs) -> None:
         pass
+
+    # Sub-step lifecycle hooks. Defaults are no-ops so existing callbacks
+    # do not need to be updated; consumers (e.g. DiagnosticsCallback) opt in.
+
+    def on_data_load_begin(self, state: TrainerState, **kwargs) -> None:
+        pass
+
+    def on_data_load_end(self, state: TrainerState, micro_batches: List[Dict[str, Any]] = None, **kwargs) -> None:
+        pass
+
+    def on_forward_begin(self, state: TrainerState, **kwargs) -> None:
+        pass
+
+    def on_forward_end(self, state: TrainerState, **kwargs) -> None:
+        pass
+
+    def on_backward_begin(self, state: TrainerState, **kwargs) -> None:
+        pass
+
+    def on_backward_end(self, state: TrainerState, **kwargs) -> None:
+        pass
+
+    def on_optimizer_step_begin(self, state: TrainerState, **kwargs) -> None:
+        pass
+
+    def on_optimizer_step_end(self, state: TrainerState, grad_norm: float = None, **kwargs) -> None:
+        pass

--- a/veomni/trainer/callbacks/base.py
+++ b/veomni/trainer/callbacks/base.py
@@ -59,16 +59,16 @@ class Callback:
     def on_data_load_end(self, state: TrainerState, micro_batches: List[Dict[str, Any]] = None, **kwargs) -> None:
         pass
 
-    def on_forward_begin(self, state: TrainerState, **kwargs) -> None:
+    def on_forward_begin(self, state: TrainerState, micro_batch: Dict[str, Any] = None, **kwargs) -> None:
         pass
 
-    def on_forward_end(self, state: TrainerState, **kwargs) -> None:
+    def on_forward_end(self, state: TrainerState, micro_batch: Dict[str, Any] = None, **kwargs) -> None:
         pass
 
-    def on_backward_begin(self, state: TrainerState, **kwargs) -> None:
+    def on_backward_begin(self, state: TrainerState, micro_batch: Dict[str, Any] = None, **kwargs) -> None:
         pass
 
-    def on_backward_end(self, state: TrainerState, **kwargs) -> None:
+    def on_backward_end(self, state: TrainerState, micro_batch: Dict[str, Any] = None, **kwargs) -> None:
         pass
 
     def on_optimizer_step_begin(self, state: TrainerState, **kwargs) -> None:


### PR DESCRIPTION
### What does this PR do?

> Adds 4 new pairs of fine-grained sub-step lifecycle hooks to `BaseTrainer` and the `Callback` base class so that downstream consumers can observe every phase inside a training step (data load, forward, backward, optimizer step). Existing callbacks are untouched — the new methods all default to no-ops.
>
> Motivation: the current callback surface only exposes `on_step_begin` / `on_step_end`, which makes it impossible for downstream code (e.g. ETTR loggers, hang-debug heartbeats, profilers) to attribute time or detect rank divergence at sub-step granularity. We hit this concretely while debugging an EP=4 + fused MoE training that progressed past step 1 but then stopped emitting tqdm output — without sub-step hooks there was no way to tell whether the hang was in fwd, bwd, optim, or the dataloader.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A (internal request)
- PR title follows `[{modules}] {type}: {description}` format

### Test

> - `make quality` passes (ruff check + format).
> - Smoke-checked the import surface: `BaseTrainer` exposes the 8 new sub-step methods (`on_data_load_*`, `on_forward_*`, `on_backward_*`, `on_optimizer_step_*`) as no-op stubs, and `Callback` exposes the matching no-op defaults.
> - `pytest tests/models/test_models_patch.py::test_models_patch_fwd_bwd[qwen3_5]` passes (no test-trainer adjustments needed — the new BaseTrainer methods default to `pass`).
> - Behavioural test pending in the downstream consumer (modelchef DiagnosticsCallback) — leaving this PR as draft until that runs end-to-end and confirms the new hooks fire at the expected boundaries.

### API and Usage Example

> A new callback subscribes by overriding any of the new `on_*` methods. No registration API change — callbacks plug into the trainer the same way as before.
>
> ```python
> from veomni.trainer.callbacks.base import Callback, TrainerState
>
> class PhaseTimer(Callback):
>     def on_forward_begin(self, state: TrainerState, micro_batch=None, **kwargs) -> None:
>         self._fwd_start = time.monotonic()
>
>     def on_forward_end(self, state: TrainerState, micro_batch=None, **kwargs) -> None:
>         tokens = micro_batch["input_ids"].numel() if micro_batch is not None else 0
>         print(f"step={state.global_step} tokens={tokens} fwd={time.monotonic() - self._fwd_start:.3f}s")
> ```
>
> The `forward_begin/end` and `backward_begin/end` hooks fire inside the per-micro-batch loop and receive the active `micro_batch` so callbacks can attribute timing or anomalies at micro-batch granularity (e.g. token counts, sequence length).

### Design & Code Changes

> - `veomni/trainer/callbacks/base.py`: add 8 no-op hook methods on `Callback` (`on_data_load_begin/end`, `on_forward_begin/end`, `on_backward_begin/end`, `on_optimizer_step_begin/end`).
> - `veomni/trainer/base.py`: add 8 matching no-op stub methods on `BaseTrainer` and insert calls at the corresponding boundaries in `train_step` / `forward_backward_step`:
>   - `on_data_load_begin/end` brackets `next(data_iterator)`.
>   - `on_forward_begin/end` brackets `model(...)` + `postforward(...)` (so loss-reduction collectives are attributed to the forward phase).
>   - `on_backward_begin/end` brackets `loss.backward()`.
>   - `on_optimizer_step_begin/end` brackets `clip_grad_norm` + `optimizer.step` + `lr_scheduler.step` + `optimizer.zero_grad`.
> - **No hand-listed dispatchers in `BaseTrainer`.** The new methods are pure `pass` stubs — none of the built-in callbacks (tqdm, wandb, environ_meter, profile, hf_ckpt, evaluate, moe_monitor, checkpointer) override the matching `Callback` hooks, so dispatching to all of them every step would be 64 no-op calls per step pretending to be wiring. Instead, trainer subclasses (e.g. modelchef's diagnostics trainer) override these methods to dispatch to their own callbacks. When/if a built-in callback eventually subscribes to a sub-step hook, add the hand-listed dispatch body in `BaseTrainer` at that point (mirroring `on_step_begin/end`).
> - No behavioural change for existing callbacks or test trainers — `BaseTrainer.on_*` default to `pass`, so partial-callback test trainers like `tests/models/test_models_patch.py::TrainerTest` and `tests/checkpoints/test_trainer_saveload.py::TrainerTest` keep working without any override.
>
> **Why this design over hand-listed dispatchers.** It is inconsistent with `on_step_begin/end` (which *does* hand-list every built-in callback), but the asymmetry is justified: `on_step_begin/end` has 8 real subscribers today, while the new sub-step hooks have 0. Adding dead dispatch code now would be both verbose and misleading; we add it when a real subscriber appears.
>
> **Drive-by consistency fix.** `BaseTrainer.on_step_begin`, `on_epoch_begin`, and `on_epoch_end` previously hand-listed only 7 of the 8 built-in callbacks — `moe_monitor_callback` was missing — while `on_step_end` / `on_train_begin/end` dispatched to all 8. `MoERouterMonitorCallback` currently only overrides `on_step_end`, so the omission is not a functional bug today; but it would silently swallow any future subscription on `on_step_begin` or `on_epoch_*`. Added the missing dispatch lines to make the surface uniform.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [ ] Added/updated documentation
- [ ] Added tests to CI workflow (or explained why not feasible)

