### PR TITLE
[model, ci] fix: migrate qwen3_5 linear-attn cache to transformers 5.9 layered DynamicCache

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -135,6 +135,7 @@ jobs:
           uv run --frozen pytest -s -x tests/models/test_vlm_trainer.py
           uv run --frozen pytest -s -x tests/models/test_padded_packed_loss.py
           uv run --frozen pytest -s -x tests/models/test_models_logits_equal_v5.py
+          uv run --frozen pytest -s -x tests/models/test_models_cache_forward_v5.py
           uv run --frozen pytest -s -x tests/models/test_model_forward_no_implicit_sync.py
           uv run --frozen pytest -s -x tests/models/test_checkpoint_tensor_converter.py
           uv run --frozen pytest -s -x tests/models/test_return_log_probs_e2e.py

--- a/tests/models/test_models_cache_forward_v5.py
+++ b/tests/models/test_models_cache_forward_v5.py
@@ -1,0 +1,286 @@
+"""``use_cache=True`` forward smoke for transformers v5 generated modeling.
+
+The sibling ``test_models_logits_equal_v5`` runs every forward with
+``use_cache=False``, so the *cache* code paths in the patchgen-generated
+modeling are never exercised by CI. That blind spot is exactly how a
+transformers-version bump can silently break inference / generation: the
+``DynamicCache`` API can change shape between releases (e.g. the 5.x migration
+to the layered ``DynamicCache`` — ``has_previous_state(layer_idx)``,
+``cache_params.layers[idx]``, ``update_conv_state`` / ``update_recurrent_state``
+for linear attention) while the bitwise-equal forward test stays green.
+
+This test closes the gap generically: for every v5 model it runs a single
+``use_cache=True`` prefill and asserts the forward does not crash and the cache
+is populated. It is a crash / cache-population smoke (VeOmni-only, no HF bitwise
+compare) — which is precisely what catches cache-API drift on the next bump.
+
+Cache families covered:
+
+- Standard attention KV cache (``DynamicCache.get_seq_length()`` advances):
+  qwen2, qwen3, qwen3_moe, deepseek_v3, glm_moe_dsa, and the VLM text towers.
+- Linear-attention layered cache (gated DeltaNet ``conv_states`` /
+  ``recurrent_states``): qwen3_5, qwen3_5_moe. Unlike the bitwise test we keep
+  the real ``linear_attention`` layers (no full-attention override) so the
+  ``update_conv_state`` / ``update_recurrent_state`` / ``_update_linear_attn_mask``
+  paths actually fire — they need fla + GPU, so those cases skip otherwise.
+"""
+
+import copy
+import importlib.util
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+import torch
+
+from veomni.ops import apply_ops_config
+from veomni.utils.device import (
+    IS_CUDA_AVAILABLE,
+    get_device_type,
+    get_dist_comm_backend,
+    get_torch_device,
+)
+from veomni.utils.import_utils import is_package_available
+
+# Reuse the sibling harness: toy-config path, input construction, dtype map.
+from .test_models_logits_equal_v5 import (
+    _DTYPE_MAP,
+    _make_inputs,
+    _release,
+    _toy,
+)
+
+
+# Required by ``dist.init_process_group`` in the module-scoped fixture.
+os.environ.setdefault("RANK", "0")
+os.environ.setdefault("LOCAL_RANK", "0")
+os.environ.setdefault("WORLD_SIZE", "1")
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "12357")
+
+_FLA_AVAILABLE = is_package_available("fla")
+_FLASH_ATTN_AVAILABLE = importlib.util.find_spec("flash_attn") is not None
+
+
+@dataclass(frozen=True)
+class CacheCase:
+    case_id: str
+    toy_config_dir: str
+    arch: str
+    kind: str  # "causal_lm" | "qwen3_5_text" | "vlm_full" | "omni_thinker"
+    attn_implementation: str = "sdpa"
+    dtype: str = "bfloat16"
+    # "standard" KV cache vs "linear" (gated DeltaNet conv/recurrent) cache.
+    cache_family: str = "standard"
+    needs_fla: bool = False
+    forward_attr: Optional[str] = None  # e.g. "thinker" for Omni
+    config_overrides: dict = field(default_factory=dict)
+
+
+_EAGER_EXPERTS = {"_experts_implementation": "eager"}
+
+CASES = [
+    # ── standard attention KV cache ──────────────────────────────────────
+    CacheCase("qwen2", _toy("qwen2_toy"), "Qwen2ForCausalLM", "causal_lm"),
+    CacheCase("qwen3", _toy("qwen3_toy"), "Qwen3ForCausalLM", "causal_lm"),
+    CacheCase("qwen3_moe", _toy("qwen3_moe_toy"), "Qwen3MoeForCausalLM", "causal_lm", config_overrides=_EAGER_EXPERTS),
+    CacheCase(
+        "deepseek_v3", _toy("deepseek_v3_toy"), "DeepseekV3ForCausalLM", "causal_lm", attn_implementation="eager"
+    ),
+    CacheCase(
+        "glm_moe_dsa", _toy("glm_moe_dsa_toy"), "GlmMoeDsaForCausalLM", "causal_lm", config_overrides=_EAGER_EXPERTS
+    ),
+    # ── VLM full forward (text tower drives the KV cache) ────────────────
+    CacheCase("qwen2_vl", _toy("qwen2vl_toy"), "Qwen2VLForConditionalGeneration", "vlm_full"),
+    CacheCase("qwen2_5_vl", _toy("qwen25vl_toy"), "Qwen2_5_VLForConditionalGeneration", "vlm_full"),
+    CacheCase("qwen3_vl", _toy("qwen3vl_toy"), "Qwen3VLForConditionalGeneration", "vlm_full"),
+    CacheCase(
+        "qwen3_vl_moe",
+        _toy("qwen3vlmoe_toy"),
+        "Qwen3VLMoeForConditionalGeneration",
+        "vlm_full",
+        config_overrides=_EAGER_EXPERTS,
+    ),
+    # ── Omni (forward on ``model.thinker``; talker/token2wav stay dark) ───
+    CacheCase(
+        "qwen2_5_omni",
+        _toy("qwen25omni_toy"),
+        "Qwen2_5OmniForConditionalGeneration",
+        "omni_thinker",
+        attn_implementation="flash_attention_2",
+        forward_attr="thinker",
+    ),
+    CacheCase(
+        "qwen3_omni_moe",
+        _toy("qwen3omni_toy"),
+        "Qwen3OmniMoeForConditionalGeneration",
+        "omni_thinker",
+        attn_implementation="flash_attention_2",
+        forward_attr="thinker",
+        config_overrides=_EAGER_EXPERTS,
+    ),
+    # ── linear-attention layered cache (gated DeltaNet) ──────────────────
+    # Keep the real linear_attention layers (no full-attention override): the
+    # whole point is to drive update_conv_state / update_recurrent_state /
+    # _update_linear_attn_mask, which need fla + GPU.
+    # No ``_experts_implementation`` override: it is a no-op on the VeOmni path
+    # (see _build_veomni_model); MoE stays eager via the all-eager ops config.
+    CacheCase(
+        "qwen3_5",
+        _toy("qwen3_5_toy"),
+        "Qwen3_5ForCausalLM",
+        "qwen3_5_text",
+        attn_implementation="flash_attention_2",
+        cache_family="linear",
+        needs_fla=True,
+    ),
+    CacheCase(
+        "qwen3_5_moe",
+        _toy("qwen3_5_moe_toy"),
+        "Qwen3_5MoeForCausalLM",
+        "qwen3_5_text",
+        attn_implementation="flash_attention_2",
+        cache_family="linear",
+        needs_fla=True,
+    ),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_rank_process_group():
+    """1-rank NCCL group for VeOmni's SP-aware attention wrappers."""
+    if not IS_CUDA_AVAILABLE:
+        yield
+        return
+    import torch.distributed as dist
+
+    we_initialised = False
+    if not dist.is_initialized():
+        get_torch_device().set_device(int(os.environ.get("LOCAL_RANK", "0")))
+        dist.init_process_group(backend=get_dist_comm_backend(), rank=0, world_size=1)
+        we_initialised = True
+    try:
+        yield
+    finally:
+        if we_initialised and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _make_config(case: CacheCase):
+    from transformers import AutoConfig
+
+    full = AutoConfig.from_pretrained(case.toy_config_dir)
+    if case.kind == "qwen3_5_text":
+        # Text sub-config, but — unlike the bitwise test — keep the real
+        # linear_attention layer_types so the gated-DeltaNet cache path runs.
+        cfg = copy.deepcopy(full.text_config)
+    else:
+        cfg = full
+    cfg.architectures = [case.arch]
+    # MoE knobs (e.g. ``_experts_implementation``) live on the language
+    # sub-config: ``cfg.text_config`` for VLMs, ``cfg.thinker_config.text_config``
+    # for Omni, ``cfg`` itself for text-only models.
+    override_target = cfg
+    if case.kind == "vlm_full" and hasattr(cfg, "text_config"):
+        override_target = cfg.text_config
+    elif case.kind == "omni_thinker" and hasattr(cfg, "thinker_config"):
+        override_target = getattr(cfg.thinker_config, "text_config", cfg.thinker_config)
+    for k, v in case.config_overrides.items():
+        setattr(override_target, k, v)
+    return cfg
+
+
+def _build_veomni_model(case: CacheCase, config):
+    """Random-init VeOmni model (a smoke test needs no real weights)."""
+    from veomni.models.auto import build_foundation_model
+
+    from ..tools.training_utils import make_eager_ops_config
+
+    if case.cache_family == "linear":
+        # Everything eager EXCEPT the three gated-DeltaNet OpSlots, which have no
+        # eager impl (the varlen path raises) and need fla. Starting from the
+        # all-eager config keeps the rest of the model — crucially the MoE
+        # experts (``moe_experts`` OpSlot, default ``fused_triton``) — off fused
+        # kernels, so this case depends only on fla + flash_attn (the skip gates)
+        # and stays a pure cache-path smoke. ``_experts_implementation`` would NOT
+        # achieve this: the patched ``*MoeExperts`` dropped the HF decorator and
+        # dispatches solely on the OpSlot.
+        apply_ops_config(
+            make_eager_ops_config(
+                attn_implementation=case.attn_implementation,
+                causal_conv1d_implementation="fla",
+                chunk_gated_delta_rule_implementation="fla",
+                rms_norm_gated_implementation="fla",
+            )
+        )
+    else:
+        apply_ops_config(make_eager_ops_config(attn_implementation=case.attn_implementation))
+
+    model = build_foundation_model(
+        config_path=config,
+        weights_path=None,
+        torch_dtype=case.dtype,
+        attn_implementation=case.attn_implementation,
+        init_device=get_device_type(),
+    )
+    return model.eval()
+
+
+def _forward_target(model, case: CacheCase):
+    # qwen3_5 text sub-config builds the *ForCausalLM directly; VLMs forward on
+    # the top-level conditional-generation model; Omni forwards on ``.thinker``.
+    if case.forward_attr is None:
+        return model
+    target = model
+    for part in case.forward_attr.split("."):
+        target = getattr(target, part)
+    return target
+
+
+def _assert_cache_populated(case: CacheCase, config, past_key_values, seq_len: int):
+    assert past_key_values is not None, f"[{case.case_id}] use_cache=True returned no past_key_values"
+
+    if case.cache_family == "linear":
+        text_cfg = config if case.kind == "qwen3_5_text" else config.text_config
+        n_linear = 0
+        for i, lt in enumerate(text_cfg.layer_types):
+            if lt != "linear_attention":
+                continue
+            layer = past_key_values.layers[i]
+            assert past_key_values.has_previous_state(i), f"[{case.case_id}] layer {i}: has_previous_state False"
+            assert getattr(layer, "conv_states", None) is not None, f"[{case.case_id}] layer {i}: conv_states None"
+            assert getattr(layer, "recurrent_states", None) is not None, f"[{case.case_id}] layer {i}: recurrent None"
+            n_linear += 1
+        assert n_linear > 0, f"[{case.case_id}] no linear-attention layers exercised"
+    else:
+        seq = past_key_values.get_seq_length()
+        assert seq == seq_len, f"[{case.case_id}] cache seq_length {seq} != prefill {seq_len}"
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.case_id for c in CASES])
+def test_cache_forward_v5(case: CacheCase):
+    """use_cache=True prefill: forward must not crash and the cache must fill."""
+    if not IS_CUDA_AVAILABLE:
+        pytest.skip("CUDA required.")
+    if not os.path.isdir(case.toy_config_dir):
+        pytest.skip(f"Path not found: {case.toy_config_dir}")
+    if case.needs_fla and not _FLA_AVAILABLE:
+        pytest.skip("flash-linear-attention (fla) required for the linear-attention cache path.")
+    if case.attn_implementation == "flash_attention_2" and not _FLASH_ATTN_AVAILABLE:
+        pytest.skip("flash_attn package not installed.")
+
+    device = get_device_type()
+    dtype = _DTYPE_MAP[case.dtype]
+    config = _make_config(case)
+    input_ids, fwd_kwargs = _make_inputs(case, config, device, dtype)
+    seq_len = input_ids.shape[-1]
+
+    model = _build_veomni_model(case, config)
+    try:
+        with torch.no_grad():
+            out = _forward_target(model, case)(input_ids=input_ids.clone(), use_cache=True, **fwd_kwargs)
+        _assert_cache_populated(case, config, out.past_key_values, seq_len)
+    finally:
+        del model
+        _release()

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
@@ -357,7 +357,7 @@
          self.recurrent_gated_delta_rule = fused_recurrent_gated_delta_rule or torch_recurrent_gated_delta_rule
 
          if not is_fast_path_available:
