### PR TITLE
[parallel] fix: keep root's auto-no-reshard so fused-linear kernels can backward

### DIFF
--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -331,8 +331,17 @@ def parallelize_model_fsdp2(
             layer_mod._fsdp_modules.append(layer_mod)
         logger.info_rank0(f"{layer_fqn=}, {layer_mod._fsdp_modules=}")
 
-    # shard root model
-    fully_shard(model, **fsdp_kwargs)
+    # Shard root WITHOUT explicit `reshard_after_forward` so FSDP2's
+    # auto-no-reshard for the root kicks in (`_fsdp_state.py:_lazy_init`).
+    # This keeps the root's params (lm_head + embeddings + final norm)
+    # unsharded between forward and backward, which is what fused-linear
+    # kernels (chunk_logprobs / chunk_topk_distill) need — they save the
+    # lm_head weight via `save_for_backward` and would otherwise hit
+    # `setStorage … storage of size 0` when the saved reference points
+    # to a freed buffer. Decoder layers reshard normally (their calls
+    # above pass `reshard_after_forward` explicitly).
+    root_fsdp_kwargs = {k: v for k, v in fsdp_kwargs.items() if k != "reshard_after_forward"}
+    fully_shard(model, **root_fsdp_kwargs)
 
     # configure manual prefetching when needed
     need_manual_prefetch = (


### PR DESCRIPTION
### Why

The fused-linear kernels in `veomni.ops.kernels.cross_entropy`
(`chunk_logprobs`, `chunk_topk_distill`) compute logits via
`h_chunk @ weight.t()` inside a custom `torch.autograd.Function` and save
the lm_head weight via `save_for_backward`. The lm_head module's
`forward` is bypassed entirely (the kernel reads `lm_head.weight`
directly and streams the projection chunk-by-chunk to avoid
materializing the `[T, V]` logits tensor).

Under FSDP2 the saved `weight` reference in `ctx.saved_tensors` must
stay valid until backward runs. PyTorch FSDP2 already has a built-in
optimization for exactly this case: at root-init time, if
`_auto_reshard_after_forward` is `True`, FSDP2 sets the root's
`post_forward_mesh_info = None` so the root's parameters are NOT
resharded after forward — they would have to be re-all-gathered
immediately for backward anyway. See upstream PyTorch
[`_fsdp_state.py`](https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_fully_shard/_fsdp_state.py):

```python
if self._fsdp_param_group and self._auto_reshard_after_forward:
    # For the root, do not reshard after forward since for training,
    # the parameters would be freed and all-gathered immediately
    self._fsdp_param_group.post_forward_mesh_info = None
```

`_auto_reshard_after_forward` is `True` only when the user did NOT pass
`reshard_after_forward` explicitly to `fully_shard`. By passing
`reshard_after_forward=enable_reshard_after_forward` to the root call,
veomni was opting out of this optimization. The root resharded after
forward, freed the unsharded buffer, and the saved `weight` reference
in the kernel's ctx pointed to freed storage. Backward crashed with
`RuntimeError: setStorage: sizes [H, V] ... storage of size 0` on the
matmul at `chunk_logprobs.py:220` / `chunk_topk_distill.py:242`.

verl's FSDP engine wraps the root the same way intentionally
(`verl/utils/fsdp_utils.py`):
```python
fully_shard(model, **fsdp_kwargs)  # fsdp2 will not reshard_after_forward for root module
```
— which is why `use_fused_kernels=True` + FSDP2 has worked in verl's
FSDP-engine recipes but crashed in veomni-engine recipes that route
through `chunk_logprobs`.

This bug is not caught by `tests/ops/test_chunk_logprobs.py` /
`tests/ops/test_chunk_topk_distill.py`, which run on single-device
tensors without FSDP2 wrapping, nor by
`tests/models/test_return_log_probs_e2e.py` which also runs
single-device. It surfaces in multi-GPU FSDP2 training that exercises
`return_log_probs=True` — for example
[verl-project/verl#6511](https://github.com/verl-project/verl/pull/6511)
(on-policy distillation with `use_fused_kernels=True`), or any
DPO/PPO actor backward that goes through `chunk_logprobs` under
`model_engine=veomni`.

### What

Drop `reshard_after_forward` from the root `fully_shard` kwargs only.
The decoder-layer `fully_shard` calls above still pass
`reshard_after_forward=enable_reshard_after_forward` explicitly, so
layer-level resharding behavior is unchanged. FSDP2's built-in
auto-no-reshard for the root kicks in, `lm_head.weight` (and the
embedding / final norm in the same root parameter group) stay
unsharded between forward and backward, and the fused-linear kernels'
backward sees a valid buffer.

**Zero extra memory cost** — this is the behavior FSDP2 already
recommends for training.

### Verification

Reproduced and verified on H100 × 2 (DP=2) and H100 × 4 (DP=2 × SP=2),
Qwen3-0.6B (tied embeddings) and Qwen3-8B (untied), with
`flash_attention_2` and `eager` attention, with/without
gradient checkpointing, with/without param + optimizer offload.

- Before: `loss.backward()` crashes with
  `setStorage: ... storage of size 0` on the matmul at
  `chunk_logprobs.py:220` / `chunk_topk_distill.py:242`.
- After: forward + backward + optimizer step succeed; per-token
  outputs (`distillation_losses`, `student_mass`, `teacher_mass`) are
  consistent with the single-GPU reference. Existing kernel unit
  tests still pass.

### Test coverage recommendation

The kernel unit tests (`tests/ops/`) and the e2e log_probs test
(`tests/models/test_return_log_probs_e2e.py`) are all single-device,
so the FSDP2 + `return_log_probs=True` interaction is currently
uncovered. A multi-GPU test that:

1. wraps a small text model with `build_parallelize_model` (FSDP2,
   default settings),
2. calls `model(input_ids, return_log_probs=True)`,
3. computes a scalar loss from `output.fused_linear_aux.log_probs`,
4. calls `loss.backward()`,
5. asserts no crash + verifies `lm_head.weight.grad` is finite,

would have caught this and would gate future regressions.
