### PR TITLE
[model] feat: wan2.2 support & pad odd-dim inputs for WanTransformer3D

### DIFF
--- a/configs/dit/wan2.2_TI2V_5B_lora.yaml
+++ b/configs/dit/wan2.2_TI2V_5B_lora.yaml
@@ -1,11 +1,7 @@
 model:
-  model_path: Wan-AI/Wan2.1-I2V-1.3B-diffusers/transformer
-  condition_model_path: Wan-AI/Wan2.1-I2V-1.3B-diffusers
+  model_path: Wan-AI/Wan2.2-TI2V-5B-Diffusers/transformer
+  condition_model_path: Wan-AI/Wan2.2-TI2V-5B-Diffusers
   ops_implementation:
-    # Wan's RoPE has a non-standard signature (rope_apply takes a single
-    # tensor plus freqs/head_dim kwargs) so the framework's default
-    # liger_kernel RoPE cannot drop in. Pin to eager explicitly until a
-    # Wan-specific liger wrapper exists.
     rotary_pos_emb_implementation: eager
   lora_config:
     rank: 128
@@ -23,10 +19,10 @@ data:
   source_name: Tom-and-Jerry-VideoGeneration-Dataset
   mm_configs:
     fps: 24
-    max_frames: 81
+    max_frames: 49
     frame_factor: 4
     frame_factor_remainder: 1
-    scale_factor: 16
+    scale_factor: 32
 
 train:
   global_batch_size: 8
@@ -41,7 +37,7 @@ train:
     fsdp_config:
       fsdp_mode: fsdp2
   checkpoint:
-    output_dir: Wan2.1-I2V-1.3B_lora
+    output_dir: Wan2.2-TI2V-5B_lora
     save_hf_weights: true
     hf_save_epochs: 5
   optimizer:
@@ -55,4 +51,4 @@ train:
   wandb:
     enable: true
     project: veomni_dit
-    name: Wan2.1-I2V-1.3B_lora
+    name: Wan2.2-TI2V-5B_lora

--- a/configs/dit/wan2.2_TI2V_5B_sft.yaml
+++ b/configs/dit/wan2.2_TI2V_5B_sft.yaml
@@ -1,0 +1,57 @@
+model:
+  model_path: Wan-AI/Wan2.2-TI2V-5B-Diffusers/transformer
+  condition_model_path: Wan-AI/Wan2.2-TI2V-5B-Diffusers
+  ops_implementation:
+    attn_implementation: flash_attention_2
+    rotary_pos_emb_implementation: eager
+
+data:
+  train_path: Wanmini480
+  train_size: 1000000000000
+  dataloader:
+    type: native
+    drop_last: true
+  datasets_type: iterable
+  data_type: diffusion
+  max_seq_len: 8192
+  text_keys: text
+  dyn_bsz_buffer_size: 200
+
+train:
+  accelerator:
+    dp_replicate_size: 1
+    ulysses_size: 4
+    fsdp_config:
+      fsdp_mode: fsdp2
+      mixed_precision:
+        enable: false
+    offload:
+      enable_activation: false
+  gradient_checkpointing:
+    enable: true
+  global_batch_size: 8
+  micro_batch_size: 1
+  bsz_warmup_ratio: 0.007
+  optimizer:
+    type: adamw
+    lr: 1.0e-5
+    lr_warmup_ratio: 0.007
+    lr_decay_style: constant
+    lr_decay_ratio: 1.0
+    weight_decay: 0.01
+    max_grad_norm: 1.0
+  vit_lr: 5.0e-6
+  init_device: meta
+  enable_full_determinism: false
+  empty_cache_steps: 500
+  checkpoint:
+    output_dir: wan2.2-ti2v-5b-sft
+    manager: dcp
+    save_epochs: 20
+    save_hf_weights: true
+  max_steps: 500
+  num_train_epochs: 100
+  wandb:
+    enable: false
+    project: Wan2.2-TI2V-5B
+    name: sft_wan22_ti2v_5b