-@@ -438,27 +627,29 @@
+@@ -438,19 +627,37 @@
          self,
          hidden_states: torch.Tensor,
          cache_params: Cache | None = None,
@@ -377,27 +377,39 @@
 -        # diverge in how the conv input is assembled and which kernel consumes the states below,
 -        # which we gate locally on `seq_len`.
 -        use_precomputed_states = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
++        # transformers 5.x replaced the bespoke per-model DynamicCache (dict-like
++        # `conv_states[layer_idx]` / `recurrent_states[layer_idx]`) with the generic layered
++        # DynamicCache: per-layer linear-attention state lives on `cache_params.layers[layer_idx]`
++        # and is read/written via `has_previous_state(layer_idx)` / `update_conv_state` /
++        # `update_recurrent_state`.
++        # `use_precomputed_states` picks the cached-decode fast path (reuse the stored conv /
++        # recurrent state) over recomputing the whole sequence (prefill). Heads-up on the
++        # `cache_position is not None` term: transformers 5.x no longer has the model's forward
++        # materialize `cache_position`, so a caller that continues from `past_key_values`
++        # without passing `cache_position` explicitly would make this term False and wrongly
++        # fall back to the prefill path mid-decode (ignoring the recurrent state, overwriting
++        # the conv cache). That is harmless TODAY because the cached path below is intentionally
++        # disabled — it raises NotImplementedError — so Qwen3.5 here is training-only. When
++        # decode support is added, drop this term and let the host-side
++        # `has_previous_state(self.layer_idx)` flag decide on its own (matches upstream).
 +        use_precomputed_states = (
 +            cache_params is not None
-+            and cache_params.has_previous_state
++            and cache_params.has_previous_state(self.layer_idx)
 +            and seq_len == 1
 +            and cache_position is not None
 +        )
 
          # getting projected states from cache if it exists
--        if use_precomputed_states:
--            conv_state = cache_params.layers[self.layer_idx].conv_states
--            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
-+        if cache_params is not None:
-+            conv_state = cache_params.conv_states[self.layer_idx]
-+            recurrent_state = cache_params.recurrent_states[self.layer_idx]
+         if use_precomputed_states:
+@@ -458,7 +665,6 @@
+             recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
 
          mixed_qkv = self.in_proj_qkv(hidden_states)
 -        mixed_qkv = mixed_qkv.transpose(1, 2)
 
          z = self.in_proj_z(hidden_states)
          z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)
-@@ -466,61 +657,149 @@
+@@ -466,61 +672,149 @@
          b = self.in_proj_b(hidden_states)
          a = self.in_proj_a(hidden_states)
 
@@ -467,7 +479,7 @@
 -                cache_params.update_conv_state(new_conv_state, self.layer_idx)
 +                mixed_qkv_t = mixed_qkv.transpose(1, 2)
 +                conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
-+                cache_params.conv_states[self.layer_idx] = conv_state
++                cache_params.update_conv_state(conv_state, self.layer_idx)
              if self.causal_conv1d_fn is not None:
 +                # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
 +                if ulysses_enabled:
@@ -579,7 +591,7 @@
              core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
                  query,
                  key,
-@@ -531,23 +810,16 @@
+@@ -531,23 +825,16 @@
                  output_final_state=cache_params is not None,
                  use_qk_l2norm_in_kernel=True,
              )
@@ -599,8 +611,7 @@
 
          # Update cache
          if cache_params is not None:
--            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
-+            cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+             cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 +
 +        # Modification: gather attention output back to sequence-sharded layout before gated norm.
 +        if ulysses_enabled:
@@ -610,7 +621,7 @@
 
          # reshape input data into 2D tensor
          core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
-@@ -557,6 +829,20 @@
+@@ -557,6 +844,20 @@
 
          output = self.out_proj(core_attn_out)
          return output
@@ -631,7 +642,7 @@
 
 
  def rotate_half(x):
-@@ -734,6 +1020,12 @@
+@@ -734,6 +1035,12 @@
          return down_proj
 
 
@@ -644,7 +655,7 @@
  class Qwen3_5RMSNorm(nn.Module):
      def __init__(self, dim: int, eps: float = 1e-6):
          super().__init__()
-@@ -743,7 +1035,16 @@
+@@ -743,7 +1050,16 @@
      def _norm(self, x):
          return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
 
@@ -661,7 +672,7 @@
          output = self._norm(x.float())
          # Llama does x.to(float16) * w whilst Qwen3_5 is (x * w).to(float16)
          # See https://github.com/huggingface/transformers/pull/29402
-@@ -752,6 +1053,12 @@
+@@ -752,6 +1068,12 @@
 
      def extra_repr(self):
          return f"{tuple(self.weight.shape)}, eps={self.eps}"
@@ -674,7 +685,7 @@
 
 
  class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
-@@ -774,19 +1081,29 @@
+@@ -774,19 +1096,29 @@
          attention_mask: torch.Tensor | None = None,
          position_ids: torch.LongTensor | None = None,
          past_key_values: Cache | None = None,
@@ -705,7 +716,7 @@
              )
          elif self.layer_type == "full_attention":
              # Self Attention
-@@ -795,6 +1112,7 @@
+@@ -795,6 +1127,7 @@
                  attention_mask=attention_mask,
                  position_ids=position_ids,
                  past_key_values=past_key_values,
@@ -713,7 +724,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -806,7 +1124,6 @@
+@@ -806,7 +1139,6 @@
          hidden_states = self.post_attention_layernorm(hidden_states)
          hidden_states = self.mlp(hidden_states)
          hidden_states = residual + hidden_states
@@ -721,7 +732,7 @@
          return hidden_states
 
 
-@@ -902,6 +1219,12 @@
+@@ -902,6 +1234,12 @@
      return q_embed, k_embed
 
 
@@ -734,7 +745,7 @@
  class Qwen3_5VisionAttention(nn.Module):
      def __init__(self, config: Qwen3_5VisionConfig) -> None:
          super().__init__()
-@@ -935,13 +1258,18 @@
+@@ -935,13 +1273,18 @@
          key_states = key_states.transpose(0, 1).unsqueeze(0)
          value_states = value_states.transpose(0, 1).unsqueeze(0)
 
@@ -756,7 +767,7 @@
              attn_output, _ = attention_interface(
                  self,
                  query_states,
-@@ -958,6 +1286,9 @@
+@@ -958,6 +1301,9 @@
                  **kwargs,
              )
          else:
