### PR TITLE
[ci] refactor: split GPU unit tests into v4/v5 parallel jobs

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -40,7 +40,12 @@ jobs:
   lint:
     uses: ./.github/workflows/check_pr_lint.yml
 
-  gpu_unit_tests:
+  # gpu_unit_tests_v4 and gpu_unit_tests_v5 run in parallel on separate l20-8
+  # runners. They share identical runner/container/env config; only the
+  # dependency sync (transformers stable vs. transformers5-exp) and the test
+  # set differ. Keep the two jobs in sync when modifying shared parts.
+
+  gpu_unit_tests_v4:
     if: github.repository_owner == 'ByteDance-Seed'
     needs: lint
     # Self-hosted L20-8 fleet managed by github_runner/ (ansible). Any free
@@ -82,16 +87,6 @@ jobs:
       - name: Sync dependencies
         run: |
           uv sync --frozen --extra gpu --extra audio --group dev
-      - name: Detect changed paths for conditional tests
-        id: changes
-        run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}"
-          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD -- || true)
-          if echo "$CHANGED" | grep -qE '(veomni/distributed/sequence_parallel/|veomni/models/transformers/qwen3_5/)'; then
-            echo "qwen3_5_ulysses=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "qwen3_5_ulysses=false" >> "$GITHUB_OUTPUT"
-          fi
       - name: Run parallel tests
         # TODO: run all tests under tests/parallel/ulysses after we verify
         #       tests/parallel/ulysses/test_ulysses_async.py still works
@@ -128,6 +123,44 @@ jobs:
       - name: Run ops tests
         run: |
           uv run --frozen pytest -s -x tests/ops
+
+  gpu_unit_tests_v5:
+    if: github.repository_owner == 'ByteDance-Seed'
+    needs: lint
+    # Same runner/container/env as gpu_unit_tests_v4 above; see comments there.
+    runs-on: [self-hosted, l20-8]
+    timeout-minutes: 60
+    container:
+      image: verl-ci-cn-beijing.cr.volces.com/veomni/open_veomni-gpu:pytorch_25_03_py3_cuda12_9
+      volumes:
+        - /mnt/veomni_ci:/mnt/veomni_ci:ro
+      options: >-
+        --gpus all
+        --ipc host
+        --shm-size 32g
+    env:
+      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com"
+      HF_ENDPOINT: "https://hf-mirror.com"
+      HF_HUB_ENABLE_HF_TRANSFER: "0"
+      NCCL_DEBUG: "WARN"
+      CI_HF_MODELS_DIR: "/mnt/veomni_ci/models"
+      CI_SAMPLES_DIR: "/mnt/veomni_ci/datasets/custom_data/samples"
+      CI_DATASET_DIR: "/mnt/veomni_ci/datasets"
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Detect changed paths for conditional tests
+        id: changes
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}"
+          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD -- || true)
+          if echo "$CHANGED" | grep -qE '(veomni/distributed/sequence_parallel/|veomni/models/transformers/qwen3_5/)'; then
+            echo "qwen3_5_ulysses=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "qwen3_5_ulysses=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Sync dependencies [transformers-v5]
         run: |
           uv sync --frozen --no-group transformers-stable --extra transformers5-exp --extra gpu --extra audio --group dev
@@ -135,7 +168,7 @@ jobs:
         # TODO: Run the following tests with proper `--no-group transformers-stable --extra transformers5-exp` to enable transformers v5.
         # Currently those tests are effectively skipped (but it's not straightforward to enable due to L20 OOM).
         run: |
-          uv run  --frozen pytest -s -x tests/models/test_model_registry.py
+          uv run --frozen pytest -s -x tests/models/test_model_registry.py
           uv run --frozen pytest -s -x tests/models/test_models_patch.py
           uv run --frozen pytest -s -x tests/models/test_vlm_trainer.py
           uv run --frozen pytest -s -x tests/models/test_models_logits_equal_v5.py


### PR DESCRIPTION
### What does this PR do?

Splits the single `gpu_unit_tests` job in `.github/workflows/gpu_unit_tests.yml`
into two independent parallel jobs:

- `gpu_unit_tests_v4` — runs the transformers-stable test set (parallel,
  models, fsdp2/clip-grad-norm, rank0 weight load, checkpoint callback,
  trainer save/load, distributed dummy_forward, data, ops).
- `gpu_unit_tests_v5` — runs the transformers5-exp test set (models v5,
  Qwen3.5 GatedDeltaNet Ulysses SP, dcp save/load, count_flops).

Both jobs gate on `lint` and run on the self-hosted `[self-hosted, l20-8]`
fleet. Verified the fleet has ≥6 distinct l20-* runners (l20-0 through l20-5
observed in recent CI history), so the two jobs can truly run in parallel
rather than queueing.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A
- PR title follows `[{modules}] {type}: {description}` format

### Test

> N/A — workflow change only. Will be exercised by this PR's own CI run; both
> `gpu_unit_tests_v4` and `gpu_unit_tests_v5` should appear as separate
> required checks and start near-simultaneously on different l20-* runners.

### API and Usage Example

> N/A

### Design & Code Changes

- Job `gpu_unit_tests` removed; replaced by `gpu_unit_tests_v4` and
  `gpu_unit_tests_v5` in `.github/workflows/gpu_unit_tests.yml`.
- v4 keeps the original `Sync dependencies` (transformers-stable extras) and
  all v4 test steps unchanged.
- v5 has its own checkout + `Sync dependencies [transformers-v5]` (no
  cross-job env switching) and runs the v5-only test steps.
- The `Detect changed paths for conditional tests` step (only used to gate
  the Qwen3.5 ulysses test) moved into the v5 job.
- container/env config is duplicated across the two jobs (GHA does not
  support YAML anchors at job level); v4 keeps the full comments, v5 has a
  brief pointer to v4 to reduce noise. A NOTE was added above both jobs
  reminding maintainers to keep shared parts in sync.

**Required follow-up after merge:** update repo branch protection / rulesets
to replace the required check `gpu_unit_tests` with `gpu_unit_tests_v4` and
`gpu_unit_tests_v5`, otherwise the old rule will block all PRs.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [ ] Added/updated documentation — N/A (CI-only change)
- [x] Added tests to CI workflow (or explained why not feasible) — change is to the CI workflow itself
