### PR TITLE
[ci] refactor: split GPU e2e tests into v4/v5 parallel jobs

### DIFF
--- a/.github/workflows/gpu_e2e_test.yml
+++ b/.github/workflows/gpu_e2e_test.yml
@@ -40,7 +40,12 @@ jobs:
   lint:
     uses: ./.github/workflows/check_pr_lint.yml
 
-  gpu_e2e_tests:
+  # gpu_e2e_tests_v4 and gpu_e2e_tests_v5 run in parallel on separate l20-8
+  # runners. They share identical runner/container/env config; only the
+  # dependency sync (transformers stable vs. transformers5-exp) and the test
+  # set differ. Keep the two jobs in sync when modifying shared parts.
+
+  gpu_e2e_tests_v4:
     if: github.repository_owner == 'ByteDance-Seed'
     needs: lint
     # Self-hosted L20-8 fleet managed by github_runner/ (ansible). See
@@ -81,6 +86,40 @@ jobs:
       - name: Run FSDP equivalence tests
         run: |
           uv run --frozen pytest -s -x tests/distributed/test_fsdp_equivalence.py
+      - name: Sync dependencies [diffusers]
+        run: |
+          uv sync --frozen --extra gpu --extra dit --group dev
+      - name: Run tests [diffusers]
+        run: |
+          uv run --frozen pytest -s -x tests/e2e/test_e2e_parallel.py::test_wan_dit_parallel_align
+
+  gpu_e2e_tests_v5:
+    if: github.repository_owner == 'ByteDance-Seed'
+    needs: lint
+    # Same runner/container/env as gpu_e2e_tests_v4 above; see comments there.
+    runs-on: [self-hosted, l20-8]
+    timeout-minutes: 60
+    container:
+      image: verl-ci-cn-beijing.cr.volces.com/veomni/open_veomni-gpu:pytorch_25_03_py3_cuda12_9
+      volumes:
+        - /mnt/veomni_ci:/mnt/veomni_ci:ro
+      options: >-
+        --gpus all
+        --ipc host
+        --shm-size 32g
+    env:
+      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com"
+      HF_ENDPOINT: "https://hf-mirror.com"
+      HF_HUB_ENABLE_HF_TRANSFER: "0"
+      NCCL_DEBUG: "WARN"
+      CI_HF_MODELS_DIR: "/mnt/veomni_ci/models"
+      CI_SAMPLES_DIR: "/mnt/veomni_ci/datasets/custom_data/samples"
+      CI_DATASET_DIR: "/mnt/veomni_ci/datasets"
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
       - name: Sync dependencies [transformers-v5]
         run: |
           uv sync --frozen --no-group transformers-stable --extra transformers5-exp --extra gpu --extra audio --group dev
@@ -92,10 +131,4 @@ jobs:
       - name: Run FSDP equivalence tests [transformers-v5]
         run: |
           uv run --frozen pytest -s -x tests/distributed/test_fsdp_equivalence.py
-      - name: Sync dependencies [diffusers]
-        run: |
-          uv sync --frozen --extra gpu --extra dit --group dev
-      - name: Run tests [diffusers]
-        run: |
-          uv run --frozen pytest -s -x tests/e2e/test_e2e_parallel.py::test_wan_dit_parallel_align
-        # TODO: Run other tests in transformers v5 env as well.
+      # TODO: Run other tests in transformers v5 env as well.

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -48,6 +48,16 @@ _NPU_PER_MODEL_OVERRIDES: Dict[str, Dict[str, str]] = {
     "qwen25_omni": {"rotary_pos_emb_implementation": "eager"},
 }
 
+# GPU per-model overrides for models whose patched ops disable a default
+# backend. Wan's ``rope_apply(x, **kwargs)`` signature is incompatible with
+# the registry-default Liger RoPE — ``device_patch.py`` marks ``liger_kernel``
+# as explicitly disabled, so any non-eager value would raise. Wan training
+# YAMLs pin ``rotary_pos_emb_implementation: eager``, but e2e tests build CLI
+# args directly (no training YAML), so we pin here as well.
+_GPU_PER_MODEL_OVERRIDES: Dict[str, Dict[str, str]] = {
+    "wan_t2v": {"rotary_pos_emb_implementation": "eager"},
+}
+
 
 def _npu_overrides(model_name: Optional[str]) -> Dict[str, str]:
     merged = dict(_NPU_OPS_DEFAULTS)
@@ -59,12 +69,14 @@ def _npu_overrides(model_name: Optional[str]) -> Dict[str, str]:
 def resolve_ops_overrides(model_name: Optional[str]) -> List[str]:
     """Return ``--model.ops_implementation.X=Y`` flags for the active hardware.
 
-    On GPU returns ``[]`` — the dataclass defaults are already optimal.
-    On NPU returns the NPU-supported backend per op, with per-model eager
-    fallbacks for ops without an NPU kernel for that specific model.
+    On GPU returns per-model overrides for models whose patched ops disable a
+    default backend (currently Wan); empty otherwise — dataclass defaults are
+    GPU-optimal. On NPU returns the NPU-supported backend per op, with
+    per-model eager fallbacks for ops without an NPU kernel for that model.
     """
     if not is_torch_npu_available():
-        return []
+        overrides = _GPU_PER_MODEL_OVERRIDES.get(model_name, {}) if model_name else {}
+        return [f"--model.ops_implementation.{k}={v}" for k, v in overrides.items()]
     return [f"--model.ops_implementation.{k}={v}" for k, v in _npu_overrides(model_name).items()]
 
 


### PR DESCRIPTION
## Summary
- Split `gpu_e2e_tests` into two parallel jobs `gpu_e2e_tests_v4` and `gpu_e2e_tests_v5`, each on its own `[self-hosted, l20-8]` runner, mirroring the layout introduced for `gpu_unit_tests` in #725.
- v4 job: transformers-stable e2e (`test_e2e_parallel.py`) + `test_fsdp_equivalence.py` + diffusers (`--extra dit`) `test_wan_dit_parallel_align`.
- v5 job: transformers5-exp e2e (`test_e2e_parallel.py`) + `test_fsdp_equivalence.py`.
- Halves wall-clock by parallelizing the two transformers tracks instead of running them sequentially in one job.

## Note for maintainers
Branch-protection required-status-checks pinned to `gpu_e2e_tests` will need to be updated to `gpu_e2e_tests_v4` and `gpu_e2e_tests_v5` (same migration that was needed for the unit-test split in #725).

## Test plan
- [ ] Both `gpu_e2e_tests_v4` and `gpu_e2e_tests_v5` are dispatched and finish green on this PR.
- [ ] Diffusers (`test_wan_dit_parallel_align`) runs as part of the v4 job.