@@ -766,7 +777,7 @@
              # Other implementations: Process each chunk separately
              lengths = cu_seqlens[1:] - cu_seqlens[:-1]
              splits = [
-@@ -1019,6 +1350,12 @@
+@@ -1019,6 +1365,12 @@
          return hidden_states
 
 
@@ -779,7 +790,7 @@
  class Qwen3_5VisionModel(Qwen3_5PreTrainedModel):
      config: Qwen3_5VisionConfig
      input_modalities = ("image", "video")
-@@ -1054,28 +1391,127 @@
+@@ -1054,28 +1406,127 @@
 
          self.post_init()
 
@@ -927,7 +938,7 @@
 
      @merge_with_config_defaults
      @capture_outputs
-@@ -1090,25 +1526,147 @@
+@@ -1090,25 +1541,147 @@
          Returns:
              `torch.Tensor`: hidden_states.
          """
@@ -1087,7 +1098,7 @@
 
          for blk in self.blocks:
              hidden_states = blk(
-@@ -1124,6 +1682,36 @@
+@@ -1124,6 +1697,36 @@
              last_hidden_state=hidden_states,
              pooler_output=merged_hidden_states,
          )
@@ -1124,7 +1135,7 @@
 
 
  @auto_docstring(
-@@ -1148,6 +1736,12 @@
+@@ -1148,6 +1751,12 @@
      hidden_states: tuple[torch.FloatTensor] | None = None
      attentions: tuple[torch.FloatTensor] | None = None
      rope_deltas: torch.LongTensor | None = None
@@ -1137,12 +1148,9 @@
 
 
  class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
-@@ -1233,19 +1827,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1235,17 +1844,45 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1160,14 +1168,18 @@
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). But we detect it host-side via the cache's ``has_previous_state()`` flag
++        — a Python bool on the linear-attention cache layer — rather than reading ``cache_position[0]``,
++        so no sync.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
 +        while avoiding the ``torch.all`` reduction + sync. A genuinely padded mask is still returned and
 +        correctly zeroed.
++
++        NOTE: transformers 5.x changed this method's 2nd arg from ``cache_position`` (a tensor) to
++        ``past_key_values`` (a layered ``DynamicCache``); the regenerated ``Qwen3_5TextModel.forward``
++        now calls ``self._update_linear_attn_mask(attention_mask, past_key_values)``.
          """
 -        linear_attn_mask = attention_mask
 -        if (past_key_values is not None and past_key_values.has_previous_state()) or (
@@ -1178,8 +1190,9 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here. `has_previous_state()` reads a
++        # host-side flag on the linear-attention cache layer (no 0-D GPU scalar), so this stays sync-free.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +
@@ -1191,7 +1204,7 @@
 
 
  @auto_docstring
-@@ -1441,64 +2058,43 @@
+@@ -1441,64 +2078,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1281,7 +1294,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1564,6 +2160,7 @@
+@@ -1564,6 +2180,7 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1289,7 +1302,7 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5ModelOutputWithPast:
          r"""
-@@ -1571,6 +2168,8 @@
+@@ -1571,6 +2188,8 @@
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
@@ -1298,7 +1311,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1578,29 +2177,169 @@
+@@ -1578,29 +2197,169 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1478,7 +1491,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1610,6 +2349,18 @@
+@@ -1610,6 +2369,18 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1497,7 +1510,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1617,6 +2368,7 @@
+@@ -1617,6 +2388,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1505,7 +1518,7 @@
              **kwargs,
          )
 
-@@ -1624,6 +2376,12 @@
+@@ -1624,6 +2396,12 @@
              **outputs,
              rope_deltas=self.rope_deltas,
          )
@@ -1518,7 +1531,7 @@
 
 
  @auto_docstring
-@@ -1654,6 +2412,7 @@
+@@ -1654,6 +2432,7 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
@@ -1526,7 +1539,7 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> CausalLMOutputWithPast:
-@@ -1686,21 +2445,50 @@
+@@ -1686,21 +2465,50 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -1581,7 +1594,7 @@
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
-@@ -1740,6 +2528,41 @@
+@@ -1740,6 +2548,41 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1623,7 +1636,7 @@
  class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1796,57 +2619,10 @@
+@@ -1796,57 +2639,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1683,7 +1696,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1857,27 +2633,54 @@
+@@ -1857,27 +2653,54 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1744,7 +1757,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2103,6 +2906,24 @@
+@@ -2103,6 +2926,24 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
@@ -637,17 +637,32 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         # Set up dimensions for reshapes later
         batch_size, seq_len, _ = hidden_states.shape
 
+        # transformers 5.x replaced the bespoke per-model DynamicCache (dict-like
+        # `conv_states[layer_idx]` / `recurrent_states[layer_idx]`) with the generic layered
+        # DynamicCache: per-layer linear-attention state lives on `cache_params.layers[layer_idx]`
+        # and is read/written via `has_previous_state(layer_idx)` / `update_conv_state` /
+        # `update_recurrent_state`.
+        # `use_precomputed_states` picks the cached-decode fast path (reuse the stored conv /
+        # recurrent state) over recomputing the whole sequence (prefill). Heads-up on the
+        # `cache_position is not None` term: transformers 5.x no longer has the model's forward
+        # materialize `cache_position`, so a caller that continues from `past_key_values`
+        # without passing `cache_position` explicitly would make this term False and wrongly
+        # fall back to the prefill path mid-decode (ignoring the recurrent state, overwriting
+        # the conv cache). That is harmless TODAY because the cached path below is intentionally
+        # disabled — it raises NotImplementedError — so Qwen3.5 here is training-only. When
+        # decode support is added, drop this term and let the host-side
+        # `has_previous_state(self.layer_idx)` flag decide on its own (matches upstream).
         use_precomputed_states = (
             cache_params is not None
-            and cache_params.has_previous_state
+            and cache_params.has_previous_state(self.layer_idx)
             and seq_len == 1
             and cache_position is not None
         )
 
         # getting projected states from cache if it exists
-        if cache_params is not None:
-            conv_state = cache_params.conv_states[self.layer_idx]
-            recurrent_state = cache_params.recurrent_states[self.layer_idx]
+        if use_precomputed_states:
+            conv_state = cache_params.layers[self.layer_idx].conv_states
+            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
 
         mixed_qkv = self.in_proj_qkv(hidden_states)
 
@@ -707,7 +722,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             if cache_params is not None:
                 mixed_qkv_t = mixed_qkv.transpose(1, 2)
                 conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
-                cache_params.conv_states[self.layer_idx] = conv_state
+                cache_params.update_conv_state(conv_state, self.layer_idx)
             if self.causal_conv1d_fn is not None:
                 # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
                 if ulysses_enabled:
@@ -813,7 +828,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
         # Update cache
         if cache_params is not None:
-            cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 
         # Modification: gather attention output back to sequence-sharded layout before gated norm.
         if ulysses_enabled:
@@ -1827,7 +1842,7 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
@@ -1841,20 +1856,25 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). But we detect it host-side via the cache's ``has_previous_state()`` flag
+        — a Python bool on the linear-attention cache layer — rather than reading ``cache_position[0]``,
+        so no sync.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
         while avoiding the ``torch.all`` reduction + sync. A genuinely padded mask is still returned and
         correctly zeroed.
+
+        NOTE: transformers 5.x changed this method's 2nd arg from ``cache_position`` (a tensor) to
+        ``past_key_values`` (a layered ``DynamicCache``); the regenerated ``Qwen3_5TextModel.forward``
+        now calls ``self._update_linear_attn_mask(attention_mask, past_key_values)``.
         """
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here. `has_previous_state()` reads a
+        # host-side flag on the linear-attention cache layer (no 0-D GPU scalar), so this stays sync-free.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
@@ -353,7 +353,7 @@
          self.recurrent_gated_delta_rule = fused_recurrent_gated_delta_rule or torch_recurrent_gated_delta_rule
 
          if not is_fast_path_available:
-@@ -438,27 +623,29 @@
+@@ -438,19 +623,35 @@
          self,
          hidden_states: torch.Tensor,
          cache_params: Cache | None = None,
@@ -373,27 +373,37 @@
 -        # diverge in how the conv input is assembled and which kernel consumes the states below,
 -        # which we gate locally on `seq_len`.
 -        use_precomputed_states = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
++        # transformers 5.x layered DynamicCache API (see GPU config): per-layer state on
++        # `cache_params.layers[layer_idx]`, accessed via `has_previous_state` / `update_conv_state`
++        # / `update_recurrent_state`.
++        # `use_precomputed_states` picks the cached-decode fast path (reuse the stored conv /
++        # recurrent state) over recomputing the whole sequence (prefill). Heads-up on the
++        # `cache_position is not None` term: transformers 5.x no longer has the model's forward
++        # materialize `cache_position`, so a caller that continues from `past_key_values`
++        # without passing `cache_position` explicitly would make this term False and wrongly
++        # fall back to the prefill path mid-decode (ignoring the recurrent state, overwriting
++        # the conv cache). That is harmless TODAY because the cached path below is intentionally
++        # disabled — it raises NotImplementedError — so Qwen3.5 here is training-only. When
++        # decode support is added, drop this term and let the host-side
++        # `has_previous_state(self.layer_idx)` flag decide on its own (matches upstream).
 +        use_precomputed_states = (
 +            cache_params is not None
-+            and cache_params.has_previous_state
++            and cache_params.has_previous_state(self.layer_idx)
 +            and seq_len == 1
 +            and cache_position is not None
 +        )
 
          # getting projected states from cache if it exists
--        if use_precomputed_states:
--            conv_state = cache_params.layers[self.layer_idx].conv_states
--            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
-+        if cache_params is not None:
-+            conv_state = cache_params.conv_states[self.layer_idx]
-+            recurrent_state = cache_params.recurrent_states[self.layer_idx]
+         if use_precomputed_states:
+@@ -458,7 +659,6 @@
+             recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
 
          mixed_qkv = self.in_proj_qkv(hidden_states)
 -        mixed_qkv = mixed_qkv.transpose(1, 2)
 
          z = self.in_proj_z(hidden_states)
          z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)
-@@ -466,61 +653,131 @@
+@@ -466,61 +666,131 @@
          b = self.in_proj_b(hidden_states)
          a = self.in_proj_a(hidden_states)
 
@@ -463,7 +473,7 @@
 -                cache_params.update_conv_state(new_conv_state, self.layer_idx)
 +                mixed_qkv_t = mixed_qkv.transpose(1, 2)
 +                conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
-+                cache_params.conv_states[self.layer_idx] = conv_state
++                cache_params.update_conv_state(conv_state, self.layer_idx)
              if self.causal_conv1d_fn is not None:
 +                # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
 +                if ulysses_enabled:
@@ -557,7 +567,7 @@
              core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
                  query,
                  key,
-@@ -531,23 +788,16 @@
+@@ -531,23 +801,16 @@
                  output_final_state=cache_params is not None,
                  use_qk_l2norm_in_kernel=True,
              )
@@ -577,8 +587,7 @@
 
          # Update cache
          if cache_params is not None:
