### PR TITLE
[ci] refactor: key the implicit-sync allowlist by function qualname

### DIFF
--- a/tests/models/test_model_forward_no_implicit_sync.py
+++ b/tests/models/test_model_forward_no_implicit_sync.py
@@ -388,6 +388,12 @@ def _def_spans(path: str) -> tuple[tuple[int, int, str], ...]:
                 walk(child, qualname + ".")  # nested defs / closures
             elif isinstance(child, ast.ClassDef):
                 walk(child, prefix + child.name + ".")
+            else:
+                # Recurse through non-def blocks (``if`` / ``try`` / ``with``
+                # version gates, etc.) keeping the same prefix — a def inside
+                # them is still at the enclosing scope, and missing it would
+                # misattribute its syncs to ``<module>``.
+                walk(child, prefix)
 
     walk(tree, "")
     return tuple(spans)
@@ -421,6 +427,10 @@ def test_enclosing_qualname_resolution(tmp_path):
         "        def inner():\n"  # 9  Foo.bar.inner
         "            return 0\n"  # 10 Foo.bar.inner
         "        return inner()\n"  # 11 Foo.bar
+        "\n"  # 12
+        "if True:\n"  # 13
+        "    def gated():\n"  # 14 gated (def inside an `if` block)
+        "        return 1\n"  # 15 gated
     )
     f = str(tmp_path / "m.py")
     with open(f, "w", encoding="utf-8") as fh:
@@ -429,6 +439,8 @@ def test_enclosing_qualname_resolution(tmp_path):
     assert _enclosing_qualname(f, 4) == "helper"
     assert _enclosing_qualname(f, 10) == "Foo.bar.inner"  # innermost def wins
     assert _enclosing_qualname(f, 11) == "Foo.bar"
+    # def inside an `if` block: still resolved (not misattributed to <module>).
+    assert _enclosing_qualname(f, 15) == "gated"
 
 
 # NCCL bootstrap env so this module is runnable on its own (``pytest

--- a/tests/models/test_model_forward_no_implicit_sync.py
+++ b/tests/models/test_model_forward_no_implicit_sync.py
@@ -78,17 +78,20 @@ two-axis rule above:
   dispatches to the fused MoE OpSlot) → allowlist with
   ``"HF-eager-only: ..."``.
 
