### PR TITLE
[model, ci] test: add implicit CUDA sync gate for qwen3_5 generated modeling

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -140,6 +140,7 @@ jobs:
           uv run --frozen pytest -s -x tests/models/test_vlm_trainer.py
           uv run --frozen pytest -s -x tests/models/test_padded_packed_loss.py
           uv run --frozen pytest -s -x tests/models/test_models_logits_equal_v5.py
+          uv run --frozen pytest -s -x tests/models/test_model_forward_no_implicit_sync.py
           uv run --frozen pytest -s -x tests/models/test_checkpoint_tensor_converter.py
           uv run --frozen pytest -s -x tests/models/test_return_log_probs_e2e.py
       - name: Run Qwen3.5 GatedDeltaNet Ulysses SP tests

--- a/tests/models/test_model_forward_no_implicit_sync.py
+++ b/tests/models/test_model_forward_no_implicit_sync.py
@@ -1,8 +1,24 @@
 """Implicit CUDA-sync gate for VeOmni-patched v5 modeling code.
 
 Runs each model's forward under ``torch.cuda.set_sync_debug_mode("warn")``
-and fails if any implicit host<->device sync originates from
+and fails if any new implicit host<->device sync site shows up in
 ``veomni/models/transformers/<model>/generated/``.
+
+The principle
+-------------
+We are gating **VeOmni's patches** (the code we wrote), not HF upstream.
+``generated/`` files are mostly HF source copied verbatim with imports
+resolved; only the bits marked ``[PATCHED CLASS]`` / ``[MODIFIED CLASS]
+Methods patched: ...`` are ours. The patchgen ``.diff`` next to each
+generated file is the authoritative ours-vs-HF view.
+
+The test inevitably observes warnings from *all* code in the generated
+file (patched and verbatim alike), so the allowlist exists to mark
+HF-verbatim sites as "not ours, leave alone". Concretely:
+
+  - **VeOmni-patched code introducing a sync** → fix the patch.
+  - **HF-verbatim code that syncs** → allowlist with reason "HF-verbatim;
+    out of scope". Do not try to improve upstream HF here.
 
 Why this matters
 ----------------
@@ -14,10 +30,9 @@ under SP/EP and small micro-batches, and can cascade into NCCL watchdog
 timeouts. See the ``debug-cuda-sync`` skill for the manual investigation
 flow against real weights.
 
-This test is the *unit-level ratchet* for the same property: it runs on
-toy configs (so only catches sync sites reachable from a tiny forward),
-but it's cheap and catches "someone added a ``.item()`` to a patch" at
-PR time. Real-model SP/EP coverage stays with the skill.
+This test is the *unit-level ratchet*: it runs on toy configs (so only
+catches sync sites reachable from a tiny forward) and is cheap enough
+to gate PRs. Real-model SP/EP coverage stays with the skill.
 
 Extending to more models
 ------------------------
@@ -28,19 +43,17 @@ counterpart, e.g. fused-MoE on the production path). Add a
 ``_MOE_IMPL_BY_CASE`` entry to override the default ``"eager"``
 backend for MoE cases.
 
-Acknowledging a necessary sync
-------------------------------
-``_ALLOWED_SYNCS`` is a per-case dict from ``(basename, lineno)`` to a
-short reason string — pre-existing acknowledged syncs (HF-inherited
-code paths, eager-only fallback loops, EP dispatch with data-dependent
-split sizes). The semantics are *ratchet*: the test fails if a new
-``(file, lineno)`` shows up in generated/ that isn't in the allowlist.
-Removing a site (by fixing the patch) is encouraged.
+When a new model's first run surfaces sync sites, decide each:
+- Read the surrounding code in the generated file and check the patchgen
+  ``.diff`` next to it. If the lines are unchanged from HF, allowlist
+  with ``"HF-verbatim: <one-line description>"``.
+- If the lines were added or modified by a VeOmni patch, fix the patch
+  to derive the value host-side.
 
-Line numbers are into the **generated** file, so if patchgen
-regenerates and shifts lines, the allowlist must be re-checked. Treat
-this the same as the checked-in ``.diff`` snapshot under each model's
-``generated/`` — both are line-aware.
+Line numbers are into the **generated** file, so a ``make patchgen``
+that shifts lines requires re-checking the allowlist. Dead allowlist
+entries (listed but no longer observed) also fail the test, so drift
+can't silently rot the gate.
 """
 
 import importlib
