### PR TITLE
[docs] chore: drop stale offline MoE merge step from Qwen3 / Qwen3-MoE / Qwen3-Omni recipes

### DIFF
--- a/docs/examples/qwen3.md
+++ b/docs/examples/qwen3.md
@@ -31,10 +31,13 @@ python3 scripts/download_hf_model.py \
     --local_dir .
 ```
 
-Merge qwen3 moe model experts to support GroupGemm optimize.
-``` shell
-python3 scripts/moe_ckpt_merge/moe_merge.py --raw_hf_path Qwen3-30B-A3B-Instruct-2507  --merge_hf_path Qwen3-30B-A3B-Instruct-2507-merge
-```
+> **Note.** VeOmni's runtime `CheckpointTensorConverter` folds the per-expert
+> HF safetensor keys into VeOmni's fused expert layout at load time, so the
+> stock HF checkpoint can be passed directly to training — no offline merge
+> step is required. `scripts/moe_ckpt_merge/moe_merge.py` is deprecated but
+> may still be useful as a one-time optimization for very large checkpoints
+> (e.g. Qwen3-235B) to amortize per-load stacking cost. See
+> `docs/transformers_v5/transformers_v5_moe_weight_loading.md` for details.
 
 ## Start training on GPU/NPU
 
@@ -52,7 +55,7 @@ bash train.sh tasks/train_text.py configs/text/qwen3.yaml \
 
 ```shell
 bash train.sh tasks/train_text.py configs/text/qwen3.yaml \
-    --model.model_path ./Qwen3-30B-A3B-Instruct-2507-merge \
+    --model.model_path ./Qwen3-30B-A3B-Instruct-2507 \
     --model.ops_implementation.moe_implementation fused_triton \
     --data.train_path ./tulu-first2000.parquet \
     --train.accelerator.fsdp_config.fsdp_mode fsdp2 \

--- a/docs/examples/qwen3_moe.md
+++ b/docs/examples/qwen3_moe.md
@@ -8,10 +8,20 @@ python3 scripts/download_hf_model.py \
   --local_dir .
 ```
 
-2. Merge qwen3 moe model experts to support GroupGemm optimize
-``` shell
-python3 scripts/moe_ckpt_merge/moe_merge.py --raw_hf_path Qwen3-30B-A3B  --merge_hf_path Qwen3-30B-A3B-merge
-```
+2. Train directly on the downloaded checkpoint
+
+VeOmni's runtime `CheckpointTensorConverter` folds the per-expert HF
+safetensor keys (`experts.{j}.gate_proj.weight`, …) into VeOmni's fused
+`gate_up_proj` / `down_proj` layout at load time. The stock HF checkpoint
+can be passed straight to training — no offline merge step is required.
+See `docs/transformers_v5/transformers_v5_moe_weight_loading.md` for the
+full format matrix and how to convert a VeOmni-format training checkpoint
+back to per-expert HF keys for inference engines.
+
+`scripts/moe_ckpt_merge/moe_merge.py` is deprecated. It still works and
+may be useful as a one-time optimization for very large checkpoints
+(e.g. Qwen3-235B) where you want to amortize the per-load stacking cost
+across many runs, but it is no longer a prerequisite.
 
 Most of the MoE models in Transformers referenced the open-source implementation of Mixtral MoE. In this implementation, MoE experts are divided into multiple blocks instead of being combined into a single `nn.Parameters`. Additionally, there are cpu-block operators like `torch.where()` and for loop, which are not very friendly for integrating MoE fusion operators.
 

--- a/docs/examples/qwen3_omni_moe.md
+++ b/docs/examples/qwen3_omni_moe.md
@@ -119,17 +119,22 @@ python3 scripts/download_hf_model.py \
     --local_dir .
 ```
 
-## Merge MoE
-
-```shell
-python3 scripts/moe_ckpt_merge/moe_merge.py \
-    --raw_hf_path Qwen3-Omni-30B-A3B-Instruct \
-    --merge_hf_path Qwen3-Omni-30B-A3B-Instruct-merge
-```
-
 ## Start training on GPU
 
 ```shell
 bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_omni/qwen3_omni.yaml \
-    --model.model_path Qwen3-Omni-30B-A3B-Instruct-merge
+    --model.model_path Qwen3-Omni-30B-A3B-Instruct
 ```
