### PR TITLE
[model] feat: register ForTokenClassification in model registries

### DIFF
--- a/veomni/models/loader.py
+++ b/veomni/models/loader.py
@@ -25,6 +25,7 @@ from transformers import (
     AutoModelForImageTextToText,
     AutoModelForSequenceClassification,
     AutoModelForTextToWaveform,
+    AutoModelForTokenClassification,
     AutoProcessor,
     PretrainedConfig,
     PreTrainedModel,
@@ -152,6 +153,12 @@ def get_model_class(model_config: PretrainedConfig):
         and type(model_config) in AutoModelForCausalLM._model_mapping.keys()
     ):
         load_class = AutoModelForCausalLM
+    elif (
+        arch_name is not None
+        and "ForTokenClassification" in arch_name
+        and type(model_config) in AutoModelForTokenClassification._model_mapping.keys()
+    ):
+        load_class = AutoModelForTokenClassification
     elif (
         arch_name is not None
         and "ForSequenceClassification" in arch_name

--- a/veomni/models/transformers/deepseek_v3/__init__.py
+++ b/veomni/models/transformers/deepseek_v3/__init__.py
@@ -29,13 +29,21 @@ def register_deepseek_v3_modeling(architecture: str):
 
     DeepseekV3ForCausalLM = gen.DeepseekV3ForCausalLM
     DeepseekV3ForSequenceClassification = gen.DeepseekV3ForSequenceClassification
+    DeepseekV3ForTokenClassification = gen.DeepseekV3ForTokenClassification
     DeepseekV3Model = gen.DeepseekV3Model
 
-    for model_cls in (DeepseekV3ForCausalLM, DeepseekV3ForSequenceClassification, DeepseekV3Model):
+    for model_cls in (
+        DeepseekV3ForCausalLM,
+        DeepseekV3ForSequenceClassification,
+        DeepseekV3ForTokenClassification,
+        DeepseekV3Model,
+    ):
         model_cls._create_checkpoint_tensor_converter = staticmethod(create_deepseek_v3_checkpoint_tensor_converter)
 
     if "ForCausalLM" in architecture:
         return DeepseekV3ForCausalLM
+    elif "ForTokenClassification" in architecture:
+        return DeepseekV3ForTokenClassification
     elif "ForSequenceClassification" in architecture:
         return DeepseekV3ForSequenceClassification
     elif "Model" in architecture:

--- a/veomni/models/transformers/llama/__init__.py
+++ b/veomni/models/transformers/llama/__init__.py
@@ -19,11 +19,14 @@ def register_llama_modeling(architecture: str):
     from .generated.patched_modeling_llama_gpu import (
         LlamaForCausalLM,
         LlamaForSequenceClassification,
+        LlamaForTokenClassification,
         LlamaModel,
     )
 
     if "ForCausalLM" in architecture:
         return LlamaForCausalLM
+    elif "ForTokenClassification" in architecture:
+        return LlamaForTokenClassification
     elif "ForSequenceClassification" in architecture:
         return LlamaForSequenceClassification
     elif "Model" in architecture:

--- a/veomni/models/transformers/qwen2/__init__.py
+++ b/veomni/models/transformers/qwen2/__init__.py
@@ -19,11 +19,14 @@ def register_qwen2_modeling(architecture: str):
     from .generated.patched_modeling_qwen2_gpu import (
         Qwen2ForCausalLM,
         Qwen2ForSequenceClassification,
+        Qwen2ForTokenClassification,
         Qwen2Model,
     )
 
     if "ForCausalLM" in architecture:
         return Qwen2ForCausalLM
+    elif "ForTokenClassification" in architecture:
+        return Qwen2ForTokenClassification
     elif "ForSequenceClassification" in architecture:
         return Qwen2ForSequenceClassification
     elif "Model" in architecture:

--- a/veomni/models/transformers/qwen3/__init__.py
+++ b/veomni/models/transformers/qwen3/__init__.py
@@ -21,17 +21,21 @@ def register_qwen3_modeling(architecture: str):
         from .generated.patched_modeling_qwen3_npu import (
             Qwen3ForCausalLM,
             Qwen3ForSequenceClassification,
+            Qwen3ForTokenClassification,
             Qwen3Model,
         )
     else:
         from .generated.patched_modeling_qwen3_gpu import (
             Qwen3ForCausalLM,
             Qwen3ForSequenceClassification,
+            Qwen3ForTokenClassification,
             Qwen3Model,
         )
 
     if "ForCausalLM" in architecture:
         return Qwen3ForCausalLM
+    elif "ForTokenClassification" in architecture:
+        return Qwen3ForTokenClassification
     elif "ForSequenceClassification" in architecture:
         return Qwen3ForSequenceClassification
     elif "Model" in architecture:

--- a/veomni/models/transformers/qwen3_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_moe/__init__.py
@@ -23,20 +23,29 @@ def register_qwen3_moe_modeling(architecture: str):
         from .generated.patched_modeling_qwen3_moe_npu import (
             Qwen3MoeForCausalLM,
             Qwen3MoeForQuestionAnswering,
+            Qwen3MoeForTokenClassification,
             Qwen3MoeModel,
         )
     else:
         from .generated.patched_modeling_qwen3_moe_gpu import (
             Qwen3MoeForCausalLM,
             Qwen3MoeForQuestionAnswering,
+            Qwen3MoeForTokenClassification,
             Qwen3MoeModel,
         )
 
-    for model_cls in (Qwen3MoeForCausalLM, Qwen3MoeForQuestionAnswering, Qwen3MoeModel):
+    for model_cls in (
+        Qwen3MoeForCausalLM,
+        Qwen3MoeForQuestionAnswering,
+        Qwen3MoeForTokenClassification,
+        Qwen3MoeModel,
+    ):
         model_cls._create_checkpoint_tensor_converter = staticmethod(create_qwen3_moe_checkpoint_tensor_converter)
 
     if "ForCausalLM" in architecture:
         return Qwen3MoeForCausalLM
+    elif "ForTokenClassification" in architecture:
+        return Qwen3MoeForTokenClassification
     elif "ForQuestionAnswering" in architecture:
         return Qwen3MoeForQuestionAnswering
     elif "Model" in architecture:


### PR DESCRIPTION
## Summary

Register `ForTokenClassification` dispatch in VeOmni's `MODELING_REGISTRY` for model families that have the class in their generated modules but don't expose it through the registry.

**Model families updated:** qwen3, qwen3_moe, qwen2, llama, deepseek_v3

**Also:** add `AutoModelForTokenClassification` to the HF backend fallback in `loader.py`, alongside the existing `AutoModelForSequenceClassification` path.

## Motivation

verl's PPO training uses a critic/value model that needs `ForTokenClassification(num_labels=1)` to produce per-token scalar values instead of vocabulary logits. VeOmni's `build_foundation_model` dispatches based on `config.architectures` through `MODELING_REGISTRY`, but only `seed_oss` registered the `ForTokenClassification` variant — all other families silently fell back to `ForCausalLM`.

This makes `VeOmniEngineWithValueHead` (added in verl PR #6453) work correctly: it rewrites `config.architectures` from `*ForCausalLM` to `*ForTokenClassification`, and VeOmni's registry now dispatches to the right class.

## Changes

- `veomni/models/loader.py`: import `AutoModelForTokenClassification`, add dispatch branch in `get_model_class`
- `veomni/models/transformers/{qwen3,qwen3_moe,qwen2,llama,deepseek_v3}/__init__.py`: import and dispatch `ForTokenClassification` in each model's registry function

## Test plan

- [ ] Verify `MODELING_REGISTRY["qwen3"]("Qwen3ForTokenClassification")` returns `Qwen3ForTokenClassification`
- [ ] Verify `build_foundation_model` with `config.architectures=["Qwen3ForTokenClassification"]` loads the correct model
- [ ] E2E: PPO training with VeOmni critic (`algorithm.adv_estimator=gae`, `critic.strategy=veomni`) produces scalar values