### PR TITLE
Revert "[dist] fix: use src_data_rank=None in load_model_weights to s…

### DIFF
--- a/tests/utils/test_rank0_load_and_broadcast_weights.py
+++ b/tests/utils/test_rank0_load_and_broadcast_weights.py
@@ -35,7 +35,6 @@ class BroadcastTestArguments:
     weights_path: str = ""
     device_type: str = get_device_type()
     backend: str = get_dist_comm_backend()
-    mode: str = "broadcast"  # "broadcast" | "load_weights"
 
 
 @dataclass
@@ -216,6 +215,7 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
         extra_parallel_placement_innermost=args.train.accelerator.extra_parallel_placement_innermost,
         extra_parallel_names=args.train.accelerator.extra_parallel_names,
         dp_mode=args.train.accelerator.fsdp_config.fsdp_mode,
+        ep_outside=args.train.accelerator.ep_outside,
     )
 
     dtensor_factory = distribute_tensor if distribute_tensor is not None else None
@@ -406,179 +406,11 @@ def test_load_dist_model_weights_matches_standard(tmp_path: Path) -> None:
         f"--test.weights_path={weights_path}",
         f"--test.device_type={get_device_type()}",
         f"--test.backend={get_dist_comm_backend()}",
-        "--test.mode=broadcast",
     ]
 
     result = subprocess.run(command, check=True)
     assert result.returncode == 0