-Line numbers are into the **generated** file, so a ``make patchgen``
-that shifts lines requires re-checking the allowlist. Dead allowlist
-entries (listed but no longer observed) also fail the test, so drift
-can't silently rot the gate.
+The allowlist is keyed by ``(generated-file, function qualname)``: each
+sync warning's line number is resolved to its enclosing function via AST,
+so a ``make patchgen`` that shifts lines does **not** rot the gate. Dead
+allowlist entries (a function that no longer issues a sync) still fail
+the test, so a landed fix can't silently leave a stale entry behind.
 """
 
+import ast
 import importlib
 import importlib.util
 import os
 import re
 import warnings
+from functools import lru_cache
 
 import pytest
 import torch
@@ -233,46 +236,37 @@ _ALG_ESSENTIAL_VL_GET_ROPE_INDEX = (
     "variable-shape mrope algorithm. Clean fix is to precompute position_ids in the data "
     "transform and skip the call; out-of-scope for this PR."
 )
-_ALLOWED_SYNCS: dict[str, dict[tuple[str, int], str]] = {
+# Keyed by ``(generated-file basename, enclosing-function qualname)`` — NOT a
+# raw line number. The qualname is resolved from the sync warning's line via
+# AST (`_enclosing_qualname`), so patchgen line shifts no longer rot the
+# allowlist, and each entry reads as the function it accepts. One entry
+# therefore covers *all* the sync sites inside that function.
+_ALLOWED_SYNCS: dict[str, dict[tuple[str, str], str]] = {
     # qwen3_vl-fa2: Stage 1 (multimodal_metadata_precompute) wired the ViT
     # forward to read precomputed `vit_image_cu_seqlens` / `vit_image_max_seqlen`
     # / `image_grid_thw_list`, so the toy test (via _attach_multimodal_metadata
     # above) skips the fallback `.tolist()` + host-side cu_seqlens build that
     # used to fire ~4 syncs. What remains:
-    #  - 1 algorithm-essential `rot_pos_ids(...).to(device)` H2D copy in
-    #    rot_pos_emb (CPU-side lru_cached helper output, over-reported by
-    #    sync-debug mode per the debug-cuda-sync skill notes).
-    #  - 6 algorithm-essential `get_rope_index` sites (HF-verbatim mrope
-    #    algorithm; see the long comment above _ALG_ESSENTIAL_VL_GET_ROPE_INDEX
-    #    for why the in-place override was reverted and the collator-side fix
-    #    tracked as follow-up).
+    #  - rot_pos_emb: an algorithm-essential `rot_pos_ids(...).to(device)` H2D
+    #    copy (CPU-side lru_cached helper output, over-reported by sync-debug).
+    #  - get_rope_index: the HF-verbatim mrope algorithm; see the long comment
+    #    above _ALG_ESSENTIAL_VL_GET_ROPE_INDEX for why the in-place override
+    #    was reverted and the collator-side fix tracked as follow-up.
     "qwen3_vl-fa2": {
-        ("patched_modeling_qwen3_vl_gpu.py", 979): (
+        ("patched_modeling_qwen3_vl_gpu.py", "Qwen3VLVisionModel.rot_pos_emb"): (
             "algorithm-essential: `rot_pos_ids(...).to(device)` H2D copy of a CPU tensor "
             "returned by the lru_cached helper; over-reported by torch sync-debug mode."
         ),
-        ("patched_modeling_qwen3_vl_gpu.py", 1478): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_gpu.py", 1499): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_gpu.py", 1501): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_gpu.py", 1505): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_gpu.py", 1509): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_gpu.py", 1547): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_gpu.py", 1549): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
+        ("patched_modeling_qwen3_vl_gpu.py", "Qwen3VLModel.get_rope_index"): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
     },
     # qwen3_vl_moe-fa2-fused: mirrors qwen3_vl (the moe config imports the
     # vision forward / rot_pos_emb / fast_pos_embed_interpolate helpers from
     # qwen3_vl and registers its own Model.forward + get_rope_index).
     "qwen3_vl_moe-fa2-fused": {
-        ("patched_modeling_qwen3_vl_moe_gpu.py", 1024): (
+        ("patched_modeling_qwen3_vl_moe_gpu.py", "Qwen3VLMoeVisionModel.rot_pos_emb"): (
             "algorithm-essential: see qwen3_vl-fa2 (rot_pos_ids H2D copy)."
         ),
-        ("patched_modeling_qwen3_vl_moe_gpu.py", 1668): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_moe_gpu.py", 1689): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_moe_gpu.py", 1691): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_moe_gpu.py", 1695): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_moe_gpu.py", 1699): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_moe_gpu.py", 1737): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
-        ("patched_modeling_qwen3_vl_moe_gpu.py", 1739): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
+        ("patched_modeling_qwen3_vl_moe_gpu.py", "Qwen3VLMoeModel.get_rope_index"): _ALG_ESSENTIAL_VL_GET_ROPE_INDEX,
     },
     # qwen3_omni_moe-fa2-fused: Stage 2 (multimodal_metadata_precompute) wired
     # the omni ViT forward to consume the precomputed cu_seqlens / max_seqlen,
@@ -280,20 +274,15 @@ _ALLOWED_SYNCS: dict[str, dict[tuple[str, int], str]] = {
     # syncs are gone. The omni ViT still calls upstream-HF
     # `fast_pos_embed_interpolate` / `rot_pos_emb` with the GPU `grid_thw`
     # tensor (those helpers were not migrated to the host list — unlike
-    # qwen3_vl), so 4 algorithm-essential D2H/H2D sites remain, documented
+    # qwen3_vl), so algorithm-essential D2H/H2D sites remain, documented
     # in PR #764. Full omni ViT-helper migration is tracked as follow-up.
     "qwen3_omni_moe-fa2-fused": {
-        ("patched_modeling_qwen3_omni_moe_gpu.py", 1278): (
-            "algorithm-essential: D2H `grid_thw.tolist()` for rot_pos_emb host-side loop."
+        ("patched_modeling_qwen3_omni_moe_gpu.py", "Qwen3OmniMoeVisionEncoder.rot_pos_emb"): (
+            "algorithm-essential: D2H `grid_thw.tolist()` for the rot_pos_emb host-side loop."
         ),
-        ("patched_modeling_qwen3_omni_moe_gpu.py", 1317): (
-            "algorithm-essential: D2H `grid_thw.tolist()` for fast_pos_embed_interpolate."
-        ),
-        ("patched_modeling_qwen3_omni_moe_gpu.py", 1359): (
-            "algorithm-essential: `torch.tensor(idx_list, device=cuda)` H2D copy; over-reported."
-        ),
-        ("patched_modeling_qwen3_omni_moe_gpu.py", 1360): (
-            "algorithm-essential: `torch.tensor(weight_list, device=cuda)` H2D copy; over-reported."
+        ("patched_modeling_qwen3_omni_moe_gpu.py", "Qwen3OmniMoeVisionEncoder.fast_pos_embed_interpolate"): (
+            "algorithm-essential: D2H `grid_thw.tolist()` + `torch.tensor(idx/weight_list, "
+            "device=cuda)` H2D copies in fast_pos_embed_interpolate; over-reported by sync-debug."
         ),
     },
 }
@@ -302,24 +291,9 @@ _ALLOWED_SYNCS: dict[str, dict[tuple[str, int], str]] = {
 # currently surface VeOmni-touched sync sites we haven't fixed yet.
 # Under the gate's principle (VeOmni-patched syncs get fixed, not
 # allowlisted), it would be misleading to add these to ``_ALLOWED_SYNCS``;
-# the skip keeps the case visible in pytest output as a reminder.
-#
-# Follow-up: a separate PR (a) fixes the patches listed below, then
-# (b) removes the case_id from this dict and (c) populates
-# ``_ALLOWED_SYNCS`` with whatever HF-verbatim sites remain after the
-# fix.
-#
-# VeOmni-touched sites currently observed (file:line in def method):
-#   qwen3_vl-fa2 (9 sites):
-#     patched_modeling_qwen3_vl_gpu.py:117,119          rot_pos_ids (add_helper)
-#     patched_modeling_qwen3_vl_gpu.py:909              rot_pos_emb
-#     patched_modeling_qwen3_vl_gpu.py:942,943,973,976  fast_pos_embed_interpolate
-#     patched_modeling_qwen3_vl_gpu.py:1029             Qwen3VLVisionModel.forward
-#     patched_modeling_qwen3_vl_gpu.py:1611             Qwen3VLModel.forward
-#   qwen3_vl_moe-fa2-fused (9 sites): same shape, mirror file
-#     patched_modeling_qwen3_vl_moe_gpu.py:147,149,953,986,987,1017,1020,1073,1792
-#   qwen3_omni_moe-fa2-fused (3 sites):
-#     patched_modeling_qwen3_omni_moe_gpu.py:1351,1362,2406  forward paths
+# the skip keeps the case visible in pytest output as a reminder. The
+# skip reason should name the offending functions and the follow-up.
+# Currently empty — all declared cases pass or are fully allowlisted.
 _PENDING_FIX_CASES: dict[str, str] = {}
 
 
@@ -386,6 +360,75 @@ def _is_generated_path(filename: str) -> bool:
     # almost always absolute, but relative-path edge cases (zip imports,
     # custom loaders) shouldn't silently bypass the gate.
     return "veomni/models/transformers/" in norm and "/generated/" in norm
+
+
+@lru_cache(maxsize=None)
+def _def_spans(path: str) -> tuple[tuple[int, int, str], ...]:
+    """``(start_lineno, end_lineno, qualname)`` for every def in a Python file.
+
+    AST-parsed once per file (lru_cached). Used to map a sync warning's raw
+    line number onto the *qualified name* of the function/method that
+    contains it — a key that survives patchgen line shifts, unlike the line
+    number itself.
+    """
+    with open(path, encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=path)
+    spans: list[tuple[int, int, str]] = []
+
+    def walk(node: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                qualname = prefix + child.name
+                # ``lineno`` is the ``def`` line, not the decorator line: a
+                # sync warning on a decorator *above* the def would resolve to
+                # the enclosing scope. None of the allowlisted functions are
+                # decorated, so this is not a live concern — revisit if a
+                # patched/HF def with a sync ever gains a decorator.
+                spans.append((child.lineno, child.end_lineno, qualname))
+                walk(child, qualname + ".")  # nested defs / closures
+            elif isinstance(child, ast.ClassDef):
+                walk(child, prefix + child.name + ".")
+
+    walk(tree, "")
+    return tuple(spans)
+
+
+def _enclosing_qualname(path: str, lineno: int) -> str:
+    """Qualified name of the innermost def at ``lineno`` (``"<module>"`` if none).
+
+    "Innermost" = the smallest line span covering ``lineno``, so a sync inside
+    a nested helper resolves to the helper, not its parent.
+    """
+    best, best_span = "<module>", None
+    for start, end, qualname in _def_spans(path):
+        if start <= lineno <= end and (best_span is None or end - start < best_span):
+            best, best_span = qualname, end - start
+    return best
+
+
+def test_enclosing_qualname_resolution(tmp_path):
+    """`_enclosing_qualname` maps a line onto its innermost def — the property
+    the line-shift-proof allowlist keying depends on. CPU-only, no GPU."""
+    src = (
+        "import torch\n"  # 1  module-level
+        "\n"  # 2
+        "def helper():\n"  # 3
+        "    x = 1\n"  # 4  helper
+        "    return x\n"  # 5  helper
+        "\n"  # 6
+        "class Foo:\n"  # 7
+        "    def bar(self):\n"  # 8  Foo.bar
+        "        def inner():\n"  # 9  Foo.bar.inner
+        "            return 0\n"  # 10 Foo.bar.inner
+        "        return inner()\n"  # 11 Foo.bar
+    )
+    f = str(tmp_path / "m.py")
+    with open(f, "w", encoding="utf-8") as fh:
+        fh.write(src)
+    assert _enclosing_qualname(f, 1) == "<module>"
+    assert _enclosing_qualname(f, 4) == "helper"
+    assert _enclosing_qualname(f, 10) == "Foo.bar.inner"  # innermost def wins
+    assert _enclosing_qualname(f, 11) == "Foo.bar"
 
 
 # NCCL bootstrap env so this module is runnable on its own (``pytest
@@ -525,30 +568,38 @@ def test_no_implicit_sync_in_generated_forward(case):
     _release()
 
     allowed = _ALLOWED_SYNCS.get(case.case_id, {})
-    captured_sites = {(os.path.basename(f), ln) for (f, ln, _) in captured if _is_generated_path(f)}
-    offending = [
-        (f, ln, msg) for (f, ln, msg) in captured if _is_generated_path(f) and (os.path.basename(f), ln) not in allowed
-    ]
-    # Dead allowlist entries: listed but no longer observed. Usually means
-    # the patch was fixed (good — delete the entry) or that patchgen
-    # shifted line numbers (re-check the underlying code, then update).
-    dead = sorted(k for k in allowed if k not in captured_sites)
+
+    # Resolve each sync warning from generated/ to the *qualified name* of the
+    # function it fired in (``(basename, qualname)``). Keying on the qualname
+    # rather than a raw line number means patchgen line shifts no longer rot
+    # the allowlist — and one entry covers every sync site inside a function.
+    # One representative line number per key is kept for the failure report.
+    observed: dict[tuple[str, str], tuple[int, str]] = {}
+    for f, ln, msg in captured:
+        if not _is_generated_path(f):
+            continue
+        key = (os.path.basename(f), _enclosing_qualname(f, ln))
+        observed.setdefault(key, (ln, msg.splitlines()[0]))
+
+    offending = sorted(k for k in observed if k not in allowed)
+    # Dead allowlist entries: a function that no longer issues any sync.
+    # Means the patch was fixed (good — delete the entry); line shifts can
+    # no longer cause this, since the key is the qualname.
+    dead = sorted(k for k in allowed if k not in observed)
 
     if offending or dead:
         problems: list[str] = []
         if offending:
-            # Dedup ``(basename, lineno)`` — even with ``simplefilter("always")``
-            # one site can fire many times (per layer, per expert, ...);
-            # the reliable signal is the *set* of sites.
-            unique = {(os.path.basename(f), ln): m.splitlines()[0] for (f, ln, m) in offending}
-            formatted = "\n".join(f"  {f}:{ln}  ::  {m}" for (f, ln), m in sorted(unique.items()))
+            formatted = "\n".join(
+                f"  {bn} :: {qn}  (e.g. line {observed[bn, qn][0]})  ::  {observed[bn, qn][1]}" for bn, qn in offending
+            )
             problems.append(
-                f"{len(unique)} new implicit CUDA sync site(s) in generated modeling:\n"
+                f"{len(offending)} new implicit CUDA sync site(s) in generated modeling:\n"
                 f"{formatted}\n"
-                f"Each line is into the generated file. Triage along two axes (owner + path):\n"
+                f"Each entry is the function the sync fires in. Triage along two axes (owner + path):\n"
                 f"  1. Check the patchgen .diff next to the generated file.\n"
-                f"     Line is *in the .diff* (added/modified by VeOmni) -> ours.\n"
-                f"     Line is *unchanged from HF* -> HF-verbatim.\n"
+                f"     Code is *in the .diff* (added/modified by VeOmni) -> ours.\n"
+                f"     Code is *unchanged from HF* -> HF-verbatim.\n"
                 f"  2. Check whether the code is on the production path or only on an\n"
                 f"     eager/fallback path that production bypasses (e.g. via an OpSlot).\n"
                 f"Then act:\n"
@@ -559,16 +610,15 @@ def test_no_implicit_sync_in_generated_forward(case):
                 f"    In the meantime, allowlist with reason 'HF-prod-pending-fix: ...'.\n"
                 f"  - Eager-only fallback + HF-verbatim -> allowlist with reason\n"
                 f"    'HF-eager-only: ...'.\n"
-                f"Add the (basename, lineno) to _ALLOWED_SYNCS[{case.case_id!r}] with the\n"
+                f"Add the (basename, qualname) to _ALLOWED_SYNCS[{case.case_id!r}] with the\n"
                 f"appropriate tag prefix."
             )
         if dead:
-            dead_fmt = "\n".join(f"  {f}:{ln}" for (f, ln) in dead)
+            dead_fmt = "\n".join(f"  {bn} :: {qn}" for bn, qn in dead)
             problems.append(
                 f"{len(dead)} dead _ALLOWED_SYNCS entr{'y' if len(dead) == 1 else 'ies'} "
                 f"for {case.case_id!r} (allowlisted but no longer observed):\n"
                 f"{dead_fmt}\n"
-                f"Either the patch was fixed (drop the entry) or patchgen shifted lines "
-                f"(re-check the source and update the lineno)."
+                f"That function no longer issues a sync — drop the entry."
             )
         raise AssertionError(f"[{case.case_id}]\n" + "\n\n".join(problems))


### PR DESCRIPTION
### What does this PR do?

The implicit-CUDA-sync gate (`tests/models/test_model_forward_no_implicit_sync.py`)
keyed its `_ALLOWED_SYNCS` allowlist by `(generated-file, line number)`. Every
patchgen regeneration that adds or removes a line shifts all downstream line
numbers, rotting the allowlist and forcing a manual re-sync — and a bare line
number tells a reviewer nothing about which sync it accepts.

This PR re-keys the allowlist by `(generated-file, enclosing-function qualname)`.
Each sync warning's line number is resolved to its enclosing `def` via AST, so
patchgen line shifts no longer rot the gate, and each entry reads as the
function it accepts.

### Checklist Before Starting

- Follow-up to #772 (the multimodal-metadata refactor, whose patchgen
  regenerations hit this line-number churn three times). Branched off #772;
  intended to merge after it.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

- `pytest tests/models/test_model_forward_no_implicit_sync.py` — **6/6 PASSED**
  on an A100 worker with the qualname-keyed allowlist.
- New CPU-only unit test `test_enclosing_qualname_resolution` covers the AST
  resolver (nested defs, methods, module scope) — runs without a GPU.
- `make quality` — passes.

### API and Usage Example

N/A — test-only change.

### Design & Code Changes

- New `_def_spans(path)` — AST-parses a generated file into
  `(start_lineno, end_lineno, qualname)` per def (lru_cached per path).
- New `_enclosing_qualname(path, lineno)` — qualname of the innermost def
  covering a line (`"<module>"` if none).
- `_ALLOWED_SYNCS` re-keyed `(basename, lineno)` → `(basename, qualname)`. One
  entry now covers every sync site inside a function — e.g. `qwen3_vl-fa2`
  went from 8 line entries to 2 qualname entries
  (`Qwen3VLVisionModel.rot_pos_emb`, `Qwen3VLModel.get_rope_index`).
- Comparison / `offending` / `dead` logic + the failure report updated to
  qualname keys.
- Deleted the stale hardcoded `file:line` list in the `_PENDING_FIX_CASES`
  comment; refreshed the module docstring.

Noted tradeoff (documented in-code): keying by qualname means a *new* sync
added inside an already-allowlisted function is accepted silently. This is
acceptable — the allowlisted functions (`get_rope_index` etc.) are HF-verbatim
and accepted as whole-function algorithm-essential anyway.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added/updated documentation (module docstring)
- [x] Added tests to CI workflow (new unit test; the gate itself already runs in CI)
