### PR TITLE
[data] feat: align StatefulDataLoader snapshot frequency to save_steps

### DIFF
--- a/veomni/data/data_loader.py
+++ b/veomni/data/data_loader.py
@@ -85,6 +85,7 @@ def build_native_dataloader(
     build_collate_fn: bool = True,
     collate_fn_kwargs: Optional[Dict[str, Any]] = None,
     multiprocessing_context=None,
+    save_steps: int = 0,
 ) -> "DistributedDataloader":
     """Build the native training dataloader.
 
@@ -205,6 +206,11 @@ def build_native_dataloader(
         )
 
     worker_init_fn = _build_worker_init_fn(worker_num_threads) if worker_num_threads is not None else None
+    # Snapshot is only consumed at save; widen to save_steps in worker mode (1:1 next/step), else keep the every-step default so resume sees a fresh snapshot.
+    if save_steps and save_steps > 0 and not (dyn_bsz and dyn_bsz_runtime == "main"):
+        snapshot_every_n_steps = save_steps
+    else:
+        snapshot_every_n_steps = 1
     dataloader = DistributedDataloader(
         dataset,
         batch_size=dataloader_batch_size,
@@ -217,6 +223,7 @@ def build_native_dataloader(
         prefetch_factor=prefetch_factor,
         worker_init_fn=worker_init_fn,
         multiprocessing_context=multiprocessing_context,
+        snapshot_every_n_steps=snapshot_every_n_steps,
     )
 
     if dyn_bsz and dyn_bsz_runtime == "main":

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -474,6 +474,7 @@ class BaseTrainer(Stateful, ABC):
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             seed=args.train.seed,
             collate_fn=self.collate_fn,
+            save_steps=args.train.checkpoint.save_steps,
             **dataloader_kwargs,
         )
 

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -381,6 +381,7 @@ class DiTTrainer:
                 prefetch_factor=args.data.dataloader.prefetch_factor,
                 seed=args.train.seed,
                 collate_fn=DiTDataCollator(),
+                save_steps=args.train.checkpoint.save_steps,
             )
         else:
             self.base.train_dataloader = None


### PR DESCRIPTION
StatefulDataLoader snapshots the full per-worker iteration state every `snapshot_every_n_steps` (default 1 = every step). The snapshot — state-tree unflatten + deepcopy + worker->main IPC — runs inside every __next__ but is only ever consumed when a training checkpoint is saved. At default frequency this dominated DataLoader time in profiling (a Qwen3.5-4B 32-GPU run on a downstream fork spent ~2.6 s/step on snapshot bookkeeping, the bulk of a 10% DataLoader cost, more than the actual worker->main data fetch).

The official TorchData guidance is exactly this: "If the state is large, this value can be increased (and ideally set to the frequency of training checkpointing) to reduce the overhead of transferring state every step."

Plumb `save_steps` from the trainer into build_native_dataloader and set `snapshot_every_n_steps = save_steps` (the checkpoint cadence). When checkpointing is off (save_steps <= 0, e.g. smoke/profile runs) fall back to `max(train_steps, 1)` to disable per-step snapshots entirely.

Correctness: StatefulDataLoader resumes by fast-forwarding from the latest snapshot plus a recorded step offset, so a checkpoint that lands off a snapshot boundary still resumes exactly — verified bit-wise on a downstream save/resume e2e test (save_steps=5, max_steps=10, resume reproduces the remaining steps bit-for-bit).


- StatefulDataLoader README(meta-pytorch/data):
  https://github.com/meta-pytorch/data/blob/main/torchdata/stateful_dataloader/README.md
  - StatefulDataLoader Tutorial:
  https://meta-pytorch.org/data/main/stateful_dataloader_tutorial.html

HuggingFace accelerate issue
 - 🚀 Feature Request: Improve stateful_dataloader by passing snapshot_every_n_steps · Issue #3243:
  https://github.com/huggingface/accelerate/issues/3243

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
