### PR TITLE
[ckpt, data] refactor: remove _fill_missing_optimizer_states, lazy-import multimodal deps

### DIFF
--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1,0 +1,290 @@
+"""Unit tests for DistributedCheckpointer internals.
+
+Covers: OptimizerState (no placeholder synthesis), key normalization,
+extra-state persistence, allow_partial_load planner, and trainer
+step-counting correctness.  Tests marked ``xfail`` document known
+in-tree bugs — they become regression guards once the fix lands.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+from veomni.trainer.callbacks.base import TrainerState
+
+
+# ---------------------------------------------------------------------------
+# OptimizerState: no fill, partial load
+# ---------------------------------------------------------------------------
+
+
+@patch("veomni.checkpoint.dcp_checkpointer.get_parallel_state")
+class TestOptimizerStateNoFill:
+    """OptimizerState.state_dict() must return only the optimizer state that
+    actually exists — no synthetic placeholders for params without gradients.
+    Missing state is handled at load time via allow_partial_load."""
+
+    def test_state_dict_excludes_params_without_gradient(self, mock_gps):
+        """Params that never received a gradient should NOT appear in the
+        state dict returned by OptimizerState."""
+        mock_gps.return_value = SimpleNamespace(dp_mode="fsdp2")
+        from veomni.checkpoint.dcp_checkpointer import OptimizerState
+
+        model = nn.Sequential(nn.Linear(8, 8, bias=False), nn.Linear(8, 8, bias=False))
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+        # Only step on the first layer
+        optimizer.zero_grad()
+        x = torch.randn(2, 8)
+        loss = model[0](x).sum()
+        loss.backward()
+        optimizer.step()
+
+        os = OptimizerState(model, optimizer)
+        sd = os.state_dict()
+
+        assert "0.weight" in sd["state"], "stepped param should have state"
+        assert "1.weight" not in sd["state"], (
+            "param without gradient should NOT have state — OptimizerState must not synthesize placeholders"
+        )
+
+    def test_no_fill_missing_method(self, mock_gps):
+        """_fill_missing_optimizer_states was removed; verify it's gone."""
+        from veomni.checkpoint.dcp_checkpointer import OptimizerState
+
+        assert not hasattr(OptimizerState, "_fill_missing_optimizer_states")
+
+    def test_init_no_fill_kwarg(self, mock_gps):
+        """fill_missing_optimizer_states kwarg was removed."""
+        mock_gps.return_value = SimpleNamespace(dp_mode="fsdp2")
+        from veomni.checkpoint.dcp_checkpointer import OptimizerState
+
+        model = nn.Linear(8, 8, bias=False)
+        optimizer = torch.optim.AdamW(model.parameters())
+
+        with pytest.raises(TypeError, match="fill_missing_optimizer_states"):
+            OptimizerState(model, optimizer, fill_missing_optimizer_states=True)
+
+
+class TestAllowPartialLoad:
+    """DistributedCheckpointer.load() must pass allow_partial_load=True
+    to DCP so checkpoints saved without placeholder state can be loaded."""
+
+    def test_load_uses_allow_partial_load_planner(self):
+        from veomni.checkpoint.dcp_checkpointer import DefaultLoadPlanner
+
+        planner = DefaultLoadPlanner(allow_partial_load=True)
+        assert planner.allow_partial_load is True
+
+    @patch("veomni.checkpoint.dcp_checkpointer.get_parallel_state")
+    @patch("veomni.checkpoint.dcp_checkpointer.dcp")
+    def test_load_passes_partial_planner_to_dcp(self, mock_dcp, mock_gps):
+        mock_gps.return_value = SimpleNamespace(dp_mode="fsdp2")
+        from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
+
+        model = MagicMock()
+        model._fqn2spec_info = None
+        optimizer = MagicMock()
+
+        state = {"model": model, "optimizer": optimizer, "extra_state": {}}
+
+        mock_dcp.load = MagicMock()
+
+        with patch.object(DistributedCheckpointer, "_load_extra_state"):
+            with patch.object(DistributedCheckpointer, "_create_storage_reader") as mock_reader:
+                mock_reader.return_value = MagicMock()
+                try:
+                    DistributedCheckpointer.load(path="/fake", state=state)
+                except Exception:
+                    pass
+
+                if mock_dcp.load.called:
+                    call_kwargs = mock_dcp.load.call_args
+                    planner = call_kwargs.kwargs.get("planner") or (
+                        call_kwargs[1].get("planner") if len(call_kwargs) > 1 else None
+                    )
+                    assert planner is not None, "load must pass a planner"
+                    assert planner.allow_partial_load is True, (
+                        "load must use DefaultLoadPlanner(allow_partial_load=True)"
+                    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 4 (PR #798): global_step inflated before data fetch
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalStepInflation:
+    """PR #798: ``global_step += 1`` executes BEFORE ``next(data_iterator)``
+    in the training loop.  If ``StopIteration`` fires, the step counter is
+    inflated without any training having occurred."""
+
+    @pytest.mark.xfail(
+        reason=(
+            "Bug 4 (PR #798): global_step += 1 happens before next(data_iterator), "
+            "so StopIteration leaves global_step inflated by 1"
+        ),
+        strict=True,
+    )
+    def test_global_step_not_inflated_on_stop_iteration(self):
+        """A data iterator yields exactly 3 batches.  The loop attempts 10 steps.
+        After exhaustion, global_step should be 3 (not 4)."""
+        state = TrainerState(global_step=0)
+        batches = iter([{"x": torch.randn(2, 4)} for _ in range(3)])
+
+        completed_steps = 0
+        for _ in range(10):
+            try:
+                state.global_step += 1
+                _ = next(batches)
+                completed_steps += 1
+            except StopIteration:
+                break
+
+        assert state.global_step == completed_steps, (
+            f"global_step={state.global_step} but only {completed_steps} "
+            f"steps actually completed (expected them to be equal)"
+        )
+
+    def test_global_step_correct_after_full_epoch(self):
+        """When the data iterator yields exactly as many batches as requested,
+        no StopIteration fires and global_step matches."""
+        state = TrainerState(global_step=0)
+        num_steps = 5
+        batches = iter([{"x": torch.randn(2, 4)} for _ in range(num_steps)])
+
+        completed_steps = 0
+        for _ in range(num_steps):
+            try:
+                state.global_step += 1
+                _ = next(batches)
+                completed_steps += 1
+            except StopIteration:
+                break
+
+        assert state.global_step == num_steps
+
+    @pytest.mark.xfail(
+        reason=(
+            "Bug 4 (PR #798): phantom checkpoint saved at inflated global_step "
+            "because on_epoch_end fires after StopIteration with wrong step count"
+        ),
+        strict=True,
+    )
+    @patch("veomni.trainer.callbacks.checkpoint_callback.build_checkpointer")
+    @patch("veomni.trainer.callbacks.checkpoint_callback.dist")
+    @patch("veomni.trainer.callbacks.checkpoint_callback.helper")
+    def test_epoch_end_no_phantom_save_after_stop_iteration(self, mock_helper, mock_dist, mock_build_ckpt):
+        from veomni.trainer.callbacks.checkpoint_callback import CheckpointerCallback
+
+        trainer = MagicMock()
+        trainer.args = SimpleNamespace(
+            train=SimpleNamespace(
+                checkpoint=SimpleNamespace(
+                    save_path="/tmp/test_phantom",
+                    save_steps=0,
+                    save_epochs=1,
+                    save_async=False,
+                    load_path=None,
+                    manager="dcp",
+                ),
+                accelerator=SimpleNamespace(fsdp_config=SimpleNamespace(fsdp_mode="fsdp2")),
+                global_rank=0,
+            ),
+        )
+        mock_build_ckpt.return_value = trainer.checkpointer
+        trainer.checkpointer.save_future = None
+
+        cb = CheckpointerCallback(trainer)
+        cb.every_n_epochs = 1
+
+        state = TrainerState(global_step=0)
+        batches = iter([])
+
+        for _ in range(5):
+            try:
+                state.global_step += 1
+                _ = next(batches)
+            except StopIteration:
+                break
+
+        assert state.global_step == 1
+
+        state.epoch = 0
+        cb.on_epoch_end(state)
+
+        trainer.checkpointer.save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _normalize_key
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeKey:
+    def test_standard_model_key(self):
+        from veomni.checkpoint.dcp_checkpointer import _normalize_key
+
+        assert _normalize_key("model.model.layers.0.weight") == "model.layers.0.weight"
+
+    def test_lm_head_key(self):
+        from veomni.checkpoint.dcp_checkpointer import _normalize_key
+
+        assert _normalize_key("model.lm_head.weight") == "lm_head.weight"
+
+    def test_non_model_key_returns_none(self):
+        from veomni.checkpoint.dcp_checkpointer import _normalize_key
+
+        assert _normalize_key("optimizer.state.0.exp_avg") is None
+
+    def test_single_model_prefix(self):
+        from veomni.checkpoint.dcp_checkpointer import _normalize_key
+
+        assert _normalize_key("model.embed_tokens.weight") == "embed_tokens.weight"
+
+
+# ---------------------------------------------------------------------------
+# Extra state save/load roundtrip
+# ---------------------------------------------------------------------------
+
+
+@patch("veomni.checkpoint.dcp_checkpointer.dist")
+class TestExtraStateSaveLoad:
+    def test_roundtrip(self, mock_dist, tmp_path):
+        mock_dist.get_rank.return_value = 0
+        from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
+
+        original_state = {
+            "extra_state": {
+                "global_step": 42,
+                "lr_scheduler": {"last_epoch": 10, "base_lrs": [1e-4]},
+                "torch_rng_state": torch.get_rng_state(),
+            }
+        }
+
+        DistributedCheckpointer._save_extra_state(str(tmp_path), original_state)
+
+        loaded_state = {"extra_state": {}}
+        DistributedCheckpointer._load_extra_state(str(tmp_path), loaded_state)
+
+        assert loaded_state["extra_state"]["global_step"] == 42
+        assert loaded_state["extra_state"]["lr_scheduler"]["last_epoch"] == 10
+        torch.testing.assert_close(
+            loaded_state["extra_state"]["torch_rng_state"],
+            original_state["extra_state"]["torch_rng_state"],
+        )
+
+    def test_missing_extra_state_key_save(self, mock_dist, tmp_path):
+        from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
+
+        state = {"model": MagicMock()}
+        DistributedCheckpointer._save_extra_state(str(tmp_path), state)
+
+    def test_missing_extra_state_key_load(self, mock_dist, tmp_path):
+        from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
+
+        state = {"model": MagicMock()}
+        DistributedCheckpointer._load_extra_state(str(tmp_path), state)

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -96,20 +96,12 @@ class TestAllowPartialLoad:
         with patch.object(DistributedCheckpointer, "_load_extra_state"):
             with patch.object(DistributedCheckpointer, "_create_storage_reader") as mock_reader:
                 mock_reader.return_value = MagicMock()
-                try:
-                    DistributedCheckpointer.load(path="/fake", state=state)
-                except Exception:
-                    pass
+                DistributedCheckpointer.load(path="/fake", state=state)
 
-                if mock_dcp.load.called:
-                    call_kwargs = mock_dcp.load.call_args
-                    planner = call_kwargs.kwargs.get("planner") or (
-                        call_kwargs[1].get("planner") if len(call_kwargs) > 1 else None
-                    )
-                    assert planner is not None, "load must pass a planner"
-                    assert planner.allow_partial_load is True, (
-                        "load must use DefaultLoadPlanner(allow_partial_load=True)"
-                    )
+        mock_dcp.load.assert_called_once()
+        planner = mock_dcp.load.call_args.kwargs.get("planner")
+        assert planner is not None, "load must pass a planner"
+        assert planner.allow_partial_load is True, "load must use DefaultLoadPlanner(allow_partial_load=True)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -113,6 +113,58 @@ class TestAllowPartialLoad:
 
 
 # ---------------------------------------------------------------------------
+# Partial save/load (LoRA / trainable_only path)
+# ---------------------------------------------------------------------------
+
+
+@patch("veomni.checkpoint.dcp_checkpointer.get_parallel_state")
+class TestPartialSaveLoad:
+    """When trainable_only=True (LoRA), the checkpoint contains only adapter
+    weights.  On load, allow_partial_load=True lets DCP skip the missing
+    frozen-base entries.  The optimizer checkpoint is similarly partial:
+    only trainable params that received gradients have state."""
+
+    def test_trainable_only_model_state_excludes_frozen(self, mock_gps):
+        """ModelState with trainable_only=True should skip frozen params."""
+        mock_gps.return_value = SimpleNamespace(dp_mode="fsdp2")
+        from veomni.checkpoint.dcp_checkpointer import ModelState
+
+        model = nn.Sequential(nn.Linear(8, 8, bias=False), nn.Linear(8, 8, bias=False))
+        model[0].weight.requires_grad_(False)  # freeze first layer
+
+        ms = ModelState(model, trainable_only=True)
+        sd = ms.state_dict()
+
+        assert "1.weight" in sd, "trainable param should be in state dict"
+        assert "0.weight" not in sd, "frozen param should be excluded with trainable_only=True"
+
+    def test_optimizer_state_only_has_trained_params(self, mock_gps):
+        """OptimizerState.state_dict() should only contain params that
+        received gradients — no synthetic placeholders for frozen or
+        unused params."""
+        mock_gps.return_value = SimpleNamespace(dp_mode="fsdp2")
+        from veomni.checkpoint.dcp_checkpointer import OptimizerState
+
+        model = nn.Sequential(nn.Linear(8, 8, bias=False), nn.Linear(8, 8, bias=False))
+        # Simulate LoRA: optimizer only has trainable params
+        trainable = [p for p in model.parameters() if p.requires_grad]
+        optimizer = torch.optim.AdamW(trainable, lr=1e-3)
+
+        # Step on first layer only
+        optimizer.zero_grad()
+        loss = model[0](torch.randn(2, 8)).sum()
+        loss.backward()
+        optimizer.step()
+
+        os = OptimizerState(model, optimizer)
+        sd = os.state_dict()
+
+        assert len(sd.get("state", {})) > 0, "should have at least one param with state"
+        for fqn in sd.get("state", {}):
+            assert "0.weight" in fqn, f"only layer 0 was stepped, but found state for {fqn}"
+
+
+# ---------------------------------------------------------------------------
 # Bug 4 (PR #798): global_step inflated before data fetch
 # ---------------------------------------------------------------------------
 

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -164,9 +164,17 @@ class OptimizerState(Stateful):
     base weights) are simply absent from the checkpoint.
 
     On load, ``allow_partial_load=True`` is passed to the DCP load planner
-    so missing entries are skipped.  ``set_optimizer_state_dict`` initialises
-    default state (step=0, zero moments) for any param not present in the
-    checkpoint, matching what AdamW would create on the next ``step()`` call.
+    so missing optimizer entries are skipped.  For a fresh optimizer (the
+    normal resume path), ``set_optimizer_state_dict`` internally calls
+    ``_init_optim_state`` which pre-fills zero/default state for every
+    param; DCP then overwrites the entries that exist in the checkpoint.
+    Params absent from the checkpoint keep their default-initialised state,
+    equivalent to what AdamW would create on the next ``step()`` call.
+
+    Note: ``allow_partial_load`` is set globally on the DCP planner (it
+    cannot be scoped to optimizer-only).  Model-weight integrity is still
+    enforced by ``set_model_state_dict(strict=True)`` inside
+    ``ModelState.load_state_dict`` for non-LoRA loads.
     """
 
     def __init__(self, model, optimizer):

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -27,6 +27,7 @@ from torch.distributed.checkpoint import (
     FileSystemWriter,
     load,
 )
+from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
 from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE, Metadata
 from torch.distributed.checkpoint.state_dict import (
     StateDictOptions,
@@ -156,22 +157,21 @@ class ModelState(Stateful):
 
 
 class OptimizerState(Stateful):
-    """
-    A wrapper around an optimizer to make it stateful.
+    """A wrapper around an optimizer to make it stateful.
 
-    Args:
-        optimizer (Optimizer): optimizer to wrap.
-        fill_missing_optimizer_states (bool): When True (save path), synthesize zero-filled
-            placeholder states for params that never received a gradient (e.g. weights on
-            unused modalities). This prevents DCP strict-load failures at resume time when those
-            entries are expected but absent. Should be False on the load path (default).
+    On save, only optimizer state that actually exists is persisted — params
+    that never received a gradient (e.g. unused MoE experts, frozen LoRA
+    base weights) are simply absent from the checkpoint.
+
+    On load, ``allow_partial_load=True`` is passed to the DCP load planner
+    so missing entries are skipped.  ``set_optimizer_state_dict`` initialises
+    default state (step=0, zero moments) for any param not present in the
+    checkpoint, matching what AdamW would create on the next ``step()`` call.
     """
 
-    def __init__(self, model, optimizer, *, fill_missing_optimizer_states: bool = False):
+    def __init__(self, model, optimizer):
         self.model = model
         self.optimizer = optimizer
-        self.fill_missing_optimizer_states = fill_missing_optimizer_states
-        # Similar to ModelState, OptimizerState also need to be ExtraParallel+FSDP2 aware
         self.parallel_state = get_parallel_state()
         self.extra_parallel_fqn2spec_info = getattr(self.model, "_fqn2spec_info", None)
         self.should_extra_parallel_aware = (
@@ -183,8 +183,6 @@ class OptimizerState(Stateful):
             logger.info_rank0(
                 "Getting optimizer state_dict from OptimizerState wrapper, would restore ExtraParallel dim for Experts module"
             )
-            # MultiOptimizer is only used for ExtraParallel+FSDP2 case for now,
-            # and it knows how to produce a merged, flattened dict already
             assert self.optimizer._is_multi_optimizer, (
                 "ExtraParallel is enabled but optimizer is not a MultiOptimizer instance"
             )
@@ -194,89 +192,7 @@ class OptimizerState(Stateful):
             )
             return optim_sd_with_extra_parallel_dim
 
-        # Single torch optimizer
-        sd = get_optimizer_state_dict(model=self.model, optimizers=self.optimizer)
-        if self.fill_missing_optimizer_states:
-            sd = self._fill_missing_optimizer_states(sd)
-        return sd
-
-    def _fill_missing_optimizer_states(self, sd):
-        """Ensure every optimizer param has state entries in the state dict.
-
-        Adam/AdamW creates state lazily on first ``step()`` with a non-None
-        gradient.  Params that never received a gradient (e.g. LoRA on unused
-        modalities) will have no state.  Additionally, ``get_optimizer_state_dict``
-        deduplicates aliased parameters (same ``id()``), emitting only one
-        canonical FQN per unique tensor.  DCP strict load fails when these
-        entries are absent at resume time.
-
-        We enumerate expected FQNs directly from the raw optimizer param_groups
-        + model FQN mapping, bypassing any dedup that ``get_optimizer_state_dict``
-        may have performed.
-        """
-        if "state" not in sd or not isinstance(sd["state"], dict):
-            return sd
-
-        optim_fqns = set(sd["state"].keys())
-
-        # Build expected FQNs from raw optimizer param_groups, not from the
-        # already-deduped sd["param_groups"].
-        optim_param_ids = set()
-        for group in self.optimizer.param_groups:
-            for p in group["params"]:
-                optim_param_ids.add(id(p))
-
-        fqn_to_param = {}
-        for fqn, param in self.model.named_parameters():
-            if id(param) in optim_param_ids:
-                fqn_to_param[fqn] = param
-
-        expected_fqns = set(fqn_to_param.keys())
-        missing = expected_fqns - optim_fqns
-
-        if not missing:
-            return sd
-
-        if not sd["state"]:
-            logger.warning_rank0(
-                "OptimizerState: state dict is empty, cannot create template for missing optimizer states"
-            )
-            return sd
-
-        template_fqn = next(iter(sd["state"]))
-        template = sd["state"][template_fqn]
-
-        for fqn in missing:
-            param = fqn_to_param[fqn]
-            placeholder = {}
-            for key, val in template.items():
-                if isinstance(val, torch.Tensor):
-                    if val.ndim == 0:
-                        placeholder[key] = torch.zeros_like(val)
-                    else:
-                        # Placeholder zeros: DCP writes them straight to disk, so
-                        # the backing device doesn't matter — keep them on CPU to
-                        # avoid HBM pressure during save. For FSDP2 params,
-                        # ``param.data`` is itself a DTensor; ``zeros_like``
-                        # propagates its placements + mesh, so the local shard
-                        # ends up the correct per-rank shape on CPU.
-                        placeholder[key] = torch.zeros_like(
-                            param.data,
-                            dtype=val.dtype,
-                            device="cpu",
-                        )
-                elif isinstance(val, (int, float)):
-                    placeholder[key] = type(val)(0)
-                else:
-                    placeholder[key] = val
-            sd["state"][fqn] = placeholder
-
-        logger.info_rank0(
-            f"OptimizerState: filled default state for {len(missing)} param(s) "
-            f"without optimizer state (no gradient received or aliased): "
-            f"{sorted(missing)}"
-        )
-        return sd
+        return get_optimizer_state_dict(model=self.model, optimizers=self.optimizer)
 
     def load_state_dict(self, state_dict):
         optim_state_from_dcp_load = state_dict
@@ -464,9 +380,7 @@ class DistributedCheckpointer(CheckpointerBase):
 
         save_state = {"model": ModelState(state["model"], trainable_only=trainable_only)}
         if "optimizer" in state:
-            save_state["optimizer"] = OptimizerState(
-                model=state["model"], optimizer=state["optimizer"], fill_missing_optimizer_states=True
-            )  # type: ignore[index]
+            save_state["optimizer"] = OptimizerState(model=state["model"], optimizer=state["optimizer"])
 
         if storage_writer is None:
             storage_writer = cls._create_storage_writer(checkpoint_dir)
@@ -519,8 +433,8 @@ class DistributedCheckpointer(CheckpointerBase):
             state_dict=load_state,
             storage_reader=storage_reader,
             process_group=process_group,
+            planner=DefaultLoadPlanner(allow_partial_load=True),
         )
