### PR TITLE
[dist, trainer] feat: add CUDA graph compile support

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -225,7 +225,11 @@ NPU validation runs at two times:
 | eval_steps | `int` | `0` | Steps between evaluations. `0` to disable. |
 | eval_epochs | `int` | `1` | Epochs between evaluations. `0` to disable. |
 | seed | `int` | `42` | Random seed. |
-| enable_compile | `bool` | `False` | Enable `torch.compile`. |
+| enable_compile | `bool` | `False` | Enable per-block `torch.compile` for CUDA Graph friendly training. This requires `dyn_bsz=True` and `pad_to_length=True` so packed inputs have stable shapes. Training steps call `torch.compiler.cudagraph_mark_step_begin()` when available so CUDA Graph Trees can separate iterations. |
+| compile_backend | `Optional[str]` | `None` | Backend passed to `torch.compile`; `None` uses PyTorch's default backend. |
+| compile_mode | `Optional[str]` | `"reduce-overhead"` | Mode passed to `torch.compile`; `"reduce-overhead"` enables CUDA Graphs when possible. |
+| compile_fullgraph | `bool` | `False` | Whether to pass `fullgraph=True` to `torch.compile`. |
+| compile_dynamic | `bool` | `False` | Whether to pass `dynamic=True` to `torch.compile`. |
 | max_steps | `Optional[int]` | `None` | Max training steps per epoch (debug only). |
 | optimizer | `OptimizerConfig` | — | Optimizer and learning-rate schedule. |
 | wandb | `WandbConfig` | — | Weights & Biases logging. |

