### PR TITLE
[ckpt, trainer] fix: avoid HBM OOM during DCP save under MoE / VLM training

### DIFF
--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -252,25 +252,14 @@ class OptimizerState(Stateful):
             for key, val in template.items():
                 if isinstance(val, torch.Tensor):
                     if val.ndim == 0:
-                        # Scalar (e.g. ``step``): cheap, keep on the template's device.
                         placeholder[key] = torch.zeros_like(val)
                     else:
-                        # MoE / VLM training reaches the first save (often
-                        # ``save_steps=100``) before every expert / modality has
-                        # seen a gradient, so ``missing`` can hold tens of
-                        # parameter-sized Adam state entries (typically
-                        # ``exp_avg`` + ``exp_avg_sq`` in fp32 — 2x bf16 param
-                        # bytes each). Allocating these on GPU under DCP save
-                        # tipped 35B-a3b VL on H100x16 over: residual forward
-                        # activations + the fresh fp32 zeros + NCCL collective
-                        # buffers ⇒ ``NCCL WARN Cuda failure 2 'out of memory'``
-                        # inside the gather. Placeholders are zeros that DCP
-                        # writes straight to disk; their device doesn't matter
-                        # — keep them on CPU so the save path doesn't fight the
-                        # training process for HBM. ``param.data`` returns the
-                        # local shard tensor for FSDP2 DTensor params, so
-                        # ``zeros_like`` preserves the correct per-rank shape
-                        # (NOT the global ``param.shape``).
+                        # Placeholder zeros: DCP writes them straight to disk, so
+                        # the backing device doesn't matter — keep them on CPU to
+                        # avoid HBM pressure during save. For FSDP2 params,
+                        # ``param.data`` is itself a DTensor; ``zeros_like``
+                        # propagates its placements + mesh, so the local shard
+                        # ends up the correct per-rank shape on CPU.
                         placeholder[key] = torch.zeros_like(
                             param.data,
                             dtype=val.dtype,

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -252,9 +252,30 @@ class OptimizerState(Stateful):
             for key, val in template.items():
                 if isinstance(val, torch.Tensor):
                     if val.ndim == 0:
+                        # Scalar (e.g. ``step``): cheap, keep on the template's device.
                         placeholder[key] = torch.zeros_like(val)
                     else:
-                        placeholder[key] = torch.zeros_like(param.data, dtype=val.dtype, device=val.device)
+                        # MoE / VLM training reaches the first save (often
+                        # ``save_steps=100``) before every expert / modality has
+                        # seen a gradient, so ``missing`` can hold tens of
+                        # parameter-sized Adam state entries (typically
+                        # ``exp_avg`` + ``exp_avg_sq`` in fp32 — 2x bf16 param
+                        # bytes each). Allocating these on GPU under DCP save
+                        # tipped 35B-a3b VL on H100x16 over: residual forward
+                        # activations + the fresh fp32 zeros + NCCL collective
+                        # buffers ⇒ ``NCCL WARN Cuda failure 2 'out of memory'``
+                        # inside the gather. Placeholders are zeros that DCP
+                        # writes straight to disk; their device doesn't matter
+                        # — keep them on CPU so the save path doesn't fight the
+                        # training process for HBM. ``param.data`` returns the
+                        # local shard tensor for FSDP2 DTensor params, so
+                        # ``zeros_like`` preserves the correct per-rank shape
+                        # (NOT the global ``param.shape``).
+                        placeholder[key] = torch.zeros_like(
+                            param.data,
+                            dtype=val.dtype,
+                            device="cpu",
+                        )
                 elif isinstance(val, (int, float)):
                     placeholder[key] = type(val)(0)
                 else:

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -123,20 +123,13 @@ class CheckpointerCallback(Callback):
             },
         }
 
-        # Release the caching allocator's residual activations / autograd
-        # buffers from the just-completed training step BEFORE DCP starts
-        # gathering state dicts. Both the dcp planner's NCCL collective
-        # buffers and (for MoE / VLM training) the placeholder Adam state
-        # allocated inside ``OptimizerState._fill_missing_optimizer_states``
-        # for params that haven't received a gradient yet land on the
-        # same allocator, so any leftover headroom here pays off twice.
-        # The post-save ``helper.empty_cache()`` below already runs after
-        # the save; without this pre-save call the save fights the training
-        # step for HBM, which manifested on Qwen3.5-35B-a3b VL h100x16 as
-        # ``NCCL WARN Cuda failure 2 'out of memory'`` inside dcp.save's
-        # gather (``include/alloc.h:228``). The cost is one ``cudaFree`` +
-        # cache reset per ``save_steps`` (default 50–200 steps), well below
-        # measurement noise.
+        # Free the training step's residual activations / autograd buffers
+        # before DCP allocates NCCL collective buffers for the gather.
+        # Mirrors the existing post-save ``empty_cache()`` below; without
+        # this pre-save call the save can fight the training step for HBM
+        # (observed as ``NCCL WARN Cuda failure 2 'out of memory'`` inside
+        # dcp.save on Qwen3.5-35B-a3b VL h100x16). Cost: one ``cudaFree``
+        # per ``save_steps``, well below noise.
         helper.empty_cache()
 
         self.trainer.checkpointer.save(

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -123,6 +123,22 @@ class CheckpointerCallback(Callback):
             },
         }
 
