### PR TITLE
[trainer] feat: add TensorBoard logging backend

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -63,6 +63,7 @@ Training loop, optimizer, parallelism, checkpointing, profiling, and logging.
 * `TrainingArguments` — `train.*`
     * `OptimizerConfig` — `train.optimizer.*`
     * `WandbConfig` — `train.wandb.*`
+    * `TensorBoardConfig` — `train.tensorboard.*`
     * `ProfileConfig` — `train.profile.*`
     * `GradientCheckpointingConfig` — `train.gradient_checkpointing.*`
     * `AcceleratorConfig` — `train.accelerator.*`
@@ -229,6 +230,7 @@ NPU validation runs at two times:
 | max_steps | `Optional[int]` | `None` | Max training steps per epoch (debug only). |
 | optimizer | `OptimizerConfig` | — | Optimizer and learning-rate schedule. |
 | wandb | `WandbConfig` | — | Weights & Biases logging. |
+| tensorboard | `TensorBoardConfig` | — | TensorBoard logging. |
 | profile | `ProfileConfig` | — | Torch profiler settings. |
 | gradient_checkpointing | `GradientCheckpointingConfig` | — | Gradient checkpointing settings. |
 | accelerator | `AcceleratorConfig` | — | Parallelism and distributed-training topology. |
@@ -262,6 +264,15 @@ NPU validation runs at two times:
 | project | `str` | `"VeOmni"` | W&B project name. |
 | name | `Optional[str]` | `None` | W&B experiment name. |
 | id | `Optional[str]` | `None` | W&B run ID for resuming a previous run. |
+
+### TensorBoardConfig
+
+`train.tensorboard.*` — TensorBoard logging via `torch.utils.tensorboard.SummaryWriter`. Independent from wandb; both can be enabled simultaneously. Scalar metrics are written on rank 0 only.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| enable | `bool` | `False` | Enable TensorBoard logging. |
+| save_dir | `Optional[str]` | `None` | Event-file directory. Defaults to `<train.checkpoint.output_dir>/tensorboard`. |
 
 ### ProfileConfig
 

--- a/docs/usage/trainer.md
+++ b/docs/usage/trainer.md
@@ -102,6 +102,7 @@ VeOmni includes several built-in callbacks:
 - **[EnvironMeterCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/trace_callback.py)**: Logs system metrics (MFU, FLOPs, memory usage).
 - **[TqdmCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/trace_callback.py)**: Displays a progress bar.
 - **[WandbTraceCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/trace_callback.py)**: Logs metrics to wandb.
+- **[TensorBoardTraceCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/trace_callback.py)**: Logs metrics to TensorBoard.
 - **[ProfileTraceCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/trace_callback.py)**: Handles profiling.
 - **[CheckpointerCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/checkpoint_callback.py)**: Saves training checkpoints.
 - **[HuggingfaceCkptCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/checkpoint_callback.py)**: Saves HuggingFace checkpoints.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "psutil",
   "timm",
   "wandb",
+  "tensorboard",
   "setuptools",
   "einops>=0.8.1",
   # matplotlib is used by veomni.utils.moe_monitor to render the per-step

