### PR TITLE
[ckpt, lora] feat: Save lora ckpt and add omni-infer with lora

### DIFF
--- a/scripts/merge_dcp_to_hf.py
+++ b/scripts/merge_dcp_to_hf.py
@@ -2,6 +2,7 @@ import argparse
 import gc
 import json
 import os
+import shutil
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Optional, Sequence, Union
 
@@ -21,6 +22,73 @@ if TYPE_CHECKING:
 
 
 logger = helper.create_logger(__name__)
+
+
+# PEFT LoRA adapter key markers. The training DCP keeps PEFT's wrapped FQNs intact
+# (e.g. ``base_model.model.<...>.lora_A.default.weight``), so a substring check on
+# the HF-normalized keys is enough to spot a LoRA checkpoint.
+_LORA_KEY_MARKERS = (".lora_A.", ".lora_B.", ".lora_embedding_A.", ".lora_embedding_B.")
+
+
+def _is_lora_key(hf_key: str) -> bool:
+    return any(marker in hf_key for marker in _LORA_KEY_MARKERS)
+
+
+def _detect_lora(all_hf_keys: Sequence[str]) -> bool:
+    """Return True if any of the HF-normalized keys looks like a PEFT LoRA adapter."""
+    return any(_is_lora_key(k) for k in all_hf_keys)
+
+
+@torch.no_grad()
+def save_lora_adapter_weights(
+    output_dir: Union[str, os.PathLike],
+    checkpoint_path: Union[str, os.PathLike],
+    save_dtype: Optional[Union[str, torch.dtype]] = "bfloat16",
+    adapter_config_path: Optional[Union[str, os.PathLike]] = None,
+) -> None:
+    """Convert a DCP checkpoint that contains a PEFT LoRA adapter to ``adapter_model.safetensors``.
+
+    Only ``*.lora_A.*`` / ``*.lora_B.*`` keys are exported, mirroring what
+    ``veomni.utils.save_safetensor_utils.save_lora_adapter_with_dcp`` writes during
+    training. The base model weights present in the DCP (frozen during LoRA fine-tuning)
+    are intentionally dropped: at inference time they must come from the original
+    base model path the LoRA was trained against.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    logger.info(f"Saving LoRA adapter to {output_dir}")
+
+    # ``shard_size=None`` forces a single shard so we get ``adapter_model.safetensors`` directly.
+    all_keys, _total_size, _all_dcp_keys = _get_sharding_plan(checkpoint_path, shard_size=None, save_dtype=save_dtype)
+    lora_keys = {hf_k: dcp_k for hf_k, dcp_k in all_keys.items() if _is_lora_key(hf_k)}
+    if not lora_keys:
+        raise RuntimeError(
+            f"LoRA conversion requested but no LoRA keys (.lora_A./.lora_B./...) found under {checkpoint_path}"
+        )
+
+    logger.info(f"Found {len(lora_keys)} LoRA tensors; loading and re-saving as adapter_model.safetensors")
+    processed_dict = _process_shard(lora_keys, checkpoint_path, save_dtype)
+
+    save_path = os.path.join(output_dir, "adapter_model.safetensors")
+    save_file(processed_dict, save_path, metadata={"format": "pt"})
+    del processed_dict
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    if adapter_config_path is not None:
+        adapter_config_path = str(adapter_config_path)
+        if not os.path.isfile(adapter_config_path):
+            raise FileNotFoundError(f"--adapter-config-path does not exist: {adapter_config_path}")
+        shutil.copyfile(adapter_config_path, os.path.join(output_dir, "adapter_config.json"))
+        logger.info(f"Copied adapter_config.json from {adapter_config_path}")
+    else:
+        logger.warning(
+            "No --adapter-config-path provided. ``adapter_model.safetensors`` was written, but you must drop "
+            "``adapter_config.json`` (from the matching training run's ``output_dir/global_step_*/``) next to it "
+            "before the adapter can be loaded by peft / diffusers."
+        )
+
+    logger.info("LoRA adapter conversion complete.")
 
 
 @torch.no_grad()
@@ -155,6 +223,26 @@ def main():
         default=2_000_000_000,
         help="Maximum shard size in bytes (default: 2GB)",
     )
+    parser.add_argument(
+        "--mode",
+        choices=("auto", "full", "lora"),
+        default="auto",
+        help=(
+            "Conversion mode. 'auto' (default) inspects DCP keys: writes adapter_model.safetensors when the "
+            "checkpoint contains PEFT LoRA keys, otherwise writes a full sharded HF safetensors dump. "
+            "'full' / 'lora' force the corresponding mode."
+        ),
+    )
+    parser.add_argument(
+        "--adapter-config-path",
+        type=str,
+        default=None,
+        help=(
+            "Path to the matching adapter_config.json produced during LoRA training "
+            "(usually under <output_dir>/global_step_*/adapter_config.json). Only used in 'lora' mode; "
+            "copied next to adapter_model.safetensors so the adapter is loadable as-is."
+        ),
+    )
     args = parser.parse_args()
 
     load_dir = args.load_dir
@@ -162,7 +250,27 @@ def main():
     model_assets_dir = args.model_assets_dir
     shard_size = args.shard_size
 
-    merge_to_hf_pt(load_dir, save_dir, model_assets_dir, shard_size=shard_size)
+    mode = args.mode
+    if mode == "auto":
+        _shards_for_detection, _size, _dcp_keys = _get_sharding_plan(load_dir, shard_size=None, save_dtype="bfloat16")
+        # _shards_for_detection is a single {hf_key: dcp_key} dict when shard_size is None
+        detected_lora = _detect_lora(_shards_for_detection.keys())
+        mode = "lora" if detected_lora else "full"
+        logger.info(
+            f"Auto-detected mode: {mode} "
+            f"({'LoRA keys present' if detected_lora else 'no LoRA keys; treating as full checkpoint'})"
+        )
+
+    if mode == "lora":
+        save_lora_adapter_weights(
+            output_dir=save_dir,
+            checkpoint_path=load_dir,
+            adapter_config_path=args.adapter_config_path,
+        )
+    else:
+        if args.adapter_config_path is not None:
+            logger.warning("--adapter-config-path is only used in 'lora' mode; ignoring.")
+        merge_to_hf_pt(load_dir, save_dir, model_assets_dir, shard_size=shard_size)
 
 
 if __name__ == "__main__":

--- a/tests/lora/test_lora_trainer_saveload.py
+++ b/tests/lora/test_lora_trainer_saveload.py
@@ -33,6 +33,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 import torch
+from torch.distributed.checkpoint import FileSystemReader
 
 from veomni.arguments import VeOmniArguments, parse_args
 from veomni.data import build_dummy_dataset
@@ -49,6 +50,9 @@ torch.multiprocessing.set_sharing_strategy("file_system")
 logger = helper.create_logger(__name__)
 
 _LORA_KEYS = ("lora_A", "lora_B")
+# Arbitrary non-zero sentinel for the frozen-base canary perturbation; any
+# non-zero value works — we only need to detect whether load overwrote it.
+_CANARY_PERTURBATION = 3.14159
 
 
 def _local(tensor: torch.Tensor) -> torch.Tensor:
@@ -102,12 +106,39 @@ class _LoraCheckpointerCallback(CheckpointerCallback):
                 if any(k in n for k in _LORA_KEYS)
             }
             assert self.trainer.golden_lora, "No LoRA parameters found in model!"
+
+            # Snapshot frozen base local shards + pick a canary param.
+            # Used at train_end to verify that loading a LoRA-only DCP does NOT
+            # overwrite frozen base weights (``StateDictOptions(strict=False)``).
+            self.trainer.golden_base = {
+                n: _local(p).detach().clone() for n, p in self.trainer.model.named_parameters() if not p.requires_grad
+            }
+            assert self.trainer.golden_base, "No frozen base parameters found in model!"
+            self.trainer.canary_name = next(iter(self.trainer.golden_base.keys()))
+
             self._save_checkpoint(state)
             self.trainer.dcp_ckpt_path = os.path.join(
                 self.trainer.args.train.checkpoint.save_path,
                 f"global_step_{state.global_step}",
             )
             logger.info_rank0(f"[test] step-1 checkpoint saved → {self.trainer.dcp_ckpt_path}")
+
+            # Invariant for trainable_only=True: the DCP must contain only LoRA
+            # tensors under the ``model.*`` namespace; any frozen base key would
+            # silently get restored on load and defeat the size optimisation.
+            model_keys = [
+                k
+                for k in FileSystemReader(self.trainer.dcp_ckpt_path).read_metadata().state_dict_metadata
+                if k.startswith("model.")
+            ]
+            base_keys_in_dcp = [k for k in model_keys if "lora_" not in k]
+            assert not base_keys_in_dcp, (
+                f"trainable_only=True should drop frozen base from the DCP, "
+                f"but found {len(base_keys_in_dcp)} non-LoRA model key(s); "
+                f"first 5: {base_keys_in_dcp[:5]}"
+            )
+            assert any("lora_" in k for k in model_keys), f"DCP contains no LoRA tensors: {model_keys[:5]}"
+            logger.info_rank0(f"[test] DCP holds {len(model_keys)} model tensors, all LoRA (no frozen base leaked).")
 
 
 # ---------------------------------------------------------------------------
@@ -138,9 +169,22 @@ class _LoraCheckCallback(Callback):
     trainer: "LoraTrainerSaveLoadTest"
 
     def on_train_end(self, state: TrainerState, **kwargs) -> None:
+        canary_name = self.trainer.canary_name
+        canary_param = dict(self.trainer.model.named_parameters())[canary_name]
+        with torch.no_grad():
+            _local(canary_param).add_(_CANARY_PERTURBATION)
+        expected_canary = self.trainer.golden_base[canary_name] + _CANARY_PERTURBATION
+
         # Restore model to the step-1 checkpoint.
         self.trainer.args.train.checkpoint.load_path = self.trainer.dcp_ckpt_path
         self.trainer.checkpointer_callback._load_checkpoint()
+
+        if not torch.allclose(_local(canary_param), expected_canary, atol=0, rtol=0):
+            raise AssertionError(
+                f"strict=False failed: frozen base param '{canary_name}' was "
+                f"overwritten by _load_checkpoint (the in-place perturbation "
+                f"of size {_CANARY_PERTURBATION} should have survived the load)."
+            )
 
         # Compare each LoRA local shard with the golden snapshot.
         mismatches = []
@@ -156,7 +200,8 @@ class _LoraCheckCallback(Callback):
             raise AssertionError(f"LoRA weight mismatch after checkpoint reload for: {mismatches}")
 
         logger.info_rank0(
-            f"[test] PASS — {len(self.trainer.golden_lora)} LoRA tensors verified identical after save/load."
+            f"[test] PASS — {len(self.trainer.golden_lora)} LoRA tensors restored from DCP; "
+            f"frozen base canary '{canary_name}' preserved across load."
         )
 
 
@@ -168,6 +213,8 @@ class _LoraCheckCallback(Callback):
 class LoraTrainerSaveLoadTest(BaseTrainer):
     # Set in _LoraCheckpointerCallback.on_step_end
     golden_lora: Dict[str, torch.Tensor]
+    golden_base: Dict[str, torch.Tensor]
+    canary_name: str
     dcp_ckpt_path: str
 
     # -- dataset / asset overrides -----------------------------------------

--- a/veomni/checkpoint/checkpointer.py
+++ b/veomni/checkpoint/checkpointer.py
@@ -60,6 +60,7 @@ class CheckpointerBase(ABC):
         state: Dict[str, Any],
         save_async: Optional[bool],
         global_steps: Optional[int],
+        trainable_only: bool = False,
     ):
         return
 
@@ -68,6 +69,7 @@ class CheckpointerBase(ABC):
         cls,
         path: str,
         state: Dict[str, Any],
+        trainable_only: bool = False,
     ):
         return
 

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -29,6 +29,7 @@ from torch.distributed.checkpoint import (
 )
 from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE, Metadata
 from torch.distributed.checkpoint.state_dict import (
+    StateDictOptions,
     get_model_state_dict,
     get_optimizer_state_dict,
     set_model_state_dict,
@@ -50,14 +51,20 @@ _EXTRA_STATE_DIR = "extra_state"
 
 
 class ModelState(Stateful):
-    """
-    A wrapper around a model to make it stateful.
+    """A wrapper around a model to make it stateful.
+
     Args:
-        model (Model): model to wrap.
+        model: model to wrap.
+        trainable_only: when ``True`` the state_dict only contains parameters with
+            ``requires_grad=True`` (uses ``StateDictOptions(ignore_frozen_params=True)``).
+            This is the LoRA / PEFT path: frozen base weights are skipped on save and
+            ``set_model_state_dict`` runs in ``strict=False`` mode on load so the
+            (already populated from ``model_path``) base params are left untouched.
     """
 
