### PR TITLE
[ci, model] test: add bitwise logits-equal tests for transformers v4 models

### DIFF
--- a/tests/models/hf_unpatch.py
+++ b/tests/models/hf_unpatch.py
@@ -28,8 +28,14 @@ dependencies (``av``, ``torchcodec``, ...). Keep the imports here narrow.
 """
 
 import transformers.models.deepseek_v3.modeling_deepseek_v3 as _hf_ds3
+import transformers.models.qwen2_5_omni.modeling_qwen2_5_omni as _hf_qwen25omni
+import transformers.models.qwen2_5_vl.modeling_qwen2_5_vl as _hf_qwen25vl
+import transformers.models.qwen2_vl.modeling_qwen2_vl as _hf_qwen2vl
 import transformers.models.qwen3.modeling_qwen3 as _hf_qwen3
 import transformers.models.qwen3_moe.modeling_qwen3_moe as _hf_qwen3_moe
+import transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe as _hf_q3omnimoe
+import transformers.models.qwen3_vl.modeling_qwen3_vl as _hf_qwen3vl
+import transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe as _hf_qwen3vlmoe
 
 
 # Cover every patch site reachable from apply_veomni_*_patch() + the Liger
@@ -71,17 +77,71 @@ _PRISTINE_HF = {
     "ds3.RMSNorm.cls": _hf_ds3.DeepseekV3RMSNorm,
     "ds3.RMSNorm.forward": _hf_ds3.DeepseekV3RMSNorm.forward,
     "ds3.MLP.cls": _hf_ds3.DeepseekV3MLP,
+    # qwen2_vl (apply_veomni_qwen2vl_patch)
+    "qwen2_vl.CausalLM.cls": _hf_qwen2vl.Qwen2VLForConditionalGeneration,
+    "qwen2_vl.Model.cls": _hf_qwen2vl.Qwen2VLModel,
+    "qwen2_vl.VisionPretrained.cls": _hf_qwen2vl.Qwen2VisionTransformerPretrainedModel,
+    "qwen2_vl.DecoderLayer.cls": _hf_qwen2vl.Qwen2VLDecoderLayer,
+    "qwen2_vl.VisionAttention.forward": _hf_qwen2vl.VisionAttention.forward,
+    # qwen2_5_vl (apply_veomni_qwen25_vl_patch)
+    "qwen2_5_vl.VisionAttention.forward": _hf_qwen25vl.Qwen2_5_VLVisionAttention.forward,
+    "qwen2_5_vl.VisionPretrained.forward": _hf_qwen25vl.Qwen2_5_VisionTransformerPretrainedModel.forward,
+    "qwen2_5_vl.Model.cls": _hf_qwen25vl.Qwen2_5_VLModel,
+    "qwen2_5_vl.CausalLM.cls": _hf_qwen25vl.Qwen2_5_VLForConditionalGeneration,
+    # qwen3_vl (apply_veomni_qwen3vl_patch)
+    "qwen3_vl.VisionAttention.forward": _hf_qwen3vl.Qwen3VLVisionAttention.forward,
+    "qwen3_vl.TextAttention.cls": _hf_qwen3vl.Qwen3VLTextAttention,
+    "qwen3_vl.TextModel._deepstack_process": _hf_qwen3vl.Qwen3VLTextModel._deepstack_process,
+    "qwen3_vl.VisionModel.fast_pos_embed_interpolate": _hf_qwen3vl.Qwen3VLVisionModel.fast_pos_embed_interpolate,
+    "qwen3_vl.VisionModel.rot_pos_emb": _hf_qwen3vl.Qwen3VLVisionModel.rot_pos_emb,
+    "qwen3_vl.VisionModel.forward": _hf_qwen3vl.Qwen3VLVisionModel.forward,
+    "qwen3_vl.Model.cls": _hf_qwen3vl.Qwen3VLModel,
+    "qwen3_vl.CausalLM.cls": _hf_qwen3vl.Qwen3VLForConditionalGeneration,
+    # qwen3_vl_moe (apply_veomni_qwen3vlmoe_patch)
+    "qwen3_vl_moe.CausalLM.cls": _hf_qwen3vlmoe.Qwen3VLMoeForConditionalGeneration,
+    "qwen3_vl_moe.Model.cls": _hf_qwen3vlmoe.Qwen3VLMoeModel,
+    "qwen3_vl_moe.TextModel._deepstack_process": _hf_qwen3vlmoe.Qwen3VLMoeTextModel._deepstack_process,
+    "qwen3_vl_moe.VisionModel.forward": _hf_qwen3vlmoe.Qwen3VLMoeVisionModel.forward,
+    "qwen3_vl_moe.VisionAttention.forward": _hf_qwen3vlmoe.Qwen3VLMoeVisionAttention.forward,
+    "qwen3_vl_moe.TextSparseMoeBlock.forward": _hf_qwen3vlmoe.Qwen3VLMoeTextSparseMoeBlock.forward,
+    "qwen3_vl_moe.TextExperts.cls": _hf_qwen3vlmoe.Qwen3VLMoeTextExperts,
+    # qwen2_5_omni (apply_veomni_qwen25omni_patch)
+    "qwen2_5_omni.CausalLM.cls": _hf_qwen25omni.Qwen2_5OmniForConditionalGeneration,
+    "qwen2_5_omni.ThinkerCausalLM.cls": _hf_qwen25omni.Qwen2_5OmniThinkerForConditionalGeneration,
+    "qwen2_5_omni.VisionEncoder.cls": _hf_qwen25omni.Qwen2_5OmniVisionEncoder,
+    "qwen2_5_omni.AudioEncoder.cls": _hf_qwen25omni.Qwen2_5OmniAudioEncoder,
+    "qwen2_5_omni.VisionAttention.forward": _hf_qwen25omni.Qwen2_5OmniVisionAttention.forward,
+    "qwen2_5_omni.PreTrainedForCondGen.get_rope_index": (
+        _hf_qwen25omni.Qwen2_5OmniPreTrainedModelForConditionalGeneration.get_rope_index
+    ),
+    # qwen3_omni_moe (apply_veomni_qwen3_omni_moe_patch). `_no_split_modules`
+    # is a list class attribute; copy it so a future in-place mutation can't
+    # corrupt the snapshot.
+    "qwen3_omni_moe.PreTrained._no_split_modules": list(_hf_q3omnimoe.Qwen3OmniMoePreTrainedModel._no_split_modules),
+    "qwen3_omni_moe.PreTrainedForCondGen.get_rope_index": (
+        _hf_q3omnimoe.Qwen3OmniMoePreTrainedModelForConditionalGeneration.get_rope_index
+    ),
+    "qwen3_omni_moe.PreTrained.init_weights": _hf_q3omnimoe.Qwen3OmniMoePreTrainedModel._init_weights,
+    "qwen3_omni_moe.VisionAttention.forward": _hf_q3omnimoe.Qwen3OmniMoeVisionAttention.forward,
+    "qwen3_omni_moe.VisionEncoder.cls": _hf_q3omnimoe.Qwen3OmniMoeVisionEncoder,
+    "qwen3_omni_moe.AudioEncoder.cls": _hf_q3omnimoe.Qwen3OmniMoeAudioEncoder,
+    "qwen3_omni_moe.ThinkerTextModel.cls": _hf_q3omnimoe.Qwen3OmniMoeThinkerTextModel,
+    "qwen3_omni_moe.ThinkerTextSparseMoeBlock.cls": _hf_q3omnimoe.Qwen3OmniMoeThinkerTextSparseMoeBlock,
+    "qwen3_omni_moe.ThinkerCausalLM.cls": _hf_q3omnimoe.Qwen3OmniMoeThinkerForConditionalGeneration,
+    "qwen3_omni_moe.CausalLM.cls": _hf_q3omnimoe.Qwen3OmniMoeForConditionalGeneration,
 }
 
 
 def apply_veomni_hf_unpatch():
     """Undo in-place veomni monkey-patches on HF model modules.
 
