### PR TITLE
[model, omni] feat: add Qwen-Image lora config

### DIFF
--- a/configs/dit/qwen_image_lora.yaml
+++ b/configs/dit/qwen_image_lora.yaml
@@ -1,0 +1,75 @@
+model:
+  model_path: Qwen/Qwen-Image/transformer
+  condition_model_path: Qwen/Qwen-Image
+  config_path: ./configs/model_configs/qwen_image/qwen_image_20b.json
+  condition_model_cfg:
+    max_sequence_length: 512
+    height: 1024
+    width: 1024
+  ops_implementation:
+    attn_implementation: eager
+    rotary_pos_emb_implementation: eager
+  lora_config:
+    rank: 128
+    alpha: 64
+    lora_modules:
+      - to_q
+      - to_k
+      - to_v
+      - to_out.0
+      - add_q_proj
+      - add_k_proj
+      - add_v_proj
+      - to_add_out
+      - net.0.proj
+      - net.2
+
+data:
+  train_path: qwen_image_train
+  train_size: 1000000000000
+  dataloader:
+    type: native
+    drop_last: true
+  datasets_type: iterable
+  data_type: diffusion
+  max_seq_len: 4096
+  text_keys: text
+  dyn_bsz_buffer_size: 200
+  source_name: Qwen-Image
+train:
+  accelerator:
+    dp_replicate_size: 1
+    ulysses_size: 1
+    fsdp_config:
+      fsdp_mode: fsdp2
+      mixed_precision:
+        enable: false
+    offload:
+      enable_activation: false
+  gradient_checkpointing:
+    enable: true
+  global_batch_size: 8
+  micro_batch_size: 1
+  bsz_warmup_ratio: 0.007
+  optimizer:
+    type: adamw
+    lr: 1.0e-4
+    lr_warmup_ratio: 0.007
+    lr_decay_style: constant
+    lr_decay_ratio: 1.0
+    weight_decay: 0.01
+    max_grad_norm: 1.0
+  init_device: meta
+  enable_full_determinism: false
+  empty_cache_steps: 500
+  checkpoint:
+    output_dir: qwen-image-lora
+    manager: dcp
+    save_epochs: 1
+    save_hf_weights: true
+  max_steps: 500
+  num_train_epochs: 3
+  wandb:
+    enable: false
+    project: Qwen-Image
+    name: lora_qwen_image

--- a/docs/key_features/lora.md
+++ b/docs/key_features/lora.md
@@ -273,6 +273,56 @@ bash train.sh tasks/train_text.py configs/text/qwen3_lora.yaml \
     --train.checkpoint.load_path auto          # auto-picks latest DCP checkpoint
 ```
 
+### 5.3 Qwen-Image LoRA (DiT, FSDP2)
+
+Config: [`configs/dit/qwen_image_lora.yaml`](../../configs/dit/qwen_image_lora.yaml)
+
+The Qwen-Image transformer uses a **dual-stream** MMDiT block: each `QwenImageTransformerBlock` carries a separate image-stream attention projection (`to_q`, `to_k`, `to_v`, `to_out.0`) and a text-stream one (`add_q_proj`, `add_k_proj`, `add_v_proj`, `to_add_out`), plus paired `img_mlp` / `txt_mlp` FeedForward sub-modules. The recommended target set covers both streams:
+
+```yaml
+model:
+  lora_config:
+    rank: 128
+    alpha: 64
+    lora_modules:
+      - to_q
+      - to_k
+      - to_v
+      - to_out.0
+      - add_q_proj
+      - add_k_proj
+      - add_v_proj
+      - to_add_out
+      - net.0.proj
+      - net.2
+
+train:
+  init_device: meta
+  accelerator:
+    fsdp_config:
+      fsdp_mode: fsdp2
+```
+
+`net.0.proj` and `net.2` are substring-matched, so they hit the Linear layers inside both `img_mlp` and `txt_mlp` (each is a `diffusers.models.attention.FeedForward`).
+
+Launch (e.g. 8 GPUs, single-node):
+
+```shell
+NPROC_PER_NODE=8
+
+bash train.sh tasks/train_dit.py configs/dit/qwen_image_lora.yaml \
+    --model.model_path           /path/to/Qwen-Image/transformer \
+    --model.condition_model_path /path/to/Qwen-Image \
+    --data.train_path            /path/to/dataset \
+    --train.global_batch_size    8 \
+    --train.micro_batch_size     1 \
+    --train.checkpoint.output_dir ./exp/qwen_image_lora \
+    --train.checkpoint.save_hf_weights true \
+    --train.num_train_epochs 3
+```
+
+`HFLoraCkptCallback` writes the trained adapter to `${output_dir}/global_step_${step}/{adapter_config.json, adapter_model.{bin,safetensors}}`, which is the standard PEFT format consumable by `PeftModel.from_pretrained` and `diffusers`' `pipeline.transformer.load_lora_adapter` (the adapter keys carry the `base_model.model.` prefix expected by `peft`).
+
 ---
 
 ## 6. Testing


### PR DESCRIPTION
### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

No need to do other things, just adding LoRA config and update Doc.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
