### PR TITLE
[ckpt] fix: fix resume

### DIFF
--- a/tests/checkpoints/test_checkpoint_callback.py
+++ b/tests/checkpoints/test_checkpoint_callback.py
@@ -125,6 +125,38 @@ class TestCheckpointerCallbackLastSavedStep:
         # Should skip — no new save call
         trainer.checkpointer.save.assert_not_called()
 
+    def test_epoch_end_skips_when_no_step_ran(self, mock_helper, mock_dist, mock_build_ckpt):
+        trainer = _make_mock_trainer()
+        mock_build_ckpt.return_value = trainer.checkpointer
+        cb = CheckpointerCallback(trainer)
+        cb.every_n_epochs = 1
+
+        state = TrainerState(global_step=35, epoch=1)
+        cb.on_epoch_begin(state)
+        assert cb._epoch_start_global_step == 35
+
+        # Simulate the empty-epoch case: no on_step_end calls, global_step
+        # untouched.
+        cb.on_epoch_end(state)
+        trainer.checkpointer.save.assert_not_called()
+        assert cb._last_saved_step == -1
+
+    def test_epoch_end_saves_when_step_ran(self, mock_helper, mock_dist, mock_build_ckpt):
+        trainer = _make_mock_trainer()
+        mock_build_ckpt.return_value = trainer.checkpointer
+        cb = CheckpointerCallback(trainer)
+        cb.every_n_steps = None  # disable step-end saves to isolate epoch-end
+        cb.every_n_epochs = 1
+
+        state = TrainerState(global_step=10, epoch=0)
+        cb.on_epoch_begin(state)
+
+        # Advance state to simulate a few successful train_step calls.
+        state.global_step = 12
+        cb.on_epoch_end(state)
+        assert trainer.checkpointer.save.call_count == 1
+        assert cb._last_saved_step == 12
+
 
 @patch("veomni.trainer.callbacks.checkpoint_callback.save_hf_safetensor")
 @patch("veomni.trainer.callbacks.checkpoint_callback.build_checkpointer")
@@ -202,3 +234,19 @@ class TestHuggingfaceCkptCallbackLastSavedStep:
         mock_save_hf.reset_mock()
         cb.on_train_end(state)
         mock_save_hf.assert_not_called()
+
+    def test_hf_epoch_end_skips_when_no_step_ran(
+        self, mock_exists, mock_helper, mock_dist, mock_build_ckpt, mock_save_hf
+    ):
+        """HF callback must also suppress epoch_end save when no step ran."""
+        trainer = _make_mock_trainer()
+        mock_build_ckpt.return_value = trainer.checkpointer
+        cb = HuggingfaceCkptCallback(trainer)
+        cb.every_n_epochs = 1
+
+        state = TrainerState(global_step=35, epoch=1)
+        cb.on_epoch_begin(state)
+
+        cb.on_epoch_end(state)
+        mock_save_hf.assert_not_called()
+        assert cb._last_saved_step == -1

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -593,9 +593,11 @@ class BaseTrainer(Stateful, ABC):
         data_iterator: Any,
     ) -> Dict[str, float]:
         args = self.args
-        self.state.global_step += 1
 
+        # Bump global_step only after next() succeeds, so a StopIteration from
+        # a half-resumed dataloader does not leave global_step inflated.
         micro_batches: List[Dict[str, Any]] = next(data_iterator)
+        self.state.global_step += 1
 
         self.on_step_begin(micro_batches=micro_batches)
 

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -39,6 +39,7 @@ class CheckpointerCallback(Callback):
         self.every_n_steps = args.train.checkpoint.save_steps
         self.every_n_epochs = args.train.checkpoint.save_epochs
         self._last_saved_step: int = -1
+        self._epoch_start_global_step: int = 0
         self.trainer.checkpointer: CheckpointerBase = build_checkpointer(
             dist_backend=args.train.accelerator.fsdp_config.fsdp_mode, ckpt_manager=args.train.checkpoint.manager
         )
@@ -47,7 +48,22 @@ class CheckpointerCallback(Callback):
         if self.every_n_steps and state.global_step % self.every_n_steps == 0:
             self._save_checkpoint(state)
 
+    def on_epoch_begin(self, state: TrainerState, **kwargs) -> None:
+        self._epoch_start_global_step = state.global_step
+
+    def _epoch_had_no_training(self, state: TrainerState, kind: str) -> bool:
+        """Return True if global_step did not advance this epoch (logs the skip)."""
+        if state.global_step <= self._epoch_start_global_step:
+            logger.info_rank0(
+                f"Skipping {kind} checkpoint save at epoch_end (epoch {state.epoch}: no training "
+                f"step ran, global_step still {state.global_step})."
+            )
+            return True
+        return False
+
     def on_epoch_end(self, state: TrainerState, **kwargs):
+        if self._epoch_had_no_training(state, kind="DCP"):
+            return
         if self.every_n_epochs and (state.epoch + 1) % self.every_n_epochs == 0:
             if state.global_step != self._last_saved_step:
                 self._save_checkpoint(state)
@@ -161,6 +177,8 @@ class HuggingfaceCkptCallback(CheckpointerCallback):
             self._save_checkpoint(state)
 
     def on_epoch_end(self, state: TrainerState, **kwargs):