--- a/docs/usage/data_packing_and_dyn_bsz.md
+++ b/docs/usage/data_packing_and_dyn_bsz.md
@@ -78,6 +78,8 @@ Example fixed batch size = 2 samples:
 `pad_to_length` can pad the packed sequence to a fixed length. This is useful to avoid uneven lengths that can trigger kernel recompilation.
 - Related GitHub issue: [#402](https://github.com/ByteDance-Seed/VeOmni/issues/402)
 `pad_to_length` is useful only when `dyn_bsz` = True, all the packed sequences in a batch will be padded to the `max_seq_len`.
+It is also required when `train.enable_compile=True`, because per-block
+`torch.compile(mode="reduce-overhead")` needs stable packed shapes to make CUDA Graph replay useful.
 
 Important details:
 

--- a/tests/distributed/test_torch_compile.py
+++ b/tests/distributed/test_torch_compile.py
@@ -1,0 +1,146 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from veomni.arguments.arguments_types import DataArguments, ModelArguments, TrainingArguments, VeOmniArguments
+from veomni.distributed.torch_compile import (
+    compile_module_forwards,
+    mark_compile_step_begin,
+    select_leaf_compile_modules,
+)
+
+
+class ToyBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(4, 4)
+
+    def forward(self, x):
+        return self.proj(x)
+
+
+def test_compile_module_forwards_replaces_forward(monkeypatch):
+    calls = []
+
+    def fake_compile(fn, **kwargs):
+        calls.append(kwargs)
+
+        def wrapped(*args, **inner_kwargs):
+            return fn(*args, **inner_kwargs)
+
+        return wrapped
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
+
+    block = ToyBlock()
+    compiled = compile_module_forwards(
+        [("layers.0", block)],
+        backend="inductor",
+        mode="reduce-overhead",
+        fullgraph=False,
+        dynamic=False,
+    )
+
+    assert compiled == 1
+    assert block._veomni_forward_compiled is True
+    assert block._veomni_original_forward is ToyBlock.forward
+    assert calls == [{"backend": "inductor", "mode": "reduce-overhead", "fullgraph": False, "dynamic": False}]
+    assert block(torch.ones(2, 4)).shape == (2, 4)
+
+
+def test_compile_module_forwards_skips_duplicate_module(monkeypatch):
+    monkeypatch.setattr(torch, "compile", lambda fn, **_: fn)
+
+    block = ToyBlock()
+    compiled = compile_module_forwards([("a", block), ("b", block)])
+
+    assert compiled == 1
+
+
+def test_mark_compile_step_begin_calls_torch_compiler_api(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr("veomni.distributed.torch_compile.get_device_type", lambda: "cuda")
+    monkeypatch.setattr(torch, "compiler", SimpleNamespace(cudagraph_mark_step_begin=lambda: calls.append("mark")))
+
+    mark_compile_step_begin(enable_compile=True)
+    mark_compile_step_begin(enable_compile=False)
+
+    assert calls == ["mark"]
+
+
+def test_mark_compile_step_begin_skips_non_cuda(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr("veomni.distributed.torch_compile.get_device_type", lambda: "npu")
+    monkeypatch.setattr(torch, "compiler", SimpleNamespace(cudagraph_mark_step_begin=lambda: calls.append("mark")))
+
+    mark_compile_step_begin(enable_compile=True)
+
+    assert calls == []
+
+
+def test_mark_compile_step_begin_skips_without_torch_compiler(monkeypatch):
+    monkeypatch.setattr("veomni.distributed.torch_compile.get_device_type", lambda: "cuda")
+    monkeypatch.delattr(torch, "compiler", raising=False)
+
+    mark_compile_step_begin(enable_compile=True)
+
+
+def test_select_leaf_compile_modules_skips_parent_targets():
+    parent = nn.Sequential(ToyBlock())
+    sibling = ToyBlock()
+
+    selected = select_leaf_compile_modules(
+        [
+            ("", nn.Sequential(parent, sibling)),
+            ("layers.0", parent),
+            ("layers.0.mlp", parent[0]),
+            ("layers.1", sibling),
+        ]
+    )
+
+    assert selected == [("layers.0.mlp", parent[0]), ("layers.1", sibling)]
+
+
+def test_select_leaf_compile_modules_keeps_root_when_it_is_only_target():
+    root = nn.Sequential(ToyBlock())
+
+    assert select_leaf_compile_modules([("", root)]) == [("", root)]
+
+
+def test_enable_compile_requires_dynamic_batching():
+    with pytest.raises(ValueError, match="train.enable_compile requires train.dyn_bsz=True"):
+        VeOmniArguments(
+            model=ModelArguments(config_path="dummy_config.json"),
+            data=DataArguments(train_path="dummy.jsonl", max_seq_len=8),
+            train=TrainingArguments(enable_compile=True, dyn_bsz=False, pad_to_length=False),
+        )
+
+
+def test_enable_compile_requires_padding_for_dynamic_batching():
+    with pytest.raises(
+        ValueError, match="train.enable_compile requires train.dyn_bsz=True and train.pad_to_length=True"
+    ):
+        VeOmniArguments(
+            model=ModelArguments(config_path="dummy_config.json"),
+            data=DataArguments(train_path="dummy.jsonl", max_seq_len=8),
+            train=TrainingArguments(enable_compile=True, dyn_bsz=True, pad_to_length=False),
+        )
+
+
+def test_enable_compile_accepts_static_padded_dynamic_batching():
+    args = VeOmniArguments(
+        model=ModelArguments(config_path="dummy_config.json"),
+        data=DataArguments(train_path="dummy.jsonl", max_seq_len=8),
+        train=TrainingArguments(
+            enable_compile=True,
+            dyn_bsz=True,
+            pad_to_length=True,
+            micro_batch_size=2,
+        ),
+    )
+
+    assert args.train.pad_to_length == 16

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -510,7 +510,23 @@ class TrainingArguments:
     )
     enable_compile: bool = field(
         default=False,
-        metadata={"help": "Enable torch compile."},
+        metadata={"help": "Enable per-block torch.compile for CUDA Graph friendly training."},
+    )
+    compile_backend: Optional[str] = field(
+        default=None,
+        metadata={"help": "Backend passed to torch.compile. None uses PyTorch's default backend."},
+    )
+    compile_mode: Optional[str] = field(
+        default="reduce-overhead",
+        metadata={"help": "Mode passed to torch.compile. 'reduce-overhead' enables CUDA Graphs when possible."},
+    )
+    compile_fullgraph: bool = field(
+        default=False,
+        metadata={"help": "Whether to pass fullgraph=True to torch.compile."},
+    )
+    compile_dynamic: bool = field(
+        default=False,
+        metadata={"help": "Whether to pass dynamic=True to torch.compile."},
     )
     max_steps: Optional[int] = field(
         default=None,
@@ -1165,6 +1181,13 @@ class VeOmniArguments:
             else:
                 self.train.pad_to_length = self.train.micro_batch_size * self.data.max_seq_len
                 logger.info_rank0(f"set pad_to_length = micro_batch_size * max_seq_len = {self.train.pad_to_length}")
+
+        if self.train.enable_compile and (not self.train.dyn_bsz or not self.train.pad_to_length):
+            raise ValueError(
+                "train.enable_compile requires train.dyn_bsz=True and train.pad_to_length=True. "
+                "Variable packed lengths trigger recompilation and prevent stable CUDA Graph capture; "
+                "see https://github.com/ByteDance-Seed/VeOmni/issues/401."
+            )
 
     def compute_train_steps(self, dataset_length: Optional[int] = None):
         if self.train.dyn_bsz:

--- a/veomni/distributed/torch_compile.py
+++ b/veomni/distributed/torch_compile.py
@@ -1,0 +1,134 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+from typing import Iterable, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from ..utils import logging
+from ..utils.device import get_device_type
+
+
+logger = logging.get_logger(__name__)
+
+
+def select_leaf_compile_modules(target_modules: Iterable[Tuple[str, nn.Module]]) -> list[Tuple[str, nn.Module]]:
+    """Keep only target modules that do not contain another target module.
+
+    If both a parent and one of its children are FSDP targets, compiling the
+    parent forward can pull the child's FSDP collectives into the compiled
+    region. Leaf targets keep FSDP communication at module boundaries.
+    """
+
+    modules = list(target_modules)
+    parent_fqns = set()
+    for module_fqn, _ in modules:
+        if module_fqn == "":
+            continue
+        parts = module_fqn.split(".")
+        for idx in range(len(parts)):
+            parent_fqns.add(".".join(parts[:idx]))
+
+    leaf_modules = [(module_fqn, module) for module_fqn, module in modules if module_fqn not in parent_fqns]
+
+    skipped = len(modules) - len(leaf_modules)
+    if skipped:
+        logger.info_rank0(f"Skip compiling {skipped} non-leaf target modules to keep FSDP collectives outside.")
+    return leaf_modules
+
+
+def compile_module_forward(
+    module: nn.Module,
+    *,
+    module_fqn: str,
+    backend: Optional[str] = None,
+    mode: Optional[str] = "reduce-overhead",
+    fullgraph: bool = False,
+    dynamic: bool = False,
+) -> bool:
+    """Compile one module's forward method in place.
+
+    Compiling the forward method instead of wrapping the whole module preserves
+    module identity for FSDP2. FSDP's pre/post-forward all-gather and reshard
+    hooks therefore stay outside the compiled region, matching the per-block
+    direction discussed in https://github.com/ByteDance-Seed/VeOmni/issues/401.
+    """
+
+    if getattr(module, "_veomni_forward_compiled", False):
+        logger.warning_rank0(f"Skip compiling {module_fqn}: forward is already compiled.")
+        return False
+
+    if not hasattr(torch, "compile"):
+        raise RuntimeError("train.enable_compile requires torch.compile, but this PyTorch build has no torch.compile.")
+
+    compile_kwargs = {
+        "fullgraph": fullgraph,
+        "dynamic": dynamic,
+    }
+    if backend is not None:
+        compile_kwargs["backend"] = backend
+    if mode is not None:
+        compile_kwargs["mode"] = mode
+
+    original_forward = module.forward
+    if hasattr(original_forward, "__func__"):
+        module._veomni_original_forward = original_forward.__func__
+        compiled_forward = torch.compile(original_forward.__func__, **compile_kwargs)
+        module.forward = types.MethodType(compiled_forward, module)
+    else:
+        module._veomni_original_forward = original_forward
+        module.forward = torch.compile(original_forward, **compile_kwargs)
+    module._veomni_forward_compiled = True
+    module._veomni_compile_config = dict(compile_kwargs)
+    logger.info_rank0(f"Compiled forward for {module_fqn} with torch.compile({compile_kwargs}).")
+    return True
+
+
+def compile_module_forwards(
+    target_modules: Iterable[Tuple[str, nn.Module]],
+    *,
+    backend: Optional[str] = None,
+    mode: Optional[str] = "reduce-overhead",
+    fullgraph: bool = False,
+    dynamic: bool = False,
+) -> int:
+    compiled = 0
+    seen_modules = set()
+    for module_fqn, module in target_modules:
+        if id(module) in seen_modules:
+            continue
+        seen_modules.add(id(module))
+        if compile_module_forward(
+            module,
+            module_fqn=module_fqn,
+            backend=backend,
+            mode=mode,
+            fullgraph=fullgraph,
+            dynamic=dynamic,
+        ):
+            compiled += 1
+
+    logger.info_rank0(f"Compiled {compiled} module forwards with torch.compile.")
+    return compiled
+
+
+def mark_compile_step_begin(enable_compile: bool) -> None:
+    """Mark a new training step for CUDA Graph Trees managed by torch.compile."""
+
+    if not enable_compile or get_device_type() != "cuda":
+        return
+    if hasattr(torch, "compiler") and hasattr(torch.compiler, "cudagraph_mark_step_begin"):
+        torch.compiler.cudagraph_mark_step_begin()

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -32,6 +32,7 @@ from ..utils import logging
 from ..utils.device import IS_NPU_AVAILABLE, get_device_type
 from .checkpoint import CheckpointFunction
 from .parallel_state import get_parallel_state
+from .torch_compile import compile_module_forwards, select_leaf_compile_modules
 from .utils import sort_fqn_by_submodule_first
 
 
@@ -80,6 +81,11 @@ def parallelize_model_fsdp2(
     mixed_precision: MixedPrecisionConfig = MixedPrecisionConfig(enable=True),  # noqa
     basic_modules: Optional[List[str]] = None,
     muon_expert_zero_comm: bool = False,
+    enable_compile: bool = False,
+    compile_backend: Optional[str] = None,
+    compile_mode: Optional[str] = "reduce-overhead",
+    compile_fullgraph: bool = False,
+    compile_dynamic: bool = False,
     **kwargs,
 ) -> "nn.Module":
     """
@@ -122,6 +128,8 @@ def parallelize_model_fsdp2(
         (fqn, mod) for fqn, mod in model.named_modules() if mod.__class__.__name__ in target_classes
     ]
     logger.info_rank0(f"target classes to shard: {target_classes}")
+
+    model._veomni_compile_enabled = False
 
     # Step 1: Apply ExtraParallel
     #   e.g. Apply expert parallelism (slice expert tensors [128,H,I] -> [16,H,I])
@@ -191,6 +199,24 @@ def parallelize_model_fsdp2(
         layer_pairs[layer_fqn] = tuple(layer_pair)
 
     logger.info_rank0(f"extra_parallel layer pairs: {layer_pairs}")
+
+    if enable_compile:
+        if get_device_type() != "cuda":
+            logger.warning_rank0("train.enable_compile is CUDA-only for now; skip torch.compile on this device.")
+        elif parallel_state.any_extra_parallel_enabled:
+            logger.warning_rank0(
+                "train.enable_compile currently skips ExtraParallel models to avoid capturing EP all-to-all "
+                "communication inside compiled blocks."
+            )
+        else:
+            compiled_count = compile_module_forwards(
+                select_leaf_compile_modules(target_modules),
+                backend=compile_backend,
+                mode=compile_mode,
+                fullgraph=compile_fullgraph,
+                dynamic=compile_dynamic,
+            )
+            model._veomni_compile_enabled = compiled_count > 0
 
     # Step 2: Update fsdp2 kwargs
     fsdp_kwargs = {"mesh": parallel_state.fsdp_mesh, "reshard_after_forward": enable_reshard_after_forward}
@@ -427,6 +453,11 @@ def build_parallelize_model(
     enable_gradient_checkpointing: bool = True,
     basic_modules: Optional[List[str]] = None,
     muon_expert_zero_comm: bool = False,
+    enable_compile: bool = False,
+    compile_backend: Optional[str] = None,
+    compile_mode: Optional[str] = "reduce-overhead",
+    compile_fullgraph: bool = False,
+    compile_dynamic: bool = False,
     **kwargs,
 ) -> "nn.Module":
     """Apply parallel strategies to the model.
@@ -475,9 +506,18 @@ def build_parallelize_model(
                 mixed_precision=mixed_precision,
                 basic_modules=basic_modules,
                 muon_expert_zero_comm=muon_expert_zero_comm,
+                enable_compile=enable_compile,
+                compile_backend=compile_backend,
+                compile_mode=compile_mode,
+                compile_fullgraph=compile_fullgraph,
+                compile_dynamic=compile_dynamic,
                 **kwargs,
             )
         else:
+            if enable_compile:
+                logger.warning_rank0("train.enable_compile is only wired for fsdp2; skip compile for DDP.")
             model = DDP(model, device_ids=[parallel_state.local_rank], process_group=parallel_state.dp_group)
+    elif enable_compile:
+        logger.warning_rank0("train.enable_compile is only wired for fsdp2; skip compile without FSDP.")
 
     return model

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -58,6 +58,7 @@ from ..data.data_transform import build_data_transform
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
 from ..distributed.offloading import build_activation_offloading_context
 from ..distributed.parallel_state import init_parallel_state
+from ..distributed.torch_compile import mark_compile_step_begin
 from ..distributed.torch_parallelize import build_parallelize_model
 from ..models import build_foundation_model, build_tokenizer
 from ..ops.batch_invariant_ops import set_batch_invariant_mode
@@ -511,6 +512,11 @@ class BaseTrainer(Stateful, ABC):
             broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
             max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
             muon_expert_zero_comm=muon_expert_zero_comm,
+            enable_compile=args.train.enable_compile,
+            compile_backend=args.train.compile_backend,
+            compile_mode=args.train.compile_mode,
+            compile_fullgraph=args.train.compile_fullgraph,
+            compile_dynamic=args.train.compile_dynamic,
             **kwargs,
         )
         self.model.train()
@@ -706,6 +712,7 @@ class BaseTrainer(Stateful, ABC):
         args = self.args
         self.state.global_step += 1
 
+        mark_compile_step_begin(getattr(self.model, "_veomni_compile_enabled", False))
         micro_batches: List[Dict[str, Any]] = next(data_iterator)
 
         self.on_step_begin(micro_batches=micro_batches)


### PR DESCRIPTION
### What does this PR do?

Adds CUDA Graph friendly per-block `torch.compile` support for FSDP2 training, addressing #401.

The implementation compiles leaf FSDP target module forwards in place so module identity and FSDP2 hooks are preserved, keeps FSDP collectives outside compiled regions, enforces padded static packed lengths for the compile path, and marks training-step boundaries for PyTorch CUDA Graph Trees when available.


### Checklist Before Starting

- Search for relative PRs/issues and link here: #401
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

Official VeOmni GPU image:

- `PYTHONPATH=/workspace/VeOmni /app/.venv/bin/python -m pytest tests/distributed/test_torch_compile.py -q` (10 passed)
- `PATH=/app/.venv/bin:$PATH make quality`

Additional manual GPU probes on a 2x A100 SXM4 official VeOmni image: FSDP2 toy model with 3 per-layer `torch.compile(mode="reduce-overhead")` blocks, `torch.compiler.cudagraph_mark_step_begin()`, grad norm, loss allreduce, and 5 optimizer steps completed successfully (`compiled=3`). A gradient-accumulation variant with 2 micro-batches per optimizer step also completed 5 optimizer steps / 10 compiled forward-backward passes.

### API and Usage Example

New training arguments:

- `train.enable_compile=True`
- `train.compile_backend`, `train.compile_mode`, `train.compile_fullgraph`, `train.compile_dynamic`

`train.enable_compile=True` requires `train.dyn_bsz=True` and `train.pad_to_length=True` so packed inputs have static shapes for CUDA Graph capture.

### Design & Code Changes

- Add `veomni.distributed.torch_compile` helpers to select leaf target modules, compile module forwards, and mark CUDA graph step boundaries.
- Wire compile options through `TrainingArguments`, `BaseTrainer`, and FSDP2 parallelization.
- Skip compile on non-CUDA devices, DDP/non-FSDP paths, and ExtraParallel models for now.
- Document compile arguments and padded packed input requirements.
- Add unit tests for compile helper behavior and argument validation.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)