+        # Release the caching allocator's residual activations / autograd
+        # buffers from the just-completed training step BEFORE DCP starts
+        # gathering state dicts. Both the dcp planner's NCCL collective
+        # buffers and (for MoE / VLM training) the placeholder Adam state
+        # allocated inside ``OptimizerState._fill_missing_optimizer_states``
+        # for params that haven't received a gradient yet land on the
+        # same allocator, so any leftover headroom here pays off twice.
+        # The post-save ``helper.empty_cache()`` below already runs after
+        # the save; without this pre-save call the save fights the training
+        # step for HBM, which manifested on Qwen3.5-35B-a3b VL h100x16 as
+        # ``NCCL WARN Cuda failure 2 'out of memory'`` inside dcp.save's
+        # gather (``include/alloc.h:228``). The cost is one ``cudaFree`` +
+        # cache reset per ``save_steps`` (default 50–200 steps), well below
+        # measurement noise.
+        helper.empty_cache()
+
         self.trainer.checkpointer.save(
             save_checkpoint_path,
             ckpt_state,


### PR DESCRIPTION
### What does this PR do?

> Two-part fix for a CUDA OOM (`NCCL WARN Cuda failure 2 'out of memory'` at `include/alloc.h:228`) reproducibly hit by Qwen3.5-35B-a3b VL on h100x16 (`ep_size=2 / ulysses_size=2 / fsdp2`) at the first `save_steps=100` DCP save. The OOM is inside `dcp.save`'s gather, not the training step. Two contributing factors are addressed:
>
> 1. `OptimizerState._fill_missing_optimizer_states` (introduced in #735 for LoRA-style sparse-grad training, but now run unconditionally on every save) allocates fresh fp32 `exp_avg` / `exp_avg_sq` placeholders the size of each missing param on the param's own device — GPU. MoE / VLM training routinely reaches the first save before every expert / modality has received a gradient, so `missing` can hold tens of full-shard-sized placeholders, all freshly malloced from HBM right as DCP starts gathering. Move the allocation to CPU; the value is zeros that DCP writes straight to disk regardless of placement.
> 2. `CheckpointCallback._save_checkpoint` only calls `helper.empty_cache()` *after* `checkpointer.save(...)`. The DCP planner's NCCL collective buffers (and any remaining GPU placeholders from the path above) compete with the just-completed training step's residual activations / autograd buffers on the same caching allocator. Add a matching `empty_cache()` call *before* the save so the gather sees freed headroom.

### Checklist Before Starting

- Search for relative PRs/issues and link here: introduced by #735 (LoRA fix); root-caused on Qwen3.5-35B-a3b VL nightly verify.
- PR title follows `[{modules}] {type}: {description}` format ✓

### Test

> Reproduced on the Qwen3.5-35B-a3b VL `h100x16` nightly yaml (`launch_qwen3_5_35b_a3b_vl_veomni_h100x16_nightly.yaml`):
> - Pre-fix: training reaches step 100/102 cleanly (loss ~0.42, ~83 min), then `do dataloader snapshot` → `Getting model/optimizer state_dict from {Model,Optimizer}State wrapper` → 2 s later `NCCL WARN Cuda failure 2 'out of memory'` inside `dcp.save`, robust-training masks the failure as RUNNING.
> - Post-fix (pending verify relaunch): expected to complete `Distributed checkpoint saved` at step 100 cleanly. Will land the verify trial link as a follow-up comment.
>
> Other affected configs (also reach `save_steps=100` and use MoE / VL where some params have no gradient at first save): `launch_qwen3_vl_30b_a3b_veomni_h100x16_nightly.yaml`, `launch_internvl3_5_30b_a3b_veomni_h100x16_nightly.yaml`. Not separately repro'd but covered by the same code paths.
>
> Unaffected (verified ✓): `launch_qwen3_vl_2b_veomni_h100x8.yaml` (dense — no missing entries → `if not missing: return sd` short-circuits), `launch_qwen3_5_35b_a3b_veomni_h100x16_nightly.yaml` (text MoE — `max_seq_len=4096` leaves enough HBM headroom that the buggy allocation still fits).

### API and Usage Example

> N/A — internal save-path change only. No public API or config flag changes. Existing `fill_missing_optimizer_states=True` (set in `dcp_checkpointer.save` at the call site that wraps `OptimizerState`) still behaves the same; on-disk DCP output is byte-identical.

### Design & Code Changes

> - `veomni/checkpoint/dcp_checkpointer.py::_fill_missing_optimizer_states` (~line 249-262): change `torch.zeros_like(param.data, dtype=val.dtype, device=val.device)` → `torch.zeros_like(param.data, dtype=val.dtype, device='cpu')`. `param.data` is preserved as the shape source (so FSDP2 DTensor params still get per-rank-shard sizing — `param.data` returns the local shard tensor, not the global). Comment block in-line explains why.
> - `veomni/trainer/callbacks/checkpoint_callback.py::_save_checkpoint` (just before `self.trainer.checkpointer.save(...)`): add `helper.empty_cache()` to release the training-step residual cache before the DCP gather. The existing post-save `empty_cache()` is left untouched. Comment block explains the timing.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (`make quality` clean)
- [ ] Added/updated documentation — N/A, internal save-path mechanism
- [ ] Added tests to CI workflow (or explained why not feasible) — no automated regression test added: reproducing the OOM requires the actual 35B-a3b VL run footprint (16 H100s, ~83 min wall) which doesn't fit any existing test tier. The fix is mechanically a `device=` arg change + an `empty_cache()` placement; the verify relaunch on the production yaml is the regression check.
