### PR TITLE
docs,ops: add Ascend 950 (A5) support documentation and hardware matrix

### DIFF
--- a/docs/get_started/installation/install.md
+++ b/docs/get_started/installation/install.md
@@ -2,11 +2,23 @@
 
 In this section, we provide the installation guide for Nvidia GPU.
 
-VeOmni also supports other hardware platform, please refer to [Ascend](install_ascend.md).
+VeOmni also supports other hardware platform, please refer to [Ascend NPU Installation](../installation/install_ascend_x86.md).
 
 ## Required Environment
 
 CUDA == 12.8
+
+## Supported Hardware and Operating Systems
+
+| Hardware | Operating System | Architecture |
+|----------|-----------------|-------------|
+| Nvidia GPU (CUDA 12.8) | Ubuntu 22.04 / 24.04 | x86_64 |
+| Ascend A2 (910B) | Ubuntu 22.04 | x86_64 / ARM64 |
+| Ascend A3 (910B) | Ubuntu 22.04 | x86_64 / ARM64 |
+| Ascend 950 (A5) | Ubuntu 22.04 | x86_64 / ARM64 |
+
+> **Note**: For detailed information about Ascend NPU hardware support, please refer to [Get Started with Ascend NPU](../hardware_support/get_started_npu.md).
+> For scenarios pending further validation on A5, please refer to [A5 Features Pending Validation](../hardware_support/a5_unsupported_features.md).
 
 ## Install with uv or pip
 

--- a/docs/get_started/installation/install_ascend_arm.md
+++ b/docs/get_started/installation/install_ascend_arm.md
@@ -1,8 +1,21 @@
 # Installation with Ascend NPU (ARM)
 
+## Supported Hardware and Operating Systems
+
+This installation guide applies to the following Ascend NPU products on ARM64 architecture:
+
+| Hardware | Operating System | CANN Version | Status |
+|----------|-----------------|--------------|--------|
+| Ascend A2 (910B) | Ubuntu 22.04 | 8.3.RC2 / 9.0.0 | ✅ Supported |
+| Ascend A3 (910B) | Ubuntu 22.04 | 9.0.0 | ✅ Supported |
+| Ascend 950 (A5) | Ubuntu 22.04 | 9.0.0 | ✅ Supported |
+
+> **Note**: A5 refers to the Ascend 950 series products. All existing unit tests and system tests pass on A5.
+> For scenarios pending further validation on A5, please refer to [A5 Features Pending Validation](../../hardware_support/a5_unsupported_features.md).
+
 ## Required Environment
 
-CANN == 8.3.RC1
+CANN == 8.3.RC1 (9.0.0 recommended for A5 and A3)
 
 ## Prepare CANN
 

--- a/docs/get_started/installation/install_ascend_x86.md
+++ b/docs/get_started/installation/install_ascend_x86.md
@@ -1,8 +1,20 @@
 # Installation with Ascend NPU (x86)
 
+## Supported Hardware and Operating Systems
+
+This installation guide applies to the following Ascend NPU products on x86_64 architecture:
+
+| Hardware | Operating System | CANN Version | Status |
+|----------|-----------------|--------------|--------|
+| Ascend A2 (910B) | Ubuntu 22.04 | 8.3.RC2 / 9.0.0 | ✅ Supported |
+| Ascend 950 (A5) | Ubuntu 22.04 | 9.0.0 | ✅ Supported |
+
+> **Note**: A5 refers to the Ascend 950 series products. All existing unit tests and system tests pass on A5.
+> For scenarios pending further validation on A5, please refer to [A5 Features Pending Validation](../../hardware_support/a5_unsupported_features.md).
+
 ## Required Environment
 
-CANN == 8.3.RC1
+CANN == 8.3.RC1 (9.0.0 recommended for A5)
 
 ## Prepare CANN
 
