### PR TITLE
[ops] fix: register NPU RoPE and RMSNorm kernels

### DIFF
--- a/tests/ops/test_moe_hw_gate.py
+++ b/tests/ops/test_moe_hw_gate.py
@@ -116,6 +116,22 @@ def test_opslot_fused_npu_on_gpu_raises():
         slot.bind("npu")
 
 
+@pytest.mark.parametrize(
+    ("op_name", "variant"),
+    [
+        ("rotary_pos_emb", "full"),
+        ("rms_norm", "standard"),
+    ],
+)
+@patch(f"{_REGISTRY_MODULE}.IS_CUDA_AVAILABLE", True)
+@patch(f"{_REGISTRY_MODULE}.IS_NPU_AVAILABLE", False)
+def test_opslot_npu_text_kernels_are_registered_and_hw_gated(op_name, variant):
+    """NPU text kernels should be known to OpSlot dispatch before HW gating."""
+    slot = OpSlot(op_name, variant)
+    with pytest.raises(RuntimeError, match="device_type='npu'"):
+        slot.bind("npu")
+
+
 def test_opslot_eager_skips_hw_check():
     """'eager' resolves to None without touching HardwareRequirement."""
     slot = OpSlot("moe_experts", "standard")
@@ -184,3 +200,14 @@ def test_bind_veomni_ops_translates_moe_implementation_and_checks_hw(_mock_cc, _
 @pytest.mark.parametrize("impl_name", ["triton", "quack", "npu"])
 def test_moe_experts_registry_has_kernel(impl_name):
     assert impl_name in KERNEL_REGISTRY.list_available("moe_experts", "standard")
+
+
+@pytest.mark.parametrize(
+    ("op_name", "variant"),
+    [
+        ("rotary_pos_emb", "full"),
+        ("rms_norm", "standard"),
+    ],
+)
+def test_npu_text_kernel_registry_has_kernel(op_name, variant):
+    assert "npu" in KERNEL_REGISTRY.list_available(op_name, variant)

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -45,27 +45,9 @@ _NPU_PER_MODEL_OVERRIDES: Dict[str, Dict[str, str]] = {
     # Multimodal RoPE has no NPU backend in the Qwen-VL family.
     "qwen2vl": {"rotary_pos_emb_implementation": "eager"},
     "qwen25vl": {"rotary_pos_emb_implementation": "eager"},
-    # qwen2 / qwen3_moe / llama3.1 / qwen2_5_omni patchgen-generated modeling
-    # declares OpSlots for rotary_pos_emb and rms_norm but KERNEL_REGISTRY
-    # has no ``npu`` KernelSpec for either — only ``liger_kernel`` (GPU). Pin
-    # both to eager until NPU KernelSpecs are registered.
-    "qwen2": {
-        "rms_norm_implementation": "eager",
-        "rotary_pos_emb_implementation": "eager",
-    },
-    "qwen3_moe": {
-        "rms_norm_implementation": "eager",
-        "rotary_pos_emb_implementation": "eager",
-    },
-    "llama3.1": {
-        "rms_norm_implementation": "eager",
-        "rotary_pos_emb_implementation": "eager",
-    },
-    # qwen2_5_omni inherits the same KERNEL_REGISTRY gap; mm RoPE has no
-    # NPU backend either, so pinning both keeps the thinker text path on
-    # eager kernels on NPU.
+    # qwen2_5_omni's multimodal RoPE has no NPU backend today, so keep RoPE
+    # eager while allowing text RMSNorm to use the NPU OpSlot kernel.
     "qwen2_5_omni": {
-        "rms_norm_implementation": "eager",
         "rotary_pos_emb_implementation": "eager",
     },
 }

--- a/veomni/ops/kernels/rms_norm/__init__.py
+++ b/veomni/ops/kernels/rms_norm/__init__.py
@@ -22,6 +22,7 @@ Models can register a ``triton`` backend via ``extra_backends`` in their
 """
 
 from ...config.registry import BackendSpec, OpScope, OpSpec, register_op
+from ...kernel_registry import KERNEL_REGISTRY, HardwareRequirement, KernelSpec
 
 
 register_op(
@@ -42,5 +43,17 @@ register_op(
                 replace_forward=True,
             ),
         },
+    )
+)
+
+
+KERNEL_REGISTRY.register(
+    KernelSpec(
+        name="npu",
+        op_name="rms_norm",
+        variant="standard",
+        factory=lambda: __import__("veomni.ops.kernels.rms_norm.npu", fromlist=["rms_norm_npu"]).rms_norm_npu,
+        hardware=HardwareRequirement(device_type="npu"),
+        description="Ascend NPU fused RMSNorm",
     )
 )

--- a/veomni/ops/kernels/rms_norm/npu.py
+++ b/veomni/ops/kernels/rms_norm/npu.py
@@ -21,11 +21,16 @@
 import torch_npu
 
 
+def rms_norm_npu(hidden_states, weight, eps):
+    """NPU optimized RMSNorm implementation for OpSlot dispatch."""
+    if hidden_states.dtype != weight.dtype:
+        hidden_states = hidden_states.to(weight.dtype)
+    return torch_npu.npu_rms_norm(hidden_states, weight, epsilon=eps)[0]
+
+
 def rms_norm_forward_npu(self, x):
     """NPU optimized implementation for RMSNorm."""
-    if x.dtype != self.weight.dtype:
-        x = x.to(self.weight.dtype)
-    return torch_npu.npu_rms_norm(x, self.weight, epsilon=self.variance_epsilon)[0]
+    return rms_norm_npu(x, self.weight, self.variance_epsilon)
 
 
-__all__ = ["rms_norm_forward_npu"]
+__all__ = ["rms_norm_forward_npu", "rms_norm_npu"]

--- a/veomni/ops/kernels/rotary/__init__.py
+++ b/veomni/ops/kernels/rotary/__init__.py
@@ -22,6 +22,7 @@ Models can register a ``triton`` (deterministic bmm / Wan DiT) backend via
 """
 
 from ...config.registry import BackendSpec, OpScope, OpSpec, register_op
+from ...kernel_registry import KERNEL_REGISTRY, HardwareRequirement, KernelSpec
 
 
 register_op(
@@ -41,5 +42,19 @@ register_op(
                 requires=("torch_npu",),
             ),
         },
+    )
+)
+
+
+KERNEL_REGISTRY.register(
+    KernelSpec(
+        name="npu",
+        op_name="rotary_pos_emb",
+        variant="full",
+        factory=lambda: (
+            __import__("veomni.ops.kernels.rotary.npu", fromlist=["apply_rotary_pos_emb_npu"]).apply_rotary_pos_emb_npu
+        ),
+        hardware=HardwareRequirement(device_type="npu"),
+        description="Ascend NPU fused RoPE (full head_dim)",
     )
 )