--- a/configs/model_configs/wan/wan22_ti2v_5b.json
+++ b/configs/model_configs/wan/wan22_ti2v_5b.json
@@ -1,0 +1,20 @@
+{
+  "_class_name": "WanTransformer3DModel",
+  "_diffusers_version": "0.33.0",
+  "patch_size": [1, 2, 2],
+  "num_attention_heads": 24,
+  "attention_head_dim": 128,
+  "in_channels": 48,
+  "out_channels": 48,
+  "text_dim": 4096,
+  "freq_dim": 256,
+  "ffn_dim": 14336,
+  "num_layers": 30,
+  "cross_attn_norm": true,
+  "qk_norm": "rms_norm_across_heads",
+  "eps": 1e-06,
+  "image_dim": null,
+  "added_kv_proj_dim": null,
+  "rope_max_seq_len": 1024,
+  "model_type": "WanTransformer3DModel"
+}

--- a/docs/examples/wan2.2_TI2V_5B.md
+++ b/docs/examples/wan2.2_TI2V_5B.md
@@ -1,0 +1,323 @@
+# Wan2.2-TI2V-5B Training Guide
+
+This guide covers LoRA fine-tuning and full-parameter SFT of [Wan2.2-TI2V-5B](https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers) using VeOmni, including dataset preparation, multi-GPU training with Ulysses Sequence Parallelism (SP), and inference with trained adapters.
+
+Wan2.2-TI2V-5B is a 5B-parameter video generation model based on the Mixture-of-Experts (MoE) architecture. It supports both Text-to-Video (T2V) and Text+Image-to-Video (TI2V) generation at 720P resolution and 24fps. The model uses an advanced Wan2.2-VAE with 16×16×4 spatial-temporal compression ratio, enabling high-quality video generation on consumer-grade GPUs such as RTX 4090.
+
+---
+
+## 1. Environment Setup
+
+```shell
+uv sync --extra gpu --dev
+source .venv/bin/activate
+```
+
+For inference, install the video I/O backend:
+
+```shell
+pip install imageio imageio-ffmpeg
+```
+
+---
+
+## 2. Download Model
+
+### Option A: HuggingFace
+
+```shell
+python3 scripts/download_hf_model.py \
+    --repo_id Wan-AI/Wan2.2-TI2V-5B-Diffusers \
+    --local_dir ./Wan2.2-TI2V-5B-Diffusers
+```
+
+### Option B: ModelScope
+
+```shell
+python3 scripts/download_ms_model.py \
+    --model_id Wan-AI/Wan2.2-TI2V-5B-Diffusers \
+    --local_dir ./Wan2.2-TI2V-5B-Diffusers
+```
+
+---
+
+## 3. Model Architecture Differences from Wan2.1
+
+| Feature | Wan2.1-T2V-1.3B | Wan2.2-TI2V-5B |
+|---|---|---|
+| Architecture | Dense Transformer | MoE (Mixture-of-Experts) |
+| Parameters | 1.3B dense | 5B total (MoE with 2 experts) |
+| `in_channels` | 16 | 48 |
+| `out_channels` | 16 | 48 |
+| `num_attention_heads` | 12 | 24 |
+| `num_layers` | 30 | 30 |
+| `ffn_dim` | 8960 | 14336 |
+| VAE `z_dim` | 16 | 48 |
+| VAE `scale_factor_spatial` | 8 | 16 |
+| VAE `in_channels` | 3 | 12 |
+| Scheduler | FlowMatchEulerDiscreteScheduler | UniPCMultistepScheduler (inference) |
+| Max Resolution | 480P | 720P |
+| Tasks | T2V | T2V + TI2V |
+
+---
+
+## 4. Prepare Dataset
+
+VeOmni supports two training workflows:
+
+| Workflow | `training_task` | Description |
+|---|---|---|
+| **Offline** (recommended) | `offline_training` | Pre-embed videos once; re-use embeddings across epochs. Saves GPU memory during training. |
+| **Online** | `online_training` | Embed videos on-the-fly each step. Requires the VAE + text encoder to stay on GPU throughout training. |
+
+### 4.1 Download the Tom and Jerry dataset
+
+This guide uses [Wild-Heart/Tom-and-Jerry-VideoGeneration-Dataset](https://huggingface.co/datasets/Wild-Heart/Tom-and-Jerry-VideoGeneration-Dataset) (~6 000 video clips, 540×360, 6 s each).
+
+```shell
+python3 scripts/download_hf_model.py \
+    --repo_id Wild-Heart/Tom-and-Jerry-VideoGeneration-Dataset \
+    --repo_type dataset \
+    --local_dir ./Tom-and-Jerry-VideoGeneration-Dataset
+```
+
+The downloaded directory has the following structure:
+
+```
+Tom-and-Jerry-VideoGeneration-Dataset/
+├── captions.txt   # one caption per line
+├── videos.txt     # one relative video path per line (mirrors captions.txt)
+└── videos/        # video files
+```
+
+### 4.2 Convert to VeOmni Parquet format
+
+The conversion script reads `captions.txt` and `videos.txt`, loads each video as raw bytes, and writes sharded Parquet files (`0.parquet`, `1.parquet`, …) with columns `prompt`, `video_bytes`, and `source`.
+
+```shell
+python3 scripts/multimodal/convert_data/tom-and-jerry.py \
+    --dataset_path ./Tom-and-Jerry-VideoGeneration-Dataset \
+    --output_dir   ./Tom-and-Jerry-VideoGeneration-Dataset-parquet
+```
+
+### 4.3 Offline Workflow (recommended)
+
+#### Step 1 – Run offline embedding (once)
+
+This step encodes every video with the VAE and every caption with the T5 text encoder, saving the embeddings as Parquet shards. It only needs to run once per dataset.
+
+```shell
+NPROC_PER_NODE=4 bash train.sh tasks/train_dit.py configs/dit/wan2.2_TI2V_5B_lora.yaml \
+    --model.model_path           ./Wan2.2-TI2V-5B-Diffusers/transformer \
+    --model.condition_model_path ./Wan2.2-TI2V-5B-Diffusers \
+    --data.train_path            ./Tom-and-Jerry-VideoGeneration-Dataset-parquet \
+    --data.source_name           Tom-and-Jerry-VideoGeneration-Dataset \
+    --data.offline_embedding_save_dir ./Tom-and-Jerry-VideoGeneration-Dataset_offline \
+    --train.training_task        offline_embedding \
+    --train.global_batch_size    4 \
+    --train.accelerator.ulysses_size 1
+```
+
+The resulting `Tom-and-Jerry-VideoGeneration-Dataset_offline/` directory contains `rank_N_shard_M.parquet` files. Each row stores two pickled tensors:
+
+| Column | Shape | Description |
+|---|---|---|
+| `latents` | `(1, 96, F, H, W)` | VAE posterior parameters (mean + log-variance concatenated along the channel axis; `96 = 2 × 48`) |
+| `context` | `(1, 512, 4096)` | T5 text embedding |
+
+#### Step 2 – Train on the offline dataset
+
+```shell
+SP_SIZE=2
+NPROC_PER_NODE=8   # 4 DP replicas × SP_SIZE=2
+
+bash train.sh tasks/train_dit.py configs/dit/wan2.2_TI2V_5B_lora.yaml \
+    --model.model_path           ./Wan2.2-TI2V-5B-Diffusers/transformer \
+    --model.condition_model_path ./Wan2.2-TI2V-5B-Diffusers \
+    --data.train_path            ./Tom-and-Jerry-VideoGeneration-Dataset_offline \
+    --data.source_name           Tom-and-Jerry-VideoGeneration-Dataset \
+    --train.training_task        offline_training \
+    --train.global_batch_size    8 \
+    --train.micro_batch_size     1 \
+    --train.accelerator.ulysses_size ${SP_SIZE} \
+    --train.checkpoint.output_dir ./exp/Wan2.2-TI2V-5B-Diffusers_lora \
+    --train.checkpoint.save_hf_weights true \
+    --train.checkpoint.save_epochs 5 \
+    --train.checkpoint.load_path auto \
+    --train.num_train_epochs 30 \
+    --train.wandb.enable false
+```
+
+### 4.4 Online Workflow
+
+Pass raw Parquet videos directly during training. The VAE and text encoder run each step.
+
+```shell
+NPROC_PER_NODE=4 bash train.sh tasks/train_dit.py configs/dit/wan2.2_TI2V_5B_lora.yaml \
+    --model.model_path           ./Wan2.2-TI2V-5B-Diffusers/transformer \
+    --model.condition_model_path ./Wan2.2-TI2V-5B-Diffusers \
+    --data.train_path            ./Tom-and-Jerry-VideoGeneration-Dataset-parquet \
+    --data.source_name           Tom-and-Jerry-VideoGeneration-Dataset \
+    --data.mm_configs.fps        24 \
+    --data.mm_configs.max_frames 49 \
+    --train.training_task        online_training \
+    --train.global_batch_size    4 \
+    --train.micro_batch_size     1 \
+    --train.accelerator.ulysses_size 1 \
+    --train.checkpoint.output_dir ./exp/Wan2.2-TI2V-5B-Diffusers_lora \
+    --train.checkpoint.save_hf_weights true \
+    --train.num_train_epochs 30
+```
+
+---
+
+## 5. Training Configuration
+
+### 5.1 LoRA Fine-tuning
+
+The default LoRA config (`configs/dit/wan2.2_TI2V_5B_lora.yaml`) targets the attention and feed-forward projections:
+
+```yaml
+model:
+  lora_config:
+    rank: 128
+    alpha: 64
+    lora_modules:
+      - to_q
+      - to_k
+      - to_v
+      - to_out.0
+      - ffn.net.0.proj
+      - ffn.net.2
+```
+
+### 5.2 Full-Parameter SFT
+
+The SFT config (`configs/dit/wan2.2_TI2V_5B_sft.yaml`) trains all parameters with a lower learning rate:
+
+```yaml
+train:
+  optimizer:
+    lr: 1.0e-5
+```
+
+### 5.3 Sequence Parallelism (SP)
+
+VeOmni supports Ulysses SP for long video sequences. SP splits the sequence dimension across GPUs within each data-parallel replica, reducing per-GPU memory while keeping training numerically equivalent to SP=1.
+
+| `ulysses_size` | GPUs (with 4 DP replicas) |
+|---|---|
+| 1 | 4 |
+| 2 | 8 |
+| 4 | 16 |
+
+Set `--train.accelerator.ulysses_size` to enable SP. The loss and gradient norms are aligned between SP=1 and SP=2 at equal DP sizes.
+
+---
+
+## 6. Checkpoint Output
+
+When `--train.checkpoint.save_hf_weights true` is set, each save produces a directory compatible with `load_lora_adapter`:
+
+```
+exp/Wan2.2-TI2V-5B-Diffusers_lora/checkpoints/
+└── global_step_200/
+    ├── adapter_config.json
+    └── adapter_model.safetensors
+```
+
+---
+
+## 7. Inference
+
+### 7.1 Base model (no LoRA) – Text-to-Video
+
+```python
+import torch
+from diffusers import AutoencoderKLWan, WanPipeline
+from diffusers.utils import export_to_video
+
+model_id = "./Wan2.2-TI2V-5B-Diffusers"
+
+vae = AutoencoderKLWan.from_pretrained(model_id, subfolder="vae", torch_dtype=torch.float32)
+pipe = WanPipeline.from_pretrained(model_id, vae=vae, torch_dtype=torch.bfloat16)
+pipe.to("cuda")
+
+prompt = (
+    "Tom, the mischievous gray cat, is sprawled out on a vibrant red pillow, "
+    "his body relaxed and his eyes half-closed, as if he's just woken up or is "
+    "about to doze off. His white paws are stretched out in front of him, and his "
+    "tail is casually draped over the edge of the pillow."
+)
+negative_prompt = (
+    "Bright tones, overexposed, static, blurred details, subtitles, style, works, "
+    "paintings, images, static, overall gray, worst quality, low quality, JPEG "
+    "compression residue, ugly, incomplete, extra fingers, poorly drawn hands, "
+    "poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, "
+    "still picture, messy background, three legs, many people in the background, "
+    "walking backwards"
+)
+
+output = pipe(
+    prompt=prompt,
+    negative_prompt=negative_prompt,
+    height=480,
+    width=832,
+    num_frames=49,
+    guidance_scale=5.0,
+).frames[0]
+
+export_to_video(output, "output.mp4", fps=15)
+```
+
+### 7.2 Base model – Text+Image-to-Video (TI2V)
+
+```python
+from PIL import Image
+
+image = Image.open("input.jpg")
+
+output = pipe(
+    prompt=prompt,
+    image=image,
+    negative_prompt=negative_prompt,
+    height=480,
+    width=832,
+    num_frames=49,
+    guidance_scale=5.0,
+).frames[0]
+
+export_to_video(output, "output_ti2v.mp4", fps=15)
+```
+
+### 7.3 With trained LoRA adapter
+
+```python
+import torch
+from diffusers import AutoencoderKLWan, WanPipeline
+from diffusers.utils import export_to_video
+
+model_id = "./Wan2.2-TI2V-5B-Diffusers"
+lora_dir = "./exp/Wan2.2-TI2V-5B-Diffusers_lora/checkpoints/global_step_200"
+
+vae = AutoencoderKLWan.from_pretrained(model_id, subfolder="vae", torch_dtype=torch.float32)
+pipe = WanPipeline.from_pretrained(model_id, vae=vae, torch_dtype=torch.bfloat16)
+pipe.to("cuda")
+
+pipe.transformer.load_lora_adapter(lora_dir, prefix="base_model.model", adapter_name="wan_lora")
+pipe.set_adapters("wan_lora", adapter_weights=1.0)  # adjust strength between 0.5–1.0
+
+prompt = "..."
+negative_prompt = "..."
+
+output = pipe(
+    prompt=prompt,
+    negative_prompt=negative_prompt,
+    height=480,
+    width=832,
+    num_frames=49,
+    guidance_scale=5.0,
+).frames[0]
+
+export_to_video(output, "output_lora.mp4", fps=15)
+```

--- a/veomni/models/diffusers/wan_t2v/wan_condition/configuration_wan_condition.py
+++ b/veomni/models/diffusers/wan_t2v/wan_condition/configuration_wan_condition.py
@@ -26,6 +26,7 @@ class WanTransformer3DConditionModelConfig(PretrainedConfig):
         ),
         cfg_negative_prob: float = 0.1,
         video_max_size: int = 480,
