### PR TITLE
[BREAKING][ops, model] feat: GPU-optimal ops defaults + strict NPU validation

### DIFF
--- a/configs/dit/wan2.1_I2V_1.3B_lora.yaml
+++ b/configs/dit/wan2.1_I2V_1.3B_lora.yaml
@@ -1,6 +1,12 @@
 model:
   model_path: Wan-AI/Wan2.1-I2V-1.3B-diffusers/transformer
   condition_model_path: Wan-AI/Wan2.1-I2V-1.3B-diffusers
+  ops_implementation:
+    # Wan's RoPE has a non-standard signature (rope_apply takes a single
+    # tensor plus freqs/head_dim kwargs) so the framework's default
+    # liger_kernel RoPE cannot drop in. Pin to eager explicitly until a
+    # Wan-specific liger wrapper exists.
+    rotary_pos_emb_implementation: eager
   lora_config:
     rank: 128
     alpha: 64

--- a/configs/dit/wan_lora.yaml
+++ b/configs/dit/wan_lora.yaml
@@ -3,6 +3,11 @@ model:
   config_path: ./configs/model_configs/wan/wani2v_14b.json
   ops_implementation:
     attn_implementation: flash_attention_2
+    # Wan's RoPE has a non-standard signature (rope_apply takes a single
+    # tensor plus freqs/head_dim kwargs) so the framework's default
+    # liger_kernel RoPE cannot drop in. Pin to eager explicitly until a
+    # Wan-specific liger wrapper exists.
+    rotary_pos_emb_implementation: eager
   lora_target_modules: q,k,v,o,ffn.0,ffn.2
   lora_rank: 32
   lora_alpha: 32

--- a/configs/dit/wan_sft.yaml
+++ b/configs/dit/wan_sft.yaml
@@ -3,6 +3,11 @@ model:
   config_path: ./configs/model_configs/wan/wani2v_14b.json
   ops_implementation:
     attn_implementation: flash_attention_2
+    # Wan's RoPE has a non-standard signature (rope_apply takes a single
+    # tensor plus freqs/head_dim kwargs) so the framework's default
+    # liger_kernel RoPE cannot drop in. Pin to eager explicitly until a
+    # Wan-specific liger wrapper exists.
+    rotary_pos_emb_implementation: eager
 
 data:
   train_path: Wanmini480

--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -14,12 +14,19 @@ selection knob.
 | Kernel | Config field | Available values | Default | Selection time |
 |--------|-------------|------------------|---------|----------------|
 | Attention | `attn_implementation` | `eager`, `sdpa`, `flash_attention_2`, `flash_attention_3`, `flash_attention_4`, `native-sparse` | `"flash_attention_2"` | Config `__post_init__` + `build_foundation_model` |
-| Cross-entropy loss | `cross_entropy_loss_implementation` | `eager`, `liger_kernel`, `npu` | `"eager"` | `apply_ops_config()` (before model build) |
-| RMSNorm | `rms_norm_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"eager"` | Model registration via ops config singleton |
-| SwiGLU MLP | `swiglu_mlp_implementation` | `eager`, `liger_kernel` | `"eager"` | Model registration via ops config singleton |
-| Rotary embedding | `rotary_pos_emb_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"eager"` | Model registration via ops config singleton |
-| Load-balancing loss | `load_balancing_loss_implementation` | `eager`, `triton` (CUDA `triton` or NPU `triton-ascend`) | `"eager"` | `apply_ops_config()` (before model build) |
-| MoE experts | `moe_implementation` | `eager`, `fused_triton`, `fused_quack` (SM90+), `fused_npu` | `"eager"` | `build_foundation_model` |
+| Cross-entropy loss | `cross_entropy_loss_implementation` | `eager`, `liger_kernel`, `chunk_loss`, `npu` | `"liger_kernel"` (GPU) | `apply_ops_config()` (before model build) |
+| RMSNorm | `rms_norm_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"liger_kernel"` (GPU) | Model registration via ops config singleton |
+| SwiGLU MLP | `swiglu_mlp_implementation` | `eager`, `liger_kernel` | `"liger_kernel"` (GPU) | Model registration via ops config singleton |
+| Rotary embedding | `rotary_pos_emb_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"liger_kernel"` (GPU) | Model registration via ops config singleton |
+| Load-balancing loss | `load_balancing_loss_implementation` | `eager`, `triton` (CUDA `triton` or NPU `triton-ascend`) | `"triton"` | `apply_ops_config()` (before model build) |
+| MoE experts | `moe_implementation` | `eager`, `fused_triton`, `fused_quack` (SM90+), `fused_npu` | `"fused_triton"` (GPU) | `build_foundation_model` |
+
+**Defaults are GPU-optimal.** On Ascend NPU the defaults above raise at
+`OpsImplementationConfig.__post_init__` time — NPU users must set every field
+explicitly to an NPU-supported value (`npu` / `chunk_loss` / `fused_npu` /
+`triton` for load-balancing loss) or to `eager` when the op has no NPU
+backend (`swiglu_mlp_implementation`, DeepSeek-V3 RMSNorm/RoPE, Qwen2-VL
+multimodal RoPE). The error message lists the allowed alternatives per op.
 
 The per-op fields are typed as plain `str` (not `Literal`), so third-party
 backends can be registered via `extra_backends` in a model's `device_patch.py`
@@ -67,10 +74,16 @@ is no per-forward "which impl?" lookup.
 when callers pass `ops_implementation=ops` (trainers do this), it runs
 `apply_ops_config(ops)` before constructing the model and reads
 `attn_implementation` from `ops`. Callers that pass neither
-`ops_implementation` nor a prior `apply_ops_config` get
-`OpsImplementationConfig()` defaults installed silently, so
+`ops_implementation` nor a prior `apply_ops_config` get an *all-eager* safe
+fallback (`_build_safe_fallback_ops_config()` in `veomni/models/auto.py`)
+installed silently — every per-op field set to `"eager"` so the fallback
+works on any accelerator without depending on Liger / Triton. The public
+`OpsImplementationConfig()` defaults are GPU-optimal and would raise on
+hosts without those packages; production training routes through trainers
+that pass that public config explicitly. The fallback exists only so
 `self.loss_function` never trips on VeOmni's extra `hidden_states=` /