--- a/tests/test_tensorboard_callback.py
+++ b/tests/test_tensorboard_callback.py
@@ -1,0 +1,324 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for TensorBoardTraceCallback.
+
+These tests import the callback class directly from its source module
+(bypassing the full veomni.trainer.callbacks package) to avoid triggering
+heavy model-loading transitive imports that require a specific transformers
+version.
+"""
+
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+
+
+def _import_trace_callback():
+    """Import trace_callback.py directly without triggering the package __init__."""
+    # First, ensure the lightweight dependencies are importable.
+    # Stub the Callback base class and logger since they import from veomni internals.
+    base_mod_name = "veomni.trainer.callbacks.base"
+    if base_mod_name not in sys.modules:
+        import types
+
+        stub = types.ModuleType(base_mod_name)
+
+        class _StubCallback:
+            def __init__(self, trainer):
+                self.trainer = trainer
+
+            def on_train_begin(self, state, **kw):
+                pass
+
+            def on_train_end(self, state, **kw):
+                pass
+
+            def on_step_begin(self, state, **kw):
+                pass
+
+            def on_step_end(self, state, **kw):
+                pass
+
+            def on_epoch_begin(self, state, **kw):
+                pass
+
+            def on_epoch_end(self, state, **kw):
+                pass
+
+        @dataclass
+        class _TrainerState:
+            global_step: int = 0
+            epoch: int = 0
+
+        stub.Callback = _StubCallback
+        stub.TrainerState = _TrainerState
+        sys.modules[base_mod_name] = stub
+
+    # Stub veomni.distributed.parallel_state
+    ps_mod_name = "veomni.distributed.parallel_state"
+    if ps_mod_name not in sys.modules:
+        import types
+
+        stub = types.ModuleType(ps_mod_name)
+        stub.get_parallel_state = lambda: None
+        sys.modules[ps_mod_name] = stub
+
+    # Stub veomni.utils.helper
+    helper_mod_name = "veomni.utils.helper"
+    if helper_mod_name not in sys.modules:
+        import types
+
+        stub = types.ModuleType(helper_mod_name)
+        sys.modules[helper_mod_name] = stub
+    utils_mod_name = "veomni.utils"
+    if utils_mod_name not in sys.modules:
+        import types
+
+        stub = types.ModuleType(utils_mod_name)
+        stub.helper = sys.modules[helper_mod_name]
+        sys.modules[utils_mod_name] = stub
+
+    # Stub veomni.utils.dist_utils
+    dist_mod_name = "veomni.utils.dist_utils"
+    if dist_mod_name not in sys.modules:
+        import types
+
+        stub = types.ModuleType(dist_mod_name)
+        stub.all_reduce = lambda v, group=None: v
+        sys.modules[dist_mod_name] = stub
+
+    # Stub veomni.utils.logging
+    logging_mod_name = "veomni.utils.logging"
+    if logging_mod_name not in sys.modules:
+        import types
+
+        stub = types.ModuleType(logging_mod_name)
+
+        class _FakeLogger:
+            def info_rank0(self, msg, *a, **kw):
+                pass
+
+            def warning_rank0(self, msg, *a, **kw):
+                pass
+
+        stub.get_logger = lambda name: _FakeLogger()
+        sys.modules[logging_mod_name] = stub
+
+    # Now import the actual module
+    spec = importlib.util.spec_from_file_location(
+        "veomni.trainer.callbacks.trace_callback",
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "veomni",
+            "trainer",
+            "callbacks",
+            "trace_callback.py",
+        ),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_trace_mod = _import_trace_callback()
+TensorBoardTraceCallback = _trace_mod.TensorBoardTraceCallback
+
+
+@dataclass
+class _TBConfig:
+    enable: bool = True
+    save_dir: Optional[str] = None
+
+
+@dataclass
+class _CheckpointConfig:
+    output_dir: str = "/tmp/test_output"
+
+
+@dataclass
+class _TrainArgs:
+    global_rank: int = 0
+    tensorboard: _TBConfig = field(default_factory=_TBConfig)
+    checkpoint: _CheckpointConfig = field(default_factory=_CheckpointConfig)
+
+
+@dataclass
+class _Args:
+    train: _TrainArgs = field(default_factory=_TrainArgs)
+
+
+class _FakeTrainer:
+    def __init__(self, args, step_env_metrics=None):
+        self.args = args
+        self.step_env_metrics = step_env_metrics or {}
+
+
+@dataclass
+class _FakeState:
+    global_step: int = 1
+
+
+@pytest.fixture
+def tmp_tb_dir():
+    d = tempfile.mkdtemp(prefix="veomni_tb_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def test_tensorboard_callback_creates_writer(tmp_tb_dir):
+    """TensorBoardTraceCallback creates a SummaryWriter on on_train_begin."""
+    args = _Args(train=_TrainArgs(tensorboard=_TBConfig(enable=True, save_dir=tmp_tb_dir)))
+    trainer = _FakeTrainer(args)
+    cb = TensorBoardTraceCallback(trainer)
+
+    cb.on_train_begin(_FakeState())
+
+    assert cb.writer is not None
+    assert os.path.isdir(tmp_tb_dir)
+
+    cb.on_train_end(_FakeState())
+    assert cb.writer is None
+
+
+def test_tensorboard_callback_writes_scalars(tmp_tb_dir):
+    """TensorBoardTraceCallback writes scalar metrics on on_step_end."""
+    args = _Args(train=_TrainArgs(tensorboard=_TBConfig(enable=True, save_dir=tmp_tb_dir)))
+    trainer = _FakeTrainer(args, step_env_metrics={"training/loss": 2.5, "training/lr": 1e-4})
+    cb = TensorBoardTraceCallback(trainer)
+
+    cb.on_train_begin(_FakeState(global_step=0))
+    cb.on_step_end(_FakeState(global_step=1))
+    cb.on_step_end(_FakeState(global_step=2))
+    cb.on_train_end(_FakeState(global_step=2))
+
+    event_files = [f for f in os.listdir(tmp_tb_dir) if "events.out.tfevents" in f]
+    assert len(event_files) > 0, "Expected TensorBoard event files to be created"
+
+
+def test_tensorboard_callback_disabled_non_rank0(tmp_tb_dir):
+    """TensorBoardTraceCallback does nothing on non-rank-0 processes."""
+    args = _Args(train=_TrainArgs(global_rank=1, tensorboard=_TBConfig(enable=True, save_dir=tmp_tb_dir)))
+    trainer = _FakeTrainer(args)
+    cb = TensorBoardTraceCallback(trainer)
+
+    cb.on_train_begin(_FakeState())
+    assert cb.writer is None
+
+
+def test_tensorboard_callback_disabled_by_config(tmp_tb_dir):
+    """TensorBoardTraceCallback does nothing when enable=False."""
+    args = _Args(train=_TrainArgs(tensorboard=_TBConfig(enable=False, save_dir=tmp_tb_dir)))
+    trainer = _FakeTrainer(args)
+    cb = TensorBoardTraceCallback(trainer)
+
+    cb.on_train_begin(_FakeState())
+    assert cb.writer is None
+
+
+def test_tensorboard_callback_default_save_dir():
+    """TensorBoardTraceCallback falls back to output_dir/tensorboard when save_dir is None."""
+    output_dir = tempfile.mkdtemp(prefix="veomni_tb_output_")
+    try:
+        args = _Args(
+            train=_TrainArgs(
+                tensorboard=_TBConfig(enable=True, save_dir=None),
+                checkpoint=_CheckpointConfig(output_dir=output_dir),
+            )
+        )
+        trainer = _FakeTrainer(args)
+        cb = TensorBoardTraceCallback(trainer)
+
+        cb.on_train_begin(_FakeState())
+        assert cb.writer is not None
+
+        expected_dir = os.path.join(output_dir, "tensorboard")
+        assert os.path.isdir(expected_dir)
+
+        cb.on_train_end(_FakeState())
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+
+
+def test_tensorboard_callback_graceful_without_package(tmp_tb_dir, monkeypatch):
+    """TensorBoardTraceCallback logs a warning if tensorboard is not installed."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "torch.utils.tensorboard":
+            raise ImportError("Mocked: tensorboard not installed")
+        return real_import(name, *args, **kwargs)
+
+    args = _Args(train=_TrainArgs(tensorboard=_TBConfig(enable=True, save_dir=tmp_tb_dir)))
+    trainer = _FakeTrainer(args)
+    cb = TensorBoardTraceCallback(trainer)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+    cb.on_train_begin(_FakeState())
+    assert cb.writer is None
+
+
+def test_tensorboard_config_dataclass():
+    """TensorBoardConfig dataclass has correct defaults."""
+    spec = importlib.util.spec_from_file_location(
+        "veomni.arguments.arguments_types",
+        os.path.join(os.path.dirname(__file__), "..", "veomni", "arguments", "arguments_types.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+
+    # Stub dependencies required by arguments_types at import time
+    logging_stub_name = "veomni.utils.logging"
+    if logging_stub_name not in sys.modules:
+        import types
+
+        stub = types.ModuleType(logging_stub_name)
+
+        class _FL:
+            def info_rank0(self, *a, **kw):
+                pass
+
+            def warning_rank0(self, *a, **kw):
+                pass
+
+        stub.get_logger = lambda name: _FL()
+        sys.modules[logging_stub_name] = stub
+
+    env_stub_name = "veomni.utils.env"
+    if env_stub_name not in sys.modules:
+        import types
+
+        stub = types.ModuleType(env_stub_name)
+        stub.get_env = lambda key, default=None: default
+        sys.modules[env_stub_name] = stub
+
+    spec.loader.exec_module(mod)
+
+    TensorBoardConfig = mod.TensorBoardConfig
+    cfg = TensorBoardConfig()
+    assert cfg.enable is False
+    assert cfg.save_dir is None
+
+    # Also verify it's a field in TrainingArguments
+    TrainingArguments = mod.TrainingArguments
+    field_names = [f.name for f in TrainingArguments.__dataclass_fields__.values()]
+    assert "tensorboard" in field_names

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -32,6 +32,7 @@ logger = logging.get_logger(__name__)
 #   train.*
 #   ├── optimizer.*          → OptimizerConfig
 #   ├── wandb.*              → WandbConfig
+#   ├── tensorboard.*        → TensorBoardConfig
 #   ├── profile.*            → ProfileConfig
 #   ├── gradient_checkpointing.*  → GradientCheckpointingConfig
 #   ├── accelerator.*        → AcceleratorConfig
@@ -170,6 +171,27 @@ class WandbConfig:
     id: Optional[str] = field(
         default=None,
         metadata={"help": "Wandb run ID for resuming a previous run."},
+    )
+
+
+@dataclass
+class TensorBoardConfig:
+    """train.tensorboard.* — TensorBoard logging (torch.utils.tensorboard.SummaryWriter).
+
+    Independent from wandb; both can run simultaneously. Scalar metrics are
+    written on global rank 0 only.
+    """
+
+    enable: bool = field(
+        default=False,
+        metadata={"help": "Enable TensorBoard logging."},
+    )
+    save_dir: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Directory to write TensorBoard event files. "
+            "Defaults to `<train.checkpoint.output_dir>/tensorboard` when None."
+        },
     )
 
 