+
+> **Note.** VeOmni's runtime `CheckpointTensorConverter` folds per-expert HF
+> safetensor keys into VeOmni's fused `gate_up_proj` / `down_proj` layout at
+> load time, so the stock HF checkpoint can be passed directly to training —
+> no offline merge step is required. See
+> `docs/transformers_v5/transformers_v5_moe_weight_loading.md` for the full
+> format matrix and how to convert a VeOmni-format training checkpoint back
+> to per-expert HF keys for inference engines.
+>
+> `scripts/moe_ckpt_merge/moe_merge.py` is deprecated. It still works and may
+> be useful as a one-time optimization for very large checkpoints (e.g.
+> Qwen3-235B) where you want to amortize the per-load stacking cost across
+> many runs, but it is no longer a prerequisite.


### PR DESCRIPTION
### What does this PR do?

> The runtime `CheckpointTensorConverter` (registered on every patchgen-generated MoE modeling class) folds per-expert HF safetensor keys (`experts.{j}.gate_proj.weight`, …) into VeOmni's fused `gate_up_proj` / `down_proj` layout at load time. As a result `scripts/moe_ckpt_merge/moe_merge.py` is no longer a prerequisite for training — and the script itself already prints a deprecation warning. The three example recipes still tell users to run it and point `model.model_path` at the `-merge` suffix, which is misleading and adds unnecessary friction. This PR removes the merge step from the recipes, points `model_path` at the stock HF checkpoint, and adds a short cross-link to `docs/transformers_v5/transformers_v5_moe_weight_loading.md`.

### Checklist Before Starting

- Search for relative PRs/issues and link here: builds on #774 (`[model, ci, docs] feat: bump transformers to 5.9.0`) and the runtime tensor-converter work it shipped; companion to #812 which adds a new Qwen3-Omni recipe that already follows this convention.
- PR title follows `[{modules}] {type}: {description}` format ✅

### Test

> Docs-only change. Verified locally:
>
> - `make quality` green.
> - `grep -n "moe_merge\|-merge" docs/examples/qwen3.md docs/examples/qwen3_moe.md docs/examples/qwen3_omni_moe.md` shows only the intentional deprecation-explainer mentions, no stale `-merge` model paths or pre-training merge commands remaining.

### API and Usage Example

> Old launch command:
>
> ```shell
> python3 scripts/moe_ckpt_merge/moe_merge.py \
>     --raw_hf_path Qwen3-Omni-30B-A3B-Instruct \
>     --merge_hf_path Qwen3-Omni-30B-A3B-Instruct-merge
> bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_omni/qwen3_omni.yaml \
>     --model.model_path Qwen3-Omni-30B-A3B-Instruct-merge
> ```
>
> New (no offline merge):
>
> ```shell
> bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_omni/qwen3_omni.yaml \
>     --model.model_path Qwen3-Omni-30B-A3B-Instruct
> ```

### Design & Code Changes

> - `docs/examples/qwen3_omni_moe.md`: drop the "## Merge MoE" section and the `-merge` suffix on `model_path`; replace with a short note explaining that the runtime tensor converter handles per-expert→fused at load time, plus a reference to `docs/transformers_v5/transformers_v5_moe_weight_loading.md` and a clarification that `moe_merge.py` is still available as a one-time optimization for very large checkpoints (e.g. Qwen3-235B).
> - `docs/examples/qwen3_moe.md`: same cleanup for the Qwen3-30B-A3B recipe.
> - `docs/examples/qwen3.md`: drop the merge step under "Qwen3-30B" and the `-merge` suffix on `model_path`.
>
> No code changes; no changes to `scripts/moe_ckpt_merge/` (the deprecation message in `moe_merge.py` stays as-is — it's still a working script for the large-checkpoint use case).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (`make quality` green)
- [x] Added/updated documentation (this PR is the doc update)
- [x] Added tests to CI workflow (N/A — docs-only)