-    def __init__(self, model):
+    def __init__(self, model, trainable_only: bool = False):
         self.model = model
+        self.trainable_only = trainable_only
 
         # Determine whether this is ExtraParallel+FSDP2 case
         # If so, we need to restore Para(e.g. EP)-dim before saving to DCP
@@ -69,7 +76,8 @@ class ModelState(Stateful):
 
     @torch.no_grad()
     def state_dict(self):
-        model_state_dict = get_model_state_dict(model=self.model)
+        options = StateDictOptions(ignore_frozen_params=True) if self.trainable_only else None
+        model_state_dict = get_model_state_dict(model=self.model, options=options)
         if self.should_extra_parallel_aware:
             logger.info_rank0(
                 "Getting model state_dict from ModelState wrapper, would restore ExtraParallel dim for ExtraParallel (e.g. Experts/Embeds) module"
@@ -91,7 +99,8 @@ class ModelState(Stateful):
         if self.should_extra_parallel_aware:
             model_state_dict = self.get_state_dict_with_extra_parallel_dim_preprocess(model_state_dict, "drop")
 
-        set_model_state_dict(model=self.model, model_state_dict=model_state_dict)
+        options = StateDictOptions(strict=False) if self.trainable_only else None
+        set_model_state_dict(model=self.model, model_state_dict=model_state_dict, options=options)
 
     def get_state_dict_with_extra_parallel_dim_preprocess(self, state_dict, action):
         extra_parallel_fqn2spec_info = self.extra_parallel_fqn2spec_info
@@ -414,6 +423,7 @@ class DistributedCheckpointer(CheckpointerBase):
         save_async: bool = False,
         global_steps: int = None,
         storage_writer: Optional[FileSystemWriter] = None,
+        trainable_only: bool = False,
     ) -> None:
         """
         save training state to distributed checkpoint
@@ -424,6 +434,12 @@ class DistributedCheckpointer(CheckpointerBase):
             save_async: whether to save asynchronously
             global_steps: global steps
             storage_writer: storage writer backend for dcp.save and dcp.async_save. If None, will use FileSystemWriter
+            trainable_only: when True, only persist parameters with ``requires_grad=True``
+                (LoRA / PEFT path). Frozen base weights are skipped on save and must be
+                re-materialised from ``model.model_path`` at resume time. The optimizer
+                state is already trainable-only by construction (the optimizer is built
+                from ``filter(lambda p: p.requires_grad, ...)``), so this flag only
+                affects the model state dump.
         return:
             None
         """