+        if self._epoch_had_no_training(state, kind="HF"):
+            return
         if self.save_hf_weights and self.every_n_epochs and (state.epoch + 1) % self.every_n_epochs == 0:
             if state.global_step != self._last_saved_step:
                 self._save_checkpoint(state)

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -469,9 +469,7 @@ class DiTTrainer:
 
     def train_step(self, data_iterator: Any) -> Dict[str, float]:
         args = self.base.args
-        self.base.state.global_step += 1
 
-        # broadcast micro_batches from sp_rank_0 to all ranks
         if get_parallel_state().sp_enabled:
             if get_parallel_state().sp_rank == 0:
                 micro_batches = next(data_iterator)
@@ -487,6 +485,8 @@ class DiTTrainer:
             micro_batches = obj_list[0]
         else:
             micro_batches = next(data_iterator)
+
+        self.base.state.global_step += 1
 
         self.on_step_begin(micro_batches=micro_batches)
 

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -332,9 +332,9 @@ class TextDPOTrainer:
 
     def train_step(self, data_iterator: Any) -> Dict[str, float]:
         args: VeOmniDPOArguments = self.base.args
-        self.base.state.global_step += 1
 
         micro_batches: List[Dict[str, Any]] = next(data_iterator)
+        self.base.state.global_step += 1
 
         self.on_step_begin(micro_batches=micro_batches)
 

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -105,9 +105,9 @@ class TextTrainer:
         data_iterator: Any,
     ) -> Dict[str, float]:
         args: VeOmniArguments = self.base.args
-        self.base.state.global_step += 1
 
         micro_batches: List[Dict[str, Any]] = next(data_iterator)
+        self.base.state.global_step += 1
 
         self.on_step_begin(micro_batches=micro_batches)
 

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -275,9 +275,9 @@ class VLMTrainer:
         data_iterator: Any,
     ) -> Dict[str, float]:
         args: VeOmniVLMArguments = self.base.args
-        self.base.state.global_step += 1
 
         micro_batches: List[Dict[str, Any]] = next(data_iterator)
+        self.base.state.global_step += 1
 
         self.on_step_begin(micro_batches=micro_batches)
 


### PR DESCRIPTION
### What does this PR do?

## Why Resume Was Broken

### Setup of the bug

```
┌──────────────────────────────────────────────────────────────────────────┐
│ Trained for 40 steps, but save_steps=5, so the last save is at step 35. │
│ Steps 36–40 were never saved before Ctrl-C.                             │
│ ──────────────────────────────────────────                              │
│ Latest ckpt on disk = global_step_35   ← this is what resume loads      │
└──────────────────────────────────────────────────────────────────────────┘
```

### The cascade

```
RESUME → load ckpt(35)
        state.global_step = 35
        start_epoch = 35 // 30 = 1
        start_step  = 35 % 30  = 5

  enter epoch 1
  └── for _ in range(5, 30):  train_step()
       │
       │  ┌─────────────────────────────────────────────────────────┐
       │  │  train_step():                                          │
       │  │                                                         │
       │  │    state.global_step += 1     # 35 → 36   ← Bug 2       │
       │  │           │                                             │
       │  │           ▼                                             │
       │  │    next(data_iterator)        # immediate StopIteration │
       │  │           │                   #   ← Bug 1               │
       │  │           │                   # (StatefulDataLoader     │
       │  │           │                   #  state never restored)  │
       │  │           ▼                                             │
       │  │    [except StopIteration → break]                       │
       │  └─────────────────────────────────────────────────────────┘
       ▼
  on_epoch_end(state):
       global_step = 36
       _last_saved_step = -1     ← callback state is not persisted,
                                   so a fresh process resets it to -1
       check:  36 ≠ -1  →  SAVE                              ← Bug 3
                  │
                  ▼
              ckpt(36)  ← bogus: this "step" never actually trained
       │
       ▼  epoch 1 finishes
  start_step is reset to 0, training advances to epoch 2
  (UI shows "Epoch 3/3")
       └── 30 fresh steps run normally — but the progress bar shows
           "0/30", which is what made it look like an epoch was skipped.
```

### After the fix

```
  train_step():
      next(data_iterator)        # fetch first
              │
              ▼  StopIteration → break  (global_step stays at 35)
                                  ↓
                                state.global_step += 1   ← never reached

  on_epoch_end(state):
      global_step (35) ≤ _epoch_start_global_step (35)
      → no step ran this epoch, skip save                  ← Bug 3 fixed

  Next resume still loads ckpt(35); no spurious ckpt(36) to mislead it.
```

### Three bugs, one chain reaction

| Bug | Location | Symptom |
|-----|----------|---------|
| 1 | `StatefulDataLoader` state was not actually restored | the very first `next()` raises `StopIteration` |
| 2 | `state.global_step += 1` happened **before** `next()` | step counter advances even though no batch was processed |
| 3 | `on_epoch_end` guard only checks `_last_saved_step` (reset to `-1` after a restart) | a "ghost" checkpoint at the inflated step number gets written |

Only **Bug 1** is the real root cause (dataloader resume). Bugs **2** and **3** amplified the symptom into "phantom checkpoint + skipped epoch". This patch only suppresses Bugs **2** and **3** so the symptoms go away; Bug **1** is tracked separately.
### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