--            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
-+            cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+             cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 +
 +        # Modification: gather attention output back to sequence-sharded layout before gated norm.
 +        if ulysses_enabled:
@@ -588,7 +597,7 @@
 
          # reshape input data into 2D tensor
          core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
-@@ -558,6 +808,20 @@
+@@ -558,6 +821,20 @@
          output = self.out_proj(core_attn_out)
          return output
 
@@ -609,7 +618,7 @@
 
  def rotate_half(x):
      """Rotates half the hidden dims of the input."""
-@@ -566,27 +830,14 @@
+@@ -566,27 +843,14 @@
      return torch.cat((-x2, x1), dim=-1)
 
 
@@ -644,7 +653,7 @@
      cos = cos.unsqueeze(unsqueeze_dim)
      sin = sin.unsqueeze(unsqueeze_dim)
 
-@@ -734,6 +985,12 @@
+@@ -734,6 +998,12 @@
          return down_proj
 
 
@@ -657,7 +666,7 @@
  class Qwen3_5RMSNorm(nn.Module):
      def __init__(self, dim: int, eps: float = 1e-6):
          super().__init__()
-@@ -743,7 +1000,16 @@
+@@ -743,7 +1013,16 @@
      def _norm(self, x):
          return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
 
@@ -674,7 +683,7 @@
          output = self._norm(x.float())
          # Llama does x.to(float16) * w whilst Qwen3_5 is (x * w).to(float16)
          # See https://github.com/huggingface/transformers/pull/29402
-@@ -752,6 +1018,12 @@
+@@ -752,6 +1031,12 @@
 
      def extra_repr(self):
          return f"{tuple(self.weight.shape)}, eps={self.eps}"
@@ -687,7 +696,7 @@
 
 
  class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
-@@ -774,19 +1046,29 @@
+@@ -774,19 +1059,29 @@
          attention_mask: torch.Tensor | None = None,
          position_ids: torch.LongTensor | None = None,
          past_key_values: Cache | None = None,
@@ -718,7 +727,7 @@
              )
          elif self.layer_type == "full_attention":
              # Self Attention
-@@ -795,6 +1077,7 @@
+@@ -795,6 +1090,7 @@
                  attention_mask=attention_mask,
                  position_ids=position_ids,
                  past_key_values=past_key_values,
@@ -726,7 +735,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -806,7 +1089,6 @@
+@@ -806,7 +1102,6 @@
          hidden_states = self.post_attention_layernorm(hidden_states)
          hidden_states = self.mlp(hidden_states)
          hidden_states = residual + hidden_states
@@ -734,7 +743,7 @@
          return hidden_states
 
 
-@@ -888,9 +1170,16 @@
+@@ -888,9 +1183,16 @@
          return x
 
 
@@ -751,7 +760,7 @@
      orig_q_dtype = q.dtype
      orig_k_dtype = k.dtype
      q, k = q.float(), k.float()
-@@ -1019,6 +1308,12 @@
+@@ -1019,6 +1321,12 @@
          return hidden_states
 
 
@@ -764,7 +773,7 @@
  class Qwen3_5VisionModel(Qwen3_5PreTrainedModel):
      config: Qwen3_5VisionConfig
      input_modalities = ("image", "video")
-@@ -1054,28 +1349,127 @@
+@@ -1054,28 +1362,127 @@
 
          self.post_init()
 
@@ -912,7 +921,7 @@
 
      @merge_with_config_defaults
      @capture_outputs