+        patch_size: tuple[int, int, int] | None = None,
         seed: Optional[int] = 42,
         **kwargs,
     ):
@@ -41,6 +42,7 @@ class WanTransformer3DConditionModelConfig(PretrainedConfig):
         self.cfg_negative_prompt = cfg_negative_prompt
         self.cfg_negative_prob = cfg_negative_prob
         self.video_max_size = video_max_size
+        self.patch_size = patch_size
         self.seed = seed
         super().__init__(**kwargs)
 

--- a/veomni/models/diffusers/wan_t2v/wan_condition/modeling_wan_condition.py
+++ b/veomni/models/diffusers/wan_t2v/wan_condition/modeling_wan_condition.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -65,11 +67,33 @@ class WanTransformer3DConditionModel(PreTrainedModel):
                 subfolder=self.config.vae_subfolder,
                 torch_dtype=torch.float32,
             )
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            base,
-            subfolder=self.config.scheduler_subfolder,
-        )
-        self.video_processor = VideoProcessor(vae_scale_factor=self.vae.config.scale_factor_spatial)
+        try:
+            self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+                base,
+                subfolder=self.config.scheduler_subfolder,
+            )
+        except Exception:
+            logger.info_rank0(
+                "FlowMatchEulerDiscreteScheduler.from_pretrained failed (checkpoint may use a different "
+                "scheduler class such as UniPCMultistepScheduler). Falling back to default config."
+            )
+            self.scheduler = FlowMatchEulerDiscreteScheduler()
+        vae_sf = self.vae.config.scale_factor_spatial
+        patch_size = self.config.patch_size
+        if patch_size is None:
+            transformer_cfg_path = Path(base) / "transformer" / "config.json"
+            if transformer_cfg_path.exists():
+                with open(transformer_cfg_path) as f:
+                    _cfg = json.load(f)
+                patch_size = _cfg.get("patch_size")
+        if patch_size is not None:
+            _, patch_h, patch_w = patch_size
+            vae_sf = vae_sf * max(patch_h, patch_w)
+            logger.info_rank0(
+                f"Aligning video H/W to multiples of {vae_sf} "
+                f"(vae_scale_factor_spatial={self.vae.config.scale_factor_spatial} * max(patch_h, patch_w)={max(patch_h, patch_w)})"
+            )
+        self.video_processor = VideoProcessor(vae_scale_factor=vae_sf)
         self._prepare_negative_prompt_embeds()
         if self.meta_init:
             del self.text_encoder
