### PR TITLE
[ops, model] feat: forward temperature and return entropy from log-probs path

### DIFF
--- a/tests/models/test_return_log_probs_e2e.py
+++ b/tests/models/test_return_log_probs_e2e.py
@@ -80,12 +80,12 @@ def _have_python_dev_headers() -> bool:
     return include is not None and os.path.isfile(os.path.join(include, "Python.h"))
 
 
-def _reference_log_probs_from_logits(
+def _reference_log_probs_and_entropy_from_logits(
     logits: torch.Tensor,
     labels: torch.Tensor,
     ignore_index: int = IGNORE_INDEX,
-) -> torch.Tensor:
-    """Reference per-token actual log-probabilities (non-positive).
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference per-token log-probabilities (non-positive) and entropy (non-negative).
 
     Routes the per-token NLL through the same
     ``_per_token_log_probs_from_logits`` helper the kernel uses (which
@@ -95,16 +95,26 @@ def _reference_log_probs_from_logits(
     only remaining numerical difference between this path and the
     chunked-fused-linear path is the lm_head matmul boundary —
     identical when ``chunk_size`` covers the whole seq, so the kernel
-    output stays bitwise equal.
+    output stays bitwise equal. Entropy is computed via the same
+    ``_per_token_entropy_from_logits`` helper for the same reason.
     """
-    from veomni.ops.kernels.cross_entropy.chunk_logprobs import _per_token_log_probs_from_logits
+    from veomni.ops.kernels.cross_entropy.chunk_logprobs import (
+        _per_token_entropy_from_logits,
+        _per_token_log_probs_from_logits,
+    )
 
     shifted = labels[..., 1:].contiguous()
     sliced = logits[..., :-1, :].contiguous()
     flat = sliced.reshape(-1, sliced.size(-1)).float()
-    log_probs_flat = _per_token_log_probs_from_logits(flat, shifted.reshape(-1), ignore_index)
+    target = shifted.reshape(-1)
+    log_probs_flat = _per_token_log_probs_from_logits(flat, target, ignore_index)
+    entropy_flat = _per_token_entropy_from_logits(flat)
+    mask = target != ignore_index
+    entropy_flat = torch.where(mask, entropy_flat, torch.zeros_like(entropy_flat))
+
     log_probs = log_probs_flat.view_as(shifted)
-    return F.pad(log_probs, (0, 1), value=0.0)  # non-positive: actual log p(y_t)
+    entropy = entropy_flat.view_as(shifted)
+    return F.pad(log_probs, (0, 1), value=0.0), F.pad(entropy, (0, 1), value=0.0)
 
 
 def _build_model(toy_path: str, ce_impl: str = "chunk_loss"):
@@ -210,16 +220,17 @@ def test_return_log_probs_bitwise_matches_logits_reference(ce_impl, toy_path, fa
         labels[1, ::5] = IGNORE_INDEX
 
         with torch.no_grad():
-            # Reference path: full-logits forward + reference log-probs.
+            # Reference path: full-logits forward + reference log-probs / entropy.
             ref_logits = model(input_ids=input_ids, use_cache=False).logits
-            ref_log_probs = _reference_log_probs_from_logits(ref_logits, labels)
+            ref_log_probs, ref_entropy = _reference_log_probs_and_entropy_from_logits(ref_logits, labels)
 
             # New path: model wrapper installed by ``build_foundation_model``
             # makes ``model(..., return_log_probs=True)`` return
             # ``output.log_probs`` (actual log-probabilities, sign already
-            # flipped) and clear ``output.logits``. ``chunk_size=L+1``
-            # forces a single chunk so the matmul boundary matches the
-            # reference forward exactly.
+            # flipped) and ``output.entropy`` (per-token softmax entropy)
+            # and clear ``output.logits``. ``chunk_size=L+1`` forces a
+            # single chunk so the matmul boundary matches the reference
+            # forward exactly.
             out = model(
                 input_ids=input_ids,
                 labels=labels,
@@ -251,23 +262,50 @@ def test_return_log_probs_bitwise_matches_logits_reference(ce_impl, toy_path, fa
             f"max_abs_diff={diff.max().item():.3e}, first_idx={first_idx}"
         )
 
+    # Entropy contract: same shape as log_probs, populated, bitwise equal
+    # to the reference (same ``_per_token_entropy_from_logits`` helper on
+    # the same fp32 logits).
+    assert out.entropy is not None, f"[{family}/{ce_impl}] entropy must be populated when return_log_probs=True"
+    assert out.entropy.shape == labels.shape, (
+        f"[{family}/{ce_impl}] entropy shape {tuple(out.entropy.shape)} != labels shape {tuple(labels.shape)}"
+    )
+    if not torch.equal(out.entropy, ref_entropy):
+        diff = (out.entropy - ref_entropy).abs()
+        ne = out.entropy != ref_entropy
+        first_idx = torch.nonzero(ne, as_tuple=False)[:5].tolist()
+        raise AssertionError(
+            f"[{family}/{ce_impl}] per-token entropy not bitwise equal: "
+            f"{int(ne.sum().item())}/{out.entropy.numel()} mismatched, "
+            f"max_abs_diff={diff.max().item():.3e}, first_idx={first_idx}"
+        )
+
     # IGNORE_INDEX masking contract: the kernel emits exactly 0 wherever
     # the shifted target is IGN (and at the trailing pad position). The
     # kernel predicts ``labels[t+1]`` from ``hidden[t]``, so an IGN at
-    # ``labels[k]`` zeros output position ``k-1``.
+    # ``labels[k]`` zeros output position ``k-1``. Both log_probs and
+    # entropy follow the same masking contract.
     shifted_target_is_ign = F.pad(labels[..., 1:] == IGNORE_INDEX, (0, 1), value=True)
-    masked_vals = out.log_probs[shifted_target_is_ign]
-    valid_vals = out.log_probs[~shifted_target_is_ign]
-    assert torch.all(masked_vals == 0.0), (
-        f"[{family}/{ce_impl}] IGN-target positions must emit 0.0, got max_abs={masked_vals.abs().max().item():.3e}"
+    masked_lp = out.log_probs[shifted_target_is_ign]
+    valid_lp = out.log_probs[~shifted_target_is_ign]
+    masked_ent = out.entropy[shifted_target_is_ign]
+    valid_ent = out.entropy[~shifted_target_is_ign]
+    assert torch.all(masked_lp == 0.0), (
+        f"[{family}/{ce_impl}] IGN-target positions must emit 0.0 log_probs, got max_abs={masked_lp.abs().max().item():.3e}"
+    )
+    assert torch.all(masked_ent == 0.0), (
+        f"[{family}/{ce_impl}] IGN-target positions must emit 0.0 entropy, got max_abs={masked_ent.abs().max().item():.3e}"
     )
     # log p(.) < 0 strictly for any non-degenerate distribution at random
     # init (probability < 1).
-    assert torch.all(valid_vals < 0), (
-        f"[{family}/{ce_impl}] valid-target positions must emit negative log_probs, got max={valid_vals.max().item():.3e}"
+    assert torch.all(valid_lp < 0), (
+        f"[{family}/{ce_impl}] valid-target positions must emit negative log_probs, got max={valid_lp.max().item():.3e}"
+    )
+    # H[p] > 0 strictly for any non-degenerate distribution.
+    assert torch.all(valid_ent > 0), (
+        f"[{family}/{ce_impl}] valid-target positions must emit positive entropy, got min={valid_ent.min().item():.3e}"
     )
 
-    del model, ref_logits, ref_log_probs, out
+    del model, ref_logits, ref_log_probs, ref_entropy, out
     _release()
 
 
@@ -276,20 +314,24 @@ def test_plain_forward_matches_verl_consumer_contract(toy_path, family):
     """Pin the verl-consumer contract on the **plain model forward path**.
 
     Verl's ``FSDPEngineWithLMHead.prepare_model_outputs`` does
-    ``log_probs = output.log_probs.squeeze(0)`` in its
+    ``log_probs = output.log_probs.squeeze(0)`` and
+    ``entropy_rmpad = output.entropy.squeeze(0)`` in its
     ``use_fused_kernels=True`` branch and expects actual
-    log-probabilities (non-positive). The integration story is:
-    verl calls ``self.module(..., return_log_probs=True)`` directly —
-    no helper imports, no engine override — and the
+    log-probabilities (non-positive) plus per-token entropy
+    (non-negative). The integration story is: verl calls
+    ``self.module(..., return_log_probs=True)`` directly — no helper
+    imports, no engine override — and the
     ``build_foundation_model``-installed wrapper makes the output's
-    ``log_probs`` field populated automatically.
+    ``log_probs`` and ``entropy`` fields populated automatically.
 
     This test pins exactly that contract:
 
-    1. ``output.log_probs`` is populated, finite, shape matches labels.
+    1. ``output.log_probs`` and ``output.entropy`` are populated, finite,
+       shape matches labels.
     2. ``output.logits`` is None — wrapper cleared it after promotion.
     3. ``output.loss`` is None.
     4. ``output.log_probs <= 0`` everywhere (actual log-probabilities).
+    5. ``output.entropy >= 0`` everywhere (softmax entropy).
     """
     _skip_unless_cuda_v4(toy_path)
     _apply_determinism()
@@ -310,11 +352,17 @@ def test_plain_forward_matches_verl_consumer_contract(toy_path, family):
     assert out.loss is None, f"[{family}] loss must be None when return_log_probs=True"
     assert out.logits is None, f"[{family}] logits must be cleared by the build_foundation_model wrapper"
     assert out.log_probs is not None, f"[{family}] log_probs must be populated by the build_foundation_model wrapper"
+    assert out.entropy is not None, f"[{family}] entropy must be populated by the build_foundation_model wrapper"
     assert out.log_probs.shape == labels.shape, (
         f"[{family}] log_probs shape {tuple(out.log_probs.shape)} != labels shape {tuple(labels.shape)}"
     )
+    assert out.entropy.shape == labels.shape, (
+        f"[{family}] entropy shape {tuple(out.entropy.shape)} != labels shape {tuple(labels.shape)}"
+    )
     assert torch.isfinite(out.log_probs).all(), f"[{family}] log_probs has non-finite values"
+    assert torch.isfinite(out.entropy).all(), f"[{family}] entropy has non-finite values"
     assert (out.log_probs <= 0).all(), f"[{family}] log_probs must be <= 0; got max={out.log_probs.max().item():.3e}"
+    assert (out.entropy >= 0).all(), f"[{family}] entropy must be >= 0; got min={out.entropy.min().item():.3e}"
 
     del model, out
     _release()

--- a/tests/ops/test_chunk_logprobs.py
+++ b/tests/ops/test_chunk_logprobs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for chunked fused linear log-probs (PPO-style).
+"""Tests for chunked fused linear log-probs and entropy (PPO-style).
 
 Pin **bitwise** parity vs a reference ``F.linear -> log_softmax ->
 gather`` implementation under deterministic algorithms + batch-invariant
@@ -20,7 +20,8 @@ mode on CUDA. Same contract that
 ``tests/models/test_return_log_probs_e2e.py::
 test_return_log_probs_bitwise_matches_logits_reference`` enforces
 end-to-end. The kernel returns per-token actual log-probabilities
-(non-positive); IGNORE_INDEX positions produce 0.
+(non-positive) **and** softmax entropy (non-negative); IGNORE_INDEX
+positions produce 0 in both outputs.
 """
 
 import os
@@ -115,13 +116,14 @@ def _assert_bitwise_equal(actual: torch.Tensor, expected: torch.Tensor, label: s
         )
 
 
-def _reference_per_token_log_probs(
+def _reference_per_token(
     hidden_states: torch.Tensor,
     weights: torch.Tensor,
     labels: torch.Tensor,
+    temperature: float = 1.0,
     ignore_index: int = IGNORE_INDEX,
-) -> torch.Tensor:
-    """Reference impl: full-logits gather. Used as ground truth.
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference impl: full-logits gather + entropy. Used as ground truth.
 
     Routes the per-token NLL through the same
     ``_per_token_log_probs_from_logits`` helper the kernel uses (which
@@ -135,10 +137,20 @@ def _reference_per_token_log_probs(
     shifted = labels[..., 1:].contiguous()
     h = hidden_states[..., :-1, :].contiguous()
     flat = h.reshape(-1, h.size(-1))
-    logits = F.linear(flat, weights).float()
-    log_probs_flat = cl._per_token_log_probs_from_logits(logits, shifted.reshape(-1), ignore_index)
+    logits = F.linear(flat, weights)
+    if temperature != 1.0:
+        logits = logits / temperature
+    logits = logits.float()
+    target = shifted.reshape(-1)
+    log_probs_flat = cl._per_token_log_probs_from_logits(logits, target, ignore_index)
+    entropy_flat = cl._per_token_entropy_from_logits(logits)
+    # Mask entropy at IGN to mirror kernel.
+    mask = target != ignore_index
+    entropy_flat = torch.where(mask, entropy_flat, torch.zeros_like(entropy_flat))
+
     log_probs = log_probs_flat.view_as(shifted)
-    return F.pad(log_probs, (0, 1), value=0.0)
+    entropy = entropy_flat.view_as(shifted)
+    return F.pad(log_probs, (0, 1), value=0.0), F.pad(entropy, (0, 1), value=0.0)
 
 
 def test_bitwise_parity_with_reference():
@@ -147,7 +159,8 @@ def test_bitwise_parity_with_reference():
     With ``chunk_size`` > total tokens the kernel collapses to one
     ``h @ weight.t()``; under batch-invariant mode that matmul + the
     log_softmax + gather are bitwise identical to the reference's
-    single ``F.linear`` + log_softmax + gather.
+    single ``F.linear`` + log_softmax + gather. Asserts both outputs
+    (log_probs and entropy).
     """
     torch.manual_seed(0)
     B, L, H, V = 2, 64, 32, 256
@@ -157,61 +170,108 @@ def test_bitwise_parity_with_reference():
     labels[0, ::7] = IGNORE_INDEX
     labels[1, 0] = IGNORE_INDEX
 
-    out = cl.chunk_logprobs_function(hidden, weights, labels, chunk_size=B * L + 1)
-    ref = _reference_per_token_log_probs(hidden, weights, labels)
+    log_probs, entropy = cl.chunk_logprobs_function(hidden, weights, labels, chunk_size=B * L + 1)
+    ref_log_probs, ref_entropy = _reference_per_token(hidden, weights, labels)
 
-    _assert_bitwise_equal(out, ref, "log_probs")
+    _assert_bitwise_equal(log_probs, ref_log_probs, "log_probs")
+    _assert_bitwise_equal(entropy, ref_entropy, "entropy")
+
+
+def test_temperature_scales_logits_bitwise():
+    """``temperature != 1.0`` divides logits before softmax.
+
+    Pin bitwise parity vs the reference path that applies the same
+    ``logits = logits / T`` divide before ``log_softmax + gather`` and
+    entropy. Confirms the wrapper ``temperature`` kwarg threads through
+    the kernel (and not e.g. silently dropped).
+    """
+    torch.manual_seed(0)
+    B, L, H, V = 2, 32, 16, 64
+    hidden = torch.randn(B, L, H, dtype=torch.float32, device=_device())
+    weights = torch.randn(V, H, dtype=torch.float32, device=_device())
+    labels = torch.randint(0, V, (B, L), dtype=torch.long, device=_device())
+
+    T = 2.5
+    log_probs, entropy = cl.chunk_logprobs_function(hidden, weights, labels, chunk_size=B * L + 1, temperature=T)
+    ref_log_probs, ref_entropy = _reference_per_token(hidden, weights, labels, temperature=T)
+
+    _assert_bitwise_equal(log_probs, ref_log_probs, "log_probs (T=2.5)")
+    _assert_bitwise_equal(entropy, ref_entropy, "entropy (T=2.5)")
 
 
 def test_ignore_index_zeroes_output_and_grad():
-    """All-IGN labels emit exactly zero output and zero gradient."""
+    """All-IGN labels emit exactly zero outputs and zero gradients.
+
+    Both ``log_probs`` and ``entropy`` are masked to 0 at IGN positions
+    (so summing either over the seq gives "value at supervised slots
+    only"), and no gradient flows through hidden_states / weights.
+    """
     torch.manual_seed(0)
     B, L, H, V = 1, 8, 4, 16
     hidden = torch.randn(B, L, H, dtype=torch.float32, device=_device(), requires_grad=True)
     weights = torch.randn(V, H, dtype=torch.float32, device=_device(), requires_grad=True)
     labels = torch.full((B, L), IGNORE_INDEX, dtype=torch.long, device=_device())
 
-    out = cl.chunk_logprobs_function(hidden, weights, labels, chunk_size=4)
-    assert torch.all(out == 0)
+    log_probs, entropy = cl.chunk_logprobs_function(hidden, weights, labels, chunk_size=4)
+    assert torch.all(log_probs == 0)
+    assert torch.all(entropy == 0)
 
-    out.sum().backward()
+    (log_probs.sum() + entropy.sum()).backward()
     assert torch.all(hidden.grad == 0)
     assert torch.all(weights.grad == 0)
 
 
-def _manual_backward_per_token_log_probs(
+def _manual_backward_per_token(
     hidden: torch.Tensor,
     weights: torch.Tensor,
     labels: torch.Tensor,
-    grad_target: torch.Tensor,
+    grad_log_probs: torch.Tensor | None,
+    grad_entropy: torch.Tensor | None,
+    temperature: float = 1.0,
     ignore_index: int = IGNORE_INDEX,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Hand-derived backward matching the kernel's explicit op sequence.
 
-    The kernel's backward computes
-    ``dlogits = dlp * (one_hot - softmax(logits))`` then
-    ``dhidden = dlogits @ weight`` and
-    ``dweight = dlogits.t() @ hidden`` (single chunk). PyTorch's stock
-    autograd path through ``log_softmax + gather`` is mathematically
-    equivalent but sequences the fp32 ops differently (scatter-then-
-    subtract vs subtract-then-multiply), so the two paths' grads agree
-    only at fp32 epsilon (~1e-7), not bitwise. To pin **bitwise**
-    parity under batch-invariant ``mm``, we mirror the kernel's
-    op sequence here and use this as the reference instead.
+    Mirrors verl's ``_fused_linear_for_ppo_bwd`` exactly:
+    ``dlogits_lp = dlp * (one_hot - softmax)``,
+    ``dlogits_ent = -dent * softmax * (log_softmax + entropy)``,
+    summed; cast back to input dtype, divide by T, then matmul.
+    PyTorch's stock autograd path through ``log_softmax + gather`` is
+    mathematically equivalent but sequences the fp32 ops differently
+    (scatter-then-subtract vs subtract-then-multiply), so the two paths'
+    grads agree only at fp32 epsilon (~1e-7), not bitwise.
     """
     shifted = labels[..., 1:].contiguous()
     h = hidden[..., :-1, :].contiguous()
     flat = h.reshape(-1, h.size(-1))
     target = shifted.reshape(-1)
-    grad_flat = grad_target[..., :-1].reshape(-1)
 
-    logits = F.linear(flat, weights).float()
+    logits = F.linear(flat, weights)
+    if temperature != 1.0:
+        logits = logits / temperature
+    logits = logits.float()
     probs = logits.softmax(dim=-1)
     mask = (target != ignore_index).float()
-    safe = target.clamp(min=0).unsqueeze(-1)
-    one_hot = torch.zeros_like(probs).scatter_(-1, safe, 1.0)
-    masked_dlp = (grad_flat * mask).unsqueeze(-1)
-    dlogits = masked_dlp * (one_hot - probs)
+
+    dlogits = torch.zeros_like(probs)
+
+    if grad_log_probs is not None:
+        dlp_flat = grad_log_probs[..., :-1].reshape(-1)
+        safe = target.clamp(min=0).unsqueeze(-1)
+        one_hot = torch.zeros_like(probs).scatter_(-1, safe, 1.0)
+        masked_dlp = (dlp_flat * mask).unsqueeze(-1)
+        dlogits = dlogits + masked_dlp * (one_hot - probs)
+
+    if grad_entropy is not None:
+        dent_flat = grad_entropy[..., :-1].reshape(-1)
+        log_probs_full = logits.log_softmax(dim=-1)
+        entropy_full = torch.logsumexp(logits, dim=-1) - torch.sum(probs * logits, dim=-1)
+        masked_dent = (dent_flat * mask).unsqueeze(-1)
+        dlogits = dlogits + probs * (log_probs_full + entropy_full.unsqueeze(-1)) * (-masked_dent)
+
+    dlogits = dlogits.to(flat.dtype)
+    if temperature != 1.0:
+        dlogits = dlogits / temperature
 
     dhidden_flat = dlogits @ weights
     dweight = dlogits.t() @ flat
@@ -222,7 +282,7 @@ def _manual_backward_per_token_log_probs(
 
 
 def test_chunk_size_invariance_forward_and_grad():
-    """Output, dhidden and dweight are bitwise invariant to ``chunk_size``.
+    """Outputs and gradients are bitwise invariant to ``chunk_size``.
 
     Under batch-invariant ``mm`` / ``_log_softmax``, every per-row
     forward output is independent of which other rows are in the matmul,
@@ -246,23 +306,27 @@ def test_chunk_size_invariance_forward_and_grad():
     labels[0, 11] = IGNORE_INDEX
     labels[0, 23] = IGNORE_INDEX
 
-    grad_target = torch.randn(B, L, dtype=torch.float32, device=_device())
+    grad_lp = torch.randn(B, L, dtype=torch.float32, device=_device())
+    grad_ent = torch.randn(B, L, dtype=torch.float32, device=_device())
 
     chunk_sizes = (24, 1024)
-    outputs = []
+    log_probs_outs = []
+    entropy_outs = []
     grads_h = []
     grads_w = []
     for chunk_size in chunk_sizes:
         h = hidden0.clone().requires_grad_(True)
         w = weights0.clone().requires_grad_(True)
-        out = cl.chunk_logprobs_function(h, w, labels, chunk_size=chunk_size)
-        (out * grad_target).sum().backward()
-        outputs.append(out.detach())
+        log_probs, entropy = cl.chunk_logprobs_function(h, w, labels, chunk_size=chunk_size)
+        ((log_probs * grad_lp).sum() + (entropy * grad_ent).sum()).backward()
+        log_probs_outs.append(log_probs.detach())
+        entropy_outs.append(entropy.detach())
         grads_h.append(h.grad.detach())
         grads_w.append(w.grad.detach())
 
-    for i in range(1, len(outputs)):
-        _assert_bitwise_equal(outputs[i], outputs[0], f"forward[chunk_size={chunk_sizes[i]}]")
+    for i in range(1, len(chunk_sizes)):
+        _assert_bitwise_equal(log_probs_outs[i], log_probs_outs[0], f"log_probs[chunk_size={chunk_sizes[i]}]")
+        _assert_bitwise_equal(entropy_outs[i], entropy_outs[0], f"entropy[chunk_size={chunk_sizes[i]}]")
         _assert_bitwise_equal(grads_h[i], grads_h[0], f"dhidden[chunk_size={chunk_sizes[i]}]")
         _assert_bitwise_equal(grads_w[i], grads_w[0], f"dweight[chunk_size={chunk_sizes[i]}]")
 
@@ -270,13 +334,14 @@ def test_chunk_size_invariance_forward_and_grad():
 def test_grad_matches_reference():
     """Gradients are bitwise identical to a hand-derived backward reference.
 
-    Uses ``_manual_backward_per_token_log_probs`` (which mirrors the
-    kernel's explicit ``dlogits = dlp * (one_hot - softmax)`` form
-    instead of relying on autograd's ``log_softmax + gather``
-    backward). Forces ``chunk_size > total tokens`` so the kernel's
-    ``dweight = dlogits.t() @ h_chunk`` is a single mm matching the
-    reference's single mm against the same matrices. Under
-    batch-invariant ``mm`` both paths produce bit-identical gradients.
+    Uses ``_manual_backward_per_token`` (which mirrors the kernel's
+    explicit ``dlogits = dlp * (one_hot - softmax) - dent * softmax *
+    (log_softmax + entropy)`` form instead of relying on autograd's
+    ``log_softmax + gather`` backward). Forces ``chunk_size > total
+    tokens`` so the kernel's ``dweight = dlogits.t() @ h_chunk`` is a
+    single mm matching the reference's single mm. Under batch-invariant
+    ``mm`` both paths produce bit-identical gradients across **both**
+    log_probs and entropy upstream gradients.
     """
     torch.manual_seed(42)
     B, L, H, V = 2, 32, 16, 64
@@ -285,17 +350,21 @@ def test_grad_matches_reference():
     labels = torch.randint(0, V, (B, L), dtype=torch.long, device=_device())
     labels[0, ::5] = IGNORE_INDEX
 
-    grad_target = torch.randn(B, L, dtype=torch.float32, device=_device())
+    grad_lp = torch.randn(B, L, dtype=torch.float32, device=_device())
+    grad_ent = torch.randn(B, L, dtype=torch.float32, device=_device())
 
     h_a = hidden0.clone().requires_grad_(True)
     w_a = weights0.clone().requires_grad_(True)
-    out_a = cl.chunk_logprobs_function(h_a, w_a, labels, chunk_size=B * L + 1)
-    (out_a * grad_target).sum().backward()
+    log_probs_a, entropy_a = cl.chunk_logprobs_function(h_a, w_a, labels, chunk_size=B * L + 1)
+    ((log_probs_a * grad_lp).sum() + (entropy_a * grad_ent).sum()).backward()
 
-    out_ref = _reference_per_token_log_probs(hidden0, weights0, labels)
-    dhidden_ref, dweight_ref = _manual_backward_per_token_log_probs(hidden0, weights0, labels, grad_target)
+    ref_log_probs, ref_entropy = _reference_per_token(hidden0, weights0, labels)
+    dhidden_ref, dweight_ref = _manual_backward_per_token(
+        hidden0, weights0, labels, grad_log_probs=grad_lp, grad_entropy=grad_ent
+    )
 
-    _assert_bitwise_equal(out_a.detach(), out_ref, "log_probs")
+    _assert_bitwise_equal(log_probs_a.detach(), ref_log_probs, "log_probs")
+    _assert_bitwise_equal(entropy_a.detach(), ref_entropy, "entropy")
     _assert_bitwise_equal(h_a.grad, dhidden_ref, "dhidden")
     _assert_bitwise_equal(w_a.grad, dweight_ref, "dweight")
 
@@ -305,7 +374,8 @@ def test_sp_enabled_skips_internal_shift(monkeypatch):
 
     Reference computes ``F.linear(hidden) -> log_softmax -> gather``
     against the *un-shifted* labels, and asserts bitwise equality to
-    the kernel under batch-invariant mode.
+    the kernel under batch-invariant mode. Both log_probs and entropy
+    are validated.
     """
     monkeypatch.setattr(cl, "get_parallel_state", lambda: _FakePS(sp_enabled=True))
 
@@ -315,14 +385,20 @@ def test_sp_enabled_skips_internal_shift(monkeypatch):
     weights = torch.randn(V, H, dtype=torch.float32, device=_device())
     labels = torch.randint(0, V, (B, L), dtype=torch.long, device=_device())
 
-    out = cl.chunk_logprobs_function(hidden, weights, labels, chunk_size=B * L + 1)
-    assert out.shape == labels.shape
+    log_probs, entropy = cl.chunk_logprobs_function(hidden, weights, labels, chunk_size=B * L + 1)
+    assert log_probs.shape == labels.shape
+    assert entropy.shape == labels.shape
 
     flat = hidden.reshape(-1, H)
     logits = F.linear(flat, weights).float()
-    expected_flat = cl._per_token_log_probs_from_logits(logits, labels.reshape(-1), IGNORE_INDEX)
-    expected = expected_flat.view_as(labels)
-    _assert_bitwise_equal(out, expected, "log_probs (sp_enabled)")
+    target = labels.reshape(-1)
+    expected_lp = cl._per_token_log_probs_from_logits(logits, target, IGNORE_INDEX).view_as(labels)
+    expected_ent = cl._per_token_entropy_from_logits(logits)
+    mask = target != IGNORE_INDEX
+    expected_ent = torch.where(mask, expected_ent, torch.zeros_like(expected_ent)).view_as(labels)
+
+    _assert_bitwise_equal(log_probs, expected_lp, "log_probs (sp_enabled)")
+    _assert_bitwise_equal(entropy, expected_ent, "entropy (sp_enabled)")
 
 
 def _maybe_load_verl_fused_linear_for_ppo():
@@ -345,22 +421,26 @@ def _maybe_load_verl_fused_linear_for_ppo():
     return mod.FusedLinearForPPOFunction
 
 
-def test_bitwise_parity_with_verl_fused_linear_for_ppo():
+@pytest.mark.parametrize("temperature", [1.0, 0.7, 2.5])
+def test_bitwise_parity_with_verl_fused_linear_for_ppo(temperature):
     """VeOmni ``chunk_logprobs_function`` is bitwise equal to verl's
-    ``FusedLinearForPPOFunction[0]`` (token_log_probs).
+    ``FusedLinearForPPOFunction`` (token_log_probs **and** entropy).
 
     Both kernels:
       1. Compute ``logits = (h @ w.t()) / T`` in input dtype, then upcast to fp32.
       2. Route per-token NLL through ``flash_attn``'s triton CE kernel.
       3. Negate to get actual log-probabilities.
-      4. Compute backward via explicit ``dlogits = dlp * (one_hot - softmax)``,
-         cast to input dtype, divide by T, then matmul.
+      4. Compute entropy ``H[p] = logsumexp(logits) - sum(p * logits)``.
+      5. Compute backward via explicit ``dlogits = dlp * (one_hot - softmax)
+         + (-dent) * softmax * (log_softmax + entropy)``, cast to input dtype,
+         divide by T, then matmul.
 
     Pinning the parity here keeps the verl ↔ VeOmni integration story
-    "drop-in": a model trained under VeOmni's per-token log-probs path
-    produces the same fp32 numbers as the same model invoked through
-    verl's fused PPO kernel, under deterministic + batch-invariant
-    mode.
+    "drop-in": a model trained under VeOmni's per-token log-probs +
+    entropy path produces the same fp32 numbers as the same model
+    invoked through verl's fused PPO kernel, under deterministic +
+    batch-invariant mode. The parametrize over temperature confirms
+    the temperature passthrough survives the verl↔VeOmni boundary.
     """
     verl_fn = _maybe_load_verl_fused_linear_for_ppo()
     if verl_fn is None:
@@ -374,23 +454,32 @@ def test_bitwise_parity_with_verl_fused_linear_for_ppo():
     # match its scope by avoiding IGN labels here.
     labels = torch.randint(0, V, (B, L), dtype=torch.long, device=_device())
 
-    grad_target = torch.randn(B, L, dtype=torch.float32, device=_device())
+    grad_lp = torch.randn(B, L, dtype=torch.float32, device=_device())
+    grad_ent = torch.randn(B, L, dtype=torch.float32, device=_device())
     chunk_size = B * L + 1  # single-chunk boundary for both kernels
 
     # VeOmni — pass ``shift_labels=labels`` so the wrapper treats them
     # as already-aligned (verl's kernel never applies a causal shift,
     # mirroring that here keeps the per-token output aligned for a
     # bit-for-bit comparison).
-    out_a = cl.chunk_logprobs_function(hidden_a, weights_a, labels, chunk_size=chunk_size, shift_labels=labels)
-    (out_a * grad_target).sum().backward()
+    log_probs_a, entropy_a = cl.chunk_logprobs_function(
+        hidden_a,
+        weights_a,
+        labels,
+        chunk_size=chunk_size,
+        shift_labels=labels,
+        temperature=temperature,
+    )
+    ((log_probs_a * grad_lp).sum() + (entropy_a * grad_ent).sum()).backward()
 
     # verl — same inputs cloned, no causal shift inside
     hidden_b = hidden_a.detach().clone().requires_grad_(True)
     weights_b = weights_a.detach().clone().requires_grad_(True)
-    out_b, _entropy_b = verl_fn.apply(hidden_b, weights_b, labels, 1.0, chunk_size)
-    (out_b * grad_target).sum().backward()
+    log_probs_b, entropy_b = verl_fn.apply(hidden_b, weights_b, labels, temperature, chunk_size)
+    ((log_probs_b * grad_lp).sum() + (entropy_b * grad_ent).sum()).backward()
 
-    _assert_bitwise_equal(out_a, out_b, "log_probs vs verl")
+    _assert_bitwise_equal(log_probs_a, log_probs_b, "log_probs vs verl")
+    _assert_bitwise_equal(entropy_a, entropy_b, "entropy vs verl")
     _assert_bitwise_equal(hidden_a.grad, hidden_b.grad, "dhidden vs verl")
     _assert_bitwise_equal(weights_a.grad, weights_b.grad, "dweight vs verl")
 
@@ -402,7 +491,7 @@ def test_explicit_shift_labels_overrides_internal_shift():
     wrapper builds ``shift_labels = F.pad(labels, (0, 1), IGN)[..., 1:]``
     so each label position is already the next-token target. The kernel
     must consume that directly (no internal shift, no trailing pad) and
-    return a tensor whose seq length matches the *passed* shift_labels.
+    return tensors whose seq length matches the *passed* shift_labels.
     """
     torch.manual_seed(11)
     B, L, H, V = 2, 16, 8, 32
@@ -412,12 +501,20 @@ def test_explicit_shift_labels_overrides_internal_shift():
     labels[0, 3] = IGNORE_INDEX
 
     shift_labels = F.pad(labels, (0, 1), value=IGNORE_INDEX)[..., 1:]
-    out = cl.chunk_logprobs_function(hidden, weights, labels, chunk_size=B * L + 1, shift_labels=shift_labels)
+    log_probs, entropy = cl.chunk_logprobs_function(
+        hidden, weights, labels, chunk_size=B * L + 1, shift_labels=shift_labels
+    )
 
-    assert out.shape == shift_labels.shape
+    assert log_probs.shape == shift_labels.shape
+    assert entropy.shape == shift_labels.shape
 
     flat = hidden.reshape(-1, H)
     logits = F.linear(flat, weights).float()
-    expected_flat = cl._per_token_log_probs_from_logits(logits, shift_labels.reshape(-1), IGNORE_INDEX)
-    expected = expected_flat.view_as(shift_labels)
-    _assert_bitwise_equal(out, expected, "log_probs (explicit shift_labels)")
+    target = shift_labels.reshape(-1)
+    expected_lp = cl._per_token_log_probs_from_logits(logits, target, IGNORE_INDEX).view_as(shift_labels)
+    expected_ent = cl._per_token_entropy_from_logits(logits)
+    mask = target != IGNORE_INDEX
+    expected_ent = torch.where(mask, expected_ent, torch.zeros_like(expected_ent)).view_as(shift_labels)
+
+    _assert_bitwise_equal(log_probs, expected_lp, "log_probs (explicit shift_labels)")
+    _assert_bitwise_equal(entropy, expected_ent, "entropy (explicit shift_labels)")

--- a/tests/ops/test_seqcls_loss.py
+++ b/tests/ops/test_seqcls_loss.py
@@ -47,7 +47,7 @@ def test_seqcls_loss_logits_path_manual_handcalc(monkeypatch):
     labels = torch.tensor([[ignore, ignore, 2]])
 
     expected = _manual_ce_one_token(logits[0, 2], target=2)
-    loss, out_logits, _log_probs = m.ForSequenceClassificationLoss(
+    loss, out_logits, _log_probs, _entropy = m.ForSequenceClassificationLoss(
         logits=logits,
         labels=labels,
         num_labels=num_labels,
@@ -94,7 +94,7 @@ def test_seqcls_loss_hidden_states_weights_path_build_logits_and_loss(monkeypatc
     supervised_logits = torch.tensor([1.0, 1.0, 2.0, -1.0])
     expected = _manual_ce_one_token(supervised_logits, target=2)
 
-    loss, out_logits, _log_probs = m.ForSequenceClassificationLoss(
+    loss, out_logits, _log_probs, _entropy = m.ForSequenceClassificationLoss(
         logits=None,
         labels=labels,
         num_labels=num_labels,
@@ -123,7 +123,7 @@ def test_seqcls_loss_prefers_cross_entropy_when_hidden_states_and_weights_presen
       - loss is computed from (hidden_states, weights, labels) via fused linear cross-entropy.
         The passed-in `logits` is NOT used for loss computation in this fused path.
       - out_logits is the flattened *input* logits, because fused_liger_kernel_cross_entropy
-        returns `(loss, logits, log_probs=None)` without materializing projected logits.
+        returns `(loss, logits, log_probs=None, entropy=None)` without materializing projected logits.
     """
     from veomni.ops.kernels.cross_entropy.liger import fused_liger_kernel_cross_entropy
 
@@ -151,7 +151,7 @@ def test_seqcls_loss_prefers_cross_entropy_when_hidden_states_and_weights_presen
     logits = torch.randn((B, T, C), device=device, dtype=torch.float32)
     labels = torch.tensor([[ignore, 1]], device=device, dtype=torch.long)
 
-    loss, out_logits, _log_probs = m.ForSequenceClassificationLoss(
+    loss, out_logits, _log_probs, _entropy = m.ForSequenceClassificationLoss(
         logits=logits,
         labels=labels,
         num_labels=C,
@@ -215,7 +215,7 @@ def test_seqcls_loss_sp_enabled_calls_reduce_with_correct_num_valid_tokens(monke
     e1 = _manual_ce_one_token(logits[0, 2], target=1)
     expected = (e0 + e1) / 2.0
 
-    loss, _, _ = m.ForSequenceClassificationLoss(
+    loss, _, _, _ = m.ForSequenceClassificationLoss(
         logits=logits,
         labels=labels,
         num_labels=num_labels,

--- a/veomni/models/transformers/deepseek_v3/modeling_deepseek_v3.py
+++ b/veomni/models/transformers/deepseek_v3/modeling_deepseek_v3.py
@@ -328,8 +328,9 @@ def deepseek_v3_forcausal_lm_forward(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
-        loss, logits, log_probs = self.loss_function(
+        loss, logits, log_probs, entropy = self.loss_function(
             logits=logits,
             labels=labels,
             vocab_size=self.config.vocab_size,
@@ -345,6 +346,7 @@ def deepseek_v3_forcausal_lm_forward(
         loss=loss,
         logits=logits,
         log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,

--- a/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_gpu.diff
+++ b/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_gpu.diff
@@ -126,7 +126,7 @@
              input_ids=input_ids,
              attention_mask=attention_mask,
              position_ids=position_ids,
-@@ -873,17 +867,34 @@
+@@ -873,17 +867,36 @@
          )
 
          hidden_states = outputs.last_hidden_state
@@ -137,13 +137,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
 -
 -        return CausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.vocab_size,
@@ -153,7 +154,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
 +                )
 +        else:
@@ -163,6 +164,7 @@
              loss=loss,
              logits=logits,
 +            log_probs=log_probs,
++            entropy=entropy,
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,

--- a/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_gpu.py
+++ b/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_gpu.py
@@ -872,10 +872,11 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.vocab_size,
@@ -885,7 +886,7 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
                 )
         else:
@@ -895,6 +896,7 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
             loss=loss,
             logits=logits,
             log_probs=log_probs,
+            entropy=entropy,
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,

--- a/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_npu.diff
+++ b/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_npu.diff
@@ -126,7 +126,7 @@
              input_ids=input_ids,
              attention_mask=attention_mask,
              position_ids=position_ids,
-@@ -873,17 +867,34 @@
+@@ -873,17 +867,36 @@
          )
 
          hidden_states = outputs.last_hidden_state
@@ -137,13 +137,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
 -
 -        return CausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.vocab_size,
@@ -153,7 +154,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
 +                )
 +        else:
@@ -163,6 +164,7 @@
              loss=loss,
              logits=logits,
 +            log_probs=log_probs,
++            entropy=entropy,
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,

--- a/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_npu.py
+++ b/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_npu.py
@@ -872,10 +872,11 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.vocab_size,
@@ -885,7 +886,7 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
                 )
         else:
@@ -895,6 +896,7 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
             loss=loss,
             logits=logits,
             log_probs=log_probs,
+            entropy=entropy,
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,

--- a/veomni/models/transformers/glm_moe_dsa/glm_moe_dsa_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/glm_moe_dsa/glm_moe_dsa_gpu_patch_gen_config.py
@@ -64,10 +64,11 @@ def glm_moe_dsa_forcausallm_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.vocab_size,
@@ -77,7 +78,7 @@ def glm_moe_dsa_forcausallm_forward_patched(
             )
         else:
             logits = self.lm_head(hidden_states)
-            loss, _, log_probs = self.loss_function(
+            loss, _, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
             )
     else:
@@ -87,6 +88,7 @@ def glm_moe_dsa_forcausallm_forward_patched(
         loss=loss,
         logits=logits,
         log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,

--- a/veomni/models/transformers/glm_moe_dsa/glm_moe_dsa_npu_patch_gen_config.py
+++ b/veomni/models/transformers/glm_moe_dsa/glm_moe_dsa_npu_patch_gen_config.py
@@ -64,10 +64,11 @@ def glm_moe_dsa_forcausallm_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.vocab_size,
@@ -77,7 +78,7 @@ def glm_moe_dsa_forcausallm_forward_patched(
             )
         else:
             logits = self.lm_head(hidden_states)
-            loss, _, log_probs = self.loss_function(
+            loss, _, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
             )
     else:
@@ -87,6 +88,7 @@ def glm_moe_dsa_forcausallm_forward_patched(
         loss=loss,
         logits=logits,
         log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,

--- a/veomni/models/transformers/llama/modeling_llama.py
+++ b/veomni/models/transformers/llama/modeling_llama.py
@@ -92,8 +92,9 @@ def llama_forcausallm_forward(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
-        loss, logits, log_probs = self.loss_function(
+        loss, logits, log_probs, entropy = self.loss_function(
             logits=logits,
             labels=labels,
             vocab_size=self.config.vocab_size,
@@ -109,6 +110,7 @@ def llama_forcausallm_forward(
         loss=loss,
         logits=logits,
         log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,

--- a/veomni/models/transformers/qwen2/generated/patched_modeling_qwen2_gpu.diff
+++ b/veomni/models/transformers/qwen2/generated/patched_modeling_qwen2_gpu.diff
@@ -278,7 +278,7 @@
              input_ids=input_ids,
              attention_mask=attention_mask,
              position_ids=position_ids,
-@@ -485,17 +486,34 @@
+@@ -485,17 +486,36 @@
          )
 
          hidden_states = outputs.last_hidden_state
@@ -289,13 +289,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
 -
 -        return CausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.vocab_size,
@@ -305,7 +306,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
 +                )
 +        else:
@@ -315,6 +316,7 @@
              loss=loss,
              logits=logits,
 +            log_probs=log_probs,
++            entropy=entropy,
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,

--- a/veomni/models/transformers/qwen2/generated/patched_modeling_qwen2_gpu.py
+++ b/veomni/models/transformers/qwen2/generated/patched_modeling_qwen2_gpu.py
@@ -491,10 +491,11 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.vocab_size,
@@ -504,7 +505,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
                 )
         else:
@@ -514,6 +515,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel, GenerationMixin):
             loss=loss,
             logits=logits,
             log_probs=log_probs,
+            entropy=entropy,
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,

--- a/veomni/models/transformers/qwen2/modeling_qwen2.py
+++ b/veomni/models/transformers/qwen2/modeling_qwen2.py
@@ -92,8 +92,9 @@ def qwen2_forcausallm_forward(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
-        loss, logits, log_probs = self.loss_function(
+        loss, logits, log_probs, entropy = self.loss_function(
             logits=logits,
             labels=labels,
             vocab_size=self.config.vocab_size,
@@ -109,6 +110,7 @@ def qwen2_forcausallm_forward(
         loss=loss,
         logits=logits,
         log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,

--- a/veomni/models/transformers/qwen2/qwen2_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen2/qwen2_gpu_patch_gen_config.py
@@ -196,10 +196,11 @@ def qwen2forcausallm_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.vocab_size,
@@ -209,7 +210,7 @@ def qwen2forcausallm_forward_patched(
             )
         else:
             logits = self.lm_head(hidden_states)
-            loss, _, log_probs = self.loss_function(
+            loss, _, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
             )
     else:
@@ -219,6 +220,7 @@ def qwen2forcausallm_forward_patched(
         loss=loss,
         logits=logits,
         log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,

--- a/veomni/models/transformers/qwen2_5_omni/modeling_qwen2_5_omni.py
+++ b/veomni/models/transformers/qwen2_5_omni/modeling_qwen2_5_omni.py
@@ -917,9 +917,10 @@ class Qwen2_5OmniThinkerForConditionalGeneration(_Qwen2_5OmniThinkerForCondition
         loss = None
         logits = None
         log_probs = None
+        entropy = None
 
         if labels is not None:
-            loss, logits, log_probs = self.loss_function(
+            loss, logits, log_probs, entropy = self.loss_function(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.get_text_config().vocab_size,
@@ -944,6 +945,7 @@ class Qwen2_5OmniThinkerForConditionalGeneration(_Qwen2_5OmniThinkerForCondition
             rope_deltas=self.rope_deltas,
         )
         out.log_probs = log_probs
+        out.entropy = entropy
         return out
 
 

--- a/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.diff
+++ b/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.diff
@@ -749,7 +749,7 @@
              input_ids=input_ids,
              pixel_values=pixel_values,
              pixel_values_videos=pixel_values_videos,
-@@ -1564,19 +1767,35 @@
+@@ -1564,19 +1767,36 @@
              **kwargs,
          )
 
@@ -766,6 +766,7 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(
 -                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
@@ -774,7 +775,7 @@
 -        return Qwen2_5_VLCausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -784,7 +785,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
 +                )
 +        else:
@@ -795,16 +796,17 @@
              loss=loss,
              logits=logits,
              past_key_values=outputs.past_key_values,
-@@ -1584,6 +1803,8 @@
+@@ -1584,6 +1804,9 @@
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -1803,5 +2024,25 @@
+@@ -1803,5 +2026,25 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.py
+++ b/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.py
@@ -1775,10 +1775,11 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPreTrainedModel, GenerationMi
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -1788,7 +1789,7 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPreTrainedModel, GenerationMi
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
                 )
         else:
@@ -1804,6 +1805,7 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPreTrainedModel, GenerationMi
             rope_deltas=outputs.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen2_5vl/modeling_qwen2_5_vl.py
+++ b/veomni/models/transformers/qwen2_5vl/modeling_qwen2_5_vl.py
@@ -665,8 +665,9 @@ class Qwen2_5_VLForConditionalGeneration(_Qwen2_5_VLForConditionalGeneration):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
-            loss, logits, log_probs = self.loss_function(
+            loss, logits, log_probs, entropy = self.loss_function(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -687,6 +688,7 @@ class Qwen2_5_VLForConditionalGeneration(_Qwen2_5_VLForConditionalGeneration):
             rope_deltas=outputs.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
 

--- a/veomni/models/transformers/qwen2_5vl/qwen2_5_vl_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen2_5vl/qwen2_5_vl_gpu_patch_gen_config.py
@@ -664,10 +664,11 @@ def qwen2_5_vl_for_conditional_generation_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -677,7 +678,7 @@ def qwen2_5_vl_for_conditional_generation_forward_patched(
             )
         else:
             logits = self.lm_head(hidden_states)
-            loss, _, log_probs = self.loss_function(
+            loss, _, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
             )
     else:
@@ -693,4 +694,5 @@ def qwen2_5_vl_for_conditional_generation_forward_patched(
         rope_deltas=outputs.rope_deltas,
     )
     output.log_probs = log_probs
+    output.entropy = entropy
     return output

--- a/veomni/models/transformers/qwen2_vl/generated/patched_modeling_qwen2_vl_gpu.diff
+++ b/veomni/models/transformers/qwen2_vl/generated/patched_modeling_qwen2_vl_gpu.diff
@@ -462,7 +462,7 @@
              image_grid_thw=image_grid_thw,
              video_grid_thw=video_grid_thw,
              position_ids=position_ids,
-@@ -1475,17 +1547,31 @@
+@@ -1475,17 +1547,32 @@
          )
 
          hidden_states = outputs.last_hidden_state
@@ -473,6 +473,7 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(
 -                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
@@ -481,7 +482,7 @@
 -        return Qwen2VLCausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -491,7 +492,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
 +                )
 +        else:
@@ -503,16 +504,17 @@
              loss=loss,
              logits=logits,
              past_key_values=outputs.past_key_values,
-@@ -1493,6 +1579,8 @@
+@@ -1493,6 +1580,9 @@
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -1710,5 +1798,19 @@
+@@ -1710,5 +1800,19 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen2_vl/generated/patched_modeling_qwen2_vl_gpu.py
+++ b/veomni/models/transformers/qwen2_vl/generated/patched_modeling_qwen2_vl_gpu.py
@@ -1550,10 +1550,11 @@ class Qwen2VLForConditionalGeneration(Qwen2VLPreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -1563,7 +1564,7 @@ class Qwen2VLForConditionalGeneration(Qwen2VLPreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
                 )
         else:
@@ -1580,6 +1581,7 @@ class Qwen2VLForConditionalGeneration(Qwen2VLPreTrainedModel, GenerationMixin):
             rope_deltas=outputs.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen2_vl/modeling_qwen2_vl.py
+++ b/veomni/models/transformers/qwen2_vl/modeling_qwen2_vl.py
@@ -489,8 +489,9 @@ class Qwen2VLForConditionalGeneration(_Qwen2VLForConditionalGeneration):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
-            loss, logits, log_probs = self.loss_function(
+            loss, logits, log_probs, entropy = self.loss_function(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.vocab_size,
@@ -511,6 +512,7 @@ class Qwen2VLForConditionalGeneration(_Qwen2VLForConditionalGeneration):
             rope_deltas=outputs.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
 

--- a/veomni/models/transformers/qwen2_vl/qwen2_vl_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen2_vl/qwen2_vl_gpu_patch_gen_config.py
@@ -467,10 +467,11 @@ def qwen2vl_for_conditional_generation_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -480,7 +481,7 @@ def qwen2vl_for_conditional_generation_forward_patched(
             )
         else:
             logits = self.lm_head(hidden_states)
-            loss, _, log_probs = self.loss_function(
+            loss, _, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
             )
     else:
@@ -497,4 +498,5 @@ def qwen2vl_for_conditional_generation_forward_patched(
         rope_deltas=outputs.rope_deltas,
     )
     output.log_probs = log_probs
+    output.entropy = entropy
     return output

--- a/veomni/models/transformers/qwen3/generated/patched_modeling_qwen3_gpu.diff
+++ b/veomni/models/transformers/qwen3/generated/patched_modeling_qwen3_gpu.diff
@@ -244,7 +244,7 @@
              input_ids=input_ids,
              attention_mask=attention_mask,
              position_ids=position_ids,
-@@ -515,25 +542,100 @@
+@@ -515,25 +542,102 @@
          )
 
          hidden_states = outputs.last_hidden_state
@@ -255,13 +255,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
 -
 -        return CausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.vocab_size,
@@ -271,7 +272,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
 +                )
 +        else:
@@ -281,6 +282,7 @@
 +            loss=loss,
 +            logits=logits,
 +            log_probs=log_probs,
++            entropy=entropy,
 +            past_key_values=outputs.past_key_values,
 +            hidden_states=outputs.hidden_states,
 +            attentions=outputs.attentions,
@@ -323,10 +325,10 @@
 +        logits = None
 +        if labels is not None:
 +            # Modification: OpSlot guard for cross-entropy loss.
-+            # Seq-cls heads have no log-probs path; the third tuple slot is
-+            # always None.
++            # Seq-cls heads have no log-probs / entropy path; the third and
++            # fourth tuple slots are always None.
 +            if veomni_seq_cls_loss.use_non_eager_impl:
-+                loss, logits, _ = veomni_seq_cls_loss(
++                loss, logits, _, _ = veomni_seq_cls_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    num_labels=self.num_labels,
@@ -336,7 +338,7 @@
 +                )
 +            else:
 +                logits = self.score(hidden_states)
-+                loss, _, _ = self.loss_function(logits=logits, labels=labels, num_labels=self.num_labels, **kwargs)
++                loss, _, _, _ = self.loss_function(logits=logits, labels=labels, num_labels=self.num_labels, **kwargs)
 +        else:
 +            logits = self.score(hidden_states)
 +

--- a/veomni/models/transformers/qwen3/generated/patched_modeling_qwen3_gpu.py
+++ b/veomni/models/transformers/qwen3/generated/patched_modeling_qwen3_gpu.py
@@ -547,10 +547,11 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.vocab_size,
@@ -560,7 +561,7 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
                 )
         else:
@@ -570,6 +571,7 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
             loss=loss,
             logits=logits,
             log_probs=log_probs,
+            entropy=entropy,
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
@@ -612,10 +614,10 @@ class Qwen3ForSequenceClassification(GenericForSequenceClassification, Qwen3PreT
         logits = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
-            # Seq-cls heads have no log-probs path; the third tuple slot is
-            # always None.
+            # Seq-cls heads have no log-probs / entropy path; the third and
+            # fourth tuple slots are always None.
             if veomni_seq_cls_loss.use_non_eager_impl:
-                loss, logits, _ = veomni_seq_cls_loss(
+                loss, logits, _, _ = veomni_seq_cls_loss(
                     logits=logits,
                     labels=labels,
                     num_labels=self.num_labels,
@@ -625,7 +627,7 @@ class Qwen3ForSequenceClassification(GenericForSequenceClassification, Qwen3PreT
                 )
             else:
                 logits = self.score(hidden_states)
-                loss, _, _ = self.loss_function(logits=logits, labels=labels, num_labels=self.num_labels, **kwargs)
+                loss, _, _, _ = self.loss_function(logits=logits, labels=labels, num_labels=self.num_labels, **kwargs)
         else:
             logits = self.score(hidden_states)
 

--- a/veomni/models/transformers/qwen3/modeling_qwen3.py
+++ b/veomni/models/transformers/qwen3/modeling_qwen3.py
@@ -98,12 +98,13 @@ def qwen3forcausallm_forward(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # The wrapper inspects ``return_log_probs`` in **kwargs and routes the
         # call to ``chunk_logprobs_function`` when True; on that path
-        # ``loss``/``logits`` are ``None`` and ``log_probs`` carries the
-        # per-token log-probabilities.
-        loss, logits, log_probs = self.loss_function(
+        # ``loss``/``logits`` are ``None`` and ``log_probs`` / ``entropy``
+        # carry the per-token log-probabilities and softmax entropy.
+        loss, logits, log_probs, entropy = self.loss_function(
             logits=logits,
             labels=labels,
             vocab_size=self.config.vocab_size,
@@ -119,6 +120,7 @@ def qwen3forcausallm_forward(
         loss=loss,
         logits=logits,
         log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,
@@ -171,9 +173,9 @@ def qwen3forSequenceClassification_forward(
     loss = None
     logits = None
     if labels is not None:
-        # Seq-cls heads have no log-probs path; the third tuple slot is
-        # always None.
-        loss, logits, _ = self.loss_function(
+        # Seq-cls heads have no log-probs / entropy path; the third and
+        # fourth tuple slots are always None.
+        loss, logits, _, _ = self.loss_function(
             logits=logits,
             labels=labels,
             num_labels=self.num_labels,

--- a/veomni/models/transformers/qwen3/qwen3_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3/qwen3_gpu_patch_gen_config.py
@@ -155,10 +155,11 @@ def qwen3_forcausallm_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.vocab_size,
@@ -168,7 +169,7 @@ def qwen3_forcausallm_forward_patched(
             )
         else:
             logits = self.lm_head(hidden_states)
-            loss, _, log_probs = self.loss_function(
+            loss, _, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
             )
     else:
@@ -178,6 +179,7 @@ def qwen3_forcausallm_forward_patched(
         loss=loss,
         logits=logits,
         log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,
@@ -219,10 +221,10 @@ def qwen3forsequenceclassification_forward_patched(
     logits = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
-        # Seq-cls heads have no log-probs path; the third tuple slot is
-        # always None.
+        # Seq-cls heads have no log-probs / entropy path; the third and
+        # fourth tuple slots are always None.
         if veomni_seq_cls_loss.use_non_eager_impl:
-            loss, logits, _ = veomni_seq_cls_loss(
+            loss, logits, _, _ = veomni_seq_cls_loss(
                 logits=logits,
                 labels=labels,
                 num_labels=self.num_labels,
@@ -232,7 +234,7 @@ def qwen3forsequenceclassification_forward_patched(
             )
         else:
             logits = self.score(hidden_states)
-            loss, _, _ = self.loss_function(logits=logits, labels=labels, num_labels=self.num_labels, **kwargs)
+            loss, _, _, _ = self.loss_function(logits=logits, labels=labels, num_labels=self.num_labels, **kwargs)
     else:
         logits = self.score(hidden_states)
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
@@ -1099,7 +1099,7 @@
 
 
  @auto_docstring
-@@ -1775,15 +2157,34 @@
+@@ -1775,15 +2157,36 @@
          hidden_states = outputs.last_hidden_state
          # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
          slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
@@ -1109,13 +1109,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
 -
 -        return CausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.vocab_size,
@@ -1125,7 +1126,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1135,10 +1136,11 @@
              loss=loss,
              logits=logits,
 +            log_probs=log_probs,
++            entropy=entropy,
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
-@@ -1817,6 +2218,12 @@
+@@ -1817,6 +2220,12 @@
      hidden_states: tuple[torch.FloatTensor] | None = None
      attentions: tuple[torch.FloatTensor] | None = None
      rope_deltas: torch.LongTensor | None = None
@@ -1151,7 +1153,7 @@
 
 
  class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
-@@ -1888,53 +2295,6 @@
+@@ -1888,53 +2297,6 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5CausalLMOutputWithPast:
@@ -1205,7 +1207,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1950,16 +2310,33 @@
+@@ -1950,16 +2312,34 @@
          )
 
          hidden_states = outputs[0]
@@ -1218,13 +1220,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
 -
 -        return Qwen3_5CausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -1234,7 +1237,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1244,16 +1247,17 @@
              loss=loss,
              logits=logits,
              past_key_values=outputs.past_key_values,
-@@ -1967,6 +2344,8 @@
+@@ -1967,6 +2347,9 @@
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -2192,6 +2571,13 @@
+@@ -2192,6 +2575,13 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
@@ -2162,10 +2162,11 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.vocab_size,
@@ -2175,7 +2176,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
                 )
         else:
@@ -2185,6 +2186,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
             loss=loss,
             logits=logits,
             log_probs=log_probs,
+            entropy=entropy,
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
@@ -2317,10 +2319,11 @@ class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -2330,7 +2333,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
                 )
         else:
@@ -2345,6 +2348,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
             rope_deltas=outputs.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
@@ -1178,7 +1178,7 @@
 
 
  @auto_docstring
-@@ -1775,15 +2133,34 @@
+@@ -1775,15 +2133,36 @@
          hidden_states = outputs.last_hidden_state
          # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
          slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
@@ -1188,13 +1188,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
 -
 -        return CausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.vocab_size,
@@ -1204,7 +1205,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1214,10 +1215,11 @@
              loss=loss,
              logits=logits,
 +            log_probs=log_probs,
++            entropy=entropy,
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
-@@ -1817,6 +2194,12 @@
+@@ -1817,6 +2196,12 @@
      hidden_states: tuple[torch.FloatTensor] | None = None
      attentions: tuple[torch.FloatTensor] | None = None
      rope_deltas: torch.LongTensor | None = None
@@ -1230,7 +1232,7 @@
 
 
  class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
-@@ -1888,53 +2271,6 @@
+@@ -1888,53 +2273,6 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5CausalLMOutputWithPast:
@@ -1284,7 +1286,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1950,16 +2286,33 @@
+@@ -1950,16 +2288,34 @@
          )
 
          hidden_states = outputs[0]
@@ -1297,13 +1299,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
 -
 -        return Qwen3_5CausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -1313,7 +1316,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1323,16 +1326,17 @@
              loss=loss,
              logits=logits,
              past_key_values=outputs.past_key_values,
-@@ -1967,6 +2320,8 @@
+@@ -1967,6 +2323,9 @@
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -2192,6 +2547,13 @@
+@@ -2192,6 +2551,13 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
@@ -2138,10 +2138,11 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.vocab_size,
@@ -2151,7 +2152,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
                 )
         else:
@@ -2161,6 +2162,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
             loss=loss,
             logits=logits,
             log_probs=log_probs,
+            entropy=entropy,
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
@@ -2293,10 +2295,11 @@ class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -2306,7 +2309,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
                 )
         else:
@@ -2321,6 +2324,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
             rope_deltas=outputs.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
@@ -1030,10 +1030,11 @@ def qwen3_5_forcausallm_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.vocab_size,
@@ -1043,7 +1044,7 @@ def qwen3_5_forcausallm_forward_patched(
             )
         else:
             logits = self.lm_head(hidden_states)
-            loss, _, log_probs = self.loss_function(
+            loss, _, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
             )
     else:
@@ -1053,6 +1054,7 @@ def qwen3_5_forcausallm_forward_patched(
         loss=loss,
         logits=logits,
         log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,
@@ -1120,10 +1122,11 @@ def qwen3_5_forconditional_generation_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -1133,7 +1136,7 @@ def qwen3_5_forconditional_generation_forward_patched(
             )
         else:
             logits = self.lm_head(hidden_states)
-            loss, _, log_probs = self.loss_function(
+            loss, _, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
             )
     else:
@@ -1148,4 +1151,5 @@ def qwen3_5_forconditional_generation_forward_patched(
         rope_deltas=outputs.rope_deltas,
     )
     output.log_probs = log_probs
+    output.entropy = entropy
     return output

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
@@ -1213,7 +1213,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1993,24 +2444,54 @@
+@@ -1993,24 +2444,55 @@
          hidden_states = outputs.last_hidden_state
          # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
          slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
@@ -1223,11 +1223,12 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits, labels, self.vocab_size, **kwargs)
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.vocab_size,
@@ -1238,9 +1239,9 @@
 +            else:
 +                logits = self.lm_head(hidden_states)
 +                # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-+                # returns (loss, logits, log_probs); unpack to match the OpSlot
-+                # branch above.
-+                loss, logits, log_probs = self.loss_function(
++                # returns (loss, logits, log_probs, entropy); unpack to match the
++                # OpSlot branch above.
++                loss, logits, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1280,11 +1281,12 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -2019,6 +2500,14 @@
+@@ -2019,6 +2501,15 @@
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 +
 +
@@ -1295,7 +1297,7 @@
 
 
  class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMixin):
-@@ -2073,6 +2562,7 @@
+@@ -2073,6 +2564,7 @@
          """
          return self.model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw, **kwargs)
 
@@ -1303,7 +1305,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -2090,57 +2580,6 @@
+@@ -2090,57 +2582,6 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5MoeCausalLMOutputWithPast:
@@ -1361,7 +1363,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -2156,29 +2595,56 @@
+@@ -2156,29 +2597,57 @@
          )
 
          hidden_states = outputs[0]
@@ -1374,11 +1376,12 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -1389,9 +1392,9 @@
 +            else:
 +                logits = self.lm_head(hidden_states)
 +                # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-+                # returns (loss, logits, log_probs); unpack to match the OpSlot
-+                # branch above.
-+                loss, logits, log_probs = self.loss_function(
++                # returns (loss, logits, log_probs, entropy); unpack to match the
++                # OpSlot branch above.
++                loss, logits, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1432,16 +1435,17 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -2188,6 +2654,8 @@
+@@ -2188,6 +2657,9 @@
              rope_deltas=outputs.rope_deltas,
              router_logits=outputs.router_logits,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -2413,6 +2881,19 @@
+@@ -2413,6 +2885,19 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -2449,10 +2449,11 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.vocab_size,
@@ -2463,9 +2464,9 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
             else:
                 logits = self.lm_head(hidden_states)
                 # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-                # returns (loss, logits, log_probs); unpack to match the OpSlot
-                # branch above.
-                loss, logits, log_probs = self.loss_function(
+                # returns (loss, logits, log_probs, entropy); unpack to match the
+                # OpSlot branch above.
+                loss, logits, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
                 )
         else:
@@ -2501,6 +2502,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
             router_logits=outputs.router_logits,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
 
@@ -2602,10 +2604,11 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMi
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -2616,9 +2619,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMi
             else:
                 logits = self.lm_head(hidden_states)
                 # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-                # returns (loss, logits, log_probs); unpack to match the OpSlot
-                # branch above.
-                loss, logits, log_probs = self.loss_function(
+                # returns (loss, logits, log_probs, entropy); unpack to match the
+                # OpSlot branch above.
+                loss, logits, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
                 )
         else:
@@ -2655,6 +2658,7 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMi
             router_logits=outputs.router_logits,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
@@ -1294,7 +1294,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1993,24 +2404,54 @@
+@@ -1993,24 +2404,55 @@
          hidden_states = outputs.last_hidden_state
          # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
          slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
@@ -1304,11 +1304,12 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits, labels, self.vocab_size, **kwargs)
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.vocab_size,
@@ -1319,9 +1320,9 @@
 +            else:
 +                logits = self.lm_head(hidden_states)
 +                # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-+                # returns (loss, logits, log_probs); unpack to match the OpSlot
-+                # branch above.
-+                loss, logits, log_probs = self.loss_function(
++                # returns (loss, logits, log_probs, entropy); unpack to match the
++                # OpSlot branch above.
++                loss, logits, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1361,11 +1362,12 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -2019,6 +2460,14 @@
+@@ -2019,6 +2461,15 @@
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 +
 +
@@ -1376,7 +1378,7 @@
 
 
  class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMixin):
-@@ -2073,6 +2522,7 @@
+@@ -2073,6 +2524,7 @@
          """
          return self.model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw, **kwargs)
 
@@ -1384,7 +1386,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -2090,57 +2540,6 @@
+@@ -2090,57 +2542,6 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5MoeCausalLMOutputWithPast:
@@ -1442,7 +1444,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -2156,29 +2555,56 @@
+@@ -2156,29 +2557,57 @@
          )
 
          hidden_states = outputs[0]
@@ -1455,11 +1457,12 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -1470,9 +1473,9 @@
 +            else:
 +                logits = self.lm_head(hidden_states)
 +                # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-+                # returns (loss, logits, log_probs); unpack to match the OpSlot
-+                # branch above.
-+                loss, logits, log_probs = self.loss_function(
++                # returns (loss, logits, log_probs, entropy); unpack to match the
++                # OpSlot branch above.
++                loss, logits, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1513,16 +1516,17 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -2188,6 +2614,8 @@
+@@ -2188,6 +2617,9 @@
              rope_deltas=outputs.rope_deltas,
              router_logits=outputs.router_logits,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -2413,6 +2841,19 @@
+@@ -2413,6 +2845,19 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -2409,10 +2409,11 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.vocab_size,
@@ -2423,9 +2424,9 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
             else:
                 logits = self.lm_head(hidden_states)
                 # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-                # returns (loss, logits, log_probs); unpack to match the OpSlot
-                # branch above.
-                loss, logits, log_probs = self.loss_function(
+                # returns (loss, logits, log_probs, entropy); unpack to match the
+                # OpSlot branch above.
+                loss, logits, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
                 )
         else:
@@ -2461,6 +2462,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
             router_logits=outputs.router_logits,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
 
@@ -2562,10 +2564,11 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMi
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -2576,9 +2579,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMi
             else:
                 logits = self.lm_head(hidden_states)
                 # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-                # returns (loss, logits, log_probs); unpack to match the OpSlot
-                # branch above.
-                loss, logits, log_probs = self.loss_function(
+                # returns (loss, logits, log_probs, entropy); unpack to match the
+                # OpSlot branch above.
+                loss, logits, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
                 )
         else:
@@ -2615,6 +2618,7 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMi
             router_logits=outputs.router_logits,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen3_5_moe/qwen3_5_moe_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5_moe/qwen3_5_moe_gpu_patch_gen_config.py
@@ -683,10 +683,11 @@ def qwen3_5_moe_forcausallm_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.vocab_size,
@@ -697,9 +698,9 @@ def qwen3_5_moe_forcausallm_forward_patched(
         else:
             logits = self.lm_head(hidden_states)
             # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-            # returns (loss, logits, log_probs); unpack to match the OpSlot
-            # branch above.
-            loss, logits, log_probs = self.loss_function(
+            # returns (loss, logits, log_probs, entropy); unpack to match the
+            # OpSlot branch above.
+            loss, logits, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
             )
     else:
@@ -735,6 +736,7 @@ def qwen3_5_moe_forcausallm_forward_patched(
         router_logits=outputs.router_logits,
     )
     output.log_probs = log_probs
+    output.entropy = entropy
     return output
 
 
@@ -783,10 +785,11 @@ def qwen3_5_moe_forconditional_generation_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -797,9 +800,9 @@ def qwen3_5_moe_forconditional_generation_forward_patched(
         else:
             logits = self.lm_head(hidden_states)
             # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-            # returns (loss, logits, log_probs); unpack to match the OpSlot
-            # branch above.
-            loss, logits, log_probs = self.loss_function(
+            # returns (loss, logits, log_probs, entropy); unpack to match the
+            # OpSlot branch above.
+            loss, logits, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
             )
     else:
@@ -836,6 +839,7 @@ def qwen3_5_moe_forconditional_generation_forward_patched(
         router_logits=outputs.router_logits,
     )
     output.log_probs = log_probs
+    output.entropy = entropy
     return output
 
 

--- a/veomni/models/transformers/qwen3_moe/generated/patched_modeling_qwen3_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_moe/generated/patched_modeling_qwen3_moe_gpu.diff
@@ -395,7 +395,7 @@
          outputs: MoeModelOutputWithPast = self.model(
              input_ids=input_ids,
              attention_mask=attention_mask,
-@@ -693,26 +711,55 @@
+@@ -693,26 +711,56 @@
          )
 
          hidden_states = outputs.last_hidden_state
@@ -407,11 +407,12 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits, labels, self.vocab_size, **kwargs)
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.vocab_size,
@@ -422,9 +423,9 @@
 +            else:
 +                logits = self.lm_head(hidden_states)
 +                # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-+                # returns (loss, logits, log_probs); unpack to match the OpSlot
-+                # branch above.
-+                loss, logits, log_probs = self.loss_function(
++                # returns (loss, logits, log_probs, entropy); unpack to match the
++                # OpSlot branch above.
++                loss, logits, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
 +                )
 +        else:
@@ -463,11 +464,12 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -721,6 +768,13 @@
+@@ -721,6 +769,14 @@
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 +
 +    def get_parallel_plan(self):

--- a/veomni/models/transformers/qwen3_moe/generated/patched_modeling_qwen3_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_moe/generated/patched_modeling_qwen3_moe_gpu.py
@@ -717,10 +717,11 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.vocab_size,
@@ -731,9 +732,9 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
             else:
                 logits = self.lm_head(hidden_states)
                 # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-                # returns (loss, logits, log_probs); unpack to match the OpSlot
-                # branch above.
-                loss, logits, log_probs = self.loss_function(
+                # returns (loss, logits, log_probs, entropy); unpack to match the
+                # OpSlot branch above.
+                loss, logits, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
                 )
         else:
@@ -769,6 +770,7 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
             router_logits=outputs.router_logits,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def get_parallel_plan(self):

--- a/veomni/models/transformers/qwen3_moe/modeling_qwen3_moe.py
+++ b/veomni/models/transformers/qwen3_moe/modeling_qwen3_moe.py
@@ -226,8 +226,9 @@ def qwen3_moe_forcausal_lm_forward(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
-        loss, logits, log_probs = self.loss_function(
+        loss, logits, log_probs, entropy = self.loss_function(
             logits=logits,
             labels=labels,
             vocab_size=self.config.vocab_size,
@@ -260,6 +261,7 @@ def qwen3_moe_forcausal_lm_forward(
         router_logits=outputs.router_logits,
     )
     output.log_probs = log_probs
+    output.entropy = entropy
     return output
 
 

--- a/veomni/models/transformers/qwen3_moe/qwen3_moe_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_moe/qwen3_moe_gpu_patch_gen_config.py
@@ -284,10 +284,11 @@ def qwen3_moe_forcausallm_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.vocab_size,
@@ -298,9 +299,9 @@ def qwen3_moe_forcausallm_forward_patched(
         else:
             logits = self.lm_head(hidden_states)
             # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-            # returns (loss, logits, log_probs); unpack to match the OpSlot
-            # branch above.
-            loss, logits, log_probs = self.loss_function(
+            # returns (loss, logits, log_probs, entropy); unpack to match the
+            # OpSlot branch above.
+            loss, logits, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
             )
     else:
@@ -336,6 +337,7 @@ def qwen3_moe_forcausallm_forward_patched(
         router_logits=outputs.router_logits,
     )
     output.log_probs = log_probs
+    output.entropy = entropy
     return output
 
 

--- a/veomni/models/transformers/qwen3_omni_moe/generated/patched_modeling_qwen3_omni_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_omni_moe/generated/patched_modeling_qwen3_omni_moe_gpu.diff
@@ -1574,7 +1574,7 @@
 
          outputs = self.model(
              attention_mask=attention_mask,
-@@ -2235,40 +2557,76 @@
+@@ -2235,40 +2557,78 @@
              use_cache=use_cache,
              output_router_logits=output_router_logits,
              cache_position=cache_position,
@@ -1591,13 +1591,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(
 -                logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size
 -            )
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -1609,9 +1610,9 @@
 +            else:
 +                logits = self.lm_head(hidden_states)
 +                # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-+                # returns (loss, logits, log_probs); unpack to match the OpSlot
-+                # branch above.
-+                loss, logits, log_probs = self.loss_function(
++                # returns (loss, logits, log_probs, entropy); unpack to match the
++                # OpSlot branch above.
++                loss, logits, log_probs, entropy = self.loss_function(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -1663,11 +1664,12 @@
              rope_deltas=self.rope_deltas,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -2319,1548 +2677,112 @@
+@@ -2319,1548 +2679,112 @@
 
          return model_inputs
 
@@ -3312,7 +3314,7 @@
 
      def disable_talker(self):
          if hasattr(self, "talker"):
-@@ -4132,19 +3054,41 @@
+@@ -4132,19 +3056,41 @@
 
          return thinker_result.sequences, talker_wavs.float()
 

--- a/veomni/models/transformers/qwen3_omni_moe/generated/patched_modeling_qwen3_omni_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_omni_moe/generated/patched_modeling_qwen3_omni_moe_gpu.py
@@ -2567,10 +2567,11 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -2582,9 +2583,9 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             else:
                 logits = self.lm_head(hidden_states)
                 # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-                # returns (loss, logits, log_probs); unpack to match the OpSlot
-                # branch above.
-                loss, logits, log_probs = self.loss_function(
+                # returns (loss, logits, log_probs, entropy); unpack to match the
+                # OpSlot branch above.
+                loss, logits, log_probs, entropy = self.loss_function(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -2626,6 +2627,7 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             rope_deltas=self.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/veomni/models/transformers/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -1229,12 +1229,13 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(hf_qwen3_omni_moe.Qwen3OmniMoe
         # shift_labels stays at length S — matching the full, unsliced hidden_states. Do NOT
         # pre-slice hidden_states[..., :-1, :] here or the shapes will mismatch.
         log_probs = None
+        entropy = None
         if labels is not None:
             # Direct ForCausalLMLoss call (no `**kwargs` passthrough), so the
-            # log-probs dispatch is unreachable here today; the third tuple
-            # slot stays ``None`` and we just unpack to keep the contract
-            # uniform with the other modelings.
-            loss, logits, log_probs = ForCausalLMLoss(
+            # log-probs / entropy dispatch is unreachable here today; the
+            # third and fourth tuple slots stay ``None`` and we just unpack
+            # to keep the contract uniform with the other modelings.
+            loss, logits, log_probs, entropy = ForCausalLMLoss(
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
                 hidden_states=hidden_states,
@@ -1266,6 +1267,7 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(hf_qwen3_omni_moe.Qwen3OmniMoe
             rope_deltas=self.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
 

--- a/veomni/models/transformers/qwen3_omni_moe/qwen3_omni_moe_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_omni_moe/qwen3_omni_moe_gpu_patch_gen_config.py
@@ -1327,10 +1327,11 @@ def qwen3_omni_moe_thinker_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -1342,9 +1343,9 @@ def qwen3_omni_moe_thinker_forward_patched(
         else:
             logits = self.lm_head(hidden_states)
             # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-            # returns (loss, logits, log_probs); unpack to match the OpSlot
-            # branch above.
-            loss, logits, log_probs = self.loss_function(
+            # returns (loss, logits, log_probs, entropy); unpack to match the
+            # OpSlot branch above.
+            loss, logits, log_probs, entropy = self.loss_function(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -1386,6 +1387,7 @@ def qwen3_omni_moe_thinker_forward_patched(
         rope_deltas=self.rope_deltas,
     )
     output.log_probs = log_probs
+    output.entropy = entropy
     return output
 
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.diff
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.diff
@@ -1283,7 +1283,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1451,16 +1908,34 @@
+@@ -1451,16 +1908,35 @@
          )
 
          hidden_states = outputs[0]
@@ -1298,13 +1298,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
 -
 -        return Qwen3VLCausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -1314,7 +1315,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1325,16 +1326,17 @@
              loss=loss,
              logits=logits,
              past_key_values=outputs.past_key_values,
-@@ -1468,6 +1943,8 @@
+@@ -1468,6 +1944,9 @@
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -1693,6 +2170,25 @@
+@@ -1693,6 +2172,25 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.py
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.py
@@ -1915,10 +1915,11 @@ class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -1928,7 +1929,7 @@ class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
                 )
         else:
@@ -1944,6 +1945,7 @@ class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
             rope_deltas=outputs.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.diff
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.diff
@@ -1407,7 +1407,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1451,16 +1936,34 @@
+@@ -1451,16 +1936,35 @@
          )
 
          hidden_states = outputs[0]
@@ -1422,13 +1422,14 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
 -
 -        return Qwen3VLCausalLMOutputWithPast(
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -1438,7 +1439,7 @@
 +                )
 +            else:
 +                logits = self.lm_head(hidden_states)
-+                loss, _, log_probs = self.loss_function(
++                loss, _, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1449,16 +1450,17 @@
              loss=loss,
              logits=logits,
              past_key_values=outputs.past_key_values,
-@@ -1468,6 +1971,8 @@
+@@ -1468,6 +1972,9 @@
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
          )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -1693,6 +2198,25 @@
+@@ -1693,6 +2200,25 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.py
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.py
@@ -1943,10 +1943,11 @@ class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -1956,7 +1957,7 @@ class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
                 )
             else:
                 logits = self.lm_head(hidden_states)
-                loss, _, log_probs = self.loss_function(
+                loss, _, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
                 )
         else:
@@ -1972,6 +1973,7 @@ class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
             rope_deltas=outputs.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen3_vl/modeling_qwen3_vl.py
+++ b/veomni/models/transformers/qwen3_vl/modeling_qwen3_vl.py
@@ -951,14 +951,16 @@ class Qwen3VLForConditionalGeneration(_Qwen3VLForConditionalGeneration):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # The wrapper inspects ``return_log_probs`` in **kwargs and routes
             # the call to ``chunk_logprobs_function`` when True; on that path
-            # ``loss``/``logits`` are ``None`` and ``log_probs`` carries the
-            # per-token log-probabilities. ``ModelOutput`` allows arbitrary
-            # attribute setting, so ``output.log_probs`` surfaces on the
+            # ``loss``/``logits`` are ``None`` and ``log_probs`` / ``entropy``
+            # carry the per-token log-probabilities and softmax entropy.
+            # ``ModelOutput`` allows arbitrary attribute setting, so
+            # ``output.log_probs`` and ``output.entropy`` surface on the
             # existing VL-specific output dataclass without a subclass.
-            loss, logits, log_probs = self.loss_function(
+            loss, logits, log_probs, entropy = self.loss_function(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -977,6 +979,7 @@ class Qwen3VLForConditionalGeneration(_Qwen3VLForConditionalGeneration):
             rope_deltas=outputs.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
 

--- a/veomni/models/transformers/qwen3_vl/qwen3_vl_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_vl/qwen3_vl_gpu_patch_gen_config.py
@@ -1108,10 +1108,11 @@ def qwen3_vl_for_conditional_generation_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -1121,7 +1122,7 @@ def qwen3_vl_for_conditional_generation_forward_patched(
             )
         else:
             logits = self.lm_head(hidden_states)
-            loss, _, log_probs = self.loss_function(
+            loss, _, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
             )
     else:
@@ -1137,4 +1138,5 @@ def qwen3_vl_for_conditional_generation_forward_patched(
         rope_deltas=outputs.rope_deltas,
     )
     output.log_probs = log_probs
+    output.entropy = entropy
     return output

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.diff
@@ -1363,7 +1363,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1644,29 +2131,59 @@
+@@ -1644,29 +2131,60 @@
          )
 
          hidden_states = outputs[0]
@@ -1378,12 +1378,13 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
 -
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -1394,9 +1395,9 @@
 +            else:
 +                logits = self.lm_head(hidden_states)
 +                # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-+                # returns (loss, logits, log_probs); unpack to match the OpSlot
-+                # branch above.
-+                loss, logits, log_probs = self.loss_function(
++                # returns (loss, logits, log_probs, entropy); unpack to match the
++                # OpSlot branch above.
++                loss, logits, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1441,7 +1442,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1674,8 +2191,10 @@
+@@ -1674,8 +2192,11 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
@@ -1450,11 +1451,12 @@
 +            router_logits=getattr(outputs, "router_logits", None),
 +        )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -1901,6 +2420,37 @@
+@@ -1901,6 +2422,37 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.py
@@ -2138,10 +2138,11 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMi
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -2152,9 +2153,9 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMi
             else:
                 logits = self.lm_head(hidden_states)
                 # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-                # returns (loss, logits, log_probs); unpack to match the OpSlot
-                # branch above.
-                loss, logits, log_probs = self.loss_function(
+                # returns (loss, logits, log_probs, entropy); unpack to match the
+                # OpSlot branch above.
+                loss, logits, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
                 )
         else:
@@ -2194,6 +2195,7 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMi
             router_logits=getattr(outputs, "router_logits", None),
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.diff
@@ -1472,7 +1472,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1644,29 +2156,59 @@
+@@ -1644,29 +2156,60 @@
          )
 
          hidden_states = outputs[0]
@@ -1487,12 +1487,13 @@
          loss = None
 +        logits = None
 +        log_probs = None
++        entropy = None
          if labels is not None:
 -            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
 -
 +            # Modification: OpSlot guard for cross-entropy loss.
 +            if veomni_causal_lm_loss.use_non_eager_impl:
-+                loss, logits, log_probs = veomni_causal_lm_loss(
++                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
 +                    logits=logits,
 +                    labels=labels,
 +                    vocab_size=self.config.text_config.vocab_size,
@@ -1503,9 +1504,9 @@
 +            else:
 +                logits = self.lm_head(hidden_states)
 +                # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-+                # returns (loss, logits, log_probs); unpack to match the OpSlot
-+                # branch above.
-+                loss, logits, log_probs = self.loss_function(
++                # returns (loss, logits, log_probs, entropy); unpack to match the
++                # OpSlot branch above.
++                loss, logits, log_probs, entropy = self.loss_function(
 +                    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
 +                )
 +        else:
@@ -1550,7 +1551,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1674,8 +2216,10 @@
+@@ -1674,8 +2217,11 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
@@ -1559,11 +1560,12 @@
 +            router_logits=getattr(outputs, "router_logits", None),
 +        )
 +        output.log_probs = log_probs
++        output.entropy = entropy
 +        return output
 
      def prepare_inputs_for_generation(
          self,
-@@ -1901,6 +2445,37 @@
+@@ -1901,6 +2447,37 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.py
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.py
@@ -2163,10 +2163,11 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMi
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
             # Modification: OpSlot guard for cross-entropy loss.
             if veomni_causal_lm_loss.use_non_eager_impl:
-                loss, logits, log_probs = veomni_causal_lm_loss(
+                loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
@@ -2177,9 +2178,9 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMi
             else:
                 logits = self.lm_head(hidden_states)
                 # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-                # returns (loss, logits, log_probs); unpack to match the OpSlot
-                # branch above.
-                loss, logits, log_probs = self.loss_function(
+                # returns (loss, logits, log_probs, entropy); unpack to match the
+                # OpSlot branch above.
+                loss, logits, log_probs, entropy = self.loss_function(
                     logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
                 )
         else:
@@ -2219,6 +2220,7 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMi
             router_logits=getattr(outputs, "router_logits", None),
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
     def prepare_inputs_for_generation(

--- a/veomni/models/transformers/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/veomni/models/transformers/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -858,8 +858,9 @@ class Qwen3VLMoeForConditionalGeneration(_Qwen3VLMoeForConditionalGeneration):
         loss = None
         logits = None
         log_probs = None
+        entropy = None
         if labels is not None:
-            loss, logits, log_probs = self.loss_function(
+            loss, logits, log_probs, entropy = self.loss_function(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -892,6 +893,7 @@ class Qwen3VLMoeForConditionalGeneration(_Qwen3VLMoeForConditionalGeneration):
             rope_deltas=outputs.rope_deltas,
         )
         output.log_probs = log_probs
+        output.entropy = entropy
         return output
 
 

--- a/veomni/models/transformers/qwen3_vl_moe/qwen3_vl_moe_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_vl_moe/qwen3_vl_moe_gpu_patch_gen_config.py
@@ -548,10 +548,11 @@ def qwen3_vl_moe_for_conditional_generation_forward_patched(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
         # Modification: OpSlot guard for cross-entropy loss.
         if veomni_causal_lm_loss.use_non_eager_impl:
-            loss, logits, log_probs = veomni_causal_lm_loss(
+            loss, logits, log_probs, entropy = veomni_causal_lm_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=self.config.text_config.vocab_size,
@@ -562,9 +563,9 @@ def qwen3_vl_moe_for_conditional_generation_forward_patched(
         else:
             logits = self.lm_head(hidden_states)
             # Modification: VeOmni's patched `loss_function` (via LOSS_MAPPING)
-            # returns (loss, logits, log_probs); unpack to match the OpSlot
-            # branch above.
-            loss, logits, log_probs = self.loss_function(
+            # returns (loss, logits, log_probs, entropy); unpack to match the
+            # OpSlot branch above.
+            loss, logits, log_probs, entropy = self.loss_function(
                 logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
             )
     else:
@@ -604,6 +605,7 @@ def qwen3_vl_moe_for_conditional_generation_forward_patched(
         router_logits=getattr(outputs, "router_logits", None),
     )
     output.log_probs = log_probs
+    output.entropy = entropy
     return output
 
 

--- a/veomni/models/transformers/seed_oss/modeling_seed_oss.py
+++ b/veomni/models/transformers/seed_oss/modeling_seed_oss.py
@@ -94,8 +94,9 @@ def seed_oss_forcausallm_forward(
     loss = None
     logits = None
     log_probs = None
+    entropy = None
     if labels is not None:
-        loss, logits, log_probs = self.loss_function(
+        loss, logits, log_probs, entropy = self.loss_function(
             logits=logits,
             labels=labels,
             vocab_size=self.config.vocab_size,
@@ -111,6 +112,7 @@ def seed_oss_forcausallm_forward(
         loss=loss,
         logits=logits,
         log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,

--- a/veomni/ops/kernels/cross_entropy/__init__.py
+++ b/veomni/ops/kernels/cross_entropy/__init__.py
@@ -20,15 +20,17 @@ cross-entropy computation to ``cross_entropy_fn`` — a single required-style
 keyword argument. The wrapper decides between two paths per call: the loss
 path (delegated to the bound ``cross_entropy_fn``) or — when the caller
 forwards ``return_log_probs=True`` through ``forward`` kwargs — the per-token
-log-probs path (delegated to ``chunk_logprobs_function``). The choice of
-which loss kernel to use is still made once, at ``install_loss_mapping`` /
-``KERNEL_REGISTRY.resolve`` time, and baked in via ``functools.partial``.
+log-probs + entropy path (delegated to ``chunk_logprobs_function``). The
+choice of which loss kernel to use is still made once, at
+``install_loss_mapping`` / ``KERNEL_REGISTRY.resolve`` time, and baked in via
+``functools.partial``.
 
-Wrapper return shape: ``(loss, logits, log_probs)``. The third slot is
-non-``None`` only on the log-probs path; on the loss path it is ``None`` so
-every model `forward` can do ``loss, _, log_probs = self.loss_function(...)``
-followed by ``outputs.log_probs = log_probs`` without a per-model branch on
-``return_log_probs``.
+Wrapper return shape: ``(loss, logits, log_probs, entropy)``. The third and
+fourth slots are non-``None`` only on the log-probs path; on the loss path
+they are ``None`` so every model `forward` can do
+``loss, _, log_probs, entropy = self.loss_function(...)`` followed by
+``outputs.log_probs = log_probs; outputs.entropy = entropy`` without a
+per-model branch on ``return_log_probs``.
 
 Two dispatch paths reach these wrappers:
 
@@ -84,15 +86,21 @@ def ForCausalLMLoss(
     *,
     cross_entropy_fn: Callable = eager_cross_entropy,
     **kwargs,
-) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
     hidden_states = kwargs.pop("hidden_states", None)
     weights = kwargs.pop("weights", None)
     # Per-call log-probs dispatch: when the caller passes `return_log_probs=True`
     # (the model `forward` simply forwards it through `**kwargs`), skip the loss
     # path and route hidden_states+weights+labels through the chunked log-probs
-    # kernel. The loss/logits slots are vacated; the third tuple slot carries
-    # the per-token log-probabilities back to the caller.
+    # kernel. The loss/logits slots are vacated; the third and fourth tuple
+    # slots carry the per-token log-probabilities and softmax entropy back to
+    # the caller.
     return_log_probs = kwargs.pop("return_log_probs", False)
+    # ``temperature`` is part of the PPO actor contract — verl divides logits
+    # by it before log_softmax. Pop here so it does not propagate into the
+    # plain loss path (where it would trip the inner CE kernel) and so the
+    # ``return_log_probs`` branch can forward it explicitly to the kernel.
+    temperature = kwargs.pop("temperature", 1.0)
 
     assert hidden_states is not None or logits is not None, "hidden_states or logits must be provided."
 
@@ -104,14 +112,15 @@ def ForCausalLMLoss(
             raise ValueError("return_log_probs=True requires hidden_states (fused-linear path).")
         if weights is None:
             raise ValueError("return_log_probs=True requires weights (lm_head weight).")
-        log_probs = chunk_logprobs_function(
+        log_probs, entropy = chunk_logprobs_function(
             hidden_states,
             weights,
             labels,
             ignore_index=ignore_index,
             shift_labels=shift_labels,
+            temperature=temperature,
         )
-        return None, None, log_probs
+        return None, None, log_probs, entropy
 
     device = logits.device if logits is not None else hidden_states.device
     # Upcast to float if we need to compute the loss to avoid potential precision issues
@@ -155,7 +164,7 @@ def ForCausalLMLoss(
     if sp_enabled:
         num_valid_tokens = (labels != ignore_index).sum()
         loss = reduce_sequence_parallel_loss(loss, num_valid_tokens)
-    return loss, logits, None
+    return loss, logits, None, None
 
 
 def ForSequenceClassificationLoss(
@@ -170,7 +179,7 @@ def ForSequenceClassificationLoss(
     *,
     cross_entropy_fn: Callable = eager_cross_entropy,
     **kwargs,
-) -> tuple[torch.Tensor, torch.Tensor | None, None]:
+) -> tuple[torch.Tensor, torch.Tensor | None, None, None]:
     r"""
     Token-level loss for sequence classification.
 
@@ -209,16 +218,20 @@ def ForSequenceClassificationLoss(
             Always ``None`` for sequence classification — the third tuple slot
             exists to keep the wrapper return shape uniform with
             ``ForCausalLMLoss`` so model `forward` call sites can unpack
-            ``(loss, logits, log_probs)`` regardless of head type.
+            ``(loss, logits, log_probs, entropy)`` regardless of head type.
+        entropy (`None`):
+            Always ``None`` for sequence classification — fourth slot exists
+            for the same uniform-unpack reason as ``log_probs``.
     """
 
     # pop fused loss kwargs
     hidden_states = kwargs.pop("hidden_states", None)
     weights = kwargs.pop("weights", None)
-    # Seq-cls heads have no log-probs path. Pop the kwarg defensively so that a
-    # caller that always forwards ``return_log_probs`` doesn't trip the inner
-    # ``cross_entropy_fn`` with an unexpected kwarg.
+    # Seq-cls heads have no log-probs path. Pop these kwargs defensively so
+    # that a caller that always forwards them doesn't trip the inner
+    # ``cross_entropy_fn`` with unexpected kwargs.
     kwargs.pop("return_log_probs", None)
+    kwargs.pop("temperature", None)
 
     if hidden_states is None and logits is None:
         raise ValueError("Either hidden_states or logits must be provided.")
@@ -261,7 +274,7 @@ def ForSequenceClassificationLoss(
     if sp_enabled:
         num_valid_tokens = (target != ignore_index).sum()
         loss = reduce_sequence_parallel_loss(loss, num_valid_tokens)
-    return loss, logits, None
+    return loss, logits, None, None
 
 
 # ── LOSS_MAPPING installation ────────────────────────────────────────────────
@@ -288,26 +301,33 @@ def _resolve_cross_entropy_fn(impl: str) -> Callable:
     )
 
 
-def _chunk_loss_dispatch(*args, **kwargs) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
-    """3-tuple shim for the ``chunk_loss`` LOSS_MAPPING entry.
+def _chunk_loss_dispatch(
+    *args, **kwargs
+) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+    """4-tuple shim for the ``chunk_loss`` LOSS_MAPPING entry.
 
     ``chunk_loss_function`` historically bypasses the ``ForCausalLMLoss``
     wrapper (it owns its own label shift + SP reduction) and is installed
     bare. To keep the wrapper return contract uniform — every model
-    forward unpacks ``loss, _, log_probs = self.loss_function(...)`` — we
-    wrap it in this shim:
+    forward unpacks ``loss, _, log_probs, entropy = self.loss_function(...)``
+    — we wrap it in this shim:
 
     - ``return_log_probs=True``: route ``hidden_states`` + ``weights`` +
       ``labels`` through ``chunk_logprobs_function``; return
-      ``(None, None, log_probs)``.
-    - otherwise: forward to ``chunk_loss_function`` and append a ``None``
-      log_probs slot to its 2-tuple return.
+      ``(None, None, log_probs, entropy)``. ``temperature`` (defaults to
+      1.0) is forwarded so the PPO actor path can scale logits inside
+      the kernel.
+    - otherwise: forward to ``chunk_loss_function`` and append two
+      ``None`` slots (log_probs, entropy) to its 2-tuple return. Pop
+      ``temperature`` defensively so a caller that always forwards it
+      doesn't trip ``chunk_loss_function``'s signature.
 
     Args/kwargs are forwarded as-is — model `forward` only ever calls this
     via keyword (``self.loss_function(logits=..., labels=..., hidden_states=...,
     weights=..., **kwargs)``), so a single ``**kwargs`` parameter is enough.
     """
     return_log_probs = kwargs.pop("return_log_probs", False)
+    temperature = kwargs.pop("temperature", 1.0)
 
     if return_log_probs:
         hidden_states = kwargs.get("hidden_states")
@@ -315,17 +335,18 @@ def _chunk_loss_dispatch(*args, **kwargs) -> tuple[torch.Tensor | None, torch.Te
         labels = kwargs.get("labels")
         if hidden_states is None or weights is None:
             raise ValueError("return_log_probs=True requires hidden_states and weights (fused-linear path).")
-        log_probs = chunk_logprobs_function(
+        log_probs, entropy = chunk_logprobs_function(
             hidden_states,
             weights,
             labels,
             ignore_index=kwargs.get("ignore_index", -100),
             shift_labels=kwargs.get("shift_labels"),
+            temperature=temperature,
         )
-        return None, None, log_probs
+        return None, None, log_probs, entropy
 
     loss, logits_out = chunk_loss_function(*args, **kwargs)
-    return loss, logits_out, None
+    return loss, logits_out, None, None
 
 
 def install_loss_mapping(impl: str = "eager") -> str:
@@ -340,20 +361,23 @@ def install_loss_mapping(impl: str = "eager") -> str:
     ``ForCausalLMLoss``).
 
     Contract — return type: **VeOmni's wrappers return ``(loss, logits,
-    log_probs)``**, not a bare ``torch.Tensor``. The 3-tuple is
+    log_probs, entropy)``**, not a bare ``torch.Tensor``. The 4-tuple is
     load-bearing: fused kernels (Liger fused linear+CE, NPU
     ``chunk_loss_function``) fold the ``lm_head`` projection into the loss,
     so the kernel — not the caller — is where logits come out. The third
-    slot, ``log_probs``, is non-``None`` only on the per-token log-probs
-    path — when the caller passes ``return_log_probs=True`` through
+    and fourth slots, ``log_probs`` and ``entropy``, are non-``None`` only
+    on the per-token log-probs path — when the caller passes
+    ``return_log_probs=True`` (and optionally ``temperature=...``) through
     ``forward`` kwargs, the wrapper short-circuits to
-    ``chunk_logprobs_function`` and returns ``(None, None, log_probs)``.
-    Every VeOmni-patched v5 modeling file in-tree unpacks as
-    ``loss, _, log_probs = self.loss_function(...)`` (or
-    ``loss, logits, log_probs = ...`` when the caller needs the fused
-    logits). The model `forward` then assigns
-    ``outputs.log_probs = log_probs`` so per-token log-probs surface on the
-    standard ``ModelOutput`` without a per-model early-exit branch.
+    ``chunk_logprobs_function`` and returns
+    ``(None, None, log_probs, entropy)``. Every VeOmni-patched v5 modeling
+    file in-tree unpacks as
+    ``loss, _, log_probs, entropy = self.loss_function(...)`` (or
+    ``loss, logits, log_probs, entropy = ...`` when the caller needs the
+    fused logits). The model `forward` then assigns
+    ``outputs.log_probs = log_probs; outputs.entropy = entropy`` so
+    per-token log-probs and entropy surface on the standard ``ModelOutput``
+    without a per-model early-exit branch.
 
     This diverges from upstream ``transformers.loss.loss_utils.ForCausalLMLoss``
     which returns a bare ``Tensor``. Mixing ``install_loss_mapping`` with

--- a/veomni/ops/kernels/cross_entropy/chunk_logprobs.py
+++ b/veomni/ops/kernels/cross_entropy/chunk_logprobs.py
@@ -12,19 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Chunked fused linear log-probs for PPO-style RL.
+"""Chunked fused linear log-probs **and** per-token entropy for PPO-style RL.
 
-Returns per-token actual log-probabilities ``log p(y_t | <t)`` while
-streaming the lm_head projection chunk-by-chunk — never materializes
-the full ``[T, V]`` logits tensor. The output is the building block
-PPO needs for policy / reference logprob recompute at long context +
-large vocab.
-
-The ``LAST_LOG_PROBS`` ``ContextVar`` lets the loss-function dispatch
-hand off per-token log-probs to a post-forward hook on the model
-without abusing the ``output.logits`` slot. The kernel sets it; the
-forward hook installed by ``build_foundation_model`` reads it and
-attaches to ``output.log_probs``.
+Returns per-token actual log-probabilities ``log p(y_t | <t)`` and the
+softmax entropy ``H[p(.|<t)] = -Σ_v p_v log p_v`` while streaming the
+lm_head projection chunk-by-chunk — never materializes the full
+``[T, V]`` logits tensor. The output is the building block PPO needs
+for policy / reference logprob recompute and entropy bonus at long
+context + large vocab.
 
 Implementation pattern follows
 ``verl/utils/experimental/torch_functional.py::FusedLinearForPPOFunction``
@@ -40,6 +35,9 @@ without behavioural surprises:
   is reshaped back to the input's leading dims.
 - ``temperature`` is applied as ``logits / T`` (chain rule
   divides ``dlogits`` by ``T`` in backward).
+- Entropy is always computed in forward (negligible vs the matmul);
+  its gradient path is only walked in backward when ``dentropy`` is
+  not ``None`` (mirrors verl, which gates the entropy-grad branch).
 
 FSDP2 contract: the saved ``weight`` reference is the lm_head
 parameter; FSDP2's pre-backward hook (installed by
@@ -51,11 +49,11 @@ contract verl already validates in production with
 
 VeOmni-specific extensions on top of verl's pattern:
 
-- ``ignore_index`` masking: ``log_probs == 0`` and zero gradient at
-  positions where ``labels == ignore_index``. Needed because
-  VeOmni's data pipeline (chat templates, packing) sets
-  IGNORE_INDEX boundaries; verl's data pipeline filters them
-  upstream so its kernel doesn't.
+- ``ignore_index`` masking: ``log_probs == 0`` and entropy ``== 0``
+  with zero gradient at positions where ``labels == ignore_index``.
+  Needed because VeOmni's data pipeline (chat templates, packing) sets
+  IGNORE_INDEX boundaries; verl's data pipeline filters them upstream
+  so its kernel doesn't.
 - Causal label shift (``labels[..., 1:]`` / ``hidden[..., :-1, :]``)
   applied internally when SP is disabled, matching the convention
   of the sibling ``chunk_loss_function``. SP-enabled callers pass
@@ -112,12 +110,27 @@ def _per_token_log_probs_from_logits(
     return torch.where(mask, log_probs, torch.zeros_like(log_probs))
 
 
+def _per_token_entropy_from_logits(logits: torch.Tensor) -> torch.Tensor:
+    """Softmax entropy ``H[p] = logsumexp(logits) - Σ p · logits``.
+
+    Op order matches verl's ``_fused_linear_for_ppo_fwd`` exactly so the
+    fp32 rounding boundary is identical: ``softmax`` then
+    ``logsumexp(logits) - sum(probs * logits)``. ``probs * logits`` is
+    materialized once (a ``[chunk, V]`` fp32 tensor, same shape as
+    ``logits``); peak chunk memory is unchanged from the log-probs path.
+    """
+    probs = logits.softmax(dim=-1)
+    return torch.logsumexp(logits, dim=-1) - torch.sum(probs * logits, dim=-1)
+
+
 class _ChunkedLinearLogProbs(torch.autograd.Function):
-    """Custom autograd Function: chunked linear projection + log-softmax + gather.
+    """Custom autograd Function: chunked linear projection + log-softmax + gather + entropy.
 
     Mirrors verl's ``FusedLinearForPPOFunction`` (custom autograd
     Function with explicit chunked forward + backward) so the FSDP2
-    correctness story is the same.
+    correctness story is the same. Returns ``(log_probs, entropy)`` as
+    a 2-tuple; the entropy gradient path in backward is only walked
+    when the caller actually backprops through the entropy output.
     """
 
     @staticmethod
@@ -129,7 +142,7 @@ class _ChunkedLinearLogProbs(torch.autograd.Function):
         temperature: float,
         chunk_size: int,
         ignore_index: int,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         ctx.set_materialize_grads(False)
 
         orig_shape = labels.shape
@@ -140,6 +153,11 @@ class _ChunkedLinearLogProbs(torch.autograd.Function):
 
         out_requires_grad = h_2d.requires_grad or weight.requires_grad
         log_probs = torch.zeros(T, device=h_2d.device, dtype=torch.float32, requires_grad=out_requires_grad)
+        # Entropy is returned in fp32; verl downcasts to ``hidden_states.dtype``
+        # but downstream RL code reads it in fp32 so we keep the higher
+        # precision here. The mask-to-zero at IGN positions is exact in either
+        # dtype, so this only affects the valid slots.
+        entropy = torch.zeros(T, device=h_2d.device, dtype=torch.float32, requires_grad=out_requires_grad)
 
         for chunk_start in range(0, T, chunk_size):
             chunk_end = min(chunk_start + chunk_size, T)
@@ -158,6 +176,14 @@ class _ChunkedLinearLogProbs(torch.autograd.Function):
             logits = logits.float()
 
             log_probs[chunk_start:chunk_end] = _per_token_log_probs_from_logits(logits, l_chunk, ignore_index)
+            chunk_entropy = _per_token_entropy_from_logits(logits)
+            # Mask entropy at IGN positions (mirrors log_probs masking).
+            # Entropy is well-defined at every position (it depends only on
+            # the softmax distribution, not the label), but downstream
+            # consumers expect IGN slots to be exactly 0 so they can sum
+            # without applying a separate mask.
+            mask = l_chunk != ignore_index
+            entropy[chunk_start:chunk_end] = torch.where(mask, chunk_entropy, torch.zeros_like(chunk_entropy))
 
         ctx.save_for_backward(h_2d, weight, l_1d)
         ctx.temperature = temperature
@@ -165,16 +191,17 @@ class _ChunkedLinearLogProbs(torch.autograd.Function):
         ctx.ignore_index = ignore_index
         ctx.orig_hidden_shape = orig_hidden_shape
 
-        return log_probs.view(orig_shape)
+        return log_probs.view(orig_shape), entropy.view(orig_shape)
 
     @staticmethod
-    def backward(ctx, dlog_probs: Optional[torch.Tensor]):
-        if dlog_probs is None:
+    def backward(ctx, dlog_probs: Optional[torch.Tensor], dentropy: Optional[torch.Tensor]):
+        if dlog_probs is None and dentropy is None:
             return None, None, None, None, None, None
 
         h_2d, weight, l_1d = ctx.saved_tensors
         T = l_1d.shape[0]
-        dlog_probs_1d = dlog_probs.reshape(-1).float()
+        dlog_probs_1d = dlog_probs.reshape(-1).float() if dlog_probs is not None else None
+        dentropy_1d = dentropy.reshape(-1).float() if dentropy is not None else None
 
         dhidden = torch.zeros_like(h_2d) if h_2d.requires_grad else None
         dweight = torch.zeros_like(weight) if weight.requires_grad else None
@@ -183,7 +210,8 @@ class _ChunkedLinearLogProbs(torch.autograd.Function):
             chunk_end = min(chunk_start + ctx.chunk_size, T)
             h_chunk = h_2d[chunk_start:chunk_end]
             l_chunk = l_1d[chunk_start:chunk_end]
-            dlp_chunk = dlog_probs_1d[chunk_start:chunk_end]
+            dlp_chunk = dlog_probs_1d[chunk_start:chunk_end] if dlog_probs_1d is not None else None
+            dent_chunk = dentropy_1d[chunk_start:chunk_end] if dentropy_1d is not None else None
 
             # Recompute logits with the same op order as forward so the
             # saved-weight reference (which FSDP2 has unsharded by now
@@ -196,14 +224,29 @@ class _ChunkedLinearLogProbs(torch.autograd.Function):
 
             probs = logits.softmax(dim=-1)
             mask = (l_chunk != ctx.ignore_index).float()
-            safe_labels = l_chunk.clamp(min=0).unsqueeze(-1)
 
+            dlogits = torch.zeros_like(probs)
+
+            # ── log_probs gradient path ──────────────────────────────────
             # ∂(gather(log_softmax(logits), labels)) / ∂logits[i, j] =
             #     δ(j == labels[i]) - softmax(logits)[i, j]
             # so dlogits[i, j] = dlog_probs[i] * (one_hot[i, j] - probs[i, j]).
-            one_hot = torch.zeros_like(probs).scatter_(-1, safe_labels, 1.0)
-            masked_dlp = (dlp_chunk * mask).unsqueeze(-1)
-            dlogits = masked_dlp * (one_hot - probs)
+            if dlp_chunk is not None:
+                safe_labels = l_chunk.clamp(min=0).unsqueeze(-1)
+                one_hot = torch.zeros_like(probs).scatter_(-1, safe_labels, 1.0)
+                masked_dlp = (dlp_chunk * mask).unsqueeze(-1)
+                dlogits = dlogits + masked_dlp * (one_hot - probs)
+
+            # ── entropy gradient path (mirrors verl exactly) ─────────────
+            # ∂H[p]/∂logits[i, j] = p_j (log p_j + H[p]) so
+            # dlogits[i, j] = -dentropy[i] * p_j * (log p_j + H[p_i])
+            # The ``-`` sign is folded into the ``-dentropy.unsqueeze(-1)``
+            # multiplier (matches verl's expression).
+            if dent_chunk is not None:
+                log_probs_full = logits.log_softmax(dim=-1)
+                entropy_full = torch.logsumexp(logits, dim=-1) - torch.sum(probs * logits, dim=-1)
+                masked_dent = (dent_chunk * mask).unsqueeze(-1)
+                dlogits = dlogits + probs * (log_probs_full + entropy_full.unsqueeze(-1)) * (-masked_dent)
 
             # Op order mirrors verl's ``_fused_linear_for_ppo_bwd``:
             # cast back to the input dtype first, then divide by
@@ -233,8 +276,8 @@ def chunk_logprobs_function(
     ignore_index: int = -100,
     shift_labels: Optional[torch.Tensor] = None,
     temperature: float = 1.0,
-) -> torch.Tensor:
-    """Compute per-token actual log-probabilities via a chunked fused linear.
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute per-token log-probabilities and entropy via a chunked fused linear.
 
     Args:
         hidden_states: ``[B, L, H]`` (or ``[L, H]`` for already-packed
@@ -242,7 +285,7 @@ def chunk_logprobs_function(
         weights: lm_head weight, ``[V, H]``. Bias is not supported.
         labels: integer label tensor with shape matching the leading
             dims of ``hidden_states``. Positions equal to
-            ``ignore_index`` produce ``0.0`` in the output (no
+            ``ignore_index`` produce ``0.0`` in both outputs (no
             gradient flows through them either).
         chunk_size: token-dim chunk for the streamed projection.
         ignore_index: label value to mask (default ``-100`` /
@@ -251,7 +294,7 @@ def chunk_logprobs_function(
             kernel uses them as-is and skips the internal causal
             shift, so callers can supply custom alignment (e.g. the
             ``ForCausalLMLoss`` SP path that pre-shifts via padding).
-            The output tensor's seq length matches ``shift_labels``
+            The output tensors' seq length matches ``shift_labels``
             (no trailing pad). When ``None``, this function applies
             the causal ``labels[..., 1:]`` /
             ``hidden_states[..., :-1, :]`` shift internally and pads
@@ -261,9 +304,17 @@ def chunk_logprobs_function(
             path). Defaults to 1.0 (no-op).
 
     Returns:
-        Per-token log-probabilities with the same shape as the input
-        ``labels``. **Sign: non-positive** (``log p(y_t)``), matches
-        HF / verl conventions — no negation needed at the call site.
+        ``(log_probs, entropy)`` — both with the same shape as the
+        input ``labels``.
+
+        - ``log_probs``: per-token ``log p(y_t)`` (non-positive). Zero
+          at IGNORE_INDEX positions and at the trailing pad slot.
+        - ``entropy``: per-token softmax entropy
+          ``H[p] = -Σ_v p_v log p_v`` (non-negative). Zero at
+          IGNORE_INDEX positions and at the trailing pad slot.
+
+        Sign conventions match HF / verl — no negation needed at the
+        call site.
     """
     sp_enabled = get_parallel_state().sp_enabled
 
@@ -286,14 +337,15 @@ def chunk_logprobs_function(
         labels_shifted = labels[..., 1:].contiguous()
         hidden_states = hidden_states[..., :-1, :].contiguous()
 
-    log_probs = _ChunkedLinearLogProbs.apply(
+    log_probs, entropy = _ChunkedLinearLogProbs.apply(
         hidden_states, weights, labels_shifted, float(temperature), int(chunk_size), int(ignore_index)
     )
 
     if not sp_enabled and not used_explicit_shift:
         # Pad with one zero at the right of the (last) seq dim so the
-        # returned tensor matches the input ``labels`` shape. The
+        # returned tensors match the input ``labels`` shape. The
         # padded slot corresponds to the final input token (no
         # next-token target) — a no-op under any sane downstream mask.
         log_probs = torch.nn.functional.pad(log_probs, (0, 1), value=0.0)
-    return log_probs
+        entropy = torch.nn.functional.pad(entropy, (0, 1), value=0.0)
+    return log_probs, entropy

--- a/veomni/utils/model_outputs.py
+++ b/veomni/utils/model_outputs.py
@@ -16,10 +16,11 @@
 
 A patched ``*ForCausalLM.forward`` returns this dataclass when called
 with ``return_log_probs=True``: ``log_probs`` carries per-token actual
-log-probabilities (non-positive), ``logits`` and ``loss`` are
-``None``. Imports are kept light (no ``veomni.data`` dependency) so
-external integrators (verl) can pull the dataclass without paying the
-data-pipeline import cost.
+log-probabilities (non-positive), ``entropy`` carries per-token softmax
+entropy (non-negative); ``logits`` and ``loss`` are ``None``. Imports
+are kept light (no ``veomni.data`` dependency) so external integrators
+(verl) can pull the dataclass without paying the data-pipeline import
+cost.
 """
 
 from dataclasses import dataclass
@@ -31,12 +32,19 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 
 @dataclass
 class CausalLMOutputWithLogProbs(CausalLMOutputWithPast):
-    """``CausalLMOutputWithPast`` extended with a per-token ``log_probs`` field.
+    """``CausalLMOutputWithPast`` extended with per-token ``log_probs`` and ``entropy`` fields.
 
-    ``log_probs`` shape matches the input ``labels`` (``[B, L]`` or
-    packed ``[L]``). Sign: non-positive — actual log-probabilities,
-    matches HF / verl conventions. Zero at IGNORE_INDEX positions and
-    the trailing pad slot.
+    Both tensors share the input ``labels`` shape (``[B, L]`` or packed
+    ``[L]``) and are zero at IGNORE_INDEX positions and the trailing
+    pad slot.
+
+    - ``log_probs``: non-positive — actual log-probabilities ``log p(y_t)``,
+      matches HF / verl conventions.
+    - ``entropy``: non-negative — softmax entropy
+      ``H[p] = -Σ_v p_v log p_v``, matches verl's
+      ``CausalLMOutputForPPO.entropy`` so the dataclass drops directly
+      into verl's ``prepare_model_outputs`` consumer.
     """
 
     log_probs: Optional[torch.Tensor] = None
+    entropy: Optional[torch.Tensor] = None


### PR DESCRIPTION
## Summary

Extends PR #711's per-token log-probs path so VeOmni-built models can fully replace verl's `FSDPEngineWithLMHead.patch_forward_with_backends` monkey patch:

- Forwards `temperature` from `ForCausalLMLoss` into `chunk_logprobs_function` (verl's PPO actor divides logits by `T` before log-softmax).
- Returns per-token softmax entropy alongside `log_probs` so `output.entropy` populates verl's `prepare_model_outputs(use_fused_kernels=True, calculate_entropy=True)` consumer (`entropy_rmpad = output.entropy.squeeze(0)`).
- Bumps the wrapper return shape from `(loss, logits, log_probs)` → `(loss, logits, log_probs, entropy)`. Every in-tree modeling + patchgen config moved to the uniform unpack `loss, _, log_probs, entropy = self.loss_function(...)` and assigns `output.entropy = entropy` next to the existing `output.log_probs` line.

## Implementation notes

- **Kernel** (`veomni/ops/kernels/cross_entropy/chunk_logprobs.py`): forward computes entropy `H[p] = logsumexp(logits) − Σ p · logits` with verl's op order; backward gates the entropy-grad path on `dentropy is not None` so the loss-only path pays no extra FLOPs. IGN-position masking applies to entropy too.
- **Wrapper** (`veomni/ops/kernels/cross_entropy/__init__.py`): pops `temperature` (default 1.0) and `return_log_probs` from kwargs; `_chunk_loss_dispatch` shim mirrors the same 4-tuple contract. `ForSequenceClassificationLoss` returns `(loss, logits, None, None)` for unpack uniformity.
- **Output dataclass** (`veomni/utils/model_outputs.py`): `CausalLMOutputWithLogProbs` gains `entropy: Optional[Tensor]`.
- **Modelings**: 12 modeling files + 11 patchgen configs updated; all `generated/*` regenerated via `python -m veomni.patchgen.check_patchgen --fix`.

## Test plan

- [x] `pytest tests/ops/test_chunk_logprobs.py -v` — 10/10 pass; new tests cover `temperature ∈ {1.0, 0.7, 2.5}` bitwise-parity vs verl's `FusedLinearForPPOFunction` on log_probs, entropy, and gradients
- [x] `pytest tests/ops/test_seqcls_loss.py -v` — 6/6 pass
- [x] `pytest tests/models/test_return_log_probs_e2e.py -v` — pins entropy shape, IGN masking, non-negative valid positions, and the verl consumer contract (`output.entropy.shape == labels.shape`)
- [x] `make quality` clean
- [x] `python -m veomni.patchgen.check_patchgen` clean (all 30+ generated files regenerated and verified)