### PR TITLE
[ops, model] refactor: register moe_experts in OpSpec registry

### DIFF
--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -74,13 +74,10 @@ def _bind_veomni_ops(modeling_module, ops_config: OpsImplementationConfig) -> bo
         obj = getattr(modeling_module, name, None)
         if not isinstance(obj, OpSlot):
             continue
-        # Resolve the user's selection through the OpSpec metadata:
-        # ``config_field`` handles the field-name convention (``moe_experts``
-        # → ``moe_implementation``, others → ``{op}_implementation``);
-        # ``value_alias_strip`` handles user-facing-vs-registry-key naming
-        # (e.g. ``fused_triton`` → ``triton``). Falls back to the
-        # ``{op}_implementation`` convention when the op isn't registered
-        # (defensive — every shipping OpSlot op should be in ``_OPS_REGISTRY``).
+        # OpSpec metadata drives the config-field lookup and value translation
+        # (e.g. ``moe_experts`` → ``moe_implementation`` field, ``fused_triton``
+        # → registry key ``triton``). Unregistered ops fall back to the
+        # ``{op}_implementation`` convention.
         spec = _OPS_REGISTRY.get(obj.op_name)
         field = spec.config_field if spec else f"{obj.op_name}_implementation"
         raw = getattr(ops_config, field, "eager")

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -66,29 +66,31 @@ def _bind_veomni_ops(modeling_module, ops_config: OpsImplementationConfig) -> bo
 
     Returns ``True`` if at least one OpSlot was found (and bound).
     """
-    found = False
+    from ..ops.config.registry import _OPS_REGISTRY
+
+    bound: list[str] = []
     moe_experts_kernel: Optional[str] = None
     for name in dir(modeling_module):
         obj = getattr(modeling_module, name, None)
-        if isinstance(obj, OpSlot):
-            # `moe_experts` is the one op whose user-facing config field is not
-            # `moe_experts_implementation` but `moe_implementation`, and its
-            # values carry a `fused_` prefix (e.g. `fused_triton`) that the
-            # KERNEL_REGISTRY entries don't. Translate here so the registry
-            # lookup finds the kernel and the HardwareRequirement check fires.
-            if obj.op_name == "moe_experts":
-                impl_name = (
-                    "eager"
-                    if ops_config.moe_implementation == "eager"
-                    else ops_config.moe_implementation.removeprefix("fused_")
-                )
-                if impl_name != "eager":
-                    moe_experts_kernel = impl_name
-            else:
-                impl_name = getattr(ops_config, f"{obj.op_name}_implementation", "eager")
-            obj.bind(impl_name)
-            logger.info_rank0(f"OpSlot '{name}' bound to '{impl_name}' -> {obj}")
-            found = True
+        if not isinstance(obj, OpSlot):
+            continue
+        # Resolve the user's selection through the OpSpec metadata:
+        # ``config_field`` handles the field-name convention (``moe_experts``
+        # → ``moe_implementation``, others → ``{op}_implementation``);
+        # ``value_alias_strip`` handles user-facing-vs-registry-key naming
+        # (e.g. ``fused_triton`` → ``triton``). Falls back to the
+        # ``{op}_implementation`` convention when the op isn't registered
+        # (defensive — every shipping OpSlot op should be in ``_OPS_REGISTRY``).
+        spec = _OPS_REGISTRY.get(obj.op_name)
+        field = spec.config_field if spec else f"{obj.op_name}_implementation"
+        raw = getattr(ops_config, field, "eager")
+        prefix = spec.value_alias_strip if spec else None
+        impl_name = raw.removeprefix(prefix) if (prefix and raw.startswith(prefix)) else raw
+
+        obj.bind(impl_name)
+        bound.append(f"{obj.op_name} ({impl_name})")
+        if obj.op_name == "moe_experts" and impl_name != "eager":
+            moe_experts_kernel = impl_name
 
     # The OpSlot only acts as an eager-vs-fused guard
     # (``slot.use_non_eager_impl``). Inside the fused branch, modeling code
@@ -101,7 +103,9 @@ def _bind_veomni_ops(modeling_module, ops_config: OpsImplementationConfig) -> bo
 
         apply_veomni_fused_moe_patch(fused_moe_kernel=moe_experts_kernel)
 
-    return found
+    if bound:
+        logger.info_rank0(f"OpSlot dispatch bound: {', '.join(bound)}.")
+    return bool(bound)
 
 
 def build_foundation_model(

--- a/veomni/ops/config/registry.py
+++ b/veomni/ops/config/registry.py
@@ -60,11 +60,9 @@ logger = logging.get_logger(__name__)
 class OpScope(str, Enum):
     GLOBAL = "global"
     PER_MODEL = "per_model"
-    # Dispatched via module-level ``OpSlot`` instances in patchgen'd modeling
-    # files; backends live in ``KERNEL_REGISTRY`` (not ``OpSpec.backends``).
-    # Registered in ``_OPS_REGISTRY`` only for ``config_field`` /
-    # ``value_alias_strip`` metadata so ``_bind_veomni_ops`` can do the
-    # config-to-registry translation generically.
+    # OpSlot-dispatched ops: backends live in ``KERNEL_REGISTRY``; the
+    # ``OpSpec`` here only carries ``config_field`` / ``value_alias_strip``
+    # metadata for ``_bind_veomni_ops``.
     OPSLOT = "opslot"
 
 
@@ -113,11 +111,9 @@ class OpSpec:
         backends: Mapping from backend name to ``BackendSpec``.
         global_slot: GLOBAL ops only. ``"module:attr"`` holding the function
             pointer; the engine performs ``setattr(module, attr, entry)``.
-        value_alias_strip: Optional prefix stripped from ``config_field``
-            values before registry lookup. Used by ``moe_experts`` so the
-            user-facing ``fused_triton`` / ``fused_quack`` / ``fused_npu``
-            names map to the registry's bare ``triton`` / ``quack`` / ``npu``
-            keys without a special-case in ``_bind_veomni_ops``.
+        value_alias_strip: Optional prefix stripped from the config value
+            before registry lookup (e.g. ``"fused_"`` so ``fused_triton``
+            resolves to registry key ``triton``).
     """
 
     name: str