-
-
-def run_load_weights_test(args: Arguments) -> None:
-    """
-    Worker entrypoint for test_load_weights_no_scatter.
-
-    Verifies that load_model_weights (which now passes src_data_rank=None to
-    distribute_tensor) produces bit-for-bit identical parameters to a reference
-    single-rank load. This is the code path fixed in:
-    https://github.com/ByteDance-Seed/VeOmni/issues/637
-    """
-    weights_path = Path(args.test.weights_path)
-    if not weights_path.exists():
-        raise ValueError("`--test.weights_path` must point to an existing directory.")
-
-    get_torch_device().set_device(args.train.local_rank)
-    dist.init_process_group(backend=args.test.backend)
-
-    init_parallel_state(
-        dp_size=args.train.accelerator.dp_size,
-        dp_replicate_size=args.train.accelerator.dp_replicate_size,
-        dp_shard_size=args.train.accelerator.dp_shard_size,
-        tp_size=args.train.accelerator.tp_size,
-        pp_size=args.train.accelerator.pp_size,
-        cp_size=args.train.accelerator.cp_size,
-        ulysses_size=args.train.accelerator.ulysses_size,
-        extra_parallel_sizes=args.train.accelerator.extra_parallel_sizes,
-        extra_parallel_placement_innermost=args.train.accelerator.extra_parallel_placement_innermost,
-        extra_parallel_names=args.train.accelerator.extra_parallel_names,
-        dp_mode=args.train.accelerator.fsdp_config.fsdp_mode,
-    )
-
-    try:
-        # build_parallelize_model with weights_path triggers load_model_weights
-        # (the every-rank-reads-from-disk path, fixed in issue #637).
-        fsdp_model = build_parallelize_model(
-            ToyModel(),
-            weights_path=str(weights_path),
-            init_device=args.train.init_device,
-            mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
-            enable_gradient_checkpointing=False,
-            basic_modules=[],
-        )
-        """
-        fsdp_model:
-        FSDPToyModel(
-            (input_embed_tokens): ToyEmbed()
-            (output_embed_tokens): ToyEmbed()
-            (linear1): Linear(in_features=4, out_features=3, bias=True)
-            (linear2): Linear(in_features=3, out_features=2, bias=False)
-            (linear3): Linear(in_features=2, out_features=1, bias=True)
-        )
-
-        reference_model:
-        ToyModel(
-            (input_embed_tokens): ToyEmbed()
-            (output_embed_tokens): ToyEmbed()
-            (linear1): Linear(in_features=4, out_features=3, bias=True)
-            (linear2): Linear(in_features=3, out_features=2, bias=False)
-            (linear3): Linear(in_features=2, out_features=1, bias=True)
-        )
-
-        """
-
-        reference_model = ToyModel().to(get_device_type())
-        load_model_weights(reference_model, str(weights_path), init_device=get_device_type())
-        reference_model = reference_model.cpu()
-
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.get_input_embeddings().weight),
-            reference_model.get_input_embeddings().weight.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.get_output_embeddings().weight),
-            reference_model.get_output_embeddings().weight.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.linear1.weight),
-            reference_model.linear1.weight.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.linear1.bias),
-            reference_model.linear1.bias.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.linear2.weight),
-            reference_model.linear2.weight.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.buffer),
-            reference_model.buffer.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.linear3.weight),
-            reference_model.linear3.weight.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            _clone_to_cpu(fsdp_model.linear3.bias),
-            reference_model.linear3.bias.detach().cpu(),
-            atol=0.0,
-            rtol=0.0,
-        )
-
-        assert fsdp_model.get_input_embeddings().weight is fsdp_model.get_output_embeddings().weight
-
-        dist.barrier()
-    finally:
-        dist.destroy_process_group()
-        from veomni.distributed import parallel_state as _ps
-
-        _ps._PARALLEL_STATE = None
-
-
-@pytest.mark.skipif(not dist.is_available(), reason="torch.distributed required")
-def test_load_weights_no_scatter(tmp_path: Path) -> None:
-    """
-    Regression test for https://github.com/ByteDance-Seed/VeOmni/issues/637.
-
-    Ensures load_model_weights with src_data_rank=None (all-ranks-read path)
-    loads bit-for-bit correct parameters into an FSDP2 model.
-    The rank0_load_and_broadcast_weights path is tested separately in
-    test_load_dist_model_weights_matches_standard.
-    """
-    checkpoint_dir = tmp_path / "ckpt"
-    weights_path = _write_checkpoint(checkpoint_dir, is_parallel=False)
-
-    world_size = 4
-    port = 12345 + random.randint(0, 100)
-    command = [
-        "torchrun",
-        f"--nproc_per_node={world_size}",
-        f"--master_port={port}",
-        "tests/utils/test_rank0_load_and_broadcast_weights.py",
-        "--model.config_path=test",
-        "--data.train_path=tests",
-        "--train.checkpoint.output_dir=.tests/cache",
-        "--train.accelerator.fsdp_config.fsdp_mode=fsdp2",
-        "--train.init_device=meta",
-        "--train.accelerator.fsdp_config.mixed_precision.enable=False",
-        "--train.gradient_checkpointing.enable=False",
-        "--train.broadcast_model_weights_from_rank0=False",
-        f"--test.weights_path={weights_path}",
-        f"--test.device_type={get_device_type()}",
-        f"--test.backend={get_dist_comm_backend()}",
-        "--test.mode=load_weights",
-    ]
-
-    result = subprocess.run(command, check=True)
-    assert result.returncode == 0
-
 
 if __name__ == "__main__":
     args = parse_args(Arguments)
-    if getattr(args.test, "mode", "broadcast") == "load_weights":
-        run_load_weights_test(args)
-    else:
-        run_rank0_broadcast_test(args)
+    run_rank0_broadcast_test(args)


### PR DESCRIPTION
…kip redundant scatter (#648)"

This reverts commit d545ede.

### What does this PR do?

I am temporarily withdrawing this contribution (PR #648) to comply with internal company policy while we finalize our corporate Contributor License Agreement (CLA).

Note on the state of the code: It appears the core logic in veomni/distributed/torch_parallelize.py (originally in #647) was missed during the merge of #648 due to a technical oversight/force-push. Because the current state of the main branch is incomplete and we lack a signed CLA, I am reverting this now to ensure a 100% clean slate.

Once the paperwork is complete, I will resubmit the full, unified fix in a fresh PR. Apologies for the administrative overhead!

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
