### PR TITLE
[parallel] feat: disable HSDP gradient all-reduce during gradient accumulation

### DIFF
--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -576,6 +576,18 @@ class BaseTrainer(Stateful, ABC):
             elif micro_step == num_micro_steps - 1:
                 self.model.set_reshard_after_backward(True)
 
+    def _configure_hsdp_allreduce(self, micro_step: int, num_micro_steps: int):
+        args: VeOmniArguments = self.args
+        if (
+            args.train.accelerator.fsdp_config.fsdp_mode == "fsdp2"
+            and args.train.accelerator.dp_replicate_size > 1
+            and num_micro_steps > 1
+        ):
+            if micro_step == 0:
+                self.model.set_requires_all_reduce(False)
+            elif micro_step == num_micro_steps - 1:
+                self.model.set_requires_all_reduce(True)
+
     def train_step(
         self,
         data_iterator: Any,
@@ -599,6 +611,7 @@ class BaseTrainer(Stateful, ABC):
         # forward and backward pass with gradient_accumulationsteps
         for micro_step, micro_batch in enumerate(micro_batches):
             self.model_reshard(micro_step, num_micro_steps)
+            self._configure_hsdp_allreduce(micro_step, num_micro_steps)
             loss: torch.Tensor
             loss_dict: Dict[str, torch.Tensor]
             # token num for fixed_ce_loss in postforward


### PR DESCRIPTION
### What does this PR do?

For HSDP, gradients require a `reduce_scatter` over the sharded dimension and an `all_reduce` over the replicated dimension. When gradient accumulation is enabled, gradient synchronization over the replicated dimension is only needed on the last micro-step. This keeps memory usage unchanged while reducing latency.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

```bash
export NCCL_DEBUG=WARN
export TOKENIZERS_PARALLELISM=false
export TORCH_NCCL_AVOID_RECORD_STREAMS=1

export WANDB_API_KEY=xxx
export WANDB_ENTITY=xxx
export WANDB_MODE=online

DISTRIBUTED_ARGS="
  --nproc_per_node $MLP_WORKER_GPU \
  --nnodes $MLP_WORKER_NUM \
  --node_rank $MLP_ROLE_INDEX \
  --master_addr $MLP_WORKER_0_HOST \
  --master_port $MLP_WORKER_0_PORT \
"

MBS=1
GBS=128
EP_SIZE=8

TRAIN_ARGS="
  --model.model_path /xxx/Qwen3.5-35B-A3B \
  --model.ops_implementation.moe_implementation fused_triton \
  --data.train_path /xxx/tulu-first2000.parquet \
  --train.accelerator.fsdp_config.fsdp_mode fsdp2 \
  --train.accelerator.fsdp_config.offload true \
  --train.accelerator.dp_replicate_size ${MLP_WORKER_NUM} \
  --train.accelerator.dp_shard_size ${MLP_WORKER_GPU} \
  --train.accelerator.ep_size ${EP_SIZE} \
  --train.init_device meta \
  --train.micro_batch_size ${MBS} \
  --train.global_batch_size ${GBS} \
  --train.checkpoint.output_dir /xxx/Qwen3.5-35B-A3B-sft-tulu \
  --train.wandb.enable true \
  --train.wandb.project VeOmni \
  --train.wandb.name Qwen3.5-35B-A3B-sft-tulu \
"

DATE=$(date +%Y%m%d_%H%M%S)

torchrun ${DISTRIBUTED_ARGS} tasks/train_text.py \
  configs/text/qwen3_5_sft.yaml \
  ${TRAIN_ARGS} $@ 2>&1 | tee logs/${DATE}_${MLP_ROLE_INDEX}_log.txt
```

#### Before
```
Epoch 1/3:   0%|          | 0/3 [09:46<?, ?it/s, total_loss: 1.40, foundation_loss: 1.40, grad_norm: 21.77, lr: 0.00]
Epoch 1/3:  33%|███▎      | 1/3 [09:46<19:32, 586.28s/it, total_loss: 1.40, foundation_loss: 1.40, grad_norm: 21.77, lr: 0.00]
Epoch 1/3:  33%|███▎      | 1/3 [17:10<19:32, 586.28s/it, total_loss: 1.52, foundation_loss: 1.52, grad_norm: 10.50, lr: 0.00]
Epoch 1/3:  67%|██████▋   | 2/3 [17:10<08:22, 502.59s/it, total_loss: 1.52, foundation_loss: 1.52, grad_norm: 10.50, lr: 0.00]
Epoch 1/3:  67%|██████▋   | 2/3 [24:25<08:22, 502.59s/it, total_loss: 1.28, foundation_loss: 1.28, grad_norm: 8.08, lr: 0.00] 
Epoch 1/3: 100%|██████████| 3/3 [24:25<00:00, 471.65s/it, total_loss: 1.28, foundation_loss: 1.28, grad_norm: 8.08, lr: 0.00]
Epoch 1/3: 100%|██████████| 3/3 [24:25<00:00, 488.38s/it, total_loss: 1.28, foundation_loss: 1.28, grad_norm: 8.08, lr: 0.00]
```

<img width="200" height="101" alt="image" src="https://github.com/user-attachments/assets/d45e1bff-0fd5-4fe4-a438-a63e1cbf297c" />


#### After
```
Epoch 1/3:   0%|          | 0/3 [09:35<?, ?it/s, total_loss: 1.40, foundation_loss: 1.40, grad_norm: 21.77, lr: 0.00]
Epoch 1/3:  33%|███▎      | 1/3 [09:35<19:11, 575.93s/it, total_loss: 1.40, foundation_loss: 1.40, grad_norm: 21.77, lr: 0.00]
Epoch 1/3:  33%|███▎      | 1/3 [16:53<19:11, 575.93s/it, total_loss: 1.52, foundation_loss: 1.52, grad_norm: 10.50, lr: 0.00]
Epoch 1/3:  67%|██████▋   | 2/3 [16:53<08:14, 494.65s/it, total_loss: 1.52, foundation_loss: 1.52, grad_norm: 10.50, lr: 0.00]
Epoch 1/3:  67%|██████▋   | 2/3 [24:03<08:14, 494.65s/it, total_loss: 1.28, foundation_loss: 1.28, grad_norm: 8.08, lr: 0.00] 
Epoch 1/3: 100%|██████████| 3/3 [24:03<00:00, 464.89s/it, total_loss: 1.28, foundation_loss: 1.28, grad_norm: 8.08, lr: 0.00]
Epoch 1/3: 100%|██████████| 3/3 [24:03<00:00, 481.06s/it, total_loss: 1.28, foundation_loss: 1.28, grad_norm: 8.08, lr: 0.00]
```

<img width="200" height="101" alt="image" src="https://github.com/user-attachments/assets/528bdb64-c036-4ff9-b7aa-971696c849e8" />


### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