@@ -97,13 +110,21 @@ _MOE_IMPL_BY_CASE: dict[str, str] = {
 # logits test forces for HF parity, and we want to drop SDPA in favour of
 # FA2. To extend, add a ``Case`` here (and optionally a ``_MOE_IMPL_BY_CASE``
 # entry for fused-MoE coverage).
+#
+# ``qwen3_5_moe-text-eager`` is intentionally absent: the eager experts
+# loop is HF-verbatim and not the production path (production uses
+# ``veomni_moe_experts_forward`` via OpSlot, exercised by the fa2-fused
+# case below). Gating MoE on that case alone keeps the allowlist focused
+# on VeOmni-patched code.
 CASES = [
-    # qwen3_5 (non-MoE, text-only sub-config) — both attention paths.
+    # qwen3_5 (non-MoE, text-only sub-config) — both attention paths through
+    # our patched Qwen3_5Model.forward.
     _logits_case("qwen3_5-text-eager"),
     _logits_case("qwen3_5-text-fa2"),
-    # qwen3_5_moe-text — eager path (kept for non-MoE-code coverage) and
-    # the production FA2 + fused-Triton MoE path.
-    _logits_case("qwen3_5_moe-text-eager"),
+    # qwen3_5_moe-text — production FA2 + fused-Triton MoE. The fused
+    # short-circuit (line ~1044 in patched_modeling_qwen3_5_moe_gpu.py)
+    # is VeOmni's; the HF eager loop body that it bypasses is verbatim
+    # and not exercised in this case.
     Case(
         "qwen3_5_moe-text-fa2-fused",
         _toy("qwen3_5_moe_toy"),
@@ -114,49 +135,35 @@ CASES = [
     ),
 ]
 
-# Pre-existing acknowledged sync sites in generated/. Keyed by
-# ``Case.case_id``; value maps ``(basename, lineno)`` -> reason.
+# Acknowledged sync sites in generated/ that are **HF-verbatim** (not
+# touched by any VeOmni patch). Keyed by ``Case.case_id``; value maps
+# ``(basename, lineno)`` -> one-line reason.
 #
-# Two flavours show up in the current baseline:
-#   - ``_update_linear_attn_mask`` (HF-inherited): a Python ``if`` on a
-#     GPU scalar (``cache_position[0]``) plus ``torch.all(mask == 1)``.
-#     The patch doesn't touch this method; the toy config forces all
-#     layers to ``full_attention`` so the linear-attention branch is
-#     unreachable, but the guard still evaluates each forward.
-#   - Eager expert loop in ``Qwen3_5MoeExperts.forward``: ``.nonzero()``
-#     → Python ``for`` over GPU tensor → ``if expert_idx == N`` →
-#     ``torch.where`` indexing. Production dispatches via
-#     ``veomni_moe_experts_forward`` and skips this path; the loop is
-#     only reachable under ``_experts_implementation="eager"`` (which
-#     the test forces for determinism).
-_LINEAR_ATTN_REASON = (
-    "HF-inherited _update_linear_attn_mask: `if cache_position[0] > 0 or "
-    "torch.all(mask == 1)`; unreachable under toy full_attention config."
-)
-_EAGER_EXPERTS_REASON = (
-    "Eager Qwen3_5MoeExperts.forward fallback loop (.nonzero() + Python for "
-    "over experts); production runs fused via veomni_moe_experts_forward."
+# Rule: every entry here MUST be HF-verbatim code. If a sync sits inside
+# a class or method that VeOmni patches, fix the patch instead. Verify
+# via the patchgen ``.diff`` next to the generated file — unchanged
+# lines are HF, changed lines are ours.
+#
+# Current entries are all the same upstream HF method:
+# ``_update_linear_attn_mask``. Both qwen3_5 and qwen3_5_moe inherit it
+# from the same upstream class hierarchy; both ``Qwen3_5{,Moe}Model``
+# are MODIFIED CLASSes but ``_update_linear_attn_mask`` is not in their
+# ``Methods patched`` list. The method does ``if cache_position[0] > 0
+# or torch.all(attention_mask == 1)`` — two implicit syncs (0-D GPU
+# scalar in Python ``if`` + full-tensor reduction). Out of scope.
+_HF_VERBATIM_LINEAR_ATTN = (
+    "HF-verbatim _update_linear_attn_mask: `if cache_position[0] > 0 or "
+    "torch.all(mask == 1)`; method not in VeOmni's patched-methods list."
 )
 _ALLOWED_SYNCS: dict[str, dict[tuple[str, int], str]] = {
     "qwen3_5-text-eager": {
-        ("patched_modeling_qwen3_5_gpu.py", 1750): _LINEAR_ATTN_REASON,
+        ("patched_modeling_qwen3_5_gpu.py", 1750): _HF_VERBATIM_LINEAR_ATTN,
     },
     "qwen3_5-text-fa2": {
-        ("patched_modeling_qwen3_5_gpu.py", 1750): _LINEAR_ATTN_REASON,
+        ("patched_modeling_qwen3_5_gpu.py", 1750): _HF_VERBATIM_LINEAR_ATTN,
     },
-    "qwen3_5_moe-text-eager": {
-        ("patched_modeling_qwen3_5_moe_gpu.py", 1052): _EAGER_EXPERTS_REASON,
-        ("patched_modeling_qwen3_5_moe_gpu.py", 1056): _EAGER_EXPERTS_REASON,
-        ("patched_modeling_qwen3_5_moe_gpu.py", 1058): _EAGER_EXPERTS_REASON,
-        ("patched_modeling_qwen3_5_moe_gpu.py", 1060): _EAGER_EXPERTS_REASON,
-        ("patched_modeling_qwen3_5_moe_gpu.py", 1062): _EAGER_EXPERTS_REASON,
-        ("patched_modeling_qwen3_5_moe_gpu.py", 1955): _LINEAR_ATTN_REASON,
-    },
-    # qwen3_5_moe-text-fa2-fused: production path (fused_triton MoE
-    # bypasses the eager expert loop). Only the HF-inherited
-    # linear-attention guard remains.
     "qwen3_5_moe-text-fa2-fused": {
-        ("patched_modeling_qwen3_5_moe_gpu.py", 1955): _LINEAR_ATTN_REASON,
+        ("patched_modeling_qwen3_5_moe_gpu.py", 1955): _HF_VERBATIM_LINEAR_ATTN,
     },
 }
 
@@ -313,14 +320,16 @@ def test_no_implicit_sync_in_generated_forward(case):
             unique = {(os.path.basename(f), ln): m.splitlines()[0] for (f, ln, m) in offending}
             formatted = "\n".join(f"  {f}:{ln}  ::  {m}" for (f, ln), m in sorted(unique.items()))
             problems.append(
-                f"{len(unique)} new implicit CUDA sync site(s) in patched modeling:\n"
+                f"{len(unique)} new implicit CUDA sync site(s) in generated modeling:\n"
                 f"{formatted}\n"
-                f"Each line is into the generated modeling file. Fix the patch to derive the "
-                f"value host-side (typical sources: 0-D GPU tensor used as a shape/index arg, "
-                f".item() for a Python int, repeat_interleave with GPU repeats, if/bool on a "
-                f"GPU scalar). If the sync is genuinely needed (e.g. EP dispatch sizes), add "
-                f"the (basename, lineno) to _ALLOWED_SYNCS[{case.case_id!r}] with a one-line "
-                f"reason."
+                f"Each line is into the generated file. Read the line and check the patchgen "
+                f".diff next to it:\n"
+                f"  - VeOmni-patched code (changed in the .diff) -> fix the patch to derive "
+                f"the value host-side (typical: 0-D GPU tensor used as a shape/index arg, "
+                f".item() for a Python int, repeat_interleave with GPU repeats, if/bool on "
+                f"a GPU scalar).\n"
+                f"  - HF-verbatim code (unchanged in the .diff) -> add (basename, lineno) to "
+                f"_ALLOWED_SYNCS[{case.case_id!r}] with reason 'HF-verbatim: <description>'."
             )
         if dead:
             dead_fmt = "\n".join(f"  {f}:{ln}" for (f, ln) in dead)

--- a/tests/models/test_model_forward_no_implicit_sync.py
+++ b/tests/models/test_model_forward_no_implicit_sync.py
@@ -176,7 +176,10 @@ _SYNC_RE = re.compile(r"called a synchronizing")
 def _is_generated_path(filename: str) -> bool:
     """True if ``filename`` lives under ``veomni/models/transformers/*/generated/``."""
     norm = filename.replace(os.sep, "/")
-    return "/veomni/models/transformers/" in norm and "/generated/" in norm
+    # No leading slash on the first substring: ``WarningMessage.filename`` is
+    # almost always absolute, but relative-path edge cases (zip imports,
+    # custom loaders) shouldn't silently bypass the gate.
+    return "veomni/models/transformers/" in norm and "/generated/" in norm
 
 
 # NCCL bootstrap env so this module is runnable on its own (``pytest
@@ -293,7 +296,10 @@ def test_no_implicit_sync_in_generated_forward(case):
             with torch.no_grad():
                 target(input_ids=input_ids.clone(), use_cache=False, **fwd_kwargs)
         for w in wlist:
-            if w.category is UserWarning and _SYNC_RE.search(str(w.message)):
+            # Filter by message text only — the regex is specific to torch's
+            # sync warning, and an exact-category check would silently drop
+            # the warning if torch ever switches to a UserWarning subclass.
+            if _SYNC_RE.search(str(w.message)):
                 captured.append((w.filename, w.lineno, str(w.message)))
     finally:
         torch.cuda.set_sync_debug_mode(prev_mode)

--- a/tests/models/test_model_forward_no_implicit_sync.py
+++ b/tests/models/test_model_forward_no_implicit_sync.py
@@ -4,21 +4,43 @@ Runs each model's forward under ``torch.cuda.set_sync_debug_mode("warn")``
 and fails if any new implicit host<->device sync site shows up in
 ``veomni/models/transformers/<model>/generated/``.
 
-The principle
--------------
-We are gating **VeOmni's patches** (the code we wrote), not HF upstream.
-``generated/`` files are mostly HF source copied verbatim with imports
-resolved; only the bits marked ``[PATCHED CLASS]`` / ``[MODIFIED CLASS]
-Methods patched: ...`` are ours. The patchgen ``.diff`` next to each
-generated file is the authoritative ours-vs-HF view.
+The principle — two axes
+------------------------
+For each surfaced sync site, decide along two independent axes:
 
-The test inevitably observes warnings from *all* code in the generated
-file (patched and verbatim alike), so the allowlist exists to mark
-HF-verbatim sites as "not ours, leave alone". Concretely:
+  1. **Owner** — VeOmni-patched (the line appears in the patchgen ``.diff``)
+     vs HF-verbatim (the line is unchanged from upstream HF, even though it
+     lives inside generated/).
+  2. **Path** — production (code runs every real training/inference step,
+     no override above it) vs eager-only fallback (code only runs under a
+     specific dev/fallback setting; production bypasses it via an OpSlot
+     or other VeOmni override above).
 
-  - **VeOmni-patched code introducing a sync** → fix the patch.
-  - **HF-verbatim code that syncs** → allowlist with reason "HF-verbatim;
-    out of scope". Do not try to improve upstream HF here.
+The rule:
+
+  - Production-path + VeOmni-patched  →  fix the patch (derive host-side,
+    precompute in the collator, etc.).
+  - Production-path + HF-verbatim     →  add an ``override_method`` patch
+    and fix there (now becomes ours). **Don't leave a production sync in
+    just because the line originated upstream** — that's an unreasonable
+    cost in our hot path.
+  - Eager-only fallback + HF-verbatim (production bypasses via OpSlot/
+    override)                          →  leave alone, allowlist if needed.
+  - Algorithm-essential (EP dispatch sizes, variable per-rank counts) →
+    accept.
+
+``_ALLOWED_SYNCS`` therefore holds two flavours of entries, distinguished
+by a tag prefix in the reason string:
+
+  - ``"HF-eager-only: ..."``          — accepted long-term; production
+                                        bypasses this code.
+  - ``"HF-prod-pending-fix: ..."``    — production-path HF-verbatim site
+                                        currently tracked for a fix
+                                        (follow-up PR named in the reason).
+  - ``"algorithm-essential: ..."``    — accepted by design.
+
+The dead-entry detection ensures the pending-fix entries get cleaned up
+when the fix lands.
 
 Why this matters
 ----------------
@@ -43,12 +65,18 @@ counterpart, e.g. fused-MoE on the production path). Add a
 ``_MOE_IMPL_BY_CASE`` entry to override the default ``"eager"``
 backend for MoE cases.
 
-When a new model's first run surfaces sync sites, decide each:
-- Read the surrounding code in the generated file and check the patchgen
-  ``.diff`` next to it. If the lines are unchanged from HF, allowlist
-  with ``"HF-verbatim: <one-line description>"``.
-- If the lines were added or modified by a VeOmni patch, fix the patch
-  to derive the value host-side.
+When a new model's first run surfaces sync sites, classify each per the
+two-axis rule above:
+
+- VeOmni-patched line (appears in the patchgen ``.diff``) → fix the patch.
+- HF-verbatim line on a production path (code runs unconditionally, no
+  VeOmni override above) → add an ``override_method`` patch to fix it;
+  in the meantime allowlist with ``"HF-prod-pending-fix: ..."`` and
+  reference the follow-up.
+- HF-verbatim line on an eager-only fallback path that production
+  bypasses (e.g. inside the eager experts loop, when production
+  dispatches to the fused MoE OpSlot) → allowlist with
+  ``"HF-eager-only: ..."``.
 
 Line numbers are into the **generated** file, so a ``make patchgen``
 that shifts lines requires re-checking the allowlist. Dead allowlist
@@ -135,35 +163,50 @@ CASES = [
     ),
 ]
 
-# Acknowledged sync sites in generated/ that are **HF-verbatim** (not
-# touched by any VeOmni patch). Keyed by ``Case.case_id``; value maps
-# ``(basename, lineno)`` -> one-line reason.
+# Acknowledged sync sites in generated/. Keyed by ``Case.case_id``;
+# value maps ``(basename, lineno)`` -> one-line reason.
 #
-# Rule: every entry here MUST be HF-verbatim code. If a sync sits inside
-# a class or method that VeOmni patches, fix the patch instead. Verify
-# via the patchgen ``.diff`` next to the generated file — unchanged
-# lines are HF, changed lines are ours.
+# Reasons MUST start with one of the category tags below — see the
+# module docstring's "principle" section for the two-axis triage. The
+# gate's pass/fail behaviour is the same across categories; the tags
+# encode follow-up state:
 #
-# Current entries are all the same upstream HF method:
-# ``_update_linear_attn_mask``. Both qwen3_5 and qwen3_5_moe inherit it
-# from the same upstream class hierarchy; both ``Qwen3_5{,Moe}Model``
-# are MODIFIED CLASSes but ``_update_linear_attn_mask`` is not in their
-# ``Methods patched`` list. The method does ``if cache_position[0] > 0
-# or torch.all(attention_mask == 1)`` — two implicit syncs (0-D GPU
-# scalar in Python ``if`` + full-tensor reduction). Out of scope.
-_HF_VERBATIM_LINEAR_ATTN = (
-    "HF-verbatim _update_linear_attn_mask: `if cache_position[0] > 0 or "
-    "torch.all(mask == 1)`; method not in VeOmni's patched-methods list."
+#   "HF-eager-only: ..."           accepted long-term; production
+#                                  bypasses this code via an OpSlot or
+#                                  override above.
+#   "HF-prod-pending-fix: ..."     production-path HF-verbatim site
+#                                  currently tracked for a fix; the
+#                                  reason names the follow-up branch /
+#                                  PR. Dead-entry detection forces
+#                                  cleanup once the fix lands.
+#   "algorithm-essential: ..."     accepted by design (EP dispatch
+#                                  sizes, variable per-rank counts).
+#
+# Current entries are all the same upstream HF method
+# ``_update_linear_attn_mask`` (called once per forward from
+# ``Qwen3_5{,Moe}Model.forward`` — production path, fires every step in
+# real Qwen3.5 since half its layers are linear_attention). Both Model
+# classes are MODIFIED CLASSes but ``_update_linear_attn_mask`` is not
+# in either's ``Methods patched`` list, so the line is HF-verbatim.
+# Per the two-axis rule (production + HF-verbatim → add an override
+# patch), it's tracked as ``HF-prod-pending-fix`` and the fix lives on
+# branch ``tingyang/fix/qwen3_5_key_fix``.
+_HF_PROD_PENDING_LINEAR_ATTN = (
+    "HF-prod-pending-fix: _update_linear_attn_mask runs unconditionally in "
+    "Qwen3_5{,Moe}Model.forward (no OpSlot above it). Two syncs: 0-D GPU "
+    "scalar `cache_position[0] > 0` in Python `if`, plus full-tensor "
+    "`torch.all(attention_mask == 1)`. Fix planned via patchgen "
+    "override_method on branch tingyang/fix/qwen3_5_key_fix."
 )
 _ALLOWED_SYNCS: dict[str, dict[tuple[str, int], str]] = {
     "qwen3_5-text-eager": {
-        ("patched_modeling_qwen3_5_gpu.py", 1750): _HF_VERBATIM_LINEAR_ATTN,
+        ("patched_modeling_qwen3_5_gpu.py", 1750): _HF_PROD_PENDING_LINEAR_ATTN,
     },
     "qwen3_5-text-fa2": {
-        ("patched_modeling_qwen3_5_gpu.py", 1750): _HF_VERBATIM_LINEAR_ATTN,
+        ("patched_modeling_qwen3_5_gpu.py", 1750): _HF_PROD_PENDING_LINEAR_ATTN,
     },
     "qwen3_5_moe-text-fa2-fused": {
-        ("patched_modeling_qwen3_5_moe_gpu.py", 1955): _HF_VERBATIM_LINEAR_ATTN,
+        ("patched_modeling_qwen3_5_moe_gpu.py", 1955): _HF_PROD_PENDING_LINEAR_ATTN,
     },
 }
 
@@ -328,14 +371,22 @@ def test_no_implicit_sync_in_generated_forward(case):
             problems.append(
                 f"{len(unique)} new implicit CUDA sync site(s) in generated modeling:\n"
                 f"{formatted}\n"
-                f"Each line is into the generated file. Read the line and check the patchgen "
-                f".diff next to it:\n"
-                f"  - VeOmni-patched code (changed in the .diff) -> fix the patch to derive "
-                f"the value host-side (typical: 0-D GPU tensor used as a shape/index arg, "
-                f".item() for a Python int, repeat_interleave with GPU repeats, if/bool on "
-                f"a GPU scalar).\n"
-                f"  - HF-verbatim code (unchanged in the .diff) -> add (basename, lineno) to "
-                f"_ALLOWED_SYNCS[{case.case_id!r}] with reason 'HF-verbatim: <description>'."
+                f"Each line is into the generated file. Triage along two axes (owner + path):\n"
+                f"  1. Check the patchgen .diff next to the generated file.\n"
+                f"     Line is *in the .diff* (added/modified by VeOmni) -> ours.\n"
+                f"     Line is *unchanged from HF* -> HF-verbatim.\n"
+                f"  2. Check whether the code is on the production path or only on an\n"
+                f"     eager/fallback path that production bypasses (e.g. via an OpSlot).\n"
+                f"Then act:\n"
+                f"  - Production + VeOmni-patched -> fix the patch (derive host-side,\n"
+                f"    precompute in the collator).\n"
+                f"  - Production + HF-verbatim -> add an override_method patch and fix\n"
+                f"    there. Don't leave a production sync in because it came from upstream.\n"
+                f"    In the meantime, allowlist with reason 'HF-prod-pending-fix: ...'.\n"
+                f"  - Eager-only fallback + HF-verbatim -> allowlist with reason\n"
+                f"    'HF-eager-only: ...'.\n"
+                f"Add the (basename, lineno) to _ALLOWED_SYNCS[{case.case_id!r}] with the\n"
+                f"appropriate tag prefix."
             )
         if dead:
             dead_fmt = "\n".join(f"  {f}:{ln}" for (f, ln) in dead)

--- a/tests/models/test_model_forward_no_implicit_sync.py
+++ b/tests/models/test_model_forward_no_implicit_sync.py
@@ -103,6 +103,7 @@ from .test_models_logits_equal_v5 import (
     _make_config,
     _make_inputs,
     _release,
+    _toy,
 )
 from .test_models_logits_equal_v5 import (
     CASES as _ALL_CASES,
@@ -115,12 +116,6 @@ def _logits_case(case_id: str) -> Case:
         if c.case_id == case_id:
             return c
     raise KeyError(f"{case_id!r} not in test_models_logits_equal_v5.CASES")
-
-
-def _toy(name: str) -> str:
-    return os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "tests", "toy_config", name
-    )
 
 
 # Per-case ``moe_implementation`` for VeOmni's ``apply_ops_config``. Defaults

--- a/tests/models/test_model_forward_no_implicit_sync.py
+++ b/tests/models/test_model_forward_no_implicit_sync.py
@@ -1,0 +1,334 @@
+"""Implicit CUDA-sync gate for VeOmni-patched v5 modeling code.
+
+Runs each model's forward under ``torch.cuda.set_sync_debug_mode("warn")``
+and fails if any implicit host<->device sync originates from
+``veomni/models/transformers/<model>/generated/``.
+
+Why this matters
+----------------
+Patched modeling can quietly serialise the host against the device by
+turning a 0-D GPU scalar into a Python int (``.item()`` / ``int(t)``),
+slicing with a GPU tensor, calling ``repeat_interleave(GPU_repeats)``,
+``if gpu_tensor:``, etc. Invisible during compute-heavy steps; expensive
+under SP/EP and small micro-batches, and can cascade into NCCL watchdog
+timeouts. See the ``debug-cuda-sync`` skill for the manual investigation
+flow against real weights.
+
+This test is the *unit-level ratchet* for the same property: it runs on
+toy configs (so only catches sync sites reachable from a tiny forward),
+but it's cheap and catches "someone added a ``.item()`` to a patch" at
+PR time. Real-model SP/EP coverage stays with the skill.
+
+Extending to more models
+------------------------
+Append a ``Case`` to ``CASES`` — either reuse one from
+``test_models_logits_equal_v5.CASES`` via ``_logits_case("...")``, or
+declare a new one inline (for cases that don't have an HF-parity
+counterpart, e.g. fused-MoE on the production path). Add a
+``_MOE_IMPL_BY_CASE`` entry to override the default ``"eager"``
+backend for MoE cases.
+
+Acknowledging a necessary sync
+------------------------------
+``_ALLOWED_SYNCS`` is a per-case dict from ``(basename, lineno)`` to a
+short reason string — pre-existing acknowledged syncs (HF-inherited
+code paths, eager-only fallback loops, EP dispatch with data-dependent
+split sizes). The semantics are *ratchet*: the test fails if a new
+``(file, lineno)`` shows up in generated/ that isn't in the allowlist.
+Removing a site (by fixing the patch) is encouraged.
+
+Line numbers are into the **generated** file, so if patchgen
+regenerates and shifts lines, the allowlist must be re-checked. Treat
+this the same as the checked-in ``.diff`` snapshot under each model's
+``generated/`` — both are line-aware.
+"""
+
+import importlib
+import importlib.util
+import os
+import re
+import warnings
+
+import pytest
+import torch
+
+from veomni.utils.device import IS_CUDA_AVAILABLE, get_device_type, get_torch_device, synchronize
+
+from .test_models_logits_equal_v5 import (
+    _DTYPE_MAP,
+    Case,
+    _apply_determinism,
+    _forward_target,
+    _make_config,
+    _make_inputs,
+    _release,
+)
+from .test_models_logits_equal_v5 import (
+    CASES as _ALL_CASES,
+)
+
+
+def _logits_case(case_id: str) -> Case:
+    """Pull a ``Case`` out of the logits-equal CASES list by ``case_id``."""
+    for c in _ALL_CASES:
+        if c.case_id == case_id:
+            return c
+    raise KeyError(f"{case_id!r} not in test_models_logits_equal_v5.CASES")
+
+
+def _toy(name: str) -> str:
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "tests", "toy_config", name
+    )
+
+
+# Per-case ``moe_implementation`` for VeOmni's ``apply_ops_config``. Defaults
+# to ``"eager"``. Set to ``"fused_triton"`` for production-path coverage
+# (A100/SM80+); the fused dispatch in ``patched_modeling_*_moe_gpu.py``
+# short-circuits the eager expert loop and replaces it with a single
+# Triton kernel call — no Python-level sync sites.
+_MOE_IMPL_BY_CASE: dict[str, str] = {
+    "qwen3_5_moe-text-fa2-fused": "fused_triton",
+}
+
+
+# Cases this gate covers. Built explicitly (rather than imported wholesale
+# from logits_equal) because we want a different MoE backend than the
+# logits test forces for HF parity, and we want to drop SDPA in favour of
+# FA2. To extend, add a ``Case`` here (and optionally a ``_MOE_IMPL_BY_CASE``
+# entry for fused-MoE coverage).
+CASES = [
+    # qwen3_5 (non-MoE, text-only sub-config) — both attention paths.
+    _logits_case("qwen3_5-text-eager"),
+    _logits_case("qwen3_5-text-fa2"),
+    # qwen3_5_moe-text — eager path (kept for non-MoE-code coverage) and
+    # the production FA2 + fused-Triton MoE path.
+    _logits_case("qwen3_5_moe-text-eager"),
+    Case(
+        "qwen3_5_moe-text-fa2-fused",
+        _toy("qwen3_5_moe_toy"),
+        "Qwen3_5MoeForCausalLM",
+        "qwen3_5_text",
+        attn_implementation="flash_attention_2",
+        dtype="bfloat16",
+    ),
+]
+
+# Pre-existing acknowledged sync sites in generated/. Keyed by
+# ``Case.case_id``; value maps ``(basename, lineno)`` -> reason.
+#
+# Two flavours show up in the current baseline:
+#   - ``_update_linear_attn_mask`` (HF-inherited): a Python ``if`` on a
+#     GPU scalar (``cache_position[0]``) plus ``torch.all(mask == 1)``.
+#     The patch doesn't touch this method; the toy config forces all
+#     layers to ``full_attention`` so the linear-attention branch is
+#     unreachable, but the guard still evaluates each forward.
+#   - Eager expert loop in ``Qwen3_5MoeExperts.forward``: ``.nonzero()``
+#     → Python ``for`` over GPU tensor → ``if expert_idx == N`` →
+#     ``torch.where`` indexing. Production dispatches via
+#     ``veomni_moe_experts_forward`` and skips this path; the loop is
+#     only reachable under ``_experts_implementation="eager"`` (which
+#     the test forces for determinism).
+_LINEAR_ATTN_REASON = (
+    "HF-inherited _update_linear_attn_mask: `if cache_position[0] > 0 or "
+    "torch.all(mask == 1)`; unreachable under toy full_attention config."
+)
+_EAGER_EXPERTS_REASON = (
+    "Eager Qwen3_5MoeExperts.forward fallback loop (.nonzero() + Python for "
+    "over experts); production runs fused via veomni_moe_experts_forward."
+)
+_ALLOWED_SYNCS: dict[str, dict[tuple[str, int], str]] = {
+    "qwen3_5-text-eager": {
+        ("patched_modeling_qwen3_5_gpu.py", 1750): _LINEAR_ATTN_REASON,
+    },
+    "qwen3_5-text-fa2": {
+        ("patched_modeling_qwen3_5_gpu.py", 1750): _LINEAR_ATTN_REASON,
+    },
+    "qwen3_5_moe-text-eager": {
+        ("patched_modeling_qwen3_5_moe_gpu.py", 1052): _EAGER_EXPERTS_REASON,
+        ("patched_modeling_qwen3_5_moe_gpu.py", 1056): _EAGER_EXPERTS_REASON,
+        ("patched_modeling_qwen3_5_moe_gpu.py", 1058): _EAGER_EXPERTS_REASON,
+        ("patched_modeling_qwen3_5_moe_gpu.py", 1060): _EAGER_EXPERTS_REASON,
+        ("patched_modeling_qwen3_5_moe_gpu.py", 1062): _EAGER_EXPERTS_REASON,
+        ("patched_modeling_qwen3_5_moe_gpu.py", 1955): _LINEAR_ATTN_REASON,
+    },
+    # qwen3_5_moe-text-fa2-fused: production path (fused_triton MoE
+    # bypasses the eager expert loop). Only the HF-inherited
+    # linear-attention guard remains.
+    "qwen3_5_moe-text-fa2-fused": {
+        ("patched_modeling_qwen3_5_moe_gpu.py", 1955): _LINEAR_ATTN_REASON,
+    },
+}
+
+
+# torch's implicit-sync warning message; emitted by
+# ``set_sync_debug_mode("warn")`` from various ATen ops.
+_SYNC_RE = re.compile(r"called a synchronizing")
+
+
+def _is_generated_path(filename: str) -> bool:
+    """True if ``filename`` lives under ``veomni/models/transformers/*/generated/``."""
+    norm = filename.replace(os.sep, "/")
+    return "/veomni/models/transformers/" in norm and "/generated/" in norm
+
+
+# NCCL bootstrap env so this module is runnable on its own (``pytest
+# tests/models/test_model_forward_no_implicit_sync.py``). In a same-process
+# pytest run the sibling logits_equal test is usually imported first and
+# its ``setdefault`` block already populated these; the fixture below
+# also no-ops if the PG is already initialised.
+os.environ.setdefault("RANK", "0")
+os.environ.setdefault("LOCAL_RANK", "0")
+os.environ.setdefault("WORLD_SIZE", "1")
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "12357")
+os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_rank_process_group():
+    """1-rank NCCL group for VeOmni's SP-aware attention wrappers.
+
+    Duplicated rather than imported from the sibling logits test because
+    pytest doesn't apply autouse fixtures across modules.
+    """
+    from veomni.utils.device import get_dist_comm_backend
+    from veomni.utils.import_utils import is_transformers_version_greater_or_equal_to
+
+    if not IS_CUDA_AVAILABLE or not is_transformers_version_greater_or_equal_to("5.2.0"):
+        yield
+        return
+
+    import torch.distributed as dist
+
+    we_initialised = False
+    if not dist.is_initialized():
+        get_torch_device().set_device(int(os.environ.get("LOCAL_RANK", "0")))
+        dist.init_process_group(backend=get_dist_comm_backend(), rank=0, world_size=1)
+        we_initialised = True
+    try:
+        yield
+    finally:
+        if we_initialised and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _build_veomni_model(case, config):
+    """Random-init VeOmni model — we only need forward to run, not match HF."""
+    from veomni.models.auto import build_foundation_model
+    from veomni.ops import apply_ops_config
+
+    training_utils = importlib.import_module("tests.tools.training_utils")
+    apply_ops_config(
+        training_utils.make_eager_ops_config(
+            attn_implementation=case.attn_implementation,
+            moe_implementation=_MOE_IMPL_BY_CASE.get(case.case_id, "eager"),
+        )
+    )
+
+    torch.manual_seed(0)
+    get_torch_device().manual_seed_all(0)
+    return build_foundation_model(
+        config_path=config,
+        weights_path=None,
+        torch_dtype=case.dtype,
+        attn_implementation=case.attn_implementation,
+        init_device=get_device_type(),
+    ).eval()
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.case_id for c in CASES])
+def test_no_implicit_sync_in_generated_forward(case):
+    """No implicit CUDA sync should originate from generated/ during forward."""
+    from veomni.utils.import_utils import is_transformers_version_greater_or_equal_to
+
+    if not is_transformers_version_greater_or_equal_to("5.2.0"):
+        pytest.skip("Scope is transformers v5 model definition only (v5 stack pins >= 5.2.0).")
+    if not IS_CUDA_AVAILABLE:
+        pytest.skip("CUDA required.")
+    if not os.path.isdir(case.toy_config_dir):
+        pytest.skip(f"Path not found: {case.toy_config_dir}")
+    if case.attn_implementation == "flash_attention_2" and importlib.util.find_spec("flash_attn") is None:
+        pytest.skip("flash_attn package not installed.")
+    if _MOE_IMPL_BY_CASE.get(case.case_id) == "fused_triton":
+        from veomni.utils.import_utils import is_fused_moe_available
+
+        if not is_fused_moe_available():
+            pytest.skip("fused_triton MoE requires triton + CUDA SM70+.")
+
+    _apply_determinism()
+
+    device = get_device_type()
+    dtype = _DTYPE_MAP[case.dtype]
+    config = _make_config(case)
+    input_ids, fwd_kwargs = _make_inputs(case, config, device, dtype)
+
+    model = _build_veomni_model(case, config)
+    target = _forward_target(model, case)
+
+    # Warmup outside debug mode: rotary cos/sin cache fill, kernel
+    # autotuning, lazy buffer materialisation — these fire once and
+    # aren't relevant to steady-state.
+    with torch.no_grad():
+        target(input_ids=input_ids.clone(), use_cache=False, **fwd_kwargs)
+    synchronize()
+
+    # ``torch.cuda.{get,set}_sync_debug_mode`` are the actual API for the
+    # debug knob this test relies on — no ``veomni.utils.device`` helper
+    # exists for it. CUDA-only by design; the ``IS_CUDA_AVAILABLE`` skip
+    # above gates the whole test, so this isn't an NPU-compat hazard.
+    prev_mode = torch.cuda.get_sync_debug_mode()
+    captured: list[tuple[str, int, str]] = []
+    try:
+        torch.cuda.set_sync_debug_mode("warn")
+        with warnings.catch_warnings(record=True) as wlist:
+            warnings.simplefilter("always")
+            with torch.no_grad():
+                target(input_ids=input_ids.clone(), use_cache=False, **fwd_kwargs)
+        for w in wlist:
+            if w.category is UserWarning and _SYNC_RE.search(str(w.message)):
+                captured.append((w.filename, w.lineno, str(w.message)))
+    finally:
+        torch.cuda.set_sync_debug_mode(prev_mode)
+
+    del model
+    _release()
+
+    allowed = _ALLOWED_SYNCS.get(case.case_id, {})
+    captured_sites = {(os.path.basename(f), ln) for (f, ln, _) in captured if _is_generated_path(f)}
+    offending = [
+        (f, ln, msg) for (f, ln, msg) in captured if _is_generated_path(f) and (os.path.basename(f), ln) not in allowed
+    ]
+    # Dead allowlist entries: listed but no longer observed. Usually means
+    # the patch was fixed (good — delete the entry) or that patchgen
+    # shifted line numbers (re-check the underlying code, then update).
+    dead = sorted(k for k in allowed if k not in captured_sites)
+
+    if offending or dead:
+        problems: list[str] = []
+        if offending:
+            # Dedup ``(basename, lineno)`` — even with ``simplefilter("always")``
+            # one site can fire many times (per layer, per expert, ...);
+            # the reliable signal is the *set* of sites.
+            unique = {(os.path.basename(f), ln): m.splitlines()[0] for (f, ln, m) in offending}
+            formatted = "\n".join(f"  {f}:{ln}  ::  {m}" for (f, ln), m in sorted(unique.items()))
+            problems.append(
+                f"{len(unique)} new implicit CUDA sync site(s) in patched modeling:\n"
+                f"{formatted}\n"
+                f"Each line is into the generated modeling file. Fix the patch to derive the "
+                f"value host-side (typical sources: 0-D GPU tensor used as a shape/index arg, "
+                f".item() for a Python int, repeat_interleave with GPU repeats, if/bool on a "
+                f"GPU scalar). If the sync is genuinely needed (e.g. EP dispatch sizes), add "
+                f"the (basename, lineno) to _ALLOWED_SYNCS[{case.case_id!r}] with a one-line "
+                f"reason."
+            )
+        if dead:
+            dead_fmt = "\n".join(f"  {f}:{ln}" for (f, ln) in dead)
+            problems.append(
+                f"{len(dead)} dead _ALLOWED_SYNCS entr{'y' if len(dead) == 1 else 'ies'} "
+                f"for {case.case_id!r} (allowlisted but no longer observed):\n"
+                f"{dead_fmt}\n"
+                f"Either the patch was fixed (drop the entry) or patchgen shifted lines "
+                f"(re-check the source and update the lineno)."
+            )
+        raise AssertionError(f"[{case.case_id}]\n" + "\n\n".join(problems))