@@ -436,7 +452,7 @@ class DistributedCheckpointer(CheckpointerBase):
         # saving extra_state first to gurantee that every saved model/optimizer ckpts have their extra_state saved before them
         cls._save_extra_state(checkpoint_dir=checkpoint_dir, state=state)
 
-        save_state = {"model": ModelState(state["model"])}
+        save_state = {"model": ModelState(state["model"], trainable_only=trainable_only)}
         if "optimizer" in state:
             save_state["optimizer"] = OptimizerState(
                 model=state["model"], optimizer=state["optimizer"], fill_missing_optimizer_states=True
@@ -456,6 +472,7 @@ class DistributedCheckpointer(CheckpointerBase):
         state: Dict[str, Any],
         process_group=None,
         storage_reader: Optional[FileSystemReader] = None,
+        trainable_only: bool = False,
     ) -> Dict[str, Any]:
         """
         load training state from distributed checkpoint
@@ -464,6 +481,11 @@ class DistributedCheckpointer(CheckpointerBase):
             state: state to load, "model" are required,  "optimizer" and "extra_state" are optional
             process_group: process group for loading checkpoint
             storage_reader: storage reader backend for dcp.load. If None, will use FileSystemReader
+            trainable_only: when True, ``set_model_state_dict`` runs in non-strict
+                mode (``StateDictOptions(strict=False)``). Use this for LoRA / PEFT
+                resumes where the DCP only contains trainable adapter weights and the
+                frozen base must come from ``model.model_path``. Safe to enable when
+                the DCP is full (extra strictness is just dropped).
 
         return:
             state: state loaded
@@ -476,7 +498,7 @@ class DistributedCheckpointer(CheckpointerBase):
         if "model" not in state:
             raise ValueError("Model must be provided to load a distributed checkpoint.")
 
-        load_state = {"model": ModelState(state["model"])}
+        load_state = {"model": ModelState(state["model"], trainable_only=trainable_only)}
         if "optimizer" in state:
             load_state["optimizer"] = OptimizerState(model=state["model"], optimizer=state["optimizer"])  # type: ignore[index]
 

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -75,9 +75,6 @@ class CheckpointerCallback(Callback):
         if getattr(self.trainer.checkpointer, "save_future", None) is not None:  # async save
             self.trainer.checkpointer.save_future.result()
 
-        # LoRA training: the DCP only contains trainable (LoRA / PEFT) params; the
-        # frozen base must have been freshly loaded from ``model.model_path`` before
-        # this point. We tolerate missing base keys via ``StateDictOptions(strict=False)``.
         self.trainer.checkpointer.load(
             args.train.checkpoint.load_path,
             state,
@@ -125,9 +122,7 @@ class CheckpointerCallback(Callback):
                 "torch_rng_state": torch.get_rng_state(),
             },
         }
-        # LoRA training: skip frozen base weights in the DCP model dump.
-        # For a 20B base with rank-128 LoRA this drops the model state from ~40 GB to ~1-2 GB.
-        # The optimizer state is already trainable-only (build_optimizer filters by requires_grad).
+
         self.trainer.checkpointer.save(
             save_checkpoint_path,
             ckpt_state,

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -75,7 +75,13 @@ class CheckpointerCallback(Callback):
         if getattr(self.trainer.checkpointer, "save_future", None) is not None:  # async save
             self.trainer.checkpointer.save_future.result()
 
-        self.trainer.checkpointer.load(args.train.checkpoint.load_path, state)
+        extra_kwargs: dict = {}
+        # LoRA training: the DCP only contains trainable (LoRA / PEFT) params; the
+        # frozen base must have been freshly loaded from ``model.model_path`` before
+        # this point. We tolerate missing base keys via ``StateDictOptions(strict=False)``.
+        if args.train.checkpoint.manager == "dcp" and bool(getattr(args.model, "lora_config", None)):
+            extra_kwargs["trainable_only"] = True
+        self.trainer.checkpointer.load(args.train.checkpoint.load_path, state, **extra_kwargs)
 
         self.trainer.state.global_step = state["extra_state"]["global_step"]
         self.trainer.start_epoch = self.trainer.state.global_step // args.train_steps
@@ -118,7 +124,15 @@ class CheckpointerCallback(Callback):
                 "torch_rng_state": torch.get_rng_state(),
             },
         }
-        self.trainer.checkpointer.save(save_checkpoint_path, ckpt_state, save_async=args.train.checkpoint.save_async)
+        extra_kwargs: dict = {}
+        # LoRA training: skip frozen base weights in the DCP model dump.
+        # For a 20B base with rank-128 LoRA this drops the model state from ~40 GB to ~1-2 GB.
+        # The optimizer state is already trainable-only (build_optimizer filters by requires_grad).
+        if args.train.checkpoint.manager == "dcp" and bool(getattr(args.model, "lora_config", None)):
+            extra_kwargs["trainable_only"] = True
+        self.trainer.checkpointer.save(
+            save_checkpoint_path, ckpt_state, save_async=args.train.checkpoint.save_async, **extra_kwargs
+        )
 
         # Empty cache and barrier
         helper.empty_cache()

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -75,13 +75,14 @@ class CheckpointerCallback(Callback):
         if getattr(self.trainer.checkpointer, "save_future", None) is not None:  # async save
             self.trainer.checkpointer.save_future.result()
 
-        extra_kwargs: dict = {}
         # LoRA training: the DCP only contains trainable (LoRA / PEFT) params; the
         # frozen base must have been freshly loaded from ``model.model_path`` before
         # this point. We tolerate missing base keys via ``StateDictOptions(strict=False)``.
-        if args.train.checkpoint.manager == "dcp" and bool(getattr(args.model, "lora_config", None)):
-            extra_kwargs["trainable_only"] = True
-        self.trainer.checkpointer.load(args.train.checkpoint.load_path, state, **extra_kwargs)
+        self.trainer.checkpointer.load(
+            args.train.checkpoint.load_path,
+            state,
+            trainable_only=bool(getattr(args.model, "lora_config", None)),
+        )
 
         self.trainer.state.global_step = state["extra_state"]["global_step"]
         self.trainer.start_epoch = self.trainer.state.global_step // args.train_steps
@@ -124,14 +125,14 @@ class CheckpointerCallback(Callback):
                 "torch_rng_state": torch.get_rng_state(),
             },
         }
-        extra_kwargs: dict = {}
         # LoRA training: skip frozen base weights in the DCP model dump.
         # For a 20B base with rank-128 LoRA this drops the model state from ~40 GB to ~1-2 GB.
         # The optimizer state is already trainable-only (build_optimizer filters by requires_grad).
-        if args.train.checkpoint.manager == "dcp" and bool(getattr(args.model, "lora_config", None)):
-            extra_kwargs["trainable_only"] = True
         self.trainer.checkpointer.save(
-            save_checkpoint_path, ckpt_state, save_async=args.train.checkpoint.save_async, **extra_kwargs
+            save_checkpoint_path,
+            ckpt_state,
+            save_async=args.train.checkpoint.save_async,
+            trainable_only=bool(getattr(args.model, "lora_config", None)),
         )
 
         # Empty cache and barrier


### PR DESCRIPTION
### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

1. Save lora ckpt only
2. Support merge lora only
3. Add omni-infer with lora

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