@@ -91,6 +115,21 @@ class WanTransformer3DConditionModel(PreTrainedModel):
         size = min(self.config.video_max_size, min(width, height))
         video = functional.resize(video, size, interpolation=InterpolationMode.BICUBIC).float().clamp(0, 255)
         video = self.video_processor.preprocess_video(video)
+
+        # Align temporal dim: Wan VAE uses causal conv3d with temporal compression
+        # ratio = scale_factor_temporal, so (num_frames - 1) must be divisible by it.
+        scale_factor_temporal = self.vae.config.scale_factor_temporal
+        num_frames = video.shape[2]
+        remainder = (num_frames - 1) % scale_factor_temporal
+        if remainder != 0:
+            target_frames = num_frames - remainder
+            if target_frames < 1:
+                target_frames = num_frames + (scale_factor_temporal - remainder)
+            video = video[:, :, :target_frames]
+            logger.info_once(
+                f"Aligned temporal dim from {num_frames} to {target_frames} "
+                f"to satisfy (T-1) % {scale_factor_temporal} == 0"
+            )
         video = video.to(device=self.vae.device, dtype=self.vae.dtype)
 
         # save mean & logvar

--- a/veomni/models/diffusers/wan_t2v/wan_transformer/__init__.py
+++ b/veomni/models/diffusers/wan_t2v/wan_transformer/__init__.py
@@ -2,7 +2,6 @@ from ....loader import MODEL_CONFIG_REGISTRY, MODELING_REGISTRY
 
 
 @MODEL_CONFIG_REGISTRY.register("WanTransformer3DModel")
