### PR TITLE
[perf] fix: enable ProfilerWithMem with NPU

### DIFF
--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -754,7 +754,7 @@ def create_profiler(
         with_stack=with_stack,
         experimental_config=experimental_config,
     )
-    if IS_CUDA_AVAILABLE and profile_memory:
+    if (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE) and profile_memory:
         return ProfilerWithMem(base_profiler)
     else:
         return base_profiler


### PR DESCRIPTION
### What does this PR do?

在NPU上开启ProfilerWithMem。

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

修改前，memory snapshot如下图：
<img width="3024" height="1504" alt="image" src="https://github.com/user-attachments/assets/aa3e92b1-665f-45ec-9601-22f090d3375f" />
修改后如下：
<img width="3024" height="1502" alt="image" src="https://github.com/user-attachments/assets/03753855-e8ae-4d6c-9d64-7ff65d7f667b" />


### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