--- a/veomni/ops/config/registry.py
+++ b/veomni/ops/config/registry.py
@@ -60,6 +60,12 @@ logger = logging.get_logger(__name__)
 class OpScope(str, Enum):
     GLOBAL = "global"
     PER_MODEL = "per_model"
+    # Dispatched via module-level ``OpSlot`` instances in patchgen'd modeling
+    # files; backends live in ``KERNEL_REGISTRY`` (not ``OpSpec.backends``).
+    # Registered in ``_OPS_REGISTRY`` only for ``config_field`` /
+    # ``value_alias_strip`` metadata so ``_bind_veomni_ops`` can do the
+    # config-to-registry translation generically.
+    OPSLOT = "opslot"
 
 
 @dataclass(frozen=True)
@@ -102,11 +108,16 @@ class OpSpec:
         name: Machine identifier, e.g. ``"rms_norm"``.
         config_field: Matching field name on ``OpsImplementationConfig``.
         label: Human-readable label used in log lines, e.g. ``"RMSNorm"``.
-        scope: ``GLOBAL`` or ``PER_MODEL``.
+        scope: ``GLOBAL``, ``PER_MODEL``, or ``OPSLOT`` (see ``OpScope``).
         default: Default backend name; must equal the dataclass default.
         backends: Mapping from backend name to ``BackendSpec``.
         global_slot: GLOBAL ops only. ``"module:attr"`` holding the function
             pointer; the engine performs ``setattr(module, attr, entry)``.
