### PR TITLE
[parallel] feat: add cpu offload for fsdp2

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -316,6 +316,7 @@ NPU validation runs at two times:
 | reshard_after_forward | `bool` | `True` | Reshard after forward (FSDP2). |
 | reshard_after_backward | `bool` | `True` | Reshard after backward (FSDP2). |
 | forward_prefetch | `bool` | `True` | Enable forward prefetch. |
+| offload | `bool` | `False` | Enable CPU offload. |
 | max_load_broadcast_size | `float` | `20.0` | Maximum size (in GB) of parameters broadcasted from rank 0 during loading weights (FSDP2). Parameters exceeding this threshold will be chunked according to the parallel plan before broadcasting. |
 | mixed_precision | `MixedPrecisionConfig` | — | Mixed precision configuration. |
 

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -255,6 +255,7 @@ def main():
         basic_modules=model._no_split_modules,
         enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
         enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
+        enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
         broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
         cpu_load_param_name=cpu_load_param_name,
         max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -134,6 +134,7 @@ def main():
         weights_path=None,
         mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
         enable_gradient_checkpointing=args.train.gradient_checkpointing.enable,
+        enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
         basic_modules=[],
         enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
         enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
@@ -185,10 +186,6 @@ def main():
             if grad is None:
                 continue
             grad_local = grad.to_local() if isinstance(grad, DTensor) else grad
