### PR TITLE
[model, docs] refactor: make patchgen reusable as a library

### DIFF
--- a/docs/transformers_v5/patchgen.md
+++ b/docs/transformers_v5/patchgen.md
@@ -415,6 +415,109 @@ python -m veomni.patchgen.run_codegen --list
 4. Verify the generated output in `veomni/models/transformers/<model>/generated/`
 5. Run `python -m veomni.patchgen.check_patchgen` to confirm CI will pass
 
+## Using patchgen from a dependent project
+
+`veomni.patchgen` is designed to be reused as a library by projects that
+depend on VeOmni and want to patch their own models — i.e. projects that
+hold patch configs **outside** the `veomni/models/transformers/` tree.
+Maintaining a separate patchgen copy per project is unnecessary — wire
+your own discovery root + CLI on top of the upstream library instead.
+
+### Transformers version
+
+The codegen layer is **transformers-version-agnostic**:
+`get_module_source(module_name)` walks `sys.path` for the module's `.py`
+file and reads it directly — it does **not** `import transformers`. A
+caller on transformers v4 can use `veomni.patchgen` the same way a v5
+caller does, provided the patch config's `source_module` resolves to an
+actual file on the installed transformers. (Patch config decorators
+themselves are free to live under `if TYPE_CHECKING:` blocks if their
+replacement bodies reference torch / version-specific HF symbols only at
+codegen time.)
+
+### Pattern: thin wrapper around library entry points
+
+The two public CLI factories are
+`veomni.patchgen.run_codegen.build_cli(discovery, prog_name=...)` and
+`veomni.patchgen.check_patchgen.build_cli(discovery, prog_name=...)`. Both
+return a `main()`-shaped callable that mounts the same arguments as the
+upstream CLIs but rooted at the caller's `DiscoveryConfig`.
+
+```python
+# <your_project>/patchgen/__main__.py
+from pathlib import Path
+from veomni.patchgen import DiscoveryConfig, build_run_codegen_cli
+
+PROJECT_DISCOVERY = DiscoveryConfig(
+    search_root=Path(__file__).resolve().parents[1] / "models",
+    package_prefix="<your_project>.models",
+    # If your project's pyproject does NOT globally ignore E501, generated
+    # files may still contain occasional long lines from upstream HF. Pass
+    # the code explicitly so the drift-checker's tmp normalization matches
+    # the per-file-ignore the checked-in generated/ files get from your
+    # pyproject.
+    ruff_extra_ignore=("E501",),
+)
+
+main = build_run_codegen_cli(PROJECT_DISCOVERY, prog_name="<your_project>.patchgen")
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+The matching drift checker:
+
+```python
+# <your_project>/patchgen/check_main.py
+from veomni.patchgen import build_check_cli
+from .__main__ import PROJECT_DISCOVERY
+
+main = build_check_cli(PROJECT_DISCOVERY, prog_name="<your_project>.patchgen.check")
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+This gives dependent projects the full upstream surface
+(`--list / --all / --dry-run / --diff / <module>` and `--fix`) without
+copy-pasting argparse or duplicating the codegen / drift-check
+implementations. Bug fixes and new patch-spec features flow in
+automatically when the caller bumps their `veomni` dependency.
+
+### What the library guarantees
+
+- `run_codegen` writes ruff-normalized output, then builds the `.diff`
+  against that normalized output. `check_patchgen` regenerates the same
+  way. The two are byte-for-byte identical, so a fresh regen never
+  produces immediate drift.
+- `load_patch_config_module` loads patch configs via
+  `importlib.util.spec_from_file_location`, so the **patch config's own
+  package `__init__.py`** (e.g. a project-specific `models/<name>/__init__.py`
+  that registers a custom HF model or pulls in heavy 3rdparty kernels) is
+  **not** executed — *provided the config is self-contained*. Configs that
+  import siblings under the same package (relative `from .sibling import …`
+  or fully-qualified `from <pkg>.sibling import …`) re-trigger that
+  package's `__init__.py`, because Python's import machinery materializes
+  parent packages when resolving any sub-package name. Once cached in
+  `sys.modules`, subsequent loads no-op the parent. Note: importing
+  `veomni.patchgen` itself still triggers `veomni/__init__.py`, which
+  imports torch and runs VeOmni's op patches — torch is therefore a hard
+  prerequisite. The loader's lightweight-env benefit is scoped to the
+  patch config's own package tree.
+- `get_module_source` reads source from disk; it does not import the
+  patched module. This is what makes the layer transformers-version
+  agnostic.
+
+### When to pass `ruff_extra_ignore`
+
+Upstream VeOmni's `pyproject.toml` globally ignores `E501` and
+per-file-ignores `E402,B007` for `generated/*.py`. The shared
+`ruff_fix_and_format` mirrors only the per-file-ignores (E402, B007),
+relying on the **caller project's** ruff config to handle E501. Projects
+whose ruff config does not globally ignore E501 must opt into the same
+treatment for the tmp-file the drift checker writes by passing
+`ruff_extra_ignore=("E501",)` on their `DiscoveryConfig`.
+
 ## Background: Why Not Monkey Patching?
 
 ### Existing Approaches and Their Trade-offs

--- a/veomni/patchgen/__init__.py
+++ b/veomni/patchgen/__init__.py
@@ -1,1 +1,92 @@
-"""VeOmni patch generation utilities."""
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""VeOmni patch generation utilities.
+
+This package is designed to be reused as a library by projects that depend
+on VeOmni so they can patch their own models in their own repos. Callers
+wire up their own discovery root + CLI via :func:`run_codegen.build_cli`
+and :func:`check_patchgen.build_cli`. See
+``docs/transformers_v5/patchgen.md`` section "Using patchgen from a
+dependent project" for the full recipe.
+
+The patchgen layer itself is transformers-version-agnostic: it only reads
+the source ``.py`` file off ``sys.path`` (no ``import transformers``
+required) and rewrites its AST. Dependent projects that pin transformers
+v4 can use this library the same way v5 callers do — provided their patch
+config targets a module file that actually exists on their installed
+transformers.
+"""
+
+from ._normalize import ruff_fix_and_format
+from .check_patchgen import build_cli as build_check_cli
+from .check_patchgen import check_config, run_check
+from .codegen import (
+    CodegenError,
+    ModelingCodeGenerator,
+    generate_from_config,
+    get_module_source,
+    load_patch_config_module,
+)
+from .patch_spec import (
+    ImportSpec,
+    Patch,
+    PatchConfig,
+    PatchType,
+    PositionedHelper,
+    create_patch_from_external,
+)
+from .run_codegen import (
+    DiscoveryConfig,
+    build_unified_diff,
+    default_diff_path,
+    default_output_dir_for_module,
+    list_patch_configs,
+    normalize_patch_module,
+    run_codegen,
+)
+from .run_codegen import (
+    build_cli as build_run_codegen_cli,
+)
+
+
+__all__ = [
+    # Patch spec
+    "Patch",
+    "PatchConfig",
+    "PatchType",
+    "ImportSpec",
+    "PositionedHelper",
+    "create_patch_from_external",
+    # Codegen
+    "CodegenError",
+    "ModelingCodeGenerator",
+    "generate_from_config",
+    "get_module_source",
+    "load_patch_config_module",
+    # Normalization
+    "ruff_fix_and_format",
+    # Discovery + run_codegen
+    "DiscoveryConfig",
+    "build_run_codegen_cli",
+    "build_unified_diff",
+    "default_diff_path",
+    "default_output_dir_for_module",
+    "list_patch_configs",
+    "normalize_patch_module",
+    "run_codegen",
+    # Drift check
+    "build_check_cli",
+    "check_config",
+    "run_check",
+]

--- a/veomni/patchgen/__init__.py
+++ b/veomni/patchgen/__init__.py
@@ -26,11 +26,25 @@ required) and rewrites its AST. Dependent projects that pin transformers
 v4 can use this library the same way v5 callers do — provided their patch
 config targets a module file that actually exists on their installed
 transformers.
+
+Lazy submodule loading
+----------------------
+
+``check_patchgen`` and ``run_codegen`` are CLI entry points designed to
+be invoked via ``python -m veomni.patchgen.<sub>``. Eagerly re-exporting
+their contents here would force ``runpy`` to load each submodule twice
+(once as a regular module via this ``__init__``, then again as
+``__main__``) and emit a confusing
+``RuntimeWarning: found in sys.modules after import of package ...``.
+
+PEP 562 ``__getattr__`` defers the import until the symbol is actually
+accessed, so the warning never fires while top-level
+``from veomni.patchgen import DiscoveryConfig`` still works.
 """
 