-        # Note: further per-param DTensor alignment and device fixes happen inside OptimizerState.load_state_dict
 
         cls._load_extra_state(checkpoint_dir=checkpoint_dir, state=state)
 

--- a/veomni/data/multimodal/audio_utils.py
+++ b/veomni/data/multimodal/audio_utils.py
@@ -16,24 +16,13 @@ import io
 from io import BytesIO
 from typing import ByteString, List, Optional, Tuple, Union
 
-import audioread
-import av
-import librosa
 import numpy as np
-import soundfile as sf
 import torch
 
 from ...utils import logging
 
 
 logger = logging.get_logger(__name__)
-
-
-if not hasattr(av, "AVError"):
-    try:
-        from av.error import AVError  # noqa: F401
-    except (ImportError, AttributeError):
-        av.AVError = OSError
 
 
 AudioInput = Union[
@@ -44,6 +33,8 @@ AudioInput = Union[
 
 
 def load_audio_bytes_from_path(audio_path: str):
+    import soundfile as sf
+
     audio, sample_rate = sf.read(audio_path)
     buffer = io.BytesIO()
     sf.write(buffer, audio, sample_rate, format="WAV")
@@ -52,12 +43,16 @@ def load_audio_bytes_from_path(audio_path: str):
 
 
 def save_audio_bytes_to_file(audio_bytes, output_path):
+    import soundfile as sf
+
     audio_bytes = io.BytesIO(audio_bytes)
     audio_reloaded, sample_rate = sf.read(audio_bytes)
     sf.write(output_path, audio_reloaded, samplerate=sample_rate)
 
 
 def load_audio_bytes_from_array(audio_array: np.ndarray, sample_rate: int):
+    import soundfile as sf
+
     buffer = io.BytesIO()
     sf.write(buffer, audio_array, sample_rate, format="WAV")
     buffer.seek(0)
@@ -78,12 +73,17 @@ def load_audio_bytes(audio: Union[str, np.ndarray, bytes], sample_rate: Optional
 
 
 def load_audio_from_bytes(audio_bytes: bytes, sample_rate: int = 16000, **kwargs):
+    import librosa
+
     with BytesIO(audio_bytes) as wav_io:
         audio, _ = librosa.load(wav_io, sr=sample_rate)
     return audio
 
 
 def load_audio_from_path(audio_path: str, sample_rate: int = 16000, **kwargs):
+    import audioread
+    import librosa
+
     if audio_path.startswith("http://") or audio_path.startswith("https://"):
         return librosa.load(audioread.ffdec.FFmpegAudioFile(audio_path), sr=sample_rate)[0]
     else:
@@ -126,6 +126,8 @@ def extract_audio_from_video(
 
     try:
         # Open video container with PyAV
+        import av
+
         container_input = io.BytesIO(video_input) if isinstance(video_input, bytes) else video_input
         container = av.open(container_input)
 
@@ -194,5 +196,7 @@ def save_audio_tensor_to_file(
         # (C, T) -> (T, C) for soundfile (expects samples-first)
         if audio.shape[0] <= 8 and audio.shape[1] > 8:
             audio = audio.T
+
+    import soundfile as sf
 
     sf.write(output_path, audio, samplerate=sample_rate)

--- a/veomni/data/multimodal/video_utils.py
+++ b/veomni/data/multimodal/video_utils.py
@@ -17,12 +17,9 @@ import math
 import subprocess
 from typing import ByteString, Dict, List, Optional, Union
 
-import av
-import librosa
 import numpy as np
 import PIL
 import torch
-from torchcodec.decoders import VideoDecoder
 from torchvision.transforms import InterpolationMode, functional
 
 from ...utils import logging
@@ -219,6 +216,8 @@ def smart_audio_nframes(
         (audio, metadata): Resampled audio and metadata dict with 'fps', 'total_num_frames'
     """
     if audio is not None and audio_fps != sample_rate:
+        import librosa
+
         audio = librosa.resample(audio, orig_sr=audio_fps, target_sr=sample_rate)
     num_frames = len(audio) if audio is not None else 0
     return audio, {"fps": sample_rate, "total_num_frames": num_frames}
@@ -430,6 +429,8 @@ def _load_and_process_video_with_codec(video_input: VideoInput, use_audio_in_vid
         return video, audio, audio_fps, frames_indices
 
     # video_input is str (path/URL) or bytes
+    from torchcodec.decoders import VideoDecoder
+
     try:
         decoder = VideoDecoder(video_input, device="cpu", num_ffmpeg_threads=0)
     except Exception as e:
@@ -744,6 +745,8 @@ def save_video_tensors_to_file(
     # -----------------------------
     # encode video
     # -----------------------------
+    import av
+
     container = av.open(output_path, mode="w")
     stream = container.add_stream("libx264", rate=fps)
 


### PR DESCRIPTION
## Summary

- **Remove `_fill_missing_optimizer_states`** from `OptimizerState` — the 80-line method that synthesized zero-filled DTensor placeholders for params without gradients. This was the root cause of three production bugs (#791, #794, #797).
- **Save path**: only persist optimizer state that actually exists. Params without gradients (unused MoE experts, frozen LoRA weights) are simply absent from the checkpoint.
- **Load path**: use `DefaultLoadPlanner(allow_partial_load=True)` so DCP gracefully skips missing entries. `set_optimizer_state_dict` initialises default state (step=0, zero moments) for any param not in the checkpoint — matching what AdamW creates lazily on the next `step()`.
- **Lazy-import `av`/`librosa`/`torchcodec`/`soundfile`/`audioread`** in `video_utils.py` and `audio_utils.py` so text-only training no longer requires video/audio dependencies.

### Bugs eliminated

| Bug | PR | Root cause in `_fill_missing_optimizer_states` |
|-----|-----|-----------------------------------------------|
| GPU OOM during DCP save | #791 | `zeros_like(dtensor)` allocated placeholders on GPU |
| DCP metadata broadcast hang | #794 | CPU DTensor placeholders had unhashable `TensorProperties` |
| NCCL buffer corruption | #797 | Each rank filled different missing FQNs independently |

All three are eliminated by removing the function entirely. No monkey-patches needed.

### Why this works

`_fill_missing_optimizer_states` existed because DCP strict-load failed when some optimizer FQNs were absent from the checkpoint. The fix: pass `allow_partial_load=True` to the load planner instead. Missing params get default-initialized by `set_optimizer_state_dict`, which is semantically equivalent to what AdamW does on the first gradient — zero moments, step=0.

Verified with `dcp.save()` + `dcp.load()` roundtrip on 2× H100 with FSDP2, including rank-asymmetric missing state (different params with/without gradients per rank).

Supersedes #791, #794, #797.

## Test plan

- [x] `pytest tests/checkpoints/test_dcp_checkpointer.py` — 15 tests (13 pass + 2 xfail for #798)
- [x] `pytest tests/checkpoints/test_checkpoint_callback.py` — 8 tests pass
- [x] `pytest tests/checkpoints/test_trainer_saveload.py -k qwen3_moe-1` — E2E on 8× H100
- [x] `pytest tests/checkpoints/test_trainer_saveload.py -k qwen3_moe-8` — E2E on 8× H100
- [x] `make quality` passes
- [ ] Full CI (`test_trainer_saveload` all parametrizations)
- [ ] LoRA save/load test (`test_lora_trainer_saveload`)