@@ -531,6 +553,7 @@ class TrainingArguments:
     # sub-argument groups
     optimizer: OptimizerConfig = field(default_factory=OptimizerConfig)
     wandb: WandbConfig = field(default_factory=WandbConfig)
+    tensorboard: TensorBoardConfig = field(default_factory=TensorBoardConfig)
     profile: ProfileConfig = field(default_factory=ProfileConfig)
     gradient_checkpointing: GradientCheckpointingConfig = field(default_factory=GradientCheckpointingConfig)
     accelerator: AcceleratorConfig = field(default_factory=AcceleratorConfig)

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -77,6 +77,7 @@ from .callbacks import (
     HuggingfaceCkptCallback,
     MoERouterMonitorCallback,
     ProfileTraceCallback,
+    TensorBoardTraceCallback,
     TqdmCallback,
     TrainerState,
     WandbTraceCallback,
@@ -445,6 +446,7 @@ class BaseTrainer(Stateful, ABC):
         self.environ_meter_callback = EnvironMeterCallback(self)
         self.tqdm_callback = TqdmCallback(self)
         self.wandb_callback = WandbTraceCallback(self)
+        self.tensorboard_callback = TensorBoardTraceCallback(self)
         self.profile_callback = ProfileTraceCallback(self)
         self.checkpointer_callback = CheckpointerCallback(self)
         if self.args.model.lora_config:
@@ -459,6 +461,7 @@ class BaseTrainer(Stateful, ABC):
         self.environ_meter_callback.on_train_begin(self.state)
         self.tqdm_callback.on_train_begin(self.state)
         self.wandb_callback.on_train_begin(self.state)
+        self.tensorboard_callback.on_train_begin(self.state)
         self.profile_callback.on_train_begin(self.state)
         self.checkpointer_callback.on_train_begin(self.state)
         self.hf_ckpt_callback.on_train_begin(self.state)
@@ -469,6 +472,7 @@ class BaseTrainer(Stateful, ABC):
         self.environ_meter_callback.on_train_end(self.state)
         self.tqdm_callback.on_train_end(self.state)
         self.wandb_callback.on_train_end(self.state)
+        self.tensorboard_callback.on_train_end(self.state)
         self.profile_callback.on_train_end(self.state)
         self.checkpointer_callback.on_train_end(self.state)
         self.hf_ckpt_callback.on_train_end(self.state)
@@ -479,6 +483,7 @@ class BaseTrainer(Stateful, ABC):
         self.environ_meter_callback.on_epoch_begin(self.state)
         self.tqdm_callback.on_epoch_begin(self.state)
         self.wandb_callback.on_epoch_begin(self.state)
+        self.tensorboard_callback.on_epoch_begin(self.state)
         self.profile_callback.on_epoch_begin(self.state)
         self.checkpointer_callback.on_epoch_begin(self.state)
         self.hf_ckpt_callback.on_epoch_begin(self.state)
@@ -488,6 +493,7 @@ class BaseTrainer(Stateful, ABC):
         self.environ_meter_callback.on_epoch_end(self.state)
         self.tqdm_callback.on_epoch_end(self.state)
         self.wandb_callback.on_epoch_end(self.state)
+        self.tensorboard_callback.on_epoch_end(self.state)
         self.profile_callback.on_epoch_end(self.state)
         self.checkpointer_callback.on_epoch_end(self.state)
         self.hf_ckpt_callback.on_epoch_end(self.state)
@@ -497,6 +503,7 @@ class BaseTrainer(Stateful, ABC):
         self.environ_meter_callback.on_step_begin(self.state, micro_batches=micro_batches)
         self.tqdm_callback.on_step_begin(self.state, micro_batches=micro_batches)
         self.wandb_callback.on_step_begin(self.state, micro_batches=micro_batches)
+        self.tensorboard_callback.on_step_begin(self.state, micro_batches=micro_batches)
         self.profile_callback.on_step_begin(self.state, micro_batches=micro_batches)
         self.checkpointer_callback.on_step_begin(self.state, micro_batches=micro_batches)
         self.hf_ckpt_callback.on_step_begin(self.state, micro_batches=micro_batches)
@@ -506,6 +513,7 @@ class BaseTrainer(Stateful, ABC):
         self.environ_meter_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
         self.tqdm_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
         self.wandb_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
+        self.tensorboard_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
         self.profile_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
         self.checkpointer_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
         self.hf_ckpt_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)