+        value_alias_strip: Optional prefix stripped from ``config_field``
+            values before registry lookup. Used by ``moe_experts`` so the
+            user-facing ``fused_triton`` / ``fused_quack`` / ``fused_npu``
+            names map to the registry's bare ``triton`` / ``quack`` / ``npu``
+            keys without a special-case in ``_bind_veomni_ops``.
     """
 
     name: str
@@ -116,6 +127,7 @@ class OpSpec:
     default: str
     backends: dict[str, BackendSpec] = field(default_factory=dict)
     global_slot: str | None = None
+    value_alias_strip: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/veomni/ops/kernels/moe/__init__.py
+++ b/veomni/ops/kernels/moe/__init__.py
@@ -110,7 +110,25 @@ def apply_veomni_fused_moe_patch(fused_moe_kernel: str = "triton") -> None:
 
 # ── OpSlot kernel registrations ──────────────────────────────────────────────
 
+from ...config.registry import OpScope, OpSpec, register_op
 from ...kernel_registry import KERNEL_REGISTRY, HardwareRequirement, KernelSpec
+
+
+# Metadata-only registration so ``_bind_veomni_ops`` can resolve
+# ``moe_experts`` -> ``moe_implementation`` and strip the ``fused_`` prefix
+# generically (no special-case branch). Backends actually live in
+# ``KERNEL_REGISTRY`` (see registrations below); ``OpSpec.backends`` stays
+# empty for ``OPSLOT`` ops.
+register_op(
+    OpSpec(
+        name="moe_experts",
+        config_field="moe_implementation",
+        label="MoE",
+        scope=OpScope.OPSLOT,
+        default="fused_triton",
+        value_alias_strip="fused_",
+    )
+)
 
 
 def _make_moe_experts_adapter(raw_forward):

--- a/veomni/ops/kernels/moe/__init__.py
+++ b/veomni/ops/kernels/moe/__init__.py
@@ -114,11 +114,9 @@ from ...config.registry import OpScope, OpSpec, register_op
 from ...kernel_registry import KERNEL_REGISTRY, HardwareRequirement, KernelSpec
 
 
-# Metadata-only registration so ``_bind_veomni_ops`` can resolve
-# ``moe_experts`` -> ``moe_implementation`` and strip the ``fused_`` prefix
-# generically (no special-case branch). Backends actually live in
-# ``KERNEL_REGISTRY`` (see registrations below); ``OpSpec.backends`` stays
-# empty for ``OPSLOT`` ops.
+# Metadata-only: declares ``moe_experts`` ↔ ``moe_implementation`` and the
+# ``fused_`` value prefix so ``_bind_veomni_ops`` translates generically.
+# Actual kernels live in ``KERNEL_REGISTRY`` below.
 register_op(
     OpSpec(
         name="moe_experts",


### PR DESCRIPTION
### What does this PR do?

> Drop the `moe_experts` special-case branch in `_bind_veomni_ops` by
> declaring its translation rules on `OpSpec` metadata.
> **Internal refactor — user config / YAML / docs unchanged.**

### Motivation

`_bind_veomni_ops` is the entry point for OpSlot dispatch — every
patchgen'd model (`qwen3_moe`, `qwen3_5_moe`, `qwen3_vl_moe`,
`qwen3_omni_moe`, `deepseek_v3`) binds its MoE / RMSNorm / RoPE / etc.
ops here. Pre-refactor:

```python
if obj.op_name == "moe_experts":
    impl_name = ... ops_config.moe_implementation.removeprefix("fused_")
else:
    impl_name = getattr(ops_config, f"{obj.op_name}_implementation", "eager")
```

Two implicit conventions are buried in this branch:

1. **Field-name convention** — every other op uses
   `{op_name}_implementation`, but MoE uses `moe_implementation` (not
   `moe_experts_implementation`). Only discoverable by grep.
2. **Value-name mapping** — every other op's config value matches its
   registry key directly; MoE values carry a `fused_` prefix
   (`fused_triton`) while the registry uses bare names (`triton`).

Neither convention is declared anywhere in the data structures — both
live only inside this if-branch. Consequences:

- Adding a new OpSlot op with non-standard naming silently breaks
  unless someone remembers to add another branch here.
- Reading `_bind_veomni_ops` doesn't tell you why MoE needs
  `removeprefix("fused_")`; you have to bounce through `KERNEL_REGISTRY`
  and `OpsImplementationConfig` to reconstruct it.

**Post-refactor**: lift both translation rules onto `OpSpec` declarative
metadata (`config_field` + new `value_alias_strip`). `_bind_veomni_ops`
becomes a generic loop with no op-specific branches. New OpSlot ops with
non-standard naming declare the mapping at registration — no edits to
the dispatch code.

### Alternatives considered

| Option | Files touched | Breaking? | Verdict |
|---|---|---|---|
| **This PR — metadata declaration** | 3 files, ~50 lines | No | ✅ Chosen |
| **A. Rename OpSlot name (`moe_experts` → `moe`)** | 5 patchgen'd models × 3 file types (`modeling_*.py`, `*_patch_gen_config.py`, `generated/*.{py,diff}`), `KERNEL_REGISTRY` registrations, tests ≈ **30 files** | No | ❌ `generated/` requires re-running patchgen; `moe` is vaguer than `moe_experts` (the actual symbol replaced is `Qwen3MoeExperts.forward`); only fixes the field-name half — `removeprefix("fused_")` still needed |
| **B. Drop the `fused_` prefix (rename user config values)** | Option A + 5 YAMLs + 6 docs + tests ≈ **50 files**; all external user YAMLs invalidated | Yes | ❌ Pure naming polish; `fused_*` is informative for users (distinguishes "which fused-MoE variant"), not worth breaking every downstream |

### Design & Code Changes

> - **`veomni/ops/config/registry.py`**
>   - `OpScope.OPSLOT` — new enum for OpSlot-dispatched ops (backends
>     live in `KERNEL_REGISTRY`, so `OpSpec.backends` stays empty).
>     `apply_per_model_patches` / `apply_global_ops` skip this scope.
>   - `OpSpec.value_alias_strip: str | None` — optional value prefix
>     stripped before registry lookup.
> - **`veomni/ops/kernels/moe/__init__.py`** — register `moe_experts`
>   as an `OPSLOT` op with `config_field="moe_implementation"` and
>   `value_alias_strip="fused_"`. Metadata-only; kernels stay in
>   `KERNEL_REGISTRY`.
> - **`veomni/models/auto.py`** — `_bind_veomni_ops` reads
>   `_OPS_REGISTRY` metadata for the translation; the
>   `obj.op_name == "moe_experts"` field/value branch is gone. The
>   MoE-specific `apply_veomni_fused_moe_patch` side-effect call stays
>   (MoE-glue, not config translation). Per-OpSlot binding logs are
>   consolidated into one line per model.

### API and Usage Example

> No user-visible change. `model.ops_implementation.moe_implementation`
> still accepts `eager` / `fused_triton` / `fused_quack` / `fused_npu`
> with identical semantics.

### Test

> - `make quality` clean.
> - `pytest tests/ops/test_moe_hw_gate.py` — 15/15 pass. The
>   `test_bind_veomni_ops_translates_moe_implementation_and_checks_hw`
>   case is the end-to-end check: simulated SM80 +
>   `moe_implementation=fused_quack` verifies the translation chain
>   `fused_quack` → registry `quack` → SM90 hardware-requirement raise.
> - Smoke: `OpSlot('moe_experts', 'standard')` with
>   `moe_implementation='eager'` leaves the slot unbound; non-eager
>   values fire the side-effect.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (`make quality` clean)
- [x] Added/updated documentation — none needed (internal refactor, no
  user-facing API change)
- [x] Added tests to CI workflow — covered by existing
  `tests/ops/test_moe_hw_gate.py`