-`weights=` kwargs. (The DiT trainer is the one exception that still calls
+`weights=` kwargs in scripts like `tasks/infer/*` that don't construct a
+trainer. (The DiT trainer is the one exception that still calls
 `apply_ops_config` manually — it has to populate the singleton before
 building the condition model, which uses `model_class._from_config(...)`
 rather than `build_foundation_model`. The subsequent
@@ -121,7 +134,7 @@ with DeepSpeed Ulysses sequence parallelism gather/scatter.
 ```yaml
 model:
   ops_implementation:
-    cross_entropy_loss_implementation: eager   # or "liger_kernel", or custom str
+    cross_entropy_loss_implementation: liger_kernel   # default; set to "chunk_loss" / "npu" / "eager" on NPU
 ```
 
 **Field:** `OpsImplementationConfig.cross_entropy_loss_implementation`
@@ -173,9 +186,9 @@ batch-invariant RMSNorm and deterministic RoPE).
 ```yaml
 model:
   ops_implementation:
-    rms_norm_implementation: eager             # eager | liger_kernel | npu | triton
-    swiglu_mlp_implementation: eager           # eager | liger_kernel
-    rotary_pos_emb_implementation: eager       # eager | liger_kernel | npu | triton
+    rms_norm_implementation: liger_kernel       # default; pin to "npu" / "eager" on NPU
+    swiglu_mlp_implementation: liger_kernel     # default; pin to "eager" on NPU (no NPU backend)
+    rotary_pos_emb_implementation: liger_kernel # default; pin to "npu" / "eager" on NPU
 ```
 
 ### Available implementations
@@ -241,7 +254,7 @@ Qwen2, Qwen3, Qwen3-MoE, Qwen2-VL, DeepSeek-V3, Llama, Seed-OSS.
 ```yaml
 model:
   ops_implementation:
-    load_balancing_loss_implementation: eager   # or "triton", or custom str
+    load_balancing_loss_implementation: triton   # default; pin to "eager" on NPU (triton-ascend not exposed as `triton`)
 ```
 
 **Field:** `OpsImplementationConfig.load_balancing_loss_implementation`
@@ -281,7 +294,7 @@ model:
 ```
 
 **Field:** `OpsImplementationConfig.moe_implementation`
-**Default:** `"eager"`
+**Default:** `"fused_triton"` (GPU). On NPU set to `"fused_npu"` or `"eager"` — `fused_triton` / `fused_quack` raise at config validation time.
 
 The mode and kernel backend are expressed as a single field. Mismatches raise
 at ``apply_veomni_fused_moe_patch`` time — no silent hardware fallback.
@@ -345,7 +358,7 @@ All four are defined in `transformers.integrations`:
 | | VeOmni | Transformers v5 |
 |---|--------|----------------|
 | **Mechanism** | `gpu_patch.py` replaces `{Model}RMSNorm` class with `LigerRMSNorm` at import time | `@use_kernel_forward_from_hub("RMSNorm")` decorator on `Qwen3MoeRMSNorm`; at `model.kernelize()` time the `kernels` library downloads and swaps in `LigerRMSNorm` from `kernels-community/liger_kernels` |
-| **Config** | `VEOMNI_USE_LIGER_KERNEL` env var | `USE_HUB_KERNELS` env var + `model.kernelize()` call |
+| **Config** | `OpsImplementationConfig.rms_norm_implementation` field (default `"liger_kernel"` on GPU) | `USE_HUB_KERNELS` env var + `model.kernelize()` call |
 | **When** | Model registration (import time) | Deferred — `kernelize()` after model init |
 | **SP support** | N/A (norm is local) | N/A |
 | **Qwen3.5 MoE gap** | Same as Qwen3 — Liger swap works | **Not annotated.** `Qwen3_5MoeRMSNorm` uses `weight * (1.0 + self.weight)` (offset-by-1 convention, weight init to zeros) instead of the standard `self.weight * x` (weight init to ones). No `@use_kernel_forward_from_hub("RMSNorm")` decorator. Standard `LigerRMSNorm` cannot replace it without accounting for the `+1.0` offset. |
@@ -355,7 +368,7 @@ All four are defined in `transformers.integrations`:
 | | VeOmni | Transformers v5 |
 |---|--------|----------------|
 | **Mechanism** | `gpu_patch.py` replaces `apply_rotary_pos_emb` function with `liger_rotary_pos_emb` at import time | `@use_kernel_func_from_hub("rotary_pos_emb")` on the `apply_rotary_pos_emb` function; `kernels` library downloads `apply_rotary_transformers` from `kernels-community/rotary`. The function is also attached to the Attention module via `@use_kernelized_func(apply_rotary_pos_emb)` so `kernelize()` can find it. |
-| **Config** | `VEOMNI_USE_LIGER_KERNEL` env var | `USE_HUB_KERNELS` env var |
+| **Config** | `OpsImplementationConfig.rotary_pos_emb_implementation` field (default `"liger_kernel"` on GPU) | `USE_HUB_KERNELS` env var |
 | **When** | Model registration (import time) | Import time (decorator) + `kernelize()` |
 | **Qwen3.5 MoE gap** | N/A — VeOmni does not yet support Qwen3.5 MoE | **Partially annotated.** `apply_rotary_pos_emb` in `Qwen3_5MoeAttention` is annotated with `@use_kernelized_func` but **not** with `@use_kernel_func_from_hub("rotary_pos_emb")`. This is because Qwen3.5 MoE uses *partial RoPE* (`partial_rotary_factor < 1.0`): it splits Q/K into rotary and pass-through parts, applies RoPE only to the rotary part, then concatenates. The standard hub kernel `apply_rotary_transformers` does not handle this split-and-concat pattern. A dedicated partial-RoPE kernel could still be used. |
 

--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -74,20 +74,15 @@ is no per-forward "which impl?" lookup.
 when callers pass `ops_implementation=ops` (trainers do this), it runs
 `apply_ops_config(ops)` before constructing the model and reads
 `attn_implementation` from `ops`. Callers that pass neither
-`ops_implementation` nor a prior `apply_ops_config` get an *all-eager* safe
-fallback (`_build_safe_fallback_ops_config()` in `veomni/models/auto.py`)
-installed silently — every per-op field set to `"eager"` so the fallback
-works on any accelerator without depending on Liger / Triton. The public
-`OpsImplementationConfig()` defaults are GPU-optimal and would raise on
-hosts without those packages; production training routes through trainers
-that pass that public config explicitly. The fallback exists only so
-`self.loss_function` never trips on VeOmni's extra `hidden_states=` /
-`weights=` kwargs in scripts like `tasks/infer/*` that don't construct a
-trainer. (The DiT trainer is the one exception that still calls
-`apply_ops_config` manually — it has to populate the singleton before
-building the condition model, which uses `model_class._from_config(...)`
-rather than `build_foundation_model`. The subsequent
-`build_foundation_model` call is idempotent.)
+`ops_implementation` nor a prior `apply_ops_config` raise `ValueError` —
+there is no silent all-eager fallback. Standalone scripts (`tasks/infer/*`)
+construct an explicit `OpsImplementationConfig` (typically all-eager so
+inference doesn't depend on Liger / Triton). The DiT trainer is the one
+exception that calls `apply_ops_config` manually — it has to populate the
+singleton before building the condition model, which uses
+`model_class._from_config(...)` rather than `build_foundation_model`. The
+subsequent `build_foundation_model` call hits the
+"singleton-already-installed" branch and leaves the prior config alone.
 
 ---
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -146,15 +146,15 @@ NPU validation runs at two times:
   six general-purpose ops (`moe`, `cross_entropy_loss`, `rms_norm`,
   `swiglu_mlp`, `rotary_pos_emb`, `load_balancing_loss`). Errors fire
   immediately with a model-agnostic allow-list.
-- **Model-build time** for Qwen3.5-only ops (`rms_norm_gated`,
+- **OpSlot-bind time** (`KERNEL_REGISTRY.resolve` via the kernel's
+  `HardwareRequirement`) for Qwen3.5-only ops (`rms_norm_gated`,
   `causal_conv1d`, `chunk_gated_delta_rule`). Validating these at config
   parse would force every NPU user to override them even when training
-  non-Qwen3.5 models. Instead, `qwen3_5_moe`'s NPU registration raises
-  upfront if any of the three is set to a non-eager value, and the OpSlot
-  bind layer is the safety net behind it. **Qwen3.5 GatedDeltaNet has no
-  NPU kernel today** — varlen training (`dyn_bsz=True`, the default) is
-  not supported on NPU; non-varlen training works only with all three
-  fields pinned to `"eager"`.
+  non-Qwen3.5 models, so the check fires only when Qwen3.5's patched
+  modeling is actually loaded. **Qwen3.5 GatedDeltaNet has no NPU kernel
+  today** — varlen training (`dyn_bsz=True`, the default) is not supported
+  on NPU; non-varlen training works only with all three fields pinned to
+  `"eager"`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -134,11 +134,27 @@ The type is `str` (not `Literal`) so third-party backends can be registered
 without modifying the config class.
 
 **Defaults are GPU-optimal** (Liger / Triton / fused_triton). On Ascend NPU
-these defaults raise at validation time (`OpsImplementationConfig.__post_init__`);
-NPU users must set every field explicitly to an NPU-supported value (`"npu"`,
-`"chunk_loss"`, `"fused_npu"`, `"triton"` for load-balancing loss via
-`triton-ascend`) or to `"eager"` when the op has no NPU backend (e.g.
-`swiglu_mlp_implementation`, DeepSeek-V3 / Qwen2-VL multimodal RoPE).
+these defaults raise; NPU users must set every field explicitly to an
+NPU-supported value (`"npu"`, `"chunk_loss"`, `"fused_npu"`, `"triton"` for
+load-balancing loss via `triton-ascend`) or to `"eager"` when the op has no
+NPU backend (e.g. `swiglu_mlp_implementation`, DeepSeek-V3 / Qwen2-VL
+multimodal RoPE).
+
+NPU validation runs at two times:
+
+- **Config-parse time** (`OpsImplementationConfig.__post_init__`) for the
+  six general-purpose ops (`moe`, `cross_entropy_loss`, `rms_norm`,
+  `swiglu_mlp`, `rotary_pos_emb`, `load_balancing_loss`). Errors fire
+  immediately with a model-agnostic allow-list.
+- **Model-build time** for Qwen3.5-only ops (`rms_norm_gated`,
+  `causal_conv1d`, `chunk_gated_delta_rule`). Validating these at config
+  parse would force every NPU user to override them even when training
+  non-Qwen3.5 models. Instead, `qwen3_5_moe`'s NPU registration raises
+  upfront if any of the three is set to a non-eager value, and the OpSlot
+  bind layer is the safety net behind it. **Qwen3.5 GatedDeltaNet has no
+  NPU kernel today** — varlen training (`dyn_bsz=True`, the default) is
+  not supported on NPU; non-varlen training works only with all three
+  fields pinned to `"eager"`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -133,15 +133,22 @@ Each `*_implementation` field selects the kernel backend for that operation.
 The type is `str` (not `Literal`) so third-party backends can be registered
 without modifying the config class.
 
+**Defaults are GPU-optimal** (Liger / Triton / fused_triton). On Ascend NPU
+these defaults raise at validation time (`OpsImplementationConfig.__post_init__`);
+NPU users must set every field explicitly to an NPU-supported value (`"npu"`,
+`"chunk_loss"`, `"fused_npu"`, `"triton"` for load-balancing loss via
+`triton-ascend`) or to `"eager"` when the op has no NPU backend (e.g.
+`swiglu_mlp_implementation`, DeepSeek-V3 / Qwen2-VL multimodal RoPE).
+
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | attn_implementation | `Optional[Literal[...]]` | `"flash_attention_2"` | Attention implementation to use. |
-| moe_implementation | `Literal["eager", "fused_triton", "fused_quack", "fused_npu"]` | `"eager"` | MoE experts forward implementation. `fused_triton` uses Triton group-gemm (GPU, SM70+); `fused_quack` uses Quack CUTLASS/CuTe (GPU, SM90+); `fused_npu` uses the NPU group-gemm kernel. Mismatches (e.g. `fused_triton` on NPU) raise at patch time — no silent fallback. |
-| cross_entropy_loss_implementation | `str` | `"eager"` | Cross-entropy loss. Known values: `eager`, `liger_kernel`, `npu` (NPU chunked loss; backs `ForCausalLM` + `ForConditionalGeneration`, `ForSequenceClassification` stays on eager). |
-| rms_norm_implementation | `str` | `"eager"` | RMSNorm. Known values: `eager`, `liger_kernel`, `npu`, `triton`. |
-| swiglu_mlp_implementation | `str` | `"eager"` | SwiGLU MLP. Known values: `eager`, `liger_kernel`. |
-| rotary_pos_emb_implementation | `str` | `"eager"` | Rotary pos emb. Known values: `eager`, `liger_kernel`, `npu`, `triton`. |
-| load_balancing_loss_implementation | `str` | `"eager"` | MoE load-balancing loss. Known values: `eager`, `triton`. |
+| moe_implementation | `str` | `"fused_triton"` | MoE experts forward implementation. `fused_triton` uses Triton group-gemm (GPU, SM70+); `fused_quack` uses Quack CUTLASS/CuTe (GPU, SM90+); `fused_npu` uses the NPU group-gemm kernel; `eager` is the reference loop. Mismatches (e.g. `fused_triton` on NPU) raise at config validation time — no silent fallback. |
+| cross_entropy_loss_implementation | `str` | `"liger_kernel"` | Cross-entropy loss. `liger_kernel` (default, GPU only) fuses `lm_head` linear + CE; requires VeOmni-patched modeling files that pass `hidden_states=`/`weights=` to `self.loss_function(...)` — unpatched HF models that pass logits will RuntimeError. `chunk_loss` is the hardware-agnostic chunked F.linear+CE (CUDA + NPU). `npu` is a back-compat alias for `chunk_loss`. `eager` is `F.cross_entropy`. |
+| rms_norm_implementation | `str` | `"liger_kernel"` | RMSNorm. Known values: `liger_kernel` (default, GPU only), `npu`, `triton` (DeepSeek-V3 only; GPU only), `eager`. |
+| swiglu_mlp_implementation | `str` | `"liger_kernel"` | SwiGLU MLP. Known values: `liger_kernel` (default, GPU only), `eager`. There is no NPU backend — NPU users must set this to `"eager"`. |
+| rotary_pos_emb_implementation | `str` | `"liger_kernel"` | Rotary pos emb. Known values: `liger_kernel` (default, GPU only), `npu`, `triton` (DeepSeek-V3 only; GPU only), `eager`. |
+| load_balancing_loss_implementation | `str` | `"triton"` | MoE load-balancing loss. `triton` (default) requires the `triton` Python package (or `triton-ascend` on NPU); raises at config validation time if the package is missing. `eager` is the pure-PyTorch reference. |
 | rms_norm_gated_implementation | `str` | `"fla"` | Gated RMSNorm (Qwen3.5 GatedDeltaNet `self.norm`). Known values: `eager`, `fla` (FLA `FusedRMSNormGated`, requires `flash-linear-attention`, GPU). No NPU backend — selecting any non-eager value on NPU raises at OpSlot bind time. |
 | causal_conv1d_implementation | `str` | `"fla"` | Varlen depthwise causal conv1d (Qwen3.5 GatedDeltaNet pre-mixer). Known values: `eager`, `fla` (FLA `causal_conv1d`, requires `flash-linear-attention`, GPU). `eager` raises at forward time for varlen training (no torch fallback handles `cu_seqlens`). No NPU backend. |
 | chunk_gated_delta_rule_implementation | `str` | `"fla"` | Chunk gated delta-rule kernel for Qwen3.5 linear attention. Known values: `eager`, `fla` (FLA `chunk_gated_delta_rule`, GPU), `flash_qla` (QwenLM FlashQLA, requires the optional `flash-qla` extra, GPU). `eager` falls back to transformers' `torch_chunk_gated_delta_rule`, which raises at forward time for varlen training. No NPU backend. |

--- a/tasks/deprecated_task/train_wan.py
+++ b/tasks/deprecated_task/train_wan.py
@@ -154,7 +154,7 @@ def main():
         weights_path=args.model.model_path,
         init_device=args.train.init_device,
         torch_dtype="bfloat16",
-        attn_implementation=args.model.ops_implementation.attn_implementation,
+        ops_implementation=args.model.ops_implementation,
     )
     model.micro_batch_size = args.train.micro_batch_size
 

--- a/tasks/infer/infer_omni_model.py
+++ b/tasks/infer/infer_omni_model.py
@@ -7,12 +7,14 @@ import torch
 from PIL import Image
 
 from veomni.arguments import InferArguments, parse_args
+from veomni.arguments.arguments_types import OpsImplementationConfig
 from veomni.data import build_multimodal_chat_template
 from veomni.data.multimodal.multimodal_transform import mask_input_ids
 from veomni.models import build_foundation_model, build_processor
 from veomni.models.seed_omni import SeedOmniModel, SeedOmniProcessor
 from veomni.utils import helper
 from veomni.utils.device import get_device_type
+from veomni.utils.import_utils import is_flash_attn_2_available
 
 
 logger = helper.create_logger(__name__)
@@ -112,6 +114,23 @@ data_mapping = {
 }
 
 
+# Inference doesn't need fused training kernels — pin every per-op field to
+# eager. ``attn_implementation`` falls back to eager on hosts without
+# flash-attn so CPU / minimal-deps environments don't crash.
+_INFERENCE_OPS = OpsImplementationConfig(
+    attn_implementation="flash_attention_2" if is_flash_attn_2_available() else "eager",
+    moe_implementation="eager",
+    cross_entropy_loss_implementation="eager",
+    rms_norm_implementation="eager",
+    swiglu_mlp_implementation="eager",
+    rotary_pos_emb_implementation="eager",
+    load_balancing_loss_implementation="eager",
+    rms_norm_gated_implementation="eager",
+    causal_conv1d_implementation="eager",
+    chunk_gated_delta_rule_implementation="eager",
+)
+
+
 def main() -> None:
     args = parse_args(Arguments)
     logger.info(json.dumps(asdict(args), indent=2))
@@ -119,7 +138,9 @@ def main() -> None:
     helper.enable_third_party_logging()
     # config model and processor
     model: SeedOmniModel = (
-        build_foundation_model(args.infer.model_path, args.infer.model_path).eval().to(get_device_type())
+        build_foundation_model(args.infer.model_path, args.infer.model_path, ops_implementation=_INFERENCE_OPS)
+        .eval()
+        .to(get_device_type())
     )
     position_id_func = model.get_position_id_func()
     modality_info = model.get_modality()

--- a/tasks/infer/infer_qwen2_vl.py
+++ b/tasks/infer/infer_qwen2_vl.py
@@ -5,9 +5,11 @@ import requests
 from PIL import Image
 
 from veomni.arguments import InferArguments, parse_args
+from veomni.arguments.arguments_types import OpsImplementationConfig
 from veomni.models import build_foundation_model, build_processor
 from veomni.utils import helper
 from veomni.utils.device import get_device_type
+from veomni.utils.import_utils import is_flash_attn_2_available
 
 
 logger = helper.create_logger(__name__)
@@ -18,12 +20,33 @@ class Arguments:
     infer: "InferArguments" = field(default_factory=InferArguments)
 
 
+# Inference doesn't need fused training kernels — pin every per-op field to
+# eager. ``attn_implementation`` falls back to eager on hosts without
+# flash-attn so CPU / minimal-deps environments don't crash.
+_INFERENCE_OPS = OpsImplementationConfig(
+    attn_implementation="flash_attention_2" if is_flash_attn_2_available() else "eager",
+    moe_implementation="eager",
+    cross_entropy_loss_implementation="eager",
+    rms_norm_implementation="eager",
+    swiglu_mlp_implementation="eager",
+    rotary_pos_emb_implementation="eager",
+    load_balancing_loss_implementation="eager",
+    rms_norm_gated_implementation="eager",
+    causal_conv1d_implementation="eager",
+    chunk_gated_delta_rule_implementation="eager",
+)
+
+
 def main() -> None:
     args = parse_args(Arguments)
     logger.info_rank0(json.dumps(asdict(args), indent=2))
     helper.set_seed(args.infer.seed)
     helper.enable_third_party_logging()
-    model = build_foundation_model(args.infer.model_path, args.infer.model_path).eval().to(get_device_type())
+    model = (
+        build_foundation_model(args.infer.model_path, args.infer.model_path, ops_implementation=_INFERENCE_OPS)
+        .eval()
+        .to(get_device_type())
+    )
     processor = build_processor(args.infer.tokenizer_path)
     image_token_id = processor.tokenizer.encode(processor.image_token)[0]
     model.config.image_token_id = image_token_id

--- a/tasks/infer/infer_text.py
+++ b/tasks/infer/infer_text.py
@@ -6,8 +6,10 @@ import torch
 from transformers import AutoTokenizer, TextStreamer
 
 from veomni.arguments import InferArguments, parse_args
+from veomni.arguments.arguments_types import OpsImplementationConfig
 from veomni.models import build_foundation_model
 from veomni.utils import helper
+from veomni.utils.import_utils import is_flash_attn_2_available
 
 
 logger = helper.create_logger(__name__)
@@ -18,12 +20,33 @@ class Arguments:
     infer: "InferArguments" = field(default_factory=InferArguments)
 
 
+# Inference doesn't need fused training kernels — pin every per-op field to
+# eager. ``attn_implementation`` falls back to eager on hosts without
+# flash-attn so CPU / minimal-deps environments don't crash.
+_INFERENCE_OPS = OpsImplementationConfig(
+    attn_implementation="flash_attention_2" if is_flash_attn_2_available() else "eager",
+    moe_implementation="eager",
+    cross_entropy_loss_implementation="eager",
+    rms_norm_implementation="eager",
+    swiglu_mlp_implementation="eager",
+    rotary_pos_emb_implementation="eager",
+    load_balancing_loss_implementation="eager",
+    rms_norm_gated_implementation="eager",
+    causal_conv1d_implementation="eager",
+    chunk_gated_delta_rule_implementation="eager",
+)
+
+
 def main() -> None:
     args = parse_args(Arguments)
     logger.info_rank0(json.dumps(asdict(args), indent=2))
     helper.set_seed(args.infer.seed)
     helper.enable_third_party_logging()
-    model = build_foundation_model(config_path=args.infer.model_path, weights_path=args.infer.model_path)
+    model = build_foundation_model(
+        config_path=args.infer.model_path,
+        weights_path=args.infer.model_path,
+        ops_implementation=_INFERENCE_OPS,
+    )
     tokenizer = AutoTokenizer.from_pretrained(args.infer.tokenizer_path, padding_side="left")
     streamer = TextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=True)
     logger.info("tips: use `clear` to remove the history, use `exit` to exit the conversation.")

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -134,6 +134,7 @@ def main():
         input_encoder=args.model.input_encoder,
         output_encoder=args.model.output_encoder,
         init_device=args.train.init_device,
+        ops_implementation=args.model.ops_implementation,
     )
 
     logger.info_rank0("Prepare data")

--- a/tests/checkpoints/utils.py
+++ b/tests/checkpoints/utils.py
@@ -7,15 +7,8 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from tools import hf_local_or_remote
+from tools import hf_local_or_remote, resolve_ops_overrides
 from tools.launch_utils import find_free_port
-
-from veomni.utils.import_utils import is_torch_npu_available
-
-
-# Pick the fused-MoE backend that matches the test hardware. On NPU the NPU
-# kernel is the only option; on GPU default to Triton (SM70+).
-_FUSED_MOE_IMPL = "fused_npu" if is_torch_npu_available() else "fused_triton"
 
 
 MODEL_CONFIGS = {
@@ -63,8 +56,10 @@ def get_checkpoint_test_command(
         "tests/checkpoints/test_trainer_saveload.py",
         f"--model.config_path {config_path}",
         f"--model.tokenizer_path {tokenizer_path}",
-        f"--model.ops_implementation.moe_implementation {_FUSED_MOE_IMPL}",
-        "--model.ops_implementation.attn_implementation flash_attention_2",
+        # Hardware-aware ops_implementation overrides. ``resolve_ops_overrides``
+        # emits NPU-supported per-op backends on NPU (with eager fallback for
+        # ops without an NPU kernel) and the GPU-optimal baseline on GPU.
+        *resolve_ops_overrides(model_name),
         "--data.train_path dummy",
         "--data.max_seq_len 128",
         f"--train.checkpoint.output_dir {output_dir}",

--- a/tests/data/multimodal/test_vlm_data_process.py
+++ b/tests/data/multimodal/test_vlm_data_process.py
@@ -139,13 +139,29 @@ def load_veomni_processor(model_path):
 
 def load_veomni_model(config_path, device):
     """Build and return the veomni model for testing."""
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    # Pin every per-op field to eager so the test builds without liger /
+    # triton / fla; FA2 is needed for varlen multimodal forward.
+    eager_ops = OpsImplementationConfig(
+        attn_implementation="flash_attention_2",
+        moe_implementation="eager",
+        cross_entropy_loss_implementation="eager",
+        rms_norm_implementation="eager",
+        swiglu_mlp_implementation="eager",
+        rotary_pos_emb_implementation="eager",
+        load_balancing_loss_implementation="eager",
+        rms_norm_gated_implementation="eager",
+        causal_conv1d_implementation="eager",
+        chunk_gated_delta_rule_implementation="eager",
+    )
     print(f"\n[Setup] Building veomni model on device: {device}")
     model = build_foundation_model(
         config_path=config_path,
         weights_path=None,
         torch_dtype="bfloat16",
-        attn_implementation="flash_attention_2",
         init_device=device,
+        ops_implementation=eager_ops,
     )
     model.eval()
     return model

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -2,11 +2,16 @@ import copy
 import os
 import random
 import subprocess
+import sys
 from functools import partial
 from typing import Any, Dict, List
 
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
 import pytest
 import yaml
+from tools import resolve_ops_overrides
 from transformers import PretrainedConfig
 from utils import DummyDataset, FakeModel, compare_global_batch, compare_items, compare_metrics, process_dummy_example
 
@@ -245,6 +250,11 @@ def build_command(dataset_type: str, dyn_bsz: bool, data_path: str):
         "--data.dataloader.pin_memory=False",
         "--train.num_train_epochs=5",
         "--train.checkpoint.output_dir=.tests/cache",
+        # Hardware-aware ops_implementation overrides. ``resolve_ops_overrides``
+        # emits NPU-supported per-op backends on NPU and ``[]`` on GPU (the
+        # dataclass defaults are already GPU-optimal). FakeModel is not
+        # registered, so ``model_name=None`` skips per-model eager fallbacks.
+        *resolve_ops_overrides(None),
     ]
     return command
 

--- a/tests/data/test_dynamic_batching_dataset.py
+++ b/tests/data/test_dynamic_batching_dataset.py
@@ -42,6 +42,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest
 import torch
+from tools import resolve_ops_overrides
 from tools.launch_utils import find_free_port
 from torch.utils.data import IterableDataset
 from transformers import PretrainedConfig
@@ -417,6 +418,8 @@ def build_command(shuffle=True, save_by_idx=True, multi_sample_per_iteration=Fal
         f"--save_by_idx={str(save_by_idx).lower()}",
         f"--multi_sample_per_iteration={str(multi_sample_per_iteration).lower()}",
         "--train.seed=42",
+        # Hardware-aware ops_implementation overrides; see test_datasets.py.
+        *resolve_ops_overrides(None),
     ]
     return command
 

--- a/tests/data/test_multisource_dataset.py
+++ b/tests/data/test_multisource_dataset.py
@@ -20,6 +20,7 @@ import pytest
 import torch
 import torch.distributed as dist
 import yaml
+from tools import resolve_ops_overrides
 from tools.launch_utils import find_free_port
 from torch.utils.data import IterableDataset
 from transformers import PretrainedConfig
@@ -849,6 +850,8 @@ def build_command():
         "--train.dyn_bsz_runtime=worker",
         "--train.bsz_warmup_ratio=0",
         "--train.max_steps=6",
+        # Hardware-aware ops_implementation overrides; see test_datasets.py.
+        *resolve_ops_overrides(None),
     ]
     return command
 

--- a/tests/distributed/test_dummy_forward.py
+++ b/tests/distributed/test_dummy_forward.py
@@ -145,6 +145,8 @@ def _asymmetric_forward_worker(model_type, config_path, batch_fn):
     from veomni.models.auto import build_foundation_model
     from veomni.utils.device import get_device_type
 
+    from ..tools.training_utils import make_eager_ops_config
+
     _apply_patches()
 
     # Tight NCCL timeout so a missing dummy_forward fails fast instead of hanging
@@ -160,8 +162,8 @@ def _asymmetric_forward_worker(model_type, config_path, batch_fn):
         config_path=config_path,
         weights_path=None,
         torch_dtype="float32",
-        attn_implementation="eager",
         init_device="meta",
+        ops_implementation=make_eager_ops_config(),
     )
     model.train()
 

--- a/tests/distributed/test_fsdp_equivalence.py
+++ b/tests/distributed/test_fsdp_equivalence.py
@@ -60,7 +60,7 @@ def _setup_model_and_data(model_name, config_path, dataset_type="text"):
     return test_dir, train_path, dummy_dataset
 
 
-def _run_single_gpu_training(config_path, model_path, train_path, output_dir):
+def _run_single_gpu_training(model_name, config_path, model_path, train_path, output_dir):
     """Run plain single-GPU training (nproc=1, no parallelism).
 
     Uses the same trainer script as the FSDP run, but with nproc=1 and no
@@ -80,6 +80,7 @@ def _run_single_gpu_training(config_path, model_path, train_path, output_dir):
         nproc=1,
         init_device=get_device_type(),
         extra_args=["--train.accelerator.fsdp_config.mixed_precision.enable=False"],
+        model_name=model_name,
     )
 
 
@@ -94,7 +95,7 @@ def _get_nproc():
     return count
 
 
-def _run_fsdp2_training(config_path, model_path, train_path, output_dir, nproc=None):
+def _run_fsdp2_training(model_name, config_path, model_path, train_path, output_dir, nproc=None):
     """Run FSDP2 distributed training and return metrics."""
     from ..tools import run_training_config
 
@@ -116,6 +117,7 @@ def _run_fsdp2_training(config_path, model_path, train_path, output_dir, nproc=N
             "--train.accelerator.ep_size=1",
             "--train.accelerator.fsdp_config.mixed_precision.enable=False",
         ],
+        model_name=model_name,
     )
 
 
@@ -141,6 +143,7 @@ def _run_fsdp_equivalence(
     try:
         # 1. Run single-GPU baseline (nproc=1, no FSDP)
         baseline_results = _run_single_gpu_training(
+            model_name=model_name,
             config_path=config_path,
             model_path=test_dir,
             train_path=train_path,
@@ -149,6 +152,7 @@ def _run_fsdp_equivalence(
 
         # 2. Run FSDP2 with all available GPUs
         fsdp2_results = _run_fsdp2_training(
+            model_name=model_name,
             config_path=config_path,
             model_path=test_dir,
             train_path=train_path,

--- a/tests/distributed/test_fsdp_equivalence.py
+++ b/tests/distributed/test_fsdp_equivalence.py
@@ -28,7 +28,7 @@ import shutil
 
 import pytest
 
-from veomni.utils.device import get_device_type
+from veomni.utils.device import IS_NPU_AVAILABLE, get_device_type
 from veomni.utils.import_utils import is_transformers_version_greater_or_equal_to
 
 from ..tools import ParallelConfig
@@ -37,6 +37,10 @@ from ..tools import ParallelConfig
 _is_transformers_v5 = is_transformers_version_greater_or_equal_to("5.0.0")
 _v4_only = pytest.mark.skipif(_is_transformers_v5, reason="Not compatible with transformers >= 5.0.0")
 _v5_only = pytest.mark.skipif(not _is_transformers_v5, reason="Requires transformers >= 5.0.0")
+# Qwen3.5 GatedDeltaNet has no NPU kernel today (varlen path unsupported).
+_qwen3_5_npu_skip = pytest.mark.skipif(
+    IS_NPU_AVAILABLE, reason="Qwen3.5 GatedDeltaNet has no NPU backend (varlen path)"
+)
 
 _DEFAULT_RTOL = 1e-1
 _DEFAULT_ATOL = 1e-1
@@ -219,7 +223,7 @@ _text_test_cases_v5 = [
         _DEFAULT_RTOL,
         _DEFAULT_ATOL,
         id="qwen3_5",
-        marks=_v5_only,
+        marks=[_v5_only, _qwen3_5_npu_skip],
     ),
     pytest.param(
         "qwen3_5_moe",
@@ -228,7 +232,7 @@ _text_test_cases_v5 = [
         _DEFAULT_RTOL,
         _DEFAULT_ATOL,
         id="qwen3_5_moe",
-        marks=_v5_only,
+        marks=[_v5_only, _qwen3_5_npu_skip],
     ),
 ]
 

--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -12,6 +12,7 @@ from veomni.utils.device import IS_NPU_AVAILABLE
 from veomni.utils.import_utils import is_diffusers_available, is_transformers_version_greater_or_equal_to
 
 from ..tools import DummyDataset, build_torchrun_cmd, compare_metrics, print_comparison_table
+from ..tools.training_utils import make_eager_ops_config
 from .utils import prepare_exec_cmd
 
 
@@ -39,8 +40,8 @@ def _materialize_weights_dir(config_path: str, output_path: str, save_original_f
         config_path=config_path,
         weights_path=None,
         torch_dtype="float32",
-        attn_implementation="eager",
         init_device="cpu",
+        ops_implementation=make_eager_ops_config(),
     )
     model.save_pretrained(output_path, save_original_format=save_original_format)
 

--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from veomni.models.auto import build_foundation_model
+from veomni.utils.device import IS_NPU_AVAILABLE
 from veomni.utils.import_utils import is_diffusers_available, is_transformers_version_greater_or_equal_to
 
 from ..tools import DummyDataset, build_torchrun_cmd, compare_metrics, print_comparison_table
@@ -19,6 +20,11 @@ _is_transformers_v5 = is_transformers_version_greater_or_equal_to("5.0.0")
 _v4_only = pytest.mark.skipif(_is_transformers_v5, reason="Not compatible with transformers >= 5.0.0")
 _v5_only = pytest.mark.skipif(not _is_transformers_v5, reason="Requires transformers >= 5.0.0")
 _dit_only = pytest.mark.skipif(not is_diffusers_available(), reason="Requires diffusers")
+# Qwen3.5 GatedDeltaNet has no NPU kernel today; eager-only path also requires
+# non-varlen training (dyn_bsz=False), but the e2e command uses dyn_bsz=True.
+_qwen3_5_npu_skip = pytest.mark.skipif(
+    IS_NPU_AVAILABLE, reason="Qwen3.5 GatedDeltaNet has no NPU backend (varlen path)"
+)
 
 
 def _materialize_weights_dir(config_path: str, output_path: str, save_original_format: bool = True) -> Path:
@@ -254,7 +260,7 @@ qwen3vl_test_cases = [
         _DEFAULT_RTOL,
         _DEFAULT_ATOL,
         None,  # max_sp_size
-        marks=_v5_only,
+        marks=[_v5_only, _qwen3_5_npu_skip],
     ),
     pytest.param(
         "qwen3_5",
@@ -263,7 +269,7 @@ qwen3vl_test_cases = [
         _DEFAULT_RTOL,
         _DEFAULT_ATOL,
         None,  # max_sp_size
-        marks=_v5_only,
+        marks=[_v5_only, _qwen3_5_npu_skip],
     ),
 ]
 

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -146,6 +146,11 @@ def prepare_exec_cmd(
                 output_dir=os.path.join(output_dir, task_name),
                 parallel_config=ParallelConfig(sp_size=mode.sp_size, ep_size=mode.ep_size, fsdp_mode="fsdp2"),
                 nproc=mode.sp_size * 4,
+                # Forwarded to ``resolve_ops_overrides`` inside
+                # ``build_torchrun_cmd`` so per-model NPU eager fallbacks
+                # (e.g. DeepSeek-V3 RMSNorm/RoPE, Qwen2-VL multimodal RoPE)
+                # are emitted on the NPU side.
+                model_name=model_name,
             )
             command_list.append((task_name, cmd_kwargs))
 

--- a/tests/models/test_models_logits_equal.py
+++ b/tests/models/test_models_logits_equal.py
@@ -391,12 +391,14 @@ def _build_veomni_model(case: Case, hf_state_dict):
     """Return a device-resident, eval-mode veomni model with HF weights loaded."""
     from veomni.models.auto import build_foundation_model
 
+    from ..tools.training_utils import make_eager_ops_config
+
     model = build_foundation_model(
         config_path=case.path,
         weights_path=None,
         torch_dtype=case.dtype,
-        attn_implementation=case.attn_implementation,
         init_device=get_device_type(),
+        ops_implementation=make_eager_ops_config(attn_implementation=case.attn_implementation),
     )
 
     if case.sync_weight_key is not None:
@@ -553,14 +555,16 @@ def _build_veomni_model_via_runtime_converter(case: Case, hf_state_dict, hf_buff
     """
     from veomni.models.auto import build_foundation_model
 
+    from ..tools.training_utils import make_eager_ops_config
+
     _save_hf_checkpoint(hf_state_dict, config, weights_dir)
 
     model = build_foundation_model(
         config_path=weights_dir,
         weights_path=weights_dir,
         torch_dtype=case.dtype,
-        attn_implementation=case.attn_implementation,
         init_device=get_device_type(),
+        ops_implementation=make_eager_ops_config(attn_implementation=case.attn_implementation),
     )
 
     # Restore non-persistent buffers (e.g. rotary inv_freq) that aren't in the

--- a/tests/models/test_models_logits_equal_v5.py
+++ b/tests/models/test_models_logits_equal_v5.py
@@ -384,41 +384,22 @@ def _build_hf_model(case: Case, config, dtype: torch.dtype):
     return model.eval()
 
 
-def _make_eager_ops_config(attn_implementation: str):
-    """OpsImplementationConfig that pins every op to its HF-equivalent path.
-
-    The Qwen3.5 GatedDeltaNet OpSlots (rms_norm_gated / causal_conv1d /
-    chunk_gated_delta_rule) never fire under our full-attention override,
-    but ``"eager"`` instead of the default ``"fla"`` keeps the test
-    runnable without ``flash-linear-attention`` installed.
-    """
-    from veomni.arguments.arguments_types import OpsImplementationConfig
-
-    return OpsImplementationConfig(
-        attn_implementation=attn_implementation,
-        moe_implementation="eager",
-        cross_entropy_loss_implementation="eager",
-        rms_norm_implementation="eager",
-        swiglu_mlp_implementation="eager",
-        rotary_pos_emb_implementation="eager",
-        load_balancing_loss_implementation="eager",
-        rms_norm_gated_implementation="eager",
-        causal_conv1d_implementation="eager",
-        chunk_gated_delta_rule_implementation="eager",
-    )
-
-
 def _build_veomni_model(case: Case, config, hf_state_dict):
     """VeOmni-generated model with HF state_dict loaded."""
     from veomni.models.auto import build_foundation_model
     from veomni.ops import apply_ops_config
 
+    from ..tools.training_utils import make_eager_ops_config
+
     # Install our eager-everywhere ops config first so ``build_foundation_model``'s
-    # "no config installed → use defaults" branch doesn't overwrite it (the
-    # defaults rebind GatedDeltaNet slots to fla and CE to chunk_loss).
+    # contract (caller passes ops_implementation OR singleton already installed)
+    # is satisfied. The Qwen3.5 GatedDeltaNet OpSlots (rms_norm_gated /
+    # causal_conv1d / chunk_gated_delta_rule) never fire under our
+    # full-attention override, but pinning them to ``"eager"`` keeps the test
+    # runnable without ``flash-linear-attention`` installed.
     # The SP-aware FA wrappers degrade to plain FA at sp_size=1, so passing
     # ``flash_attention_2`` directly is equivalent to the SP-rewritten name.
-    apply_ops_config(_make_eager_ops_config(case.attn_implementation))
+    apply_ops_config(make_eager_ops_config(attn_implementation=case.attn_implementation))
 
     model = build_foundation_model(
         config_path=config,

--- a/tests/models/test_models_patch.py
+++ b/tests/models/test_models_patch.py
@@ -17,7 +17,6 @@ from veomni.arguments import (
     ModelArguments,
     TrainingArguments,
 )
-from veomni.arguments.arguments_types import OpsImplementationConfig
 from veomni.data.data_collator import MainCollator
 from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
 from veomni.trainer.base import BaseTrainer, VeOmniArguments
@@ -27,6 +26,7 @@ from veomni.utils.import_utils import is_transformers_version_greater_or_equal_t
 from veomni.utils.loss_utils import count_loss_token
 
 from ..tools.common_utils import print_device_mem_info
+from ..tools.training_utils import make_eager_ops_config
 from .utils import (
     ModelMode,
     compare_multi_items,
@@ -398,7 +398,7 @@ def test_models_patch_fwd_bwd(
     # this the public ``OpsImplementationConfig()`` defaults (liger_kernel /
     # fused_triton / triton) would fail validation on NPU before the test
     # even runs.
-    model_config = ModelArguments(config_path=config_path, ops_implementation=OpsImplementationConfig.all_eager())
+    model_config = ModelArguments(config_path=config_path, ops_implementation=make_eager_ops_config())
     data_config = DataArguments(train_path="")
     training_config = TrainingArguments(
         checkpoint=CheckpointConfig(output_dir="./test_models_patch"),

--- a/tests/models/test_models_patch.py
+++ b/tests/models/test_models_patch.py
@@ -17,6 +17,7 @@ from veomni.arguments import (
     ModelArguments,
     TrainingArguments,
 )
+from veomni.arguments.arguments_types import OpsImplementationConfig
 from veomni.data.data_collator import MainCollator
 from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
 from veomni.trainer.base import BaseTrainer, VeOmniArguments
@@ -390,7 +391,14 @@ def test_models_patch_fwd_bwd(
             mode for mode in veomni_model_modes if mode.attn_implementation != "veomni_flash_attention_3_with_sp"
         ]
 
-    model_config = ModelArguments(config_path=config_path)
+    # The actual ops backend used per test case is set by ``set_environ_param``
+    # inside ``TrainerTest`` (which calls ``apply_ops_config`` with a
+    # mode-specific config). The ops_implementation on this ModelArguments is
+    # never consumed at training time, so we pin it to all-eager — without
+    # this the public ``OpsImplementationConfig()`` defaults (liger_kernel /
+    # fused_triton / triton) would fail validation on NPU before the test
+    # even runs.
+    model_config = ModelArguments(config_path=config_path, ops_implementation=OpsImplementationConfig.all_eager())
     data_config = DataArguments(train_path="")
     training_config = TrainingArguments(
         checkpoint=CheckpointConfig(output_dir="./test_models_patch"),

--- a/tests/models/test_padded_packed_loss.py
+++ b/tests/models/test_padded_packed_loss.py
@@ -1,11 +1,12 @@
 import pytest
 import torch
 
-from veomni.arguments.arguments_types import OpsImplementationConfig
 from veomni.data.data_collator import MainCollator
 from veomni.models import build_foundation_model
 from veomni.ops import apply_ops_config
 from veomni.utils.device import IS_CUDA_AVAILABLE, get_device_type
+
+from ..tools.training_utils import make_eager_ops_config
 
 
 def _skip_if_no_flash_attn():
@@ -22,7 +23,7 @@ def test_qwen3_loss_match_with_padded_packed_input(monkeypatch, pad_to_length):
     _skip_if_no_flash_attn()
     # Pin to all-eager so the test doesn't depend on liger-kernel / triton
     # (the public OpsImplementationConfig() defaults are GPU-optimal).
-    apply_ops_config(OpsImplementationConfig.all_eager())
+    apply_ops_config(make_eager_ops_config())
     monkeypatch.setattr(
         "veomni.data.data_collator.get_parallel_state",
         lambda: type("PS", (), {"sp_enabled": False, "sp_size": 1, "sp_rank": 0})(),

--- a/tests/models/test_padded_packed_loss.py
+++ b/tests/models/test_padded_packed_loss.py
@@ -20,21 +20,9 @@ def _skip_if_no_flash_attn():
 @pytest.mark.parametrize("pad_to_length", [16])
 def test_qwen3_loss_match_with_padded_packed_input(monkeypatch, pad_to_length):
     _skip_if_no_flash_attn()
-    # Use an explicit all-eager config so the test runs on dev boxes without
-    # liger-kernel / triton — the new OpsImplementationConfig() defaults are
-    # GPU-optimal and require both packages. The CUDA + flash-attn gate above
-    # already filters most environments, but the eager pin keeps this test
-    # decoupled from the framework defaults.
-    apply_ops_config(
-        OpsImplementationConfig(
-            moe_implementation="eager",
-            cross_entropy_loss_implementation="eager",
-            rms_norm_implementation="eager",
-            swiglu_mlp_implementation="eager",
-            rotary_pos_emb_implementation="eager",
-            load_balancing_loss_implementation="eager",
-        )
-    )
+    # Pin to all-eager so the test doesn't depend on liger-kernel / triton
+    # (the public OpsImplementationConfig() defaults are GPU-optimal).
+    apply_ops_config(OpsImplementationConfig.all_eager())
     monkeypatch.setattr(
         "veomni.data.data_collator.get_parallel_state",
         lambda: type("PS", (), {"sp_enabled": False, "sp_size": 1, "sp_rank": 0})(),

--- a/tests/models/test_padded_packed_loss.py
+++ b/tests/models/test_padded_packed_loss.py
@@ -20,7 +20,21 @@ def _skip_if_no_flash_attn():
 @pytest.mark.parametrize("pad_to_length", [16])
 def test_qwen3_loss_match_with_padded_packed_input(monkeypatch, pad_to_length):
     _skip_if_no_flash_attn()
-    apply_ops_config(OpsImplementationConfig())
+    # Use an explicit all-eager config so the test runs on dev boxes without
+    # liger-kernel / triton — the new OpsImplementationConfig() defaults are
+    # GPU-optimal and require both packages. The CUDA + flash-attn gate above
+    # already filters most environments, but the eager pin keeps this test
+    # decoupled from the framework defaults.
+    apply_ops_config(
+        OpsImplementationConfig(
+            moe_implementation="eager",
+            cross_entropy_loss_implementation="eager",
+            rms_norm_implementation="eager",
+            swiglu_mlp_implementation="eager",
+            rotary_pos_emb_implementation="eager",
+            load_balancing_loss_implementation="eager",
+        )
+    )
     monkeypatch.setattr(
         "veomni.data.data_collator.get_parallel_state",
         lambda: type("PS", (), {"sp_enabled": False, "sp_size": 1, "sp_rank": 0})(),

--- a/tests/models/test_vlm_trainer.py
+++ b/tests/models/test_vlm_trainer.py
@@ -45,17 +45,12 @@ _FREEZE_VIT_VLM_CASES = (
 @pytest.mark.parametrize("config_path", _FREEZE_VIT_VLM_CASES)
 def test_freeze_vit_on_vlm_model(config_path, freeze_vit):
     # This test only constructs the model on `meta` and verifies freeze
-    # behaviour — it never runs forward. Use an explicit eager
-    # OpsImplementationConfig so Qwen3.5 build works on NPU (no FLA backend)
-    # and on GPU hosts that don't have flash-linear-attention installed; the
-    # eager linear-attention path raises at forward-time only, which this
-    # test does not exercise.
-    ops_implementation = OpsImplementationConfig(
-        attn_implementation="eager",
-        rms_norm_gated_implementation="eager",
-        causal_conv1d_implementation="eager",
-        chunk_gated_delta_rule_implementation="eager",
-    )
+    # behaviour — it never runs forward. Use ``all_eager()`` so the build
+    # works everywhere: it pins every per-op field (including the Qwen3.5
+    # GatedDeltaNet trio that has no FLA backend on NPU and the GPU-only
+    # liger/triton defaults that fail NPU validation). Eager paths that raise
+    # only at forward time are fine because this test never forwards.
+    ops_implementation = OpsImplementationConfig.all_eager(attn_implementation="eager")
     model = build_foundation_model(
         config_path=config_path,
         weights_path=None,

--- a/tests/models/test_vlm_trainer.py
+++ b/tests/models/test_vlm_trainer.py
@@ -67,7 +67,10 @@ def test_freeze_vit_on_vlm_model(config_path, freeze_vit):
     assert visual is not None
 
     args = VeOmniVLMArguments(
-        model=VLMMModelArguments(config_path=config_path),
+        model=VLMMModelArguments(
+            config_path=config_path,
+            ops_implementation=OpsImplementationConfig.all_eager(),
+        ),
         data=VLMMDataArguments(train_path="dummy"),
     )
     args.train.freeze_vit = freeze_vit

--- a/tests/models/test_vlm_trainer.py
+++ b/tests/models/test_vlm_trainer.py
@@ -2,7 +2,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from veomni.arguments.arguments_types import OpsImplementationConfig
 from veomni.models import build_foundation_model
 from veomni.trainer.vlm_trainer import (
     VeOmniVLMArguments,
@@ -12,6 +11,8 @@ from veomni.trainer.vlm_trainer import (
     _get_vlm_visual_module,
 )
 from veomni.utils.import_utils import is_transformers_version_greater_or_equal_to
+
+from ..tools.training_utils import make_eager_ops_config
 
 
 _FREEZE_VIT_VLM_CASES_TRANSFORMERS_V4 = [
@@ -45,12 +46,13 @@ _FREEZE_VIT_VLM_CASES = (
 @pytest.mark.parametrize("config_path", _FREEZE_VIT_VLM_CASES)
 def test_freeze_vit_on_vlm_model(config_path, freeze_vit):
     # This test only constructs the model on `meta` and verifies freeze
-    # behaviour — it never runs forward. Use ``all_eager()`` so the build
-    # works everywhere: it pins every per-op field (including the Qwen3.5
-    # GatedDeltaNet trio that has no FLA backend on NPU and the GPU-only
-    # liger/triton defaults that fail NPU validation). Eager paths that raise
-    # only at forward time are fine because this test never forwards.
-    ops_implementation = OpsImplementationConfig.all_eager(attn_implementation="eager")
+    # behaviour — it never runs forward. Use an all-eager ops config so the
+    # build works everywhere: it pins every per-op field (including the
+    # Qwen3.5 GatedDeltaNet trio that has no FLA backend on NPU and the
+    # GPU-only liger/triton defaults that fail NPU validation). Eager paths
+    # that raise only at forward time are fine because this test never
+    # forwards.
+    ops_implementation = make_eager_ops_config()
     model = build_foundation_model(
         config_path=config_path,
         weights_path=None,
@@ -64,7 +66,7 @@ def test_freeze_vit_on_vlm_model(config_path, freeze_vit):
     args = VeOmniVLMArguments(
         model=VLMMModelArguments(
             config_path=config_path,
-            ops_implementation=OpsImplementationConfig.all_eager(),
+            ops_implementation=make_eager_ops_config(),
         ),
         data=VLMMDataArguments(train_path="dummy"),
     )

--- a/tests/ops/test_comp.py
+++ b/tests/ops/test_comp.py
@@ -161,10 +161,26 @@ def compare(args, model, grid_thw, ref_fn, test_fn):
 
 
 def main(args):
-    # Initialize the model and get the visual
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+
+    # Initialize the model and get the visual. Pin every per-op field to
+    # eager so the benchmark builds without liger / triton / fla.
+    eager_ops = OpsImplementationConfig(
+        attn_implementation="eager",
+        moe_implementation="eager",
+        cross_entropy_loss_implementation="eager",
+        rms_norm_implementation="eager",
+        swiglu_mlp_implementation="eager",
+        rotary_pos_emb_implementation="eager",
+        load_balancing_loss_implementation="eager",
+        rms_norm_gated_implementation="eager",
+        causal_conv1d_implementation="eager",
+        chunk_gated_delta_rule_implementation="eager",
+    )
     dummy_model = build_foundation_model(
         config_path=args.config_path,
         init_device=args.device,
+        ops_implementation=eager_ops,
     ).model.visual
 
     dummy_model.pos_embed.weight = torch.nn.Parameter(torch.randn_like(dummy_model.pos_embed.weight))

--- a/tests/ops/test_moe_hw_gate.py
+++ b/tests/ops/test_moe_hw_gate.py
@@ -160,7 +160,18 @@ def test_bind_veomni_ops_translates_moe_implementation_and_checks_hw(_mock_cc, _
     # Start from all-eager so this test exercises only the moe_experts
     # OpSlot binding, not the GPU-optimal defaults (which would require
     # liger-kernel + triton in the test environment).
-    ops_config = OpsImplementationConfig.all_eager(moe_implementation="fused_quack")
+    ops_config = OpsImplementationConfig(
+        attn_implementation="eager",
+        moe_implementation="fused_quack",
+        cross_entropy_loss_implementation="eager",
+        rms_norm_implementation="eager",
+        swiglu_mlp_implementation="eager",
+        rotary_pos_emb_implementation="eager",
+        load_balancing_loss_implementation="eager",
+        rms_norm_gated_implementation="eager",
+        causal_conv1d_implementation="eager",
+        chunk_gated_delta_rule_implementation="eager",
+    )
     # Simulate a patchgen'd modeling module with a moe_experts OpSlot.
     fake_module = SimpleNamespace(veomni_moe_experts_forward=OpSlot("moe_experts", "standard"))
 

--- a/tests/ops/test_moe_hw_gate.py
+++ b/tests/ops/test_moe_hw_gate.py
@@ -135,10 +135,17 @@ def test_opslot_unknown_kernel_name_raises():
 # ---------------------------------------------------------------------------
 
 
+# ``OpsImplementationConfig.__post_init__`` runs ``_validate_implementations``
+# which calls ``veomni.utils.import_utils.is_torch_npu_available`` directly —
+# the registry-level IS_NPU_AVAILABLE patches above don't reach it. Mock the
+# validator's NPU detection so this GPU-scenario test can construct a config
+# with ``fused_quack`` on the NPU CI runner without the validator firing
+# before the bind step we actually want to exercise.
+@patch("veomni.utils.import_utils.is_torch_npu_available", return_value=False)
 @patch(f"{_REGISTRY_MODULE}.IS_CUDA_AVAILABLE", True)
 @patch(f"{_REGISTRY_MODULE}.IS_NPU_AVAILABLE", False)
 @patch(f"{_REGISTRY_MODULE}.get_gpu_compute_capability", return_value=80)
-def test_bind_veomni_ops_translates_moe_implementation_and_checks_hw(_mock_cc):
+def test_bind_veomni_ops_translates_moe_implementation_and_checks_hw(_mock_cc, _mock_npu):
     """Reproducer for the silent-fallback regression:
 
     User sets ``moe_implementation='fused_quack'`` on an A100. The binding
@@ -150,17 +157,10 @@ def test_bind_veomni_ops_translates_moe_implementation_and_checks_hw(_mock_cc):
     from veomni.arguments.arguments_types import OpsImplementationConfig
     from veomni.models.auto import _bind_veomni_ops
 
-    # Pin every other op to ``eager`` so this test exercises the moe_experts
-    # OpSlot binding without coupling to the global GPU-optimal defaults
-    # (which would require liger-kernel + triton in the test environment).
-    ops_config = OpsImplementationConfig(
-        moe_implementation="fused_quack",
-        cross_entropy_loss_implementation="eager",
-        rms_norm_implementation="eager",
-        swiglu_mlp_implementation="eager",
-        rotary_pos_emb_implementation="eager",
-        load_balancing_loss_implementation="eager",
-    )
+    # Start from all-eager so this test exercises only the moe_experts
+    # OpSlot binding, not the GPU-optimal defaults (which would require
+    # liger-kernel + triton in the test environment).
+    ops_config = OpsImplementationConfig.all_eager(moe_implementation="fused_quack")
     # Simulate a patchgen'd modeling module with a moe_experts OpSlot.
     fake_module = SimpleNamespace(veomni_moe_experts_forward=OpSlot("moe_experts", "standard"))
 

--- a/tests/ops/test_moe_hw_gate.py
+++ b/tests/ops/test_moe_hw_gate.py
@@ -150,7 +150,17 @@ def test_bind_veomni_ops_translates_moe_implementation_and_checks_hw(_mock_cc):
     from veomni.arguments.arguments_types import OpsImplementationConfig
     from veomni.models.auto import _bind_veomni_ops
 
-    ops_config = OpsImplementationConfig(moe_implementation="fused_quack")
+    # Pin every other op to ``eager`` so this test exercises the moe_experts
+    # OpSlot binding without coupling to the global GPU-optimal defaults
+    # (which would require liger-kernel + triton in the test environment).
+    ops_config = OpsImplementationConfig(
+        moe_implementation="fused_quack",
+        cross_entropy_loss_implementation="eager",
+        rms_norm_implementation="eager",
+        swiglu_mlp_implementation="eager",
+        rotary_pos_emb_implementation="eager",
+        load_balancing_loss_implementation="eager",
+    )
     # Simulate a patchgen'd modeling module with a moe_experts OpSlot.
     fake_module = SimpleNamespace(veomni_moe_experts_forward=OpSlot("moe_experts", "standard"))
 

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -12,6 +12,8 @@ from .training_utils import (
     ParallelConfig,
     build_torchrun_cmd,
     materialize_weights,
+    npu_skip_marker,
     release_device_memory,
+    resolve_ops_overrides,
     run_training_config,
 )

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -12,7 +12,6 @@ from .training_utils import (
     ParallelConfig,
     build_torchrun_cmd,
     materialize_weights,
-    npu_skip_marker,
     release_device_memory,
     resolve_ops_overrides,
     run_training_config,

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -11,6 +11,8 @@ from .launch_utils import find_free_port, torchrun
 from .training_utils import (
     ParallelConfig,
     build_torchrun_cmd,
+    make_eager_ops_config,
+    make_npu_ops_config,
     materialize_weights,
     release_device_memory,
     resolve_ops_overrides,

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -11,130 +11,56 @@ import subprocess
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-import pytest
-
 from veomni.utils.import_utils import is_torch_npu_available
 
 from .launch_utils import find_free_port
 
 
-# ── ops_implementation overrides for tests ──────────────────────────────────
-#
-# OpsImplementationConfig defaults are GPU-optimal (Liger / Triton). On NPU
-# those defaults raise at config validation time (liger_kernel is GPU-only),
-# so every NPU test must explicitly opt every op down to an NPU-supported
-# value (or to ``eager`` for ops with no NPU backend at all).
-#
-# ``resolve_ops_overrides(model_name)`` is the single source of truth for
-# this mapping. It returns the list of ``--model.ops_implementation.X=Y``
-# CLI flags to inject into ``torchrun`` commands so every test on every
-# accelerator passes the validator with the fastest backend that actually
-# runs on the host.
-
-# Default NPU values per op. Models without an NPU kernel for a given op
-# override these in ``_NPU_PER_MODEL_OVERRIDES`` below.
+# NPU ops_implementation overrides per model. The public
+# ``OpsImplementationConfig`` defaults are GPU-optimal (Liger / Triton) and
+# raise on NPU at config validation time, so every NPU test must override
+# every per-op field. ``_NPU_OPS_DEFAULTS`` is the baseline; entries in
+# ``_NPU_PER_MODEL_OVERRIDES`` (DeepSeek-V3, Qwen-VL family) pin specific
+# fields to ``eager`` where the model has no NPU kernel.
 _NPU_OPS_DEFAULTS: Dict[str, str] = {
     "attn_implementation": "flash_attention_2",
     "moe_implementation": "fused_npu",
     "cross_entropy_loss_implementation": "chunk_loss",
     "rms_norm_implementation": "npu",
     "rotary_pos_emb_implementation": "npu",
-    # SwiGLU has no NPU backend in the registry — eager is the only option.
-    "swiglu_mlp_implementation": "eager",
-    # NPU ships ``triton-ascend`` (not mainline ``triton``); the existing
-    # ``tests/models/utils.py`` infra already gates the fused load-balancing-loss
-    # kernel behind ``is_package_available("triton")`` for the same reason. The
-    # validator uses the same check, so the ``"triton"`` value would raise on
-    # the NPU CI runner. Default to eager for safety.
+    "swiglu_mlp_implementation": "eager",  # no NPU backend
+    # NPU ships ``triton-ascend`` (not mainline ``triton``); the validator
+    # gates ``triton`` on ``is_package_available("triton")`` so the fused
+    # load-balancing-loss kernel would raise on the NPU runner. Pin to eager.
     "load_balancing_loss_implementation": "eager",
 }
 
-# Per-model overrides: ops that exist in the registry but have no NPU backend
-# for this specific model. These fall back to ``eager``. Anything not listed
-# here picks up ``_NPU_OPS_DEFAULTS``.
 _NPU_PER_MODEL_OVERRIDES: Dict[str, Dict[str, str]] = {
-    # DeepSeek-V3 only registers GPU-only Triton kernels for RMSNorm
-    # (batch-invariant) and RoPE (deterministic). Eager fallback on NPU.
     "deepseek_v3": {
+        # batch-invariant RMSNorm + deterministic RoPE are GPU-only Triton
         "rms_norm_implementation": "eager",
         "rotary_pos_emb_implementation": "eager",
     },
-    # Multimodal RoPE has no NPU backend in any of the Qwen-VL family
-    # (Qwen2-VL / Qwen2.5-VL / Qwen2.5-Omni share the same multimodal RoPE
-    # symbol via qwen2_vl/device_patch.py). Eager fallback on NPU.
+    # Multimodal RoPE has no NPU backend in the Qwen-VL family.
     "qwen2vl": {"rotary_pos_emb_implementation": "eager"},
     "qwen25vl": {"rotary_pos_emb_implementation": "eager"},
     "qwen25_omni": {"rotary_pos_emb_implementation": "eager"},
 }
 
-# GPU baseline. The OpsImplementationConfig defaults are already GPU-optimal,
-# so these flags are effectively redundant — we still pass them explicitly so
-# the CLI invocation matches what production users see in ``configs/*.yaml``
-# and a future default change cannot silently shift CI semantics.
-#
-# NOTE: the unset fields (cross_entropy / rms_norm / rotary / swiglu /
-# load_balancing) inherit the public OpsImplementationConfig defaults
-# (``liger_kernel`` / ``triton``). Those defaults silently require
-# ``liger-kernel`` and ``triton`` to be installed on the GPU CI image (both
-# ship in the ``gpu`` extra of pyproject.toml). If a future GPU image drops
-# either package, every test using this baseline will fail at config
-# validation time with a clear error message — but the link back here may
-# not be obvious. Add explicit ``--model.ops_implementation.X=eager`` flags
-# below if the CI image diverges from the ``gpu`` extra.
-_GPU_OPS_DEFAULTS: Dict[str, str] = {
-    "attn_implementation": "flash_attention_2",
-    "moe_implementation": "fused_triton",
-}
-
-# Models that cannot run on NPU at all — e.g. a forward path requires a kernel
-# that has no NPU backend AND no eager fallback. Tests should mark the model
-# parametrization with ``npu_skip_marker(model_name)`` so the test is skipped
-# (rather than failing in validation) when ``is_torch_npu_available()``.
-#
-# Empty today; populated when models with strict eager-incompatible kernels
-# land (e.g. Qwen3.5 GatedDeltaNet's ``chunk_gated_delta_rule`` OpSlot, which
-# raises in eager mode for varlen training).
-_NPU_SKIP_MODELS: set = set()
-
 
 def resolve_ops_overrides(model_name: Optional[str]) -> List[str]:
-    """Return the list of ``--model.ops_implementation.X=Y`` flags to apply
-    for *model_name* on the active hardware.
+    """Return ``--model.ops_implementation.X=Y`` flags for the active hardware.
 
-    On GPU the OpsImplementationConfig defaults are already optimal; we still
-    emit the attention + MoE flags explicitly to match production YAML.
-
-    On NPU we override every configurable op to an NPU-supported value (or
-    eager when no NPU backend exists for that op or that model). The returned
-    flags pass the OpsImplementationConfig._validate_implementations gate.
-
-    Pass ``model_name=None`` for tests that don't tie to a specific model
-    (e.g. raw distributed tests); the result is the GPU/NPU baseline without
-    any model-specific eager fallbacks.
+    On GPU returns ``[]`` — the dataclass defaults are already optimal.
+    On NPU returns the NPU-supported backend per op, with per-model eager
+    fallbacks for ops without an NPU kernel for that specific model.
     """
-    if is_torch_npu_available():
-        merged: Dict[str, str] = dict(_NPU_OPS_DEFAULTS)
-        if model_name is not None:
-            merged.update(_NPU_PER_MODEL_OVERRIDES.get(model_name, {}))
-        return [f"--model.ops_implementation.{k}={v}" for k, v in merged.items()]
-    return [f"--model.ops_implementation.{k}={v}" for k, v in _GPU_OPS_DEFAULTS.items()]
-
-
-def npu_skip_marker(model_name: str):
-    """``pytest.mark.skipif`` that skips a model's test parametrization on NPU
-    when no NPU+eager combination of ops backends can run the model.
-
-    Use as ``marks=[npu_skip_marker(model_name)]`` (or list-extended onto an
-    existing marks list) on ``pytest.param(...)`` entries. The skip activates
-    only when ``is_torch_npu_available()``; on GPU the marker is a no-op.
-    """
-    return pytest.mark.skipif(
-        is_torch_npu_available() and model_name in _NPU_SKIP_MODELS,
-        reason=(
-            f"{model_name} has no NPU-compatible kernel for at least one "
-            "required op (and no eager fallback) — skipping on NPU."
-        ),
-    )
+    if not is_torch_npu_available():
+        return []
+    merged = dict(_NPU_OPS_DEFAULTS)
+    if model_name is not None:
+        merged.update(_NPU_PER_MODEL_OVERRIDES.get(model_name, {}))
+    return [f"--model.ops_implementation.{k}={v}" for k, v in merged.items()]
 
 
 def release_device_memory():
@@ -183,11 +109,9 @@ def build_torchrun_cmd(
         init_device: Device for model initialization. Use "meta" for FSDP
             (multi-GPU), device type for single-GPU (no FSDP wrapping).
         model_name: Short model identifier (e.g. ``"qwen3_moe"``,
-            ``"deepseek_v3"``). Used by ``resolve_ops_overrides`` to pick
-            NPU-compatible per-op backends when running on NPU. Pass ``None``
-            for tests that don't tie to a specific model — the GPU/NPU
-            baseline is still emitted but no model-specific eager fallbacks
-            are applied.
+            ``"deepseek_v3"``). Forwarded to ``resolve_ops_overrides`` so
+            NPU runs pick the right per-model eager fallbacks. ``None`` is
+            fine for tests not tied to a specific model.
     """
     port = find_free_port()
     if nproc is not None:

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -11,14 +11,130 @@ import subprocess
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
+import pytest
+
 from veomni.utils.import_utils import is_torch_npu_available
 
 from .launch_utils import find_free_port
 
 
-# Pick the fused-MoE backend that matches the test hardware. On NPU the NPU
-# kernel is the only option; on GPU default to Triton (SM70+).
-_FUSED_MOE_IMPL = "fused_npu" if is_torch_npu_available() else "fused_triton"
+# ── ops_implementation overrides for tests ──────────────────────────────────
+#
+# OpsImplementationConfig defaults are GPU-optimal (Liger / Triton). On NPU
+# those defaults raise at config validation time (liger_kernel is GPU-only),
+# so every NPU test must explicitly opt every op down to an NPU-supported
+# value (or to ``eager`` for ops with no NPU backend at all).
+#
+# ``resolve_ops_overrides(model_name)`` is the single source of truth for
+# this mapping. It returns the list of ``--model.ops_implementation.X=Y``
+# CLI flags to inject into ``torchrun`` commands so every test on every
+# accelerator passes the validator with the fastest backend that actually
+# runs on the host.
+
+# Default NPU values per op. Models without an NPU kernel for a given op
+# override these in ``_NPU_PER_MODEL_OVERRIDES`` below.
+_NPU_OPS_DEFAULTS: Dict[str, str] = {
+    "attn_implementation": "flash_attention_2",
+    "moe_implementation": "fused_npu",
+    "cross_entropy_loss_implementation": "chunk_loss",
+    "rms_norm_implementation": "npu",
+    "rotary_pos_emb_implementation": "npu",
+    # SwiGLU has no NPU backend in the registry — eager is the only option.
+    "swiglu_mlp_implementation": "eager",
+    # NPU ships ``triton-ascend`` (not mainline ``triton``); the existing
+    # ``tests/models/utils.py`` infra already gates the fused load-balancing-loss
+    # kernel behind ``is_package_available("triton")`` for the same reason. The
+    # validator uses the same check, so the ``"triton"`` value would raise on
+    # the NPU CI runner. Default to eager for safety.
+    "load_balancing_loss_implementation": "eager",
+}
+
+# Per-model overrides: ops that exist in the registry but have no NPU backend
+# for this specific model. These fall back to ``eager``. Anything not listed
+# here picks up ``_NPU_OPS_DEFAULTS``.
+_NPU_PER_MODEL_OVERRIDES: Dict[str, Dict[str, str]] = {
+    # DeepSeek-V3 only registers GPU-only Triton kernels for RMSNorm
+    # (batch-invariant) and RoPE (deterministic). Eager fallback on NPU.
+    "deepseek_v3": {
+        "rms_norm_implementation": "eager",
+        "rotary_pos_emb_implementation": "eager",
+    },
+    # Multimodal RoPE has no NPU backend in any of the Qwen-VL family
+    # (Qwen2-VL / Qwen2.5-VL / Qwen2.5-Omni share the same multimodal RoPE
+    # symbol via qwen2_vl/device_patch.py). Eager fallback on NPU.
+    "qwen2vl": {"rotary_pos_emb_implementation": "eager"},
+    "qwen25vl": {"rotary_pos_emb_implementation": "eager"},
+    "qwen25_omni": {"rotary_pos_emb_implementation": "eager"},
+}
+
+# GPU baseline. The OpsImplementationConfig defaults are already GPU-optimal,
+# so these flags are effectively redundant — we still pass them explicitly so
+# the CLI invocation matches what production users see in ``configs/*.yaml``
+# and a future default change cannot silently shift CI semantics.
+#
+# NOTE: the unset fields (cross_entropy / rms_norm / rotary / swiglu /
+# load_balancing) inherit the public OpsImplementationConfig defaults
+# (``liger_kernel`` / ``triton``). Those defaults silently require
+# ``liger-kernel`` and ``triton`` to be installed on the GPU CI image (both
+# ship in the ``gpu`` extra of pyproject.toml). If a future GPU image drops
+# either package, every test using this baseline will fail at config
+# validation time with a clear error message — but the link back here may
+# not be obvious. Add explicit ``--model.ops_implementation.X=eager`` flags
+# below if the CI image diverges from the ``gpu`` extra.
+_GPU_OPS_DEFAULTS: Dict[str, str] = {
+    "attn_implementation": "flash_attention_2",
+    "moe_implementation": "fused_triton",
+}
+
+# Models that cannot run on NPU at all — e.g. a forward path requires a kernel
+# that has no NPU backend AND no eager fallback. Tests should mark the model
+# parametrization with ``npu_skip_marker(model_name)`` so the test is skipped
+# (rather than failing in validation) when ``is_torch_npu_available()``.
+#
+# Empty today; populated when models with strict eager-incompatible kernels
+# land (e.g. Qwen3.5 GatedDeltaNet's ``chunk_gated_delta_rule`` OpSlot, which
+# raises in eager mode for varlen training).
+_NPU_SKIP_MODELS: set = set()
+
+
+def resolve_ops_overrides(model_name: Optional[str]) -> List[str]:
+    """Return the list of ``--model.ops_implementation.X=Y`` flags to apply
+    for *model_name* on the active hardware.
+
+    On GPU the OpsImplementationConfig defaults are already optimal; we still
+    emit the attention + MoE flags explicitly to match production YAML.
+
+    On NPU we override every configurable op to an NPU-supported value (or
+    eager when no NPU backend exists for that op or that model). The returned
+    flags pass the OpsImplementationConfig._validate_implementations gate.
+
+    Pass ``model_name=None`` for tests that don't tie to a specific model
+    (e.g. raw distributed tests); the result is the GPU/NPU baseline without
+    any model-specific eager fallbacks.
+    """
+    if is_torch_npu_available():
+        merged: Dict[str, str] = dict(_NPU_OPS_DEFAULTS)
+        if model_name is not None:
+            merged.update(_NPU_PER_MODEL_OVERRIDES.get(model_name, {}))
+        return [f"--model.ops_implementation.{k}={v}" for k, v in merged.items()]
+    return [f"--model.ops_implementation.{k}={v}" for k, v in _GPU_OPS_DEFAULTS.items()]
+
+
+def npu_skip_marker(model_name: str):
+    """``pytest.mark.skipif`` that skips a model's test parametrization on NPU
+    when no NPU+eager combination of ops backends can run the model.
+
+    Use as ``marks=[npu_skip_marker(model_name)]`` (or list-extended onto an
+    existing marks list) on ``pytest.param(...)`` entries. The skip activates
+    only when ``is_torch_npu_available()``; on GPU the marker is a no-op.
+    """
+    return pytest.mark.skipif(
+        is_torch_npu_available() and model_name in _NPU_SKIP_MODELS,
+        reason=(
+            f"{model_name} has no NPU-compatible kernel for at least one "
+            "required op (and no eager fallback) — skipping on NPU."
+        ),
+    )
 
 
 def release_device_memory():
@@ -56,6 +172,7 @@ def build_torchrun_cmd(
     extra_args: Optional[List[str]] = None,
     nproc: Optional[int] = None,
     init_device: str = "meta",
+    model_name: Optional[str] = None,
 ) -> List[str]:
     """Build a torchrun command for distributed test execution.
 
@@ -65,6 +182,12 @@ def build_torchrun_cmd(
             for plain single-GPU training.
         init_device: Device for model initialization. Use "meta" for FSDP
             (multi-GPU), device type for single-GPU (no FSDP wrapping).
+        model_name: Short model identifier (e.g. ``"qwen3_moe"``,
+            ``"deepseek_v3"``). Used by ``resolve_ops_overrides`` to pick
+            NPU-compatible per-op backends when running on NPU. Pass ``None``
+            for tests that don't tie to a specific model — the GPU/NPU
+            baseline is still emitted but no model-specific eager fallbacks
+            are applied.
     """
     port = find_free_port()
     if nproc is not None:
@@ -85,8 +208,6 @@ def build_torchrun_cmd(
         "--data.dyn_bsz_buffer_size=1",
         "--train.global_batch_size=16",
         "--train.micro_batch_size=1",
-        "--model.ops_implementation.attn_implementation=flash_attention_2",
-        f"--model.ops_implementation.moe_implementation={_FUSED_MOE_IMPL}",
         f"--train.init_device={init_device}",
         "--train.bsz_warmup_ratio=0",
         "--train.num_train_epochs=1",
@@ -98,6 +219,7 @@ def build_torchrun_cmd(
         "--train.max_steps=2",
         f"--train.checkpoint.output_dir={output_dir}",
         f"--model.model_path={model_path}",
+        *resolve_ops_overrides(model_name),
     ]
 
     if parallel_config is not None:
@@ -149,8 +271,13 @@ def run_training_config(
     nproc: Optional[int] = None,
     extra_args: Optional[List[str]] = None,
     init_device: str = "meta",
+    model_name: Optional[str] = None,
 ) -> Dict:
     """Run a single training configuration and return metrics from log.
+
+    Args:
+        model_name: Short model identifier (forwarded to ``build_torchrun_cmd``
+            for NPU-aware ops_implementation overrides).
 
     Returns:
         Dict of {metric_name: list_of_values} loaded from the JSON log.
@@ -166,6 +293,7 @@ def run_training_config(
         nproc=nproc,
         extra_args=extra_args,
         init_device=init_device,
+        model_name=model_name,
     )
 
     print(f"\n{'=' * 60}")

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -11,6 +11,7 @@ import subprocess
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
+from veomni.arguments.arguments_types import OpsImplementationConfig
 from veomni.utils.import_utils import is_torch_npu_available
 
 from .launch_utils import find_free_port
@@ -48,6 +49,13 @@ _NPU_PER_MODEL_OVERRIDES: Dict[str, Dict[str, str]] = {
 }
 
 
+def _npu_overrides(model_name: Optional[str]) -> Dict[str, str]:
+    merged = dict(_NPU_OPS_DEFAULTS)
+    if model_name is not None:
+        merged.update(_NPU_PER_MODEL_OVERRIDES.get(model_name, {}))
+    return merged
+
+
 def resolve_ops_overrides(model_name: Optional[str]) -> List[str]:
     """Return ``--model.ops_implementation.X=Y`` flags for the active hardware.
 
@@ -57,10 +65,48 @@ def resolve_ops_overrides(model_name: Optional[str]) -> List[str]:
     """
     if not is_torch_npu_available():
         return []
-    merged = dict(_NPU_OPS_DEFAULTS)
-    if model_name is not None:
-        merged.update(_NPU_PER_MODEL_OVERRIDES.get(model_name, {}))
-    return [f"--model.ops_implementation.{k}={v}" for k, v in merged.items()]
+    return [f"--model.ops_implementation.{k}={v}" for k, v in _npu_overrides(model_name).items()]
+
+
+def make_eager_ops_config(**overrides) -> OpsImplementationConfig:
+    """Hardware-agnostic ``OpsImplementationConfig`` with every field = ``"eager"``.
+
+    For tests / inference scripts that don't need fused kernels and shouldn't
+    depend on liger / triton or the active accelerator. ``**overrides`` flips
+    specific fields (e.g. ``make_eager_ops_config(attn_implementation="flash_attention_2")``)
+    without enumerating the rest.
+    """
+    return OpsImplementationConfig(
+        attn_implementation=overrides.pop("attn_implementation", "eager"),
+        moe_implementation=overrides.pop("moe_implementation", "eager"),
+        cross_entropy_loss_implementation=overrides.pop("cross_entropy_loss_implementation", "eager"),
+        rms_norm_implementation=overrides.pop("rms_norm_implementation", "eager"),
+        swiglu_mlp_implementation=overrides.pop("swiglu_mlp_implementation", "eager"),
+        rotary_pos_emb_implementation=overrides.pop("rotary_pos_emb_implementation", "eager"),
+        load_balancing_loss_implementation=overrides.pop("load_balancing_loss_implementation", "eager"),
+        rms_norm_gated_implementation=overrides.pop("rms_norm_gated_implementation", "eager"),
+        causal_conv1d_implementation=overrides.pop("causal_conv1d_implementation", "eager"),
+        chunk_gated_delta_rule_implementation=overrides.pop("chunk_gated_delta_rule_implementation", "eager"),
+        **overrides,
+    )
+
+
+def make_npu_ops_config(model_name: Optional[str] = None, **overrides) -> OpsImplementationConfig:
+    """NPU-recommended ``OpsImplementationConfig`` for tests running on Ascend.
+
+    Encodes the per-op NPU backend table (``_NPU_OPS_DEFAULTS``) plus per-model
+    eager fallbacks for ops without an NPU kernel (DeepSeek-V3, Qwen-VL family).
+    ``**overrides`` flips specific fields after the recommended values are
+    applied.
+    """
+    merged = _npu_overrides(model_name)
+    merged.update(overrides)
+    # Qwen3.5 GatedDeltaNet ops have no NPU kernel today — pin to eager so the
+    # config validates at parse time.
+    merged.setdefault("rms_norm_gated_implementation", "eager")
+    merged.setdefault("causal_conv1d_implementation", "eager")
+    merged.setdefault("chunk_gated_delta_rule_implementation", "eager")
+    return OpsImplementationConfig(**merged)
 
 
 def release_device_memory():
@@ -178,8 +224,8 @@ def materialize_weights(config_path: str, output_path: str, save_original_format
         config_path=config_path,
         weights_path=None,
         torch_dtype="float32",
-        attn_implementation="eager",
         init_device=get_device_type(),
+        ops_implementation=make_eager_ops_config(),
     )
     model.save_pretrained(output_path, save_original_format=save_original_format)
 

--- a/tests/utils/test_model_loader.py
+++ b/tests/utils/test_model_loader.py
@@ -55,18 +55,26 @@ def run_environ_meter(args: Arguments):
         config_path=args.model.config_path,
         weights_path=args.model.model_path,
         init_device=args.train.init_device,
+        ops_implementation=args.model.ops_implementation,
     )
     print(f"Model Class: {type(model)}")
 
 
+_MODEL_NAME_FOR_OVERRIDES = {
+    # Maps the parametrize model_path to the short name used by
+    # _NPU_PER_MODEL_OVERRIDES — only matters on NPU.
+    "qwen2vl-7b-instruct": "qwen2vl",
+    "llama3_2-3b-instruct": None,
+}
+
+
 @pytest.mark.parametrize(
     "model_path",
-    [
-        "qwen2vl-7b-instruct",
-        "llama3_2-3b-instruct",
-    ],
+    list(_MODEL_NAME_FOR_OVERRIDES.keys()),
 )
 def test_model_loader(model_path):
+    from tests.tools.training_utils import resolve_ops_overrides
+
     port = 12345 + random.randint(0, 100)
 
     command = [
@@ -78,6 +86,9 @@ def test_model_loader(model_path):
         "--data.train_path=tests",
         "--train.checkpoint.output_dir=.tests/cache",
         f"--train.init_device={get_device_type()}",
+        # On NPU the dataclass defaults raise at parse time; pin to the
+        # NPU-supported backend per op. No-op on GPU.
+        *resolve_ops_overrides(_MODEL_NAME_FOR_OVERRIDES[model_path]),
     ]
 
     result = subprocess.run(command, check=True)

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -625,6 +625,28 @@ class TrainingArguments:
 #
 
 
+# Explicit allow-list of backend names that work on Ascend NPU per
+# ``*_implementation`` field. ``"eager"`` is always implicitly compatible
+# (no entry needed). Used by ``OpsImplementationConfig._validate_implementations``
+# to raise a clear error when the GPU-optimal defaults are kept on an NPU host.
+#
+# Why an explicit list (rather than inferring from ``BackendSpec.requires``):
+# - ``triton`` for ``load_balancing_loss`` runs on NPU via the ``triton-ascend``
+#   wheel and is hardware-agnostic. Inferring "GPU-only" from "no torch_npu in
+#   requires" would wrongly reject it.
+# - DeepSeek-V3's ``triton`` backends for ``rms_norm`` / ``rotary_pos_emb`` use
+#   mainline-CUDA-only kernels (batch-invariant RMSNorm, deterministic RoPE)
+#   despite the same ``"triton"`` name. Those must NOT be allowed on NPU.
+#
+# Update this map whenever a new NPU-compatible backend is registered.
+_NPU_COMPATIBLE_BACKENDS_PER_OP: Dict[str, frozenset] = {
+    "rms_norm_implementation": frozenset({"npu"}),
+    "rotary_pos_emb_implementation": frozenset({"npu"}),
+    "swiglu_mlp_implementation": frozenset(),  # eager-only on NPU.
+    "load_balancing_loss_implementation": frozenset({"triton"}),  # triton-ascend on NPU.
+}
+
+
 @dataclass
 class OpsImplementationConfig:
     """model.ops_implementation.* — Attention, MoE, and fused kernel implementation.
@@ -633,11 +655,19 @@ class OpsImplementationConfig:
     The type is ``str`` (not ``Literal``) so that third-party backends can be
     registered without modifying this class.
 
+    Defaults are GPU-optimal (Liger / Triton / fused_triton). On Ascend NPU
+    these defaults raise at validation time — NPU users must explicitly set
+    each field to an NPU-supported value (see the per-field help text for the
+    allowed NPU values, and use ``"eager"`` when no NPU backend exists for a
+    given op such as ``swiglu_mlp_implementation`` or DeepSeek-V3 RMSNorm/RoPE).
+
     Well-known values:
 
-    - ``"eager"`` (default): PyTorch / HuggingFace reference implementation.
-    - ``"liger_kernel"``: LigerKernel fused implementation (GPU and NPU, requires
-      ``liger-kernel``).
+    - ``"eager"``: PyTorch / HuggingFace reference implementation. Always
+      available (no kernel dependency); use this on NPU when the op has no
+      native NPU backend.
+    - ``"liger_kernel"``: LigerKernel fused implementation (GPU only — requires
+      ``liger-kernel``; not supported on NPU).
     - ``"npu"``: Ascend NPU fused implementation (requires ``torch_npu``).
       Applies ``npu_rms_norm`` / ``npu_rotary_mul`` from
       ``veomni.ops.kernels.{rms_norm,rotary}.npu``.
@@ -659,14 +689,17 @@ class OpsImplementationConfig:
         metadata={"help": "Attention implementation to use."},
     )
     moe_implementation: str = field(
-        default="eager",
+        default="fused_triton",
         metadata={
             "help": "MoE experts forward implementation. "
-            "OSS backends: 'fused_triton' (Triton group-gemm, GPU, SM70+), "
+            "OSS backends: 'fused_triton' (default, Triton group-gemm, GPU, SM70+), "
             "'fused_quack' (Quack CUTLASS/CuTe, GPU, SM90+), "
             "'fused_npu' (NPU group-gemm, requires torch_npu), "
-            "'eager' (default, reference loop). "
+            "'eager' (reference loop). "
             "The backend must match the hardware — no silent fallback. "
+            "On NPU you MUST set this to 'fused_npu' or 'eager'; the GPU "
+            "defaults ('fused_triton', 'fused_quack') will raise at config "
+            "validation time. "
             "Legacy alias: 'fused' is auto-resolved to 'fused_quack' on GPU "
             "and 'fused_npu' on NPU (deprecated; emit a migration warning). "
             "Typed as plain str (not Literal) so third-party backends can be "
@@ -677,51 +710,71 @@ class OpsImplementationConfig:
         },
     )
     cross_entropy_loss_implementation: str = field(
-        default="chunk_loss",
+        default="liger_kernel",
         metadata={
             "help": "Cross-entropy loss implementation. "
-            "'chunk_loss' (default) computes the loss in chunks via "
-            "F.linear + eager CE; works on both CUDA and Ascend NPU. "
-            "'liger_kernel' uses LigerFusedLinearCrossEntropyLoss (requires liger-kernel, GPU). "
+            "'liger_kernel' (default, GPU only) uses LigerFusedLinearCrossEntropyLoss; "
+            "this fuses the lm_head linear with CE and never materializes the "
+            "full logits tensor, which is the lowest-memory path for large "
+            "vocabularies. It REQUIRES that the model's forward pass through "
+            "`hidden_states=` and `weights=self.lm_head.weight` to "
+            "`self.loss_function(...)` (every VeOmni-patched modeling file "
+            "does this). Unpatched HF models that still pass logits will hit "
+            "RuntimeError — switch to 'chunk_loss' or 'eager' in that case. "
+            "'chunk_loss' computes the loss in chunks via F.linear + eager CE; "
+            "hardware-agnostic (CUDA + NPU). "
             "'npu' is a back-compat alias for 'chunk_loss' that additionally "
             "asserts torch_npu is installed. "
-            "'eager' uses PyTorch F.cross_entropy without chunking."
+            "'eager' uses PyTorch F.cross_entropy without chunking. "
+            "On NPU set this to 'chunk_loss' / 'npu' / 'eager'; 'liger_kernel' "
+            "raises at config validation time."
         },
     )
     rms_norm_implementation: str = field(
-        default="eager",
+        default="liger_kernel",
         metadata={
             "help": "RMSNorm implementation. "
-            "'liger_kernel' uses LigerRMSNorm. "
+            "'liger_kernel' (default, GPU only) uses LigerRMSNorm. "
             "'npu' uses torch_npu.npu_rms_norm (requires torch_npu). "
-            "'triton' uses batch-invariant fused Triton kernel (DeepSeek V3). "
-            "'eager' (default) uses the HuggingFace default."
+            "'triton' uses batch-invariant fused Triton kernel (DeepSeek V3 only; GPU only). "
+            "'eager' uses the HuggingFace default. "
+            "On NPU set this to 'npu' (or 'eager' for models without an NPU "
+            "RMSNorm backend, e.g. DeepSeek-V3); 'liger_kernel' / 'triton' "
+            "raise at config validation time."
         },
     )
     swiglu_mlp_implementation: str = field(
-        default="eager",
+        default="liger_kernel",
         metadata={
             "help": "SwiGLU MLP implementation. "
-            "'liger_kernel' uses LigerSwiGLUMLP. "
-            "'eager' (default) uses the HuggingFace default."
+            "'liger_kernel' (default, GPU only) uses LigerSwiGLUMLP. "
+            "'eager' uses the HuggingFace default. "
+            "There is no NPU backend for this op — on NPU you MUST set this "
+            "to 'eager'."
         },
     )
     rotary_pos_emb_implementation: str = field(
-        default="eager",
+        default="liger_kernel",
         metadata={
             "help": "Rotary positional embedding implementation. "
-            "'liger_kernel' uses liger_rotary_pos_emb. "
+            "'liger_kernel' (default, GPU only) uses liger_rotary_pos_emb. "
             "'npu' uses torch_npu.npu_rotary_mul (requires torch_npu). "
-            "'triton' uses deterministic Triton bmm kernel (DeepSeek V3). "
-            "'eager' (default) uses the HuggingFace default."
+            "'triton' uses deterministic Triton bmm kernel (DeepSeek V3 only; GPU only). "
+            "'eager' uses the HuggingFace default. "
+            "On NPU set this to 'npu' (or 'eager' for models without an NPU "
+            "RoPE backend, e.g. DeepSeek-V3 and Qwen2-VL multimodal RoPE); "
+            "'liger_kernel' / 'triton' raise at config validation time."
         },
     )
     load_balancing_loss_implementation: str = field(
-        default="eager",
+        default="triton",
         metadata={
             "help": "MoE load-balancing loss implementation. "
-            "'triton' uses a fused Triton kernel (requires triton or triton-ascend). "
-            "'eager' (default) uses PyTorch reference."
+            "'triton' (default) uses a fused Triton kernel; this is strict — "
+            "if the 'triton' Python package is not installed (or 'triton-ascend' "
+            "on NPU) it raises at config validation time. Set to 'eager' to "
+            "fall back to the pure-PyTorch reference. "
+            "'eager' uses the PyTorch reference."
         },
     )
     rms_norm_gated_implementation: str = field(
@@ -788,25 +841,149 @@ class OpsImplementationConfig:
         """Validate that requested backends are actually available.
 
         Walks the kernel registry so new ops/backends are discovered
-        automatically.  Importing ``veomni.ops`` here is what triggers every
+        automatically. Importing ``veomni.ops`` here is what triggers every
         op module to call ``register_op``.
+
+        Two classes of error:
+        1. Hardware mismatch — selected backend cannot run on the active
+           accelerator (the typical case is GPU-only ``liger_kernel`` /
+           ``triton`` / ``fused_triton`` / ``fused_quack`` selected on NPU,
+           or an ``npu`` / ``fused_npu`` backend selected on a non-NPU host).
+        2. Package missing — ``liger-kernel`` / ``torch_npu`` / ``triton``
+           is requested but not installed.
+
+        Hardware mismatch is checked first because the actionable fix is
+        platform-specific (switch to ``npu`` / ``chunk_loss`` / ``eager``)
+        and that fix doesn't depend on whether a GPU-only package happens
+        to be installed.
+
+        ``_NPU_COMPATIBLE_BACKENDS_PER_OP`` (module-level) is the explicit
+        allow-list of backend names that work on Ascend NPU. ``"eager"`` is
+        always implicitly compatible (no entry in ``op.backends``).
         """
         from ..ops import config as ops_config_pkg  # noqa: F401  import side-effect
         from ..ops.config.registry import list_ops
+        from ..utils.import_utils import is_package_available, is_torch_npu_available
 
+        npu_runtime = is_torch_npu_available()
+
+        # Hard assertion that the NPU allow-list and the registry stay in
+        # sync. If a new ops is registered in ``veomni/ops/kernels/*/__init__.py``
+        # without a matching entry in ``_NPU_COMPATIBLE_BACKENDS_PER_OP`` (even
+        # an empty frozenset), the validator would silently allow only ``eager``
+        # for that op on NPU — which would be a confusing silent regression.
+        # Surface it loudly at config-parse time instead.
+        registered_fields = {op.config_field for op in list_ops()}
+        missing = registered_fields - _NPU_COMPATIBLE_BACKENDS_PER_OP.keys()
+        if missing:
+            raise RuntimeError(
+                f"Op fields {sorted(missing)} are registered in _OPS_REGISTRY but missing from "
+                f"_NPU_COMPATIBLE_BACKENDS_PER_OP in arguments_types.py. Add an entry "
+                f"(empty frozenset for eager-only on NPU) to keep the NPU validator honest."
+            )
+
+        # ── 1. Per-op (rms_norm / rotary_pos_emb / swiglu_mlp / load_balancing_loss) ──
         for op in list_ops():
             value = getattr(self, op.config_field)
+
+            # 1a. Hardware mismatch on NPU. The check is on the explicit
+            # allow-list (not on ``backend.requires``) for two reasons:
+            # - ``triton`` for load-balancing loss runs on NPU via triton-ascend,
+            #   while DeepSeek-V3's batch-invariant RMSNorm / deterministic RoPE
+            #   Triton backends (registered per-model via ``extra_backends``)
+            #   are mainline-CUDA-only despite the same ``"triton"`` name.
+            # - Per-model ``extra_backends`` aren't in ``op.backends``, so a
+            #   value like ``rms_norm_implementation="triton"`` (DeepSeek-V3's
+            #   GPU-only kernel) wouldn't trip a ``backend.requires`` check.
+            if npu_runtime and value != "eager":
+                npu_compat = _NPU_COMPATIBLE_BACKENDS_PER_OP.get(op.config_field, frozenset())
+                if value not in npu_compat:
+                    alternatives = sorted(npu_compat | {"eager"})
+                    raise ValueError(
+                        f"{op.config_field}={value!r} is GPU-only and cannot run on Ascend NPU. "
+                        f"On NPU set {op.config_field} to one of {alternatives}. "
+                        f"Use 'eager' if this op has no native NPU kernel for your model "
+                        f"(e.g. swiglu_mlp_implementation, or DeepSeek-V3 / Qwen2-VL multimodal RoPE)."
+                    )
+
             backend = op.backends.get(value)
             if backend is None:
+                # ``"eager"`` is always implicit (no entry in op.backends);
+                # unknown values may be a third-party registration we cannot
+                # validate from here. Either way, nothing more to check.
                 continue
+
+            # 1b. Package availability.
             for pkg in backend.requires:
                 if pkg == "liger_kernel" and not is_liger_kernel_available():
-                    raise ValueError(f"{op.config_field}='{value}' requires liger-kernel to be installed.")
-                if pkg == "torch_npu":
-                    from ..utils.import_utils import is_torch_npu_available
+                    raise ValueError(
+                        f"{op.config_field}={value!r} requires the 'liger-kernel' Python package, "
+                        f"which is not installed. `pip install liger-kernel`, or set "
+                        f"{op.config_field}='eager' to use the HuggingFace reference."
+                    )
+                if pkg == "torch_npu" and not npu_runtime:
+                    raise ValueError(
+                        f"{op.config_field}={value!r} requires torch_npu and an Ascend NPU, "
+                        f"but neither is available on this host."
+                    )
 
-                    if not is_torch_npu_available():
-                        raise ValueError(f"{op.config_field}='{value}' requires torch_npu to be installed.")
+            # 1c. ``load_balancing_loss_implementation='triton'`` requires the
+            # ``triton`` Python package on CUDA (or ``triton-ascend`` on NPU).
+            # The BackendSpec doesn't list this in ``requires`` because Triton
+            # is a transitive dependency of many things; gate it explicitly so
+            # the error message points users at the fix.
+            if op.config_field == "load_balancing_loss_implementation" and value == "triton":
+                if not is_package_available("triton"):
+                    raise ValueError(
+                        "load_balancing_loss_implementation='triton' requires the 'triton' "
+                        "Python package (or 'triton-ascend' on NPU), which is not installed. "
+                        "Install triton, or set load_balancing_loss_implementation='eager' "
+                        "for the pure-PyTorch reference."
+                    )
+
+        # ── 2. cross_entropy_loss_implementation (not in _OPS_REGISTRY) ──
+        ce_value = self.cross_entropy_loss_implementation
+        if ce_value == "liger_kernel":
+            if npu_runtime:
+                raise ValueError(
+                    "cross_entropy_loss_implementation='liger_kernel' is GPU-only and cannot run "
+                    "on Ascend NPU. On NPU set cross_entropy_loss_implementation to 'chunk_loss' "
+                    "(recommended; same low-memory chunked F.linear+CE), 'npu' (back-compat alias "
+                    "for 'chunk_loss'), or 'eager'."
+                )
+            if not is_liger_kernel_available():
+                raise ValueError(
+                    "cross_entropy_loss_implementation='liger_kernel' requires the 'liger-kernel' "
+                    "Python package, which is not installed. `pip install liger-kernel`, "
+                    "or set cross_entropy_loss_implementation='chunk_loss' (hardware-agnostic, "
+                    "low-memory) / 'eager' (PyTorch F.cross_entropy)."
+                )
+        elif ce_value == "npu" and not npu_runtime:
+            raise ValueError(
+                "cross_entropy_loss_implementation='npu' requires torch_npu and an Ascend NPU. "
+                "Use 'chunk_loss' for the same kernel without the NPU gate."
+            )
+
+        # ── 3. moe_implementation (not in _OPS_REGISTRY) ──
+        # Hardware mismatches for MoE are also caught at apply_veomni_fused_moe_patch /
+        # OpSlot.bind time, but we duplicate the check here so the error fires
+        # at config-parse time with a single, consistent message — before any
+        # model is built.
+        moe_value = self.moe_implementation
+        moe_gpu_only = {"fused_triton", "fused_quack"}
+        moe_npu_only = {"fused_npu"}
+        if npu_runtime and moe_value in moe_gpu_only:
+            raise ValueError(
+                f"moe_implementation={moe_value!r} is GPU-only and cannot run on Ascend NPU. "
+                f"On NPU set moe_implementation to 'fused_npu' (NPU group-gemm) or 'eager' "
+                f"(reference loop)."
+            )
+        if not npu_runtime and moe_value in moe_npu_only:
+            raise ValueError(
+                f"moe_implementation={moe_value!r} requires Ascend NPU. On GPU set "
+                f"moe_implementation to 'fused_triton' (SM70+), 'fused_quack' (SM90+), "
+                f"or 'eager'."
+            )
 
 
 @dataclass

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -624,15 +624,14 @@ class TrainingArguments:
 #
 
 
-# NPU compatibility tables for ``OpsImplementationConfig._validate_implementations``.
-# ``"eager"`` is always allowed (implicit). Anything not in ``_NPU_ALLOWED[field]``
-# raises on NPU; anything in ``_NPU_REQUIRED[field]`` raises on non-NPU hosts.
+# NPU compatibility tables for ``_validate_implementations``. ``"eager"`` is
+# always allowed implicitly. A value not in ``_NPU_ALLOWED[field]`` raises on
+# NPU; a value in ``_NPU_REQUIRED[field]`` raises off NPU.
 #
-# Hardcoded (rather than inferred from ``BackendSpec.requires``) because two
-# backends share the name ``"triton"`` but have different hardware semantics:
-# load-balancing-loss triton runs on NPU via ``triton-ascend``, while
-# DeepSeek-V3's batch-invariant RMSNorm / deterministic RoPE triton kernels
-# are mainline-CUDA-only.
+# Hardcoded (not inferred from ``BackendSpec.requires``) because the name
+# ``"triton"`` is reused with different hardware semantics — NPU
+# triton-ascend for load-balancing loss vs. CUDA-only mainline triton for
+# DeepSeek-V3 RMSNorm / RoPE.
 _NPU_ALLOWED: Dict[str, frozenset] = {
     "rms_norm_implementation": frozenset({"npu"}),
     "rotary_pos_emb_implementation": frozenset({"npu"}),
@@ -652,15 +651,15 @@ _NPU_REQUIRED: Dict[str, frozenset] = {
 class OpsImplementationConfig:
     """model.ops_implementation.* — kernel backend selection per op.
 
-    Defaults are GPU-optimal (Liger / Triton / fused_triton). On Ascend NPU
-    those defaults raise at validation time — NPU users must opt every
-    per-op field into an NPU-supported value (or ``"eager"`` when the op
-    has no NPU kernel for the model). Per-op fields are typed ``str`` so
-    third-party backends register without changing this dataclass.
+    Defaults are GPU-optimal (Liger / Triton / fused_triton); they raise on
+    NPU at validation time. NPU users must pin every per-op field to an
+    NPU-supported value, or ``"eager"`` when the op has no NPU kernel.
+    Per-op fields are ``str`` so third-party backends can register without
+    changing this dataclass.
 
-    Backend names: ``"eager"`` (HF reference, always available),
+    Backends: ``"eager"`` (HF reference, always available),
     ``"liger_kernel"`` (GPU, needs ``liger-kernel``), ``"npu"`` (Ascend),
-    ``"triton"`` (CUDA ``triton`` or NPU ``triton-ascend``).
+    ``"triton"`` (CUDA ``triton`` / NPU ``triton-ascend``).
     """
 
     attn_implementation: Optional[
@@ -679,49 +678,47 @@ class OpsImplementationConfig:
     moe_implementation: str = field(
         default="fused_triton",
         metadata={
-            "help": "MoE experts forward. Values: 'fused_triton' (default, GPU SM70+), "
-            "'fused_quack' (GPU SM90+), 'fused_npu' (NPU), 'eager'. Hardware mismatch "
-            "raises at config validation. Legacy alias 'fused' auto-resolves to "
-            "'fused_quack' (GPU) / 'fused_npu' (NPU) with a deprecation warning."
+            "help": "MoE experts forward. 'fused_triton' (default, GPU SM70+) | "
+            "'fused_quack' (GPU SM90+) | 'fused_npu' (NPU) | 'eager'. "
+            "Hardware mismatch raises at config validation. Legacy 'fused' "
+            "auto-resolves to fused_quack/fused_npu with a deprecation warning."
         },
     )
     cross_entropy_loss_implementation: str = field(
         default="liger_kernel",
         metadata={
-            "help": "Cross-entropy loss. Values: 'liger_kernel' (default, GPU; fused "
-            "linear+CE — requires VeOmni-patched modeling files passing `hidden_states=` "
-            "and `weights=` to `self.loss_function`; unpatched HF models RuntimeError), "
-            "'chunk_loss' (hardware-agnostic chunked F.linear+CE), 'npu' (chunk_loss "
-            "alias gated on torch_npu), 'eager' (PyTorch F.cross_entropy)."
+            "help": "Cross-entropy loss. 'liger_kernel' (default, GPU; fused linear+CE — "
+            "requires VeOmni-patched modeling that passes hidden_states=/weights= to "
+            "self.loss_function; unpatched HF models raise) | 'chunk_loss' (chunked "
+            "F.linear+CE, hardware-agnostic) | 'npu' (chunk_loss + torch_npu gate) | "
+            "'eager' (PyTorch F.cross_entropy)."
         },
     )
     rms_norm_implementation: str = field(
         default="liger_kernel",
         metadata={
-            "help": "RMSNorm. Values: 'liger_kernel' (default, GPU), 'npu', "
-            "'triton' (DeepSeek-V3 batch-invariant only; GPU), 'eager'."
+            "help": "RMSNorm. 'liger_kernel' (default, GPU) | 'npu' | "
+            "'triton' (DeepSeek-V3 batch-invariant; GPU only) | 'eager'."
         },
     )
     swiglu_mlp_implementation: str = field(
         default="liger_kernel",
         metadata={
-            "help": "SwiGLU MLP. Values: 'liger_kernel' (default, GPU), 'eager'. "
-            "No NPU backend — NPU users must set 'eager'."
+            "help": "SwiGLU MLP. 'liger_kernel' (default, GPU) | 'eager'. No NPU backend — NPU users must set 'eager'."
         },
     )
     rotary_pos_emb_implementation: str = field(
         default="liger_kernel",
         metadata={
-            "help": "Rotary positional embedding. Values: 'liger_kernel' (default, GPU), "
-            "'npu', 'triton' (DeepSeek-V3 deterministic only; GPU), 'eager'."
+            "help": "Rotary positional embedding. 'liger_kernel' (default, GPU) | "
+            "'npu' | 'triton' (DeepSeek-V3 deterministic; GPU only) | 'eager'."
         },
     )
     load_balancing_loss_implementation: str = field(
         default="triton",
         metadata={
-            "help": "MoE load-balancing loss. Values: 'triton' (default; requires "
-            "the 'triton' / 'triton-ascend' package — raises at validation if missing), "
-            "'eager' (PyTorch reference)."
+            "help": "MoE load-balancing loss. 'triton' (default; needs 'triton' on CUDA "
+            "or 'triton-ascend' on NPU — raises at validation if missing) | 'eager'."
         },
     )
     rms_norm_gated_implementation: str = field(
@@ -758,16 +755,14 @@ class OpsImplementationConfig:
 
     @classmethod
     def all_eager(cls, **overrides) -> "OpsImplementationConfig":
-        """Hardware-agnostic ops config (every per-op field set to ``"eager"``).
+        """Hardware-agnostic config (every per-op field = ``"eager"``).
 
-        Use this from tests or standalone scripts that don't need GPU-optimal
-        kernels and shouldn't depend on optional packages (liger / triton) or
-        the active accelerator. ``attn_implementation`` keeps the dataclass
-        default — eager fallback is HF's job there.
+        For tests / standalone scripts that don't need fused kernels and shouldn't
+        depend on liger / triton or the active accelerator. ``attn_implementation``
+        keeps its dataclass default (HF handles eager fallback there).
 
-        ``**overrides`` lets a caller flip individual fields off the eager
-        baseline (e.g. ``all_eager(moe_implementation="fused_quack")`` for an
-        MoE-specific test) without having to enumerate the other five fields.
+        ``**overrides`` flips specific fields (e.g.
+        ``all_eager(moe_implementation="fused_quack")``) without enumerating the rest.
         """
         return cls(
             moe_implementation=overrides.pop("moe_implementation", "eager"),
@@ -808,14 +803,13 @@ class OpsImplementationConfig:
         self._validate_implementations()
 
     def _validate_implementations(self):
-        """Fail fast on hardware/op mismatch.
+        """Fail fast on hardware/op mismatch at config-parse time.
 
-        Only the things easier to catch at config-parse time than at
-        kernel-bind time live here. Package availability (``liger-kernel`` /
-        ``torch_npu``) and per-model backend compatibility are validated by
-        the resolution sites — ``apply_per_model_patches`` / ``apply_global_ops``
-        / ``install_loss_mapping`` / ``KERNEL_REGISTRY.resolve`` — so we
-        don't duplicate them here.
+        Only checks things cheaper to catch here than at bind time. Package
+        availability (liger / torch_npu) and per-model backend compatibility
+        are validated by the resolution sites (``apply_per_model_patches`` /
+        ``apply_global_ops`` / ``install_loss_mapping`` /
+        ``KERNEL_REGISTRY.resolve``) — not duplicated here.
         """
         from ..utils.import_utils import is_package_available, is_torch_npu_available
 
@@ -835,10 +829,9 @@ class OpsImplementationConfig:
             if not on_npu and value in _NPU_REQUIRED.get(field_name, frozenset()):
                 raise ValueError(f"{field_name}={value!r} requires Ascend NPU but none is available.")
 
-        # The fused load-balancing-loss kernel imports ``triton`` at module
-        # top level, so a missing package would surface as a noisy ImportError
-        # at apply_global_ops time. Surface it here with a clear actionable
-        # message instead.
+        # The Triton load-balancing-loss kernel imports ``triton`` at module
+        # top — surface a missing package here with an actionable message
+        # instead of a noisy ImportError at apply_global_ops time.
         if self.load_balancing_loss_implementation == "triton" and not is_package_available("triton"):
             raise ValueError(
                 "load_balancing_loss_implementation='triton' requires the 'triton' package "

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -652,10 +652,24 @@ class OpsImplementationConfig:
     """model.ops_implementation.* — kernel backend selection per op.
 
     Defaults are GPU-optimal (Liger / Triton / fused_triton); they raise on
-    NPU at validation time. NPU users must pin every per-op field to an
-    NPU-supported value, or ``"eager"`` when the op has no NPU kernel.
-    Per-op fields are ``str`` so third-party backends can register without
-    changing this dataclass.
+    NPU. NPU users must pin every per-op field to an NPU-supported value, or
+    ``"eager"`` when the op has no NPU kernel. Per-op fields are ``str`` so
+    third-party backends can register without changing this dataclass.
+
+    NPU validation runs at two times:
+
+    - **Config-parse time** (``__post_init__``) for ops registered in the
+      legacy per-model registry: ``rms_norm``, ``rotary_pos_emb``,
+      ``swiglu_mlp``, ``load_balancing_loss``, plus ``cross_entropy_loss``
+      and ``moe``. Errors fire immediately with a model-agnostic allow-list.
+    - **Model-build time** (``OpSlot.bind`` via ``KERNEL_REGISTRY.resolve``)
+      for Qwen3.5-only ops: ``rms_norm_gated``, ``causal_conv1d``,
+      ``chunk_gated_delta_rule``. These OpSlots only exist in Qwen3.5's
+      patched modeling module, so config-parse-time validation would force
+      every NPU user to override them even when training non-Qwen3.5 models.
+      Validating at bind time defers the check until Qwen3.5 is actually
+      loaded; ``register_qwen3_5_moe_modeling`` adds an upfront NPU guard
+      with a Qwen3.5-aware error message.
 
     Backends: ``"eager"`` (HF reference, always available),
     ``"liger_kernel"`` (GPU, needs ``liger-kernel``), ``"npu"`` (Ascend),
@@ -780,6 +794,12 @@ class OpsImplementationConfig:
             swiglu_mlp_implementation=overrides.pop("swiglu_mlp_implementation", "eager"),
             rotary_pos_emb_implementation=overrides.pop("rotary_pos_emb_implementation", "eager"),
             load_balancing_loss_implementation=overrides.pop("load_balancing_loss_implementation", "eager"),
+            # Qwen3.5 GatedDeltaNet ops — only meaningful for that model, but
+            # listed here so the safe-fallback path doesn't pull in
+            # flash-linear-attention on hosts that don't have it.
+            rms_norm_gated_implementation=overrides.pop("rms_norm_gated_implementation", "eager"),
+            causal_conv1d_implementation=overrides.pop("causal_conv1d_implementation", "eager"),
+            chunk_gated_delta_rule_implementation=overrides.pop("chunk_gated_delta_rule_implementation", "eager"),
             **overrides,
         )
 

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -767,42 +767,6 @@ class OpsImplementationConfig:
         },
     )
 
-    @classmethod
-    def all_eager(cls, **overrides) -> "OpsImplementationConfig":
-        """Hardware-agnostic config (every per-op field = ``"eager"``).
-
-        For tests / standalone scripts that don't need fused kernels and shouldn't
-        depend on liger / triton or the active accelerator. ``**overrides`` flips
-        specific fields (e.g. ``all_eager(moe_implementation="fused_quack")``)
-        without enumerating the rest.
-
-        ``attn_implementation`` keeps the dataclass default (``flash_attention_2``)
-        when flash-attn is importable — production GPU hosts usually have it.
-        Falls back to ``"eager"`` when it isn't, so CPU / minimal-deps
-        environments don't crash on import-time FA loading.
-        """
-        from ..utils.import_utils import is_flash_attn_2_available
-
-        attn = overrides.pop("attn_implementation", None)
-        if attn is None:
-            attn = "flash_attention_2" if is_flash_attn_2_available() else "eager"
-        return cls(
-            attn_implementation=attn,
-            moe_implementation=overrides.pop("moe_implementation", "eager"),
-            cross_entropy_loss_implementation=overrides.pop("cross_entropy_loss_implementation", "eager"),
-            rms_norm_implementation=overrides.pop("rms_norm_implementation", "eager"),
-            swiglu_mlp_implementation=overrides.pop("swiglu_mlp_implementation", "eager"),
-            rotary_pos_emb_implementation=overrides.pop("rotary_pos_emb_implementation", "eager"),
-            load_balancing_loss_implementation=overrides.pop("load_balancing_loss_implementation", "eager"),
-            # Qwen3.5 GatedDeltaNet ops — only meaningful for that model, but
-            # listed here so the safe-fallback path doesn't pull in
-            # flash-linear-attention on hosts that don't have it.
-            rms_norm_gated_implementation=overrides.pop("rms_norm_gated_implementation", "eager"),
-            causal_conv1d_implementation=overrides.pop("causal_conv1d_implementation", "eager"),
-            chunk_gated_delta_rule_implementation=overrides.pop("chunk_gated_delta_rule_implementation", "eager"),
-            **overrides,
-        )
-
     def __post_init__(self):
         if get_env("MODELING_BACKEND") == "veomni":
             replacements = {

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -667,9 +667,9 @@ class OpsImplementationConfig:
       ``chunk_gated_delta_rule``. These OpSlots only exist in Qwen3.5's
       patched modeling module, so config-parse-time validation would force
       every NPU user to override them even when training non-Qwen3.5 models.
-      Validating at bind time defers the check until Qwen3.5 is actually
-      loaded; ``register_qwen3_5_moe_modeling`` adds an upfront NPU guard
-      with a Qwen3.5-aware error message.
+      The kernel's ``HardwareRequirement`` raises if a non-eager value is
+      requested on NPU; the varlen (``dyn_bsz=True``) caveat is documented
+      in the field metadata.
 
     Backends: ``"eager"`` (HF reference, always available),
     ``"liger_kernel"`` (GPU, needs ``liger-kernel``), ``"npu"`` (Ascend),

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -21,7 +21,6 @@ from typing import Dict, List, Literal, Optional
 
 from ..utils import logging
 from ..utils.env import get_env
-from ..utils.import_utils import is_liger_kernel_available
 
 
 logger = logging.get_logger(__name__)
@@ -625,54 +624,43 @@ class TrainingArguments:
 #
 
 
-# Explicit allow-list of backend names that work on Ascend NPU per
-# ``*_implementation`` field. ``"eager"`` is always implicitly compatible
-# (no entry needed). Used by ``OpsImplementationConfig._validate_implementations``
-# to raise a clear error when the GPU-optimal defaults are kept on an NPU host.
+# NPU compatibility tables for ``OpsImplementationConfig._validate_implementations``.
+# ``"eager"`` is always allowed (implicit). Anything not in ``_NPU_ALLOWED[field]``
+# raises on NPU; anything in ``_NPU_REQUIRED[field]`` raises on non-NPU hosts.
 #
-# Why an explicit list (rather than inferring from ``BackendSpec.requires``):
-# - ``triton`` for ``load_balancing_loss`` runs on NPU via the ``triton-ascend``
-#   wheel and is hardware-agnostic. Inferring "GPU-only" from "no torch_npu in
-#   requires" would wrongly reject it.
-# - DeepSeek-V3's ``triton`` backends for ``rms_norm`` / ``rotary_pos_emb`` use
-#   mainline-CUDA-only kernels (batch-invariant RMSNorm, deterministic RoPE)
-#   despite the same ``"triton"`` name. Those must NOT be allowed on NPU.
-#
-# Update this map whenever a new NPU-compatible backend is registered.
-_NPU_COMPATIBLE_BACKENDS_PER_OP: Dict[str, frozenset] = {
+# Hardcoded (rather than inferred from ``BackendSpec.requires``) because two
+# backends share the name ``"triton"`` but have different hardware semantics:
+# load-balancing-loss triton runs on NPU via ``triton-ascend``, while
+# DeepSeek-V3's batch-invariant RMSNorm / deterministic RoPE triton kernels
+# are mainline-CUDA-only.
+_NPU_ALLOWED: Dict[str, frozenset] = {
     "rms_norm_implementation": frozenset({"npu"}),
     "rotary_pos_emb_implementation": frozenset({"npu"}),
-    "swiglu_mlp_implementation": frozenset(),  # eager-only on NPU.
-    "load_balancing_loss_implementation": frozenset({"triton"}),  # triton-ascend on NPU.
+    "swiglu_mlp_implementation": frozenset(),
+    "load_balancing_loss_implementation": frozenset({"triton"}),
+    "cross_entropy_loss_implementation": frozenset({"chunk_loss", "npu"}),
+    "moe_implementation": frozenset({"fused_npu"}),
+}
+
+_NPU_REQUIRED: Dict[str, frozenset] = {
+    "cross_entropy_loss_implementation": frozenset({"npu"}),
+    "moe_implementation": frozenset({"fused_npu"}),
 }
 
 
 @dataclass
 class OpsImplementationConfig:
-    """model.ops_implementation.* — Attention, MoE, and fused kernel implementation.
-
-    Each ``*_implementation`` field selects the kernel backend for that operation.
-    The type is ``str`` (not ``Literal``) so that third-party backends can be
-    registered without modifying this class.
+    """model.ops_implementation.* — kernel backend selection per op.
 
     Defaults are GPU-optimal (Liger / Triton / fused_triton). On Ascend NPU
-    these defaults raise at validation time — NPU users must explicitly set
-    each field to an NPU-supported value (see the per-field help text for the
-    allowed NPU values, and use ``"eager"`` when no NPU backend exists for a
-    given op such as ``swiglu_mlp_implementation`` or DeepSeek-V3 RMSNorm/RoPE).
+    those defaults raise at validation time — NPU users must opt every
+    per-op field into an NPU-supported value (or ``"eager"`` when the op
+    has no NPU kernel for the model). Per-op fields are typed ``str`` so
+    third-party backends register without changing this dataclass.
 
-    Well-known values:
-
-    - ``"eager"``: PyTorch / HuggingFace reference implementation. Always
-      available (no kernel dependency); use this on NPU when the op has no
-      native NPU backend.
-    - ``"liger_kernel"``: LigerKernel fused implementation (GPU only — requires
-      ``liger-kernel``; not supported on NPU).
-    - ``"npu"``: Ascend NPU fused implementation (requires ``torch_npu``).
-      Applies ``npu_rms_norm`` / ``npu_rotary_mul`` from
-      ``veomni.ops.kernels.{rms_norm,rotary}.npu``.
-    - ``"triton"``: Triton fused implementation (GPU with ``triton`` package, or
-      NPU with ``triton-ascend``).
+    Backend names: ``"eager"`` (HF reference, always available),
+    ``"liger_kernel"`` (GPU, needs ``liger-kernel``), ``"npu"`` (Ascend),
+    ``"triton"`` (CUDA ``triton`` or NPU ``triton-ascend``).
     """
 
     attn_implementation: Optional[
@@ -686,95 +674,54 @@ class OpsImplementationConfig:
         ]
     ] = field(
         default="flash_attention_2",
-        metadata={"help": "Attention implementation to use."},
+        metadata={"help": "Attention implementation."},
     )
     moe_implementation: str = field(
         default="fused_triton",
         metadata={
-            "help": "MoE experts forward implementation. "
-            "OSS backends: 'fused_triton' (default, Triton group-gemm, GPU, SM70+), "
-            "'fused_quack' (Quack CUTLASS/CuTe, GPU, SM90+), "
-            "'fused_npu' (NPU group-gemm, requires torch_npu), "
-            "'eager' (reference loop). "
-            "The backend must match the hardware — no silent fallback. "
-            "On NPU you MUST set this to 'fused_npu' or 'eager'; the GPU "
-            "defaults ('fused_triton', 'fused_quack') will raise at config "
-            "validation time. "
-            "Legacy alias: 'fused' is auto-resolved to 'fused_quack' on GPU "
-            "and 'fused_npu' on NPU (deprecated; emit a migration warning). "
-            "Typed as plain str (not Literal) so third-party backends can be "
-            "plugged in via `apply_veomni_fused_moe_patch` (legacy-dispatch "
-            "models) or `KERNEL_REGISTRY.register(op_name='moe_experts', ...)` "
-            "(OpSlot-dispatch models), matching the extensibility of the "
-            "other *_implementation fields."
+            "help": "MoE experts forward. Values: 'fused_triton' (default, GPU SM70+), "
+            "'fused_quack' (GPU SM90+), 'fused_npu' (NPU), 'eager'. Hardware mismatch "
+            "raises at config validation. Legacy alias 'fused' auto-resolves to "
+            "'fused_quack' (GPU) / 'fused_npu' (NPU) with a deprecation warning."
         },
     )
     cross_entropy_loss_implementation: str = field(
         default="liger_kernel",
         metadata={
-            "help": "Cross-entropy loss implementation. "
-            "'liger_kernel' (default, GPU only) uses LigerFusedLinearCrossEntropyLoss; "
-            "this fuses the lm_head linear with CE and never materializes the "
-            "full logits tensor, which is the lowest-memory path for large "
-            "vocabularies. It REQUIRES that the model's forward pass through "
-            "`hidden_states=` and `weights=self.lm_head.weight` to "
-            "`self.loss_function(...)` (every VeOmni-patched modeling file "
-            "does this). Unpatched HF models that still pass logits will hit "
-            "RuntimeError — switch to 'chunk_loss' or 'eager' in that case. "
-            "'chunk_loss' computes the loss in chunks via F.linear + eager CE; "
-            "hardware-agnostic (CUDA + NPU). "
-            "'npu' is a back-compat alias for 'chunk_loss' that additionally "
-            "asserts torch_npu is installed. "
-            "'eager' uses PyTorch F.cross_entropy without chunking. "
-            "On NPU set this to 'chunk_loss' / 'npu' / 'eager'; 'liger_kernel' "
-            "raises at config validation time."
+            "help": "Cross-entropy loss. Values: 'liger_kernel' (default, GPU; fused "
+            "linear+CE — requires VeOmni-patched modeling files passing `hidden_states=` "
+            "and `weights=` to `self.loss_function`; unpatched HF models RuntimeError), "
+            "'chunk_loss' (hardware-agnostic chunked F.linear+CE), 'npu' (chunk_loss "
+            "alias gated on torch_npu), 'eager' (PyTorch F.cross_entropy)."
         },
     )
     rms_norm_implementation: str = field(
         default="liger_kernel",
         metadata={
-            "help": "RMSNorm implementation. "
-            "'liger_kernel' (default, GPU only) uses LigerRMSNorm. "
-            "'npu' uses torch_npu.npu_rms_norm (requires torch_npu). "
-            "'triton' uses batch-invariant fused Triton kernel (DeepSeek V3 only; GPU only). "
-            "'eager' uses the HuggingFace default. "
-            "On NPU set this to 'npu' (or 'eager' for models without an NPU "
-            "RMSNorm backend, e.g. DeepSeek-V3); 'liger_kernel' / 'triton' "
-            "raise at config validation time."
+            "help": "RMSNorm. Values: 'liger_kernel' (default, GPU), 'npu', "
+            "'triton' (DeepSeek-V3 batch-invariant only; GPU), 'eager'."
         },
     )
     swiglu_mlp_implementation: str = field(
         default="liger_kernel",
         metadata={
-            "help": "SwiGLU MLP implementation. "
-            "'liger_kernel' (default, GPU only) uses LigerSwiGLUMLP. "
-            "'eager' uses the HuggingFace default. "
-            "There is no NPU backend for this op — on NPU you MUST set this "
-            "to 'eager'."
+            "help": "SwiGLU MLP. Values: 'liger_kernel' (default, GPU), 'eager'. "
+            "No NPU backend — NPU users must set 'eager'."
         },
     )
     rotary_pos_emb_implementation: str = field(
         default="liger_kernel",
         metadata={
-            "help": "Rotary positional embedding implementation. "
-            "'liger_kernel' (default, GPU only) uses liger_rotary_pos_emb. "
-            "'npu' uses torch_npu.npu_rotary_mul (requires torch_npu). "
-            "'triton' uses deterministic Triton bmm kernel (DeepSeek V3 only; GPU only). "
-            "'eager' uses the HuggingFace default. "
-            "On NPU set this to 'npu' (or 'eager' for models without an NPU "
-            "RoPE backend, e.g. DeepSeek-V3 and Qwen2-VL multimodal RoPE); "
-            "'liger_kernel' / 'triton' raise at config validation time."
+            "help": "Rotary positional embedding. Values: 'liger_kernel' (default, GPU), "
+            "'npu', 'triton' (DeepSeek-V3 deterministic only; GPU), 'eager'."
         },
     )
     load_balancing_loss_implementation: str = field(
         default="triton",
         metadata={
-            "help": "MoE load-balancing loss implementation. "
-            "'triton' (default) uses a fused Triton kernel; this is strict — "
-            "if the 'triton' Python package is not installed (or 'triton-ascend' "
-            "on NPU) it raises at config validation time. Set to 'eager' to "
-            "fall back to the pure-PyTorch reference. "
-            "'eager' uses the PyTorch reference."
+            "help": "MoE load-balancing loss. Values: 'triton' (default; requires "
+            "the 'triton' / 'triton-ascend' package — raises at validation if missing), "
+            "'eager' (PyTorch reference)."
         },
     )
     rms_norm_gated_implementation: str = field(
@@ -809,6 +756,29 @@ class OpsImplementationConfig:
         },
     )
 
+    @classmethod
+    def all_eager(cls, **overrides) -> "OpsImplementationConfig":
+        """Hardware-agnostic ops config (every per-op field set to ``"eager"``).
+
+        Use this from tests or standalone scripts that don't need GPU-optimal
+        kernels and shouldn't depend on optional packages (liger / triton) or
+        the active accelerator. ``attn_implementation`` keeps the dataclass
+        default — eager fallback is HF's job there.
+
+        ``**overrides`` lets a caller flip individual fields off the eager
+        baseline (e.g. ``all_eager(moe_implementation="fused_quack")`` for an
+        MoE-specific test) without having to enumerate the other five fields.
+        """
+        return cls(
+            moe_implementation=overrides.pop("moe_implementation", "eager"),
+            cross_entropy_loss_implementation=overrides.pop("cross_entropy_loss_implementation", "eager"),
+            rms_norm_implementation=overrides.pop("rms_norm_implementation", "eager"),
+            swiglu_mlp_implementation=overrides.pop("swiglu_mlp_implementation", "eager"),
+            rotary_pos_emb_implementation=overrides.pop("rotary_pos_emb_implementation", "eager"),
+            load_balancing_loss_implementation=overrides.pop("load_balancing_loss_implementation", "eager"),
+            **overrides,  # any remaining (e.g. attn_implementation) flow through
+        )
+
     def __post_init__(self):
         if get_env("MODELING_BACKEND") == "veomni":
             replacements = {
@@ -838,151 +808,41 @@ class OpsImplementationConfig:
         self._validate_implementations()
 
     def _validate_implementations(self):
-        """Validate that requested backends are actually available.
+        """Fail fast on hardware/op mismatch.
 
-        Walks the kernel registry so new ops/backends are discovered
-        automatically. Importing ``veomni.ops`` here is what triggers every
-        op module to call ``register_op``.
-
-        Two classes of error:
-        1. Hardware mismatch — selected backend cannot run on the active
-           accelerator (the typical case is GPU-only ``liger_kernel`` /
-           ``triton`` / ``fused_triton`` / ``fused_quack`` selected on NPU,
-           or an ``npu`` / ``fused_npu`` backend selected on a non-NPU host).
-        2. Package missing — ``liger-kernel`` / ``torch_npu`` / ``triton``
-           is requested but not installed.
-
-        Hardware mismatch is checked first because the actionable fix is
-        platform-specific (switch to ``npu`` / ``chunk_loss`` / ``eager``)
-        and that fix doesn't depend on whether a GPU-only package happens
-        to be installed.
-
-        ``_NPU_COMPATIBLE_BACKENDS_PER_OP`` (module-level) is the explicit
-        allow-list of backend names that work on Ascend NPU. ``"eager"`` is
-        always implicitly compatible (no entry in ``op.backends``).
+        Only the things easier to catch at config-parse time than at
+        kernel-bind time live here. Package availability (``liger-kernel`` /
+        ``torch_npu``) and per-model backend compatibility are validated by
+        the resolution sites — ``apply_per_model_patches`` / ``apply_global_ops``
+        / ``install_loss_mapping`` / ``KERNEL_REGISTRY.resolve`` — so we
+        don't duplicate them here.
         """
-        from ..ops import config as ops_config_pkg  # noqa: F401  import side-effect
-        from ..ops.config.registry import list_ops
         from ..utils.import_utils import is_package_available, is_torch_npu_available
 
-        npu_runtime = is_torch_npu_available()
+        on_npu = is_torch_npu_available()
 
-        # Hard assertion that the NPU allow-list and the registry stay in
-        # sync. If a new ops is registered in ``veomni/ops/kernels/*/__init__.py``
-        # without a matching entry in ``_NPU_COMPATIBLE_BACKENDS_PER_OP`` (even
-        # an empty frozenset), the validator would silently allow only ``eager``
-        # for that op on NPU — which would be a confusing silent regression.
-        # Surface it loudly at config-parse time instead.
-        registered_fields = {op.config_field for op in list_ops()}
-        missing = registered_fields - _NPU_COMPATIBLE_BACKENDS_PER_OP.keys()
-        if missing:
-            raise RuntimeError(
-                f"Op fields {sorted(missing)} are registered in _OPS_REGISTRY but missing from "
-                f"_NPU_COMPATIBLE_BACKENDS_PER_OP in arguments_types.py. Add an entry "
-                f"(empty frozenset for eager-only on NPU) to keep the NPU validator honest."
-            )
-
-        # ── 1. Per-op (rms_norm / rotary_pos_emb / swiglu_mlp / load_balancing_loss) ──
-        for op in list_ops():
-            value = getattr(self, op.config_field)
-
-            # 1a. Hardware mismatch on NPU. The check is on the explicit
-            # allow-list (not on ``backend.requires``) for two reasons:
-            # - ``triton`` for load-balancing loss runs on NPU via triton-ascend,
-            #   while DeepSeek-V3's batch-invariant RMSNorm / deterministic RoPE
-            #   Triton backends (registered per-model via ``extra_backends``)
-            #   are mainline-CUDA-only despite the same ``"triton"`` name.
-            # - Per-model ``extra_backends`` aren't in ``op.backends``, so a
-            #   value like ``rms_norm_implementation="triton"`` (DeepSeek-V3's
-            #   GPU-only kernel) wouldn't trip a ``backend.requires`` check.
-            if npu_runtime and value != "eager":
-                npu_compat = _NPU_COMPATIBLE_BACKENDS_PER_OP.get(op.config_field, frozenset())
-                if value not in npu_compat:
-                    alternatives = sorted(npu_compat | {"eager"})
-                    raise ValueError(
-                        f"{op.config_field}={value!r} is GPU-only and cannot run on Ascend NPU. "
-                        f"On NPU set {op.config_field} to one of {alternatives}. "
-                        f"Use 'eager' if this op has no native NPU kernel for your model "
-                        f"(e.g. swiglu_mlp_implementation, or DeepSeek-V3 / Qwen2-VL multimodal RoPE)."
-                    )
-
-            backend = op.backends.get(value)
-            if backend is None:
-                # ``"eager"`` is always implicit (no entry in op.backends);
-                # unknown values may be a third-party registration we cannot
-                # validate from here. Either way, nothing more to check.
+        for field_name, npu_ok in _NPU_ALLOWED.items():
+            value = getattr(self, field_name)
+            if value == "eager":
                 continue
-
-            # 1b. Package availability.
-            for pkg in backend.requires:
-                if pkg == "liger_kernel" and not is_liger_kernel_available():
-                    raise ValueError(
-                        f"{op.config_field}={value!r} requires the 'liger-kernel' Python package, "
-                        f"which is not installed. `pip install liger-kernel`, or set "
-                        f"{op.config_field}='eager' to use the HuggingFace reference."
-                    )
-                if pkg == "torch_npu" and not npu_runtime:
-                    raise ValueError(
-                        f"{op.config_field}={value!r} requires torch_npu and an Ascend NPU, "
-                        f"but neither is available on this host."
-                    )
-
-            # 1c. ``load_balancing_loss_implementation='triton'`` requires the
-            # ``triton`` Python package on CUDA (or ``triton-ascend`` on NPU).
-            # The BackendSpec doesn't list this in ``requires`` because Triton
-            # is a transitive dependency of many things; gate it explicitly so
-            # the error message points users at the fix.
-            if op.config_field == "load_balancing_loss_implementation" and value == "triton":
-                if not is_package_available("triton"):
-                    raise ValueError(
-                        "load_balancing_loss_implementation='triton' requires the 'triton' "
-                        "Python package (or 'triton-ascend' on NPU), which is not installed. "
-                        "Install triton, or set load_balancing_loss_implementation='eager' "
-                        "for the pure-PyTorch reference."
-                    )
-
-        # ── 2. cross_entropy_loss_implementation (not in _OPS_REGISTRY) ──
-        ce_value = self.cross_entropy_loss_implementation
-        if ce_value == "liger_kernel":
-            if npu_runtime:
+            if on_npu and value not in npu_ok:
+                allowed = sorted(npu_ok | {"eager"})
                 raise ValueError(
-                    "cross_entropy_loss_implementation='liger_kernel' is GPU-only and cannot run "
-                    "on Ascend NPU. On NPU set cross_entropy_loss_implementation to 'chunk_loss' "
-                    "(recommended; same low-memory chunked F.linear+CE), 'npu' (back-compat alias "
-                    "for 'chunk_loss'), or 'eager'."
+                    f"{field_name}={value!r} is not supported on Ascend NPU. "
+                    f"Set to one of {allowed}; 'eager' is the universal fallback "
+                    f"for ops with no NPU kernel for the current model."
                 )
-            if not is_liger_kernel_available():
-                raise ValueError(
-                    "cross_entropy_loss_implementation='liger_kernel' requires the 'liger-kernel' "
-                    "Python package, which is not installed. `pip install liger-kernel`, "
-                    "or set cross_entropy_loss_implementation='chunk_loss' (hardware-agnostic, "
-                    "low-memory) / 'eager' (PyTorch F.cross_entropy)."
-                )
-        elif ce_value == "npu" and not npu_runtime:
-            raise ValueError(
-                "cross_entropy_loss_implementation='npu' requires torch_npu and an Ascend NPU. "
-                "Use 'chunk_loss' for the same kernel without the NPU gate."
-            )
+            if not on_npu and value in _NPU_REQUIRED.get(field_name, frozenset()):
+                raise ValueError(f"{field_name}={value!r} requires Ascend NPU but none is available.")
 
-        # ── 3. moe_implementation (not in _OPS_REGISTRY) ──
-        # Hardware mismatches for MoE are also caught at apply_veomni_fused_moe_patch /
-        # OpSlot.bind time, but we duplicate the check here so the error fires
-        # at config-parse time with a single, consistent message — before any
-        # model is built.
-        moe_value = self.moe_implementation
-        moe_gpu_only = {"fused_triton", "fused_quack"}
-        moe_npu_only = {"fused_npu"}
-        if npu_runtime and moe_value in moe_gpu_only:
+        # The fused load-balancing-loss kernel imports ``triton`` at module
+        # top level, so a missing package would surface as a noisy ImportError
+        # at apply_global_ops time. Surface it here with a clear actionable
+        # message instead.
+        if self.load_balancing_loss_implementation == "triton" and not is_package_available("triton"):
             raise ValueError(
-                f"moe_implementation={moe_value!r} is GPU-only and cannot run on Ascend NPU. "
-                f"On NPU set moe_implementation to 'fused_npu' (NPU group-gemm) or 'eager' "
-                f"(reference loop)."
-            )
-        if not npu_runtime and moe_value in moe_npu_only:
-            raise ValueError(
-                f"moe_implementation={moe_value!r} requires Ascend NPU. On GPU set "
-                f"moe_implementation to 'fused_triton' (SM70+), 'fused_quack' (SM90+), "
-                f"or 'eager'."
+                "load_balancing_loss_implementation='triton' requires the 'triton' package "
+                "(or 'triton-ascend' on NPU). Install it or set the field to 'eager'."
             )
 
 

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -642,6 +642,8 @@ _NPU_ALLOWED: Dict[str, frozenset] = {
 }
 
 _NPU_REQUIRED: Dict[str, frozenset] = {
+    "rms_norm_implementation": frozenset({"npu"}),
+    "rotary_pos_emb_implementation": frozenset({"npu"}),
     "cross_entropy_loss_implementation": frozenset({"npu"}),
     "moe_implementation": frozenset({"fused_npu"}),
 }

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -758,20 +758,29 @@ class OpsImplementationConfig:
         """Hardware-agnostic config (every per-op field = ``"eager"``).
 
         For tests / standalone scripts that don't need fused kernels and shouldn't
-        depend on liger / triton or the active accelerator. ``attn_implementation``
-        keeps its dataclass default (HF handles eager fallback there).
+        depend on liger / triton or the active accelerator. ``**overrides`` flips
+        specific fields (e.g. ``all_eager(moe_implementation="fused_quack")``)
+        without enumerating the rest.
 
-        ``**overrides`` flips specific fields (e.g.
-        ``all_eager(moe_implementation="fused_quack")``) without enumerating the rest.
+        ``attn_implementation`` keeps the dataclass default (``flash_attention_2``)
+        when flash-attn is importable — production GPU hosts usually have it.
+        Falls back to ``"eager"`` when it isn't, so CPU / minimal-deps
+        environments don't crash on import-time FA loading.
         """
+        from ..utils.import_utils import is_flash_attn_2_available
+
+        attn = overrides.pop("attn_implementation", None)
+        if attn is None:
+            attn = "flash_attention_2" if is_flash_attn_2_available() else "eager"
         return cls(
+            attn_implementation=attn,
             moe_implementation=overrides.pop("moe_implementation", "eager"),
             cross_entropy_loss_implementation=overrides.pop("cross_entropy_loss_implementation", "eager"),
             rms_norm_implementation=overrides.pop("rms_norm_implementation", "eager"),
             swiglu_mlp_implementation=overrides.pop("swiglu_mlp_implementation", "eager"),
             rotary_pos_emb_implementation=overrides.pop("rotary_pos_emb_implementation", "eager"),
             load_balancing_loss_implementation=overrides.pop("load_balancing_loss_implementation", "eager"),
-            **overrides,  # any remaining (e.g. attn_implementation) flow through
+            **overrides,
         )
 
     def __post_init__(self):
@@ -811,7 +820,18 @@ class OpsImplementationConfig:
         ``apply_global_ops`` / ``install_loss_mapping`` /
         ``KERNEL_REGISTRY.resolve``) — not duplicated here.
         """
+        from ..ops import config as _ops_config_pkg  # noqa: F401  triggers op registrations
+        from ..ops.config.registry import list_ops
         from ..utils.import_utils import is_package_available, is_torch_npu_available
+
+        # Coverage check: every registered op must appear in ``_NPU_ALLOWED``,
+        # otherwise a future op addition silently bypasses NPU validation.
+        registered_fields = {op.config_field for op in list_ops()}
+        missing = registered_fields - _NPU_ALLOWED.keys()
+        assert not missing, (
+            f"NPU allow-list missing entries for registered ops: {sorted(missing)}. "
+            f"Add them to _NPU_ALLOWED in arguments_types.py."
+        )
 
         on_npu = is_torch_npu_available()
 

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -39,6 +39,30 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
+def _build_safe_fallback_ops_config() -> OpsImplementationConfig:
+    """Conservative all-eager OpsImplementationConfig for the silent fallback path.
+
+    Used by ``build_foundation_model`` when the caller passes neither
+    ``ops_implementation`` nor a prior ``apply_ops_config`` call. The public
+    ``OpsImplementationConfig()`` defaults are GPU-optimal (Liger / Triton /
+    fused_triton) and raise on hosts without those packages, but standalone
+    callers (inference scripts, weight-materialization helpers, dummy-forward
+    tests) need a baseline that works everywhere — so we use ``"eager"`` for
+    every per-op field. ``attn_implementation`` keeps the GPU-friendly
+    ``"flash_attention_2"`` default; ``MODELING_BACKEND`` rewrites it to the
+    SP-aware variant in ``__post_init__`` and ``flash_attention_2`` itself
+    has graceful HF fallbacks (sdpa) when the package is missing.
+    """
+    return OpsImplementationConfig(
+        moe_implementation="eager",
+        cross_entropy_loss_implementation="eager",
+        rms_norm_implementation="eager",
+        swiglu_mlp_implementation="eager",
+        rotary_pos_emb_implementation="eager",
+        load_balancing_loss_implementation="eager",
+    )
+
+
 def build_tokenizer(tokenizer_path: str) -> "PreTrainedTokenizer":
     """
     Builds the tokenizer.
@@ -136,10 +160,19 @@ def build_foundation_model(
     provided we run ``apply_ops_config`` before constructing the model, and the
     resolved ``attn_implementation`` is read from it (the explicit
     ``attn_implementation`` kwarg is ignored in that case). Trainers always
-    pass ``ops_implementation``; standalone scripts that omit it get a default
-    ``OpsImplementationConfig()`` installed automatically — unless something
-    earlier (e.g. a ``DiTTrainer`` building a condition model first) already
-    installed one, in which case we leave it alone.
+    pass ``ops_implementation``; standalone scripts that omit it (e.g.
+    ``tasks/infer/*``, ``tests/e2e/test_e2e_parallel._materialize_weights_dir``,
+    ``tests/distributed/test_dummy_forward``) get an *all-eager* fallback
+    config installed automatically — unless something earlier (e.g. a
+    ``DiTTrainer`` building a condition model first) already installed one,
+    in which case we leave it alone.
+
+    The fallback is intentionally conservative (every per-op field set to
+    ``"eager"``, no Liger / Triton / fused kernels) so it works on every
+    accelerator without depending on optional packages. Production training
+    paths route through trainers that pass the user's
+    ``OpsImplementationConfig`` explicitly, which carries the GPU-optimal
+    defaults.
     """
     from ..ops import apply_ops_config
     from ..ops.config.singleton import get_ops_config
@@ -148,7 +181,7 @@ def build_foundation_model(
         apply_ops_config(ops_implementation)
         attn_implementation = ops_implementation.attn_implementation
     elif get_ops_config() is None:
-        apply_ops_config(OpsImplementationConfig())
+        apply_ops_config(_build_safe_fallback_ops_config())
 
     if config_kwargs is None:
         config_kwargs = {}

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -62,46 +62,46 @@ def build_config(config_path: str, **config_kwargs) -> "PretrainedConfig":
 
 
 def _bind_veomni_ops(modeling_module, ops_config: OpsImplementationConfig) -> bool:
-    """Bind all OpSlot instances found in *modeling_module*.
+    """Bind every OpSlot in *modeling_module* from *ops_config*.
 
     Returns ``True`` if at least one OpSlot was found (and bound).
     """
-    found = False
+    bound: list[str] = []
     moe_experts_kernel: Optional[str] = None
     for name in dir(modeling_module):
         obj = getattr(modeling_module, name, None)
-        if isinstance(obj, OpSlot):
-            # `moe_experts` is the one op whose user-facing config field is not
-            # `moe_experts_implementation` but `moe_implementation`, and its
-            # values carry a `fused_` prefix (e.g. `fused_triton`) that the
-            # KERNEL_REGISTRY entries don't. Translate here so the registry
-            # lookup finds the kernel and the HardwareRequirement check fires.
-            if obj.op_name == "moe_experts":
-                impl_name = (
-                    "eager"
-                    if ops_config.moe_implementation == "eager"
-                    else ops_config.moe_implementation.removeprefix("fused_")
-                )
-                if impl_name != "eager":
-                    moe_experts_kernel = impl_name
-            else:
-                impl_name = getattr(ops_config, f"{obj.op_name}_implementation", "eager")
-            obj.bind(impl_name)
-            logger.info_rank0(f"OpSlot '{name}' bound to '{impl_name}' -> {obj}")
-            found = True
+        if not isinstance(obj, OpSlot):
+            continue
+        # ``moe_experts`` reads ``moe_implementation`` (not the
+        # ``{op}_implementation`` convention) and its values carry a
+        # ``fused_`` prefix the registry entries don't. Translate so the
+        # registry lookup finds the kernel and the HardwareRequirement
+        # check fires.
+        if obj.op_name == "moe_experts":
+            impl_name = (
+                "eager"
+                if ops_config.moe_implementation == "eager"
+                else ops_config.moe_implementation.removeprefix("fused_")
+            )
+            if impl_name != "eager":
+                moe_experts_kernel = impl_name
+        else:
+            impl_name = getattr(ops_config, f"{obj.op_name}_implementation", "eager")
+        obj.bind(impl_name)
+        bound.append(f"{obj.op_name} ({impl_name})")
 
-    # The OpSlot only acts as an eager-vs-fused guard
-    # (``slot.use_non_eager_impl``). Inside the fused branch, modeling code
-    # calls ``veomni.ops.fused_moe_forward(...)``, which dispatches through
-    # the module-level pointer ``veomni.ops.kernels.moe._fused_moe_forward``.
-    # Bind that pointer here to the kernel matching the slot so the two stay
-    # in sync. Eager bindings leave the pointer untouched.
+    # OpSlot is just an eager-vs-fused guard; inside the fused branch the
+    # generated modeling code dispatches through the module-level pointer
+    # ``veomni.ops.kernels.moe._fused_moe_forward``. Keep the pointer in
+    # sync with the slot's bound kernel; eager leaves it untouched.
     if moe_experts_kernel is not None:
         from ..ops.kernels.moe import apply_veomni_fused_moe_patch
 
         apply_veomni_fused_moe_patch(fused_moe_kernel=moe_experts_kernel)
 
-    return found
+    if bound:
+        logger.info_rank0(f"OpSlot dispatch bound: {', '.join(bound)}.")
+    return bool(bound)
 
 
 def build_foundation_model(
@@ -132,16 +132,14 @@ def build_foundation_model(
 
     If weights_path is provided, it loads the pre-trained weights, otherwise it initializes weights.
 
-    Ops dispatch is owned by this function: when ``ops_implementation`` is
-    provided we run ``apply_ops_config`` before constructing the model, and
-    the resolved ``attn_implementation`` is read from it (the explicit
-    ``attn_implementation`` kwarg is ignored in that case). Trainers always
-    pass ``ops_implementation``; standalone scripts that omit it (e.g.
-    ``tasks/infer/*``, weight-materialization helpers, dummy-forward tests)
-    get ``OpsImplementationConfig.all_eager()`` installed automatically so
-    they work on every accelerator without depending on liger / triton —
-    unless something earlier (e.g. a ``DiTTrainer`` building a condition
-    model first) already installed one, in which case we leave it alone.
+    Ops dispatch: if ``ops_implementation`` is given we run ``apply_ops_config``
+    before constructing the model and the resolved ``attn_implementation`` is
+    read from it (the kwarg is ignored). Trainers always pass it. Standalone
+    scripts (``tasks/infer/*``, weight-materialization, dummy-forward tests)
+    get an ``all_eager()`` config installed automatically — works on every
+    accelerator without requiring liger / triton. If something earlier already
+    installed an ops config (e.g. ``DiTTrainer`` building a condition model
+    first), we leave it alone.
     """
     from ..ops import apply_ops_config
     from ..ops.config.singleton import get_ops_config

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -39,30 +39,6 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-def _build_safe_fallback_ops_config() -> OpsImplementationConfig:
-    """Conservative all-eager OpsImplementationConfig for the silent fallback path.
-
-    Used by ``build_foundation_model`` when the caller passes neither
-    ``ops_implementation`` nor a prior ``apply_ops_config`` call. The public
-    ``OpsImplementationConfig()`` defaults are GPU-optimal (Liger / Triton /
-    fused_triton) and raise on hosts without those packages, but standalone
-    callers (inference scripts, weight-materialization helpers, dummy-forward
-    tests) need a baseline that works everywhere — so we use ``"eager"`` for
-    every per-op field. ``attn_implementation`` keeps the GPU-friendly
-    ``"flash_attention_2"`` default; ``MODELING_BACKEND`` rewrites it to the
-    SP-aware variant in ``__post_init__`` and ``flash_attention_2`` itself
-    has graceful HF fallbacks (sdpa) when the package is missing.
-    """
-    return OpsImplementationConfig(
-        moe_implementation="eager",
-        cross_entropy_loss_implementation="eager",
-        rms_norm_implementation="eager",
-        swiglu_mlp_implementation="eager",
-        rotary_pos_emb_implementation="eager",
-        load_balancing_loss_implementation="eager",
-    )
-
-
 def build_tokenizer(tokenizer_path: str) -> "PreTrainedTokenizer":
     """
     Builds the tokenizer.
@@ -157,22 +133,15 @@ def build_foundation_model(
     If weights_path is provided, it loads the pre-trained weights, otherwise it initializes weights.
 
     Ops dispatch is owned by this function: when ``ops_implementation`` is
-    provided we run ``apply_ops_config`` before constructing the model, and the
-    resolved ``attn_implementation`` is read from it (the explicit
+    provided we run ``apply_ops_config`` before constructing the model, and
+    the resolved ``attn_implementation`` is read from it (the explicit
     ``attn_implementation`` kwarg is ignored in that case). Trainers always
     pass ``ops_implementation``; standalone scripts that omit it (e.g.
-    ``tasks/infer/*``, ``tests/e2e/test_e2e_parallel._materialize_weights_dir``,
-    ``tests/distributed/test_dummy_forward``) get an *all-eager* fallback
-    config installed automatically — unless something earlier (e.g. a
-    ``DiTTrainer`` building a condition model first) already installed one,
-    in which case we leave it alone.
-
-    The fallback is intentionally conservative (every per-op field set to
-    ``"eager"``, no Liger / Triton / fused kernels) so it works on every
-    accelerator without depending on optional packages. Production training
-    paths route through trainers that pass the user's
-    ``OpsImplementationConfig`` explicitly, which carries the GPU-optimal
-    defaults.
+    ``tasks/infer/*``, weight-materialization helpers, dummy-forward tests)
+    get ``OpsImplementationConfig.all_eager()`` installed automatically so
+    they work on every accelerator without depending on liger / triton —
+    unless something earlier (e.g. a ``DiTTrainer`` building a condition
+    model first) already installed one, in which case we leave it alone.
     """
     from ..ops import apply_ops_config
     from ..ops.config.singleton import get_ops_config
@@ -181,7 +150,7 @@ def build_foundation_model(
         apply_ops_config(ops_implementation)
         attn_implementation = ops_implementation.attn_implementation
     elif get_ops_config() is None:
-        apply_ops_config(_build_safe_fallback_ops_config())
+        apply_ops_config(OpsImplementationConfig.all_eager())
 
     if config_kwargs is None:
         config_kwargs = {}

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -151,14 +151,23 @@ def build_foundation_model(
     if ops_implementation is not None:
         apply_ops_config(ops_implementation)
         attn_implementation = ops_implementation.attn_implementation
-    elif get_ops_config() is None:
-        raise ValueError(
-            "build_foundation_model requires `ops_implementation` (or a prior "
-            "`apply_ops_config(...)` call). Trainers pass "
-            "`args.model.ops_implementation`; standalone scripts must "
-            "construct an `OpsImplementationConfig` explicitly. "
-            "There is no longer a silent all-eager fallback."
-        )
+    else:
+        installed = get_ops_config()
+        if installed is None:
+            raise ValueError(
+                "build_foundation_model requires `ops_implementation` (or a prior "
+                "`apply_ops_config(...)` call). Trainers pass "
+                "`args.model.ops_implementation`; standalone scripts must "
+                "construct an `OpsImplementationConfig` explicitly. "
+                "There is no longer a silent all-eager fallback."
+            )
+        # Caller pre-installed the singleton (e.g. DiTTrainer building a
+        # condition model). Honour the installed config's attn unless the
+        # caller passed an explicit override — without this, the model
+        # silently uses the loader's HF default instead of the SP-aware
+        # variant the user selected.
+        if attn_implementation is None:
+            attn_implementation = installed.attn_implementation
 
     if config_kwargs is None:
         config_kwargs = {}

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -108,10 +108,10 @@ def build_foundation_model(
     config_path: Union[str, PretrainedConfig],
     weights_path: Optional[str] = None,
     torch_dtype: Literal["float16", "bfloat16", "float32"] = "bfloat16",
-    # ``None`` = "no caller preference" — let the resolution below pick: from
-    # ``ops_implementation`` if given, else from the all-eager fallback (which
-    # itself drops to ``"eager"`` on no-flash-attn hosts). A non-None value
-    # is treated as an explicit caller override and preserved as-is.
+    # ``None`` = "no caller preference" — resolved from ``ops_implementation``
+    # below. A non-None value is treated as an explicit caller override and
+    # preserved as-is (used by callers that pre-installed the ops singleton
+    # via ``apply_ops_config`` and only need to pin attn here).
     attn_implementation: Optional[
         Literal[
             "eager",
@@ -136,14 +136,14 @@ def build_foundation_model(
 
     If weights_path is provided, it loads the pre-trained weights, otherwise it initializes weights.
 
-    Ops dispatch: if ``ops_implementation`` is given we run ``apply_ops_config``
-    before constructing the model and the resolved ``attn_implementation`` is
-    read from it (the kwarg is ignored). Trainers always pass it. Standalone
-    scripts (``tasks/infer/*``, weight-materialization, dummy-forward tests)
-    get an ``all_eager()`` config installed automatically — works on every
-    accelerator without requiring liger / triton. If something earlier already
-    installed an ops config (e.g. ``DiTTrainer`` building a condition model
-    first), we leave it alone.
+    Ops dispatch: callers must pass ``ops_implementation`` *or* pre-install a
+    singleton via ``apply_ops_config(...)``. There is no silent all-eager
+    fallback — passing neither raises ``ValueError``. Trainers pass
+    ``args.model.ops_implementation``; standalone scripts (``tasks/infer/*``)
+    construct an explicit ``OpsImplementationConfig``. ``DiTTrainer`` builds a
+    condition model first via ``apply_ops_config`` and then calls into here
+    without the kwarg, which is fine — the singleton-already-installed branch
+    leaves it alone.
     """
     from ..ops import apply_ops_config
     from ..ops.config.singleton import get_ops_config
@@ -152,15 +152,13 @@ def build_foundation_model(
         apply_ops_config(ops_implementation)
         attn_implementation = ops_implementation.attn_implementation
     elif get_ops_config() is None:
-        # Standalone callers only (tasks/infer/*, materialize_weights,
-        # dummy-forward tests); trainers always pass ``ops_implementation``.
-        # Install an all-eager singleton so per-op resolution doesn't crash.
-        # For attn, only adopt the fallback's value when the caller didn't
-        # pass an explicit one (so no-flash-attn hosts get ``"eager"``).
-        fallback = OpsImplementationConfig.all_eager()
-        apply_ops_config(fallback)
-        if attn_implementation is None:
-            attn_implementation = fallback.attn_implementation
+        raise ValueError(
+            "build_foundation_model requires `ops_implementation` (or a prior "
+            "`apply_ops_config(...)` call). Trainers pass "
+            "`args.model.ops_implementation`; standalone scripts must "
+            "construct an `OpsImplementationConfig` explicitly. "
+            "There is no longer a silent all-eager fallback."
+        )
 
     if config_kwargs is None:
         config_kwargs = {}

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -108,6 +108,10 @@ def build_foundation_model(
     config_path: Union[str, PretrainedConfig],
     weights_path: Optional[str] = None,
     torch_dtype: Literal["float16", "bfloat16", "float32"] = "bfloat16",
+    # ``None`` = "no caller preference" — let the resolution below pick: from
+    # ``ops_implementation`` if given, else from the all-eager fallback (which
+    # itself drops to ``"eager"`` on no-flash-attn hosts). A non-None value
+    # is treated as an explicit caller override and preserved as-is.
     attn_implementation: Optional[
         Literal[
             "eager",
@@ -120,7 +124,7 @@ def build_foundation_model(
             "veomni_flash_attention_4_with_sp",
             "native-sparse",
         ]
-    ] = "veomni_flash_attention_2_with_sp",
+    ] = None,
     init_device: Literal["cpu", "cuda", "npu", "meta"] = "cuda",
     config_kwargs: Optional[Dict[str, Any]] = None,
     encoder_data_balance: Optional[bool] = False,
@@ -148,7 +152,15 @@ def build_foundation_model(
         apply_ops_config(ops_implementation)
         attn_implementation = ops_implementation.attn_implementation
     elif get_ops_config() is None:
-        apply_ops_config(OpsImplementationConfig.all_eager())
+        # Standalone callers only (tasks/infer/*, materialize_weights,
+        # dummy-forward tests); trainers always pass ``ops_implementation``.
+        # Install an all-eager singleton so per-op resolution doesn't crash.
+        # For attn, only adopt the fallback's value when the caller didn't
+        # pass an explicit one (so no-flash-attn hosts get ``"eager"``).
+        fallback = OpsImplementationConfig.all_eager()
+        apply_ops_config(fallback)
+        if attn_implementation is None:
+            attn_implementation = fallback.attn_implementation
 
     if config_kwargs is None:
         config_kwargs = {}

--- a/veomni/models/seed_omni/auto.py
+++ b/veomni/models/seed_omni/auto.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, Literal, Optional
 
 import torch
 
+from ...arguments.arguments_types import OpsImplementationConfig
 from ...distributed.parallel_state import get_parallel_state
 from ...utils.import_utils import is_transformers_version_greater_or_equal_to
 from ..auto import build_config, build_foundation_model, build_processor, build_tokenizer
@@ -92,10 +93,30 @@ def build_omni_model(
     attn_implementation: Optional[Literal["eager", "sdpa", "flash_attention_2"]] = "flash_attention_2",
     init_device: Literal["cpu", "cuda", "npu"] = "cuda",
     config_kwargs: Optional[Dict[str, Any]] = None,
+    ops_implementation: Optional[OpsImplementationConfig] = None,
 ) -> "PreTrainedModel":
     """
     Builds omni modality model using foundation model, encoders, and decoders.
+
+    ``ops_implementation`` is required (or a prior ``apply_ops_config(...)``
+    must have installed the singleton). The SeedOmniConfig branch forwards
+    it to ``build_foundation_model``; the encoder/decoder branch builds
+    ``SeedOmniModel._from_config`` directly so we install the singleton
+    here too — the foundation submodule's ``self.loss_function`` needs
+    VeOmni's ``LOSS_MAPPING``.
     """
+    from ...ops import apply_ops_config
+    from ...ops.config.singleton import get_ops_config
+
+    if ops_implementation is not None:
+        apply_ops_config(ops_implementation)
+    elif get_ops_config() is None:
+        raise ValueError(
+            "build_omni_model requires `ops_implementation` (or a prior "
+            "`apply_ops_config(...)` call). Trainers pass "
+            "`args.model.ops_implementation`."
+        )
+
     if decoders is None:
         decoders = {}
     if encoders is None:
@@ -114,6 +135,7 @@ def build_omni_model(
             attn_implementation=attn_implementation,
             init_device=init_device,
             config_kwargs=config_kwargs,
+            ops_implementation=ops_implementation,
         )
 
     foundation_config = foundation_config.to_dict()

--- a/veomni/models/transformers/qwen2_vl/device_patch.py
+++ b/veomni/models/transformers/qwen2_vl/device_patch.py
@@ -42,14 +42,10 @@ def apply_veomni_qwen2vl_device_patch():
                     entry="liger_kernel.transformers.qwen2vl_mrope:liger_multimodal_rotary_pos_emb",
                     requires=("liger_kernel",),
                 ),
-                # The registry's default ``npu`` backend targets the standard
-                # ``apply_rotary_pos_emb_npu`` kernel, which does not handle
-                # Qwen2-VL's multimodal RoPE layout. ``None`` marks it as
-                # *explicitly disabled* so ``apply_per_model_patches`` raises
-                # with a model-specific "explicitly disabled for Qwen2-VL"
-                # message rather than silently binding the wrong-shape kernel.
-                # NPU users must set ``rotary_pos_emb_implementation: eager``
-                # in their YAML.
+                # Registry default ``apply_rotary_pos_emb_npu`` doesn't fit
+                # Qwen2-VL's multimodal RoPE layout. ``None`` = explicitly
+                # disabled — raises cleanly instead of binding a wrong-shape
+                # kernel. NPU users must pin ``rotary_pos_emb_implementation: eager``.
                 "npu": None,  # type: ignore[dict-item]
             },
         },

--- a/veomni/models/transformers/qwen2_vl/device_patch.py
+++ b/veomni/models/transformers/qwen2_vl/device_patch.py
@@ -42,7 +42,14 @@ def apply_veomni_qwen2vl_device_patch():
                     entry="liger_kernel.transformers.qwen2vl_mrope:liger_multimodal_rotary_pos_emb",
                     requires=("liger_kernel",),
                 ),
-                # No ``npu`` backend for multimodal RoPE; clear the registry default.
+                # The registry's default ``npu`` backend targets the standard
+                # ``apply_rotary_pos_emb_npu`` kernel, which does not handle
+                # Qwen2-VL's multimodal RoPE layout. ``None`` marks it as
+                # *explicitly disabled* so ``apply_per_model_patches`` raises
+                # with a model-specific "explicitly disabled for Qwen2-VL"
+                # message rather than silently binding the wrong-shape kernel.
+                # NPU users must set ``rotary_pos_emb_implementation: eager``
+                # in their YAML.
                 "npu": None,  # type: ignore[dict-item]
             },
         },

--- a/veomni/models/transformers/qwen3_5_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_5_moe/__init__.py
@@ -16,6 +16,37 @@ from ....utils.import_utils import is_transformers_version_greater_or_equal_to
 from ...loader import MODELING_REGISTRY
 
 
+# Qwen3.5 GatedDeltaNet's three fused ops (FusedRMSNormGated, causal_conv1d,
+# chunk_gated_delta_rule) currently only ship GPU backends via FLA / FlashQLA.
+# OpSlot.bind would already raise if a non-eager value is requested on NPU,
+# but the message is generic ("Kernel 'fla' for op='X' requires
+# device_type='gpu'"). We pre-check at NPU registration so the error is
+# Qwen3.5-aware and tells the user what to set, including the varlen caveat.
+_QWEN35_NPU_FIELDS = (
+    "rms_norm_gated_implementation",
+    "causal_conv1d_implementation",
+    "chunk_gated_delta_rule_implementation",
+)
+
+
+def _assert_qwen3_5_npu_supported() -> None:
+    """Raise on NPU when Qwen3.5's GatedDeltaNet ops are not pinned to eager."""
+    from ....ops.config.singleton import get_ops_config
+
+    ops = get_ops_config()
+    if ops is None:
+        return
+    bad = {f: getattr(ops, f) for f in _QWEN35_NPU_FIELDS if getattr(ops, f) != "eager"}
+    if bad:
+        offending = ", ".join(f"{k}={v!r}" for k, v in bad.items())
+        raise RuntimeError(
+            f"Qwen3.5 GatedDeltaNet has no NPU backend today (offending: {offending}). "
+            f"On NPU, pin {list(_QWEN35_NPU_FIELDS)} to 'eager'. "
+            f"Note: 'eager' only supports non-varlen training (set train.dyn_bsz=False); "
+            f"varlen training on NPU is not supported until an NPU kernel lands."
+        )
+
+
 # qwen3_5_moe is added in transformers 5.2.0.
 if is_transformers_version_greater_or_equal_to("5.2.0"):
 
@@ -27,6 +58,7 @@ if is_transformers_version_greater_or_equal_to("5.2.0"):
                 Qwen3_5MoeForConditionalGeneration,
             )
         elif IS_NPU_AVAILABLE:
+            _assert_qwen3_5_npu_supported()
             from .generated.patched_modeling_qwen3_5_moe_npu import (
                 Qwen3_5MoeForCausalLM,
                 Qwen3_5MoeForConditionalGeneration,
@@ -44,6 +76,7 @@ if is_transformers_version_greater_or_equal_to("5.2.0"):
         if IS_CUDA_AVAILABLE:
             from .generated.patched_modeling_qwen3_5_moe_gpu import Qwen3_5MoeForCausalLM
         elif IS_NPU_AVAILABLE:
+            _assert_qwen3_5_npu_supported()
             from .generated.patched_modeling_qwen3_5_moe_npu import Qwen3_5MoeForCausalLM
 
         return Qwen3_5MoeForCausalLM

--- a/veomni/models/transformers/qwen3_5_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_5_moe/__init__.py
@@ -18,34 +18,10 @@ from ...loader import MODELING_REGISTRY
 
 # Qwen3.5 GatedDeltaNet's three fused ops (FusedRMSNormGated, causal_conv1d,
 # chunk_gated_delta_rule) currently only ship GPU backends via FLA / FlashQLA.
-# OpSlot.bind would already raise if a non-eager value is requested on NPU,
-# but the message is generic ("Kernel 'fla' for op='X' requires
-# device_type='gpu'"). We pre-check at NPU registration so the error is
-# Qwen3.5-aware and tells the user what to set, including the varlen caveat.
-_QWEN35_NPU_FIELDS = (
-    "rms_norm_gated_implementation",
-    "causal_conv1d_implementation",
-    "chunk_gated_delta_rule_implementation",
-)
-
-
-def _assert_qwen3_5_npu_supported() -> None:
-    """Raise on NPU when Qwen3.5's GatedDeltaNet ops are not pinned to eager."""
-    from ....ops.config.singleton import get_ops_config
-
-    ops = get_ops_config()
-    if ops is None:
-        return
-    bad = {f: getattr(ops, f) for f in _QWEN35_NPU_FIELDS if getattr(ops, f) != "eager"}
-    if bad:
-        offending = ", ".join(f"{k}={v!r}" for k, v in bad.items())
-        raise RuntimeError(
-            f"Qwen3.5 GatedDeltaNet has no NPU backend today (offending: {offending}). "
-            f"On NPU, pin {list(_QWEN35_NPU_FIELDS)} to 'eager'. "
-            f"Note: 'eager' only supports non-varlen training (set train.dyn_bsz=False); "
-            f"varlen training on NPU is not supported until an NPU kernel lands."
-        )
-
+# Setting any of these to a non-eager value on NPU raises at OpSlot.bind via
+# KERNEL_REGISTRY.resolve's HardwareRequirement check; the varlen
+# (dyn_bsz=True) caveat is documented in docs/usage/arguments.md and on the
+# OpsImplementationConfig field metadata.
 
 # qwen3_5_moe is added in transformers 5.2.0.
 if is_transformers_version_greater_or_equal_to("5.2.0"):
@@ -58,7 +34,6 @@ if is_transformers_version_greater_or_equal_to("5.2.0"):
                 Qwen3_5MoeForConditionalGeneration,
             )
         elif IS_NPU_AVAILABLE:
-            _assert_qwen3_5_npu_supported()
             from .generated.patched_modeling_qwen3_5_moe_npu import (
                 Qwen3_5MoeForCausalLM,
                 Qwen3_5MoeForConditionalGeneration,
@@ -76,7 +51,6 @@ if is_transformers_version_greater_or_equal_to("5.2.0"):
         if IS_CUDA_AVAILABLE:
             from .generated.patched_modeling_qwen3_5_moe_gpu import Qwen3_5MoeForCausalLM
         elif IS_NPU_AVAILABLE:
-            _assert_qwen3_5_npu_supported()
             from .generated.patched_modeling_qwen3_5_moe_npu import Qwen3_5MoeForCausalLM
 
         return Qwen3_5MoeForCausalLM

--- a/veomni/models/transformers/qwen3_vl/device_patch.py
+++ b/veomni/models/transformers/qwen3_vl/device_patch.py
@@ -35,12 +35,10 @@ def apply_veomni_qwen3vl_device_patch():
             "rotary_pos_emb": "apply_rotary_pos_emb",
             "rms_norm": "Qwen3VLTextRMSNorm",
         },
-        # Historically only the NPU backend was wired up for Qwen3-VL; keep
-        # the liger_kernel backends disabled so configs that enable liger for
-        # other models do not silently alter Qwen3-VL semantics.
-        extra_backends={
-            "rotary_pos_emb": {"liger_kernel": None},
-            "rms_norm": {"liger_kernel": None},
-        },
+        # Qwen3-VL's RMSNorm and RoPE follow the standard HF shapes
+        # (Qwen3VLTextRMSNorm = T5LayerNorm form `weight * x / rms`;
+        # apply_rotary_pos_emb signature `(q, k, cos, sin, unsqueeze_dim=1)`),
+        # so the registry's default `liger_kernel` backends drop in cleanly —
+        # no model-specific overrides needed.
         custom_patches=_custom_qwen3vl,
     )

--- a/veomni/models/transformers/qwen3_vl/device_patch.py
+++ b/veomni/models/transformers/qwen3_vl/device_patch.py
@@ -35,10 +35,9 @@ def apply_veomni_qwen3vl_device_patch():
             "rotary_pos_emb": "apply_rotary_pos_emb",
             "rms_norm": "Qwen3VLTextRMSNorm",
         },
-        # Qwen3-VL's RMSNorm and RoPE follow the standard HF shapes
-        # (Qwen3VLTextRMSNorm = T5LayerNorm form `weight * x / rms`;
-        # apply_rotary_pos_emb signature `(q, k, cos, sin, unsqueeze_dim=1)`),
-        # so the registry's default `liger_kernel` backends drop in cleanly —
-        # no model-specific overrides needed.
+        # Qwen3-VL's RMSNorm/RoPE follow standard HF shapes (T5-form
+        # ``weight * x / rms``; ``apply_rotary_pos_emb(q, k, cos, sin, ...)``),
+        # so the registry's default Liger backends drop in cleanly — no
+        # per-model overrides needed.
         custom_patches=_custom_qwen3vl,
     )

--- a/veomni/models/transformers/wan/device_patch.py
+++ b/veomni/models/transformers/wan/device_patch.py
@@ -67,9 +67,16 @@ def apply_veomni_wan_device_patch():
                 ),
             },
             "rotary_pos_emb": {
-                # Wan's RoPE is a module-level function rather than the
-                # standard ``apply_rotary_pos_emb`` shape, so disable the
-                # registry-default liger_kernel backend.
+                # Wan's RoPE is a module-level ``rope_apply(x, **kwargs)`` with
+                # a non-standard signature (single tensor + freqs/head_dim
+                # kwargs), so the registry-default ``liger_kernel`` backend
+                # — which expects ``(q, k, cos, sin)`` — cannot drop in.
+                # ``None`` here marks the backend as *explicitly disabled* so
+                # ``apply_per_model_patches`` raises with a model-specific
+                # "explicitly disabled for Wan" message rather than silently
+                # binding the wrong-signature kernel and crashing at runtime.
+                # Wan YAMLs pin ``rotary_pos_emb_implementation: eager`` to
+                # avoid the raise.
                 "liger_kernel": None,
                 "npu": BackendSpec(
                     entry="veomni.models.transformers.wan.npu_patch:rope_apply_fused",

--- a/veomni/models/transformers/wan/device_patch.py
+++ b/veomni/models/transformers/wan/device_patch.py
@@ -14,25 +14,6 @@
 # limitations under the License.
 
 from ....ops.config.registry import BackendSpec, apply_per_model_patches
-from ....utils import logging
-
-
-logger = logging.get_logger(__name__)
-
-
-def _custom_wan(ops_config, applied):
-    # Wan's Triton RoPE lives in ``veomni.ops.kernels.rotary.triton_wan`` and
-    # depends on Triton being importable; fall back silently if unavailable.
-    if ops_config.rotary_pos_emb_implementation == "triton":
-        try:
-            from veomni.ops.kernels.rotary.triton_wan import apply_rotary_emb
-
-            from . import modeling_wan
-
-            modeling_wan.rope_apply = apply_rotary_emb
-            applied.append("RoPE (triton)")
-        except ImportError:
-            logger.warning_rank0("Triton RoPE for Wan requested but not available, using eager.")
 
 
 def apply_veomni_wan_device_patch():
@@ -78,7 +59,14 @@ def apply_veomni_wan_device_patch():
                     entry="veomni.models.transformers.wan.npu_patch:rope_apply_fused",
                     requires=("torch_npu",),
                 ),
+                # Wan's own Triton RoPE (matches the model-specific
+                # ``rope_apply`` signature). Registered here rather than in a
+                # ``custom_patches`` callback so the strict-raise contract in
+                # ``apply_per_model_patches`` accepts it.
+                "triton": BackendSpec(
+                    entry="veomni.ops.kernels.rotary.triton_wan:apply_rotary_emb",
+                    requires=("triton",),
+                ),
             },
         },
-        custom_patches=_custom_wan,
     )

--- a/veomni/models/transformers/wan/device_patch.py
+++ b/veomni/models/transformers/wan/device_patch.py
@@ -67,16 +67,12 @@ def apply_veomni_wan_device_patch():
                 ),
             },
             "rotary_pos_emb": {
-                # Wan's RoPE is a module-level ``rope_apply(x, **kwargs)`` with
-                # a non-standard signature (single tensor + freqs/head_dim
-                # kwargs), so the registry-default ``liger_kernel`` backend
-                # — which expects ``(q, k, cos, sin)`` — cannot drop in.
-                # ``None`` here marks the backend as *explicitly disabled* so
-                # ``apply_per_model_patches`` raises with a model-specific
-                # "explicitly disabled for Wan" message rather than silently
-                # binding the wrong-signature kernel and crashing at runtime.
-                # Wan YAMLs pin ``rotary_pos_emb_implementation: eager`` to
-                # avoid the raise.
+                # Wan's ``rope_apply(x, **kwargs)`` has a non-standard
+                # signature (single tensor + freqs/head_dim kwargs), so the
+                # registry-default Liger backend — expecting ``(q, k, cos, sin)``
+                # — cannot drop in. ``None`` = explicitly disabled, so we
+                # raise cleanly instead of crashing inside the wrong-signature
+                # kernel at runtime. Wan YAMLs pin ``rotary_pos_emb_implementation: eager``.
                 "liger_kernel": None,
                 "npu": BackendSpec(
                     entry="veomni.models.transformers.wan.npu_patch:rope_apply_fused",

--- a/veomni/ops/config/registry.py
+++ b/veomni/ops/config/registry.py
@@ -238,9 +238,16 @@ def apply_per_model_patches(
         extra_backends: Model-specific overrides merged on top of the registry
             defaults for each op.  Shape
             ``{op_name: {backend_name: BackendSpec | None}}``.  A ``BackendSpec``
-            value overrides or adds a backend; a ``None`` value disables a
-            registry-default backend for this model (used e.g. by Qwen2-VL
-            which has no NPU backend for multimodal RoPE).
+            value overrides or adds a backend. A ``None`` value is an
+            **explicit-raise opt-out**: the global registry default would
+            otherwise leak through and bind a kernel whose signature does not
+            match this model's target symbol (e.g. Wan's ``rope_apply(x, **kw)``
+            cannot host the standard liger ``(q, k, cos, sin)`` kernel; Qwen2-VL's
+            ``apply_multimodal_rotary_pos_emb`` cannot host the standard NPU
+            rotary kernel). Setting the value to ``None`` makes the validator
+            raise with a model-specific "explicitly disabled" message instead
+            of silently producing a runtime crash. The user then pins the
+            field to ``eager`` (or another supported backend) in their YAML.
         custom_patches: Optional callback invoked with
             ``(ops_config, applied_list)`` for truly one-off behaviour that
             does not fit the ``BackendSpec`` shape.
@@ -268,7 +275,49 @@ def apply_per_model_patches(
         else:
             backend = op.backends.get(value)
         if backend is None:
-            continue
+            # ``"eager"`` is the only legitimate "no backend" outcome —
+            # every op leaves the HF default in place when the user picks
+            # eager. Anything else means the user requested a backend that
+            # this model does not support; raise so the misconfiguration
+            # surfaces instead of silently shipping eager (which would
+            # leave the user thinking they got the fast kernel they asked
+            # for).
+            #
+            # ``extra_backends[value] = None`` is an *explicit-raise* opt-out
+            # for cases where the global registry default cannot drop in to
+            # this model's symbol (e.g. Wan's ``rope_apply(x, **kwargs)``
+            # cannot host the standard ``liger_rotary_pos_emb(q, k, cos, sin)``;
+            # Qwen2-VL's ``apply_multimodal_rotary_pos_emb`` cannot host the
+            # standard NPU rotary kernel). Without the opt-out the global
+            # default would silently bind the wrong kernel and crash at
+            # runtime with a confusing signature error. We raise here with a
+            # model-specific "explicitly disabled" message so the user knows
+            # to set the field to ``eager`` (or pick a backend the model
+            # actually wires up).
+            if value == "eager":
+                continue
+            # ``available`` lists every backend that *can* be selected for
+            # this model: registry defaults that the model did not opt out
+            # of, plus model-specific entries with a real BackendSpec, plus
+            # the implicit ``eager``. Explicitly-disabled entries (those
+            # with a ``None`` value in ``extra_backends``) are filtered
+            # out — listing them would contradict the "is explicitly
+            # disabled" message the user just got.
+            disabled = {k for k, v in op_overrides.items() if v is None}
+            registry_alts = (op.backends.keys() | op_overrides.keys()) - disabled
+            available = sorted(registry_alts | {"eager"})
+            if value in op_overrides and op_overrides[value] is None:
+                raise ValueError(
+                    f"{op.config_field}={value!r} is explicitly disabled for {model_name} — "
+                    f"the model has no kernel matching this backend's signature. "
+                    f"Set {op.config_field} to one of {available}. "
+                    f"Use 'eager' if you want the HuggingFace reference for this op."
+                )
+            raise ValueError(
+                f"{op.config_field}={value!r} is not a registered backend for {model_name}. "
+                f"Set {op.config_field} to one of {available}. "
+                f"Use 'eager' if you want the HuggingFace reference for this op."
+            )
 
         _check_requires(backend.requires)
         entry_obj = _import_entry(backend.entry)

--- a/veomni/ops/config/registry.py
+++ b/veomni/ops/config/registry.py
@@ -163,17 +163,21 @@ def _import_entry(entry: str) -> object:
 
 def _check_requires(requires: tuple[str, ...]) -> None:
     """Validate that the listed packages are importable."""
+    from ...utils.import_utils import is_liger_kernel_available, is_package_available, is_torch_npu_available
+
     for pkg in requires:
         if pkg == "liger_kernel":
-            from ...utils.import_utils import is_liger_kernel_available
-
             if not is_liger_kernel_available():
                 raise RuntimeError("liger_kernel backend requested but liger-kernel is not installed.")
         elif pkg == "torch_npu":
-            from ...utils.import_utils import is_torch_npu_available
-
             if not is_torch_npu_available():
                 raise RuntimeError("npu backend requested but torch_npu is not installed.")
+        elif pkg == "triton":
+            if not is_package_available("triton"):
+                raise RuntimeError(
+                    "triton backend requested but the 'triton' package is not installed "
+                    "(or 'triton-ascend' on NPU). Install it or set the field to 'eager'."
+                )
         else:
             raise ValueError(f"Unsupported 'requires' token: {pkg!r}")
 

--- a/veomni/ops/config/registry.py
+++ b/veomni/ops/config/registry.py
@@ -218,6 +218,61 @@ def apply_global_ops(ops_config: OpsImplementationConfig) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+def _resolve_backend(
+    op: OpSpec,
+    value: str,
+    op_overrides: dict[str, BackendSpec | None],
+) -> BackendSpec | None:
+    """Pick the BackendSpec for *value*, preferring the model-specific override.
+
+    Returns ``None`` when there is no backend to apply — either ``value == "eager"``
+    (HF default stays in place), the model explicitly opted out via
+    ``op_overrides[value] = None``, or *value* is unknown. The caller is
+    responsible for distinguishing these cases.
+    """
+    if value in op_overrides:
+        return op_overrides[value]
+    return op.backends.get(value)
+
+
+def _raise_no_backend(
+    model_name: str,
+    op: OpSpec,
+    value: str,
+    op_overrides: dict[str, BackendSpec | None],
+) -> None:
+    """Raise ``ValueError`` for a non-eager value with no resolvable backend.
+
+    Distinguishes "explicitly disabled" (``op_overrides[value] is None``) from
+    "unknown name" so the user gets a clear pointer at what to fix in the YAML.
+    """
+    explicitly_disabled = value in op_overrides and op_overrides[value] is None
+    disabled_names = {k for k, v in op_overrides.items() if v is None}
+    available = sorted(((op.backends.keys() | op_overrides.keys()) - disabled_names) | {"eager"})
+    reason = (
+        f"is explicitly disabled for {model_name} (no kernel matching this backend's signature)"
+        if explicitly_disabled
+        else f"is not a registered backend for {model_name}"
+    )
+    raise ValueError(
+        f"{op.config_field}={value!r} {reason}. "
+        f"Set {op.config_field} to one of {available}. "
+        f"Use 'eager' for the HuggingFace reference."
+    )
+
+
+def _patch_target(hf_module: ModuleType, target_attr: str, backend: BackendSpec) -> None:
+    """Apply the resolved BackendSpec to ``hf_module.<target>``."""
+    entry_obj = _import_entry(backend.entry)
+    if backend.entry_is_factory:
+        entry_obj = entry_obj()
+    effective_target = backend.target_override or target_attr
+    if backend.replace_forward:
+        getattr(hf_module, effective_target).forward = entry_obj
+    else:
+        setattr(hf_module, effective_target, entry_obj)
+
+
 def apply_per_model_patches(
     hf_module: ModuleType,
     model_name: str,
@@ -229,107 +284,48 @@ def apply_per_model_patches(
     """Patch ``hf_module`` based on the current ``OpsImplementationConfig``.
 
     Args:
-        hf_module: HuggingFace modeling module (or any module whose attrs will
-            be replaced).
-        model_name: Display name used in log lines.
-        targets: Mapping from op name (registered via ``register_op``) to the
-            attribute on ``hf_module`` to patch.  For example
-            ``{"rms_norm": "LlamaRMSNorm"}``.
-        extra_backends: Model-specific overrides merged on top of the registry
-            defaults for each op.  Shape
-            ``{op_name: {backend_name: BackendSpec | None}}``.  A ``BackendSpec``
-            value overrides or adds a backend. A ``None`` value is an
-            **explicit-raise opt-out**: the global registry default would
-            otherwise leak through and bind a kernel whose signature does not
-            match this model's target symbol (e.g. Wan's ``rope_apply(x, **kw)``
-            cannot host the standard liger ``(q, k, cos, sin)`` kernel; Qwen2-VL's
-            ``apply_multimodal_rotary_pos_emb`` cannot host the standard NPU
-            rotary kernel). Setting the value to ``None`` makes the validator
-            raise with a model-specific "explicitly disabled" message instead
-            of silently producing a runtime crash. The user then pins the
-            field to ``eager`` (or another supported backend) in their YAML.
-        custom_patches: Optional callback invoked with
-            ``(ops_config, applied_list)`` for truly one-off behaviour that
-            does not fit the ``BackendSpec`` shape.
+        hf_module: HuggingFace modeling module whose attributes get replaced.
+        model_name: Display name used in log lines and error messages.
+        targets: ``{op_name: hf_module_attr}`` — e.g. ``{"rms_norm": "LlamaRMSNorm"}``.
+        extra_backends: Per-model overrides keyed ``{op_name: {backend_name: spec}}``.
+            A ``BackendSpec`` adds or replaces a backend. A ``None`` value is an
+            **explicit opt-out** for cases where the registry default cannot
+            drop into the model's target symbol (e.g. Wan ``rope_apply(x, **kw)``
+            vs. Liger's ``(q, k, cos, sin)``); the user then sees a clear
+            "explicitly disabled" error instead of a runtime kernel crash.
+        custom_patches: Optional ``(ops_config, applied_list) -> None`` escape
+            hatch for one-off model behavior that does not fit ``BackendSpec``.
     """
     ops_config = get_ops_config()
     if ops_config is None:
         return
 
-    applied: list[str] = []
     extra_backends = extra_backends or {}
+    applied: list[str] = []
 
     for op_name, target_attr in targets.items():
         try:
             op = get_op(op_name)
         except KeyError as e:
             raise KeyError(f"Unknown op {op_name!r} referenced by {model_name} device_patch.py.") from e
-
         if op.scope != OpScope.PER_MODEL:
             raise ValueError(f"{model_name}: op {op_name!r} is {op.scope.value}, not per_model.")
 
         value = getattr(ops_config, op.config_field)
         op_overrides = extra_backends.get(op_name, {})
-        if value in op_overrides:
-            backend = op_overrides[value]  # may be None (explicitly disabled)
-        else:
-            backend = op.backends.get(value)
+        backend = _resolve_backend(op, value, op_overrides)
+
         if backend is None:
-            # ``"eager"`` is the only legitimate "no backend" outcome —
-            # every op leaves the HF default in place when the user picks
-            # eager. Anything else means the user requested a backend that
-            # this model does not support; raise so the misconfiguration
-            # surfaces instead of silently shipping eager (which would
-            # leave the user thinking they got the fast kernel they asked
-            # for).
-            #
-            # ``extra_backends[value] = None`` is an *explicit-raise* opt-out
-            # for cases where the global registry default cannot drop in to
-            # this model's symbol (e.g. Wan's ``rope_apply(x, **kwargs)``
-            # cannot host the standard ``liger_rotary_pos_emb(q, k, cos, sin)``;
-            # Qwen2-VL's ``apply_multimodal_rotary_pos_emb`` cannot host the
-            # standard NPU rotary kernel). Without the opt-out the global
-            # default would silently bind the wrong kernel and crash at
-            # runtime with a confusing signature error. We raise here with a
-            # model-specific "explicitly disabled" message so the user knows
-            # to set the field to ``eager`` (or pick a backend the model
-            # actually wires up).
+            # ``eager`` is the only no-backend case that's by-design (HF
+            # default stays). Everything else is a misconfiguration; raise
+            # rather than silently downgrading to eager, which would let the
+            # user think they got the fast kernel they asked for.
             if value == "eager":
                 continue
-            # ``available`` lists every backend that *can* be selected for
-            # this model: registry defaults that the model did not opt out
-            # of, plus model-specific entries with a real BackendSpec, plus
-            # the implicit ``eager``. Explicitly-disabled entries (those
-            # with a ``None`` value in ``extra_backends``) are filtered
-            # out — listing them would contradict the "is explicitly
-            # disabled" message the user just got.
-            disabled = {k for k, v in op_overrides.items() if v is None}
-            registry_alts = (op.backends.keys() | op_overrides.keys()) - disabled
-            available = sorted(registry_alts | {"eager"})
-            if value in op_overrides and op_overrides[value] is None:
-                raise ValueError(
-                    f"{op.config_field}={value!r} is explicitly disabled for {model_name} — "
-                    f"the model has no kernel matching this backend's signature. "
-                    f"Set {op.config_field} to one of {available}. "
-                    f"Use 'eager' if you want the HuggingFace reference for this op."
-                )
-            raise ValueError(
-                f"{op.config_field}={value!r} is not a registered backend for {model_name}. "
-                f"Set {op.config_field} to one of {available}. "
-                f"Use 'eager' if you want the HuggingFace reference for this op."
-            )
+            _raise_no_backend(model_name, op, value, op_overrides)
 
         _check_requires(backend.requires)
-        entry_obj = _import_entry(backend.entry)
-        if backend.entry_is_factory:
-            entry_obj = entry_obj()
-
-        effective_target = backend.target_override or target_attr
-        if backend.replace_forward:
-            getattr(hf_module, effective_target).forward = entry_obj
-        else:
-            setattr(hf_module, effective_target, entry_obj)
-
+        _patch_target(hf_module, target_attr, backend)
         applied.append(f"{op.label} ({value})")
 
     if custom_patches is not None:

--- a/veomni/ops/config/registry.py
+++ b/veomni/ops/config/registry.py
@@ -223,12 +223,11 @@ def _resolve_backend(
     value: str,
     op_overrides: dict[str, BackendSpec | None],
 ) -> BackendSpec | None:
-    """Pick the BackendSpec for *value*, preferring the model-specific override.
+    """Pick the BackendSpec for *value*, preferring the per-model override.
 
-    Returns ``None`` when there is no backend to apply — either ``value == "eager"``
-    (HF default stays in place), the model explicitly opted out via
-    ``op_overrides[value] = None``, or *value* is unknown. The caller is
-    responsible for distinguishing these cases.
+    Returns ``None`` when there's nothing to bind: ``value == "eager"`` (keep
+    HF default), the model explicitly opted out (``op_overrides[value] = None``),
+    or *value* is unknown. The caller distinguishes these cases.
     """
     if value in op_overrides:
         return op_overrides[value]
@@ -241,10 +240,10 @@ def _raise_no_backend(
     value: str,
     op_overrides: dict[str, BackendSpec | None],
 ) -> None:
-    """Raise ``ValueError`` for a non-eager value with no resolvable backend.
+    """Raise on a non-eager value with no resolvable backend.
 
     Distinguishes "explicitly disabled" (``op_overrides[value] is None``) from
-    "unknown name" so the user gets a clear pointer at what to fix in the YAML.
+    "unknown backend" so the user knows whether to switch to eager or fix a typo.
     """
     explicitly_disabled = value in op_overrides and op_overrides[value] is None
     disabled_names = {k for k, v in op_overrides.items() if v is None}
@@ -262,7 +261,7 @@ def _raise_no_backend(
 
 
 def _patch_target(hf_module: ModuleType, target_attr: str, backend: BackendSpec) -> None:
-    """Apply the resolved BackendSpec to ``hf_module.<target>``."""
+    """Bind *backend* onto ``hf_module.<target_attr>``."""
     entry_obj = _import_entry(backend.entry)
     if backend.entry_is_factory:
         entry_obj = entry_obj()
@@ -285,16 +284,16 @@ def apply_per_model_patches(
 
     Args:
         hf_module: HuggingFace modeling module whose attributes get replaced.
-        model_name: Display name used in log lines and error messages.
+        model_name: Display name for log lines and error messages.
         targets: ``{op_name: hf_module_attr}`` — e.g. ``{"rms_norm": "LlamaRMSNorm"}``.
-        extra_backends: Per-model overrides keyed ``{op_name: {backend_name: spec}}``.
-            A ``BackendSpec`` adds or replaces a backend. A ``None`` value is an
-            **explicit opt-out** for cases where the registry default cannot
-            drop into the model's target symbol (e.g. Wan ``rope_apply(x, **kw)``
-            vs. Liger's ``(q, k, cos, sin)``); the user then sees a clear
-            "explicitly disabled" error instead of a runtime kernel crash.
-        custom_patches: Optional ``(ops_config, applied_list) -> None`` escape
-            hatch for one-off model behavior that does not fit ``BackendSpec``.
+        extra_backends: Per-model overrides ``{op_name: {backend_name: spec}}``.
+            ``BackendSpec`` adds/replaces a backend; ``None`` is an **explicit
+            opt-out** for cases where the registry default doesn't fit the
+            model's target signature (e.g. Wan ``rope_apply(x, **kw)`` vs.
+            Liger ``(q, k, cos, sin)``). Users then get a clean "explicitly
+            disabled" error instead of a runtime crash.
+        custom_patches: ``(ops_config, applied_list) -> None`` escape hatch for
+            one-off behavior that doesn't fit ``BackendSpec``.
     """
     ops_config = get_ops_config()
     if ops_config is None:
@@ -316,10 +315,10 @@ def apply_per_model_patches(
         backend = _resolve_backend(op, value, op_overrides)
 
         if backend is None:
-            # ``eager`` is the only no-backend case that's by-design (HF
-            # default stays). Everything else is a misconfiguration; raise
-            # rather than silently downgrading to eager, which would let the
-            # user think they got the fast kernel they asked for.
+            # ``eager`` is the only intentional no-backend case (HF default
+            # stays). Anything else is a misconfiguration — raise instead of
+            # silently downgrading, otherwise users think they got the fast
+            # kernel they asked for.
             if value == "eager":
                 continue
             _raise_no_backend(model_name, op, value, op_overrides)

--- a/veomni/ops/kernels/cross_entropy/__init__.py
+++ b/veomni/ops/kernels/cross_entropy/__init__.py
@@ -49,8 +49,8 @@ Contract: ``apply_ops_config(ops_config)`` must run before any model is built,
 otherwise ``LOSS_MAPPING`` contains HF's stock wrapper which doesn't understand
 ``hidden_states=``/``weights=`` kwargs. ``build_foundation_model`` owns this:
 pass ``ops_implementation=...`` (trainers do) and it installs the config;
-otherwise it falls back to ``OpsImplementationConfig.all_eager()`` so
-standalone scripts work on any accelerator without requiring liger / triton.
+callers that omit it must have pre-installed a singleton via
+``apply_ops_config`` themselves, otherwise ``build_foundation_model`` raises.
 """
 
 from functools import partial

--- a/veomni/ops/kernels/cross_entropy/__init__.py
+++ b/veomni/ops/kernels/cross_entropy/__init__.py
@@ -49,8 +49,12 @@ Contract: ``apply_ops_config(ops_config)`` must run before any model is built,
 otherwise ``LOSS_MAPPING`` contains HuggingFace's stock wrapper which does not
 understand ``hidden_states=``/``weights=`` kwargs. ``build_foundation_model``
 owns this — pass ``ops_implementation=...`` (trainers do this) and it will
-install the config; otherwise it falls back to ``OpsImplementationConfig()``
-defaults.
+install the config; otherwise it falls back to an all-eager safe configuration
+via ``_build_safe_fallback_ops_config()`` in ``veomni/models/auto.py``. The
+public ``OpsImplementationConfig()`` defaults are GPU-optimal (``liger_kernel``
+fused linear+CE) and would raise on hosts without ``liger-kernel`` installed,
+which is why the standalone-script fallback uses an all-eager config rather
+than the public defaults.
 """
 
 from functools import partial

--- a/veomni/ops/kernels/cross_entropy/__init__.py
+++ b/veomni/ops/kernels/cross_entropy/__init__.py
@@ -46,15 +46,11 @@ Two dispatch paths reach these wrappers:
    already knows it wants a fused kernel calls the ``OpSlot`` directly.
 
 Contract: ``apply_ops_config(ops_config)`` must run before any model is built,
-otherwise ``LOSS_MAPPING`` contains HuggingFace's stock wrapper which does not
-understand ``hidden_states=``/``weights=`` kwargs. ``build_foundation_model``
-owns this — pass ``ops_implementation=...`` (trainers do this) and it will
-install the config; otherwise it falls back to an all-eager safe configuration
-via ``_build_safe_fallback_ops_config()`` in ``veomni/models/auto.py``. The
-public ``OpsImplementationConfig()`` defaults are GPU-optimal (``liger_kernel``
-fused linear+CE) and would raise on hosts without ``liger-kernel`` installed,
-which is why the standalone-script fallback uses an all-eager config rather
-than the public defaults.
+otherwise ``LOSS_MAPPING`` contains HF's stock wrapper which doesn't understand
+``hidden_states=``/``weights=`` kwargs. ``build_foundation_model`` owns this:
+pass ``ops_implementation=...`` (trainers do) and it installs the config;
+otherwise it falls back to ``OpsImplementationConfig.all_eager()`` so
+standalone scripts work on any accelerator without requiring liger / triton.
 """
 
 from functools import partial

--- a/veomni/ops/kernels/load_balancing_loss/__init__.py
+++ b/veomni/ops/kernels/load_balancing_loss/__init__.py
@@ -71,7 +71,7 @@ register_op(
         config_field="load_balancing_loss_implementation",
         label="LoadBalancingLoss",
         scope=OpScope.GLOBAL,
-        default="eager",
+        default="triton",
         global_slot="veomni.ops.kernels.load_balancing_loss:_load_balancing_loss",
         backends={
             "eager": BackendSpec(entry="veomni.ops.kernels.load_balancing_loss.eager:load_balancing_loss_pytorch"),

--- a/veomni/ops/kernels/rms_norm/__init__.py
+++ b/veomni/ops/kernels/rms_norm/__init__.py
@@ -30,7 +30,7 @@ register_op(
         config_field="rms_norm_implementation",
         label="RMSNorm",
         scope=OpScope.PER_MODEL,
-        default="eager",
+        default="liger_kernel",
         backends={
             "liger_kernel": BackendSpec(
                 entry="liger_kernel.transformers.rms_norm:LigerRMSNorm",

--- a/veomni/ops/kernels/rotary/__init__.py
+++ b/veomni/ops/kernels/rotary/__init__.py
@@ -30,7 +30,7 @@ register_op(
         config_field="rotary_pos_emb_implementation",
         label="RoPE",
         scope=OpScope.PER_MODEL,
-        default="eager",
+        default="liger_kernel",
         backends={
             "liger_kernel": BackendSpec(
                 entry="liger_kernel.transformers.rope:liger_rotary_pos_emb",

--- a/veomni/ops/kernels/swiglu/__init__.py
+++ b/veomni/ops/kernels/swiglu/__init__.py
@@ -27,7 +27,7 @@ register_op(
         config_field="swiglu_mlp_implementation",
         label="SwiGLU",
         scope=OpScope.PER_MODEL,
-        default="eager",
+        default="liger_kernel",
         backends={
             "liger_kernel": BackendSpec(
                 entry="liger_kernel.transformers.swiglu:LigerSwiGLUMLP",


### PR DESCRIPTION
### What does this PR do?

> Flip `OpsImplementationConfig` per-op defaults from `"eager"` to GPU-optimal
> (Liger / Triton / fused_triton), tighten the NPU validator and per-model
> dispatch, and remove the silent all-eager fallback in
> `build_foundation_model` so misconfigurations raise loudly instead of
> silently downgrading.
>
> Default changes (GPU):
>
> | Field | Old | New |
> |---|---|---|
> | `attn_implementation` | `flash_attention_2` | unchanged |
> | `moe_implementation` | `eager` | `fused_triton` |
> | `cross_entropy_loss_implementation` | `chunk_loss` | `liger_kernel` |
> | `rms_norm_implementation` | `eager` | `liger_kernel` |
> | `swiglu_mlp_implementation` | `eager` | `liger_kernel` |
> | `rotary_pos_emb_implementation` | `eager` | `liger_kernel` |
> | `load_balancing_loss_implementation` | `eager` | `triton` |
> | `rms_norm_gated_implementation` | `eager` | unchanged (Qwen3.5; FLA, GPU-only) |
> | `causal_conv1d_implementation` | `eager` | unchanged (Qwen3.5; FLA, GPU-only) |
> | `chunk_gated_delta_rule_implementation` | `eager` | unchanged (Qwen3.5; FLA, GPU-only) |
>
> Three behaviour changes flow from this:
>
> 1. **NPU users must pin every per-op field explicitly** — to an NPU-supported
>    value (`npu` / `chunk_loss` / `fused_npu` / `triton`) or `eager` when the
>    op has no NPU backend. The validator raises at config-parse time with a
>    per-op allow-list. The Qwen3.5 GatedDeltaNet trio (`rms_norm_gated` /
>    `causal_conv1d` / `chunk_gated_delta_rule`, added in #714) is validated
>    at OpSlot-bind time instead — these slots only exist in Qwen3.5's
>    patched module, so config-parse validation would force every NPU user
>    to override them even when training non-Qwen3.5 models. The kernel's
>    `HardwareRequirement` is the single source of truth.
>
> 2. **Per-model dispatch is strict-only.** `apply_per_model_patches` raises
>    on every missing backend except `eager`. Models with structurally
>    incompatible kernels (Wan `rope_apply`, Qwen2-VL multimodal RoPE on NPU)
>    opt out via `extra_backends[name] = None`, which is now an
>    *explicit-raise marker* with a `"explicitly disabled for {model}"`
>    message instead of a silent skip.
>
> 3. **`build_foundation_model` requires explicit ops.** Callers must pass
>    `ops_implementation=...` or pre-install a singleton via
>    `apply_ops_config(...)`; passing neither raises `ValueError`. The prior
>    silent all-eager fallback masked bugs like `train_wan` / `seed_omni`
>    passing only `attn_implementation` and having it silently overridden.
>
> Builds on #678 (registration-based kernel framework), #708 (chunk_loss
> reshape fix), #711 (chunked log-probs), #714 (Qwen3.5 GatedDeltaNet OpSlot
> dispatch), and #720 (temperature/entropy in log-probs forward).

### API and Usage Example

> **GPU**: existing YAMLs that don't override the per-op fields now pick up
> the GPU-optimal kernels automatically. The `gpu` extra ships
> `liger-kernel` + `triton`, so no setup change is needed.
>
> **NPU**: pin every per-op field. Minimal NPU-friendly YAML:
>
> ```yaml
> model:
>   ops_implementation:
>     attn_implementation: flash_attention_2
>     moe_implementation: fused_npu
>     cross_entropy_loss_implementation: chunk_loss
>     rms_norm_implementation: npu
>     rotary_pos_emb_implementation: npu
>     swiglu_mlp_implementation: eager           # no NPU backend
>     load_balancing_loss_implementation: eager  # triton-ascend not exposed as `triton`
>     # Qwen3.5 GatedDeltaNet trio — only meaningful for Qwen3.5 MoE; pin to
>     # eager on NPU (no NPU kernel) and set train.dyn_bsz=False (eager path
>     # only supports non-varlen training):
>     rms_norm_gated_implementation: eager
>     causal_conv1d_implementation: eager
>     chunk_gated_delta_rule_implementation: eager
> ```
>
> **Models with structurally-incompatible kernels** (Wan `rope_apply`,
> Qwen2-VL multimodal RoPE on NPU) ship pinned. Wan's three YAMLs include
> `rotary_pos_emb_implementation: eager`.

### Design & Code Changes

> **Defaults & validation** — `veomni/arguments/arguments_types.py`,
> `veomni/ops/kernels/{rms_norm,rotary,swiglu,load_balancing_loss}/__init__.py`
>
> - Flip per-op dataclass defaults; sync each `OpSpec.default` to match.
> - Rewrite `_validate_implementations`:
>   1. Hard-assert at parse time that every registered op (`list_ops()`) has
>      an entry in `_NPU_ALLOWED` — catches future op additions that miss
>      the map.
>   2. Check NPU compatibility against the explicit `_NPU_ALLOWED`
>      allow-list with a per-op error message.
>   3. Gate `load_balancing_loss=triton` on `is_package_available("triton")`.
> - Per-package availability for `liger_kernel` / `torch_npu` / `triton` is
>   checked at the resolution sites (`apply_per_model_patches` /
>   `apply_global_ops`), not duplicated in the validator.
>
> *Trade-off — hardcoded allow-list*: `_NPU_ALLOWED` is hand-curated rather
> than derived from `BackendSpec.requires`, because the name `"triton"` is
> reused with different hardware semantics (NPU `triton-ascend` for
> load-balancing loss vs. CUDA-only mainline Triton for DeepSeek-V3
> RMSNorm/RoPE). A `requires`-based inference would conflate them.
> Third-party NPU backends still extend cleanly via per-model
> `extra_backends` in `device_patch.py`.
>
> **Strict ops contract** — `veomni/models/auto.py`
>
> - Remove the silent all-eager fallback. `build_foundation_model` raises
>   `ValueError` when neither `ops_implementation` is passed nor a prior
>   `apply_ops_config(...)` has installed a singleton. Trainers always pass
>   `args.model.ops_implementation`. Callers that previously relied on the
>   fallback now construct an explicit `OpsImplementationConfig`:
>   - `tasks/infer/{infer_text,infer_qwen2_vl,infer_omni_model}.py` — pin
>     every per-op field to `eager`, with `flash_attention_2` for attn when
>     the package is importable so they keep working on CPU/minimal-deps
>     hosts;
>   - `tasks/deprecated_task/train_wan.py` — pass full
>     `args.model.ops_implementation` instead of just `attn_implementation`;
>   - `veomni/models/seed_omni/auto.py::build_omni_model` — accept and
>     forward an `ops_implementation` kwarg; `tasks/omni/train_omni_model.py`
>     passes `args.model.ops_implementation`.
> - `attn_implementation` resolution: caller passes `ops_implementation` →
>   use `ops.attn_implementation` (kwarg ignored); caller pre-installed the
>   singleton via `apply_ops_config` → use the singleton's
>   `attn_implementation` unless an explicit kwarg was passed (the explicit
>   value wins); neither passed and no singleton → raise.
> - `OpsImplementationConfig.all_eager()` is removed (it was an escape hatch
>   masquerading as public API). Tests that need a hardware-agnostic config
>   use `tests/tools/training_utils.py::make_eager_ops_config(**overrides)`;
>   NPU tests use `make_npu_ops_config(model_name=...)` for the recommended
>   NPU backend per op (consolidates the `_NPU_OPS_DEFAULTS` /
>   `_NPU_PER_MODEL_OVERRIDES` table that already powered
>   `resolve_ops_overrides`).
>
> **Per-model device patches**
>
> - `qwen3_vl/device_patch.py` — drop historical `liger_kernel: None`
>   opt-outs (verified standard-shape RMSNorm + RoPE).
> - `wan/device_patch.py` — keep `rotary_pos_emb: liger_kernel: None` as the
>   explicit-raise marker; **move Wan's Triton RoPE from the `_custom_wan`
>   callback into `extra_backends["rotary_pos_emb"]["triton"]`** so it
>   survives the strict-raise gate (a callback can't run after the gate
>   rejects unknown backends).
> - `qwen2_vl/device_patch.py` — keep `rotary_pos_emb: npu: None` as the
>   explicit-raise marker for the multimodal RoPE NPU mismatch.
> - `qwen3_5_moe/__init__.py` — Qwen3.5 GatedDeltaNet's NPU rejection runs
>   solely through `KERNEL_REGISTRY.resolve`'s `HardwareRequirement` check
>   (single source of truth). The varlen `dyn_bsz=False` caveat is
>   documented on the `OpsImplementationConfig` field metadata and in
>   `docs/usage/arguments.md`.
> - `configs/dit/wan*.yaml` (3 files) — pin
>   `rotary_pos_emb_implementation: eager`.
>
> **Test infrastructure** — `tests/tools/training_utils.py` and downstream
>
> - `resolve_ops_overrides(model_name)` emits hardware-aware
>   `--model.ops_implementation.X=Y` flags for NPU torchruns;
>   `_NPU_PER_MODEL_OVERRIDES` covers DeepSeek-V3 (no NPU RMSNorm/RoPE) and
>   Qwen2-VL / Qwen2.5-VL / Qwen2.5-Omni (multimodal RoPE).
> - `make_eager_ops_config(**overrides)` and `make_npu_ops_config(model_name)`
>   replace `OpsImplementationConfig.all_eager()` across tests; both pin the
>   Qwen3.5 GatedDeltaNet trio to `eager` so tests don't pull in
>   `flash-linear-attention` on hosts that don't have it.
> - `model_name` threaded through `build_torchrun_cmd` /
>   `run_training_config` and into `tests/e2e/utils.py`,
>   `tests/distributed/test_fsdp_equivalence.py`, `tests/checkpoints/utils.py`,
>   `tests/data/{test_datasets,test_multisource_dataset,test_dynamic_batching_dataset}.py`.
> - `tests/{e2e/test_e2e_parallel,distributed/test_fsdp_equivalence}.py` —
>   skip `qwen3_5` / `qwen3_5_moe` parametrize cases on NPU (no NPU
>   GatedDeltaNet kernel; eager path only supports non-varlen, but the e2e
>   command uses `dyn_bsz=True`).
>
> **Docs** — `docs/usage/arguments.md`, `docs/design/kernel_selection.md`
>
> - Refresh defaults table, NPU validation contract, lifecycle "Ownership"
>   paragraph (now describes the strict-raise contract); replace
>   `VEOMNI_USE_LIGER_KERNEL` references in the transformers-v5 comparison
>   table with the corresponding `OpsImplementationConfig` field name.

### Test

> - `make quality` clean.
> - `pytest tests/ops/test_moe_hw_gate.py` — 15/15 pass.
> - `pytest tests/models/{test_padded_packed_loss,test_vlm_trainer}.py` —
>   pass; targeted `test_models_patch.py::test_models_patch_fwd_bwd[qwen2]`
>   passes.
> - `build_foundation_model(...)` with no `ops_implementation` raises
>   `ValueError` with the documented message; happy path with
>   `ops_implementation=make_eager_ops_config()` builds cleanly.
> - GPU host: constructed `OpsImplementationConfig()` with new defaults —
>   validates clean; logs show `liger_kernel` / `fused_triton` / `triton`
>   bound for every op.
> - Mocked `is_torch_npu_available()=True`: every GPU-only choice raises
>   with the listed alternatives. The all-NPU config (`fused_npu` +
>   `chunk_loss` + `npu` + `eager` + `triton`) passes.
> - Per-model strict-raise: simulated `apply_per_model_patches` for
>   Wan-shape `extra_backends` confirms `rotary_pos_emb=liger_kernel`
>   (default) raises with `"explicitly disabled for Wan"` +
>   `available=['eager','npu','triton']`; explicit
>   `rotary_pos_emb=eager` succeeds.
> - Verified Qwen3-VL `Qwen3VLTextRMSNorm` + `apply_rotary_pos_emb` are
>   HF-standard on transformers v4.57.3 and v5 — the `liger_kernel` lift
>   is safe.
>
> Pending CI:
>
> - `gpu_e2e_test.yml` / `gpu_unit_tests.yml` — should pass with the `gpu`
>   extra (ships liger-kernel + flash-attn).
> - `npu_e2e_test.yml` / `npu_unit_tests.yml` — `resolve_ops_overrides`
>   threaded through every torchrun in
>   `tests/{e2e,distributed,checkpoints,data}` emits NPU-supported
>   overrides per model.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added/updated documentation
- [x] Added tests to CI workflow (or explained why not feasible) —
  `resolve_ops_overrides` covers every model NPU CI exercises;
  `test_moe_hw_gate.py` pins all-eager. The change is config-default +
  validator behavior, exercised end-to-end by every
  `tests/e2e/test_e2e_parallel.py` parametrization.
