### PR TITLE
[parallel] fix stride error in npu when dsp+recompute

### DIFF
--- a/veomni/distributed/sequence_parallel/data.py
+++ b/veomni/distributed/sequence_parallel/data.py
@@ -81,7 +81,7 @@ def slice_input_tensor(
         x = pad_tensor(x, dim, padding_size, padding_value)
     slc = [slice(None)] * len(x.shape)
     slc[dim] = slice(unit * sp_rank, unit * (sp_rank + 1))
-    return x[tuple(slc)].contiguous()
+    return x[tuple(slc)].clone()
 
 
 def slice_input_tensor_scale_grad(


### PR DESCRIPTION
### What does this PR do?

Fixes a stride metadata mismatch in sequence-parallel tensor slicing.

`slice_input_tensor()` now uses `.clone()` instead of `.contiguous()` after slicing. On NPU, slicing a gathered tensor with shape like `[1, sp * seq_len, hidden]` along the sequence dimension can produce a tensor that is reported as contiguous but still keeps the original gathered tensor's batch stride. Because `.contiguous()` is a no-op in that case, activation checkpoint recomputation may save tensors with different strides from the original forward pass.

Using `.clone()` materializes the sliced tensor with canonical stride, preventing checkpoint metadata mismatch errors in Qwen3-VL sequence-parallel recomputation.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A
- PR title follows `[{modules}] {type}: {description}` format
  - Suggested title: `[parallel] fix: normalize sliced SP tensor stride`

### Test

Validated the NPU stride behavior manually:

- Sliced tensor stride: `(140, 5, 1)`
- After `.contiguous()`: `(140, 5, 1)`
- After `.clone()`: `(35, 5, 1)`

Also verified the repro test fails before this fix when forward/recompute strides differ.

### API and Usage Example

No public API change.

### Design & Code Changes

- Updated `veomni/distributed/sequence_parallel/data.py`
- Changed `slice_input_tensor()` to return `x[tuple(slc)].clone()`
- This ensures sequence-parallel slices are materialized with normalized tensor metadata before being consumed by checkpointed recomputation paths.

### Checklist Before Submitting

- [ ] Read the Contribute Guide
- [ ] Applied pre-commit checks
- [ ] Added/updated documentation
- [ ] If `tasks/` training scripts were moved or renamed: N/A
- [ ] Added tests to CI workflow or explained why not feasible