-@@ -1090,25 +1484,147 @@
+@@ -1090,25 +1497,147 @@
          Returns:
              `torch.Tensor`: hidden_states.
          """
@@ -1072,7 +1081,7 @@
 
          for blk in self.blocks:
              hidden_states = blk(
-@@ -1124,6 +1640,36 @@
+@@ -1124,6 +1653,36 @@
              last_hidden_state=hidden_states,
              pooler_output=merged_hidden_states,
          )
@@ -1109,7 +1118,7 @@
 
 
  @auto_docstring(
-@@ -1148,6 +1694,12 @@
+@@ -1148,6 +1707,12 @@
      hidden_states: tuple[torch.FloatTensor] | None = None
      attentions: tuple[torch.FloatTensor] | None = None
      rope_deltas: torch.LongTensor | None = None
@@ -1122,12 +1131,9 @@
 
 
  class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
-@@ -1233,19 +1785,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1235,17 +1800,45 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1145,14 +1151,18 @@
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). But we detect it host-side via the cache's ``has_previous_state()`` flag
++        — a Python bool on the linear-attention cache layer — rather than reading ``cache_position[0]``,
++        so no sync.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
 +        while avoiding the ``torch.all`` reduction + sync. A genuinely padded mask is still returned and
 +        correctly zeroed.
++
++        NOTE: transformers 5.x changed this method's 2nd arg from ``cache_position`` (a tensor) to
++        ``past_key_values`` (a layered ``DynamicCache``); the regenerated ``Qwen3_5TextModel.forward``
++        now calls ``self._update_linear_attn_mask(attention_mask, past_key_values)``.
          """
 -        linear_attn_mask = attention_mask
 -        if (past_key_values is not None and past_key_values.has_previous_state()) or (
@@ -1163,8 +1173,9 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here. `has_previous_state()` reads a
++        # host-side flag on the linear-attention cache layer (no 0-D GPU scalar), so this stays sync-free.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +
@@ -1176,7 +1187,7 @@
 
 
  @auto_docstring
-@@ -1441,64 +2016,43 @@
+@@ -1441,64 +2034,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1266,7 +1277,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1564,6 +2118,7 @@
+@@ -1564,6 +2136,7 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1274,7 +1285,7 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5ModelOutputWithPast:
          r"""
-@@ -1571,6 +2126,8 @@
+@@ -1571,6 +2144,8 @@
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
@@ -1283,7 +1294,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1578,29 +2135,169 @@
+@@ -1578,29 +2153,169 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1463,7 +1474,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1610,6 +2307,18 @@
+@@ -1610,6 +2325,18 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1482,7 +1493,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1617,6 +2326,7 @@
+@@ -1617,6 +2344,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1490,7 +1501,7 @@
              **kwargs,
          )
 
-@@ -1624,6 +2334,12 @@
+@@ -1624,6 +2352,12 @@
              **outputs,
              rope_deltas=self.rope_deltas,
          )
@@ -1503,7 +1514,7 @@
 
 
  @auto_docstring
-@@ -1654,6 +2370,7 @@
+@@ -1654,6 +2388,7 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
@@ -1511,7 +1522,7 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> CausalLMOutputWithPast:
-@@ -1686,21 +2403,50 @@
+@@ -1686,21 +2421,50 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -1566,7 +1577,7 @@
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
-@@ -1740,6 +2486,31 @@
+@@ -1740,6 +2504,31 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1598,7 +1609,7 @@
  class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1796,57 +2567,10 @@
+@@ -1796,57 +2585,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1658,7 +1669,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1857,27 +2581,54 @@
+@@ -1857,27 +2599,54 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1719,7 +1730,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2103,6 +2854,24 @@
+@@ -2103,6 +2872,24 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
@@ -633,17 +633,30 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         # Set up dimensions for reshapes later
         batch_size, seq_len, _ = hidden_states.shape
 
+        # transformers 5.x layered DynamicCache API (see GPU config): per-layer state on
+        # `cache_params.layers[layer_idx]`, accessed via `has_previous_state` / `update_conv_state`
+        # / `update_recurrent_state`.
+        # `use_precomputed_states` picks the cached-decode fast path (reuse the stored conv /
+        # recurrent state) over recomputing the whole sequence (prefill). Heads-up on the
+        # `cache_position is not None` term: transformers 5.x no longer has the model's forward
+        # materialize `cache_position`, so a caller that continues from `past_key_values`
+        # without passing `cache_position` explicitly would make this term False and wrongly
+        # fall back to the prefill path mid-decode (ignoring the recurrent state, overwriting
+        # the conv cache). That is harmless TODAY because the cached path below is intentionally
+        # disabled — it raises NotImplementedError — so Qwen3.5 here is training-only. When
+        # decode support is added, drop this term and let the host-side
+        # `has_previous_state(self.layer_idx)` flag decide on its own (matches upstream).
         use_precomputed_states = (
             cache_params is not None
-            and cache_params.has_previous_state
+            and cache_params.has_previous_state(self.layer_idx)
             and seq_len == 1
             and cache_position is not None
         )
 
         # getting projected states from cache if it exists
-        if cache_params is not None:
-            conv_state = cache_params.conv_states[self.layer_idx]
-            recurrent_state = cache_params.recurrent_states[self.layer_idx]
+        if use_precomputed_states:
+            conv_state = cache_params.layers[self.layer_idx].conv_states
+            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
 
         mixed_qkv = self.in_proj_qkv(hidden_states)
 
@@ -703,7 +716,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             if cache_params is not None:
                 mixed_qkv_t = mixed_qkv.transpose(1, 2)
                 conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
-                cache_params.conv_states[self.layer_idx] = conv_state
+                cache_params.update_conv_state(conv_state, self.layer_idx)
             if self.causal_conv1d_fn is not None:
                 # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
                 if ulysses_enabled:
@@ -791,7 +804,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
         # Update cache
         if cache_params is not None:
-            cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 
         # Modification: gather attention output back to sequence-sharded layout before gated norm.
         if ulysses_enabled:
@@ -1785,7 +1798,7 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
@@ -1799,20 +1812,25 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). But we detect it host-side via the cache's ``has_previous_state()`` flag
+        — a Python bool on the linear-attention cache layer — rather than reading ``cache_position[0]``,
+        so no sync.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
         while avoiding the ``torch.all`` reduction + sync. A genuinely padded mask is still returned and
         correctly zeroed.
+
+        NOTE: transformers 5.x changed this method's 2nd arg from ``cache_position`` (a tensor) to
+        ``past_key_values`` (a layered ``DynamicCache``); the regenerated ``Qwen3_5TextModel.forward``
+        now calls ``self._update_linear_attn_mask(attention_mask, past_key_values)``.
         """
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here. `has_previous_state()` reads a
+        # host-side flag on the linear-attention cache layer (no 0-D GPU scalar), so this stays sync-free.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 

--- a/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
@@ -323,14 +323,32 @@ def qwen3_5_gated_deltanet_forward_patched(
     # Set up dimensions for reshapes later
     batch_size, seq_len, _ = hidden_states.shape
 
+    # transformers 5.x replaced the bespoke per-model DynamicCache (dict-like
+    # `conv_states[layer_idx]` / `recurrent_states[layer_idx]`) with the generic layered
+    # DynamicCache: per-layer linear-attention state lives on `cache_params.layers[layer_idx]`
+    # and is read/written via `has_previous_state(layer_idx)` / `update_conv_state` /
+    # `update_recurrent_state`.
+    # `use_precomputed_states` picks the cached-decode fast path (reuse the stored conv /
+    # recurrent state) over recomputing the whole sequence (prefill). Heads-up on the
+    # `cache_position is not None` term: transformers 5.x no longer has the model's forward
+    # materialize `cache_position`, so a caller that continues from `past_key_values`
+    # without passing `cache_position` explicitly would make this term False and wrongly
+    # fall back to the prefill path mid-decode (ignoring the recurrent state, overwriting
+    # the conv cache). That is harmless TODAY because the cached path below is intentionally
+    # disabled — it raises NotImplementedError — so Qwen3.5 here is training-only. When
+    # decode support is added, drop this term and let the host-side
+    # `has_previous_state(self.layer_idx)` flag decide on its own (matches upstream).
     use_precomputed_states = (
-        cache_params is not None and cache_params.has_previous_state and seq_len == 1 and cache_position is not None
+        cache_params is not None
+        and cache_params.has_previous_state(self.layer_idx)
+        and seq_len == 1
+        and cache_position is not None
     )
 
     # getting projected states from cache if it exists
-    if cache_params is not None:
-        conv_state = cache_params.conv_states[self.layer_idx]
-        recurrent_state = cache_params.recurrent_states[self.layer_idx]
+    if use_precomputed_states:
+        conv_state = cache_params.layers[self.layer_idx].conv_states
+        recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
 
     mixed_qkv = self.in_proj_qkv(hidden_states)
 
@@ -390,7 +408,7 @@ def qwen3_5_gated_deltanet_forward_patched(
         if cache_params is not None:
             mixed_qkv_t = mixed_qkv.transpose(1, 2)
             conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
-            cache_params.conv_states[self.layer_idx] = conv_state
+            cache_params.update_conv_state(conv_state, self.layer_idx)
         if self.causal_conv1d_fn is not None:
             # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
             if ulysses_enabled:
@@ -496,7 +514,7 @@ def qwen3_5_gated_deltanet_forward_patched(
 
     # Update cache
     if cache_params is not None:
-        cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+        cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 
     # Modification: gather attention output back to sequence-sharded layout before gated norm.
     if ulysses_enabled:
@@ -518,7 +536,7 @@ def qwen3_5_gated_deltanet_forward_patched(
     "Qwen3_5TextModel._update_linear_attn_mask",
     description="Avoid host-device sync: decide linear-attention padding-mask zeroing without reading GPU scalars.",
 )
-def qwen3_5_text_model_update_linear_attn_mask(self, attention_mask, cache_position):
+def qwen3_5_text_model_update_linear_attn_mask(self, attention_mask, past_key_values):
     """
     Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
@@ -532,20 +550,25 @@ def qwen3_5_text_model_update_linear_attn_mask(self, attention_mask, cache_posit
     ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
     cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
     only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-    a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-    ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-    than reading ``cache_position[0]``, so no sync.
+    a 1-token decode step). But we detect it host-side via the cache's ``has_previous_state()`` flag
+    — a Python bool on the linear-attention cache layer — rather than reading ``cache_position[0]``,
+    so no sync.
 
     The all-ones short-circuit is the one we drop: returning the all-ones mask makes
     ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
     while avoiding the ``torch.all`` reduction + sync. A genuinely padded mask is still returned and
     correctly zeroed.
+
+    NOTE: transformers 5.x changed this method's 2nd arg from ``cache_position`` (a tensor) to
+    ``past_key_values`` (a layered ``DynamicCache``); the regenerated ``Qwen3_5TextModel.forward``
+    now calls ``self._update_linear_attn_mask(attention_mask, past_key_values)``.
     """
     if attention_mask is None:
         return None
     # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-    # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-    if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+    # apply_mask_to_padding_states, and upstream returns None here. `has_previous_state()` reads a
+    # host-side flag on the linear-attention cache layer (no 0-D GPU scalar), so this stays sync-free.
+    if past_key_values is not None and past_key_values.has_previous_state():
         return None
     return attention_mask
 

--- a/veomni/models/transformers/qwen3_5/qwen3_5_npu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5/qwen3_5_npu_patch_gen_config.py
@@ -251,14 +251,30 @@ def qwen3_5_gated_deltanet_forward_patched(
     # Set up dimensions for reshapes later
     batch_size, seq_len, _ = hidden_states.shape
 
+    # transformers 5.x layered DynamicCache API (see GPU config): per-layer state on
+    # `cache_params.layers[layer_idx]`, accessed via `has_previous_state` / `update_conv_state`
+    # / `update_recurrent_state`.
+    # `use_precomputed_states` picks the cached-decode fast path (reuse the stored conv /
+    # recurrent state) over recomputing the whole sequence (prefill). Heads-up on the
+    # `cache_position is not None` term: transformers 5.x no longer has the model's forward
+    # materialize `cache_position`, so a caller that continues from `past_key_values`
+    # without passing `cache_position` explicitly would make this term False and wrongly
+    # fall back to the prefill path mid-decode (ignoring the recurrent state, overwriting
+    # the conv cache). That is harmless TODAY because the cached path below is intentionally
+    # disabled — it raises NotImplementedError — so Qwen3.5 here is training-only. When
+    # decode support is added, drop this term and let the host-side
+    # `has_previous_state(self.layer_idx)` flag decide on its own (matches upstream).
     use_precomputed_states = (
-        cache_params is not None and cache_params.has_previous_state and seq_len == 1 and cache_position is not None
+        cache_params is not None
+        and cache_params.has_previous_state(self.layer_idx)
+        and seq_len == 1
+        and cache_position is not None
     )
 
     # getting projected states from cache if it exists
-    if cache_params is not None:
-        conv_state = cache_params.conv_states[self.layer_idx]
-        recurrent_state = cache_params.recurrent_states[self.layer_idx]
+    if use_precomputed_states:
+        conv_state = cache_params.layers[self.layer_idx].conv_states
+        recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
 
     mixed_qkv = self.in_proj_qkv(hidden_states)
 
@@ -318,7 +334,7 @@ def qwen3_5_gated_deltanet_forward_patched(
         if cache_params is not None:
             mixed_qkv_t = mixed_qkv.transpose(1, 2)
             conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
-            cache_params.conv_states[self.layer_idx] = conv_state
+            cache_params.update_conv_state(conv_state, self.layer_idx)
         if self.causal_conv1d_fn is not None:
             # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
             if ulysses_enabled:
@@ -406,7 +422,7 @@ def qwen3_5_gated_deltanet_forward_patched(
 
     # Update cache
     if cache_params is not None:
-        cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+        cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 
     # Modification: gather attention output back to sequence-sharded layout before gated norm.
     if ulysses_enabled:

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
@@ -363,7 +363,7 @@
          self.recurrent_gated_delta_rule = fused_recurrent_gated_delta_rule or torch_recurrent_gated_delta_rule
 
          if not is_fast_path_available:
-@@ -434,27 +632,29 @@
+@@ -434,19 +632,37 @@
          self,
          hidden_states: torch.Tensor,
          cache_params: Cache | None = None,
@@ -383,27 +383,39 @@
 -        # diverge in how the conv input is assembled and which kernel consumes the states below,
 -        # which we gate locally on `seq_len`.
 -        use_precomputed_states = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
++        # transformers 5.x replaced the bespoke per-model DynamicCache (dict-like
++        # `conv_states[layer_idx]` / `recurrent_states[layer_idx]`) with the generic layered
++        # DynamicCache: per-layer linear-attention state lives on `cache_params.layers[layer_idx]`
++        # and is read/written via `has_previous_state(layer_idx)` / `update_conv_state` /
++        # `update_recurrent_state`.
++        # `use_precomputed_states` picks the cached-decode fast path (reuse the stored conv /
++        # recurrent state) over recomputing the whole sequence (prefill). Heads-up on the
++        # `cache_position is not None` term: transformers 5.x no longer has the model's forward
++        # materialize `cache_position`, so a caller that continues from `past_key_values`
++        # without passing `cache_position` explicitly would make this term False and wrongly
++        # fall back to the prefill path mid-decode (ignoring the recurrent state, overwriting
++        # the conv cache). That is harmless TODAY because the cached path below is intentionally
++        # disabled — it raises NotImplementedError — so Qwen3.5 here is training-only. When
++        # decode support is added, drop this term and let the host-side
++        # `has_previous_state(self.layer_idx)` flag decide on its own (matches upstream).
 +        use_precomputed_states = (
 +            cache_params is not None
-+            and cache_params.has_previous_state
++            and cache_params.has_previous_state(self.layer_idx)
 +            and seq_len == 1
 +            and cache_position is not None
 +        )
 
          # getting projected states from cache if it exists
--        if use_precomputed_states:
--            conv_state = cache_params.layers[self.layer_idx].conv_states
--            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
-+        if cache_params is not None:
-+            conv_state = cache_params.conv_states[self.layer_idx]
-+            recurrent_state = cache_params.recurrent_states[self.layer_idx]
+         if use_precomputed_states:
+@@ -454,7 +670,6 @@
+             recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
 
          mixed_qkv = self.in_proj_qkv(hidden_states)
 -        mixed_qkv = mixed_qkv.transpose(1, 2)
 
          z = self.in_proj_z(hidden_states)
          z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)
-@@ -462,61 +662,149 @@
+@@ -462,61 +677,149 @@
          b = self.in_proj_b(hidden_states)
          a = self.in_proj_a(hidden_states)
 
@@ -473,7 +485,7 @@
 -                cache_params.update_conv_state(new_conv_state, self.layer_idx)
 +                mixed_qkv_t = mixed_qkv.transpose(1, 2)
 +                conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
-+                cache_params.conv_states[self.layer_idx] = conv_state
++                cache_params.update_conv_state(conv_state, self.layer_idx)
              if self.causal_conv1d_fn is not None:
 +                # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
 +                if ulysses_enabled:
@@ -585,7 +597,7 @@
              core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
                  query,
                  key,
-@@ -527,23 +815,16 @@
+@@ -527,23 +830,16 @@
                  output_final_state=cache_params is not None,
                  use_qk_l2norm_in_kernel=True,
              )
@@ -605,8 +617,7 @@
 
          # Update cache
          if cache_params is not None:
--            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
-+            cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+             cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 +
 +        # Modification: gather attention output back to sequence-sharded layout before gated norm.
 +        if ulysses_enabled:
@@ -616,7 +627,7 @@
 
          # reshape input data into 2D tensor
          core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
-@@ -553,6 +834,20 @@
+@@ -553,6 +849,20 @@
 
          output = self.out_proj(core_attn_out)
          return output
@@ -637,7 +648,7 @@
 
 
  def rotate_half(x):
-@@ -732,12 +1027,24 @@
+@@ -732,12 +1042,24 @@
          return down_proj
 
 
@@ -664,7 +675,7 @@
          self.num_experts = config.num_experts
          self.hidden_dim = config.hidden_size
          self.intermediate_dim = config.moe_intermediate_size
-@@ -751,6 +1058,11 @@
+@@ -751,6 +1073,11 @@
          top_k_index: torch.Tensor,
          top_k_weights: torch.Tensor,
      ) -> torch.Tensor:
@@ -676,7 +687,7 @@
          final_hidden_states = torch.zeros_like(hidden_states)
          with torch.no_grad():
              expert_mask = torch.nn.functional.one_hot(top_k_index, num_classes=self.num_experts)
-@@ -791,6 +1103,12 @@
+@@ -791,6 +1118,12 @@
          return router_logits, router_scores, router_indices
 
 
@@ -689,7 +700,7 @@
  class Qwen3_5MoeSparseMoeBlock(nn.Module):
      def __init__(self, config):
          super().__init__()
-@@ -799,18 +1117,47 @@
+@@ -799,18 +1132,47 @@
          self.shared_expert = Qwen3_5MoeMLP(config, intermediate_size=config.shared_expert_intermediate_size)
          self.shared_expert_gate = torch.nn.Linear(config.hidden_size, 1, bias=False)
 
@@ -738,7 +749,7 @@
 
 
  class Qwen3_5MoeRMSNorm(nn.Module):
-@@ -822,15 +1169,24 @@
+@@ -822,15 +1184,24 @@
      def _norm(self, x):
          return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
 
@@ -765,7 +776,7 @@
 
 
  class Qwen3_5MoeDecoderLayer(GradientCheckpointingLayer):
-@@ -846,6 +1202,7 @@
+@@ -846,6 +1217,7 @@
          self.input_layernorm = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
          self.post_attention_layernorm = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
@@ -773,7 +784,7 @@
      def forward(
          self,
          hidden_states: torch.Tensor,
-@@ -853,19 +1210,29 @@
+@@ -853,19 +1225,29 @@
          attention_mask: torch.Tensor | None = None,
          position_ids: torch.LongTensor | None = None,
          past_key_values: Cache | None = None,
@@ -804,7 +815,7 @@
              )
          elif self.layer_type == "full_attention":
              # Self Attention
-@@ -874,6 +1241,7 @@
+@@ -874,6 +1256,7 @@
                  attention_mask=attention_mask,
                  position_ids=position_ids,
                  past_key_values=past_key_values,
@@ -812,7 +823,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -888,7 +1256,6 @@
+@@ -888,7 +1271,6 @@
          if isinstance(hidden_states, tuple):
              hidden_states, _ = hidden_states
          hidden_states = residual + hidden_states
@@ -820,7 +831,7 @@
          return hidden_states
 
 
-@@ -990,6 +1357,12 @@
+@@ -990,6 +1372,12 @@
      return q_embed, k_embed
 
 
@@ -833,7 +844,7 @@
  class Qwen3_5MoeVisionAttention(nn.Module):
      def __init__(self, config: Qwen3_5MoeVisionConfig) -> None:
          super().__init__()
-@@ -1023,13 +1396,18 @@
+@@ -1023,13 +1411,18 @@
          key_states = key_states.transpose(0, 1).unsqueeze(0)
          value_states = value_states.transpose(0, 1).unsqueeze(0)
 
@@ -855,7 +866,7 @@
              attn_output, _ = attention_interface(
                  self,
                  query_states,
-@@ -1046,6 +1424,9 @@
+@@ -1046,6 +1439,9 @@
                  **kwargs,
              )
          else:
@@ -865,7 +876,7 @@
              # Other implementations: Process each chunk separately
              lengths = cu_seqlens[1:] - cu_seqlens[:-1]
              splits = [
-@@ -1107,6 +1488,12 @@
+@@ -1107,6 +1503,12 @@
          return hidden_states
 
 
@@ -878,7 +889,7 @@
  class Qwen3_5MoeVisionModel(Qwen3_5MoePreTrainedModel):
      config: Qwen3_5MoeVisionConfig
      input_modalities = ("image", "video")
-@@ -1142,28 +1529,127 @@
+@@ -1142,28 +1544,127 @@
 
          self.post_init()
 
@@ -1026,7 +1037,7 @@
 
      @merge_with_config_defaults
      @capture_outputs
-@@ -1178,25 +1664,147 @@
+@@ -1178,25 +1679,147 @@
          Returns:
              `torch.Tensor`: hidden_states.
          """
@@ -1186,7 +1197,7 @@
 
          for blk in self.blocks:
              hidden_states = blk(
-@@ -1212,6 +1820,36 @@
+@@ -1212,6 +1835,36 @@
              last_hidden_state=hidden_states,
              pooler_output=merged_hidden_states,
          )
@@ -1223,7 +1234,7 @@
 
 
  @auto_docstring(
-@@ -1268,6 +1906,37 @@
+@@ -1268,6 +1921,37 @@
      rope_deltas: torch.LongTensor | None = None
      router_logits: tuple[torch.FloatTensor] | None = None
      aux_loss: torch.FloatTensor | None = None
@@ -1261,12 +1272,9 @@
 
 
  class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
-@@ -1353,19 +2022,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1355,17 +2039,45 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1284,14 +1292,18 @@
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). But we detect it host-side via the cache's ``has_previous_state()`` flag
++        — a Python bool on the linear-attention cache layer — rather than reading ``cache_position[0]``,
++        so no sync.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
 +        while avoiding the ``torch.all`` reduction + sync. A genuinely padded mask is still returned and
 +        correctly zeroed.
++
++        NOTE: transformers 5.x changed this method's 2nd arg from ``cache_position`` (a tensor) to
++        ``past_key_values`` (a layered ``DynamicCache``); the regenerated ``Qwen3_5TextModel.forward``
++        now calls ``self._update_linear_attn_mask(attention_mask, past_key_values)``.
          """
 -        linear_attn_mask = attention_mask
 -        if (past_key_values is not None and past_key_values.has_previous_state()) or (
@@ -1302,8 +1314,9 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here. `has_previous_state()` reads a
++        # host-side flag on the linear-attention cache layer (no 0-D GPU scalar), so this stays sync-free.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +
@@ -1315,7 +1328,7 @@
 
 
  @auto_docstring
-@@ -1376,7 +2068,19 @@
+@@ -1376,7 +2088,19 @@
      config: Qwen3_5MoeConfig
      _no_split_modules = ["Qwen3_5MoeDecoderLayer", "Qwen3_5MoeVisionBlock"]
 
@@ -1335,7 +1348,7 @@
          super().__init__(config)
          self.visual = Qwen3_5MoeVisionModel._from_config(config.vision_config)
          self.language_model = Qwen3_5MoeTextModel._from_config(config.text_config)
-@@ -1561,64 +2265,43 @@
+@@ -1561,64 +2285,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1425,7 +1438,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1684,6 +2367,7 @@
+@@ -1684,6 +2387,7 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1433,7 +1446,7 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5MoeModelOutputWithPast:
          r"""
-@@ -1691,6 +2375,8 @@
+@@ -1691,6 +2395,8 @@
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
@@ -1442,7 +1455,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1698,29 +2384,170 @@
+@@ -1698,29 +2404,170 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1623,7 +1636,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1730,6 +2557,17 @@
+@@ -1730,6 +2577,17 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1641,7 +1654,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1737,6 +2575,7 @@
+@@ -1737,6 +2595,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1649,7 +1662,7 @@
              **kwargs,
          )
 
-@@ -1828,6 +2667,12 @@
+@@ -1828,6 +2687,12 @@
      return overall_loss * num_experts
 
 
@@ -1662,7 +1675,7 @@
  @auto_docstring
  class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -1848,6 +2693,7 @@
+@@ -1848,6 +2713,7 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -1670,7 +1683,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1860,9 +2706,10 @@
+@@ -1860,9 +2726,10 @@
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
          output_router_logits: bool | None = None,
@@ -1682,7 +1695,7 @@
          r"""
          labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
              Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
-@@ -1899,30 +2746,70 @@
+@@ -1899,30 +2766,70 @@
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
              output_router_logits=output_router_logits,
@@ -1765,7 +1778,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1930,7 +2817,14 @@
+@@ -1930,7 +2837,14 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
@@ -1781,7 +1794,7 @@
 
 
  class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMixin):
-@@ -1977,6 +2871,7 @@
+@@ -1977,6 +2891,7 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1789,7 +1802,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1990,105 +2885,93 @@
+@@ -1990,105 +2905,93 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1950,7 +1963,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2314,6 +3197,30 @@
+@@ -2314,6 +3217,30 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -642,17 +642,32 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         # Set up dimensions for reshapes later
         batch_size, seq_len, _ = hidden_states.shape
 
+        # transformers 5.x replaced the bespoke per-model DynamicCache (dict-like
+        # `conv_states[layer_idx]` / `recurrent_states[layer_idx]`) with the generic layered
+        # DynamicCache: per-layer linear-attention state lives on `cache_params.layers[layer_idx]`
+        # and is read/written via `has_previous_state(layer_idx)` / `update_conv_state` /
+        # `update_recurrent_state`.
+        # `use_precomputed_states` picks the cached-decode fast path (reuse the stored conv /
+        # recurrent state) over recomputing the whole sequence (prefill). Heads-up on the
+        # `cache_position is not None` term: transformers 5.x no longer has the model's forward
+        # materialize `cache_position`, so a caller that continues from `past_key_values`
+        # without passing `cache_position` explicitly would make this term False and wrongly
+        # fall back to the prefill path mid-decode (ignoring the recurrent state, overwriting
+        # the conv cache). That is harmless TODAY because the cached path below is intentionally
+        # disabled — it raises NotImplementedError — so Qwen3.5 here is training-only. When
+        # decode support is added, drop this term and let the host-side
+        # `has_previous_state(self.layer_idx)` flag decide on its own (matches upstream).
         use_precomputed_states = (
             cache_params is not None
-            and cache_params.has_previous_state
+            and cache_params.has_previous_state(self.layer_idx)
             and seq_len == 1
             and cache_position is not None
         )
 
         # getting projected states from cache if it exists
-        if cache_params is not None:
-            conv_state = cache_params.conv_states[self.layer_idx]
-            recurrent_state = cache_params.recurrent_states[self.layer_idx]
+        if use_precomputed_states:
+            conv_state = cache_params.layers[self.layer_idx].conv_states
+            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
 
         mixed_qkv = self.in_proj_qkv(hidden_states)
 
@@ -712,7 +727,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             if cache_params is not None:
                 mixed_qkv_t = mixed_qkv.transpose(1, 2)
                 conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
-                cache_params.conv_states[self.layer_idx] = conv_state
+                cache_params.update_conv_state(conv_state, self.layer_idx)
             if self.causal_conv1d_fn is not None:
                 # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
                 if ulysses_enabled:
@@ -818,7 +833,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
         # Update cache
         if cache_params is not None:
-            cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 
         # Modification: gather attention output back to sequence-sharded layout before gated norm.
         if ulysses_enabled:
@@ -2022,7 +2037,7 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
@@ -2036,20 +2051,25 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). But we detect it host-side via the cache's ``has_previous_state()`` flag
+        — a Python bool on the linear-attention cache layer — rather than reading ``cache_position[0]``,
+        so no sync.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
         while avoiding the ``torch.all`` reduction + sync. A genuinely padded mask is still returned and
         correctly zeroed.
+
+        NOTE: transformers 5.x changed this method's 2nd arg from ``cache_position`` (a tensor) to
+        ``past_key_values`` (a layered ``DynamicCache``); the regenerated ``Qwen3_5TextModel.forward``
+        now calls ``self._update_linear_attn_mask(attention_mask, past_key_values)``.
         """
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here. `has_previous_state()` reads a
+        # host-side flag on the linear-attention cache layer (no 0-D GPU scalar), so this stays sync-free.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
@@ -362,7 +362,7 @@
          self.recurrent_gated_delta_rule = fused_recurrent_gated_delta_rule or torch_recurrent_gated_delta_rule
 
          if not is_fast_path_available:
-@@ -434,27 +631,29 @@
+@@ -434,19 +631,35 @@
          self,
          hidden_states: torch.Tensor,
          cache_params: Cache | None = None,
@@ -382,27 +382,37 @@
 -        # diverge in how the conv input is assembled and which kernel consumes the states below,
 -        # which we gate locally on `seq_len`.
 -        use_precomputed_states = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
++        # transformers 5.x layered DynamicCache API (see GPU config): per-layer state on
++        # `cache_params.layers[layer_idx]`, accessed via `has_previous_state` / `update_conv_state`
++        # / `update_recurrent_state`.
++        # `use_precomputed_states` picks the cached-decode fast path (reuse the stored conv /
++        # recurrent state) over recomputing the whole sequence (prefill). Heads-up on the
++        # `cache_position is not None` term: transformers 5.x no longer has the model's forward
++        # materialize `cache_position`, so a caller that continues from `past_key_values`
++        # without passing `cache_position` explicitly would make this term False and wrongly
++        # fall back to the prefill path mid-decode (ignoring the recurrent state, overwriting
++        # the conv cache). That is harmless TODAY because the cached path below is intentionally
++        # disabled — it raises NotImplementedError — so Qwen3.5 here is training-only. When
++        # decode support is added, drop this term and let the host-side
++        # `has_previous_state(self.layer_idx)` flag decide on its own (matches upstream).
 +        use_precomputed_states = (
 +            cache_params is not None
-+            and cache_params.has_previous_state
++            and cache_params.has_previous_state(self.layer_idx)
 +            and seq_len == 1
 +            and cache_position is not None
 +        )
 
          # getting projected states from cache if it exists
--        if use_precomputed_states:
--            conv_state = cache_params.layers[self.layer_idx].conv_states
--            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
-+        if cache_params is not None:
-+            conv_state = cache_params.conv_states[self.layer_idx]
-+            recurrent_state = cache_params.recurrent_states[self.layer_idx]
+         if use_precomputed_states:
+@@ -454,7 +667,6 @@
+             recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
 
          mixed_qkv = self.in_proj_qkv(hidden_states)
 -        mixed_qkv = mixed_qkv.transpose(1, 2)
 
          z = self.in_proj_z(hidden_states)
          z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)
-@@ -462,61 +661,131 @@
+@@ -462,61 +674,131 @@
          b = self.in_proj_b(hidden_states)
          a = self.in_proj_a(hidden_states)
 
@@ -472,7 +482,7 @@
 -                cache_params.update_conv_state(new_conv_state, self.layer_idx)
 +                mixed_qkv_t = mixed_qkv.transpose(1, 2)
 +                conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
-+                cache_params.conv_states[self.layer_idx] = conv_state
++                cache_params.update_conv_state(conv_state, self.layer_idx)
              if self.causal_conv1d_fn is not None:
 +                # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
 +                if ulysses_enabled:
@@ -566,7 +576,7 @@
              core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
                  query,
                  key,
-@@ -527,23 +796,16 @@
+@@ -527,23 +809,16 @@
                  output_final_state=cache_params is not None,
                  use_qk_l2norm_in_kernel=True,
              )
@@ -586,8 +596,7 @@
 
          # Update cache
          if cache_params is not None:
--            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
-+            cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+             cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 +
 +        # Modification: gather attention output back to sequence-sharded layout before gated norm.
 +        if ulysses_enabled:
@@ -597,7 +606,7 @@
 
          # reshape input data into 2D tensor
          core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
-@@ -554,6 +816,20 @@
+@@ -554,6 +829,20 @@
          output = self.out_proj(core_attn_out)
          return output
 
@@ -618,7 +627,7 @@
 
  def rotate_half(x):
      """Rotates half the hidden dims of the input."""
-@@ -562,27 +838,14 @@
+@@ -562,27 +851,14 @@
      return torch.cat((-x2, x1), dim=-1)
 
 
@@ -653,7 +662,7 @@
      cos = cos.unsqueeze(unsqueeze_dim)
      sin = sin.unsqueeze(unsqueeze_dim)
 
-@@ -732,12 +995,24 @@
+@@ -732,12 +1008,24 @@
          return down_proj
 
 
@@ -680,7 +689,7 @@
          self.num_experts = config.num_experts
          self.hidden_dim = config.hidden_size
          self.intermediate_dim = config.moe_intermediate_size
-@@ -751,6 +1026,11 @@
+@@ -751,6 +1039,11 @@
          top_k_index: torch.Tensor,
          top_k_weights: torch.Tensor,
      ) -> torch.Tensor:
@@ -692,7 +701,7 @@
          final_hidden_states = torch.zeros_like(hidden_states)
          with torch.no_grad():
              expert_mask = torch.nn.functional.one_hot(top_k_index, num_classes=self.num_experts)
-@@ -791,6 +1071,12 @@
+@@ -791,6 +1084,12 @@
          return router_logits, router_scores, router_indices
 
 
@@ -705,7 +714,7 @@
  class Qwen3_5MoeSparseMoeBlock(nn.Module):
      def __init__(self, config):
          super().__init__()
-@@ -799,18 +1085,47 @@
+@@ -799,18 +1098,47 @@
          self.shared_expert = Qwen3_5MoeMLP(config, intermediate_size=config.shared_expert_intermediate_size)
          self.shared_expert_gate = torch.nn.Linear(config.hidden_size, 1, bias=False)
 
@@ -754,7 +763,7 @@
 
 
  class Qwen3_5MoeRMSNorm(nn.Module):
-@@ -822,15 +1137,30 @@
+@@ -822,15 +1150,30 @@
      def _norm(self, x):
          return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
 
@@ -786,7 +795,7 @@
 
 
  class Qwen3_5MoeDecoderLayer(GradientCheckpointingLayer):
-@@ -846,6 +1176,7 @@
+@@ -846,6 +1189,7 @@
          self.input_layernorm = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
          self.post_attention_layernorm = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
@@ -794,7 +803,7 @@
      def forward(
          self,
          hidden_states: torch.Tensor,
-@@ -853,19 +1184,29 @@
+@@ -853,19 +1197,29 @@
          attention_mask: torch.Tensor | None = None,
          position_ids: torch.LongTensor | None = None,
          past_key_values: Cache | None = None,
@@ -825,7 +834,7 @@
              )
          elif self.layer_type == "full_attention":
              # Self Attention
-@@ -874,6 +1215,7 @@
+@@ -874,6 +1228,7 @@
                  attention_mask=attention_mask,
                  position_ids=position_ids,
                  past_key_values=past_key_values,
@@ -833,7 +842,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -888,7 +1230,6 @@
+@@ -888,7 +1243,6 @@
          if isinstance(hidden_states, tuple):
              hidden_states, _ = hidden_states
          hidden_states = residual + hidden_states
@@ -841,7 +850,7 @@
          return hidden_states
 
 
-@@ -976,9 +1317,16 @@
+@@ -976,9 +1330,16 @@
          return x
 
 
@@ -858,7 +867,7 @@
      orig_q_dtype = q.dtype
      orig_k_dtype = k.dtype
      q, k = q.float(), k.float()
-@@ -1107,6 +1455,12 @@
+@@ -1107,6 +1468,12 @@
          return hidden_states
 
 
@@ -871,7 +880,7 @@
  class Qwen3_5MoeVisionModel(Qwen3_5MoePreTrainedModel):
      config: Qwen3_5MoeVisionConfig
      input_modalities = ("image", "video")
-@@ -1142,28 +1496,127 @@
+@@ -1142,28 +1509,127 @@
 
          self.post_init()
 
@@ -1019,7 +1028,7 @@
 
      @merge_with_config_defaults
      @capture_outputs
-@@ -1178,25 +1631,147 @@
+@@ -1178,25 +1644,147 @@
          Returns:
              `torch.Tensor`: hidden_states.
          """
@@ -1179,7 +1188,7 @@
 
          for blk in self.blocks:
              hidden_states = blk(
-@@ -1212,6 +1787,36 @@
+@@ -1212,6 +1800,36 @@
              last_hidden_state=hidden_states,
              pooler_output=merged_hidden_states,
          )
@@ -1216,7 +1225,7 @@
 
 
  @auto_docstring(
-@@ -1268,6 +1873,37 @@
+@@ -1268,6 +1886,37 @@
      rope_deltas: torch.LongTensor | None = None
      router_logits: tuple[torch.FloatTensor] | None = None
      aux_loss: torch.FloatTensor | None = None
@@ -1254,12 +1263,9 @@
 
 
  class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
-@@ -1353,19 +1989,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1355,17 +2004,45 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1277,14 +1283,18 @@
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). But we detect it host-side via the cache's ``has_previous_state()`` flag
++        — a Python bool on the linear-attention cache layer — rather than reading ``cache_position[0]``,
++        so no sync.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
 +        while avoiding the ``torch.all`` reduction + sync. A genuinely padded mask is still returned and
 +        correctly zeroed.
++
++        NOTE: transformers 5.x changed this method's 2nd arg from ``cache_position`` (a tensor) to
++        ``past_key_values`` (a layered ``DynamicCache``); the regenerated ``Qwen3_5TextModel.forward``
++        now calls ``self._update_linear_attn_mask(attention_mask, past_key_values)``.
          """
 -        linear_attn_mask = attention_mask
 -        if (past_key_values is not None and past_key_values.has_previous_state()) or (
@@ -1295,8 +1305,9 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here. `has_previous_state()` reads a
++        # host-side flag on the linear-attention cache layer (no 0-D GPU scalar), so this stays sync-free.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +
@@ -1308,7 +1319,7 @@
 
 
  @auto_docstring
-@@ -1376,7 +2035,19 @@
+@@ -1376,7 +2053,19 @@
      config: Qwen3_5MoeConfig
      _no_split_modules = ["Qwen3_5MoeDecoderLayer", "Qwen3_5MoeVisionBlock"]
 
@@ -1328,7 +1339,7 @@
          super().__init__(config)
          self.visual = Qwen3_5MoeVisionModel._from_config(config.vision_config)
          self.language_model = Qwen3_5MoeTextModel._from_config(config.text_config)
-@@ -1561,64 +2232,43 @@
+@@ -1561,64 +2250,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1418,7 +1429,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1684,6 +2334,7 @@
+@@ -1684,6 +2352,7 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1426,7 +1437,7 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5MoeModelOutputWithPast:
          r"""
-@@ -1691,6 +2342,8 @@
+@@ -1691,6 +2360,8 @@
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
@@ -1435,7 +1446,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1698,29 +2351,170 @@
+@@ -1698,29 +2369,170 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1616,7 +1627,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1730,6 +2524,17 @@
+@@ -1730,6 +2542,17 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1634,7 +1645,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1737,6 +2542,7 @@
+@@ -1737,6 +2560,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1642,7 +1653,7 @@
              **kwargs,
          )
 
-@@ -1828,6 +2634,12 @@
+@@ -1828,6 +2652,12 @@
      return overall_loss * num_experts
 
 
@@ -1655,7 +1666,7 @@
  @auto_docstring
  class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -1848,6 +2660,7 @@
+@@ -1848,6 +2678,7 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -1663,7 +1674,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1860,9 +2673,10 @@
+@@ -1860,9 +2691,10 @@
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
          output_router_logits: bool | None = None,
@@ -1675,7 +1686,7 @@
          r"""
          labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
              Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
-@@ -1899,30 +2713,70 @@
+@@ -1899,30 +2731,70 @@
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
              output_router_logits=output_router_logits,
@@ -1758,7 +1769,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1930,7 +2784,14 @@
+@@ -1930,7 +2802,14 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
@@ -1774,7 +1785,7 @@
 
 
  class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMixin):
-@@ -1977,6 +2838,7 @@
+@@ -1977,6 +2856,7 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1782,7 +1793,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1990,105 +2852,93 @@
+@@ -1990,105 +2870,93 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1943,7 +1954,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2314,6 +3164,30 @@
+@@ -2314,6 +3182,30 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -641,17 +641,30 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         # Set up dimensions for reshapes later
         batch_size, seq_len, _ = hidden_states.shape
 
+        # transformers 5.x layered DynamicCache API (see GPU config): per-layer state on
+        # `cache_params.layers[layer_idx]`, accessed via `has_previous_state` / `update_conv_state`
+        # / `update_recurrent_state`.
+        # `use_precomputed_states` picks the cached-decode fast path (reuse the stored conv /
+        # recurrent state) over recomputing the whole sequence (prefill). Heads-up on the
+        # `cache_position is not None` term: transformers 5.x no longer has the model's forward
+        # materialize `cache_position`, so a caller that continues from `past_key_values`
+        # without passing `cache_position` explicitly would make this term False and wrongly
+        # fall back to the prefill path mid-decode (ignoring the recurrent state, overwriting
+        # the conv cache). That is harmless TODAY because the cached path below is intentionally
+        # disabled — it raises NotImplementedError — so Qwen3.5 here is training-only. When
+        # decode support is added, drop this term and let the host-side
+        # `has_previous_state(self.layer_idx)` flag decide on its own (matches upstream).
         use_precomputed_states = (
             cache_params is not None
-            and cache_params.has_previous_state
+            and cache_params.has_previous_state(self.layer_idx)
             and seq_len == 1
             and cache_position is not None
         )
 
         # getting projected states from cache if it exists
-        if cache_params is not None:
-            conv_state = cache_params.conv_states[self.layer_idx]
-            recurrent_state = cache_params.recurrent_states[self.layer_idx]
+        if use_precomputed_states:
+            conv_state = cache_params.layers[self.layer_idx].conv_states
+            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
 
         mixed_qkv = self.in_proj_qkv(hidden_states)
 
@@ -711,7 +724,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             if cache_params is not None:
                 mixed_qkv_t = mixed_qkv.transpose(1, 2)
                 conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
-                cache_params.conv_states[self.layer_idx] = conv_state
+                cache_params.update_conv_state(conv_state, self.layer_idx)
             if self.causal_conv1d_fn is not None:
                 # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
                 if ulysses_enabled:
@@ -799,7 +812,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
         # Update cache
         if cache_params is not None:
-            cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 
         # Modification: gather attention output back to sequence-sharded layout before gated norm.
         if ulysses_enabled:
@@ -1989,7 +2002,7 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
@@ -2003,20 +2016,25 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). But we detect it host-side via the cache's ``has_previous_state()`` flag
+        — a Python bool on the linear-attention cache layer — rather than reading ``cache_position[0]``,
+        so no sync.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
         while avoiding the ``torch.all`` reduction + sync. A genuinely padded mask is still returned and
         correctly zeroed.
+
+        NOTE: transformers 5.x changed this method's 2nd arg from ``cache_position`` (a tensor) to
+        ``past_key_values`` (a layered ``DynamicCache``); the regenerated ``Qwen3_5TextModel.forward``
+        now calls ``self._update_linear_attn_mask(attention_mask, past_key_values)``.
         """
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here. `has_previous_state()` reads a
+        # host-side flag on the linear-attention cache layer (no 0-D GPU scalar), so this stays sync-free.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 


### PR DESCRIPTION
### What does this PR do?

> Fixes a transformers 5.x regression in the `qwen3_5` / `qwen3_5_moe` gated-DeltaNet
> (linear-attention) cache path, surfaced after the 5.2 → 5.9 model upgrade, and adds a
> general `use_cache=True` test that closes the CI blind spot that let it through.
>
> transformers 5.x replaced the bespoke per-model `DynamicCache` (dict-like
> `conv_states[idx]` / `recurrent_states[idx]`, `has_previous_state` attribute) with the
> generic **layered** `DynamicCache`. The patch configs still used the old API, so any
> `use_cache=True` forward crashed — most notably `_update_linear_attn_mask`, whose
> upstream-verbatim caller now passes a `DynamicCache` where the override expected a
> tensor and called `.shape[-1]` on it.

### Checklist Before Starting

- Related: follow-up to the transformers 5.9 bump (#774).
- PR title follows `[{modules}] {type}: {description}` format.

### Test

> - New `tests/models/test_models_cache_forward_v5.py`: one `use_cache=True` prefill across
>   all 13 v5 models, asserting the cache populates. The existing bitwise test
>   (`test_models_logits_equal_v5`) runs `use_cache=False` and is blind to cache-API drift —
>   this is the gap that let the bug through.
> - Linear cases (`qwen3_5`, `qwen3_5_moe`) keep the real `linear_attention` layers (no
>   full-attention override) so `update_conv_state` / `update_recurrent_state` /
>   `_update_linear_attn_mask` actually fire; they need `fla` + GPU and skip otherwise.
> - The smoke is isolated to the cache path: linear cases run all non-DeltaNet ops eager
>   (incl. MoE) so they depend only on `fla` + `flash_attn` (the skip gates), not fused-MoE.
> - **13/13 pass on an 8xA100 worker** (transformers 5.9 + fla). Wired into
>   `gpu_unit_tests.yml` next to `test_models_logits_equal_v5`.
> - GPU-only by design (gated on `IS_CUDA_AVAILABLE`), matching the existing v5 forward-test
>   precedent; on NPU every case skips. `make quality` clean.

### API and Usage Example

> N/A — internal modeling / test change, no public API surface.

### Design & Code Changes

> - `qwen3_5_{gpu,npu}_patch_gen_config.py`: migrate the gated-DeltaNet cache to the v5
>   layered `DynamicCache`:
>   - `has_previous_state(layer_idx)` (method, not attribute);
>   - per-layer state via `cache_params.layers[idx].conv_states/.recurrent_states`, read only
>     under `use_precomputed_states` (the layered state is `None` until initialized);
>   - writes via `update_conv_state(state, idx)` / `update_recurrent_state(state, idx)`;
>   - `_update_linear_attn_mask` 2nd arg `cache_position` → `past_key_values`, detection via
>     `past_key_values.has_previous_state()` (host-side flag, still sync-free).
> - Regenerated `generated/` files (patchgen, drift-clean). `qwen3_5_moe` reuses the patch
>   functions via import, so its generated files update with no config diff of its own.
> - `tests/models/test_models_cache_forward_v5.py` + `gpu_unit_tests.yml` wiring.

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] Applied pre-commit checks
- [x] Added/updated documentation (N/A — no API/config/workflow surface change)
- [x] Added tests to CI workflow