--- a/tests/special_sanity/check_device_api_usage.py
+++ b/tests/special_sanity/check_device_api_usage.py
@@ -54,6 +54,11 @@ CUDA_KEYWORD_CHECK_WHITELIST = [
     "tests/special_sanity/check_device_api_usage.py",
     "tests/tools/common_utils.py",
     "veomni/utils/lora_utils.py",
+    # Implicit-CUDA-sync gate. Calls ``torch.cuda.{get,set}_sync_debug_mode``
+    # directly because the API is intrinsically CUDA-only and has no
+    # ``veomni.utils.device`` equivalent; the test is gated on
+    # ``IS_CUDA_AVAILABLE`` so it skips on non-CUDA hosts.
+    "tests/models/test_model_forward_no_implicit_sync.py",
 ]
 
 # directory or file path must contain keyword "nccl"


### PR DESCRIPTION
### What does this PR do?

Adds a unit-level **ratchet test** that detects implicit host↔device CUDA syncs in VeOmni-patched v5 modeling under `veomni/models/transformers/*/generated/`. The gate runs each model's forward under `torch.cuda.set_sync_debug_mode("warn")`, captures the warnings, and fails if a new sync site shows up that isn't on the per-case allowlist. Companion to the manual `debug-cuda-sync` skill (real-weights / SP/EP investigation flow) — this test is the cheap PR-time regression gate.