--- a/veomni/trainer/callbacks/__init__.py
+++ b/veomni/trainer/callbacks/__init__.py
@@ -25,6 +25,7 @@ from .trace_callback import (
     EnvironMeterCallback,
     MoERouterMonitorCallback,
     ProfileTraceCallback,
+    TensorBoardTraceCallback,
     TqdmCallback,
     WandbTraceCallback,
 )
@@ -38,6 +39,7 @@ __all__ = [
     "HFLoraCkptCallback",
     "EvaluateCallback",
     "WandbTraceCallback",
+    "TensorBoardTraceCallback",
     "ProfileTraceCallback",
     "EnvironMeterCallback",
     "MoERouterMonitorCallback",

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import time
 from typing import TYPE_CHECKING, Any, Dict, List
 
@@ -156,6 +157,58 @@ class WandbTraceCallback(Callback):
             import wandb
 
             wandb.log(self.trainer.step_env_metrics, step=state.global_step)
+
+
+class TensorBoardTraceCallback(Callback):
+    """Writes scalar training metrics to TensorBoard event files.
+
+    Runs on global rank 0 only. Enabled independently from wandb via
+    ``train.tensorboard.enable``.
+    """
+
+    def __init__(self, trainer: "BaseTrainer") -> None:
+        super().__init__(trainer)
+        self.writer = None
+
+    def on_train_begin(self, state: TrainerState, **kwargs) -> None:
+        args: "VeOmniArguments" = self.trainer.args
+        if not (args.train.global_rank == 0 and args.train.tensorboard.enable):
+            return
+
+        try:
+            from torch.utils.tensorboard import SummaryWriter
+        except ImportError:
+            logger.warning_rank0(
+                "TensorBoard logging is enabled but the 'tensorboard' package is not installed. "
+                "Install it with: pip install tensorboard. Skipping TensorBoard logging."
+            )
+            return
+
+        save_dir = args.train.tensorboard.save_dir or os.path.join(args.train.checkpoint.output_dir, "tensorboard")
+        os.makedirs(save_dir, exist_ok=True)
+
+        self.writer = SummaryWriter(log_dir=save_dir)
+        logger.info_rank0(f"TensorBoard logging enabled. Event files: {save_dir}")
+
+    def on_step_end(self, state: TrainerState, **kwargs) -> None:
+        if self.writer is None:
+            return
+
+        metrics = getattr(self.trainer, "step_env_metrics", None)
+        if not metrics:
+            return
+
+        for tag, value in metrics.items():
+            if isinstance(value, (int, float)):
+                self.writer.add_scalar(tag, value, global_step=state.global_step)
+            elif hasattr(value, "item"):
+                self.writer.add_scalar(tag, value.item(), global_step=state.global_step)
+
+    def on_train_end(self, state: TrainerState, **kwargs) -> None:
+        if self.writer is not None:
+            self.writer.flush()
+            self.writer.close()
+            self.writer = None
 
 
 class ProfileTraceCallback(Callback):


### PR DESCRIPTION
## Summary

Add a lightweight TensorBoard logging callback (`TensorBoardTraceCallback`) that writes scalar training metrics (loss, lr, MFU, throughput, etc.) to event files via `torch.utils.tensorboard.SummaryWriter`.

- **Independent from wandb** — both backends can run simultaneously
- **Rank-0 only** — no file contention in distributed training
- **Graceful fallback** — logs a clear warning when `tensorboard` is not installed
- **New config**: `train.tensorboard.enable` / `train.tensorboard.save_dir`

## Motivation

Many teams prefer TensorBoard over wandb for metric visualization — it's self-hosted, has no external service dependency, and integrates natively with PyTorch. This PR adds first-class TensorBoard support without removing or changing the existing wandb integration.

## Changes

| File | Change |
| --- | --- |
| `veomni/arguments/arguments_types.py` | New `TensorBoardConfig` dataclass |
| `veomni/trainer/callbacks/trace_callback.py` | New `TensorBoardTraceCallback` class |
| `veomni/trainer/callbacks/__init__.py` | Export new callback |
| `veomni/trainer/base.py` | Integrate callback into all lifecycle hooks |
| `pyproject.toml` | Add `tensorboard` dependency |
| `docs/usage/arguments.md` | Document `TensorBoardConfig` |
| `docs/usage/trainer.md` | List new callback |
| `tests/test_tensorboard_callback.py` | 7 unit tests covering all code paths |

## Usage

```yaml
train:
  tensorboard:
    enable: true
    save_dir: /path/to/tb_logs  # optional, defaults to <output_dir>/tensorboard
```

Then visualize with:
```bash
tensorboard --logdir /path/to/tb_logs
```

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] 7 unit tests in `tests/test_tensorboard_callback.py` (all pass):
  - Writer creation on rank 0
  - Scalar metric writing and event file generation
  - Disabled on non-rank-0
  - Disabled when `enable=False`
  - Default `save_dir` fallback to `<output_dir>/tensorboard`
  - Graceful handling when tensorboard package is missing
  - Config dataclass correctness