-@MODEL_CONFIG_REGISTRY.register("dit")
 def register_wan_diffusers_transformer_config():
     from .configuration_wan_transformer import WanTransformer3DModelConfig
 
@@ -10,7 +9,6 @@ def register_wan_diffusers_transformer_config():
 
 
 @MODELING_REGISTRY.register("WanTransformer3DModel")
-@MODELING_REGISTRY.register("dit")
 def register_wan_diffusers_transformer_modeling(architecture: str):
     from .modeling_wan_transformer import WanTransformer3DModel as VeOmniWanTransformer3DModel
     from .modeling_wan_transformer import apply_veomni_wan_transformer_patch

--- a/veomni/models/diffusers/wan_t2v/wan_transformer/__init__.py
+++ b/veomni/models/diffusers/wan_t2v/wan_transformer/__init__.py
@@ -2,6 +2,7 @@ from ....loader import MODEL_CONFIG_REGISTRY, MODELING_REGISTRY
 
 
 @MODEL_CONFIG_REGISTRY.register("WanTransformer3DModel")
+@MODEL_CONFIG_REGISTRY.register("dit")
 def register_wan_diffusers_transformer_config():
     from .configuration_wan_transformer import WanTransformer3DModelConfig
 
@@ -9,6 +10,7 @@ def register_wan_diffusers_transformer_config():
 
 
 @MODELING_REGISTRY.register("WanTransformer3DModel")
+@MODELING_REGISTRY.register("dit")
 def register_wan_diffusers_transformer_modeling(architecture: str):
     from .modeling_wan_transformer import WanTransformer3DModel as VeOmniWanTransformer3DModel
     from .modeling_wan_transformer import apply_veomni_wan_transformer_patch

--- a/veomni/models/diffusers/wan_t2v/wan_transformer/modeling_wan_transformer.py
+++ b/veomni/models/diffusers/wan_t2v/wan_transformer/modeling_wan_transformer.py
@@ -179,6 +179,7 @@ def WanTransformer3DModel_forward(
 ):
     batch_size, num_channels, num_frames, height, width = hidden_states.shape
     p_t, p_h, p_w = self.config.patch_size
+
     post_patch_num_frames = num_frames // p_t
     post_patch_height = height // p_h
     post_patch_width = width // p_w


### PR DESCRIPTION
### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.
1. wan2.2 support
2. fix: pad odd-dim inputs for WanTransformer3D

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