-            if args.train.accelerator.fsdp_config.offload:
-                assert grad_local.device.type == "cpu", (
-                    f"Expected offloaded grad for {name} to be on cpu, got {grad_local.device.type}."
-                )
             logger.info_rank0(f"{msg}: the local grad for {name}: {grad_local}")
             if name == "decoder.moe.experts":
                 torch.testing.assert_close(
@@ -276,97 +273,16 @@ def main():
     dist.destroy_process_group()
 
 
-def test_clip_grad_norm_fsdp2_no_extra_parallel():
+def _run_clip_grad_norm_fsdp2_test(ep_size: int, emb_size: int, cpu_offload: bool) -> None:
     command = [
         "torchrun",
         "--nnodes=1",
         "--nproc_per_node=8",
         "--master_port=4321",
         "tests/utils/test_extra_parallel_clip_grad_norm.py",
-        "--train.accelerator.ep_size=1",
+        f"--train.accelerator.ep_size={ep_size}",
         "--train.accelerator.ep_outside=False",
-        "--train.accelerator.extra_parallel_sizes=1",
-        "--train.accelerator.extra_parallel_placement_innermost=False",
-        "--train.accelerator.extra_parallel_names=emb",
-        "--train.accelerator.fsdp_config.fsdp_mode=fsdp2",
-        "--train.init_device=meta",
-        "--train.checkpoint.output_dir='debug'",
-    ]
-    result = subprocess.run(command, check=True)
-    assert result.returncode == 0
-
-
-def test_clip_grad_norm_fsdp2_ep4():
-    command = [
-        "torchrun",
-        "--nnodes=1",
-        "--nproc_per_node=8",
-        "--master_port=4321",
-        "tests/utils/test_extra_parallel_clip_grad_norm.py",
-        "--train.accelerator.ep_size=4",
-        "--train.accelerator.ep_outside=False",
-        "--train.accelerator.extra_parallel_sizes=1",
-        "--train.accelerator.extra_parallel_placement_innermost=False",
-        "--train.accelerator.extra_parallel_names=emb",
-        "--train.accelerator.fsdp_config.fsdp_mode=fsdp2",
-        "--train.init_device=meta",
-        "--train.checkpoint.output_dir='debug'",
-    ]
-    result = subprocess.run(command, check=True)
-    assert result.returncode == 0
-
-
-def test_clip_grad_norm_fsdp2_ep8():
-    command = [
-        "torchrun",
-        "--nnodes=1",
-        "--nproc_per_node=8",
-        "--master_port=4321",
-        "tests/utils/test_extra_parallel_clip_grad_norm.py",
-        "--train.accelerator.ep_size=8",
-        "--train.accelerator.ep_outside=False",
-        "--train.accelerator.extra_parallel_sizes=1",
-        "--train.accelerator.extra_parallel_placement_innermost=False",
-        "--train.accelerator.extra_parallel_names=emb",
-        "--train.accelerator.fsdp_config.fsdp_mode=fsdp2",
-        "--train.init_device=meta",
-        "--train.checkpoint.output_dir='debug'",
-    ]
-    result = subprocess.run(command, check=True)
-    assert result.returncode == 0
-
-
-def test_clip_grad_norm_fsdp2_emb8():
-    command = [
-        "torchrun",
-        "--nnodes=1",
-        "--nproc_per_node=8",
-        "--master_port=4321",
-        "tests/utils/test_extra_parallel_clip_grad_norm.py",
-        "--train.accelerator.ep_size=1",
-        "--train.accelerator.ep_outside=False",
-        "--train.accelerator.extra_parallel_sizes=8",
-        "--train.accelerator.extra_parallel_placement_innermost=False",
-        "--train.accelerator.extra_parallel_names=emb",
-        "--train.accelerator.fsdp_config.fsdp_mode=fsdp2",
-        "--train.init_device=meta",
-        "--train.checkpoint.output_dir='debug'",
-    ]
-    result = subprocess.run(command, check=True)
-    assert result.returncode == 0
-
-
-@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
-def test_clip_grad_norm_fsdp2_ep2_emb4(cpu_offload: bool):
-    command = [
-        "torchrun",
-        "--nnodes=1",
-        "--nproc_per_node=8",
-        "--master_port=4321",
-        "tests/utils/test_extra_parallel_clip_grad_norm.py",
-        "--train.accelerator.ep_size=2",
-        "--train.accelerator.ep_outside=False",
-        "--train.accelerator.extra_parallel_sizes=4",
+        f"--train.accelerator.extra_parallel_sizes={emb_size}",
         "--train.accelerator.extra_parallel_placement_innermost=False",
         "--train.accelerator.extra_parallel_names=emb",
         "--train.accelerator.fsdp_config.fsdp_mode=fsdp2",
@@ -377,6 +293,31 @@ def test_clip_grad_norm_fsdp2_ep2_emb4(cpu_offload: bool):
         command.append("--train.accelerator.fsdp_config.offload=True")
     result = subprocess.run(command, check=True)
     assert result.returncode == 0
+
+
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_clip_grad_norm_fsdp2_no_extra_parallel(cpu_offload: bool):
+    _run_clip_grad_norm_fsdp2_test(ep_size=1, emb_size=1, cpu_offload=cpu_offload)
+
+
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_clip_grad_norm_fsdp2_ep4(cpu_offload: bool):
+    _run_clip_grad_norm_fsdp2_test(ep_size=4, emb_size=1, cpu_offload=cpu_offload)
+
+
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_clip_grad_norm_fsdp2_ep8(cpu_offload: bool):
+    _run_clip_grad_norm_fsdp2_test(ep_size=8, emb_size=1, cpu_offload=cpu_offload)
+
+
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_clip_grad_norm_fsdp2_emb8(cpu_offload: bool):
+    _run_clip_grad_norm_fsdp2_test(ep_size=1, emb_size=8, cpu_offload=cpu_offload)
+
+
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_clip_grad_norm_fsdp2_ep2_emb4(cpu_offload: bool):
+    _run_clip_grad_norm_fsdp2_test(ep_size=2, emb_size=4, cpu_offload=cpu_offload)
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -2,6 +2,7 @@ import math
 import subprocess
 from dataclasses import dataclass, field
 
+import pytest
 import torch
 import torch.distributed as dist
 from torch.distributed._tensor import DTensor, Shard
@@ -184,6 +185,10 @@ def main():
             if grad is None:
                 continue
             grad_local = grad.to_local() if isinstance(grad, DTensor) else grad
+            if args.train.accelerator.fsdp_config.offload:
+                assert grad_local.device.type == "cpu", (
+                    f"Expected offloaded grad for {name} to be on cpu, got {grad_local.device.type}."
+                )
             logger.info_rank0(f"{msg}: the local grad for {name}: {grad_local}")
             if name == "decoder.moe.experts":
                 torch.testing.assert_close(
@@ -351,7 +356,8 @@ def test_clip_grad_norm_fsdp2_emb8():
     assert result.returncode == 0
 
 
-def test_clip_grad_norm_fsdp2_ep2_emb4():
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_clip_grad_norm_fsdp2_ep2_emb4(cpu_offload: bool):
     command = [
         "torchrun",
         "--nnodes=1",
@@ -367,6 +373,8 @@ def test_clip_grad_norm_fsdp2_ep2_emb4():
         "--train.init_device=meta",
         "--train.checkpoint.output_dir='debug'",
     ]
+    if cpu_offload:
+        command.append("--train.accelerator.fsdp_config.offload=True")
     result = subprocess.run(command, check=True)
     assert result.returncode == 0
 

--- a/tests/utils/test_rank0_load_and_broadcast_weights.py
+++ b/tests/utils/test_rank0_load_and_broadcast_weights.py
@@ -405,7 +405,7 @@ def test_load_dist_model_weights_matches_standard(tmp_path: Path, cpu_offload: b
     checkpoint_dir = tmp_path / "ckpt"
     weights_path = _write_checkpoint(checkpoint_dir, is_parallel=True)
 
-    world_size = 2
+    world_size = 4
     port = 12345 + random.randint(0, 100)
     command = [
         "torchrun",
@@ -580,7 +580,7 @@ def test_load_weights_no_scatter(tmp_path: Path, cpu_offload: bool) -> None:
     checkpoint_dir = tmp_path / "ckpt"
     weights_path = _write_checkpoint(checkpoint_dir, is_parallel=False)
 
-    world_size = 2
+    world_size = 4
     port = 12345 + random.randint(0, 100)
     command = [
         "torchrun",

--- a/tests/utils/test_rank0_load_and_broadcast_weights.py
+++ b/tests/utils/test_rank0_load_and_broadcast_weights.py
@@ -191,9 +191,23 @@ def _write_checkpoint(checkpoint_dir: Path, is_parallel: bool) -> str:
 def _clone_to_cpu(tensor: torch.Tensor) -> torch.Tensor:
     if DTensor is not None and isinstance(tensor, DTensor):
         assert Replicate is not None
+        local_tensor = tensor.to_local()
+        if local_tensor.device.type == "cpu":
+            mesh_device_type = tensor.device_mesh.device_type
+            if mesh_device_type == "cpu":
+                raise RuntimeError("CPU DTensor gather is not supported in this test helper.")
+            tensor = tensor.to(mesh_device_type)
         placements = [Replicate()] * tensor.device_mesh.ndim
         tensor = tensor.redistribute(tensor.device_mesh, placements).to_local()
     return tensor.detach().cpu().clone()
+
+
+def _assert_model_parameters_on_device(model: nn.Module, expected_device_type: str) -> None:
+    for name, param in model.named_parameters():
+        local_param = param.to_local() if DTensor is not None and isinstance(param, DTensor) else param
+        assert local_param.device.type == expected_device_type, (
+            f"Expected {name} to be on {expected_device_type}, got {local_param.device.type}."
+        )
 
 
 def run_rank0_broadcast_test(args: Arguments) -> None:
@@ -221,6 +235,8 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
     dtensor_factory = distribute_tensor if distribute_tensor is not None else None
     if dtensor_factory is None:
         raise RuntimeError("torch.distributed.tensor.distribute_tensor is required for fsdp2 weight loading test")
+    dtensor_to_cpu = args.train.accelerator.fsdp_config.offload
+    load_device = "cpu" if dtensor_to_cpu else get_device_type()
 
     try:
         rank0_load_model = ToyMoeAndEmbedModel()
@@ -262,6 +278,7 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
             init_device=args.train.init_device,
             mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
             enable_gradient_checkpointing=False,
+            enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
             basic_modules=[],
             broadcast_model_weights_from_rank0=True,
         )
@@ -274,7 +291,7 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
         rank0_load_and_broadcast_weights(
             rank0_load_model,
             str(weights_path),
-            init_device=get_device_type(),
+            init_device=load_device,
             dtensor_factory=dtensor_factory,
             cpu_load_param_name=cpu_load_param_name,
             max_load_broadcast_size=0.0,
@@ -287,6 +304,7 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
             init_device=args.train.init_device,
             mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
             enable_gradient_checkpointing=False,
+            enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
             basic_modules=[],
             broadcast_model_weights_from_rank0=False,
         )
@@ -295,9 +313,12 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
         load_model_weights(
             all_rank_load_model,
             str(weights_path),
-            init_device=get_device_type(),
+            init_device=load_device,
             dtensor_factory=dtensor_factory,
         )
+        if dtensor_to_cpu:
+            _assert_model_parameters_on_device(rank0_load_model, "cpu")
+            _assert_model_parameters_on_device(all_rank_load_model, "cpu")
         torch.testing.assert_close(
             rank0_load_model.get_input_embeddings().weight,
             all_rank_load_model.get_input_embeddings().weight,
@@ -379,11 +400,12 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
 
 
 @pytest.mark.skipif(not dist.is_available(), reason="torch.distributed required")
-def test_load_dist_model_weights_matches_standard(tmp_path: Path) -> None:
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_load_dist_model_weights_matches_standard(tmp_path: Path, cpu_offload: bool) -> None:
     checkpoint_dir = tmp_path / "ckpt"
     weights_path = _write_checkpoint(checkpoint_dir, is_parallel=True)
 
-    world_size = 4
+    world_size = 2
     port = 12345 + random.randint(0, 100)
     command = [
         "torchrun",
@@ -408,6 +430,8 @@ def test_load_dist_model_weights_matches_standard(tmp_path: Path) -> None:
         f"--test.backend={get_dist_comm_backend()}",
         "--test.mode=broadcast",
     ]
+    if cpu_offload:
+        command.append("--train.accelerator.fsdp_config.offload=True")
 
     result = subprocess.run(command, check=True)
     assert result.returncode == 0
@@ -452,6 +476,7 @@ def run_load_weights_test(args: Arguments) -> None:
             init_device=args.train.init_device,
             mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
             enable_gradient_checkpointing=False,
+            enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
             basic_modules=[],
         )
         """
@@ -478,6 +503,9 @@ def run_load_weights_test(args: Arguments) -> None:
         reference_model = ToyModel().to(get_device_type())
         load_model_weights(reference_model, str(weights_path), init_device=get_device_type())
         reference_model = reference_model.cpu()
+
+        if args.train.accelerator.fsdp_config.offload:
+            _assert_model_parameters_on_device(fsdp_model, "cpu")
 
         torch.testing.assert_close(
             _clone_to_cpu(fsdp_model.get_input_embeddings().weight),
@@ -539,7 +567,8 @@ def run_load_weights_test(args: Arguments) -> None:
 
 
 @pytest.mark.skipif(not dist.is_available(), reason="torch.distributed required")
-def test_load_weights_no_scatter(tmp_path: Path) -> None:
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_load_weights_no_scatter(tmp_path: Path, cpu_offload: bool) -> None:
     """
     Regression test for https://github.com/ByteDance-Seed/VeOmni/issues/637.
 
@@ -551,7 +580,7 @@ def test_load_weights_no_scatter(tmp_path: Path) -> None:
     checkpoint_dir = tmp_path / "ckpt"
     weights_path = _write_checkpoint(checkpoint_dir, is_parallel=False)
 
-    world_size = 4
+    world_size = 2
     port = 12345 + random.randint(0, 100)
     command = [
         "torchrun",
@@ -571,6 +600,8 @@ def test_load_weights_no_scatter(tmp_path: Path) -> None:
         f"--test.backend={get_dist_comm_backend()}",
         "--test.mode=load_weights",
     ]
+    if cpu_offload:
+        command.append("--train.accelerator.fsdp_config.offload=True")
 
     result = subprocess.run(command, check=True)
     assert result.returncode == 0

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -612,12 +612,6 @@ class TrainingArguments:
         else:
             raise ValueError(f"`global_batch_size` should be a multiple of {self.micro_batch_size * acc.dp_size}.")
 
-<<<<<<< HEAD
-=======
-        if self.gradient_accumulation_steps > 1 and acc.fsdp_config.offload and acc.fsdp_config.fsdp_mode == "fsdp1":
-            raise ValueError("Gradient accumulation is not supported with FSDP1 CPU offload.")
-
->>>>>>> 2f38a99 ([parallel] feat: add cpu offload for fsdp2)
         # dataloader batch size
         if self.dyn_bsz:
             if self.dyn_bsz_runtime == "main":

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -292,6 +292,10 @@ class FSDPConfig:
         default=True,
         metadata={"help": "Enable forward prefetch."},
     )
+    offload: bool = field(
+        default=False,
+        metadata={"help": "Enable CPU offload for FSDP2."},
+    )
     max_load_broadcast_size: float = field(
         default=20.0,
         metadata={
@@ -608,6 +612,12 @@ class TrainingArguments:
         else:
             raise ValueError(f"`global_batch_size` should be a multiple of {self.micro_batch_size * acc.dp_size}.")
 
+<<<<<<< HEAD
+=======
+        if self.gradient_accumulation_steps > 1 and acc.fsdp_config.offload and acc.fsdp_config.fsdp_mode == "fsdp1":
+            raise ValueError("Gradient accumulation is not supported with FSDP1 CPU offload.")
+
+>>>>>>> 2f38a99 ([parallel] feat: add cpu offload for fsdp2)
         # dataloader batch size
         if self.dyn_bsz:
             if self.dyn_bsz_runtime == "main":

--- a/veomni/distributed/fsdp2/clip_grad_norm.py
+++ b/veomni/distributed/fsdp2/clip_grad_norm.py
@@ -30,6 +30,15 @@ def clip_grad_norm(
             foreach=foreach,
         )
 
+    if getattr(model, "_fsdp_cpu_offload_enabled", False):
+        return _cpu_offload_fsdp2_clip_grad_norm(
+            model,
+            max_norm,
+            norm_type=norm_type,
+            error_if_nonfinite=error_if_nonfinite,
+            foreach=foreach,
+        )
+
     grad_norm = torch.nn.utils.clip_grad_norm_(
         model.parameters(),
         max_norm,
@@ -40,6 +49,25 @@ def clip_grad_norm(
     if isinstance(grad_norm, DTensor):
         grad_norm = grad_norm.full_tensor()
     return grad_norm
+
+
+@torch.no_grad()
+def _cpu_offload_fsdp2_clip_grad_norm(
+    model, max_norm: float, norm_type: float = 2.0, error_if_nonfinite: bool = False, foreach: bool | None = None
+) -> torch.Tensor:
+    ps = get_parallel_state()
+    params = [p for p in model.parameters() if p.grad is not None]
+    total_norm_or_pth_sum = _fsdp2_reduce_group(
+        params=params,
+        norm_type=norm_type,
+        reduce_groups=[("fsdp", ps.fsdp_group)],
+    )
+    total_norm = _finalize_total_norm(total_norm_or_pth_sum, norm_type)
+    _raise_if_nonfinite(total_norm, norm_type, error_if_nonfinite)
+
+    torch.nn.utils.clip_grads_with_norm_(params, max_norm, total_norm, foreach=foreach)
+
+    return total_norm
 
 
 @torch.no_grad()
@@ -113,7 +141,9 @@ def extra_parallel_fsdp2_clip_grad_norm(
     if math.isinf(norm_type):
         total_norm = torch.maximum(non_extra_parallel_total, *extra_parallel_total.values())
     else:
-        total_norm = (non_extra_parallel_total + sum(extra_parallel_total.values())) ** (1.0 / float(norm_type))
+        total_norm = _finalize_total_norm(non_extra_parallel_total + sum(extra_parallel_total.values()), norm_type)
+
+    _raise_if_nonfinite(total_norm, norm_type, error_if_nonfinite)
 
     # Apply the same clip coefficient to both groups
     for para in ps.extra_parallel_names:
@@ -121,6 +151,23 @@ def extra_parallel_fsdp2_clip_grad_norm(
     torch.nn.utils.clip_grads_with_norm_(non_extra_parallel_params, max_norm, total_norm, foreach=foreach)
 
     return total_norm
+
+
+def _finalize_total_norm(total_norm_or_pth_sum: torch.Tensor, norm_type: float) -> torch.Tensor:
+    if math.isinf(norm_type):
+        return total_norm_or_pth_sum
+    return total_norm_or_pth_sum ** (1.0 / float(norm_type))
+
+
+def _raise_if_nonfinite(total_norm: torch.Tensor, norm_type: float, error_if_nonfinite: bool) -> None:
+    if not error_if_nonfinite:
+        return
+    if bool((~torch.isfinite(total_norm)).item()):
+        raise RuntimeError(
+            f"The total norm of order {norm_type} for gradients from `parameters` is non-finite, "
+            "so it cannot be clipped. To disable this error and scale the gradients by the non-finite norm anyway, "
+            "set `error_if_nonfinite=False`"
+        )
 
 
 # compute local sum of param gard norm

--- a/veomni/distributed/fsdp2/clip_grad_norm.py
+++ b/veomni/distributed/fsdp2/clip_grad_norm.py
@@ -131,23 +131,23 @@ def _local_pth_sum(params: List[torch.nn.Parameter], p: float) -> torch.Tensor:
         for g in grads
     ]
 
-    default_device = grads_local[0].device if len(grads_local) > 0 else torch.device(get_device_type())
-    res = torch.tensor(0.0, device=default_device, dtype=torch.float32)
+    reduce_device = torch.device(get_device_type())
+    res = torch.tensor(0.0, device=reduce_device, dtype=torch.float32)
     with torch.no_grad():
         grouped_grads_local = _group_tensors_by_device_and_dtype([grads_local])
         for (device, _), ([device_grads_local], _) in grouped_grads_local.items():
             if _has_foreach_support(device_grads_local, device) or _device_has_foreach_support(device):
                 out = torch._foreach_pow_(torch._foreach_norm(device_grads_local, p), p)
-                res += torch.sum(torch.stack(out)).to(default_device)
+                res += torch.sum(torch.stack(out)).to(reduce_device)
             else:
                 for grad_local in device_grads_local:
                     gn = torch.norm(grad_local, p=p)
-                    res = res + (gn**p).to(default_device)
+                    res = res + (gn**p).to(reduce_device)
     return res
 
 
 def _local_max(params: List[torch.nn.Parameter]) -> torch.Tensor:
-    dev = None
+    reduce_device = torch.device(get_device_type())
     mx = None
     for q in params:
         g = q.grad
@@ -157,14 +157,12 @@ def _local_max(params: List[torch.nn.Parameter]) -> torch.Tensor:
             g_local = g.to_local()
         else:
             g_local = g
-        if dev is None:
-            dev = g_local.device
-            mx = torch.tensor(0.0, device=dev, dtype=torch.float32)
+        if mx is None:
+            mx = torch.tensor(0.0, device=reduce_device, dtype=torch.float32)
         gn = torch.max(torch.abs(g_local.detach().to(torch.float32)))
-        mx = torch.maximum(mx, gn)
+        mx = torch.maximum(mx, gn.to(reduce_device))
     if mx is None:
-        dev = torch.device(get_device_type())
-        mx = torch.tensor(0.0, device=dev, dtype=torch.float32)
+        mx = torch.tensor(0.0, device=reduce_device, dtype=torch.float32)
     return mx
 
 

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -21,7 +21,7 @@ import torch
 import torch.nn as nn
 from torch.distributed._composable.fsdp import MixedPrecisionPolicy, fully_shard
 from torch.distributed._tensor import Shard
-from torch.distributed.fsdp import FSDPModule
+from torch.distributed.fsdp import FSDPModule, CPUOffloadPolicy
 from torch.distributed.tensor.parallel import parallelize_module
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.checkpoint import noop_context_fn
@@ -203,6 +203,11 @@ def parallelize_model_fsdp2(
             cast_forward_inputs=mixed_precision.cast_forward_inputs,
         )
         fsdp_kwargs["mp_policy"] = mp_policy
+    # prepare offload_policy kwargs
+    enable_fsdp_cpu_offload = kwargs.pop("enable_fsdp_offload", False)
+    if enable_fsdp_cpu_offload:
+        logger.info_rank0("Enable FSDP2 CPU offload for parameters, gradients, and optimizer states.")
+        fsdp_kwargs["offload_policy"] = CPUOffloadPolicy()
 
     if hasattr(model, "get_ignore_modules_in_mixed_precision"):
         modules_to_ignore_in_mixed_precision = model.get_ignore_modules_in_mixed_precision()
@@ -351,9 +356,10 @@ def parallelize_model_fsdp2(
 
     # Handle meta initialization for FSDP2 (fallback if pre-load not done)
     assert kwargs.get("init_device") == "meta", "Please use init_device: meta for FSDP2"
+    materialize_device = "cpu" if enable_fsdp_cpu_offload else get_device_type()
 
     if weights_path is None:
-        model.to_empty(device=get_device_type())
+        model.to_empty(device=materialize_device)
         _reset_hf_initialized_flag(model)
         model.init_weights()
     else:
@@ -373,7 +379,7 @@ def parallelize_model_fsdp2(
             rank0_load_and_broadcast_weights(
                 model,
                 weights_path,
-                get_device_type(),
+                materialize_device,
                 dtensor_factory=distribute_tensor,
                 cpu_load_param_name=kwargs.get("cpu_load_param_name", None),
                 max_load_broadcast_size=kwargs.get("max_load_broadcast_size", 20.0),
@@ -386,7 +392,7 @@ def parallelize_model_fsdp2(
             load_model_weights(
                 model,
                 weights_path,
-                get_device_type(),
+                materialize_device,
                 dtensor_factory=_dt_local_split,
                 is_peft_model=is_peft_model,
                 adapter_path=adapter_path,

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -21,7 +21,7 @@ import torch
 import torch.nn as nn
 from torch.distributed._composable.fsdp import MixedPrecisionPolicy, fully_shard
 from torch.distributed._tensor import Shard
-from torch.distributed.fsdp import FSDPModule, CPUOffloadPolicy
+from torch.distributed.fsdp import CPUOffloadPolicy, FSDPModule
 from torch.distributed.tensor.parallel import parallelize_module
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.checkpoint import noop_context_fn
@@ -205,6 +205,7 @@ def parallelize_model_fsdp2(
         fsdp_kwargs["mp_policy"] = mp_policy
     # prepare offload_policy kwargs
     enable_fsdp_cpu_offload = kwargs.pop("enable_fsdp_offload", False)
+    model._fsdp_cpu_offload_enabled = enable_fsdp_cpu_offload
     if enable_fsdp_cpu_offload:
         logger.info_rank0("Enable FSDP2 CPU offload for parameters, gradients, and optimizer states.")
         fsdp_kwargs["offload_policy"] = CPUOffloadPolicy()

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -42,7 +42,7 @@ from transformers.utils.hub import cached_file, get_checkpoint_shard_files
 
 from ..distributed.parallel_state import get_parallel_state
 from ..utils import logging
-from ..utils.device import synchronize
+from ..utils.device import get_device_type, synchronize
 from ..utils.helper import empty_cache, get_cache_dir, get_dtype_size
 from ..utils.import_utils import is_diffusers_available
 from .checkpoint_tensor_loading import get_checkpoint_tensor_converter, maybe_convert_checkpoint_tensor
@@ -176,6 +176,7 @@ def _dispatch_parameter(
     tensor: "torch.Tensor",
     dtensor_factory: Optional[Callable[["torch.Tensor", Any, Any], "torch.Tensor"]] = None,
     parallel_plan: Optional["ParallelPlan"] = None,
+    dtensor_to_cpu: bool = False,
 ) -> None:
     """
     Assigns parameter to an empty model.
@@ -190,15 +191,17 @@ def _dispatch_parameter(
     if parallel_plan is not None:
         tensor = parallel_plan.shard_tensor(tensor, full_param_name, orig_tensor.shape)
 
-    tensor = tensor.to(orig_tensor)
     if hasattr(orig_tensor, "device_mesh"):  # dtensor
-        if orig_tensor.device.type == "cpu":
-            raise ValueError("Cannot load dtensor on CPU.")
-
+        if dtensor_factory is None:
+            raise ValueError("dtensor parameter requires a dtensor_factory.")
         device_mesh = orig_tensor.device_mesh
         placements = orig_tensor.placements
-        module._parameters[local_name].data.copy_(dtensor_factory(tensor, device_mesh, placements))
+        sharded_tensor = dtensor_factory(tensor.to(dtype=orig_tensor.dtype), device_mesh, placements)
+        if dtensor_to_cpu:
+            sharded_tensor = sharded_tensor.to("cpu")
+        module._parameters[local_name].data.copy_(sharded_tensor)
     else:  # not dtensor
+        tensor = tensor.to(orig_tensor)
         module._parameters[local_name].data.copy_(tensor)
 
 
@@ -207,6 +210,7 @@ def _dispatch_buffer(
     name: str,
     buffer: "torch.Tensor",
     dtensor_factory: Optional[Callable[["torch.Tensor", Any, Any], "torch.Tensor"]] = None,
+    dtensor_to_cpu: bool = False,
 ) -> None:
     """
     Assigns buffer to an empty model.
@@ -220,9 +224,18 @@ def _dispatch_buffer(
 
         device_mesh = orig_tensor.device_mesh
         placements = orig_tensor.placements
-        module._buffers[name] = dtensor_factory(buffer.to(dtype=orig_tensor.dtype), device_mesh, placements)
+        sharded_buffer = dtensor_factory(buffer.to(dtype=orig_tensor.dtype), device_mesh, placements)
+        if dtensor_to_cpu:
+            sharded_buffer = sharded_buffer.to("cpu")
+        module._buffers[name] = sharded_buffer
     else:
         module._buffers[name].copy_(buffer.to(device=orig_tensor.device, dtype=orig_tensor.dtype))
+
+
+def _get_communication_device(init_device: Literal["cpu", "cuda", "npu"]) -> torch.device:
+    if init_device == "cpu":
+        return torch.device(get_device_type())
+    return torch.device(init_device)
 
 
 def _init_parameter(
@@ -301,6 +314,7 @@ def load_model_weights(
     buffer_dict = {name: buffer.clone() for name, buffer in model.named_buffers()}
     parameter_names_to_load = {name for name, _ in model.named_parameters()}
     model.to_empty(device=init_device)
+    dtensor_to_cpu = init_device == "cpu"
 
     # Get parallel plan if available
     parallel_plan = None
@@ -326,7 +340,7 @@ def load_model_weights(
             buffer_dict[name] = tensor.clone()
         elif name in parameter_names_to_load:
             parameter_names_to_load.remove(name)
-            _dispatch_parameter(model, name, tensor, dtensor_factory, parallel_plan)
+            _dispatch_parameter(model, name, tensor, dtensor_factory, parallel_plan, dtensor_to_cpu)
         else:
             logger.info_rank0(f"Unexpected key in state dict: {name}.")
 
@@ -361,7 +375,9 @@ def load_model_weights(
             parameter_names_to_load=parameter_names_to_load,
         )
 
-    post_process_after_weight_loading(model, buffer_dict, parameter_names_to_load, dtensor_factory)
+    post_process_after_weight_loading(
+        model, buffer_dict, parameter_names_to_load, dtensor_factory, dtensor_to_cpu=dtensor_to_cpu
+    )
 
 
 @torch.no_grad()
@@ -386,6 +402,7 @@ def rank0_load_and_broadcast_weights(
     buffer_dict = {name: buffer.clone() for name, buffer in model.named_buffers()}
     parameter_names_to_load = {name for name, _ in model.named_parameters()}
     model.to_empty(device=init_device)
+    dtensor_to_cpu = init_device == "cpu"
 
     # Get parallel plan if available
     parallel_plan = None
@@ -404,7 +421,7 @@ def rank0_load_and_broadcast_weights(
 
     converter = get_checkpoint_tensor_converter(model)
     global_rank = get_parallel_state().global_rank
-    torch_device = torch.device(init_device)
+    torch_device = _get_communication_device(init_device)
 
     def _broadcast_and_dispatch(name, shape, dtype, tensor):
         """Broadcast a single (name, tensor) from rank0 and dispatch it."""
@@ -424,7 +441,7 @@ def rank0_load_and_broadcast_weights(
             buffer_dict[name] = tensor.detach().clone()
         elif name in parameter_names_to_load:
             parameter_names_to_load.discard(name)
-            _dispatch_parameter(model, name, tensor, dtensor_factory, parallel_plan)
+            _dispatch_parameter(model, name, tensor, dtensor_factory, parallel_plan, dtensor_to_cpu)
         else:
             if global_rank == 0:
                 logger.info_rank0(f"Unexpected key in state dict: {name}.")
@@ -531,22 +548,23 @@ def rank0_load_and_broadcast_weights(
 
             chunk_loaded_data = list(tensor.chunk(para_size, dim=0))
 
-        assert shard_tensor.is_cuda, "Shard parameter should be on CUDA."
         is_shard_tensor_dtensor = hasattr(shard_tensor, "device_mesh")
         if is_shard_tensor_dtensor:
             device_mesh = shard_tensor.device_mesh
             placements = shard_tensor.placements
+            shard_comm_device = torch.device(device_mesh.device_type)
         else:
             device_mesh = None
             placements = None
+            shard_comm_device = _get_communication_device(init_device)
 
         broadcast_buffer = torch.empty(
             shard_tensor.shape,
             dtype=shard_tensor.dtype,
-            device=shard_tensor.device,
+            device=shard_comm_device,
         )
         shard_dst_ranks = _get_extra_parallel_shard_dst_ranks(
-            parallel_state, para_group_name, para_size, shard_tensor.device
+            parallel_state, para_group_name, para_size, shard_comm_device
         )
         for chunk_id in range(para_size):
             # For example:
@@ -574,9 +592,12 @@ def rank0_load_and_broadcast_weights(
 
                 if global_rank in dst_ranks:
                     if is_shard_tensor_dtensor:
-                        shard_tensor.copy_(dtensor_factory(broadcast_buffer, device_mesh, placements).contiguous())
+                        chunk_tensor = dtensor_factory(broadcast_buffer, device_mesh, placements).contiguous()
+                        if dtensor_to_cpu:
+                            chunk_tensor = chunk_tensor.to("cpu")
+                        shard_tensor.copy_(chunk_tensor)
                     else:
-                        shard_tensor.copy_(broadcast_buffer.contiguous())
+                        shard_tensor.copy_(broadcast_buffer.to(shard_tensor.device).contiguous())
 
             elif global_rank in send_seq:
                 if is_shard_tensor_dtensor:
@@ -588,9 +609,12 @@ def rank0_load_and_broadcast_weights(
                 dist.recv(broadcast_buffer, src=0, tag=tag)
 
                 if is_shard_tensor_dtensor:
-                    shard_tensor.copy_(dtensor_factory(broadcast_buffer, device_mesh, placements).contiguous())
+                    chunk_tensor = dtensor_factory(broadcast_buffer, device_mesh, placements).contiguous()
+                    if dtensor_to_cpu:
+                        chunk_tensor = chunk_tensor.to("cpu")
+                    shard_tensor.copy_(chunk_tensor)
                 else:
-                    shard_tensor.copy_(broadcast_buffer.contiguous())
+                    shard_tensor.copy_(broadcast_buffer.to(shard_tensor.device).contiguous())
 
         logger.info_rank0(
             f"{name=}, {shape=}, {dtype=}, chunk and broadcast time (ms) spent: {1000 * (time.perf_counter() - start_time)}"
@@ -731,7 +755,9 @@ def rank0_load_and_broadcast_weights(
             parameter_names_to_load=parameter_names_to_load,
         )
 
-    post_process_after_weight_loading(model, buffer_dict, parameter_names_to_load, dtensor_factory)
+    post_process_after_weight_loading(
+        model, buffer_dict, parameter_names_to_load, dtensor_factory, dtensor_to_cpu=dtensor_to_cpu
+    )
 
 
 def post_process_after_weight_loading(
@@ -739,6 +765,7 @@ def post_process_after_weight_loading(
     buffer_dict,
     parameter_names_left: Optional[set[str]] = None,
     dtensor_factory: Optional[Callable[["torch.Tensor", Any, Any], "torch.Tensor"]] = None,
+    dtensor_to_cpu: bool = False,
 ):
     """
     shared logic after weight loading that handles buffer, missing weight keys and tied embedding weights.
@@ -746,7 +773,7 @@ def post_process_after_weight_loading(
     parameter_names_left = parameter_names_left or set()
 
     for name, buffer in buffer_dict.items():
-        _dispatch_buffer(model, name, buffer, dtensor_factory)
+        _dispatch_buffer(model, name, buffer, dtensor_factory, dtensor_to_cpu=dtensor_to_cpu)
     if parameter_names_left:
         logger.info_rank0(f"Find missing key(s) in state dict: {parameter_names_left}, initialize them.")
         for name in sorted(parameter_names_left):

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -396,6 +396,7 @@ class BaseTrainer(Stateful, ABC):
             ),
             enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
             enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
+            enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
             broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
             max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
             muon_expert_zero_comm=muon_expert_zero_comm,

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -161,6 +161,7 @@ class TextDPOTrainer:
             ),
             enable_reentrant=False,
             enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
+            enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
             broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
             cpu_load_param_name=cpu_load_param_name,
             max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,


### PR DESCRIPTION
### What does this PR do?

add cpu offload for fsdp2

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