@@ -11,6 +23,8 @@ Choose one of the following methods to use CANN:
 1. Install CANN according to the [official documentation](https://www.hiascend.com/document/detail/zh/canncommercial/83RC1/softwareinst/instg/instg_quick.html?Mode=PmIns&InstallType=local&OS=openEuler&Software=cannToolKit)
 
 2. Download and use [the CANN image](https://www.hiascend.com/developer/ascendhub/detail/17da20d1c2b6493cb38765adeba85884)
+
+> **Note**: For Ascend 950 (A5) products, please use CANN 9.0.0.
 
 ## Install with uv or pip
 

--- a/docs/hardware_support/AscendDockerUsage/build_a5_docker.md
+++ b/docs/hardware_support/AscendDockerUsage/build_a5_docker.md
@@ -1,0 +1,50 @@
+# Ascend 950 (A5) Docker Image Build and Usage Guide
+
+## Overview
+This guide provides step-by-step instructions for building and using the Ascend 950 (A5) Docker image for VeOmni framework. The A5 product is part of the Ascend 950 series and supports both x86_64 and ARM64 architectures.
+
+> **Note**: For Ascend A2 (910B) Docker images, please refer to [Ascend A2 Docker Guide](../build_a2_docker.md).
+> **Note**: The A5 Docker image is currently under preparation and will be available soon.
+
+## Prerequisites
+- Docker installed on your system
+- Access to Ascend 950 (A5) hardware accelerators
+- Network access to pull the base image and install dependencies
+- Proxy configuration (if required in your environment)
+
+## Supported Base Image
+
+The A5 Docker image is based on the following CANN base image (to be released):
+
+```bash
+# for x86
+docker pull --platform=amd64 swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0.0-950-ubuntu22.04-py3.11
+
+# for arm64
+docker pull --platform=arm64 swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0.0-950-ubuntu22.04-py3.11
+```
+
+> **Note**: The base image tag for A5 will be updated once published by the Ascend platform team. Please check back for the latest image.
+
+## Build and Run Instructions
+
+Build and run instructions for A5 will be added once the Docker image is ready. The A5 Docker image will follow the same structure as the A2/A3 images, with appropriate CANN 9.0.0 base and VeOmni dependencies pre-installed.
+
+## Operator Configuration for A5
+
+When training on A5, use the following operator configuration in your YAML:
+
+```yaml
+model:
+  ops_implementation:
+    attn_implementation: "sdpa"
+    moe_implementation: "fused_npu"
+    cross_entropy_loss_implementation: "npu"
+    rms_norm_implementation: "npu"
+    rotary_pos_emb_implementation: "npu"
+    swiglu_mlp_implementation: "eager"
+    load_balancing_loss_implementation: "eager"
+    rms_norm_gated_implementation: "eager"
+```
+
+> **Note**: Do not use `flash_attention_2` or `liger_kernel` backends on A5. See [A5 Features Pending Validation](../a5_unsupported_features.md) for details.

--- a/docs/hardware_support/FAQ.md
+++ b/docs/hardware_support/FAQ.md
@@ -30,7 +30,7 @@ NODE_RANK=${NODE_RANK:=0}
 MASTER_ADDR=${MASTER_ADDR:=192.168.1.100}
 # Master node port (default works for most cases)
 MASTER_PORT=${MASTER_PORT:=12345}
-# Number of NPUs per node (A2: max 8, A3: max 16)
+# Number of NPUs per node (A2/A5: max 8, A3: max 16)
 NPROC_PER_NODE=${NPROC_PER_NODE:=8}
 ```
 
@@ -41,7 +41,7 @@ NPROC_PER_NODE=${NPROC_PER_NODE:=8}
 - `NODE_RANK`: Unique identifier for each node (0 to NNODES-1)
 - `MASTER_ADDR`: IP address of the master node (same for all machines)
 - `MASTER_PORT`: Communication port (default: 12345)
-- `NPROC_PER_NODE`: NPUs per node (A2: max 8, A3: max 16)
+- `NPROC_PER_NODE`: NPUs per node (A2/A5: max 8, A3: max 16)
 
 **Important Notes**:
 - All nodes must communicate via `MASTER_ADDR:MASTER_PORT`
@@ -126,3 +126,27 @@ pip install transformers==5.9.0
 **Version Recommendations**:
 - VeOmni pins Transformers `5.9.0` (see `pyproject.toml`). Other v5 minor
   versions may work but are not exercised in CI.
+
+## Q: What is the support status of Ascend 950 (A5) products?
+
+### A: A5 is supported; most features are validated, some scenarios are pending further verification
+
+Ascend 950 (A5) products are Ascend 950 series NPUs. VeOmni has verified that all existing unit tests and system tests pass on A5 hardware. Most features are theoretically supported; some scenarios require additional validation due to differences in memory capacity, inter-chip bandwidth, and compute capabilities compared to A2 (910B).
+
+**Validated on A5:**
+- Qwen3 8B / Qwen3-VL 8B (FSDP2 + SP)
+- Basic training workflows (pre-training, SFT)
+- All NPU-optimized operators (RMSNorm, RoPE, GroupGEMM, chunked cross-entropy)
+
+**Scenarios pending further validation on A5:**
+- Multi-node Expert Parallelism (EP) for MoE models > 8B
+- Wan2.1 training (uses FSDP1 backend)
+- Training models > 8B parameters
+- Sequence length > 32K for models ≥ 30B
+- `flash_attention_2` with Triton backend — use `sdpa` on A5 for now
+- `liger_kernel` MoE backend — use `moe_implementation: fused_npu` on A5 for now
+
+For details, see:
+[A5 Features Pending Validation](a5_unsupported_features.md)
+
+> **Note**: When running on A5, configure `attn_implementation: "sdpa"` in your YAML config. As validation progresses, additional operator backends may become available on A5.

--- a/docs/hardware_support/a5_unsupported_features.md
+++ b/docs/hardware_support/a5_unsupported_features.md
@@ -1,0 +1,50 @@
+# A5 (Ascend 950) Features Pending Validation
+
+This document lists features and scenarios on Ascend 950 (A5) products that have **not yet been fully validated** in VeOmni.
+
+> For the full hardware support matrix, see [Get Started with Ascend NPU](get_started_npu.md).
+
+## Validation Status
+
+All existing unit tests (UT) and system tests (ST) in VeOmni have been verified to pass on A5 hardware. The features listed below are **theoretically supported** but have not yet undergone the same level of validation as on A2 (910B) products.
+
+## Scenarios Pending Further Validation on A5
+
+| Feature / Scenario | Current Status | Notes |
+|---|---|---|
+| Multi-node Expert Parallelism (EP) for MoE models > 8B | Pending validation | A5 inter-chip bandwidth differs from A2 (910B); multi-node EP for large MoE models requires additional verification |
+| Wan2.1 (1.3B) training | Pending validation | Wan2.1 on NPU uses the FSDP1 backend; validation on A5 is pending |
+| Training models > 8B parameters | Pending validation | A5 HBM capacity differs from A2; large model training requires additional verification |
+| Sequence length > 32K for models ≥ 30B | Pending validation | A5 memory bandwidth and capacity for very long sequences require additional verification |
+| `flash_attention_2` Triton backend | Pending validation | The Triton-based flash attention backend availability on A5 is pending verification |
+| `liger_kernel` MoE backend | Pending validation | Liger-Kernel support on A5 hardware is pending verification |
+| Multi-node training with > 8 nodes | Pending validation | A5 cluster configurations beyond 8 nodes require additional verification |
+
+## NPU Operator Implementation Recommendations for A5
+
+When running on A5, the following operator configurations are recommended until further validation is complete:
+
+```yaml
+model:
+  ops_implementation:
+    attn_implementation: "sdpa"
+    moe_implementation: "fused_npu"
+    cross_entropy_loss_implementation: "npu"
+    rms_norm_implementation: "npu"
+    rotary_pos_emb_implementation: "npu"
+    swiglu_mlp_implementation: "eager"
+    load_balancing_loss_implementation: "eager"
+    rms_norm_gated_implementation: "eager"
+```
+
+> **Note**: The above configuration is recommended for A5 based on current validation status. As validation progresses, additional operator backends may become available on A5.
+
+## Verification Status
+
+| Category | A5 Status |
+|---|---|
+| Unit Tests (UT) | ✅ All passed |
+| System Tests (ST) | ✅ All passed |
+| CI Runner | A5 self-hosted runner (in preparation) |
+
+For questions about A5 support, please open an [issue](https://github.com/ByteDance-Seed/VeOmni/issues) with the `ascend-npu` label.

--- a/docs/hardware_support/get_started_npu.md
+++ b/docs/hardware_support/get_started_npu.md
@@ -14,6 +14,8 @@ This guide provides comprehensive information for using VeOmni framework with As
 
 ## Key Updates
 
+2026/6/6: VeOmni supports Ascend 950 (A5) products. All existing unit tests and system tests pass on A5. See [A5 Features Pending Validation](a5_unsupported_features.md) for scenarios that require additional verification.
+
 2026/5/11: VeOmni provides images of the version of Ascend Cann9.0.0.
 
 2025/12/23: VeOmni supports training on Ascend NPU.
@@ -40,6 +42,20 @@ VeOmni also provides Docker support for Ascend NPUs. For detailed instructions o
 
 - [Ascend A3 Docker Image Build and Usage Guide](./AscendDockerUsage/build_a3_docker.md)
 - [Ascend A2 Docker Image Build and Usage Guide](./AscendDockerUsage/build_a2_docker.md)
+- [Ascend 950 (A5) Docker Image Build and Usage Guide](./AscendDockerUsage/build_a5_docker.md)
+
+### Supported Hardware
+
+VeOmni supports the following Ascend NPU products:
+
+| Product | Chip | Architecture | Max NPUs per node | CANN Version | Status |
+|---------|------|-------------|-------------------|--------------|--------|
+| Ascend A2 (910B) | Ascend 910B | x86_64 / ARM64 | 8 | 8.3rc2 / 9.0.0 | ✅ Supported |
+| Ascend A3 (910B) | Ascend 910B | x86_64 / ARM64 | 16 | 9.0.0 | ✅ Supported |
+| Ascend 950 (A5) | Ascend 950 | x86_64 / ARM64 | 8 | 9.0.0 | ✅ Supported |
+
+> **Note**: A5 refers to the Ascend 950 series products. All existing unit tests and system tests in VeOmni have been verified to pass on A5 hardware.
+> For scenarios pending further validation on A5, please refer to [A5 Features Pending Validation](a5_unsupported_features.md).
 
 ## Version Compatibility
 
@@ -50,26 +66,32 @@ The following table shows the supported software versions for VeOmni when runnin
 | 0.1.0 | 2.7.1                | 2.7.1             | 8.3rc2/9.0.0      | 3.11           |
 | main  | In-development    | In-development | In-development | In-development |
 
-## Supported Models
+## Supported Models on Ascend NPU
 
 VeOmni supports a wide range of models on Ascend NPUs, including large language models, multimodal models, and diffusion models. Below is a comprehensive list of supported models with their features:
 
 | Model                | Model Size       | Support | FSDP1 | FSDP2 | EP | SP | Note                                           |
 |----------------------|------------------|---------|-------|-------|----|----|------------------------------------------------|
-| [Qwen3](../examples/qwen3.md) | 8B              | ✅       |       | ✅     |    | ✅   |
-|                      | 30B               | ✅       |       | ✅     | ✅    | ✅   |
-| [Qwen3.5](../examples/qwen3.md) | 9B    |          |         | ✅    |      |✅    | supporting   |
-|                      | 35B-A3B              |         |       | ✅     |✅    |✅    |  supporting                                   |
-| [Qwen3-VL](../examples/qwen3_vl.md) | 8B               | ✅       |       | ✅     |    | ✅  |                               |
-|                      | 30B              | ✅       |       | ✅     | ✅  | ✅  |                                                |
-| [Wan2.1](../examples/wan2.1.md)    | 1.3B              | ✅       | ✅     |       |    | ✅  | prototype                              |
-| [Qwen3Omni](../examples/qwen3_omni_moe.md)    | 30B              | ✅       |   | ✅        |    | ✅  | prototype                              |
+| [Qwen3](../examples/qwen3.md) | 8B              | ✅       |       | ✅     |    | ✅   | A2/A3/A5 |
+|                      | 30B               | ✅       |       | ✅     | ✅    | ✅   | A2/A3; EP pending validation on A5 |
+| [Qwen3.5](../examples/qwen3.md) | 9B    |          |         | ✅    |      |✅    | supporting; A2/A3/A5 |
+|                      | 35B-A3B              |         |       | ✅     |✅    |✅    | supporting; A2/A3; pending validation on A5 |
+| [Qwen3-VL](../examples/qwen3_vl.md) | 8B               | ✅       |       | ✅     |    | ✅  | A2/A3/A5 |
+|                      | 30B              | ✅       |       | ✅     | ✅  | ✅  | A2/A3; pending validation on A5 |
+| [Wan2.1](../examples/wan2.1.md)    | 1.3B              | ✅       | ✅     |       |    | ✅  | prototype; A2; pending validation on A5 |
+| [Qwen3Omni](../examples/qwen3_omni_moe.md)    | 30B              | ✅       |   | ✅        |    | ✅  | prototype; A2/A3; pending validation on A5 |
 
 **Legend:**
 - **FSDP1**: Fully Sharded Data Parallel version 1
 - **FSDP2**: Fully Sharded Data Parallel version 2 (recommended)
 - **EP**: Expert Parallel - for MoE models
 - **SP**: Sequence Parallel - enables longer sequence training
+
+**Hardware annotations:**
+- **A2**: Ascend A2 (910B) server product
+- **A3**: Ascend A3 (910B) server product
+- **A5**: Ascend 950 server product
+- If a model row does not explicitly list A5, it means that configuration has not yet been validated on A5. See [A5 Features Pending Validation](a5_unsupported_features.md) for details.
 
 For detailed configuration files and training examples, please refer to the [configs](https://github.com/ByteDance-Seed/VeOmni/tree/main/configs) directory in the repository.
 

--- a/docs/hardware_support/typical_usage.md
+++ b/docs/hardware_support/typical_usage.md
@@ -2,10 +2,12 @@
 
 This document provides a complete step-by-step guide for training the Qwen3-VL 8B model on Ascend NPUs. Follow these instructions carefully to ensure a successful training experience.
 
+> **Note**: This guide is validated on Ascend A2 (910B) and Ascend 950 (A5) products. For A5-specific operator configuration, see the NPU-friendly operator block below.
+
 ## Prerequisites
 
 - Ascend NPU environment with CANN 9.0.0 installed
-- VeOmni framework installed (see [Installation](get_started_npu.md#installation) section)
+- VeOmni framework installed (see [Installation](../get_started/installation/install_ascend_x86.md) section)
 - Sufficient storage space for dataset and model weights
 
 ## Step 1: Download Dataset
@@ -75,6 +77,8 @@ model:
     causal_conv1d_implementation: eager
     chunk_gated_delta_rule_implementation: eager
 ```
+
+> **A5 (Ascend 950) Note**: If you are running on A5 hardware, replace `attn_implementation: flash_attention_2` with `attn_implementation: "sdpa"`. The Flash Attention 2 Triton backend is pending validation on A5. See [A5 Features Pending Validation](../a5_unsupported_features.md) for details.
 
 These configurations specify the optimal implementation for each operator type when running on NPUs:
 - Use NPU-optimized implementations where available (rms_norm_implementation: npu)

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ hardware_support/precision_analysis.md
 hardware_support/profiling_analysis.md
 hardware_support/AscendDockerUsage/build_a2_docker.md
 hardware_support/AscendDockerUsage/build_a3_docker.md
+hardware_support/a5_unsupported_features.md
 hardware_support/FAQ.md
 ```
 


### PR DESCRIPTION
## Summary

Adds comprehensive Ascend 950 (A5) series product support documentation to VeOmni, addressing hardware support transparency requirements.

## A5 Terminology

Per 昇腾 field convention, A5 is referred to as **Ascend 950 series products** throughout this PR.

## Changes

### New Files
- `docs/hardware_support/a5_unsupported_features.md` — Scenarios pending further validation on A5 (UT/ST pass; all features theoretically supported; some multi-node / large-model / specific-kernel configurations require additional verification)
- `docs/hardware_support/AscendDockerUsage/build_a5_docker.md` — Docker guide for A5 (marked as under preparation, pending A5 image publication)

### Modified Files
- `docs/get_started/installation/install.md` — Added Supported Hardware table with A2/A3/A5
- `docs/get_started/installation/install_ascend_x86.md` — Added A5 to hardware table, CANN 9.0.0 note for A5
- `docs/get_started/installation/install_ascend_arm.md` — Added A5 to hardware table, CANN 9.0.0 note for A5
- `docs/hardware_support/get_started_npu.md` — Added Supported Hardware table (A2/A3/A5), updated model matrix with per-row A5 annotations, corrected A3 architecture to x86_64 / ARM64
- `docs/hardware_support/FAQ.md` — Added Q&A entry for A5 support status with "pending validation" framing
- `docs/hardware_support/typical_usage.md` — Added A5-specific operator config note (use sdpa instead of flash_attention_2)
- `docs/index.md` — Added a5_unsupported_features.md to toctree

## Verification

All existing unit tests (UT) and system tests (ST) have been verified to pass on A5 hardware (Ascend 950 series).

## Checklist

- [x] A5 support documented in all installation guides
- [x] A5 validation status document created (pending validation framing)
- [x] Hardware support matrix updated with per-model A5 annotations
- [x] A3 architecture corrected to x86_64 / ARM64 throughout
- [x] A5 FAQ entry added
- [x] A5 Docker guide added (under preparation)
- [x] A5 terminology reviewed by documentation team
- [x] A5 UT/ST test results confirmed by test team