### PR TITLE
[model, omni] feat: Update Qwen-Image & Add veomni fsdp state API

### DIFF
--- a/veomni/distributed/offloading.py
+++ b/veomni/distributed/offloading.py
@@ -87,7 +87,7 @@ def build_activation_offloading_context(
     return model_fwd_context, model_bwd_context
 
 
-def _reset_fsdp2_training_state(model: "torch.nn.Module") -> None:
+def _reset_training_state(model: "torch.nn.Module") -> None:
     """Force every FSDP2 param-group on ``model`` back to the IDLE training state.
 
     FSDP2's per-param-group ``_training_state`` is normally advanced by the
@@ -119,7 +119,7 @@ def _reset_fsdp2_training_state(model: "torch.nn.Module") -> None:
 
 
 @torch.no_grad()
-def offload_fsdp2_model_to_cpu(model: "torch.nn.Module", empty_cache: bool = True) -> None:
+def offload_model_to_cpu(model: "torch.nn.Module", empty_cache: bool = True) -> None:
     """Move a model wrapped by FSDP2 ``fully_shard`` to CPU.
 
     Resets any stranded FSDP2 training state, calls ``reshard()`` to drop
@@ -131,7 +131,7 @@ def offload_fsdp2_model_to_cpu(model: "torch.nn.Module", empty_cache: bool = Tru
             move so the released device memory becomes available to peers
             (e.g. a co-located vLLM rollout).
     """
-    _reset_fsdp2_training_state(model)
+    _reset_training_state(model)
     reshard = getattr(model, "reshard", None)
     if callable(reshard):
         reshard()
@@ -141,9 +141,7 @@ def offload_fsdp2_model_to_cpu(model: "torch.nn.Module", empty_cache: bool = Tru
 
 
 @torch.no_grad()
-def load_fsdp2_model_to_gpu(
-    model: "torch.nn.Module", device: Optional[Union[str, "torch.device", int]] = None
-) -> None:
+def load_model_to_gpu(model: "torch.nn.Module", device: Optional[Union[str, "torch.device", int]] = None) -> None:
     """Move a model wrapped by FSDP2 ``fully_shard`` back to a device.
 
     Args:
@@ -164,7 +162,7 @@ def _iter_inner_optimizers(optimizer: "torch.optim.Optimizer") -> "Iterable[torc
 
 
 @torch.no_grad()
-def offload_fsdp2_optimizer(optimizer: "torch.optim.Optimizer") -> None:
+def offload_optimizer(optimizer: "torch.optim.Optimizer") -> None:
     """Move all optimizer state tensors to CPU in place.
 
     Compatible with VeOmni's ``MultiOptimizer`` wrapper as well as a plain
@@ -182,7 +180,7 @@ def offload_fsdp2_optimizer(optimizer: "torch.optim.Optimizer") -> None:
 
 
 @torch.no_grad()
-def load_fsdp2_optimizer(
+def load_optimizer(
     optimizer: "torch.optim.Optimizer",
     device: Union[str, "torch.device", int],
 ) -> None:

--- a/veomni/distributed/offloading.py
+++ b/veomni/distributed/offloading.py
@@ -20,6 +20,8 @@ from typing import Iterable, Optional, Tuple, Union
 import torch
 from torch.autograd.graph import saved_tensors_hooks
 
+from ..utils.device import empty_cache, get_device_id, get_device_type
+
 
 class OffloadPolicy(enum.Enum):
     OFFLOAD = 0
@@ -119,7 +121,7 @@ def _reset_training_state(model: "torch.nn.Module") -> None:
 
 
 @torch.no_grad()
-def offload_model_to_cpu(model: "torch.nn.Module", empty_cache: bool = True) -> None:
+def offload_model_to_cpu(model: "torch.nn.Module", empty_device_cache: bool = True) -> None:
     """Move a model wrapped by FSDP2 ``fully_shard`` to CPU.
 
     Resets any stranded FSDP2 training state, calls ``reshard()`` to drop
@@ -127,17 +129,18 @@ def offload_model_to_cpu(model: "torch.nn.Module", empty_cache: bool = True) -> 
 
     Args:
         model: Root module returned by :func:`parallelize_model_fsdp2`.
-        empty_cache: If ``True``, calls ``torch.cuda.empty_cache()`` after the
-            move so the released device memory becomes available to peers
-            (e.g. a co-located vLLM rollout).
+        empty_device_cache: If ``True``, calls
+            :func:`veomni.utils.device.empty_cache` after the move so the
+            released device memory becomes available to peers (e.g. a
+            co-located vLLM rollout).
     """
     _reset_training_state(model)
     reshard = getattr(model, "reshard", None)
     if callable(reshard):
         reshard()
     model.cpu()
-    if empty_cache and torch.cuda.is_available():
-        torch.cuda.empty_cache()
+    if empty_device_cache and get_device_type() != "cpu":
+        empty_cache()
 
 
 @torch.no_grad()
@@ -149,7 +152,7 @@ def load_model_to_gpu(model: "torch.nn.Module", device: Optional[Union[str, "tor
         device: Target device. Defaults to the current CUDA device.
     """
     if device is None:
-        device = torch.cuda.current_device() if torch.cuda.is_available() else "cpu"
+        device = get_device_id() if get_device_type() != "cpu" else "cpu"
     model.to(device)
 
 

--- a/veomni/distributed/offloading.py
+++ b/veomni/distributed/offloading.py
@@ -15,7 +15,7 @@
 
 import enum
 from contextlib import nullcontext
-from typing import Tuple, Union
+from typing import Iterable, Optional, Tuple, Union
 
 import torch
 from torch.autograd.graph import saved_tensors_hooks
@@ -85,3 +85,114 @@ def build_activation_offloading_context(
             model_fwd_context = custom_save_on_cpu(gpu_limit_in_gb=activation_gpu_limit, pin_memory=False)
 
     return model_fwd_context, model_bwd_context
+
+
+def _reset_fsdp2_training_state(model: "torch.nn.Module") -> None:
+    """Force every FSDP2 param-group on ``model`` back to the IDLE training state.
+
+    FSDP2's per-param-group ``_training_state`` is normally advanced by the
+    forward / pre-backward hooks. In RL training loops where the same actor
+    module is repeatedly placed on / off GPU between rollouts and optimizer
+    steps, the training state can be stranded in ``FORWARD`` / ``PRE_BACKWARD``
+    if an outer code path errors out or the engine swaps to vLLM mid-call.
+    The next ``reshard()`` then trips an internal assert.
+
+    This helper is intentionally defensive: the FSDP2 module / training-state
+    APIs are private, so we tolerate ``ImportError`` / ``AttributeError`` to
+    avoid breaking offloading on PyTorch versions where the layout shifts.
+    """
+    try:
+        from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
+        from torch.distributed.fsdp._fully_shard._fsdp_state import _get_module_fsdp_state
+    except ImportError:
+        return
+
+    for module in model.modules():
+        state = _get_module_fsdp_state(module)
+        param_group = getattr(state, "_fsdp_param_group", None) if state is not None else None
+        if param_group is None:
+            continue
+        try:
+            param_group._training_state = TrainingState.IDLE
+        except AttributeError:
+            continue
+
+
+@torch.no_grad()
+def offload_fsdp2_model_to_cpu(model: "torch.nn.Module", empty_cache: bool = True) -> None:
+    """Move a model wrapped by FSDP2 ``fully_shard`` to CPU.
+
+    Resets any stranded FSDP2 training state, calls ``reshard()`` to drop
+    unsharded parameter all-gathers, and moves remaining parameters to CPU.
+
+    Args:
+        model: Root module returned by :func:`parallelize_model_fsdp2`.
+        empty_cache: If ``True``, calls ``torch.cuda.empty_cache()`` after the
+            move so the released device memory becomes available to peers
+            (e.g. a co-located vLLM rollout).
+    """
+    _reset_fsdp2_training_state(model)
+    reshard = getattr(model, "reshard", None)
+    if callable(reshard):
+        reshard()
+    model.cpu()
+    if empty_cache and torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+@torch.no_grad()
+def load_fsdp2_model_to_gpu(
+    model: "torch.nn.Module", device: Optional[Union[str, "torch.device", int]] = None
+) -> None:
+    """Move a model wrapped by FSDP2 ``fully_shard`` back to a device.
+
+    Args:
+        model: Root module returned by :func:`parallelize_model_fsdp2`.
+        device: Target device. Defaults to the current CUDA device.
+    """
+    if device is None:
+        device = torch.cuda.current_device() if torch.cuda.is_available() else "cpu"
+    model.to(device)
+
+
+def _iter_inner_optimizers(optimizer: "torch.optim.Optimizer") -> "Iterable[torch.optim.Optimizer]":
+    if optimizer is None:
+        return ()
+    if getattr(optimizer, "_is_multi_optimizer", False):
+        return optimizer.optimizers_dict.values()
+    return (optimizer,)
+
+
+@torch.no_grad()
+def offload_fsdp2_optimizer(optimizer: "torch.optim.Optimizer") -> None:
+    """Move all optimizer state tensors to CPU in place.
+
+    Compatible with VeOmni's ``MultiOptimizer`` wrapper as well as a plain
+    :class:`torch.optim.Optimizer`.
+    """
+    for opt in _iter_inner_optimizers(optimizer):
+        if not opt.state:
+            continue
+        for param_group in opt.param_groups:
+            for param in param_group["params"]:
+                state = opt.state[param]
+                for key, value in state.items():
+                    if isinstance(value, torch.Tensor):
+                        state[key] = value.to("cpu", non_blocking=True)
+
+
+@torch.no_grad()
+def load_fsdp2_optimizer(
+    optimizer: "torch.optim.Optimizer",
+    device: Union[str, "torch.device", int],
+) -> None:
+    """Move all optimizer state tensors back to ``device`` in place."""
+    for opt in _iter_inner_optimizers(optimizer):
+        if not opt.state:
+            continue
+        for param_group in opt.param_groups:
+            for param in param_group["params"]:
+                state = opt.state[param]
+                for key, value in state.items():
+                    if isinstance(value, torch.Tensor):
+                        state[key] = value.to(device, non_blocking=True)

--- a/veomni/models/diffusers/qwen_image/qwen_image_condition/modeling_qwen_image_condition.py
+++ b/veomni/models/diffusers/qwen_image/qwen_image_condition/modeling_qwen_image_condition.py
@@ -197,11 +197,16 @@ class QwenImageConditionModel(PreTrainedModel):
 
         return prompt_embeds, prompt_embeds_mask
 
-    def _encode_image_to_latents(self, image) -> torch.Tensor:
-        # Return the raw posterior parameters ([1, 2*z_dim, F, H, W]
+    def _encode_image_to_latents(self, image) -> tuple[torch.Tensor, list[tuple[int, int, int]]]:
+        # Return the raw posterior parameters ([1, 2*z_dim, F, H, W]) alongside the
+        # packed image grid ``[(1, H // 2, W // 2)]`` so downstream callers can resample a
+        # fresh latent on every training step (mode() reduces diversity) without
+        # re-deriving the grid from the latent shape.
         image_tensor = self._image_to_tensor(image).to(device=self.vae.device, dtype=self.vae.dtype)
         posterior: DiagonalGaussianDistribution = self.vae.encode(image_tensor).latent_dist
-        return posterior.parameters
+        parameters = posterior.parameters
+        latent_height, latent_width = int(parameters.shape[-2]), int(parameters.shape[-1])
+        return parameters, [(1, latent_height // 2, latent_width // 2)]
 
     @torch.no_grad()
     def get_condition(self, inputs, images, **kwargs) -> dict[str, Any]:
@@ -209,11 +214,14 @@ class QwenImageConditionModel(PreTrainedModel):
         prompt_embeds, prompt_embeds_mask = self.encode_prompt(prompt=prompts)
 
         latents_list = []
+        img_shapes_list = []
         for sample_images in images:
             sample_images = self._as_list(sample_images)
             if len(sample_images) != 1:
                 raise ValueError("Qwen-Image text-to-image training expects exactly one target image per sample.")
-            latents_list.append(self._encode_image_to_latents(sample_images[0]))
+            sample_params, sample_img_shapes = self._encode_image_to_latents(sample_images[0])
+            latents_list.append(sample_params)
+            img_shapes_list.append(sample_img_shapes)
 
         encoder_hidden_states = [prompt_embeds[idx : idx + 1] for idx in range(len(prompts))]
         if prompt_embeds_mask is None:
@@ -225,6 +233,7 @@ class QwenImageConditionModel(PreTrainedModel):
             "latents": latents_list,
             "encoder_hidden_states": encoder_hidden_states,
             "encoder_hidden_states_mask": encoder_hidden_states_mask,
+            "img_shapes": img_shapes_list,
         }
 
     def process_condition(
@@ -247,22 +256,23 @@ class QwenImageConditionModel(PreTrainedModel):
                 ready_inputs["img_shapes"] = img_shapes
             return ready_inputs
 
-        if latents is None or encoder_hidden_states is None:
+        if latents is None or encoder_hidden_states is None or img_shapes is None:
             raise ValueError(
-                "Qwen-Image condition processing requires latents (raw VAE posterior parameters from "
-                "``get_condition``) and encoder hidden states."
+                "Qwen-Image condition processing requires latents (raw VAE posterior parameters "
+                "from ``get_condition``), encoder hidden states, and img_shapes."
             )
 
         latents_list = self._as_list(latents)
         encoder_hidden_states_list = self._as_list(encoder_hidden_states, len(latents_list))
         encoder_hidden_states_mask_list = self._as_list(encoder_hidden_states_mask, len(latents_list))
+        img_shapes_list = self._as_list(img_shapes, len(latents_list))
 
-        first_params = latents_list[0]
-        first_h, first_w = int(first_params.shape[-2]), int(first_params.shape[-1])
-        image_seq_len = (first_h // 2) * (first_w // 2)
-        for idx, sample_params in enumerate(latents_list[1:], start=1):
-            sample_h, sample_w = int(sample_params.shape[-2]), int(sample_params.shape[-1])
-            sample_seq_len = (sample_h // 2) * (sample_w // 2)
+        def _seq_len(grid: list[tuple[int, int, int]]) -> int:
+            return sum(f * h * w for f, h, w in grid)
+
+        image_seq_len = _seq_len(img_shapes_list[0])
+        for idx, sample_img_shapes in enumerate(img_shapes_list[1:], start=1):
+            sample_seq_len = _seq_len(sample_img_shapes)
             if sample_seq_len != image_seq_len:
                 # ``mu`` shifts the FlowMatchEulerDiscreteScheduler schedule based on the
                 # packed image sequence length; a single ``set_timesteps`` call therefore
@@ -302,14 +312,12 @@ class QwenImageConditionModel(PreTrainedModel):
         if self.config.guidance_scale is not None:
             packed_conditions["guidance"] = []
 
-        for sample_params, sample_context, sample_context_mask in zip(
-            latents_list, encoder_hidden_states_list, encoder_hidden_states_mask_list
+        for sample_params, sample_context, sample_context_mask, sample_img_shapes in zip(
+            latents_list, encoder_hidden_states_list, encoder_hidden_states_mask_list, img_shapes_list
         ):
             sample_latents_raw = DiagonalGaussianDistribution(sample_params).mode()
             sample_latents_norm = self._normalize_latents(sample_latents_raw).to(self.generator.device)
             sample_latents = self._pack_latents(sample_latents_norm)
-            latent_height, latent_width = sample_latents_norm.shape[-2:]
-            sample_img_shapes = [(1, latent_height // 2, latent_width // 2)]
 
             noise = torch.randn(
                 sample_latents.shape,

--- a/veomni/models/diffusers/qwen_image/qwen_image_transformer/modeling_qwen_image_transformer.py
+++ b/veomni/models/diffusers/qwen_image/qwen_image_transformer/modeling_qwen_image_transformer.py
@@ -84,18 +84,65 @@ class QwenImageTransformer2DModel(PreTrainedModel, _QwenImageTransformerInitShim
 
         raise ValueError(f"Unsupported img_shapes format: {sample_img_shapes}")
 
+    def predict_noise(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_mask: torch.Tensor | None = None,
+        img_shapes: Any = None,
+        guidance: torch.Tensor | None = None,
+        additional_t_cond: torch.Tensor | None = None,
+        return_dict: bool = False,
+    ):
+        """Single raw noise prediction via the diffusers backbone.
+
+        This is the sole wrapper around the underlying diffusers ``forward``:
+        it casts inputs to the model dtype and forwards everything else
+        through. Both the supervised loss path and the inference / RL path
+        in :meth:`forward` go through this method to avoid duplicated logic.
+        """
+        param_dtype = self.dtype
+        return _QwenImageTransformer2DModel.forward(
+            self,
+            hidden_states=hidden_states.to(dtype=param_dtype),
+            timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states.to(dtype=param_dtype),
+            encoder_hidden_states_mask=encoder_hidden_states_mask,
+            img_shapes=img_shapes,
+            guidance=guidance,
+            additional_t_cond=additional_t_cond,
+            return_dict=return_dict,
+        )
+
     def forward(
         self,
         hidden_states: torch.Tensor | list[torch.Tensor],
         timestep: torch.Tensor | list[torch.Tensor],
         encoder_hidden_states: torch.Tensor | list[torch.Tensor],
-        training_target: torch.Tensor | list[torch.Tensor],
-        img_shapes: Any,
+        training_target: torch.Tensor | list[torch.Tensor] | None = None,
+        img_shapes: Any = None,
         encoder_hidden_states_mask: torch.Tensor | list[torch.Tensor] | None = None,
         guidance: torch.Tensor | list[torch.Tensor] | None = None,
         additional_t_cond: torch.Tensor | list[torch.Tensor] | None = None,
         latents: torch.Tensor | list[torch.Tensor] | None = None,
+        return_dict: bool = True,
     ):
+        if training_target is None:
+            return self.predict_noise(
+                hidden_states=hidden_states,
+                timestep=timestep,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_hidden_states_mask=encoder_hidden_states_mask,
+                img_shapes=img_shapes,
+                guidance=guidance,
+                additional_t_cond=additional_t_cond,
+                return_dict=return_dict,
+            )
+
+        if img_shapes is None:
+            raise ValueError("Qwen-Image supervised training forward requires `img_shapes`.")
+
         hidden_states_list = self._as_list(hidden_states)
         sample_count = len(hidden_states_list)
         timestep_list = self._as_list(timestep, sample_count)
@@ -105,8 +152,6 @@ class QwenImageTransformer2DModel(PreTrainedModel, _QwenImageTransformerInitShim
         mask_list = self._as_list(encoder_hidden_states_mask, sample_count)
         guidance_list = self._as_list(guidance, sample_count)
         additional_t_cond_list = self._as_list(additional_t_cond, sample_count)
-
-        param_dtype = self.dtype
 
         per_sample_losses = []
         predictions = []
@@ -129,10 +174,7 @@ class QwenImageTransformer2DModel(PreTrainedModel, _QwenImageTransformerInitShim
             guidance_list,
             additional_t_cond_list,
         ):
-            sample_hs = sample_hs.to(dtype=param_dtype)
-            sample_enc_hs = sample_enc_hs.to(dtype=param_dtype)
-            prediction = _QwenImageTransformer2DModel.forward(
-                self,
+            prediction = self.predict_noise(
                 hidden_states=sample_hs,
                 timestep=sample_ts,
                 encoder_hidden_states=sample_enc_hs,
@@ -140,7 +182,6 @@ class QwenImageTransformer2DModel(PreTrainedModel, _QwenImageTransformerInitShim
                 img_shapes=self._normalize_img_shapes(sample_img_shapes),
                 guidance=sample_guidance,
                 additional_t_cond=sample_add_t_cond,
-                return_dict=False,
             )[0]
             predictions.append(prediction)
             per_sample_loss = F.mse_loss(prediction.float(), sample_target.float(), reduction="none")


### PR DESCRIPTION
### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

1. Update Qwen-Image

2. Add veomni fsdp state API

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