### PR DESCRIPTION
### What does this PR do?

  Fixes NPU OpSlot dispatch for text RoPE and RMSNorm kernels.

  When running text training on Ascend NPU with:

  ```bash
  --model.ops_implementation.rms_norm_implementation npu \
  --model.ops_implementation.rotary_pos_emb_implementation npu
```

  model construction failed while binding OpSlots:
```
  KeyError: "Unknown kernel 'npu' for op='rotary_pos_emb', variant='full'. Available: ['liger_kernel', 'eager']"
```

  The config registry already exposes npu backends for rotary_pos_emb and rms_norm, but the runtime KERNEL_REGISTRY used by `OpSlot.bind()` did not register the corresponding NPU KernelSpecs. This PR registers those missing kernels and updates the NPU test helper so text models can use the NPU backends instead of forced eager fallbacks.

  ### Checklist Before Starting

  - Search for relative PRs/issues and link here: No related issue found.
  - PR title follows [{modules}] {type}: {description} format (enforced by check_pr_title.yml (.github/workflows/
    check_pr_title.yml))
      - Allowed modules: agent, ci, ckpt, config, data, dist, docker, docs, logging, lora, misc, model, omni, optim, ops,
        parallel, perf, release, task, trainer
      - Allowed types: feat, fix, refactor, chore, test
      - Breaking changes: prepend [BREAKING] — e.g. [BREAKING][parallel, model] feat: dynamic batching

  ### Test

  Local checks:

  git diff --check
  python3 -m py_compile \
    veomni/ops/kernels/rms_norm/npu.py \
    veomni/ops/kernels/rms_norm/__init__.py \
    veomni/ops/kernels/rotary/__init__.py \
    tests/ops/test_moe_hw_gate.py \
    tests/tools/training_utils.py

  NPU validation:

  Before this PR, text training on Ascend NPU with:
```
  --model.ops_implementation.rms_norm_implementation npu \
  --model.ops_implementation.rotary_pos_emb_implementation npu
```
  failed during model build with:
```
  KeyError: "Unknown kernel 'npu' for op='rotary_pos_emb', variant='full'. Available: ['liger_kernel', 'eager']"
```
  After this change, the missing NPU kernels are registered in KERNEL_REGISTRY

  ### API and Usage Example

  No API change.

  ### Design & Code Changes

  - Register rotary_pos_emb/full with the npu implementation in KERNEL_REGISTRY.
  - Register rms_norm/standard with the npu implementation in KERNEL_REGISTRY.
  - Add an OpSlot-compatible functional RMSNorm wrapper around torch_npu.npu_rms_norm.
  - Add registry/hardware-gate regression coverage for NPU text kernels.
  - Remove obsolete NPU eager fallbacks for qwen2, qwen3_moe, and llama3.1 in test training utilities now that the NPU text
    kernels are registered.
  - Keep qwen2_5_omni RoPE on eager in tests because its multimodal RoPE path still has no NPU backend.

  ### Checklist Before Submitting

  - Read the Contribute Guide (https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
  - Applied pre-commit checks: Not run locally; environment missing uv / ruff.
  - Added/updated documentation: Not needed, no API or workflow change.
  - If tasks/ training scripts were moved or renamed: Not applicable.
  - Added tests to CI workflow (or explained why not feasible): Added regression tests under tests/ops/test_moe_hw_gate.py; no CI
    workflow change needed because this extends an existing test file.

  **NPU validation:**

  ```bash

  python tasks/train_text.py ... \
    --model.ops_implementation.rms_norm_implementation npu \
    --model.ops_implementation.rotary_pos_emb_implementation npu
```

  Result: model build passed and training started successfully on Ascend NPU.