+from typing import TYPE_CHECKING
+
 from ._normalize import ruff_fix_and_format
-from .check_patchgen import build_cli as build_check_cli
-from .check_patchgen import check_config, run_check
 from .codegen import (
     CodegenError,
     ModelingCodeGenerator,
@@ -46,18 +60,78 @@ from .patch_spec import (
     PositionedHelper,
     create_patch_from_external,
 )
-from .run_codegen import (
-    DiscoveryConfig,
-    build_unified_diff,
-    default_diff_path,
-    default_output_dir_for_module,
-    list_patch_configs,
-    normalize_patch_module,
-    run_codegen,
-)
-from .run_codegen import (
-    build_cli as build_run_codegen_cli,
-)
+
+
+# Lazy re-exports for the CLI-bearing submodules. Mapping is
+# ``<public name in this package>: (<submodule>, <attr in submodule>)``.
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    # check_patchgen
+    "build_check_cli": ("check_patchgen", "build_cli"),
+    "check_config": ("check_patchgen", "check_config"),
+    "run_check": ("check_patchgen", "run_check"),
+    # run_codegen
+    "DiscoveryConfig": ("run_codegen", "DiscoveryConfig"),
+    "build_run_codegen_cli": ("run_codegen", "build_cli"),
+    "build_unified_diff": ("run_codegen", "build_unified_diff"),
+    "default_diff_path": ("run_codegen", "default_diff_path"),
+    "default_output_dir_for_module": ("run_codegen", "default_output_dir_for_module"),
+    "list_patch_configs": ("run_codegen", "list_patch_configs"),
+    "normalize_patch_module": ("run_codegen", "normalize_patch_module"),
+    "run_codegen": ("run_codegen", "run_codegen"),
+}
+
+
+def __getattr__(name: str):
+    """PEP 562 lazy attribute lookup.
+
+    Resolves names in ``_LAZY_EXPORTS`` by importing the backing submodule
+    on first access, then caches the resolved value in ``globals()`` so
+    subsequent accesses skip ``__getattr__`` entirely.
+
+    Subtlety: ``run_codegen`` is both a public function AND the name of
+    the submodule that defines it. Python's import machinery executes
+    ``setattr(parent_pkg, submodule_name, submodule)`` after loading a
+    submodule, which would leave ``veomni.patchgen.run_codegen`` pointing
+    at the submodule (overriding any prior function binding) whenever
+    *any* lazy lookup imports that submodule for *any* symbol. We work
+    around it by pre-binding **all** re-exports from the just-imported
+    submodule, so the function shadows the submodule entry before
+    control returns to the caller.
+    """
+    if name in _LAZY_EXPORTS:
+        from importlib import import_module
+
+        submod_name = _LAZY_EXPORTS[name][0]
+        submod = import_module(f".{submod_name}", __name__)
+        for export_name, (sm, sm_attr) in _LAZY_EXPORTS.items():
+            if sm == submod_name:
+                globals()[export_name] = getattr(submod, sm_attr)
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
+
+# Re-import the lazy names under TYPE_CHECKING so static analysers, IDE
+# autocomplete, and Sphinx see them as ordinary re-exports. These imports
+# are skipped at runtime — the only runtime path is __getattr__ above.
+if TYPE_CHECKING:
+    from .check_patchgen import build_cli as build_check_cli
+    from .check_patchgen import check_config, run_check
+    from .run_codegen import (
+        DiscoveryConfig,
+        build_unified_diff,
+        default_diff_path,
+        default_output_dir_for_module,
+        list_patch_configs,
+        normalize_patch_module,
+        run_codegen,
+    )
+    from .run_codegen import (
+        build_cli as build_run_codegen_cli,
+    )
 
 
 __all__ = [
@@ -76,7 +150,7 @@ __all__ = [
     "load_patch_config_module",
     # Normalization
     "ruff_fix_and_format",
-    # Discovery + run_codegen
+    # Discovery + run_codegen (lazy)
     "DiscoveryConfig",
     "build_run_codegen_cli",
     "build_unified_diff",
@@ -85,7 +159,7 @@ __all__ = [
     "list_patch_configs",
     "normalize_patch_module",
     "run_codegen",
-    # Drift check
+    # Drift check (lazy)
     "build_check_cli",
     "check_config",
     "run_check",

--- a/veomni/patchgen/_normalize.py
+++ b/veomni/patchgen/_normalize.py
@@ -1,0 +1,84 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared post-generation normalization step.
+
+``run_codegen`` (writing a fresh artifact) and ``check_patchgen`` (validating
+the committed artifact) must apply the **same** ruff normalization so the two
+paths agree byte-for-byte. Without this, a contributor running ``run_codegen``
+could commit a file that immediately fails ``check_patchgen`` whenever ruff
+would rewrite a single line of the raw codegen output.
+
+The ``--ignore`` set mirrors the per-file-ignores VeOmni's ``pyproject.toml``
+declares for ``veomni/models/transformers/**/generated/*.py``:
+
+- ``E402`` — generated files paste external imports at original class
+  positions (e.g. ``create_patch_from_external`` inline aliases), not at
+  the top of the file.
+- ``B007`` — upstream Transformers occasionally has unused loop variables.
+
+``E501`` is already in the project-wide ``[tool.ruff].ignore`` list and so is
+not repeated here. Downstream projects whose ``pyproject.toml`` does NOT
+ignore ``E501`` globally should pass their own ``extra_ignore`` instead of
+relying on this default.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_IGNORE = ("E402", "B007")
+
+
+def ruff_fix_and_format(
+    path: Path,
+    *,
+    extra_ignore: Optional[tuple[str, ...]] = None,
+    isolated: bool = False,
+) -> None:
+    """Run ``ruff check --fix`` + ``ruff format`` on *path*.
+
+    Args:
+        path: file to normalize in-place.
+        extra_ignore: additional ruff codes to suppress on top of
+            :data:`DEFAULT_IGNORE`. Downstream callers whose project ``ruff``
+            config differs from VeOmni's (e.g. no global ``E501`` ignore) can
+            pass ``("E501",)`` here so the temp file the drift checker writes
+            is normalized against the same effective rule set as the
+            checked-in generated file.
+        isolated: if True, pass ``--isolated`` to ``ruff`` so the project's
+            ``pyproject.toml`` is ignored — ruff falls back to its built-in
+            defaults (line-length 88, no per-file-ignores). This gives
+            location-independent output: the same temp file produces the
+            same normalized form regardless of where ``ruff`` happens to
+            discover a ``pyproject.toml``. Recommended for dependent
+            projects whose generated files were originally produced under
+            ``--isolated``. VeOmni's own files were generated without
+            ``--isolated``, so the upstream CLI keeps the False default to
+            preserve byte-identity with the checked-in artifacts.
+    """
+    ignore = list(DEFAULT_IGNORE)
+    if extra_ignore:
+        ignore.extend(extra_ignore)
+    check_cmd = ["ruff", "check", "--fix", "--quiet"]
+    format_cmd = ["ruff", "format", "--quiet"]
+    if isolated:
+        check_cmd.append("--isolated")
+        format_cmd.append("--isolated")
+    check_cmd.extend(["--ignore", ",".join(ignore), str(path)])
+    format_cmd.append(str(path))
+    subprocess.run(check_cmd, check=True, capture_output=True)
+    subprocess.run(format_cmd, check=True, capture_output=True)

--- a/veomni/patchgen/_normalize.py
+++ b/veomni/patchgen/_normalize.py
@@ -80,5 +80,20 @@ def ruff_fix_and_format(
         format_cmd.append("--isolated")
     check_cmd.extend(["--ignore", ",".join(ignore), str(path)])
     format_cmd.append(str(path))
-    subprocess.run(check_cmd, check=True, capture_output=True)
-    subprocess.run(format_cmd, check=True, capture_output=True)
+    try:
+        subprocess.run(check_cmd, check=True, capture_output=True)
+        subprocess.run(format_cmd, check=True, capture_output=True)
+    except subprocess.CalledProcessError as exc:
+        # ``capture_output=True`` swallows ruff's diagnostics into the
+        # exception object, where they're invisible by default. Re-raise
+        # with stdout + stderr inlined so syntax errors in generated files
+        # (or a missing ruff binary path quirk) show up directly in the
+        # caller's traceback.
+        stdout = exc.stdout.decode("utf-8", errors="replace") if exc.stdout else ""
+        stderr = exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""
+        raise RuntimeError(
+            f"ruff normalization failed (exit {exc.returncode})\n"
+            f"command: {' '.join(exc.cmd)}\n"
+            f"stdout:\n{stdout}\n"
+            f"stderr:\n{stderr}"
+        ) from exc

--- a/veomni/patchgen/check_patchgen.py
+++ b/veomni/patchgen/check_patchgen.py
@@ -72,14 +72,22 @@ def check_config(
     fix: bool = False,
     ruff_extra_ignore: tuple[str, ...] = (),
     ruff_isolated: bool = False,
+    search_roots: Optional[list[Path]] = None,
 ) -> bool:
     """Check a single config for drift.
 
     Returns True when the checked-in files are up to date (or were fixed).
+
+    Args:
+        search_roots: optional list of filesystem roots to prepend to the
+            loader's file-walk. Pass ``[discovery.package_root]`` from a
+            caller that drives discovery via ``DiscoveryConfig`` so the
+            loader still resolves the config file when the project isn't
+            installed on ``sys.path``.
     """
     # Use the patchgen-aware loader so parent ``__init__.py`` side effects
     # (heavy 3rdparty imports) don't gate the drift check.
-    module = load_patch_config_module(module_name)
+    module = load_patch_config_module(module_name, search_roots=search_roots)
     config = module.config
 
     output_dir = default_output_dir_for_module(module)
@@ -182,6 +190,7 @@ def run_check(
             fix=fix,
             ruff_extra_ignore=discovery.ruff_extra_ignore,
             ruff_isolated=discovery.ruff_isolated,
+            search_roots=[discovery.package_root],
         )
         if not ok:
             all_ok = False

--- a/veomni/patchgen/check_patchgen.py
+++ b/veomni/patchgen/check_patchgen.py
@@ -105,7 +105,7 @@ def check_config(
 
     try:
         ruff_fix_and_format(tmp_path, extra_ignore=ruff_extra_ignore or None, isolated=ruff_isolated)
-        normalized_py = tmp_path.read_text()
+        normalized_py = tmp_path.read_text(encoding="utf-8")
     finally:
         tmp_path.unlink(missing_ok=True)
 
@@ -122,11 +122,11 @@ def check_config(
     # -- compare ----------------------------------------------------------------
     ok = True
 
-    existing_py = checked_in_py.read_text() if checked_in_py.exists() else ""
+    existing_py = checked_in_py.read_text(encoding="utf-8") if checked_in_py.exists() else ""
     if existing_py != normalized_py:
         if fix:
             checked_in_py.parent.mkdir(parents=True, exist_ok=True)
-            checked_in_py.write_text(normalized_py)
+            checked_in_py.write_text(normalized_py, encoding="utf-8")
             print(f"  FIXED {checked_in_py}")
         else:
             ok = False
@@ -140,11 +140,13 @@ def check_config(
             print(f"  DRIFT {checked_in_py}")
             sys.stdout.writelines(diff)
 
-    existing_diff = strip_diff_trailing_ws(checked_in_diff.read_text()) if checked_in_diff.exists() else ""
+    existing_diff = (
+        strip_diff_trailing_ws(checked_in_diff.read_text(encoding="utf-8")) if checked_in_diff.exists() else ""
+    )
     if existing_diff != normalized_diff:
         if fix:
             checked_in_diff.parent.mkdir(parents=True, exist_ok=True)
-            checked_in_diff.write_text(normalized_diff)
+            checked_in_diff.write_text(normalized_diff, encoding="utf-8")
             print(f"  FIXED {checked_in_diff}")
         else:
             ok = False

--- a/veomni/patchgen/check_patchgen.py
+++ b/veomni/patchgen/check_patchgen.py
@@ -15,9 +15,9 @@
 """
 CI check script for patchgen determinism.
 
-Discovers all patch gen configs, regenerates each one, runs ruff check --fix
-and ruff format on the output, then compares against the checked-in .py and
-.diff files.  Exits 1 if any drift is detected.
+Discovers all patch gen configs (default: VeOmni's own), regenerates each
+one, normalizes the output through the shared ruff pipeline, and compares
+against the checked-in ``.py`` and ``.diff`` files. Exits 1 on any drift.
 
 Usage:
     # Check mode (CI) - exits 1 on drift
@@ -25,64 +25,61 @@ Usage:
 
     # Fix mode - overwrite checked-in files with regenerated output
     python -m veomni.patchgen.check_patchgen --fix
+
+Projects that depend on VeOmni get the same CLI rooted at their own search
+path via :func:`build_cli`, so they can drift-check their own patch configs::
+
+    # <your_project>/patchgen/check_main.py
+    from pathlib import Path
+    from veomni.patchgen.check_patchgen import build_cli
+    from veomni.patchgen.run_codegen import DiscoveryConfig
+
+    main = build_cli(
+        DiscoveryConfig(
+            search_root=Path(__file__).resolve().parent.parent / "models",
+            package_prefix="<your_project>.models",
+            ruff_extra_ignore=("E501",),
+        ),
+        prog_name="<your_project>.patchgen.check",
+    )
 """
+
+from __future__ import annotations
 
 import argparse
 import difflib
-import importlib
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Callable, Optional
 
-from .codegen import ModelingCodeGenerator
+from ._normalize import ruff_fix_and_format
+from .codegen import ModelingCodeGenerator, load_patch_config_module
 from .run_codegen import (
+    VEOMNI_DISCOVERY,
+    DiscoveryConfig,
     build_unified_diff,
     default_diff_path,
     default_output_dir_for_module,
     list_patch_configs,
+    strip_diff_trailing_ws,
 )
 
 
-def _ruff_fix_and_format(path: Path) -> None:
-    """Run ``ruff check --fix`` and ``ruff format`` on *path*.
-
-    We pass ``--ignore E402,B007`` because generated files may have imports
-    after non-import code (e.g. ``create_patch_from_external`` inline
-    import aliases) which is unavoidable, and upstream Transformers
-    sources may contain unused loop variables that trigger ``B007``.
-    In the real repo this is handled by per-file-ignores in
-    pyproject.toml, but temp files live outside the project tree so the
-    config does not apply.
-    """
-    subprocess.run(
-        ["ruff", "check", "--fix", "--quiet", "--ignore", "E402,B007", str(path)],
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["ruff", "format", "--quiet", str(path)],
-        check=True,
-        capture_output=True,
-    )
-
-
-def _strip_trailing_ws(text: str) -> str:
-    """Strip trailing whitespace from every line.
-
-    Unified diffs produced by :func:`difflib.unified_diff` leave trailing
-    spaces on context lines which editors and pre-commit hooks may strip,
-    causing spurious drift.
-    """
-    return "\n".join(line.rstrip() for line in text.splitlines()) + "\n" if text else text
-
-
-def check_config(module_name: str, *, fix: bool = False) -> bool:
+def check_config(
+    module_name: str,
+    *,
+    fix: bool = False,
+    ruff_extra_ignore: tuple[str, ...] = (),
+    ruff_isolated: bool = False,
+) -> bool:
     """Check a single config for drift.
 
     Returns True when the checked-in files are up to date (or were fixed).
     """
-    module = importlib.import_module(module_name)
+    # Use the patchgen-aware loader so parent ``__init__.py`` side effects
+    # (heavy 3rdparty imports) don't gate the drift check.
+    module = load_patch_config_module(module_name)
     config = module.config
 
     output_dir = default_output_dir_for_module(module)
@@ -99,14 +96,13 @@ def check_config(module_name: str, *, fix: bool = False) -> bool:
         tmp_path = Path(tmp.name)
 
     try:
-        # -- run ruff on temp file to normalize style ---------------------------
-        _ruff_fix_and_format(tmp_path)
+        ruff_fix_and_format(tmp_path, extra_ignore=ruff_extra_ignore or None, isolated=ruff_isolated)
         normalized_py = tmp_path.read_text()
     finally:
         tmp_path.unlink(missing_ok=True)
 
     # -- generate diff ----------------------------------------------------------
-    normalized_diff = _strip_trailing_ws(
+    normalized_diff = strip_diff_trailing_ws(
         build_unified_diff(
             original_source=generator.source_code,
             generated_source=normalized_py,
@@ -118,11 +114,7 @@ def check_config(module_name: str, *, fix: bool = False) -> bool:
     # -- compare ----------------------------------------------------------------
     ok = True
 
-    if checked_in_py.exists():
-        existing_py = checked_in_py.read_text()
-    else:
-        existing_py = ""
-
+    existing_py = checked_in_py.read_text() if checked_in_py.exists() else ""
     if existing_py != normalized_py:
         if fix:
             checked_in_py.parent.mkdir(parents=True, exist_ok=True)
@@ -140,11 +132,7 @@ def check_config(module_name: str, *, fix: bool = False) -> bool:
             print(f"  DRIFT {checked_in_py}")
             sys.stdout.writelines(diff)
 
-    if checked_in_diff.exists():
-        existing_diff = _strip_trailing_ws(checked_in_diff.read_text())
-    else:
-        existing_diff = ""
-
+    existing_diff = strip_diff_trailing_ws(checked_in_diff.read_text()) if checked_in_diff.exists() else ""
     if existing_diff != normalized_diff:
         if fix:
             checked_in_diff.parent.mkdir(parents=True, exist_ok=True)
@@ -167,16 +155,20 @@ def check_config(module_name: str, *, fix: bool = False) -> bool:
     return ok
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Check patchgen generated files for drift")
-    parser.add_argument(
-        "--fix",
-        action="store_true",
-        help="Overwrite checked-in files with regenerated output",
-    )
-    args = parser.parse_args()
+def run_check(
+    discovery: DiscoveryConfig = VEOMNI_DISCOVERY,
+    *,
+    fix: bool = False,
+    configs: Optional[list[str]] = None,
+) -> int:
+    """Run a drift check across ``configs`` (or auto-discover via ``discovery``).
 
-    configs = list_patch_configs()
+    Returns a process exit code (0 = clean / fixed, 1 = drift in check mode,
+    0 if no configs found at all).
+    """
+    if configs is None:
+        configs = list_patch_configs(discovery)
+
     if not configs:
         print("No patch configs found.")
         return 0
@@ -185,7 +177,12 @@ def main() -> int:
     all_ok = True
     for cfg in configs:
         print(f"[{cfg}]")
-        ok = check_config(cfg, fix=args.fix)
+        ok = check_config(
+            cfg,
+            fix=fix,
+            ruff_extra_ignore=discovery.ruff_extra_ignore,
+            ruff_isolated=discovery.ruff_isolated,
+        )
         if not ok:
             all_ok = False
 
@@ -193,9 +190,46 @@ def main() -> int:
     if all_ok:
         print("All generated files are up to date.")
         return 0
-    else:
-        print("Generated files are out of date. Run: python -m veomni.patchgen.check_patchgen --fix")
-        return 1
+    print("Generated files are out of date. Re-run with --fix.")
+    return 1
+
+
+def _build_parser(prog_name: Optional[str] = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=prog_name,
+        description="Check patchgen generated files for drift",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Overwrite checked-in files with regenerated output",
+    )
+    return parser
+
+
+def build_cli(
+    discovery: DiscoveryConfig,
+    prog_name: Optional[str] = None,
+) -> Callable[[Optional[list[str]]], int]:
+    """Return a ``main()``-shaped callable that runs a drift check rooted at
+    ``discovery``.
+
+    Downstream projects mount their own ``python -m <pkg>.patchgen.check``
+    CLI without copy-pasting argparse.
+    """
+    parser = _build_parser(prog_name=prog_name)
+
+    def _main(argv: Optional[list[str]] = None) -> int:
+        args = parser.parse_args(argv)
+        return run_check(discovery, fix=args.fix)
+
+    return _main
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    return run_check(VEOMNI_DISCOVERY, fix=args.fix)
 
 
 if __name__ == "__main__":

--- a/veomni/patchgen/codegen.py
+++ b/veomni/patchgen/codegen.py
@@ -28,9 +28,12 @@ The generated file will:
 
 import ast
 import importlib
+import importlib.util
 import inspect
 import re
+import sys
 import textwrap
+import types
 from pathlib import Path
 from typing import Any, Optional
 
@@ -41,6 +44,24 @@ class CodegenError(Exception):
     """Exception raised during code generation."""
 
     pass
+
+
+def _find_module_file(module_name: str) -> Optional[Path]:
+    """Walk ``sys.path`` (and CWD) to locate ``module_name`` as a ``.py`` file.
+
+    Returns the first matching path or ``None`` when nothing is found. We do
+    not import the module — important for drift checking from CI lint envs
+    where the upstream HF modeling file would otherwise pull in ``torch`` /
+    GPU kernels just to read its source.
+    """
+    parts = module_name.split(".")
+    rel = Path(*parts).with_suffix(".py")
+    candidates = [Path(root) / rel for root in sys.path if root]
+    candidates.append(Path.cwd() / rel)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def get_module_source(module_name: str) -> str:
@@ -54,8 +75,24 @@ def get_module_source(module_name: str) -> str:
         The source code as a string.
 
     Raises:
-        CodegenError: If the module cannot be imported or source cannot be obtained.
+        CodegenError: If the source cannot be obtained.
+
+    Resolution order:
+        1. File-walk ``sys.path`` (and CWD) for ``module_name``'s ``.py`` file
+           and read it directly — does NOT import the module. This lets drift
+           checks run in lightweight envs that don't have the module's runtime
+           dependencies (torch, transformers) installed.
+        2. Fall back to ``importlib.import_module`` + ``inspect.getsource`` for
+           namespace packages, ``.pyc``-only installs, or anything else that
+           the file walk cannot resolve.
     """
+    file_path = _find_module_file(module_name)
+    if file_path is not None:
+        try:
+            return file_path.read_text()
+        except OSError as e:
+            raise CodegenError(f"Cannot read source for '{module_name}' at {file_path}: {e}") from e
+
     try:
         module = importlib.import_module(module_name)
     except ImportError as e:
@@ -67,6 +104,75 @@ def get_module_source(module_name: str) -> str:
         raise CodegenError(f"Cannot get source for module '{module_name}': {e}") from e
 
     return source
+
+
+def load_patch_config_module(module_name: str, search_roots: Optional[list[Path]] = None) -> types.ModuleType:
+    """Load a patch-config module via ``spec_from_file_location`` when possible.
+
+    The benefit kicks in when the patch config is **self-contained** —
+    i.e. its body only imports from ``veomni.patchgen`` and third-party
+    libraries, with no imports from its own package or siblings. In that
+    case the loader skips executing the config's package ``__init__.py``
+    (which a downstream project might use to register custom HF models,
+    pull in custom CUDA kernels, etc.).
+
+    Configs that **do** import siblings under the same package re-trigger
+    that package's ``__init__.py``. This is unavoidable: Python's import
+    machinery always materializes parent packages when resolving any
+    sub-package name, whether the import is relative
+    (``from .sibling import ...``) or fully qualified
+    (``from <pkg>.sibling import ...``). Once a parent is cached in
+    ``sys.modules`` (e.g. an earlier config under the same parent was
+    already loaded), subsequent loads no-op the parent.
+
+    Note: importing the patchgen library itself still runs
+    ``veomni/__init__.py``, so VeOmni's own runtime (torch, op patches) is
+    a hard prerequisite for using this function. The "skip parent
+    ``__init__``" benefit is scoped to the patch config's own package.
+
+    Resolution order:
+      1. If ``module_name`` maps to a file on disk under ``search_roots`` /
+         ``sys.path`` / CWD, load it via ``importlib.util.spec_from_file_location``.
+      2. Otherwise fall back to ordinary ``importlib.import_module``.
+
+    Contract: every call re-executes the file and overwrites
+    ``sys.modules[module_name]``. Callers must not cache class objects
+    returned from one call and reuse them after a subsequent call for the
+    same name — the cached classes belong to a stale module instance.
+    """
+    parts = module_name.split(".")
+    rel = Path(*parts).with_suffix(".py")
+    candidates: list[Path] = []
+    if search_roots:
+        candidates.extend(root / rel for root in search_roots)
+    candidates.extend(Path(p) / rel for p in sys.path if p)
+    candidates.append(Path.cwd() / rel)
+
+    file_path = next((p for p in candidates if p.is_file()), None)
+    if file_path is None:
+        return importlib.import_module(module_name)
+
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        return importlib.import_module(module_name)
+
+    mod = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec so:
+    #   1. inspect.getsource(cls) on classes defined inside ``mod`` succeeds
+    #      — inspect resolves source via ``sys.modules[cls.__module__].__file__``,
+    #      so an unregistered leaf breaks ``@config.replace_class`` codegen.
+    #   2. classes inside ``mod`` that reference each other via dotted name
+    #      can resolve those references during decoration.
+    # Skipping parent ``__init__.py`` execution (the whole point of this
+    # loader) still works: Python does not lazily import parents when the
+    # leaf is already registered.
+    sys.modules[module_name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return mod
 
 
 def _unwrap_to_inspectable(obj: Any) -> Any:

--- a/veomni/patchgen/codegen.py
+++ b/veomni/patchgen/codegen.py
@@ -166,11 +166,18 @@ def load_patch_config_module(module_name: str, search_roots: Optional[list[Path]
     # Skipping parent ``__init__.py`` execution (the whole point of this
     # loader) still works: Python does not lazily import parents when the
     # leaf is already registered.
+    # Stash the previous entry (if any) so we restore it on exec failure
+    # instead of leaking a missing key — otherwise a partially-loaded
+    # second call would wipe out the previous successful load.
+    previous = sys.modules.get(module_name)
     sys.modules[module_name] = mod
     try:
         spec.loader.exec_module(mod)
     except Exception:
-        sys.modules.pop(module_name, None)
+        if previous is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous
         raise
     return mod
 

--- a/veomni/patchgen/codegen.py
+++ b/veomni/patchgen/codegen.py
@@ -89,7 +89,7 @@ def get_module_source(module_name: str) -> str:
     file_path = _find_module_file(module_name)
     if file_path is not None:
         try:
-            return file_path.read_text()
+            return file_path.read_text(encoding="utf-8")
         except OSError as e:
             raise CodegenError(f"Cannot read source for '{module_name}' at {file_path}: {e}") from e
 
@@ -1230,7 +1230,7 @@ class ModelingCodeGenerator:
         # 5. Write to file if path provided
         if output_path:
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(output)
+            output_path.write_text(output, encoding="utf-8")
             print(f"Generated: {output_path}")
 
         return output

--- a/veomni/patchgen/run_codegen.py
+++ b/veomni/patchgen/run_codegen.py
@@ -109,9 +109,17 @@ class DiscoveryConfig:
         ``sys.path`` (e.g. fresh clone, sandboxed CI). For
         ``DiscoveryConfig(search_root=Path('X/myproj/models'),
         package_prefix='myproj.models')`` this returns ``Path('X')``.
+
+        ``search_root`` is ``.resolve()``-d first so a relative input like
+        ``Path('models')`` whose ``parents`` chain is shorter than
+        ``len(package_prefix.split('.'))`` does not raise ``IndexError``.
+        Resolving against CWD also matches how a user would normally
+        construct a relative path here (e.g. running the CLI from the
+        project root).
         """
         depth = len(self.package_prefix.split("."))
-        return self.search_root.parents[depth - 1] if depth > 0 else self.search_root
+        resolved = self.search_root.resolve()
+        return resolved.parents[depth - 1] if depth > 0 else resolved
 
 
 # VeOmni's own discovery — used by this module's CLI.
@@ -340,7 +348,7 @@ def run_codegen(
             extra_ignore=ruff_extra_ignore or None,
             isolated=ruff_isolated,
         )
-        output = output_path.read_text()
+        output = output_path.read_text(encoding="utf-8")
 
         print(f"\n✓ Generated: {output_path}")
         print(f"  Lines: {len(output.splitlines())}")
@@ -355,7 +363,7 @@ def run_codegen(
                 )
             )
             diff_path = default_diff_path(output_dir, config.target_file)
-            diff_path.write_text(diff_output)
+            diff_path.write_text(diff_output, encoding="utf-8")
             print(f"✓ Diff: {diff_path}")
             print(f"  Lines: {len(diff_output.splitlines())}")
 

--- a/veomni/patchgen/run_codegen.py
+++ b/veomni/patchgen/run_codegen.py
@@ -33,24 +33,78 @@ Usage:
 
     # Generate modeling code and save unified diff alongside it
     python -m veomni.patchgen.run_codegen veomni.models.transformers.qwen3.qwen3_gpu_patch_gen_config --diff
+
+Projects that depend on VeOmni can mount their own CLI rooted at their own
+search path via :func:`build_cli`, so they patch their own models without
+copy-pasting the runner::
+
+    # <your_project>/patchgen/__main__.py
+    from pathlib import Path
+    from veomni.patchgen.run_codegen import build_cli, DiscoveryConfig
+
+    main = build_cli(
+        DiscoveryConfig(
+            search_root=Path(__file__).resolve().parent.parent / "models",
+            package_prefix="<your_project>.models",
+        ),
+        prog_name="<your_project>.patchgen",
+    )
+    if __name__ == "__main__":
+        raise SystemExit(main())
 """
+
+from __future__ import annotations
 
 import argparse
 import difflib
-import importlib
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
-from .codegen import CodegenError, ModelingCodeGenerator
+from ._normalize import ruff_fix_and_format
+from .codegen import CodegenError, ModelingCodeGenerator, load_patch_config_module
 from .patch_spec import PatchConfig
 
 
 MODULE_DIR = Path(__file__).parent
 VEOMNI_DIR = MODULE_DIR.parent
-MODELS_DIR = VEOMNI_DIR / "models" / "transformers"
 PACKAGE_NAME = __package__ or "veomni.patchgen"
-PATCHES_PACKAGE = "veomni.models.transformers.qwen3.patches"
+
+
+@dataclass(frozen=True)
+class DiscoveryConfig:
+    """Where to find ``*_patch_gen_config.py`` files and how to name them.
+
+    Args:
+        search_root: directory to walk for ``*_patch_gen_config.py`` files.
+        package_prefix: dotted package prefix prepended to each file's path
+            relative to ``search_root`` to form an importable module name.
+            For VeOmni's own configs: ``search_root=veomni/models/transformers``
+            + ``package_prefix="veomni.models.transformers"``.
+        legacy_patches_prefix: optional shortcut prefix that callers can use on
+            the CLI. VeOmni keeps ``"patches.<name>"`` as legacy shorthand for
+            ``"veomni.models.transformers.qwen3.patches.<name>"``; downstream
+            projects typically leave this ``None``.
+        ruff_extra_ignore: ruff codes to add on top of the default
+            ``E402,B007`` when normalizing generated files. Downstream callers
+            whose ``pyproject.toml`` does NOT globally ignore ``E501`` should
+            set ``("E501",)`` here.
+    """
+
+    search_root: Path
+    package_prefix: str
+    legacy_patches_prefix: Optional[str] = None
+    ruff_extra_ignore: tuple[str, ...] = ()
+    ruff_isolated: bool = False  # pass --isolated to ruff (line-length 88, no project config)
+
+
+# VeOmni's own discovery — used by this module's CLI.
+VEOMNI_DISCOVERY = DiscoveryConfig(
+    search_root=VEOMNI_DIR / "models" / "transformers",
+    package_prefix="veomni.models.transformers",
+    legacy_patches_prefix="veomni.models.transformers.qwen3.patches",
+)
 
 
 def build_unified_diff(
@@ -79,41 +133,68 @@ def default_diff_path(output_dir: Path, target_file: str) -> Path:
     return output_dir / Path(target_file).with_suffix(".diff").name
 
 
-def list_patch_configs(models_dir: Path = MODELS_DIR) -> list[str]:
-    """List all available patch configurations under veomni/models/transformers.
+def strip_diff_trailing_ws(text: str) -> str:
+    """Strip trailing whitespace from every line.
 
-    Configs live at the model root (e.g. ``qwen3/qwen3_gpu_patch_gen_config.py``),
-    not inside ``patches/`` subdirectories.  We discover them by globbing for
-    ``*_patch_gen_config.py`` recursively.
+    Unified diffs produced by :func:`difflib.unified_diff` leave a single
+    trailing space on context lines whose source line was empty. Editors
+    and pre-commit hooks routinely strip that, so without this normalization
+    the freshly-written ``.diff`` would drift the moment any editor touches
+    it.
     """
-    configs = []
-    if not models_dir.exists():
+    return "\n".join(line.rstrip() for line in text.splitlines()) + "\n" if text else text
+
+
+def list_patch_configs(discovery: DiscoveryConfig = VEOMNI_DISCOVERY) -> list[str]:
+    """Discover ``*_patch_gen_config.py`` files under ``discovery.search_root``.
+
+    Each file's path relative to ``search_root`` is joined with
+    ``discovery.package_prefix`` to form the importable module name. The
+    module is then imported (via :func:`load_patch_config_module`, so parent
+    ``__init__.py`` side effects are bypassed) and kept only if it exposes a
+    ``config`` attribute of type :class:`PatchConfig`.
+    """
+    configs: list[str] = []
+    if not discovery.search_root.exists():
         return configs
 
-    for py_file in sorted(models_dir.rglob("*_patch_gen_config.py")):
+    for py_file in sorted(discovery.search_root.rglob("*_patch_gen_config.py")):
         if py_file.name.startswith("_"):
             continue
-        module_path = py_file.relative_to(VEOMNI_DIR).with_suffix("")
-        module_name = ".".join(("veomni",) + module_path.parts)
+        rel_path = py_file.relative_to(discovery.search_root).with_suffix("")
+        module_name = ".".join((discovery.package_prefix, *rel_path.parts))
         try:
-            module = importlib.import_module(module_name)
-            if hasattr(module, "config") and isinstance(module.config, PatchConfig):
-                configs.append(module_name)
+            module = load_patch_config_module(module_name)
         except ImportError:
             continue
+        if hasattr(module, "config") and isinstance(module.config, PatchConfig):
+            configs.append(module_name)
 
     return configs
 
 
-def normalize_patch_module(patch_module: str) -> str:
+def normalize_patch_module(patch_module: str, discovery: DiscoveryConfig = VEOMNI_DISCOVERY) -> str:
+    """Apply VeOmni-flavored shortcuts to ``patch_module``.
+
+    - Fully-qualified ``veomni.patchgen.<X>`` is returned unchanged.
+    - ``patches.<X>`` is expanded to ``discovery.legacy_patches_prefix.<X>``
+      when a ``legacy_patches_prefix`` is defined.
+    - Anything else is returned unchanged.
+    """
     if patch_module.startswith(f"{PACKAGE_NAME}."):
         return patch_module
-    if patch_module.startswith("patches."):
-        return f"{PATCHES_PACKAGE}.{patch_module.removeprefix('patches.')}"
+    if discovery.legacy_patches_prefix and patch_module.startswith("patches."):
+        return f"{discovery.legacy_patches_prefix}.{patch_module.removeprefix('patches.')}"
     return patch_module
 
 
 def default_output_dir_for_module(module: object) -> Path:
+    """``<patch_module_dir>/generated/``, with ``patches/`` parents collapsed.
+
+    If the patch module lives in a ``patches/`` subdirectory (the legacy
+    VeOmni layout), the generated/ dir sits next to that subdir. Otherwise
+    it sits directly next to the config file.
+    """
     module_path = Path(module.__file__).resolve()
     if module_path.parent.name == "patches":
         return module_path.parent.parent / "generated"
@@ -152,6 +233,9 @@ def run_codegen(
     dry_run: bool = False,
     save_diff: bool = False,
     verbose: bool = False,
+    ruff_extra_ignore: tuple[str, ...] = (),
+    ruff_isolated: bool = False,
+    discovery: DiscoveryConfig = VEOMNI_DISCOVERY,
 ) -> Optional[str]:
     """
     Run code generation for a patch configuration.
@@ -163,15 +247,40 @@ def run_codegen(
         dry_run: If True, don't write files
         save_diff: If True, save a unified diff alongside the generated modeling file
         verbose: If True, print detailed progress
+        ruff_extra_ignore: extra ruff codes passed through to
+            :func:`ruff_fix_and_format`. Use this when the caller's
+            ``pyproject.toml`` differs from VeOmni's (e.g. no global E501
+            ignore).
+        discovery: discovery config used to expand the legacy
+            ``patches.<name>`` shorthand. Defaults to ``VEOMNI_DISCOVERY``
+            so direct VeOmni Python-API callers keep working unchanged.
+            Projects depending on VeOmni that hold their own legacy
+            shorthand should pass their own ``DiscoveryConfig``.
 
     Returns:
-        The generated source code, or None on error
+        The generated source code (post-normalization), or None on error.
+
+    Notes:
+        The written file is normalized via ``ruff check --fix`` + ``ruff
+        format`` before this function returns, and the ``.diff`` (when
+        ``save_diff=True``) is built from the normalized form. This guarantees
+        ``run_codegen`` output matches what :mod:`check_patchgen` validates
+        against — so a fresh regen never produces immediate drift.
     """
     try:
-        # Import the patch module
+        # Preserve the legacy ``patches.<name>`` shorthand for direct
+        # Python-API callers (the pre-refactor ``run_codegen`` used to do
+        # this internally). CLI entrypoints already normalize earlier
+        # against their own ``DiscoveryConfig``; for them this call is a
+        # no-op because the input is already fully qualified. Projects whose
+        # discovery sets no ``legacy_patches_prefix`` are also unaffected.
+        patch_module = normalize_patch_module(patch_module, discovery)
         if verbose:
             print(f"Loading patch module: {patch_module}")
-        module = importlib.import_module(normalize_patch_module(patch_module))
+        # Use spec_from_file_location so heavy parent __init__.py side effects
+        # (model registries, torch kernels, ...) are not triggered just to read
+        # the config object.
+        module = load_patch_config_module(patch_module)
         config = getattr(module, config_name)
 
         if output_dir is None:
@@ -202,17 +311,30 @@ def run_codegen(
 
         # Actually generate
         output_path = output_dir / config.target_file
-        output = generator.generate(output_path)
+        generator.generate(output_path)
+
+        # Normalize via the same ruff pipeline that check_patchgen validates
+        # against. Without this, raw codegen output can drift from the
+        # committed form whenever ruff would rewrite a single line, and a
+        # contributor running run_codegen would commit immediate drift.
+        ruff_fix_and_format(
+            output_path,
+            extra_ignore=ruff_extra_ignore or None,
+            isolated=ruff_isolated,
+        )
+        output = output_path.read_text()
 
         print(f"\n✓ Generated: {output_path}")
         print(f"  Lines: {len(output.splitlines())}")
 
         if save_diff:
-            diff_output = build_unified_diff(
-                original_source=generator.source_code,
-                generated_source=output,
-                source_module=config.source_module,
-                target_file=config.target_file,
+            diff_output = strip_diff_trailing_ws(
+                build_unified_diff(
+                    original_source=generator.source_code,
+                    generated_source=output,
+                    source_module=config.source_module,
+                    target_file=config.target_file,
+                )
             )
             diff_path = default_diff_path(output_dir, config.target_file)
             diff_path.write_text(diff_output)
@@ -236,16 +358,17 @@ def run_codegen(
         return None
 
 
-def main():
+def _build_parser(prog_name: Optional[str] = None) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
+        prog=prog_name,
         description="Modeling Code Generator - Generate patched HuggingFace modeling code",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s veomni.models.transformers.qwen3.qwen3_gpu_patch_gen_config
-  %(prog)s veomni.models.transformers.qwen3.qwen3_gpu_patch_gen_config -o /path/to/output
-  %(prog)s veomni.models.transformers.qwen3.qwen3_gpu_patch_gen_config --dry-run
-  %(prog)s veomni.models.transformers.qwen3.qwen3_gpu_patch_gen_config --diff
+  %(prog)s <patch_module>
+  %(prog)s <patch_module> -o /path/to/output
+  %(prog)s <patch_module> --dry-run
+  %(prog)s <patch_module> --diff
   %(prog)s --list
         """,
     )
@@ -294,27 +417,30 @@ Examples:
         action="store_true",
         help="Print detailed progress",
     )
+    return parser
 
-    args = parser.parse_args()
 
-    # List mode
+def _run_with_discovery(
+    args: argparse.Namespace,
+    discovery: DiscoveryConfig,
+    parser: argparse.ArgumentParser,
+) -> int:
     if args.list:
         print("Available patch configurations:")
-        configs = list_patch_configs()
+        configs = list_patch_configs(discovery)
         if configs:
-            for config in configs:
-                print(f"  • {config}")
+            for cfg in configs:
+                print(f"  • {cfg}")
         else:
             print("  (none found)")
         return 0
 
-    # --all mode: regenerate every discovered config
     if args.all:
-        configs = list_patch_configs()
+        configs = list_patch_configs(discovery)
         if not configs:
             print("No patch configs found.", file=sys.stderr)
             return 1
-        failed = []
+        failed: list[str] = []
         for cfg in configs:
             print(f"\n{'=' * 70}")
             print(f"Generating: {cfg}")
@@ -326,6 +452,9 @@ Examples:
                 dry_run=args.dry_run,
                 save_diff=args.diff,
                 verbose=args.verbose,
+                ruff_extra_ignore=discovery.ruff_extra_ignore,
+                ruff_isolated=discovery.ruff_isolated,
+                discovery=discovery,
             )
             if result is None:
                 failed.append(cfg)
@@ -335,21 +464,50 @@ Examples:
         print(f"\nAll {len(configs)} configs generated successfully.")
         return 0
 
-    # Require patch_module for generation
     if not args.patch_module:
+        # ``parser.error`` writes the standard ``usage:`` line and exits 2,
+        # matching argparse's own missing-argument behavior so the CLI UX
+        # stays consistent across the various error paths.
         parser.error("patch_module is required unless using --list or --all")
 
-    # Run generation
     result = run_codegen(
-        patch_module=normalize_patch_module(args.patch_module),
+        patch_module=args.patch_module,
         output_dir=args.output_dir,
         config_name=args.config_name,
         dry_run=args.dry_run,
         save_diff=args.diff,
         verbose=args.verbose,
+        ruff_extra_ignore=discovery.ruff_extra_ignore,
+        ruff_isolated=discovery.ruff_isolated,
+        discovery=discovery,
     )
 
     return 0 if result else 1
+
+
+def build_cli(
+    discovery: DiscoveryConfig,
+    prog_name: Optional[str] = None,
+) -> Callable[[Optional[list[str]]], int]:
+    """Return a ``main()``-shaped callable that runs a run_codegen CLI rooted
+    at ``discovery``.
+
+    Projects that depend on VeOmni mount their own ``python -m <pkg>.patchgen``
+    CLI without copy-pasting argparse. See module docstring for the recipe.
+    """
+    parser = _build_parser(prog_name=prog_name)
+
+    def _main(argv: Optional[list[str]] = None) -> int:
+        args = parser.parse_args(argv)
+        return _run_with_discovery(args, discovery, parser)
+
+    return _main
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    return _run_with_discovery(args, VEOMNI_DISCOVERY, parser)
 
 
 if __name__ == "__main__":

--- a/veomni/patchgen/run_codegen.py
+++ b/veomni/patchgen/run_codegen.py
@@ -98,6 +98,21 @@ class DiscoveryConfig:
     ruff_extra_ignore: tuple[str, ...] = ()
     ruff_isolated: bool = False  # pass --isolated to ruff (line-length 88, no project config)
 
+    @property
+    def package_root(self) -> Path:
+        """Filesystem directory that holds the **first segment** of
+        ``package_prefix`` — i.e. the directory that must be on ``sys.path``
+        for the package's modules to import normally.
+
+        Used to seed ``load_patch_config_module(search_roots=...)`` so the
+        file-walk works even when the project is not installed on
+        ``sys.path`` (e.g. fresh clone, sandboxed CI). For
+        ``DiscoveryConfig(search_root=Path('X/myproj/models'),
+        package_prefix='myproj.models')`` this returns ``Path('X')``.
+        """
+        depth = len(self.package_prefix.split("."))
+        return self.search_root.parents[depth - 1] if depth > 0 else self.search_root
+
 
 # VeOmni's own discovery — used by this module's CLI.
 VEOMNI_DISCOVERY = DiscoveryConfig(
@@ -158,13 +173,14 @@ def list_patch_configs(discovery: DiscoveryConfig = VEOMNI_DISCOVERY) -> list[st
     if not discovery.search_root.exists():
         return configs
 
+    search_roots = [discovery.package_root]
     for py_file in sorted(discovery.search_root.rglob("*_patch_gen_config.py")):
         if py_file.name.startswith("_"):
             continue
         rel_path = py_file.relative_to(discovery.search_root).with_suffix("")
         module_name = ".".join((discovery.package_prefix, *rel_path.parts))
         try:
-            module = load_patch_config_module(module_name)
+            module = load_patch_config_module(module_name, search_roots=search_roots)
         except ImportError:
             continue
         if hasattr(module, "config") and isinstance(module.config, PatchConfig):
@@ -279,8 +295,10 @@ def run_codegen(
             print(f"Loading patch module: {patch_module}")
         # Use spec_from_file_location so heavy parent __init__.py side effects
         # (model registries, torch kernels, ...) are not triggered just to read
-        # the config object.
-        module = load_patch_config_module(patch_module)
+        # the config object. ``discovery.package_root`` seeds the loader's
+        # search path so projects that aren't installed on ``sys.path`` still
+        # resolve the patch config file.
+        module = load_patch_config_module(patch_module, search_roots=[discovery.package_root])
         config = getattr(module, config_name)
 
         if output_dir is None:


### PR DESCRIPTION
### What does this PR do?

> Turn `veomni/patchgen/` from a VeOmni-internal CLI into a reusable
> library so projects depending on VeOmni can patchgen their own
> models in their own repos — without copy-pasting argparse, the codegen
> pipeline, or the drift-check logic.

### Checklist Before Starting

- Search for relative PRs/issues and link here: builds on the patchgen capability introduced in #486 and the CI verifier in #559.
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))

### Test

> - `make quality` — ruff check + format, all clean.
> - `python -m veomni.patchgen.check_patchgen` — 0 drift across all 22
>   `*_patch_gen_config.py` files. Generated modeling files are
>   byte-for-byte identical to `main`.
> - End-to-end smoke test simulating a downstream project: instantiate
>   `DiscoveryConfig` pointing to a temporary repo, mount
>   `build_run_codegen_cli` / `build_check_cli`, verify `list_patch_configs`
>   honors the downstream search root (does NOT walk VeOmni's tree), and
>   verify `load_patch_config_module` skips the downstream package's
>   `__init__.py` for a self-contained config (the test puts a
>   `raise RuntimeError(...)` in the package init and confirms it does
>   not fire).
> - CLI smoke: `python -m veomni.patchgen.run_codegen` (no args) emits
>   the standard argparse `usage:` line + the missing-arg error
>   (regression fix vs. the bare `print + return 2` introduced earlier
>   in the branch).

### API and Usage Example

> Public surface in `veomni.patchgen`:
>
> - `DiscoveryConfig(search_root, package_prefix, legacy_patches_prefix=None, ruff_extra_ignore=(), ruff_isolated=False)`
> - `build_run_codegen_cli(discovery, prog_name=...)` → `main()`-shaped callable
> - `build_check_cli(discovery, prog_name=...)` → `main()`-shaped callable
> - `run_codegen(patch_module, output_dir, ..., discovery=VEOMNI_DISCOVERY)`
> - `run_check(discovery, fix=False)`
> - `load_patch_config_module(module_name, search_roots=None)`
> - `ruff_fix_and_format(path, extra_ignore=None, isolated=False)`
> - existing: `PatchConfig`, `Patch`, `PatchType`, `ImportSpec`,
>   `PositionedHelper`, `create_patch_from_external`,
>   `ModelingCodeGenerator`, `generate_from_config`, `get_module_source`,
>   `CodegenError`
>
> Recipe for a dependent project (full version in `docs/transformers_v5/patchgen.md`):
>
> ```python
> # <your_project>/patchgen/__main__.py
> from pathlib import Path
> from veomni.patchgen import DiscoveryConfig, build_run_codegen_cli
>
> DISCOVERY = DiscoveryConfig(
>     search_root=Path(__file__).resolve().parents[1] / "models",
>     package_prefix="<your_project>.models",
>     # pyproject does NOT globally ignore E501:
>     ruff_extra_ignore=("E501",),
> )
>
> main = build_run_codegen_cli(DISCOVERY, prog_name="<your_project>.patchgen")
> if __name__ == "__main__":
>     raise SystemExit(main())
> ```
>
> ```python
> # <your_project>/patchgen/check_main.py
> from veomni.patchgen import build_check_cli
> from .__main__ import DISCOVERY
>
> main = build_check_cli(DISCOVERY, prog_name="<your_project>.patchgen.check")
> if __name__ == "__main__":
>     raise SystemExit(main())
> ```

### Design & Code Changes

> - **`_normalize.py` (new)** — shared `ruff_fix_and_format(path, extra_ignore, isolated)` so `run_codegen` (writes a fresh artifact) and `check_patchgen` (validates the committed artifact) apply the same normalization. Without this, a contributor running `run_codegen` could commit a file that immediately fails `check_patchgen` whenever ruff would rewrite a single line.
> - **`run_codegen.py`** — extract `DiscoveryConfig` dataclass + `build_cli(discovery, prog_name=...)` factory. The factory returns a `main()`-shaped callable so a dependent project's `__main__.py` is a one-line wrap. CLI surface (`--list / --all / --dry-run / --diff / <module>`) reused verbatim. The programmatic `run_codegen()` API gained a `discovery=VEOMNI_DISCOVERY` keyword so the legacy `patches.<name>` shorthand expansion honors the caller's discovery instead of hardcoding VeOmni's.
> - **`check_patchgen.py`** — same `build_cli` pattern for the drift checker. `check_config` and the shared diff/ruff helpers are exposed.
> - **`codegen.py`** — add `load_patch_config_module(module_name, search_roots=None)`. Loads the config via `importlib.util.spec_from_file_location` when possible so the config's own package `__init__.py` is skipped for **self-contained configs** (configs that only import from `veomni.patchgen.patch_spec` and external libs). Configs that import siblings under the same package re-trigger that package's `__init__` (unavoidable by Python's import machinery — both relative and fully-qualified sibling imports walk the parent chain); once cached, subsequent loads no-op. Docstring scopes the benefit accurately and documents the "every call re-execs, do not cache class objects across calls" contract.
> - **`__init__.py`** — promote the public surface listed above.
> - **`docs/transformers_v5/patchgen.md`** — add a "Using patchgen from a dependent project" section with the full recipe, ruff_extra_ignore guidance, and the honest scoping of `load_patch_config_module`'s lightweight-env benefit (does NOT obviate torch, which `veomni/__init__.py` requires).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (`make quality` clean)
- [x] Added/updated documentation (`docs/transformers_v5/patchgen.md`)
- [x] Added tests to CI workflow (or explained why not feasible) — covered by existing `check_patchgen` CI gate (introduced in #559); end-to-end downstream simulation included in the PR's Test section above