### The principle (two axes)

For each surfaced sync site, classify along **two independent axes**:

1. **Owner** — VeOmni-patched (line in patchgen `.diff`) vs HF-verbatim (unchanged from upstream, even though it lives inside `generated/`).
2. **Path** — production (runs every step, no override above) vs eager-only fallback (production bypasses via OpSlot / other VeOmni override).

The rule:

| | Production path | Eager-only fallback (production bypasses) |
|---|---|---|
| **VeOmni-patched** | Fix the patch | Fix the patch |
| **HF-verbatim** | **Add an `override_method` patch and fix** (becomes ours) | Leave alone / allowlist |

`_ALLOWED_SYNCS` entries are tagged in the reason string:

- `"HF-eager-only: ..."` — accepted long-term (production bypasses).
- `"HF-prod-pending-fix: ..."` — production-path HF-verbatim; tracked for fix; reason names the follow-up branch / PR.
- `"algorithm-essential: ..."` — accepted by design.

### Coverage

3 cases, ~13s on A100, wired into `gpu_unit_tests_v5` next to `test_models_logits_equal_v5.py`:

- `qwen3_5-text-eager` — non-MoE, eager attention through our patched `Qwen3_5Model.forward`.
- `qwen3_5-text-fa2` — non-MoE, FA2 path through the same patched forward.
- `qwen3_5_moe-text-fa2-fused` — production path: FA2 + `fused_triton` MoE, exercising VeOmni's OpSlot short-circuit in `Qwen3_5MoeExperts.forward`.

