### PR TITLE
[ckpt] fix: sync missing-keys set across ranks in _fill_missing_optim…

### DIFF
--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -16,7 +16,7 @@
 import gc
 import os
 from collections import OrderedDict
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import torch
 import torch.distributed as dist
@@ -205,14 +205,17 @@ class OptimizerState(Stateful):
 
         Adam/AdamW creates state lazily on first ``step()`` with a non-None
         gradient.  Params that never received a gradient (e.g. LoRA on unused
-        modalities) will have no state.  Additionally, ``get_optimizer_state_dict``
-        deduplicates aliased parameters (same ``id()``), emitting only one
-        canonical FQN per unique tensor.  DCP strict load fails when these
-        entries are absent at resume time.
+        modalities, or MoE experts that haven't been routed to yet) will have
+        no state.  Additionally, ``get_optimizer_state_dict`` deduplicates
+        aliased parameters (same ``id()``), emitting only one canonical FQN
+        per unique tensor.  DCP strict load fails when these entries are
+        absent at resume time.
 
-        We enumerate expected FQNs directly from the raw optimizer param_groups
-        + model FQN mapping, bypassing any dedup that ``get_optimizer_state_dict``
-        may have performed.
+        We enumerate expected FQNs directly from the raw optimizer
+        param_groups + model FQN mapping, bypassing any dedup that
+        ``get_optimizer_state_dict`` may have performed, then synchronize the
+        missing set across DP ranks so every rank fills the SAME placeholders
+        (see the inline comment below for why this is required for MoE).
         """
         if "state" not in sd or not isinstance(sd["state"], dict):
             return sd
@@ -232,7 +235,27 @@ class OptimizerState(Stateful):
                 fqn_to_param[fqn] = param
 
         expected_fqns = set(fqn_to_param.keys())
-        missing = expected_fqns - optim_fqns
+        local_missing = expected_fqns - optim_fqns
+
+        # MoE training: experts fire on different ranks across the first few
+        # steps, so each rank's ``local_missing`` set is rank-asymmetric. If
+        # we let that through, ``sd["state"]`` ends up with rank-asymmetric
+        # keys -- DCP's ``_save_state_dict`` then broadcasts metadata of
+        # unequal pickled size across ranks, producing NCCL buffer corruption
+        # (manifests as UnpicklingError variants or a Watchdog timeout at the
+        # first save). Sync the missing set across ranks so every rank fills
+        # the SAME placeholders. The collective is tiny (FQN strings only) and
+        # runs at most once per save -- negligible overhead.
+        if dist.is_initialized() and dist.get_world_size() > 1:
+            gathered: List[Optional[Set[str]]] = [None] * dist.get_world_size()
+            dist.all_gather_object(gathered, local_missing)
+            missing: Set[str] = set().union(*(g or set() for g in gathered))
+            # Defensive: drop any FQN this rank doesn't recognize. With FSDP2
+            # ``model.named_parameters()`` is rank-symmetric, so this is a
+            # no-op in practice but guards against unusual parallelism setups.
+            missing &= expected_fqns
+        else:
+            missing = local_missing
 
         if not missing:
             return sd


### PR DESCRIPTION
…izer_states

MoE training (and any other workload with rank-asymmetric optimizer state population) makes each rank's local 'missing' set diverge, because experts fire on different ranks at different times during the first few steps. Without synchronization, sd['state'] ends up with rank-asymmetric keys -- DCP's _save_state_dict then broadcasts metadata of unequal pickled size, producing NCCL buffer corruption that manifests as one of:

  - _pickle.UnpicklingError: invalid load key, '\x00'.
  - _pickle.UnpicklingError: NEWOBJ_EX class argument must be a type, not ChunkStorageMetadata
  - AttributeError: 'dict' object has no attribute 'add'
  - Watchdog timeout SeqNum=16915 ALLGATHER NumelIn=1
  - Watchdog timeout SeqNum=16918 BROADCAST NumelIn=2820231

all_gather_object the local-missing set (FQN strings only) and take the union, so every rank fills the same placeholders. The collective is a few KB per rank and runs once per save -- negligible overhead vs the 10-30s DCP save itself.

Verified by bisect on qwen3.5-35B-a3b-vl ep_size=1 save_steps=10: failure was traced to PR #772 (precompute multimodal forward metadata in dataloader), which perturbed ViT numerics enough to flip MoE router top-K on borderline tokens. The root cause is in fill_missing, not in the routing perturbation -- this fix restores save symmetry regardless.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
