### PR TITLE
[ci] chore: keep strict MoE e2e tolerance; document L20 cross-EP flake

### DIFF
--- a/tests/checkpoints/utils.py
+++ b/tests/checkpoints/utils.py
@@ -83,6 +83,14 @@ def get_checkpoint_test_command(
         "--train.checkpoint.manager dcp",
         "--train.checkpoint.save_async True",
         f"--train.checkpoint.save_hf_weights {save_hf_weights}",
+        # The DCP-then-merge run and the direct-HF run must produce
+        # bit-equivalent weights for `check_state_dict` (default fp32
+        # `torch.testing.assert_close` ~1.3e-6). Best-effort: locks in
+        # cudnn / NCCL / CUBLAS_WORKSPACE_CONFIG seeds and calls
+        # `torch.use_deterministic_algorithms(True, warn_only=True)` —
+        # ops without a deterministic kernel still warn, so residual
+        # nondeterminism is possible but much less likely.
+        "--train.enable_full_determinism True",
     ]
 
     exec_script = " \\\n".join(params)

--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -143,38 +143,53 @@ def _assert_parallel_alignment(
         compare_metrics(res, rtol=rtol, atol=atol)
         return
 
-    ep1_runs = {k: v for k, v in res.items() if "_ep1" in k}
-    ep2_runs = {k: v for k, v in res.items() if "_ep2" in k}
+    # Group runs by EP size parsed from the trailing `_ep<N>` segment of the
+    # task name (set by `prepare_exec_cmd`). `rpartition` plus integer parse
+    # avoids the substring trap of `"_ep1" in k` (which would also match
+    # `_ep10`) and naturally extends to any EP grid larger than {1, 2}.
+    runs_by_ep: dict[int, dict] = {}
+    for k, v in res.items():
+        head, sep, tail = k.rpartition("_ep")
+        if not sep or not tail.isdigit():
+            raise AssertionError(f"MoE run key missing _ep<N> suffix: {k!r}")
+        runs_by_ep.setdefault(int(tail), {})[k] = v
 
-    if not ep1_runs or not ep2_runs:
+    if len(runs_by_ep) < 2:
         # Single-EP slice (e.g. max_sp_size filtered everything down). Fall
         # back to the dense comparison.
         compare_metrics(res, rtol=rtol, atol=atol)
         return
 
-    if len(ep1_runs) >= 2:
-        compare_metrics(ep1_runs, rtol=rtol, atol=atol)
-    if len(ep2_runs) >= 2:
-        compare_metrics(ep2_runs, rtol=rtol, atol=atol)
+    # Same-EP runs (only SP varies) must match within strict tolerance.
+    for ep_runs in runs_by_ep.values():
+        if len(ep_runs) >= 2:
+            compare_metrics(ep_runs, rtol=rtol, atol=atol)
 
-    # One representative per EP for the cross-EP check.
-    ep1_name = next(iter(ep1_runs))
-    ep2_name = next(iter(ep2_runs))
-    cross = {ep1_name: ep1_runs[ep1_name], ep2_name: ep2_runs[ep2_name]}
+    # Cross-EP: pick the smallest EP as the baseline and compare each other
+    # EP value against it. Loss stays close (router output is the same
+    # averaged signal) so it uses the strict tolerance; grad_norm uses the
+    # relaxed tolerance to absorb routing-flip noise.
+    ep_values = sorted(runs_by_ep.keys())
+    base_ep = ep_values[0]
+    base_name = next(iter(runs_by_ep[base_ep]))
+    base_run = runs_by_ep[base_ep][base_name]
 
-    metric_keys = list(cross[ep1_name].keys())
+    metric_keys = list(base_run.keys())
     grad_keys = [k for k in metric_keys if "grad_norm" in k]
     other_keys = [k for k in metric_keys if k not in grad_keys]
 
-    if other_keys:
-        compare_metrics(cross, rtol=rtol, atol=atol, keys=other_keys)
-    if grad_keys:
-        compare_metrics(
-            cross,
-            rtol=_MOE_CROSS_EP_GRAD_NORM_RTOL,
-            atol=_MOE_CROSS_EP_GRAD_NORM_ATOL,
-            keys=grad_keys,
-        )
+    for other_ep in ep_values[1:]:
+        other_name = next(iter(runs_by_ep[other_ep]))
+        cross = {base_name: base_run, other_name: runs_by_ep[other_ep][other_name]}
+        if other_keys:
+            compare_metrics(cross, rtol=rtol, atol=atol, keys=other_keys)
+        if grad_keys:
+            compare_metrics(
+                cross,
+                rtol=_MOE_CROSS_EP_GRAD_NORM_RTOL,
+                atol=_MOE_CROSS_EP_GRAD_NORM_ATOL,
+                keys=grad_keys,
+            )
 
 
 _DEFAULT_RTOL = 1e-1

--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -24,14 +24,29 @@ _dit_only = pytest.mark.skipif(not is_diffusers_available(), reason="Requires di
 def _materialize_weights_dir(config_path: str, output_path: str, save_original_format: bool = True) -> Path:
     # Seed CPU RNG and init on CPU so the materialized checkpoint is bit-identical
     # across pytest invocations *and* across GPU architectures (L20 in CI vs
-    # H100/A100 locally). Without this, the four sub-runs of the (sp, ep) grid
-    # would still see the same weights within one pytest run, but successive
-    # runs would each materialize a different random init, giving every CI
-    # attempt a different cross-config divergence to chew on.
+    # H100/A100 locally). Without this, the four sub-runs (sp/ep grid) would
+    # share weights within one pytest run but differ between runs.
     #
-    # Note: a seeded init does NOT guarantee that EP=1 and EP=2 produce
-    # close grad_norms — see `_assert_parallel_alignment` for why cross-EP
-    # divergence is intrinsic to MoE training and how the test handles it.
+    # Cross-EP grad_norm flake (L20 only). On the CI L20 hardware we have seen
+    # the step-2 EP=1 vs EP=2 grad_norm spread reach ~0.87 on a single seed,
+    # blowing past the 0.1 rtol/atol envelope below. Root cause is bf16 noise
+    # in the MoE all_to_all + group_gemm M-dim reshuffle that drifts the
+    # layer-0 expert output by ~1e-3, which flips ~1% of layer-1 top-k routing
+    # decisions and cascades through layer 3 (~5% flips) into the optimizer
+    # step. Determinism flags (`enable_full_determinism`,
+    # `enable_high_precision_for_bf16`, `enable_batch_invariant_mode`) cannot
+    # close this gap because EP and non-EP paths are structurally different:
+    # different per-rank token composition after `all_to_all`, and the world
+    # is reorganized as `ep × ep_fsdp` so FSDP gradient reduction occurs over
+    # a different rank set in bf16.
+    #
+    # We deliberately keep the strict tolerance. On H100 (8×80GB), 100
+    # in-process reps under all three determinism flags returned bit-identical
+    # results across reps with cross-EP step-2 spread = 0.0547 — well inside
+    # the bound. Relaxing the tolerance globally would mask real regressions
+    # on the hardware that does not exhibit the L20 flake. If CI flakes on
+    # this assertion, retry first; if it persists, investigate the L20
+    # mechanism rather than widening the assertion.
     torch.manual_seed(0)
     model = build_foundation_model(
         config_path=config_path,
@@ -95,101 +110,9 @@ def main(
 
     for key in log_keys:
         print_comparison_table(res, key, title=model_name)
-    _assert_parallel_alignment(res, is_moe=is_moe, rtol=rtol, atol=atol)
+    compare_metrics(res, rtol=rtol, atol=atol)
 
     shutil.rmtree(test_path)
-
-
-# Cross-EP grad_norm tolerance for MoE models. Loss stays close (router output
-# is the same averaged signal) but grad_norm picks up the routing-flip cascade
-# documented in `_assert_parallel_alignment`. 0.5 rtol + 1.0 atol absorbs the
-# observed CI range (≤0.9 absolute spread on toy configs) while still catching
-# order-of-magnitude regressions in the EP path.
-_MOE_CROSS_EP_GRAD_NORM_RTOL = 0.5
-_MOE_CROSS_EP_GRAD_NORM_ATOL = 1.0
-
-
-def _assert_parallel_alignment(
-    res: dict,
-    *,
-    is_moe: bool,
-    rtol: float,
-    atol: float,
-) -> None:
-    """Compare metrics across distributed configs with MoE-aware tolerances.
-
-    For dense (non-MoE) models, every parallel config (varying only SP) must
-    match within (rtol, atol).
-
-    For MoE models, the configs span both SP and EP. EP=1 vs EP=2 cannot be
-    bitwise-aligned because:
-      - the EP path runs experts on a different per-rank token composition
-        (after all_to_all) than the non-EP path (only local tokens), and
-      - the world is reorganized as ep × ep_fsdp, so FSDP gradient
-        reduction occurs over a different rank set in bf16.
-    Even with deterministic kernels and stable argsort, the residual bf16
-    noise in the router input flips top-k decisions for a small fraction of
-    tokens (~1% by layer 1, ~5% by layer 3, growing each step). On toy
-    configs this can amplify the cross-EP grad_norm spread above the strict
-    tolerance on certain GPUs.
-
-    Strategy:
-      - same-EP runs (only SP varies): strict tolerance — SP must not change
-        forward/backward semantics.
-      - cross-EP runs: loss is checked at strict tolerance (it's stable);
-        grad_norm uses a relaxed tolerance to absorb routing-flip noise.
-    """
-    if not is_moe:
-        compare_metrics(res, rtol=rtol, atol=atol)
-        return
-
-    # Group runs by EP size parsed from the trailing `_ep<N>` segment of the
-    # task name (set by `prepare_exec_cmd`). `rpartition` plus integer parse
-    # avoids the substring trap of `"_ep1" in k` (which would also match
-    # `_ep10`) and naturally extends to any EP grid larger than {1, 2}.
-    runs_by_ep: dict[int, dict] = {}
-    for k, v in res.items():
-        head, sep, tail = k.rpartition("_ep")
-        if not sep or not tail.isdigit():
-            raise AssertionError(f"MoE run key missing _ep<N> suffix: {k!r}")
-        runs_by_ep.setdefault(int(tail), {})[k] = v
-
-    if len(runs_by_ep) < 2:
-        # Single-EP slice (e.g. max_sp_size filtered everything down). Fall
-        # back to the dense comparison.
-        compare_metrics(res, rtol=rtol, atol=atol)
-        return
-
-    # Same-EP runs (only SP varies) must match within strict tolerance.
-    for ep_runs in runs_by_ep.values():
-        if len(ep_runs) >= 2:
-            compare_metrics(ep_runs, rtol=rtol, atol=atol)
-
-    # Cross-EP: pick the smallest EP as the baseline and compare each other
-    # EP value against it. Loss stays close (router output is the same
-    # averaged signal) so it uses the strict tolerance; grad_norm uses the
-    # relaxed tolerance to absorb routing-flip noise.
-    ep_values = sorted(runs_by_ep.keys())
-    base_ep = ep_values[0]
-    base_name = next(iter(runs_by_ep[base_ep]))
-    base_run = runs_by_ep[base_ep][base_name]
-
-    metric_keys = list(base_run.keys())
-    grad_keys = [k for k in metric_keys if "grad_norm" in k]
-    other_keys = [k for k in metric_keys if k not in grad_keys]
-
-    for other_ep in ep_values[1:]:
-        other_name = next(iter(runs_by_ep[other_ep]))
-        cross = {base_name: base_run, other_name: runs_by_ep[other_ep][other_name]}
-        if other_keys:
-            compare_metrics(cross, rtol=rtol, atol=atol, keys=other_keys)
-        if grad_keys:
-            compare_metrics(
-                cross,
-                rtol=_MOE_CROSS_EP_GRAD_NORM_RTOL,
-                atol=_MOE_CROSS_EP_GRAD_NORM_ATOL,
-                keys=grad_keys,
-            )
 
 
 _DEFAULT_RTOL = 1e-1

--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -27,26 +27,33 @@ def _materialize_weights_dir(config_path: str, output_path: str, save_original_f
     # H100/A100 locally). Without this, the four sub-runs (sp/ep grid) would
     # share weights within one pytest run but differ between runs.
     #
-    # Cross-EP grad_norm flake (L20 only). On the CI L20 hardware we have seen
-    # the step-2 EP=1 vs EP=2 grad_norm spread reach ~0.87 on a single seed,
-    # blowing past the 0.1 rtol/atol envelope below. Root cause is bf16 noise
-    # in the MoE all_to_all + group_gemm M-dim reshuffle that drifts the
-    # layer-0 expert output by ~1e-3, which flips ~1% of layer-1 top-k routing
-    # decisions and cascades through layer 3 (~5% flips) into the optimizer
-    # step. Determinism flags (`enable_full_determinism`,
-    # `enable_high_precision_for_bf16`, `enable_batch_invariant_mode`) cannot
-    # close this gap because EP and non-EP paths are structurally different:
-    # different per-rank token composition after `all_to_all`, and the world
-    # is reorganized as `ep × ep_fsdp` so FSDP gradient reduction occurs over
-    # a different rank set in bf16.
+    # Cross-EP structural spread on H100. EP=1 vs EP=2 paths are structurally
+    # different — different per-rank token composition after `all_to_all`,
+    # and the world is reorganized as `ep × ep_fsdp` so FSDP gradient
+    # reduction occurs over a different rank set in bf16. On 8×H100 we ran
+    # 100 in-process reps under all three determinism flags
+    # (`enable_full_determinism`, `enable_high_precision_for_bf16`,
+    # `enable_batch_invariant_mode`) and observed bit-identical results
+    # across reps with cross-EP step-2 grad_norm spread = 0.0547 — well
+    # inside the 0.1 envelope below.
     #
-    # We deliberately keep the strict tolerance. On H100 (8×80GB), 100
-    # in-process reps under all three determinism flags returned bit-identical
-    # results across reps with cross-EP step-2 spread = 0.0547 — well inside
-    # the bound. Relaxing the tolerance globally would mask real regressions
-    # on the hardware that does not exhibit the L20 flake. If CI flakes on
-    # this assertion, retry first; if it persists, investigate the L20
-    # mechanism rather than widening the assertion.
+    # CI L20 outlier (unexplained). We have seen one CI run on L20 where the
+    # step-2 cross-EP spread reached ~0.87, which is 16× the deterministic
+    # H100 baseline. The 100-rep H100 result rules out generic bf16 EP-path
+    # noise as the cause: that noise produces a stable 0.055 spread and is
+    # not stochastic across reps. Whatever drives the L20 0.87 number is
+    # therefore something the H100 environment does not see — most likely
+    # CI machine instability (driver / NCCL build, kernel autotune cache,
+    # Ada-vs-Hopper kernel selection, transient host load) rather than a
+    # model-side bug. We do not have L20 access to run the 100-rep
+    # robustness check, so this remains a hypothesis.
+    #
+    # Keep the strict tolerance. Relaxing it globally to absorb a single
+    # unexplained L20 outlier would mask real EP-path regressions on the
+    # hardware where the test is robust. If CI flakes on this assertion,
+    # retry first; if it persists, capture the failing logs and investigate
+    # L20-specific causes (driver, NCCL build, kernel autotune cache) before
+    # widening the bound.
     torch.manual_seed(0)
     model = build_foundation_model(
         config_path=config_path,

--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -23,11 +23,15 @@ _dit_only = pytest.mark.skipif(not is_diffusers_available(), reason="Requires di
 
 def _materialize_weights_dir(config_path: str, output_path: str, save_original_format: bool = True) -> Path:
     # Seed CPU RNG and init on CPU so the materialized checkpoint is bit-identical
-    # across pytest invocations *and* across GPU architectures (L20 in CI vs A100
-    # locally). Without this, the four sub-runs (sp/ep grid) shared weights within
-    # one pytest run but differed between runs, making SP/EP-vs-no-EP grad-norm
-    # comparisons flaky at the toy-config scale (CI hit a seed where the EP=2 vs
-    # EP=1 step-2 grad_norm diff was 0.69, blowing past the 0.1 atol+rtol envelope).
+    # across pytest invocations *and* across GPU architectures (L20 in CI vs
+    # H100/A100 locally). Without this, the four sub-runs of the (sp, ep) grid
+    # would still see the same weights within one pytest run, but successive
+    # runs would each materialize a different random init, giving every CI
+    # attempt a different cross-config divergence to chew on.
+    #
+    # Note: a seeded init does NOT guarantee that EP=1 and EP=2 produce
+    # close grad_norms — see `_assert_parallel_alignment` for why cross-EP
+    # divergence is intrinsic to MoE training and how the test handles it.
     torch.manual_seed(0)
     model = build_foundation_model(
         config_path=config_path,
@@ -91,9 +95,86 @@ def main(
 
     for key in log_keys:
         print_comparison_table(res, key, title=model_name)
-    compare_metrics(res, rtol=rtol, atol=atol)
+    _assert_parallel_alignment(res, is_moe=is_moe, rtol=rtol, atol=atol)
 
     shutil.rmtree(test_path)
+
+
+# Cross-EP grad_norm tolerance for MoE models. Loss stays close (router output
+# is the same averaged signal) but grad_norm picks up the routing-flip cascade
+# documented in `_assert_parallel_alignment`. 0.5 rtol + 1.0 atol absorbs the
+# observed CI range (≤0.9 absolute spread on toy configs) while still catching
+# order-of-magnitude regressions in the EP path.
+_MOE_CROSS_EP_GRAD_NORM_RTOL = 0.5
+_MOE_CROSS_EP_GRAD_NORM_ATOL = 1.0
+
+
+def _assert_parallel_alignment(
+    res: dict,
+    *,
+    is_moe: bool,
+    rtol: float,
+    atol: float,
+) -> None:
+    """Compare metrics across distributed configs with MoE-aware tolerances.
+
+    For dense (non-MoE) models, every parallel config (varying only SP) must
+    match within (rtol, atol).
+
+    For MoE models, the configs span both SP and EP. EP=1 vs EP=2 cannot be
+    bitwise-aligned because:
+      - the EP path runs experts on a different per-rank token composition
+        (after all_to_all) than the non-EP path (only local tokens), and
+      - the world is reorganized as ep × ep_fsdp, so FSDP gradient
+        reduction occurs over a different rank set in bf16.
+    Even with deterministic kernels and stable argsort, the residual bf16
+    noise in the router input flips top-k decisions for a small fraction of
+    tokens (~1% by layer 1, ~5% by layer 3, growing each step). On toy
+    configs this can amplify the cross-EP grad_norm spread above the strict
+    tolerance on certain GPUs.
+
+    Strategy:
+      - same-EP runs (only SP varies): strict tolerance — SP must not change
+        forward/backward semantics.
+      - cross-EP runs: loss is checked at strict tolerance (it's stable);
+        grad_norm uses a relaxed tolerance to absorb routing-flip noise.
+    """
+    if not is_moe:
+        compare_metrics(res, rtol=rtol, atol=atol)
+        return
+
+    ep1_runs = {k: v for k, v in res.items() if "_ep1" in k}
+    ep2_runs = {k: v for k, v in res.items() if "_ep2" in k}
+
+    if not ep1_runs or not ep2_runs:
+        # Single-EP slice (e.g. max_sp_size filtered everything down). Fall
+        # back to the dense comparison.
+        compare_metrics(res, rtol=rtol, atol=atol)
+        return
+
+    if len(ep1_runs) >= 2:
+        compare_metrics(ep1_runs, rtol=rtol, atol=atol)
+    if len(ep2_runs) >= 2:
+        compare_metrics(ep2_runs, rtol=rtol, atol=atol)
+
+    # One representative per EP for the cross-EP check.
+    ep1_name = next(iter(ep1_runs))
+    ep2_name = next(iter(ep2_runs))
+    cross = {ep1_name: ep1_runs[ep1_name], ep2_name: ep2_runs[ep2_name]}
+
+    metric_keys = list(cross[ep1_name].keys())
+    grad_keys = [k for k in metric_keys if "grad_norm" in k]
+    other_keys = [k for k in metric_keys if k not in grad_keys]
+
+    if other_keys:
+        compare_metrics(cross, rtol=rtol, atol=atol, keys=other_keys)
+    if grad_keys:
+        compare_metrics(
+            cross,
+            rtol=_MOE_CROSS_EP_GRAD_NORM_RTOL,
+            atol=_MOE_CROSS_EP_GRAD_NORM_ATOL,
+            keys=grad_keys,
+        )
 
 
 _DEFAULT_RTOL = 1e-1


### PR DESCRIPTION
### What does this PR do?

Two test-only changes to address recurring CI flakes on MoE e2e tests:

- `tests/e2e/test_e2e_parallel.py` keeps the strict `rtol = atol = 0.1`
  cross-config comparison and grows an in-place comment in
  `_materialize_weights_dir` that records what we know (and don't know)
  about the L20 cross-EP grad_norm flake.
- `tests/checkpoints/utils.py:get_checkpoint_test_command` passes
  `--train.enable_full_determinism true`. The save/load test runs two
  back-to-back trainings of the same config and bitwise-compares state
  dicts (default fp32 ~1.3e-6); without the flag, cudnn / NCCL /
  `CUBLAS_WORKSPACE_CONFIG` can drift between runs and flake the compare.

### Checklist Before Starting

- PR title follows `[{modules}] {type}: {description}`.
- No related external issue; derived from CI failure analysis.

### What we found, and what we suspect

We ran a 100-rep in-process robustness check on 8×H100 with all three
determinism flags on (`enable_full_determinism`,
`enable_high_precision_for_bf16`, `enable_batch_invariant_mode`) — same
flags the production e2e test path uses. Each rep restores a snapshotted
model, rebuilds the optimizer + lr scheduler, reseeds RNGs, and runs the
same 2 train_steps the test runs. Harness lives at
`tingyang/qwen3_moe_ci/` (gitignored).

| environment | reps | step-2 cross-EP spread | within strict 0.1? |
|---|---|---|---|
| H100 8×80GB, full determinism, in-process | 100 | 0.0547 (bit-identical across reps) | yes |
| L20 CI (single observed flake) | 1 | ~0.87 | no |

What we conclude:

- The structural EP=1 vs EP=2 difference (different per-rank token
  composition after `all_to_all`, `ep × ep_fsdp` rank reorganization
  changing the bf16 gradient reduction order) does produce a real spread,
  but on H100 under full determinism it lands at a stable **0.055** —
  16× inside the strict envelope.
- The **L20 0.87 outlier is not explained by that structural gap**, since
  the H100 sees the same EP path and stays bit-identical at 0.055 across
  100 reps. Whatever drives the L20 number is something the H100
  environment does not see — most likely **CI machine instability**:
  driver / NCCL build, kernel autotune cache, Ada vs Hopper kernel
  selection, transient host load. We don't have L20 access to repeat the
  100-rep check, so this is a working hypothesis, not a proven cause.
- Globally relaxing the bound to absorb the L20 outlier would let real
  EP-path regressions on H100/A100 slip past — a 2× bias on the ~4.0 base
  would still fit inside e.g. `rtol=0.5, atol=1.0`. Not worth it for an
  unexplained, possibly-CI-only failure.

If CI flakes here again:

1. Retry — transient CI noise is by far the most likely cause.
2. If it persists, capture the failing logs and compare driver, NCCL
   version, autotune cache, host load against passing runs before
   widening the bound.
3. If a real EP-path regression is later confirmed, fix the model, not
   the tolerance.

### Test

Local verification on 8×H100, transformers 4.57.3:

```
$ uv run --frozen pytest -s -x tests/e2e/test_e2e_parallel.py::test_text_parallel_align \
      -k "qwen3_moe and not v5"
================= 1 passed, 7 deselected in 290.34s (0:04:50) ==================
```

Strict-tolerance pass:

```
qwen3_moe_train_text_test_sp1_ep1  grad_norm = 2.6121, 4.5245
qwen3_moe_train_text_test_sp1_ep2  grad_norm = 2.5982, 4.5224
qwen3_moe_train_text_test_sp2_ep1  grad_norm = 2.6124, 4.5353
qwen3_moe_train_text_test_sp2_ep2  grad_norm = 2.5984, 4.4806
```

### API and Usage Example

N/A — internal test plumbing only.

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] Applied pre-commit checks (`make quality` clean)
- [x] No new docs needed (rationale lives in the `_materialize_weights_dir` comment)
- [x] Test path is the same one that runs in `gpu_e2e_test.yml` — no workflow changes needed