**No eager-MoE case**. Eager `Qwen3_5MoeExperts.forward` body is HF-verbatim (VeOmni only adds the OpSlot short-circuit at the top); production never runs it because `fused_triton` bypasses the loop. Gating it would force the allowlist to absorb 5 HF-verbatim sync sites from an algorithm-inherent loop that's not on any real codepath, while adding no signal for VeOmni-patched code. The fa2-fused case covers everything we own on the MoE side.

The fa2-fused case also doubles as **structural validation of the OpSlot short-circuit**: if `fused_triton` silently fell back to the HF eager loop, those 5 verbatim sync sites would re-fire and the test would fail. It passes → the short-circuit is intact.

### Findings from baseline

3 entries in `_ALLOWED_SYNCS`, all the same upstream method `_update_linear_attn_mask`:

- `patched_modeling_qwen3_5_gpu.py:1750` (qwen3_5-text-eager + qwen3_5-text-fa2)
- `patched_modeling_qwen3_5_moe_gpu.py:1955` (qwen3_5_moe-text-fa2-fused)

The method is HF-verbatim (not in either Model class's `Methods patched:` list) but it's called unconditionally from `Qwen3_5{,Moe}Model.forward` and there's no VeOmni override above it — i.e. **production path**. Per the rule it should be fixed via an `override_method` patch (which makes it ours). Tagged `HF-prod-pending-fix` and pointing at branch `tingyang/fix/qwen3_5_key_fix` (where the fix already exists; needs rebase). When that fix lands the allowlist entries become dead and the gate's dead-entry detection forces the cleanup.

### Test

- `pytest tests/models/test_model_forward_no_implicit_sync.py` — 3 passed in ~13s on A100.
- `make quality` — passes.
- `make patchgen` — no `_ALLOWED_SYNCS` line numbers drift.

### API and Usage Example

No API changes — test-only addition plus one CI step.

### Design & Code Changes

- `tests/models/test_model_forward_no_implicit_sync.py` (new): runs forward under `set_sync_debug_mode("warn")`, captures `UserWarning`s matching `r"called a synchronizing"`, fails on any site whose `WarningMessage.filename` lives under `veomni/models/transformers/*/generated/` that isn't in the per-case `_ALLOWED_SYNCS` allowlist. Also fails on **dead** allowlist entries (listed but no longer observed) so a `make patchgen` line-shift can't silently rot the gate.
- Cases declared explicitly (not imported wholesale from `test_models_logits_equal_v5`) because the gate wants a different MoE backend than the logits test forces for HF parity, and prefers FA2 over SDPA. `_MOE_IMPL_BY_CASE` maps `case_id` → MoE backend.
- Warmup forward outside debug mode (so one-time rotary/kernel-autotune syncs don't pollute), then the measured forward inside the warning-capture block.
- `is_fused_moe_available()` skip for fused_triton cases — clear skip on a triton-less CI host instead of a confusing failure inside `apply_ops_config`.
- Assertion failure message walks the maintainer through the two-axis triage (read the line + check the patchgen `.diff` + decide path) and the right reason-tag.
- `.github/workflows/gpu_unit_tests.yml`: one pytest invocation in `Run models tests`, right after `test_models_logits_equal_v5.py`.
- `tests/special_sanity/check_device_api_usage.py`: add the test file to the CUDA-keyword allowlist (`torch.cuda.{get,set}_sync_debug_mode` has no `veomni.utils.device` equivalent and is intrinsically CUDA-only; test is `IS_CUDA_AVAILABLE`-gated).

### Follow-up work (not in this PR)

- **Land the existing `tingyang/fix/qwen3_5_key_fix` work** to fix `_update_linear_attn_mask` via `override_method` and kill the 3 `HF-prod-pending-fix` allowlist entries. Also lands the ViT-side fixes already on that branch.
- **Extend gate** to `qwen3_vl`, `qwen3_vl_moe`, `qwen3_omni_moe` — first cut in stacked PR #761.
- **Refactor**: extract the shared v5 test helpers (`_DTYPE_MAP`, `Case`, `_apply_determinism`, `_forward_target`, `_make_config`, `_make_inputs`, `_release`) into `tests/models/_v5_helpers.py` so the sync test doesn't import 7 private names from the sibling logits test.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added/updated documentation (test docstring is comprehensive; no separate docs file warranted)
- [x] Added tests to CI workflow (this IS a new CI test, wired into `gpu_unit_tests_v5`)