-    `apply_veomni_*_patch()` in each of `qwen3/`, `qwen3_moe/`, `deepseek_v3/`
-    mutates the HF model modules directly (forward swaps, class swaps, new
-    `get_parallel_plan` methods). Without this restore, the first parametrize
-    case to build a veomni model leaks its patches into every subsequent HF
-    build in the same test session.
+    `apply_veomni_*_patch()` in each of `qwen3/`, `qwen3_moe/`, `deepseek_v3/`,
+    `qwen2_vl/`, `qwen2_5vl/`, `qwen3_vl/`, `qwen3_vl_moe/`, `qwen2_5_omni/`
+    and `qwen3_omni_moe/` mutates the HF model modules directly (forward swaps,
+    class swaps, new `get_parallel_plan` / `dummy_forward` methods). Without
+    this restore, the first parametrize case to build a veomni model leaks
+    its patches into every subsequent HF build in the same test session,
+    silently turning HF-vs-VeOmni comparisons into VeOmni-vs-VeOmni.
     """
     # Step 1: restore in-class forward methods on pristine class objects.
     # This handles both the always-on forward swaps and the Triton branch's
@@ -99,9 +159,43 @@ def apply_veomni_hf_unpatch():
     _hf_ds3.DeepseekV3ForCausalLM.forward = _PRISTINE_HF["ds3.CausalLM.forward"]
     _hf_ds3.DeepseekV3PreTrainedModel._init_weights = _PRISTINE_HF["ds3.PreTrained.init_weights"]
 
+    # qwen2_vl: VisionAttention.forward only — class swaps are handled in step 2.
+    _hf_qwen2vl.VisionAttention.forward = _PRISTINE_HF["qwen2_vl.VisionAttention.forward"]
+    # qwen2_5_vl: vision-tower forwards on classes that aren't themselves swapped.
+    _hf_qwen25vl.Qwen2_5_VLVisionAttention.forward = _PRISTINE_HF["qwen2_5_vl.VisionAttention.forward"]
+    _hf_qwen25vl.Qwen2_5_VisionTransformerPretrainedModel.forward = _PRISTINE_HF["qwen2_5_vl.VisionPretrained.forward"]
+    # qwen3_vl: vision-tower + text-model in-class methods.
+    _hf_qwen3vl.Qwen3VLVisionAttention.forward = _PRISTINE_HF["qwen3_vl.VisionAttention.forward"]
+    _hf_qwen3vl.Qwen3VLTextModel._deepstack_process = _PRISTINE_HF["qwen3_vl.TextModel._deepstack_process"]
+    _hf_qwen3vl.Qwen3VLVisionModel.fast_pos_embed_interpolate = _PRISTINE_HF[
+        "qwen3_vl.VisionModel.fast_pos_embed_interpolate"
+    ]
+    _hf_qwen3vl.Qwen3VLVisionModel.rot_pos_emb = _PRISTINE_HF["qwen3_vl.VisionModel.rot_pos_emb"]
+    _hf_qwen3vl.Qwen3VLVisionModel.forward = _PRISTINE_HF["qwen3_vl.VisionModel.forward"]
+    # qwen3_vl_moe: vision + text-MoE in-class methods.
+    _hf_qwen3vlmoe.Qwen3VLMoeTextModel._deepstack_process = _PRISTINE_HF["qwen3_vl_moe.TextModel._deepstack_process"]
+    _hf_qwen3vlmoe.Qwen3VLMoeVisionModel.forward = _PRISTINE_HF["qwen3_vl_moe.VisionModel.forward"]
+    _hf_qwen3vlmoe.Qwen3VLMoeVisionAttention.forward = _PRISTINE_HF["qwen3_vl_moe.VisionAttention.forward"]
+    _hf_qwen3vlmoe.Qwen3VLMoeTextSparseMoeBlock.forward = _PRISTINE_HF["qwen3_vl_moe.TextSparseMoeBlock.forward"]
+    # qwen2_5_omni: vision-attention forward + rope-index method.
+    _hf_qwen25omni.Qwen2_5OmniVisionAttention.forward = _PRISTINE_HF["qwen2_5_omni.VisionAttention.forward"]
+    _hf_qwen25omni.Qwen2_5OmniPreTrainedModelForConditionalGeneration.get_rope_index = _PRISTINE_HF[
+        "qwen2_5_omni.PreTrainedForCondGen.get_rope_index"
+    ]
+    # qwen3_omni_moe: vision-attention forward + a few PreTrained-class attributes.
+    _hf_q3omnimoe.Qwen3OmniMoePreTrainedModel._no_split_modules = list(
+        _PRISTINE_HF["qwen3_omni_moe.PreTrained._no_split_modules"]
+    )
+    _hf_q3omnimoe.Qwen3OmniMoePreTrainedModelForConditionalGeneration.get_rope_index = _PRISTINE_HF[
+        "qwen3_omni_moe.PreTrainedForCondGen.get_rope_index"
+    ]
+    _hf_q3omnimoe.Qwen3OmniMoePreTrainedModel._init_weights = _PRISTINE_HF["qwen3_omni_moe.PreTrained.init_weights"]
+    _hf_q3omnimoe.Qwen3OmniMoeVisionAttention.forward = _PRISTINE_HF["qwen3_omni_moe.VisionAttention.forward"]
+
     # Step 2: restore module-level names for classes / functions that the
     # Liger branch swaps out wholesale, plus the class swaps done by the
-    # always-on patch (Qwen3MoeSparseMoeBlock, DeepseekV3MoE).
+    # always-on patch (Qwen3MoeSparseMoeBlock, DeepseekV3MoE, every VLM/Omni
+    # *ForConditionalGeneration / *Model, etc.).
     _hf_qwen3.apply_rotary_pos_emb = _PRISTINE_HF["qwen3.apply_rotary_pos_emb"]
     _hf_qwen3.Qwen3RMSNorm = _PRISTINE_HF["qwen3.RMSNorm.cls"]
     _hf_qwen3.Qwen3MLP = _PRISTINE_HF["qwen3.MLP.cls"]
@@ -115,8 +209,46 @@ def apply_veomni_hf_unpatch():
     _hf_ds3.DeepseekV3RMSNorm = _PRISTINE_HF["ds3.RMSNorm.cls"]
     _hf_ds3.DeepseekV3MLP = _PRISTINE_HF["ds3.MLP.cls"]
 
-    # Step 3: remove `get_parallel_plan` methods injected onto HF causal-LM
-    # classes by apply_veomni_*_patch.
+    _hf_qwen2vl.Qwen2VLForConditionalGeneration = _PRISTINE_HF["qwen2_vl.CausalLM.cls"]
+    _hf_qwen2vl.Qwen2VLModel = _PRISTINE_HF["qwen2_vl.Model.cls"]
+    _hf_qwen2vl.Qwen2VisionTransformerPretrainedModel = _PRISTINE_HF["qwen2_vl.VisionPretrained.cls"]
+    _hf_qwen2vl.Qwen2VLDecoderLayer = _PRISTINE_HF["qwen2_vl.DecoderLayer.cls"]
+
+    _hf_qwen25vl.Qwen2_5_VLModel = _PRISTINE_HF["qwen2_5_vl.Model.cls"]
+    _hf_qwen25vl.Qwen2_5_VLForConditionalGeneration = _PRISTINE_HF["qwen2_5_vl.CausalLM.cls"]
+
+    _hf_qwen3vl.Qwen3VLTextAttention = _PRISTINE_HF["qwen3_vl.TextAttention.cls"]
+    _hf_qwen3vl.Qwen3VLModel = _PRISTINE_HF["qwen3_vl.Model.cls"]
+    _hf_qwen3vl.Qwen3VLForConditionalGeneration = _PRISTINE_HF["qwen3_vl.CausalLM.cls"]
+
+    _hf_qwen3vlmoe.Qwen3VLMoeForConditionalGeneration = _PRISTINE_HF["qwen3_vl_moe.CausalLM.cls"]
+    _hf_qwen3vlmoe.Qwen3VLMoeModel = _PRISTINE_HF["qwen3_vl_moe.Model.cls"]
+    _hf_qwen3vlmoe.Qwen3VLMoeTextExperts = _PRISTINE_HF["qwen3_vl_moe.TextExperts.cls"]
+
+    _hf_qwen25omni.Qwen2_5OmniForConditionalGeneration = _PRISTINE_HF["qwen2_5_omni.CausalLM.cls"]
+    _hf_qwen25omni.Qwen2_5OmniThinkerForConditionalGeneration = _PRISTINE_HF["qwen2_5_omni.ThinkerCausalLM.cls"]
+    _hf_qwen25omni.Qwen2_5OmniVisionEncoder = _PRISTINE_HF["qwen2_5_omni.VisionEncoder.cls"]
+    _hf_qwen25omni.Qwen2_5OmniAudioEncoder = _PRISTINE_HF["qwen2_5_omni.AudioEncoder.cls"]
+
+    _hf_q3omnimoe.Qwen3OmniMoeVisionEncoder = _PRISTINE_HF["qwen3_omni_moe.VisionEncoder.cls"]
+    _hf_q3omnimoe.Qwen3OmniMoeAudioEncoder = _PRISTINE_HF["qwen3_omni_moe.AudioEncoder.cls"]
+    _hf_q3omnimoe.Qwen3OmniMoeThinkerTextModel = _PRISTINE_HF["qwen3_omni_moe.ThinkerTextModel.cls"]
+    _hf_q3omnimoe.Qwen3OmniMoeThinkerTextSparseMoeBlock = _PRISTINE_HF["qwen3_omni_moe.ThinkerTextSparseMoeBlock.cls"]
+    _hf_q3omnimoe.Qwen3OmniMoeThinkerForConditionalGeneration = _PRISTINE_HF["qwen3_omni_moe.ThinkerCausalLM.cls"]
+    _hf_q3omnimoe.Qwen3OmniMoeForConditionalGeneration = _PRISTINE_HF["qwen3_omni_moe.CausalLM.cls"]
+
+    # Step 3: remove `get_parallel_plan` / `dummy_forward` methods that the
+    # patches inject onto HF classes (no native version to restore to).
     for cls in (_hf_qwen3_moe.Qwen3MoeForCausalLM, _hf_ds3.DeepseekV3ForCausalLM):
         if "get_parallel_plan" in cls.__dict__:
             delattr(cls, "get_parallel_plan")
+    for cls in (_hf_qwen3vlmoe.Qwen3VLMoePreTrainedModel, _hf_q3omnimoe.Qwen3OmniMoePreTrainedModel):
+        if "get_parallel_plan" in cls.__dict__:
+            delattr(cls, "get_parallel_plan")
+    for cls in (
+        _hf_qwen25vl.Qwen2_5_VisionTransformerPretrainedModel,
+        _hf_qwen3vl.Qwen3VLVisionModel,
+        _hf_qwen3vlmoe.Qwen3VLMoeVisionModel,
+    ):
+        if "dummy_forward" in cls.__dict__:
+            delattr(cls, "dummy_forward")

--- a/tests/models/test_models_logits_equal.py
+++ b/tests/models/test_models_logits_equal.py
@@ -10,7 +10,13 @@ from typing import Optional
 import pytest
 import torch
 
-from veomni.utils.device import IS_CUDA_AVAILABLE, empty_cache, get_device_type, get_torch_device
+from veomni.utils.device import (
+    IS_CUDA_AVAILABLE,
+    empty_cache,
+    get_device_type,
+    get_dist_comm_backend,
+    get_torch_device,
+)
 
 # Importing `hf_unpatch` here (rather than from `utils`) captures pristine HF
 # class attributes before any veomni import has a chance to monkey-patch them,
@@ -43,16 +49,15 @@ _DTYPE_MAP = {"float32": torch.float32, "bfloat16": torch.bfloat16}
 
 @dataclass(frozen=True)
 class Case:
-    """A test case pairing an HF model config with a veomni build.
+    """One bitwise-equal comparison between a native HF build and a VeOmni build.
 
-    HF is random-initialised from the toy config; its state dict is then
-    copied into the veomni model. `sync_weight_key` selects a layout
-    adapter from `tests/models/weight_sync_adapters.py`; needed for MoE
-    models whose veomni layout stacks experts into a single tensor.
-
-    `attn_implementation` is passed through to both HF and veomni. For
-    `"flash_attention_2"` the dtype must be bf16/fp16 (FA2 requirement),
-    so each case pairs an attention backend with the appropriate dtype.
+    `sync_weight_key` -> a layout adapter in `weight_sync_adapters.py`;
+    needed for MoE models whose VeOmni layout stacks experts.
+    `attn_implementation` is forwarded to both sides; FA2 requires bf16.
+    The HF class is resolved from `config.architectures[0]` (no per-case
+    override). `forward_attr` targets a submodule (`model.thinker` for
+    Omni) while state-dict load still happens at the root, so the talker /
+    vision sub-modules get the same random init on both sides.
     """
 
     case_id: str
