### PR TITLE
[dist] fix: update dtensor_factory to use partial for local split in paralle…

### DIFF
--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -14,6 +14,7 @@
 
 
 import types
+from functools import partial
 from typing import List, Optional, Tuple
 
 import torch
@@ -381,11 +382,12 @@ def parallelize_model_fsdp2(
             )
         else:
             logger.info_rank0("Every rank would read weights from disk and expect this to be slow!")
+            _dt_local_split = partial(distribute_tensor, src_data_rank=None)
             load_model_weights(
                 model,
                 weights_path,
                 get_device_type(),
-                dtensor_factory=distribute_tensor,
+                dtensor_factory=_dt_local_split,
                 is_peft_model=is_peft_model,
                 adapter_path=adapter_path,
             )


### PR DESCRIPTION

### What does this PR do?
Add the missed file from https://github.com/ByteDance-Seed/VeOmni/pull/648 that initial mentioned at https://github.com/ByteDance-Seed/VeOmni/pull/647 
> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
