### PR TITLE
[config, ci, docs] chore: relax uv pin from ==0.11.16 to a 0.9.8-0.11 range

### DIFF
--- a/.agents/knowledge/uv.md
+++ b/.agents/knowledge/uv.md
@@ -4,13 +4,22 @@ VeOmni uses [uv](https://docs.astral.sh/uv/) for dependency management. This doc
 
 ## uv Version
 
-Pinned to a specific version for reproducibility. **Three locations must stay in sync:**
+`pyproject.toml` constrains uv to a **range** (currently `>=0.9.8,<0.12`, i.e.
+0.9.8 through 0.11.x) so local devs aren't forced onto one weekly uv build —
+they're encouraged to stay reasonably current within it, and the window will be
+tightened later. Reproducibility is preserved because every place that produces
+or consumes the lockfile installs a **concrete**, in-range uv and never
+re-resolves: the Dockerfiles `COPY` a fixed uv and `uv sync --locked`, the
+container CI jobs `uv run --frozen`, and the `check_patchgen` CI job (which runs
+on `ubuntu-latest`, not a prebuilt image) pins uv via `setup-uv`'s `version:`
+input. **Every concrete uv pin must stay inside the pyproject range.**
 
 | Location | Format |
 |----------|--------|
-| `pyproject.toml` -> `[tool.uv]` -> `required-version` | `"==X.Y.Z"` |
-| `docker/cuda/Dockerfile.cu129` | `COPY --from=ghcr.io/astral-sh/uv:X.Y.Z` |
+| `pyproject.toml` -> `[tool.uv]` -> `required-version` | range, e.g. `">=0.9.8,<0.12"` |
+| `docker/cuda/Dockerfile.cu129` | `COPY --from=ghcr.io/astral-sh/uv:X.Y.Z` (concrete, inside range) |
 | `docker/ascend/Dockerfile.*` | same pattern |
+| `.github/workflows/check_patchgen.yml` | `setup-uv` `version: "X.Y.Z"` (concrete, inside range) |
 
 ## Dependency Layout
 
@@ -88,6 +97,6 @@ uv sync --locked --all-packages --extra gpu --dev
 1. **Always commit `uv.lock` with `pyproject.toml`** — Docker builds use `--locked`.
 2. **torch version changes touch 4+ places** in pyproject.toml (extras, overrides, sources, wheel URL).
 3. **flash-attn wheels are torch-version-specific** — bumping torch requires new wheels.
-4. **uv version changes require Docker rebuilds** — update Dockerfiles and release new images.
+4. **uv version changes require Docker rebuilds** — update Dockerfiles and release new images. The Dockerfile uv pin must stay inside the `required-version` range in `pyproject.toml`.
 5. **`override-dependencies` markers are load-bearing** — the `extra == 'gpu'` guards prevent uv from downloading wrong torch variants.
 6. **`transformers==5.9.0` is the only supported version** — pinned via the `transformers-stable` default dependency group. New code targets v5 APIs (FSDP2 + patchgen-generated modeling) only.

--- a/.github/workflows/check_patchgen.yml
+++ b/.github/workflows/check_patchgen.yml
@@ -31,6 +31,13 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
+        with:
+          # Pin a concrete uv inside the pyproject required-version range
+          # (>=0.9.8,<0.12). This job runs on ubuntu-latest (not a prebuilt
+          # image), so without a pin setup-uv floats to the newest uv and would
+          # fail the required-version check the moment uv ships a release above
+          # the range ceiling. Keep this in sync with the docker/ uv pin.
+          version: "0.11.16"
 
       - name: Check patchgen drift
         run: uv run --extra gpu --dev python -m veomni.patchgen.check_patchgen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,13 +158,19 @@ transformers-stable = [
 ]
 
 [tool.uv]
-# This locks the uv version so that we have a consistent uv behavior across the board.
-# Inconsistent uv versions might generate different uv lock files which creates chaos.
+# Accept a range of uv versions rather than an exact pin. Supported range:
+# 0.9.8 through 0.11.x; developers are encouraged to stay reasonably current
+# within it. An exact pin goes stale almost immediately (uv ships weekly —
+# 0.11.17 landed days after we pinned 0.11.16) and needlessly blocks local
+# devs whose uv differs by a patch release. This window will be tightened
+# again later.
 #
-# NOTE 1: Update this at least once per month as uv releases new version every week.
-# NOTE 2: When updating this line, make sure to update Dockerfile under docker/ to the same
-#         version and release new docker images.
-required-version = "==0.11.16"
+# Reproducibility is preserved because CI and the docker/ images install a
+# concrete, in-range uv (currently 0.11.16) and never re-resolve the lockfile
+# (docker: `uv sync --locked`; CI: `uv run --frozen`). Those concrete uv pins
+# — the docker/ Dockerfiles and .github/workflows/check_patchgen.yml — must
+# stay inside this range.
+required-version = ">=0.9.8,<0.12"
 no-build-isolation-package = [
     "flash-attn",
     "flash-attn-3",


### PR DESCRIPTION
### What does this PR do?

> Relaxes the uv version requirement from an exact pin (`==0.11.16`) to a range
> (`>=0.9.8,<0.12`, i.e. 0.9.8 through 0.11.x).
>
> An exact pin forces every local dev onto a single weekly uv build and goes
> stale almost immediately — uv 0.11.17 shipped days after we pinned 0.11.16,
> so anyone on a slightly different patch release is blocked from `uv sync`.
> The range lets devs stay on any 0.9.8–0.11.x build (they're encouraged to
> stay reasonably current); the window will be tightened again later.
>
> Reproducibility is unaffected: every place that produces or consumes the
> lockfile still installs a concrete, in-range uv and never re-resolves — the
> `docker/` images `COPY` a fixed uv + `uv sync --locked`, and the container CI
> jobs use `uv run --frozen`. `uv.lock` is unchanged by this PR (the uv
> `required-version` field does not enter the lockfile).

### Checklist Before Starting

- Search for related PRs/issues: follow-up to #782 (the `==0.9.8 -> ==0.11.16` bump).
- PR title follows `[{modules}] {type}: {description}` format.

### Test

> No behavior change to the framework. Verified locally:
> - `uv lock --check` → `Resolved 213 packages`, exit 0; `uv.lock` shows no diff.
> - `make quality` → ruff check + format both pass.
> - Installed uv (0.11.16) satisfies the new range.

### API and Usage Example

> N/A — dependency/tooling policy change only.

### High-Level Design / Code Changes

> - `pyproject.toml`: `[tool.uv] required-version` `==0.11.16` → `>=0.9.8,<0.12`;
>   rewrote the surrounding comment to document the supported range, the
>   "stay current / will tighten later" policy, and the concrete in-range pins
>   that preserve reproducibility.
> - `.github/workflows/check_patchgen.yml`: pin `setup-uv` to a concrete
>   in-range uv (`version: "0.11.16"`). This job runs on `ubuntu-latest` (not a
>   prebuilt image), so without a pin `setup-uv` floats to the newest uv and
>   would fail the `required-version` check the moment uv ships a release above
>   the range ceiling. Kept in sync with the `docker/` uv pin.
> - `.agents/knowledge/uv.md`: documented the range + concrete-pin policy and
>   corrected the prior wording that described all CI as `--locked` (container
>   CI actually uses `--frozen`).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added/updated documentation
- [ ] Added tests to CI workflow (N/A — tooling-config change; CI's existing `required-version` check exercises it)