@@ -60,18 +65,55 @@ class Case:
     sync_weight_key: Optional[str]
     attn_implementation: str = "eager"
     dtype: str = "float32"
+    forward_attr: Optional[str] = None
 
 
 def _toy(name: str) -> str:
     return os.path.join(REPO_ROOT, "tests", "toy_config", name)
 
 
+# Scope: transformers v4, single CUDA rank.
+# Causal-LM cases use text-only input_ids (shape (1, 32), vocab floor
+# 32000 to dodge every 151xxx multimodal placeholder id).
+# VL / Omni cases add a dummy 2x2 image (1 placeholder token after merger)
+# so the visual tower actually runs. Audio is a follow-up: Omni passes
+# zero `audio_mask` to satisfy the patched asserts but no `input_features`,
+# so the audio tower stays dark.
+#
+# Two MoE families (qwen3_vl_moe, qwen3_omni_moe) skip the eager+fp32
+# variant: HF v4 `_init_weights` hard-codes bf16 for the language tower,
+# so an fp32 case there would just be testing a half-cast model.
 CASES = [
+    # ---- text-only causal-LM ----
     # eager + fp32
+    Case("qwen2_5-toy-eager", _toy("qwen25_toy"), sync_weight_key=None),
+    Case("llama3_1-toy-eager", _toy("llama31_toy"), sync_weight_key=None),
+    Case("seed_oss-toy-eager", _toy("seed_oss_toy"), sync_weight_key=None),
     Case("qwen3-toy-eager", _toy("qwen3_toy"), sync_weight_key=None),
     Case("qwen3_moe-toy-eager", _toy("qwen3_moe_toy"), sync_weight_key="qwen3_moe"),
     Case("deepseek_v3-toy-eager", _toy("deepseek_v3_toy"), sync_weight_key="deepseek_v3"),
     # flash_attention_2 + bf16 (FA2 does not support fp32)
+    Case(
+        "qwen2_5-toy-fa2",
+        _toy("qwen25_toy"),
+        sync_weight_key=None,
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+    Case(
+        "llama3_1-toy-fa2",
+        _toy("llama31_toy"),
+        sync_weight_key=None,
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+    Case(
+        "seed_oss-toy-fa2",
+        _toy("seed_oss_toy"),
+        sync_weight_key=None,
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
     Case(
         "qwen3-toy-fa2",
         _toy("qwen3_toy"),
@@ -93,6 +135,75 @@ CASES = [
         attn_implementation="flash_attention_2",
         dtype="bfloat16",
     ),
+    # ---- VLMs ----
+    # eager + fp32
+    Case("qwen2_vl-toy-eager", _toy("qwen2vl_toy"), sync_weight_key=None),
+    Case("qwen2_5_vl-toy-eager", _toy("qwen25vl_toy"), sync_weight_key=None),
+    Case("qwen3_vl-toy-eager", _toy("qwen3vl_toy"), sync_weight_key=None),
+    # flash_attention_2 + bf16
+    Case(
+        "qwen2_vl-toy-fa2",
+        _toy("qwen2vl_toy"),
+        sync_weight_key=None,
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+    Case(
+        "qwen2_5_vl-toy-fa2",
+        _toy("qwen25vl_toy"),
+        sync_weight_key=None,
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+    Case(
+        "qwen3_vl-toy-fa2",
+        _toy("qwen3vl_toy"),
+        sync_weight_key=None,
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+    # qwen3_vl_moe: HF init forces bf16 for the language tower, so only
+    # fa2+bf16 exercises a self-consistent dtype assignment. State-dict
+    # layout already matches between HF and VeOmni (both stack
+    # `experts.gate_up_proj` / `experts.down_proj`), so no sync adapter.
+    Case(
+        "qwen3_vl_moe-toy-fa2",
+        _toy("qwen3vlmoe_toy"),
+        sync_weight_key=None,
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+    # ---- Omni (thinker-only forward) ----
+    # The Omni public class is a thinker+talker wrapper; we run forward on
+    # `model.thinker` so the comparison stays focused on the thinker stack
+    # (text + visual + audio). State-dict load still happens at the root,
+    # so talker/audio/visual sub-modules get the same random init on both
+    # sides.
+    Case(
+        "qwen2_5_omni-toy-eager",
+        _toy("qwen25omni_toy"),
+        sync_weight_key=None,
+        forward_attr="thinker",
+    ),
+    Case(
+        "qwen2_5_omni-toy-fa2",
+        _toy("qwen25omni_toy"),
+        sync_weight_key=None,
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+        forward_attr="thinker",
+    ),
+    # qwen3_omni_moe: HF forces bf16 on the thinker; thinker experts use
+    # per-expert HF layout, stacked on the VeOmni side -> needs the
+    # `qwen3_omni_moe` sync adapter from `weight_sync_adapters.py`.
+    Case(
+        "qwen3_omni_moe-toy-fa2",
+        _toy("qwen3omni_toy"),
+        sync_weight_key="qwen3_omni_moe",
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+        forward_attr="thinker",
+    ),
 ]
 
 
@@ -103,30 +214,177 @@ def _apply_determinism():
     torch.use_deterministic_algorithms(True, warn_only=True)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _single_rank_process_group():
+    """Module-scoped 1-rank process group for the v4 patches' all_gather calls.
+
+    Some patches (qwen2_5_vl) call `dist.all_gather` unconditionally — even
+    at sp_size=1 — and crash without a default group. Teardown only fires
+    if we created the group, so we don't yank state from unrelated tests.
+    Mirrors the test bodies' skip gates so a skip-only environment doesn't
+    pay an init cost.
+    """
+    from veomni.utils.import_utils import is_transformers_version_greater_or_equal_to
+
+    if not IS_CUDA_AVAILABLE or is_transformers_version_greater_or_equal_to("5.0.0"):
+        yield
+        return
+
+    import torch.distributed as dist
+
+    we_initialised = False
+    if not dist.is_initialized():
+        # Bind the accelerator before init_process_group: on multi-GPU CI
+        # hosts the comm library can otherwise pick the wrong visible device
+        # and hang/fail. The IS_CUDA_AVAILABLE gate above already ensures
+        # we have an accelerator here.
+        get_torch_device().set_device(int(os.environ.get("LOCAL_RANK", "0")))
+        dist.init_process_group(backend=get_dist_comm_backend(), rank=0, world_size=1)
+        we_initialised = True
+    try:
+        yield
+    finally:
+        if we_initialised and dist.is_initialized():
+            dist.destroy_process_group()
+
+
 def _release():
     gc.collect()
     if IS_CUDA_AVAILABLE:
         empty_cache()
 
 
+def _resolve_hf_class(config):
+    """Look up the concrete HF class from `config.architectures[0]`.
+
+    Every toy config carries the concrete class name there, so one lookup
+    covers causal-LMs, VLMs, and Omni wrappers — the latter aren't in any
+    `AutoModel*` mapping anyway.
+    """
+    import transformers
+
+    arch = config.architectures[0]
+    return getattr(transformers, arch)
+
+
 def _build_hf_model(case: Case):
     """Return a device-resident, eval-mode HF model randomly initialised from config."""
-    from transformers import AutoConfig, AutoModelForCausalLM
+    from transformers import AutoConfig
 
     apply_veomni_hf_unpatch()
     config = AutoConfig.from_pretrained(case.path)
     torch.manual_seed(0)
     get_torch_device().manual_seed_all(0)
-    # Init directly on device so init-time buffers (e.g. rotary `inv_freq`)
-    # use the same arithmetic path as the veomni build, which allocates under
-    # `torch.device(get_device_type())` via its CustomizedModelingLoader.
+    cls = _resolve_hf_class(config)
+    target_dtype = _DTYPE_MAP[case.dtype]
+    # `_from_config` inits weights directly at `target_dtype` — a
+    # `cls(config).to(bf16)` path would init in fp32 first, producing
+    # different random bytes than VeOmni's bf16-from-the-start build (RNG
+    # output depends on tensor dtype). Allocating on-device matches
+    # VeOmni's init path so rotary `inv_freq` and friends share arithmetic.
     with torch.device(get_device_type()):
-        model_hf = AutoModelForCausalLM.from_config(
+        model_hf = cls._from_config(
             config,
-            torch_dtype=_DTYPE_MAP[case.dtype],
+            torch_dtype=target_dtype,
             attn_implementation=case.attn_implementation,
         )
     return model_hf.eval()
+
+
+# Causal-LM toy configs that have no `vision_config` / `thinker_config` —
+# every forward kwargs construction below stays a no-op for these.
+_CAUSAL_LM_MODEL_TYPES = frozenset({"qwen2", "qwen3", "qwen3_moe", "llama", "seed_oss", "deepseek_v3"})
+
+
+def _vision_section(config):
+    """Return `(vision_config, image_token_id, audio_token_id)` or `(None,)*3`.
+
+    Top-level VLs carry `vision_config` on the root; Omni nests it under
+    `thinker_config`. The placeholder field was renamed `_index` -> `_id`
+    between qwen2_5_omni and qwen3_omni_moe — accept either.
+    """
+    if config.model_type in _CAUSAL_LM_MODEL_TYPES:
+        return None, None, None
+    if hasattr(config, "thinker_config"):
+        cfg = config.thinker_config
+    else:
+        cfg = config
+    vision_config = getattr(cfg, "vision_config", None)
+    if vision_config is None:
+        return None, None, None
+    # Don't `or` — token id 0 is technically valid and would short-circuit.
+    image_token = getattr(cfg, "image_token_index", None)
+    if image_token is None:
+        image_token = getattr(cfg, "image_token_id", None)
+    audio_token = getattr(cfg, "audio_token_index", None)
+    if audio_token is None:
+        audio_token = getattr(cfg, "audio_token_id", None)
+    return vision_config, image_token, audio_token
+
+
+def _make_inputs(case: Case, config, device, dtype):
+    """Build `(input_ids, forward_kwargs)` for the case.
+
+    Causal-LM: text-only `(1, 32)` ids, vocab floor 32000 dodges every
+    151xxx multimodal placeholder.
+
+    VL / Omni: same base ids but the first
+    `n_tokens = grid_t * grid_h * grid_w // spatial_merge_size**2` positions
+    hold `image_token_id`, alongside dummy `pixel_values` +
+    `image_grid_thw = [[1, 2, 2]]`. `n_tokens` matches what the merger
+    emits, so the patched `masked_scatter` consumes every embedding once.
+    `pixel_values` shape comes from `vision_config` (qwen2/2.5: patch_size
+    14; qwen3: 16). `image_mask` / `video_mask` (and `audio_mask` for
+    Omni) are passed explicitly because the patches otherwise call
+    `dist.all_gather` to recompute them. Audio is a follow-up: Omni
+    passes zero `audio_mask` for the asserts but no `input_features`.
+    """
+    base_gen = torch.Generator(device=device).manual_seed(0)
+    base_input_ids = torch.randint(0, 32000, (1, 32), device=device, dtype=torch.long, generator=base_gen)
+
+    vision_config, image_token_id, _ = _vision_section(config)
+    if vision_config is None:
+        return base_input_ids, {}
+
+    patch_size = getattr(vision_config, "patch_size", 14)
+    temporal_patch_size = getattr(vision_config, "temporal_patch_size", 2)
+    in_channels = getattr(vision_config, "in_channels", getattr(vision_config, "in_chans", 3))
+    spatial_merge_size = getattr(vision_config, "spatial_merge_size", 2)
+
+    grid_t, grid_h, grid_w = 1, spatial_merge_size, spatial_merge_size
+    num_patches = grid_t * grid_h * grid_w
+    n_tokens = num_patches // (spatial_merge_size**2)
+    feat_dim = in_channels * temporal_patch_size * patch_size * patch_size
+
+    pix_gen = torch.Generator(device=device).manual_seed(1)
+    pixel_values = torch.randn(num_patches, feat_dim, dtype=dtype, device=device, generator=pix_gen)
+    image_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]], dtype=torch.long, device=device)
+
+    input_ids = base_input_ids.clone()
+    input_ids[0, :n_tokens] = image_token_id
+
+    image_mask = input_ids == image_token_id
+    video_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+
+    forward_kwargs = {
+        "pixel_values": pixel_values,
+        "image_grid_thw": image_grid_thw,
+        "image_mask": image_mask,
+        "video_mask": video_mask,
+    }
+    if case.forward_attr == "thinker":
+        forward_kwargs["audio_mask"] = torch.zeros_like(input_ids, dtype=torch.bool)
+    return input_ids, forward_kwargs
+
+
+def _forward_target(model, case: Case):
+    """Return the submodule we run forward on (`model` itself by default)."""
+    if case.forward_attr is None:
+        return model
+    target = model
+    for part in case.forward_attr.split("."):
+        target = getattr(target, part)
+    return target
 
 
 def _build_veomni_model(case: Case, hf_state_dict):
@@ -178,26 +436,36 @@ def test_logits_bitwise_equal(case: Case):
     if case.attn_implementation == "flash_attention_2" and importlib.util.find_spec("flash_attn") is None:
         pytest.skip("flash_attn package not installed.")
 
-    _apply_determinism()
+    from transformers import AutoConfig
 
+    _apply_determinism()
     device_type = get_device_type()
-    gen = torch.Generator(device=device_type).manual_seed(0)
-    # Vocab floor of 32000 dodges special tokens across Qwen3 (151936),
-    # Qwen3MoE (151936), and DeepseekV3 (129280).
-    input_ids = torch.randint(0, 32000, (1, 32), device=device_type, dtype=torch.long, generator=gen)
+    target_dtype = _DTYPE_MAP[case.dtype]
+    config = AutoConfig.from_pretrained(case.path)
+    input_ids, fwd_kwargs = _make_inputs(case, config, device_type, target_dtype)
 
     # --- HF phase (must precede any veomni model build) ---
     model_hf = _build_hf_model(case)
     with torch.no_grad():
-        logits_hf = model_hf(input_ids=input_ids, use_cache=False).logits.detach().clone()
+        logits_hf = (
+            _forward_target(model_hf, case)(input_ids=input_ids.clone(), use_cache=False, **fwd_kwargs)
+            .logits.detach()
+            .clone()
+        )
     hf_state_dict = copy.deepcopy(model_hf.state_dict())
     del model_hf
     _release()
 
     # --- veomni phase ---
+    # `input_ids.clone()` — the patched Omni thinker zeroes placeholder
+    # positions in-place before embedding, so reuse a fresh tensor.
     model_ve = _build_veomni_model(case, hf_state_dict)
     with torch.no_grad():
-        logits_ve = model_ve(input_ids=input_ids, use_cache=False).logits.detach().clone()
+        logits_ve = (
+            _forward_target(model_ve, case)(input_ids=input_ids.clone(), use_cache=False, **fwd_kwargs)
+            .logits.detach()
+            .clone()
+        )
     del model_ve, hf_state_dict
     _release()
 
@@ -255,63 +523,33 @@ def _save_hf_checkpoint(state_dict: dict, config, dst_dir: str) -> None:
 
 
 def _build_veomni_model_via_runtime_converter(case: Case, hf_state_dict, hf_buffers, config, weights_dir: str):
-    """Build VeOmni model by going through `build_foundation_model(weights_path=...)`.
+    """Build a VeOmni model by routing load through the runtime converter.
 
-    This is the path real users hit after this PR: pass the original HF checkpoint
-    directly, let the v4 converter stack per-expert keys at load time. No manual
-    sync adapter, no offline merge.
+    This is the path real users hit: a per-expert HF checkpoint dir that
+    the v4 stacking converter consumes at load time, no offline merge.
 
-    Why we patch non-persistent buffers below
-    -----------------------------------------
+    Why we restore HF's non-persistent buffers after load
+    -----------------------------------------------------
+    The rotary `inv_freq` is registered `persistent=False`, so it isn't in
+    the safetensors. On the `weights_path != None` path, the model is built
+    under `init_empty_weights()`, which patches `register_parameter` but
+    not `register_buffer` — so `inv_freq` is computed on CPU during
+    `__init__`, snapshotted, then `.to(device)`-copied to CUDA. That
+    CPU-computed-then-moved value differs from a directly-on-CUDA
+    `1.0 / (base ** ...)` by one ULP, propagating into a non-zero logits
+    delta (~1e-6 qwen3_moe, ~3e-3 deepseek_v3) — enough to fail
+    `torch.equal`.
 
-    The HF rotary `inv_freq` buffer is registered with ``persistent=False`` in
-    upstream transformers, so it is **not** in ``model.state_dict()`` and therefore
-    does not round-trip through safetensors. Whatever values end up in
-    ``model.rotary_emb.inv_freq`` after load come entirely from VeOmni's loader
-    init flow, not from the checkpoint.
+    This is a pre-existing loader-level quirk on path 2, not a converter
+    regression: every offline-merged MoE checkpoint loaded through
+    `weights_path=<merged_dir>` hits the same CPU->CUDA `inv_freq` move.
+    The sibling test (`weights_path is None`) builds under
+    `with torch.device(init_device)` and so dodges it.
 
-    VeOmni's loader has two construction paths in
-    ``CustomizedModelingLoader.load_model``:
-
-    1. ``weights_path is None`` (random-init build, used by the sibling
-       ``test_logits_bitwise_equal``): the model is constructed under
-       ``with torch.device(init_device)``. The rotary embedding's
-       ``inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float() / dim))``
-       executes directly on CUDA, bit-matching the HF reference build which
-       does the same.
-
-    2. ``weights_path != None`` (every real training run, including offline-
-       merged MoE checkpoints from the pre-PR world): the model is
-       constructed under ``init_empty_weights() + no_init_weights()``. Note
-       that accelerate's ``init_empty_weights()`` patches ``register_parameter``
-       to use the meta device, but by default does **not** patch
-       ``register_buffer`` — so the rotary embedding's ``inv_freq`` math runs
-       as a regular **CPU** tensor during ``__init__``. ``load_model_weights``
-       then snapshots ``buffer_dict = {n: b.clone() for n, b in named_buffers()}``
-       (CPU values), runs ``model.to_empty(device=init_device)`` (which wipes
-       buffer storage to uninitialized memory on CUDA), and finally
-       ``post_process_after_weight_loading`` calls ``_dispatch_buffer`` which
-       does ``buf.to(device, dtype)`` — a bit-exact CPU→CUDA copy. So
-       ``inv_freq`` ends up as **CPU-computed** ``1.0 / (base ** ...)`` moved
-       to CUDA, which differs from CUDA-computed ``1.0 / (base ** ...)`` by
-       one ULP per element.
-
-    That 1-ULP gap propagates through attention into a small but non-zero
-    logits delta — enough to fail ``torch.equal`` (we observed ~1e-6 for
-    qwen3_moe and ~3e-3 for deepseek_v3). It is a **pre-existing property of
-    path 2**, not something this PR's converter introduced: every offline-
-    merged MoE checkpoint loaded through ``weights_path=<merged_dir>`` had
-    the same CPU→CUDA ``inv_freq`` move. The sibling test simply never tripped
-    on it because it uses path 1.
-
-    To keep this smoke test a true bitwise check on the converter's
-    *parameter* loading — and not a regression test for a separate loader-
-    level fp jitter that would belong in its own fix — we copy HF's
-    non-persistent buffers into the model after load.
-
-    A proper loader-level fix would be to call ``init_empty_weights(
-    include_buffers=True)`` and recompute buffers on ``init_device`` after
-    ``to_empty``. That is out of scope here; tracked separately.
+    Restoring HF's buffers after load keeps this test a bitwise check on
+    the converter's *parameter* loading. A proper loader fix
+    (`init_empty_weights(include_buffers=True)` + recompute on
+    `init_device` after `to_empty`) is tracked separately.
     """
     from veomni.models.auto import build_foundation_model
 
@@ -344,22 +582,16 @@ def _build_veomni_model_via_runtime_converter(case: Case, hf_state_dict, hf_buff
 
 @pytest.mark.parametrize("case", _RUNTIME_CONVERTER_CASES, ids=[c.case_id for c in _RUNTIME_CONVERTER_CASES])
 def test_logits_bitwise_equal_via_runtime_converter(case: Case):
-    """Smoke test: per-expert HF checkpoint -> on-the-fly converter -> bitwise-equal forward.
+    """Smoke test: HF checkpoint -> runtime converter -> bitwise-equal forward.
 
-    Complements ``test_logits_bitwise_equal``: that one syncs HF weights into
-    the VeOmni model via the manual adapter in ``weight_sync_adapters.py``.
-    This one saves the HF state dict to disk as a real HF checkpoint and
-    routes loading through ``load_model_weights`` -> ``MoEV4StackingConverter``,
-    exercising the same code path users hit when pointing training at a vanilla
-    HF model dir. Bitwise-equal logits prove the runtime converter produces
-    the exact same stacked parameter tensors the manual adapter does.
+    Complements `test_logits_bitwise_equal`: that one syncs HF weights via
+    the manual adapter; this one writes a real per-expert HF checkpoint and
+    routes loading through `MoEV4StackingConverter`, the path users hit
+    with a vanilla HF model dir. Bitwise-equal logits prove the converter
+    produces the exact same stacked tensors the manual adapter does.
 
-    Note on non-persistent buffers: ``_build_veomni_model_via_runtime_converter``
-    copies HF's ``inv_freq`` (and any other ``persistent=False`` buffers) into
-    the loaded model before the forward. That step works around a separate,
-    pre-existing loader quirk on the ``weights_path != None`` path that has
-    nothing to do with this PR's converter — see the helper's docstring for
-    the full explanation.
+    See `_build_veomni_model_via_runtime_converter` for why HF's
+    non-persistent buffers are restored before the forward.
     """
     from transformers import AutoConfig
 
@@ -377,16 +609,20 @@ def test_logits_bitwise_equal_via_runtime_converter(case: Case):
     _apply_determinism()
 
     device_type = get_device_type()
-    gen = torch.Generator(device=device_type).manual_seed(0)
-    input_ids = torch.randint(0, 32000, (1, 32), device=device_type, dtype=torch.long, generator=gen)
+    target_dtype = _DTYPE_MAP[case.dtype]
+    hf_config = AutoConfig.from_pretrained(case.path)
+    input_ids, fwd_kwargs = _make_inputs(case, hf_config, device_type, target_dtype)
 
     # --- HF phase (must precede any veomni model build, same as the sibling test) ---
     model_hf = _build_hf_model(case)
     with torch.no_grad():
-        logits_hf = model_hf(input_ids=input_ids, use_cache=False).logits.detach().clone()
+        logits_hf = (
+            _forward_target(model_hf, case)(input_ids=input_ids.clone(), use_cache=False, **fwd_kwargs)
+            .logits.detach()
+            .clone()
+        )
     hf_state_dict = copy.deepcopy(model_hf.state_dict())
     hf_buffers = {n: b.detach().clone() for n, b in model_hf.named_buffers()}
-    hf_config = AutoConfig.from_pretrained(case.path)
     del model_hf
     _release()
 
@@ -395,7 +631,11 @@ def test_logits_bitwise_equal_via_runtime_converter(case: Case):
     try:
         model_ve = _build_veomni_model_via_runtime_converter(case, hf_state_dict, hf_buffers, hf_config, tmp_dir)
         with torch.no_grad():
-            logits_ve = model_ve(input_ids=input_ids, use_cache=False).logits.detach().clone()
+            logits_ve = (
+                _forward_target(model_ve, case)(input_ids=input_ids.clone(), use_cache=False, **fwd_kwargs)
+                .logits.detach()
+                .clone()
+            )
         del model_ve
         _release()
     finally:

--- a/tests/toy_config/qwen25omni_toy/config.json
+++ b/tests/toy_config/qwen25omni_toy/config.json
@@ -1,6 +1,6 @@
 {
     "architectures": [
-      "Qwen2_5OmniModel"
+      "Qwen2_5OmniForConditionalGeneration"
     ],
     "enable_audio_output": false,
     "enable_talker": true,


### PR DESCRIPTION
### What does this PR do?

> Adds a single-GPU bitwise logits-equality test (`tests/models/test_models_logits_equal.py`) that compares pristine HuggingFace forwards against VeOmni's monkey-patched HF models on transformers v4. Coverage spans causal-LM (qwen2.5, llama3.1, seed_oss, qwen3, qwen3_moe, deepseek_v3), VLM (qwen2_vl, qwen2_5_vl, qwen3_vl, qwen3_vl_moe), and Omni thinker (qwen2_5_omni, qwen3_omni_moe) families. VL and Omni cases run a real multimodal forward — a single dummy 2x2 image — so the visual tower actually executes; the comparison guards against silent numerical drift in both the language and visual stacks.
>
> Two parallel test functions: `test_logits_bitwise_equal` exercises every family via the manual layout adapter in `tests/models/weight_sync_adapters.py`; `test_logits_bitwise_equal_via_runtime_converter` covers the MoE families (qwen3_moe, deepseek_v3) through the `MoEV4StackingConverter` path real users hit when pointing at a vanilla HF checkpoint dir.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A
- PR title follows `[{modules}] {type}: {description}` format

### Test

> 26/26 cases (22 forward + 4 runtime-converter) pass on a single A100 in ~38s under the existing `transformers-stable` group (transformers 4.57.3).
>
> CI: `.github/workflows/gpu_unit_tests.yml` already runs `tests/models/` under transformers v4, so the new file is picked up without workflow edits. Module-wide skip gates (`is_transformers_version_greater_or_equal_to("5.0.0")`, `IS_CUDA_AVAILABLE`) make the file a no-op outside that scope, and the autouse process-group fixture mirrors those gates so a transformers v5 environment does not pay an unnecessary NCCL init.

### API and Usage Example

> N/A — test-only change.

### Design & Code Changes

> - **Test scaffolding**. `tests/models/test_models_logits_equal.py` parametrises cases pairing HF toy configs with VeOmni builds. HF runs first (before any VeOmni import that could monkey-patch HF classes), state-dict is copied to VeOmni via `weight_sync_adapters`, then bitwise equality is asserted on the logits.
>
> - **HF class resolution.** No per-case `hf_class` override; `_resolve_hf_class(config)` looks up `config.architectures[0]` against the `transformers` namespace, which works uniformly for plain causal-LMs (`Qwen2ForCausalLM` ...), VLMs (`Qwen2_5_VLForConditionalGeneration` ...), and the Omni wrappers (`Qwen2_5OmniForConditionalGeneration` ...). Construction goes through `cls._from_config(config, torch_dtype=..., attn_implementation=...)` so weight-init RNG sees the requested dtype directly — a `cls(config).to(bf16)` path would init in fp32 first, breaking bitwise equality against VeOmni's bf16-from-the-start build.
>
> - **Forward inputs.** `_make_inputs(case, config, device, dtype)` is the single place that builds input_ids + forward kwargs:
>   - Causal-LM: text-only forward, vocab floor 32000 dodges every 151xxx multimodal placeholder id.
>   - VL / Omni: same base ids, but the first `n_tokens = grid_t * grid_h * grid_w // spatial_merge_size**2` positions are overwritten with `image_token_id` and dummy `pixel_values` + `image_grid_thw = [[1, 2, 2]]` are passed alongside, so the visual tower runs and the patched `masked_scatter` consumes every image embedding exactly once. `pixel_values` shape and dtype are derived from `vision_config` (qwen2/2.5: patch_size=14; qwen3: patch_size=16). `image_mask` / `video_mask` (and `audio_mask` for Omni) are passed explicitly because the VeOmni patches otherwise call `dist.all_gather` on input_ids to recompute them.
>   - Audio (`input_features`) is a follow-up: Omni cases pass zero `audio_mask` to satisfy the patched asserts, but no `input_features` means the audio tower stays dark.
>
> - **Process group fixture.** `_single_rank_process_group` is a module-scoped 1-rank NCCL group required by the qwen2_5_vl patch's unconditional `dist.all_gather`. Before init it binds the accelerator via `get_torch_device().set_device(LOCAL_RANK)` so multi-GPU CI hosts don't have NCCL pick the wrong visible device. Init/destroy is gated on whether the fixture itself created the group, and it mirrors the test bodies' transformers-version + CUDA skip gates so a skip-only environment doesn't pay an init cost.
>
> - **HF class restoration (`tests/models/hf_unpatch.py`).** Extended to cover every `apply_veomni_*_patch()` site for the added VLM / Omni families (qwen2_vl, qwen2_5_vl, qwen3_vl, qwen3_vl_moe, qwen2_5_omni, qwen3_omni_moe). These patches do in-place class swaps on the `transformers.models.*` modules (e.g. `hf_qwen2vl.Qwen2VLForConditionalGeneration = ...`), so without restoring them the eager case for a family would leak its VeOmni-patched classes into the same family's fa2 case, silently turning the bitwise comparison into VeOmni-vs-VeOmni. The helper snapshots pristine attributes at import time and restores class swaps + replaced in-class methods (forward / `_deepstack_process` / `get_rope_index` / `_init_weights` / `_no_split_modules`); methods VeOmni adds (`dummy_forward`, `get_parallel_plan`) are removed via `delattr`.
>
> - **Toy-config fix.** `tests/toy_config/qwen25omni_toy/config.json`: `architectures[0]` was `Qwen2_5OmniModel`, which doesn't exist in transformers 4.57.3; corrected to `Qwen2_5OmniForConditionalGeneration` (the class VeOmni's loader returns for this config anyway). Required by the new config-driven HF class resolution.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [ ] Applied pre-commit checks
- [ ] Added/updated documentation
- [ ] Added tests to CI workflow (or explained why not feasible)
