### PR TITLE
[data, trainer] feat: support effective-token dynamic batching

### DIFF
--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -101,7 +101,7 @@ Core files:
     - Optional effective-token mode (`"effective"`) uses `(labels != IGNORE_INDEX).sum()` when `labels` are present, and falls back to `attention_mask.sum()` otherwise.
     - With FA varlen, `attention_mask` is still expected to be all-ones over packed length; boundaries come from `position_ids` and `cu_seq_lens`.
     - When SP is enabled, `attention_mask` must use `sp_pad_value=1` (asserted in `MainCollator.__post_init__`).
-    - In effective-token mode, the batching heuristic may admit a packed sequence whose physical token count exceeds `micro_batch_size * max_seq_len`; tune the token budget accordingly.
+    - In effective-token mode, dynamic batching still applies a hard physical-token cap of `micro_batch_size * max_seq_len` during micro-batch selection to avoid unbounded prompt-heavy batches; a single sample may still exceed the cap by itself and should be controlled by preprocessing.
 
 12. **`IGNORE_INDEX` (-100) for loss masking**
     - Labels set to `IGNORE_INDEX` are excluded from loss computation.

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -96,10 +96,12 @@ Core files:
     - These must be in the batch dict **before** the model forward pass. Recomputing per-layer causes host-device sync.
     - Multimodal models may have 3D position_ids `(B, dim, L)` — FA uses the first row `[:, 0, :]`.
 
-11. **`attention_mask` sum = token count for dynamic batching**
-    - Dynamic batching (`DynamicBatchingSizeDataset`, `DynBszBuffer`) uses `attention_mask.sum()` as the length function.
-    - With FA varlen, `attention_mask` is expected to be all-ones over packed length; boundaries come from `position_ids` and `cu_seq_lens`.
+11. **Dynamic batching token counting must match `dyn_bsz_count_mode`**
+    - Default / legacy behavior (`train.dyn_bsz_count_mode="total"`) uses `attention_mask.sum()` as the length function in `DynamicBatchingSizeDataset` and `DynBszBuffer`.
+    - Optional effective-token mode (`"effective"`) uses `(labels != IGNORE_INDEX).sum()` when `labels` are present, and falls back to `attention_mask.sum()` otherwise.
+    - With FA varlen, `attention_mask` is still expected to be all-ones over packed length; boundaries come from `position_ids` and `cu_seq_lens`.
     - When SP is enabled, `attention_mask` must use `sp_pad_value=1` (asserted in `MainCollator.__post_init__`).
+    - In effective-token mode, the batching heuristic may admit a packed sequence whose physical token count exceeds `micro_batch_size * max_seq_len`; tune the token budget accordingly.
 
 12. **`IGNORE_INDEX` (-100) for loss masking**
     - Labels set to `IGNORE_INDEX` are excluded from loss computation.

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -211,7 +211,7 @@ NPU validation runs at two times:
 
 | dyn_bsz | `bool` | `True` | Enable dynamic batch size for padding-free training. |
 | dyn_bsz_runtime | `Literal["main", "worker"]` | `"main"` | Where dynamic batching runs. `"main"` keeps the legacy main-process batching path; `"worker"` batches inside DataLoader workers to support exact `StatefulDataLoader` resume. |
-| dyn_bsz_count_mode | `Literal["total", "effective"]` | `"total"` | How dynamic batching counts tokens. `"total"` uses `attention_mask.sum()` (legacy behavior); `"effective"` counts only `labels != IGNORE_INDEX` so DP ranks are balanced by loss-contributing tokens. |
+| dyn_bsz_count_mode | `Literal["total", "effective"]` | `"total"` | How dynamic batching counts tokens. `"total"` uses `attention_mask.sum()` (legacy behavior); `"effective"` counts only `labels != IGNORE_INDEX` for balancing while still capping each micro batch by physical tokens (`micro_batch_size * max_seq_len`). |
 | micro_batch_size | `int` | `1` | Number of samples per iteration on each device. |
 | global_batch_size | `Optional[int]` | `None` | Global batch size. If `None`, uses `micro_batch_size × dp_size`. |
 | num_train_epochs | `int` | `1` | Number of training epochs. |

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -211,7 +211,8 @@ NPU validation runs at two times:
 
 | dyn_bsz | `bool` | `True` | Enable dynamic batch size for padding-free training. |
 | dyn_bsz_runtime | `Literal["main", "worker"]` | `"main"` | Where dynamic batching runs. `"main"` keeps the legacy main-process batching path; `"worker"` batches inside DataLoader workers to support exact `StatefulDataLoader` resume. |
-| dyn_bsz_count_mode | `Literal["total", "effective"]` | `"total"` | How dynamic batching counts tokens. `"total"` uses `attention_mask.sum()` (legacy behavior); `"effective"` counts only `labels != IGNORE_INDEX` for balancing while still capping each micro batch by physical tokens (`micro_batch_size * max_seq_len`). |
+| dyn_bsz_count_mode | `Literal["total", "effective"]` | `"total"` | How dynamic batching counts tokens. `"total"` uses `attention_mask.sum()` (legacy behavior); `"effective"` counts only `labels != IGNORE_INDEX` for balancing while still applying a physical-token cap. |
+| dyn_bsz_physical_overflow_ratio | `float` | `1.5` | Physical-token cap multiplier used with `dyn_bsz_count_mode="effective"`: `ceil(micro_batch_size * max_seq_len * ratio)`. Values above `1.0` allow controlled physical overflow so effective-token batching does not degenerate into total-token batching. |
 | micro_batch_size | `int` | `1` | Number of samples per iteration on each device. |
 | global_batch_size | `Optional[int]` | `None` | Global batch size. If `None`, uses `micro_batch_size × dp_size`. |
 | num_train_epochs | `int` | `1` | Number of training epochs. |

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -210,6 +210,8 @@ NPU validation runs at two times:
 | --- | --- | --- | --- |
 
 | dyn_bsz | `bool` | `True` | Enable dynamic batch size for padding-free training. |
+| dyn_bsz_runtime | `Literal["main", "worker"]` | `"main"` | Where dynamic batching runs. `"main"` keeps the legacy main-process batching path; `"worker"` batches inside DataLoader workers to support exact `StatefulDataLoader` resume. |
+| dyn_bsz_count_mode | `Literal["total", "effective"]` | `"total"` | How dynamic batching counts tokens. `"total"` uses `attention_mask.sum()` (legacy behavior); `"effective"` counts only `labels != IGNORE_INDEX` so DP ranks are balanced by loss-contributing tokens. |
 | micro_batch_size | `int` | `1` | Number of samples per iteration on each device. |
 | global_batch_size | `Optional[int]` | `None` | Global batch size. If `None`, uses `micro_batch_size × dp_size`. |
 | num_train_epochs | `int` | `1` | Number of training epochs. |

--- a/docs/usage/data_packing_and_dyn_bsz.md
+++ b/docs/usage/data_packing_and_dyn_bsz.md
@@ -66,7 +66,7 @@ dyn_bsz decides how many samples to pack so total tokens ~ target budget. If you
 * `total` (default): count all packed tokens via `attention_mask.sum()`. This matches the physical sequence budget and preserves legacy behavior.
 * `effective`: count only tokens with `labels != IGNORE_INDEX`. This is useful for prompt-heavy SFT data where DP ranks can have similar packed lengths but very different amounts of loss-contributing tokens.
 
-When `dyn_bsz_count_mode=effective`, the budget is still enforced on an effective-token estimate during sample selection, so the final packed sequence can be longer than `micro_batch_size * max_seq_len` if many prompt tokens are masked from loss. Tune `micro_batch_size`, `max_seq_len`, and `dyn_bsz_buffer_size` with that tradeoff in mind.
+When `dyn_bsz_count_mode=effective`, sample selection targets the effective-token budget while also enforcing a hard physical-token cap of `micro_batch_size * max_seq_len` for each micro batch. This prevents prompt-heavy examples with very few labels from being packed into an unbounded physical sequence. A single sample can still be longer than this cap by itself, so keep preprocessing/truncation aligned with `data.max_seq_len`.
 
 ### dyn_bsz = False (Recommended for SFT)
 

--- a/docs/usage/data_packing_and_dyn_bsz.md
+++ b/docs/usage/data_packing_and_dyn_bsz.md
@@ -61,6 +61,13 @@ Example packed batch (one micro‑batch):
 
 dyn_bsz decides how many samples to pack so total tokens ~ target budget. If your target is, say, 10 tokens, it packs all 4 here.
 
+`train.dyn_bsz_count_mode` controls how that budget is measured:
+
+* `total` (default): count all packed tokens via `attention_mask.sum()`. This matches the physical sequence budget and preserves legacy behavior.
+* `effective`: count only tokens with `labels != IGNORE_INDEX`. This is useful for prompt-heavy SFT data where DP ranks can have similar packed lengths but very different amounts of loss-contributing tokens.
+
+When `dyn_bsz_count_mode=effective`, the budget is still enforced on an effective-token estimate during sample selection, so the final packed sequence can be longer than `micro_batch_size * max_seq_len` if many prompt tokens are masked from loss. Tune `micro_batch_size`, `max_seq_len`, and `dyn_bsz_buffer_size` with that tradeoff in mind.
+
 ### dyn_bsz = False (Recommended for SFT)
 
 Goal: still pack with position_ids, but batch size is fixed in number of samples, not by tokens. The num of samples in a batch is determined by the `micro_batch_size`.

--- a/docs/usage/data_packing_and_dyn_bsz.md
+++ b/docs/usage/data_packing_and_dyn_bsz.md
@@ -66,7 +66,7 @@ dyn_bsz decides how many samples to pack so total tokens ~ target budget. If you
 * `total` (default): count all packed tokens via `attention_mask.sum()`. This matches the physical sequence budget and preserves legacy behavior.
 * `effective`: count only tokens with `labels != IGNORE_INDEX`. This is useful for prompt-heavy SFT data where DP ranks can have similar packed lengths but very different amounts of loss-contributing tokens.
 
-When `dyn_bsz_count_mode=effective`, sample selection targets the effective-token budget while also enforcing a hard physical-token cap of `micro_batch_size * max_seq_len` for each micro batch. This prevents prompt-heavy examples with very few labels from being packed into an unbounded physical sequence. A single sample can still be longer than this cap by itself, so keep preprocessing/truncation aligned with `data.max_seq_len`.
+When `dyn_bsz_count_mode=effective`, sample selection targets the effective-token budget while also enforcing a hard physical-token cap of `ceil(micro_batch_size * max_seq_len * train.dyn_bsz_physical_overflow_ratio)` for each micro batch. The ratio defaults to `1.5`, so effective-token batches can be physically longer than the legacy total-token budget while still bounding prompt-heavy examples with very few labels. Set the ratio closer to `1.0` for a tighter OOM guard, or higher for more effective-token balancing headroom. A single sample can still be longer than this cap by itself, so keep preprocessing/truncation aligned with `data.max_seq_len`.
 
 ### dyn_bsz = False (Recommended for SFT)
 

--- a/tasks/deprecated_task/train_qwen_vl.py
+++ b/tasks/deprecated_task/train_qwen_vl.py
@@ -198,6 +198,7 @@ def main():
         max_seq_len=args.data.max_seq_len,
         train_steps=args.train_steps,
         dyn_bsz=args.train.dyn_bsz,
+        dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
         dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
         bsz_warmup_ratio=args.train.bsz_warmup_ratio,
         bsz_warmup_init_mbtoken=args.train.bsz_warmup_init_mbtoken,

--- a/tasks/deprecated_task/train_qwen_vl.py
+++ b/tasks/deprecated_task/train_qwen_vl.py
@@ -199,6 +199,7 @@ def main():
         train_steps=args.train_steps,
         dyn_bsz=args.train.dyn_bsz,
         dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
+        dyn_bsz_physical_overflow_ratio=args.train.dyn_bsz_physical_overflow_ratio,
         dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
         bsz_warmup_ratio=args.train.bsz_warmup_ratio,
         bsz_warmup_init_mbtoken=args.train.bsz_warmup_init_mbtoken,

--- a/tasks/deprecated_task/train_torch.py
+++ b/tasks/deprecated_task/train_torch.py
@@ -121,6 +121,7 @@ def main():
         max_seq_len=args.data.max_seq_len,
         train_steps=args.train_steps,
         dyn_bsz=args.train.dyn_bsz,
+        dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
         dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
         bsz_warmup_ratio=args.train.bsz_warmup_ratio,
         bsz_warmup_init_mbtoken=args.train.bsz_warmup_init_mbtoken,

--- a/tasks/deprecated_task/train_torch.py
+++ b/tasks/deprecated_task/train_torch.py
@@ -122,6 +122,7 @@ def main():
         train_steps=args.train_steps,
         dyn_bsz=args.train.dyn_bsz,
         dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
+        dyn_bsz_physical_overflow_ratio=args.train.dyn_bsz_physical_overflow_ratio,
         dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
         bsz_warmup_ratio=args.train.bsz_warmup_ratio,
         bsz_warmup_init_mbtoken=args.train.bsz_warmup_init_mbtoken,

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -207,6 +207,7 @@ def main():
         max_seq_len=args.data.max_seq_len,
         train_steps=args.train_steps,
         dyn_bsz=args.train.dyn_bsz,
+        dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
         bsz_warmup_ratio=args.train.bsz_warmup_ratio,
         dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
         bsz_warmup_init_mbtoken=args.train.bsz_warmup_init_mbtoken,

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -208,6 +208,7 @@ def main():
         train_steps=args.train_steps,
         dyn_bsz=args.train.dyn_bsz,
         dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
+        dyn_bsz_physical_overflow_ratio=args.train.dyn_bsz_physical_overflow_ratio,
         bsz_warmup_ratio=args.train.bsz_warmup_ratio,
         dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
         bsz_warmup_init_mbtoken=args.train.bsz_warmup_init_mbtoken,

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -141,6 +141,10 @@ def test_build_dataloader_dyn_bsz_count_mode(
         assert isinstance(dl, DynamicBatchSizeDataLoader)
         assert isinstance(dl.batching_strategy, TextBatchingStrategy)
         assert dl.batching_strategy.buffer._get_length_fn is m_ds.get_length_by_labels_fn
+        assert dl.batching_strategy.physical_token_cap == 32
+        assert dl.batching_strategy.buffer._get_physical_length_fn is m_ds.get_length_by_attention_mask_fn
     else:
         assert isinstance(dl.dataset, m_ds.DynamicBatchingSizeDataset)
         assert dl.dataset.get_length_fn is m_ds.get_length_by_labels_fn
+        assert dl.dataset.physical_token_cap == 32
+        assert dl.dataset.get_physical_length_fn is m_ds.get_length_by_attention_mask_fn

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -141,10 +141,81 @@ def test_build_dataloader_dyn_bsz_count_mode(
         assert isinstance(dl, DynamicBatchSizeDataLoader)
         assert isinstance(dl.batching_strategy, TextBatchingStrategy)
         assert dl.batching_strategy.buffer._get_length_fn is m_ds.get_length_by_labels_fn
-        assert dl.batching_strategy.physical_token_cap == 32
+        assert dl.batching_strategy.physical_token_cap == 48
         assert dl.batching_strategy.buffer._get_physical_length_fn is m_ds.get_length_by_attention_mask_fn
     else:
         assert isinstance(dl.dataset, m_ds.DynamicBatchingSizeDataset)
         assert dl.dataset.get_length_fn is m_ds.get_length_by_labels_fn
-        assert dl.dataset.physical_token_cap == 32
+        assert dl.dataset.physical_token_cap == 48
         assert dl.dataset.get_physical_length_fn is m_ds.get_length_by_attention_mask_fn
+
+
+def test_build_dataloader_dyn_bsz_physical_overflow_ratio(monkeypatch, dummy_dataset_ci):
+    import veomni.data.data_loader as m_dl
+    import veomni.data.dataset as m_ds
+
+    ps = _fake_ps(sp_size=1)
+    monkeypatch.setattr(m_dl, "get_parallel_state", lambda: ps)
+    monkeypatch.setattr(m_ds, "get_parallel_state", lambda: ps)
+
+    dataset = build_dataset(
+        dataset_name="iterable",
+        train_path=dummy_dataset_ci.save_path,
+        transform=partial(process_dummy_example, max_seq_len=16),
+        seed=0,
+    )
+    dl = build_dataloader(
+        "native",
+        dataset=dataset,
+        micro_batch_size=2,
+        global_batch_size=4,
+        dataloader_batch_size=1,
+        max_seq_len=16,
+        train_steps=1,
+        num_workers=0,
+        dyn_bsz=True,
+        dyn_bsz_runtime="main",
+        dyn_bsz_count_mode="effective",
+        dyn_bsz_physical_overflow_ratio=1.25,
+        dyn_bsz_buffer_size=1,
+        drop_last=True,
+        prefetch_factor=None,
+        seed=0,
+    )
+
+    assert dl.batching_strategy.physical_token_cap == 40
+
+
+def test_build_dataloader_rejects_invalid_physical_overflow_ratio(monkeypatch, dummy_dataset_ci):
+    import veomni.data.data_loader as m_dl
+    import veomni.data.dataset as m_ds
+
+    ps = _fake_ps(sp_size=1)
+    monkeypatch.setattr(m_dl, "get_parallel_state", lambda: ps)
+    monkeypatch.setattr(m_ds, "get_parallel_state", lambda: ps)
+
+    dataset = build_dataset(
+        dataset_name="iterable",
+        train_path=dummy_dataset_ci.save_path,
+        transform=partial(process_dummy_example, max_seq_len=16),
+        seed=0,
+    )
+    with pytest.raises(ValueError, match="dyn_bsz_physical_overflow_ratio must be >= 1.0"):
+        build_dataloader(
+            "native",
+            dataset=dataset,
+            micro_batch_size=2,
+            global_batch_size=4,
+            dataloader_batch_size=1,
+            max_seq_len=16,
+            train_steps=1,
+            num_workers=0,
+            dyn_bsz=True,
+            dyn_bsz_runtime="main",
+            dyn_bsz_count_mode="effective",
+            dyn_bsz_physical_overflow_ratio=0.5,
+            dyn_bsz_buffer_size=1,
+            drop_last=True,
+            prefetch_factor=None,
+            seed=0,
+        )

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -6,6 +6,7 @@ import pytest
 from utils import DummyDataset, process_dummy_example
 
 from veomni.data import build_dataloader, build_dataset
+from veomni.data.dynamic_batching import DynamicBatchSizeDataLoader, TextBatchingStrategy
 
 
 def _fake_ps(sp_size: int):
@@ -97,3 +98,49 @@ def test_build_dataloader_dyn_bsz_sp_filling(
         assert len(micro_batches) == global_batch_size // micro_batch_size
         for micro_batch in micro_batches:
             assert len(micro_batch["id"]) == micro_batch_size
+
+
+@pytest.mark.parametrize("dyn_bsz_runtime", ["main", "worker"])
+def test_build_dataloader_dyn_bsz_count_mode(
+    monkeypatch, dummy_dataset_ci, dyn_bsz_runtime: Literal["main", "worker"]
+):
+    import veomni.data.data_collator as m_col
+    import veomni.data.data_loader as m_dl
+    import veomni.data.dataset as m_ds
+
+    ps = _fake_ps(sp_size=1)
+    monkeypatch.setattr(m_dl, "get_parallel_state", lambda: ps)
+    monkeypatch.setattr(m_ds, "get_parallel_state", lambda: ps)
+    monkeypatch.setattr(m_col, "get_parallel_state", lambda: ps)
+
+    dataset = build_dataset(
+        dataset_name="iterable",
+        train_path=dummy_dataset_ci.save_path,
+        transform=partial(process_dummy_example, max_seq_len=16),
+        seed=0,
+    )
+    dl = build_dataloader(
+        "native",
+        dataset=dataset,
+        micro_batch_size=2,
+        global_batch_size=4,
+        dataloader_batch_size=1 if dyn_bsz_runtime == "main" else 2,
+        max_seq_len=16,
+        train_steps=1,
+        num_workers=0,
+        dyn_bsz=True,
+        dyn_bsz_runtime=dyn_bsz_runtime,
+        dyn_bsz_count_mode="effective",
+        dyn_bsz_buffer_size=1,
+        drop_last=True,
+        prefetch_factor=None,
+        seed=0,
+    )
+
+    if dyn_bsz_runtime == "main":
+        assert isinstance(dl, DynamicBatchSizeDataLoader)
+        assert isinstance(dl.batching_strategy, TextBatchingStrategy)
+        assert dl.batching_strategy.buffer._get_length_fn is m_ds.get_length_by_labels_fn
+    else:
+        assert isinstance(dl.dataset, m_ds.DynamicBatchingSizeDataset)
+        assert dl.dataset.get_length_fn is m_ds.get_length_by_labels_fn

--- a/tests/data/test_dynamic_batching_dataset.py
+++ b/tests/data/test_dynamic_batching_dataset.py
@@ -339,6 +339,13 @@ def test_get_length_fn_by_count_mode():
     }
     assert get_length_by_labels_fn(unsupported_labels_sample) == 2
 
+    input_ids_only_sample = {"input_ids": np.arange(4)}
+    assert get_length_by_labels_fn(input_ids_only_sample) == 4
+    assert get_length_by_labels_fn([list_sample, np_sample]) == 5
+    assert get_length_by_labels_fn(None) == 0
+    assert get_length_by_labels_fn("raw-sample") == 1
+    assert get_length_by_labels_fn({}) == 1
+
     with pytest.raises(ValueError, match="Unknown dyn_bsz count_mode"):
         get_length_fn_by_count_mode("bad-mode")
 

--- a/tests/data/test_dynamic_batching_dataset.py
+++ b/tests/data/test_dynamic_batching_dataset.py
@@ -40,6 +40,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import numpy as np
 import pytest
 import torch
 from tools import resolve_ops_overrides
@@ -63,6 +64,7 @@ from veomni.data.data_collator import MainCollator
 from veomni.data.dataset import (
     DynamicBatchingSizeDataset,
     get_length_by_attention_mask_fn,
+    get_length_by_input_ids_fn,
     get_length_by_labels_fn,
     get_length_fn_by_count_mode,
 )
@@ -307,9 +309,28 @@ def test_get_length_fn_by_count_mode():
 
     assert get_length_by_attention_mask_fn(sample) == 5
     assert get_length_by_labels_fn(sample) == 3
+    assert get_length_by_input_ids_fn(sample) == 5
     assert get_length_fn_by_count_mode("total")(sample) == 5
     assert get_length_fn_by_count_mode("effective")(sample) == 3
     assert get_length_by_labels_fn({"attention_mask": sample["attention_mask"]}) == 5
+
+    list_sample = {
+        "input_ids": [1, 2, 3, 4, 5],
+        "attention_mask": [1, 1, 1, 1, 0],
+        "labels": [IGNORE_INDEX, 2, IGNORE_INDEX, 4, 5],
+    }
+    assert get_length_by_attention_mask_fn(list_sample) == 4
+    assert get_length_by_labels_fn(list_sample) == 3
+    assert get_length_by_input_ids_fn(list_sample) == 5
+
+    np_sample = {
+        "input_ids": np.arange(5),
+        "attention_mask": np.array([1, 1, 1, 0, 0]),
+        "labels": np.array([IGNORE_INDEX, 1, 2, IGNORE_INDEX, IGNORE_INDEX]),
+    }
+    assert get_length_by_attention_mask_fn(np_sample) == 3
+    assert get_length_by_labels_fn(np_sample) == 2
+    assert get_length_by_input_ids_fn(np_sample) == 5
 
     with pytest.raises(ValueError, match="Unknown dyn_bsz count_mode"):
         get_length_fn_by_count_mode("bad-mode")
@@ -334,6 +355,58 @@ def test_text_batching_strategy_effective_count_mode():
     assert len(total_batch) == 1
     assert len(effective_batch) == 2
     assert sum(batch_sample["attention_mask"].sum().item() for batch_sample in effective_batch) == 8
+
+
+def test_text_batching_strategy_effective_mode_honors_physical_cap():
+    strategy = TextBatchingStrategy(
+        token_micro_bsz=4,
+        buffer_size=1,
+        get_length_fn=get_length_by_labels_fn,
+        physical_token_cap=8,
+        get_physical_length_fn=get_length_by_attention_mask_fn,
+    )
+    samples = [
+        _make_sample(token_id=1, total_tokens=6, effective_tokens=2),
+        _make_sample(token_id=2, total_tokens=6, effective_tokens=2),
+        _make_sample(token_id=3, total_tokens=2, effective_tokens=2),
+    ]
+
+    for sample in samples:
+        strategy.put_item(sample)
+
+    micro_batch = strategy.get_micro_batch(step=0)
+
+    assert [sample["input_ids"][0].item() for sample in micro_batch] == [1, 3]
+    assert sum(sample["attention_mask"].sum().item() for sample in micro_batch) == 8
+    assert strategy.buffer.all_token_cnt == 2
+    assert strategy.buffer.all_physical_token_cnt == 6
+
+
+def test_dynamic_batching_size_dataset_effective_mode_honors_physical_cap():
+    class PromptHeavyDataset(IterableDataset):
+        def __iter__(self):
+            for sample in [
+                _make_sample(token_id=1, total_tokens=6, effective_tokens=2),
+                _make_sample(token_id=2, total_tokens=6, effective_tokens=2),
+                _make_sample(token_id=3, total_tokens=2, effective_tokens=2),
+            ]:
+                yield sample
+
+    dynamic_ds = DynamicBatchingSizeDataset(
+        dataset=PromptHeavyDataset(),
+        micro_batch_seq_length=4,
+        ready_for_micro_batch_threshold=1,
+        dynamic_batching_collate_fn=lambda samples: samples,
+        get_length_fn=get_length_by_labels_fn,
+        physical_token_cap=8,
+        get_physical_length_fn=get_length_by_attention_mask_fn,
+        save_by_idx=False,
+    )
+
+    micro_batches = list(dynamic_ds)
+
+    assert [[sample["input_ids"][0].item() for sample in batch] for batch in micro_batches] == [[1], [2, 3]]
+    assert [sum(sample["attention_mask"].sum().item() for sample in batch) for batch in micro_batches] == [6, 8]
 
 
 @pytest.mark.parametrize("save_by_idx", [False, True])

--- a/tests/data/test_dynamic_batching_dataset.py
+++ b/tests/data/test_dynamic_batching_dataset.py
@@ -332,6 +332,13 @@ def test_get_length_fn_by_count_mode():
     assert get_length_by_labels_fn(np_sample) == 2
     assert get_length_by_input_ids_fn(np_sample) == 5
 
+    unsupported_labels_sample = {
+        "input_ids": [1, 2, 3],
+        "attention_mask": [1, 1, 0],
+        "labels": (IGNORE_INDEX, 1, 2),
+    }
+    assert get_length_by_labels_fn(unsupported_labels_sample) == 2
+
     with pytest.raises(ValueError, match="Unknown dyn_bsz count_mode"):
         get_length_fn_by_count_mode("bad-mode")
 

--- a/tests/data/test_dynamic_batching_dataset.py
+++ b/tests/data/test_dynamic_batching_dataset.py
@@ -60,11 +60,18 @@ from utils import (
 from veomni.arguments import VeOmniArguments, parse_args
 from veomni.data import build_dataloader
 from veomni.data.data_collator import MainCollator
-from veomni.data.dataset import DynamicBatchingSizeDataset
+from veomni.data.dataset import (
+    DynamicBatchingSizeDataset,
+    get_length_by_attention_mask_fn,
+    get_length_by_labels_fn,
+    get_length_fn_by_count_mode,
+)
+from veomni.data.dynamic_batching import TextBatchingStrategy
 from veomni.distributed.parallel_state import get_parallel_state
 from veomni.trainer.base import BaseTrainer
 from veomni.trainer.callbacks import Callback, EnvironMeterCallback, TrainerState
 from veomni.utils import helper
+from veomni.utils.constants import IGNORE_INDEX
 from veomni.utils.device import get_device_type
 
 
@@ -78,6 +85,16 @@ DATASET_SIZE = 50
 
 def get_length_fn(item):
     return item["attention_mask"].sum()
+
+
+def _make_sample(token_id: int, total_tokens: int = 4, effective_tokens: int = 2) -> Dict[str, torch.Tensor]:
+    labels = torch.full((total_tokens,), IGNORE_INDEX, dtype=torch.long)
+    labels[:effective_tokens] = token_id
+    return {
+        "input_ids": torch.full((total_tokens,), token_id, dtype=torch.long),
+        "attention_mask": torch.ones(total_tokens, dtype=torch.long),
+        "labels": labels,
+    }
 
 
 def single_sample_transform(sample: Dict[str, torch.Tensor]):
@@ -283,6 +300,40 @@ def test_dynamic_batching_without_get_item():
             get_length_fn=get_length_fn,
             save_by_idx=True,
         )
+
+
+def test_get_length_fn_by_count_mode():
+    sample = _make_sample(token_id=7, total_tokens=5, effective_tokens=3)
+
+    assert get_length_by_attention_mask_fn(sample) == 5
+    assert get_length_by_labels_fn(sample) == 3
+    assert get_length_fn_by_count_mode("total")(sample) == 5
+    assert get_length_fn_by_count_mode("effective")(sample) == 3
+    assert get_length_by_labels_fn({"attention_mask": sample["attention_mask"]}) == 5
+
+    with pytest.raises(ValueError, match="Unknown dyn_bsz count_mode"):
+        get_length_fn_by_count_mode("bad-mode")
+
+
+def test_text_batching_strategy_effective_count_mode():
+    total_strategy = TextBatchingStrategy(token_micro_bsz=4, buffer_size=1)
+    effective_strategy = TextBatchingStrategy(
+        token_micro_bsz=4,
+        buffer_size=1,
+        get_length_fn=get_length_by_labels_fn,
+    )
+    samples = [_make_sample(token_id=1), _make_sample(token_id=2)]
+
+    for sample in samples:
+        total_strategy.put_item(sample)
+        effective_strategy.put_item(sample)
+
+    total_batch = total_strategy.get_micro_batch(step=0)
+    effective_batch = effective_strategy.get_micro_batch(step=0)
+
+    assert len(total_batch) == 1
+    assert len(effective_batch) == 2
+    assert sum(batch_sample["attention_mask"].sum().item() for batch_sample in effective_batch) == 8
 
 
 @pytest.mark.parametrize("save_by_idx", [False, True])
@@ -492,6 +543,7 @@ class TrainerTest(BaseTrainer):
             bsz_warmup_init_mbtoken=args.train.bsz_warmup_init_mbtoken,
             dyn_bsz=args.train.dyn_bsz,
             dyn_bsz_runtime=args.train.dyn_bsz_runtime,
+            dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             dyn_bsz_dataset_save_by_idx=self.save_by_idx,
             seed=args.train.seed,

--- a/tests/data/test_dynamic_batching_dataset.py
+++ b/tests/data/test_dynamic_batching_dataset.py
@@ -371,6 +371,30 @@ def test_text_batching_strategy_effective_count_mode():
     assert sum(batch_sample["attention_mask"].sum().item() for batch_sample in effective_batch) == 8
 
 
+def test_text_batching_strategy_effective_mode_can_overflow_total_budget_with_larger_physical_cap():
+    strategy = TextBatchingStrategy(
+        token_micro_bsz=4,
+        buffer_size=1,
+        get_length_fn=get_length_by_labels_fn,
+        physical_token_cap=6,
+        get_physical_length_fn=get_length_by_attention_mask_fn,
+    )
+    samples = [
+        _make_sample(token_id=1, total_tokens=3, effective_tokens=2),
+        _make_sample(token_id=2, total_tokens=3, effective_tokens=2),
+        _make_sample(token_id=3, total_tokens=3, effective_tokens=2),
+    ]
+
+    for sample in samples:
+        strategy.put_item(sample)
+
+    micro_batch = strategy.get_micro_batch(step=0)
+
+    assert [sample["input_ids"][0].item() for sample in micro_batch] == [1, 2]
+    assert sum(sample["labels"].ne(IGNORE_INDEX).sum().item() for sample in micro_batch) == 4
+    assert sum(sample["attention_mask"].sum().item() for sample in micro_batch) == 6
+
+
 def test_text_batching_strategy_effective_mode_honors_physical_cap():
     strategy = TextBatchingStrategy(
         token_micro_bsz=4,
@@ -394,6 +418,33 @@ def test_text_batching_strategy_effective_mode_honors_physical_cap():
     assert sum(sample["attention_mask"].sum().item() for sample in micro_batch) == 8
     assert strategy.buffer.all_token_cnt == 2
     assert strategy.buffer.all_physical_token_cnt == 6
+
+
+def test_dynamic_batching_size_dataset_effective_mode_can_overflow_total_budget_with_larger_physical_cap():
+    class PromptHeavyDataset(IterableDataset):
+        def __iter__(self):
+            for sample in [
+                _make_sample(token_id=1, total_tokens=3, effective_tokens=2),
+                _make_sample(token_id=2, total_tokens=3, effective_tokens=2),
+                _make_sample(token_id=3, total_tokens=3, effective_tokens=2),
+            ]:
+                yield sample
+
+    dynamic_ds = DynamicBatchingSizeDataset(
+        dataset=PromptHeavyDataset(),
+        micro_batch_seq_length=4,
+        ready_for_micro_batch_threshold=1,
+        dynamic_batching_collate_fn=lambda samples: samples,
+        get_length_fn=get_length_by_labels_fn,
+        physical_token_cap=6,
+        get_physical_length_fn=get_length_by_attention_mask_fn,
+        save_by_idx=False,
+    )
+
+    micro_batches = list(dynamic_ds)
+
+    assert [[sample["input_ids"][0].item() for sample in batch] for batch in micro_batches] == [[1, 2], [3]]
+    assert [sum(sample["attention_mask"].sum().item() for sample in batch) for batch in micro_batches] == [6, 3]
 
 
 def test_dynamic_batching_size_dataset_effective_mode_honors_physical_cap():
@@ -631,6 +682,7 @@ class TrainerTest(BaseTrainer):
             dyn_bsz=args.train.dyn_bsz,
             dyn_bsz_runtime=args.train.dyn_bsz_runtime,
             dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
+            dyn_bsz_physical_overflow_ratio=args.train.dyn_bsz_physical_overflow_ratio,
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             dyn_bsz_dataset_save_by_idx=self.save_by_idx,
             seed=args.train.seed,

--- a/tests/data/test_multisource_dataset.py
+++ b/tests/data/test_multisource_dataset.py
@@ -184,6 +184,7 @@ class TrainerTest(BaseTrainer):
             dyn_bsz=args.train.dyn_bsz,
             dyn_bsz_runtime=args.train.dyn_bsz_runtime,
             dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
+            dyn_bsz_physical_overflow_ratio=args.train.dyn_bsz_physical_overflow_ratio,
             bsz_warmup_ratio=args.train.bsz_warmup_ratio,
             dyn_bsz_buffer_size=1,
             dyn_bsz_dataset_save_by_idx=False,

--- a/tests/data/test_multisource_dataset.py
+++ b/tests/data/test_multisource_dataset.py
@@ -183,6 +183,7 @@ class TrainerTest(BaseTrainer):
             train_steps=args.train_steps,
             dyn_bsz=args.train.dyn_bsz,
             dyn_bsz_runtime=args.train.dyn_bsz_runtime,
+            dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
             bsz_warmup_ratio=args.train.bsz_warmup_ratio,
             dyn_bsz_buffer_size=1,
             dyn_bsz_dataset_save_by_idx=False,

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -468,6 +468,18 @@ class TrainingArguments:
         default="main",
         metadata={"help": "Which process dynamic batching runs in: main process or DataLoader worker."},
     )
+    dyn_bsz_count_mode: Literal["total", "effective"] = field(
+        default="total",
+        metadata={
+            "help": (
+                "How dynamic batching counts tokens when packing a micro batch. "
+                "'total' (default, legacy) sums attention_mask; 'effective' sums "
+                "only loss-contributing tokens (labels != IGNORE_INDEX), which "
+                "balances effective tokens across DP ranks at the cost of slightly "
+                "more padding."
+            )
+        },
+    )
     init_device: Literal["cpu", "cuda", "meta", "npu"] = field(
         default="meta",
         metadata={

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -475,8 +475,19 @@ class TrainingArguments:
                 "How dynamic batching counts tokens when packing a micro batch. "
                 "'total' (default, legacy) sums attention_mask; 'effective' sums "
                 "only loss-contributing tokens (labels != IGNORE_INDEX), which "
-                "balances effective tokens across DP ranks at the cost of slightly "
-                "more padding."
+                "balances effective tokens across DP ranks at the cost of allowing "
+                "controlled physical-token overflow."
+            )
+        },
+    )
+    dyn_bsz_physical_overflow_ratio: float = field(
+        default=1.5,
+        metadata={
+            "help": (
+                "Physical-token cap multiplier used when dyn_bsz_count_mode='effective'. "
+                "The cap is ceil(micro_batch_size * max_seq_len * ratio), so values "
+                "> 1.0 let effective-token batching differ from total-token batching "
+                "while still bounding prompt-heavy micro batches."
             )
         },
     )
@@ -548,6 +559,11 @@ class TrainingArguments:
     checkpoint: CheckpointConfig = field(default_factory=CheckpointConfig)
 
     def __post_init__(self):
+        if self.dyn_bsz_physical_overflow_ratio < 1.0:
+            raise ValueError(
+                f"dyn_bsz_physical_overflow_ratio must be >= 1.0, got {self.dyn_bsz_physical_overflow_ratio}."
+            )
+
         self._train_steps = -1
         self.local_rank = int(os.getenv("LOCAL_RANK", 0))
         self.global_rank = int(os.getenv("RANK", 0))

--- a/veomni/data/data_loader.py
+++ b/veomni/data/data_loader.py
@@ -30,7 +30,7 @@ from .data_collator import (
     NoopDataCollator,
     UnpackDataCollator,
 )
-from .dataset import DynamicBatchingSizeDataset, get_length_fn_by_count_mode
+from .dataset import DynamicBatchingSizeDataset, get_length_by_attention_mask_fn, get_length_fn_by_count_mode
 from .dynamic_batching import DynamicBatchSizeDataLoader, TextBatchingStrategy
 
 
@@ -167,6 +167,8 @@ def build_native_dataloader(
         )
         dyn_bsz_collate_fn = collate_fn
         dyn_bsz_length_fn = get_length_fn_by_count_mode(dyn_bsz_count_mode)
+        physical_token_cap = batching_token_len if dyn_bsz_count_mode == "effective" else None
+        dyn_bsz_physical_length_fn = get_length_by_attention_mask_fn if dyn_bsz_count_mode == "effective" else None
         if dyn_bsz_runtime == "main":
             batching_strategy = TextBatchingStrategy(
                 token_micro_bsz=batching_token_len,
@@ -174,6 +176,8 @@ def build_native_dataloader(
                 bsz_warmup_steps=bsz_warmup_steps,
                 bsz_warmup_init_mbtoken=bsz_warmup_init_mbtoken,
                 get_length_fn=dyn_bsz_length_fn,
+                physical_token_cap=physical_token_cap,
+                get_physical_length_fn=dyn_bsz_physical_length_fn,
             )
 
             collate_fn = UnpackDataCollator()
@@ -183,6 +187,8 @@ def build_native_dataloader(
                 micro_batch_seq_length=batching_token_len,
                 ready_for_micro_batch_threshold=dyn_bsz_buffer_size,
                 get_length_fn=dyn_bsz_length_fn,
+                physical_token_cap=physical_token_cap,
+                get_physical_length_fn=dyn_bsz_physical_length_fn,
                 dynamic_batching_collate_fn=dyn_bsz_collate_fn,
                 save_by_idx=dyn_bsz_dataset_save_by_idx,
             )

--- a/veomni/data/data_loader.py
+++ b/veomni/data/data_loader.py
@@ -30,7 +30,7 @@ from .data_collator import (
     NoopDataCollator,
     UnpackDataCollator,
 )
-from .dataset import DynamicBatchingSizeDataset, get_length_by_attention_mask_fn
+from .dataset import DynamicBatchingSizeDataset, get_length_fn_by_count_mode
 from .dynamic_batching import DynamicBatchSizeDataLoader, TextBatchingStrategy
 
 
@@ -72,6 +72,7 @@ def build_native_dataloader(
     bsz_warmup_init_mbtoken: int = 200,
     dyn_bsz: bool = True,
     dyn_bsz_runtime: Literal["main", "worker"] = "main",
+    dyn_bsz_count_mode: Literal["total", "effective"] = "total",
     dyn_bsz_dataset_save_by_idx: bool = False,  # Whether to save dynamic-batching buffers by index for worker-side checkpoint/resume.
     dyn_bsz_buffer_size: int = 200,
     num_workers: int = 8,
@@ -165,12 +166,14 @@ def build_native_dataloader(
             f"bsz_warmup_init_mbtoken: {bsz_warmup_init_mbtoken}."
         )
         dyn_bsz_collate_fn = collate_fn
+        dyn_bsz_length_fn = get_length_fn_by_count_mode(dyn_bsz_count_mode)
         if dyn_bsz_runtime == "main":
             batching_strategy = TextBatchingStrategy(
                 token_micro_bsz=batching_token_len,
                 buffer_size=dyn_bsz_buffer_size,
                 bsz_warmup_steps=bsz_warmup_steps,
                 bsz_warmup_init_mbtoken=bsz_warmup_init_mbtoken,
+                get_length_fn=dyn_bsz_length_fn,
             )
 
             collate_fn = UnpackDataCollator()
@@ -179,7 +182,7 @@ def build_native_dataloader(
                 dataset=dataset,
                 micro_batch_seq_length=batching_token_len,
                 ready_for_micro_batch_threshold=dyn_bsz_buffer_size,
-                get_length_fn=get_length_by_attention_mask_fn,
+                get_length_fn=dyn_bsz_length_fn,
                 dynamic_batching_collate_fn=dyn_bsz_collate_fn,
                 save_by_idx=dyn_bsz_dataset_save_by_idx,
             )

--- a/veomni/data/data_loader.py
+++ b/veomni/data/data_loader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import math
 from typing import Any, Callable, Dict, Literal, Optional
 
 import torch
@@ -73,6 +74,7 @@ def build_native_dataloader(
     dyn_bsz: bool = True,
     dyn_bsz_runtime: Literal["main", "worker"] = "main",
     dyn_bsz_count_mode: Literal["total", "effective"] = "total",
+    dyn_bsz_physical_overflow_ratio: float = 1.5,
     dyn_bsz_dataset_save_by_idx: bool = False,  # Whether to save dynamic-batching buffers by index for worker-side checkpoint/resume.
     dyn_bsz_buffer_size: int = 200,
     num_workers: int = 8,
@@ -167,8 +169,16 @@ def build_native_dataloader(
         )
         dyn_bsz_collate_fn = collate_fn
         dyn_bsz_length_fn = get_length_fn_by_count_mode(dyn_bsz_count_mode)
-        physical_token_cap = batching_token_len if dyn_bsz_count_mode == "effective" else None
-        dyn_bsz_physical_length_fn = get_length_by_attention_mask_fn if dyn_bsz_count_mode == "effective" else None
+        if dyn_bsz_count_mode == "effective":
+            if dyn_bsz_physical_overflow_ratio < 1.0:
+                raise ValueError(
+                    f"dyn_bsz_physical_overflow_ratio must be >= 1.0, got {dyn_bsz_physical_overflow_ratio}."
+                )
+            physical_token_cap = math.ceil(batching_token_len * dyn_bsz_physical_overflow_ratio)
+            dyn_bsz_physical_length_fn = get_length_by_attention_mask_fn
+        else:
+            physical_token_cap = None
+            dyn_bsz_physical_length_fn = None
         if dyn_bsz_runtime == "main":
             batching_strategy = TextBatchingStrategy(
                 token_micro_bsz=batching_token_len,

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -288,7 +288,7 @@ def get_length_by_input_ids_fn(sample):
     return _numel_sequence_like(sample["input_ids"])
 
 
-def get_length_by_labels_fn(sample):
+def get_length_by_labels_fn(sample: Any) -> int:
     """Return effective token length from ``labels`` (i.e. tokens contributing to loss).
 
     A token contributes to loss iff its label is not ``IGNORE_INDEX``. Falls back to
@@ -298,6 +298,13 @@ def get_length_by_labels_fn(sample):
     set additional ``IGNORE_INDEX`` positions later, but balancing is decided here at
     sample ingestion time.
     """
+    if sample is None:
+        return 0
+    if isinstance(sample, list):
+        return sum(get_length_by_labels_fn(item) for item in sample)
+    if not isinstance(sample, dict):
+        return 1
+
     if "labels" in sample:
         labels = sample["labels"]
         if isinstance(labels, torch.Tensor):
@@ -307,7 +314,25 @@ def get_length_by_labels_fn(sample):
         if isinstance(labels, list):
             return sum(1 for label in labels if label != IGNORE_INDEX)
 
-    return get_length_by_attention_mask_fn(sample)
+    if "attention_mask" in sample:
+        attention_mask = sample["attention_mask"]
+        if isinstance(attention_mask, torch.Tensor):
+            return int(attention_mask.sum().item())
+        if isinstance(attention_mask, np.ndarray):
+            return int(attention_mask.sum())
+        if isinstance(attention_mask, list):
+            return int(sum(attention_mask))
+
+    if "input_ids" in sample:
+        input_ids = sample["input_ids"]
+        if isinstance(input_ids, torch.Tensor):
+            return int(input_ids.numel())
+        if isinstance(input_ids, np.ndarray):
+            return int(input_ids.size)
+        if isinstance(input_ids, list):
+            return len(input_ids)
+
+    return 1
 
 
 def get_length_fn_by_count_mode(count_mode: str):

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -298,17 +298,16 @@ def get_length_by_labels_fn(sample):
     set additional ``IGNORE_INDEX`` positions later, but balancing is decided here at
     sample ingestion time.
     """
-    if "labels" not in sample:
-        return get_length_by_attention_mask_fn(sample)
+    if "labels" in sample:
+        labels = sample["labels"]
+        if isinstance(labels, torch.Tensor):
+            return int((labels != IGNORE_INDEX).sum().item())
+        if isinstance(labels, np.ndarray):
+            return int((labels != IGNORE_INDEX).sum())
+        if isinstance(labels, list):
+            return sum(1 for label in labels if label != IGNORE_INDEX)
 
-    labels = sample["labels"]
-    if isinstance(labels, torch.Tensor):
-        return int((labels != IGNORE_INDEX).sum().item())
-    if isinstance(labels, np.ndarray):
-        return int((labels != IGNORE_INDEX).sum())
-    if isinstance(labels, (list, tuple)):
-        return sum(label != IGNORE_INDEX for label in labels)
-    return int(labels != IGNORE_INDEX)
+    return get_length_by_attention_mask_fn(sample)
 
 
 def get_length_fn_by_count_mode(count_mode: str):

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -252,13 +252,40 @@ class EnergonDataset(IterativeDataset):
             logger.debug(f"Dataset {type(self._data).__name__} does not support set_epoch or state reset")
 
 
+def _sum_sequence_like(value: Any) -> int:
+    """Return the sum of tensor, ndarray, list, tuple, or scalar values."""
+    if isinstance(value, torch.Tensor):
+        return int(value.sum().item())
+    if isinstance(value, np.ndarray):
+        return int(value.sum())
+    if isinstance(value, (list, tuple)):
+        return int(sum(value))
+    return int(value)
+
+
+def _numel_sequence_like(value: Any) -> int:
+    """Return the flattened element count of tensor, ndarray, list, tuple, or scalar values."""
+    if isinstance(value, torch.Tensor):
+        return int(value.numel())
+    if isinstance(value, np.ndarray):
+        return int(value.size)
+    if isinstance(value, (list, tuple)):
+        return len(value)
+    return int(value)
+
+
 def get_length_by_attention_mask_fn(sample):
     """Return token length from ``attention_mask``.
 
     Defined as a top-level helper instead of an inline lambda because ``spawn``
     worker mode requires the callable to be pickleable.
     """
-    return int(sample["attention_mask"].sum())
+    return _sum_sequence_like(sample["attention_mask"])
+
+
+def get_length_by_input_ids_fn(sample):
+    """Return physical token length from ``input_ids``."""
+    return _numel_sequence_like(sample["input_ids"])
 
 
 def get_length_by_labels_fn(sample):
@@ -271,9 +298,17 @@ def get_length_by_labels_fn(sample):
     set additional ``IGNORE_INDEX`` positions later, but balancing is decided here at
     sample ingestion time.
     """
-    if "labels" in sample:
-        return int((sample["labels"] != IGNORE_INDEX).sum())
-    return int(sample["attention_mask"].sum())
+    if "labels" not in sample:
+        return get_length_by_attention_mask_fn(sample)
+
+    labels = sample["labels"]
+    if isinstance(labels, torch.Tensor):
+        return int((labels != IGNORE_INDEX).sum().item())
+    if isinstance(labels, np.ndarray):
+        return int((labels != IGNORE_INDEX).sum())
+    if isinstance(labels, (list, tuple)):
+        return sum(label != IGNORE_INDEX for label in labels)
+    return int(labels != IGNORE_INDEX)
 
 
 def get_length_fn_by_count_mode(count_mode: str):
@@ -281,10 +316,9 @@ def get_length_fn_by_count_mode(count_mode: str):
 
     - ``"total"``: count all tokens via ``attention_mask`` (legacy behavior; matches
       the physical-token budget ``micro_batch_size * max_seq_len``).
-    - ``"effective"``: count only tokens with ``labels != IGNORE_INDEX``. Note that
-      the packing budget is still in physical tokens, so the actual packed sequence
-      may exceed ``max_seq_len`` when many prompt-heavy samples are buffered.
-      Tune ``max_seq_len`` / ``micro_batch_size`` accordingly.
+    - ``"effective"``: count only tokens with ``labels != IGNORE_INDEX``. A separate
+      physical-token cap should still be enforced by dynamic batching to avoid
+      unbounded prompt-heavy micro batches.
     """
     if count_mode == "total":
         return get_length_by_attention_mask_fn
@@ -792,6 +826,8 @@ class DynamicBatchingSizeDataset(IterableDataset):
         dynamic_batching_collate_fn: Callable,
         save_by_idx: bool = True,
         get_length_fn: Optional[Callable] = get_length_by_attention_mask_fn,
+        physical_token_cap: Optional[int] = None,
+        get_physical_length_fn: Optional[Callable] = get_length_by_attention_mask_fn,
         force_generate_long_sequence: bool = False,
     ) -> None:
         """Initialize the DynamicBatchingSizeDataset.
@@ -856,6 +892,8 @@ class DynamicBatchingSizeDataset(IterableDataset):
         self.ready_for_micro_batch_threshold = ready_for_micro_batch_threshold
         self.micro_batch_seq_length = micro_batch_seq_length
         self.get_length_fn = get_length_fn
+        self.physical_token_cap = physical_token_cap
+        self.get_physical_length_fn = get_physical_length_fn
 
         self.save_by_idx = save_by_idx
 
@@ -866,6 +904,7 @@ class DynamicBatchingSizeDataset(IterableDataset):
         self._buffer = []
         self._buffer_of_output_index = []
         self._buffer_token_count = 0
+        self._buffer_physical_token_count = 0
 
         self._just_resumed = False  # Flag to indicate if the dataset has just been resumed from a checkpoint, used to skip buffer checks on the first iteration after resume.
 
@@ -905,15 +944,22 @@ class DynamicBatchingSizeDataset(IterableDataset):
             self._buffer = []
             self._buffer_of_output_index = []
             self._buffer_token_count = 0
+            self._buffer_physical_token_count = 0
         else:
             self._just_resumed = False
 
         while True:
             try:
-                if (
+                effective_ready = (
                     len(self._buffer) >= self.ready_for_micro_batch_threshold
                     and self._buffer_token_count >= self.micro_batch_seq_length
-                ):
+                )
+                physical_ready = (
+                    len(self._buffer) >= self.ready_for_micro_batch_threshold
+                    and self.physical_token_cap is not None
+                    and self._buffer_physical_token_count >= self.physical_token_cap
+                )
+                if effective_ready or physical_ready:
                     micro_batch = self._get_micro_batch()
                     micro_batch = self.dynamic_batching_collate_fn(micro_batch)
                     if micro_batch is not None:
@@ -930,14 +976,16 @@ class DynamicBatchingSizeDataset(IterableDataset):
                 samples_to_add = item if isinstance(item, list) else [item]
                 for sample_idx, sample in enumerate(samples_to_add):
                     length = self.get_length_fn(sample)
+                    physical_length = (
+                        self.get_physical_length_fn(sample) if self.get_physical_length_fn is not None else length
+                    )
                     if length > self.micro_batch_seq_length and not self.force_generate_long_sequence:
                         # TODO: record the count of discarded long examples for monitoring
                         logger.warning(
                             f"Sample length {length} exceeds micro batch seq length {self.micro_batch_seq_length}, skipping. If you want to force generate a micro batch with this sample, enable force_generate_long_sequence."
                         )
                         continue
-
-                    self._buffer.append((sample, length))
+                    self._buffer.append((sample, length, physical_length))
                     if self.save_by_idx:
                         # Save one output-index entry per buffered sample.
                         # An upstream dataset may yield ``list[dict]`` in one
@@ -945,6 +993,7 @@ class DynamicBatchingSizeDataset(IterableDataset):
                         # sample within that list during resume.
                         self._buffer_of_output_index.append((output_index, sample_idx))
                     self._buffer_token_count += length
+                    self._buffer_physical_token_count += physical_length
 
             except Exception as e:
                 if isinstance(e, StopIteration):
@@ -981,10 +1030,12 @@ class DynamicBatchingSizeDataset(IterableDataset):
         """
         micro_batch = []
         seq_length = 0
+        physical_seq_length = 0
         indices_to_remove_from_buffer = []
 
         for idx, item in enumerate(self._buffer):
             sample, length = item[0], item[1]
+            physical_length = item[2] if len(item) > 2 else length
 
             if length + seq_length > self.micro_batch_seq_length:
                 if seq_length > 0:
@@ -993,9 +1044,18 @@ class DynamicBatchingSizeDataset(IterableDataset):
                     # Usually it is impossible to reach this branch because too long samples would not be added to the buffer if force_generate_long_sequence is False.
                     continue
 
+            if self.physical_token_cap is not None and physical_length + physical_seq_length > self.physical_token_cap:
+                if seq_length > 0:
+                    continue
+                logger.warning(
+                    f"Sample physical length {physical_length} exceeds physical token cap {self.physical_token_cap}; emitting it alone."
+                )
+
             micro_batch.append(sample)
             seq_length += length
+            physical_seq_length += physical_length
             self._buffer_token_count -= length
+            self._buffer_physical_token_count -= physical_length
             indices_to_remove_from_buffer.append(idx)
 
             if seq_length >= self.micro_batch_seq_length:
@@ -1028,6 +1088,7 @@ class DynamicBatchingSizeDataset(IterableDataset):
             "save_by_idx": self.save_by_idx,
             # Make sure we store an integer instead of any tensor
             "buffer_token_count": int(self._buffer_token_count),
+            "buffer_physical_token_count": int(self._buffer_physical_token_count),
         }
 
         # the state_dict might be called frequently with StatefulDataloaders(see more details of snapshot_every_n_steps)
@@ -1082,17 +1143,33 @@ class DynamicBatchingSizeDataset(IterableDataset):
                     cached_output_index = output_index
                 restored_sample = cached_restored_samples[sample_idx]
                 length = self.get_length_fn(restored_sample)
-                self._buffer.append((restored_sample, length))
+                physical_length = (
+                    self.get_physical_length_fn(restored_sample) if self.get_physical_length_fn is not None else length
+                )
+                self._buffer.append((restored_sample, length, physical_length))
                 if self.save_by_idx:
                     self._buffer_of_output_index.append(output_index_entry)
                 self._buffer_token_count += length
+                self._buffer_physical_token_count += physical_length
         else:
-            self._buffer = state_dict["buffer"]
+            self._buffer = [
+                item
+                if len(item) > 2
+                else (
+                    item[0],
+                    item[1],
+                    self.get_physical_length_fn(item[0]) if self.get_physical_length_fn is not None else item[1],
+                )
+                for item in state_dict["buffer"]
+            ]
             if self.save_by_idx and len(self._buffer) > 0:
                 raise ValueError("save_by_idx is True, but previous buffer contains valid samples instead of indices")
             self._buffer_of_output_index = []
 
         self._buffer_token_count = state_dict["buffer_token_count"]
+        self._buffer_physical_token_count = state_dict.get(
+            "buffer_physical_token_count", sum(item[2] if len(item) > 2 else item[1] for item in self._buffer)
+        )
         # Verify buffer_token_count matches the sum of token lengths
         assert self._buffer_token_count == sum([item[1] for item in self._buffer]), (
             "buffer_token_count does not match the sum of token lengths in buffer"
@@ -1100,6 +1177,9 @@ class DynamicBatchingSizeDataset(IterableDataset):
         assert self._buffer_token_count == sum(self.get_length_fn(item[0]) for item in self._buffer), (
             "buffer_token_count does not match the sum of lengths computed from samples in buffer"
         )
+        assert self._buffer_physical_token_count == sum(
+            item[2] if len(item) > 2 else item[1] for item in self._buffer
+        ), "buffer_physical_token_count does not match the sum of physical lengths in buffer"
         del state_dict["buffer"]
 
         if "dynamic_batch_upstream_dataset_state" in state_dict:

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -37,6 +37,7 @@ except ImportError:
 
 from ..distributed.parallel_state import get_parallel_state
 from ..utils import logging
+from ..utils.constants import IGNORE_INDEX
 from ..utils.dist_utils import main_process_first
 from ..utils.multisource_utils import parse_multisource_config
 
@@ -258,6 +259,38 @@ def get_length_by_attention_mask_fn(sample):
     worker mode requires the callable to be pickleable.
     """
     return int(sample["attention_mask"].sum())
+
+
+def get_length_by_labels_fn(sample):
+    """Return effective token length from ``labels`` (i.e. tokens contributing to loss).
+
+    A token contributes to loss iff its label is not ``IGNORE_INDEX``. Falls back to
+    ``attention_mask`` when ``labels`` is absent (e.g. some unsupervised pipelines).
+
+    Note: this counts pre-pack labels; ``PackingCollator`` and SP label shifting may
+    set additional ``IGNORE_INDEX`` positions later, but balancing is decided here at
+    sample ingestion time.
+    """
+    if "labels" in sample:
+        return int((sample["labels"] != IGNORE_INDEX).sum())
+    return int(sample["attention_mask"].sum())
+
+
+def get_length_fn_by_count_mode(count_mode: str):
+    """Return the per-sample length callable selected by ``count_mode``.
+
+    - ``"total"``: count all tokens via ``attention_mask`` (legacy behavior; matches
+      the physical-token budget ``micro_batch_size * max_seq_len``).
+    - ``"effective"``: count only tokens with ``labels != IGNORE_INDEX``. Note that
+      the packing budget is still in physical tokens, so the actual packed sequence
+      may exceed ``max_seq_len`` when many prompt-heavy samples are buffered.
+      Tune ``max_seq_len`` / ``micro_batch_size`` accordingly.
+    """
+    if count_mode == "total":
+        return get_length_by_attention_mask_fn
+    if count_mode == "effective":
+        return get_length_by_labels_fn
+    raise ValueError(f"Unknown dyn_bsz count_mode: {count_mode!r} (expected 'total' or 'effective')")
 
 
 def _supports_output_index_for_resume(dataset: Any) -> bool:

--- a/veomni/data/dynamic_batching.py
+++ b/veomni/data/dynamic_batching.py
@@ -35,15 +35,24 @@ class DynBszBuffer:
             decide when a micro batch is ready. Defaults to ``attention_mask.sum()``
             (i.e. total tokens). Pass a callable counting only ``labels != IGNORE_INDEX``
             to balance by effective (loss-contributing) tokens.
+        get_physical_length_fn: optional callable returning the physical per-sample
+            token count used as a hard cap while selecting a micro batch.
     """
 
-    def __init__(self, get_length_fn: Optional[Callable[[Dict[str, Any]], int]] = None):
+    def __init__(
+        self,
+        get_length_fn: Optional[Callable[[Dict[str, Any]], int]] = None,
+        get_physical_length_fn: Optional[Callable[[Dict[str, Any]], int]] = None,
+    ):
         self._buffer = []
         self._buffer_sample_lens = []
+        self._buffer_physical_lens = []
         self.del_idxs = []
         self.cur_idx = 0
         self.all_token_cnt = 0
+        self.all_physical_token_cnt = 0
         self._get_length_fn = get_length_fn
+        self._get_physical_length_fn = get_physical_length_fn
 
     def append(self, item: Dict[str, Any]):
         """
@@ -60,26 +69,42 @@ class DynBszBuffer:
             if "attention_mask" not in item:
                 raise KeyError("Expected 'attention_mask' in item")
             length = int(item["attention_mask"].sum())
+        if self._get_physical_length_fn is not None:
+            physical_length = self._get_physical_length_fn(item)
+        else:
+            physical_length = length
         self._buffer_sample_lens.append(length)
+        self._buffer_physical_lens.append(physical_length)
         self.all_token_cnt += length
+        self.all_physical_token_cnt += physical_length
 
-    def get_samples(self, n_token_per_iter: int, force: bool = True):
+    def get_samples(self, n_token_per_iter: int, force: bool = True, physical_token_cap: Optional[int] = None):
         """
         get samples from the buffer.
         Args:
             n_token_per_iter: the number of tokens to get.
             force: if True, the first sample will be returned even if it is not full.
+            This can emit one sample that exceeds ``physical_token_cap`` by itself,
+            but the cap still prevents adding more samples to that micro batch.
         Returns:
             samples: a list of samples.
         """
         cum_seq_len = 0
+        cum_physical_len = 0
         samples = []
         while self.cur_idx < len(self._buffer) and cum_seq_len < n_token_per_iter:
             seq_len = self._buffer_sample_lens[self.cur_idx]
+            physical_seq_len = self._buffer_physical_lens[self.cur_idx]
+            fits_effective_budget = seq_len <= n_token_per_iter - cum_seq_len
+            fits_physical_cap = physical_token_cap is None or (
+                physical_seq_len <= physical_token_cap - cum_physical_len
+            )
+            first_forced_sample = force is True and cum_seq_len == 0
             if self.cur_idx not in self.del_idxs and (
-                (force is True and cum_seq_len == 0) or (seq_len <= n_token_per_iter - cum_seq_len)
+                first_forced_sample or (fits_effective_budget and fits_physical_cap)
             ):
                 cum_seq_len += seq_len
+                cum_physical_len += physical_seq_len
                 samples.append(self._buffer[self.cur_idx])
                 self.del_idxs.append(self.cur_idx)
             self.cur_idx += 1
@@ -95,10 +120,14 @@ class DynBszBuffer:
         """
         self.cur_idx = 0
         self.all_token_cnt -= sum([self._buffer_sample_lens[idx] for idx in self.del_idxs])
+        self.all_physical_token_cnt -= sum([self._buffer_physical_lens[idx] for idx in self.del_idxs])
         buffer_len = len(self._buffer)
         self._buffer = [self._buffer[idx] for idx in range(buffer_len) if idx not in self.del_idxs]
         self._buffer_sample_lens = [
             self._buffer_sample_lens[idx] for idx in range(buffer_len) if idx not in self.del_idxs
+        ]
+        self._buffer_physical_lens = [
+            self._buffer_physical_lens[idx] for idx in range(buffer_len) if idx not in self.del_idxs
         ]
         self.del_idxs = []
 
@@ -141,6 +170,10 @@ class TextBatchingStrategy(BaseBatchingStrategy):
         bsz_warmup_init_mbtoken: the initial number of tokens to get for each request.
         buffer_size: the size of the buffer.
         get_length_fn: optional per-sample length callable; see ``DynBszBuffer``.
+        physical_token_cap: optional hard cap on the total physical tokens selected
+            into each micro batch.
+        get_physical_length_fn: optional per-sample physical length callable; see
+            ``DynBszBuffer``.
     """
 
     def __init__(
@@ -150,6 +183,8 @@ class TextBatchingStrategy(BaseBatchingStrategy):
         bsz_warmup_steps: int = 0,
         bsz_warmup_init_mbtoken: int = 200,
         get_length_fn: Optional[Callable[[Dict[str, Any]], int]] = None,
+        physical_token_cap: Optional[int] = None,
+        get_physical_length_fn: Optional[Callable[[Dict[str, Any]], int]] = None,
     ) -> None:
         super().__init__()
         self._step = 0
@@ -160,10 +195,18 @@ class TextBatchingStrategy(BaseBatchingStrategy):
             assert self.bsz_warmup_init_mbtoken > 0
 
         self.buffer_size = buffer_size  # minimum samples in buffer
-        self.buffer = DynBszBuffer(get_length_fn=get_length_fn)
+        self.physical_token_cap = physical_token_cap
+        self.get_physical_length_fn = get_physical_length_fn
+        self.buffer = DynBszBuffer(get_length_fn=get_length_fn, get_physical_length_fn=get_physical_length_fn)
 
     def is_ready_for_micro_batch(self) -> bool:
-        return len(self.buffer) >= self.buffer_size and self.buffer.all_token_cnt >= self.token_micro_bsz
+        effective_ready = len(self.buffer) >= self.buffer_size and self.buffer.all_token_cnt >= self.token_micro_bsz
+        physical_ready = (
+            len(self.buffer) >= self.buffer_size
+            and self.physical_token_cap is not None
+            and self.buffer.all_physical_token_cnt >= self.physical_token_cap
+        )
+        return effective_ready or physical_ready
 
     def put_item(self, item: Dict[str, Any]):
         if item["input_ids"].shape[-1] <= 1:
@@ -191,7 +234,7 @@ class TextBatchingStrategy(BaseBatchingStrategy):
 
         self._step = step
         cur_token_micro_bsz = self.get_cur_token_micro_bsz()
-        samples = self.buffer.get_samples(cur_token_micro_bsz)
+        samples = self.buffer.get_samples(cur_token_micro_bsz, physical_token_cap=self.physical_token_cap)
         self.buffer.flush()  # remove the selected samples.
         return samples
 

--- a/veomni/data/dynamic_batching.py
+++ b/veomni/data/dynamic_batching.py
@@ -29,14 +29,21 @@ logger = logging.get_logger(__name__)
 class DynBszBuffer:
     """
     A buffer to store samples for dynamic batch size.
+
+    Args:
+        get_length_fn: optional callable returning the per-sample token count used to
+            decide when a micro batch is ready. Defaults to ``attention_mask.sum()``
+            (i.e. total tokens). Pass a callable counting only ``labels != IGNORE_INDEX``
+            to balance by effective (loss-contributing) tokens.
     """
 
-    def __init__(self):
+    def __init__(self, get_length_fn: Optional[Callable[[Dict[str, Any]], int]] = None):
         self._buffer = []
         self._buffer_sample_lens = []
         self.del_idxs = []
         self.cur_idx = 0
         self.all_token_cnt = 0
+        self._get_length_fn = get_length_fn
 
     def append(self, item: Dict[str, Any]):
         """
@@ -47,10 +54,14 @@ class DynBszBuffer:
                 whose ``.sum()`` gives the number of valid tokens for batching.
         """
         self._buffer.append(item)
-        if "attention_mask" not in item:
-            raise KeyError("Expected 'attention_mask' in item")
-        self._buffer_sample_lens.append(item["attention_mask"].sum())
-        self.all_token_cnt += self._buffer_sample_lens[-1]
+        if self._get_length_fn is not None:
+            length = self._get_length_fn(item)
+        else:
+            if "attention_mask" not in item:
+                raise KeyError("Expected 'attention_mask' in item")
+            length = int(item["attention_mask"].sum())
+        self._buffer_sample_lens.append(length)
+        self.all_token_cnt += length
 
     def get_samples(self, n_token_per_iter: int, force: bool = True):
         """
@@ -129,6 +140,7 @@ class TextBatchingStrategy(BaseBatchingStrategy):
         bsz_warmup_steps: the number of steps to warm up the batch size.
         bsz_warmup_init_mbtoken: the initial number of tokens to get for each request.
         buffer_size: the size of the buffer.
+        get_length_fn: optional per-sample length callable; see ``DynBszBuffer``.
     """
 
     def __init__(
@@ -137,6 +149,7 @@ class TextBatchingStrategy(BaseBatchingStrategy):
         buffer_size: int = 500,
         bsz_warmup_steps: int = 0,
         bsz_warmup_init_mbtoken: int = 200,
+        get_length_fn: Optional[Callable[[Dict[str, Any]], int]] = None,
     ) -> None:
         super().__init__()
         self._step = 0
@@ -147,7 +160,7 @@ class TextBatchingStrategy(BaseBatchingStrategy):
             assert self.bsz_warmup_init_mbtoken > 0
 
         self.buffer_size = buffer_size  # minimum samples in buffer
-        self.buffer = DynBszBuffer()
+        self.buffer = DynBszBuffer(get_length_fn=get_length_fn)
 
     def is_ready_for_micro_batch(self) -> bool:
         return len(self.buffer) >= self.buffer_size and self.buffer.all_token_cnt >= self.token_micro_bsz

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -472,6 +472,7 @@ class BaseTrainer(Stateful, ABC):
             dyn_bsz=args.train.dyn_bsz,
             dyn_bsz_runtime=args.train.dyn_bsz_runtime,
             dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
+            dyn_bsz_physical_overflow_ratio=args.train.dyn_bsz_physical_overflow_ratio,
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             seed=args.train.seed,
             collate_fn=self.collate_fn,

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -471,6 +471,7 @@ class BaseTrainer(Stateful, ABC):
             bsz_warmup_init_mbtoken=args.train.bsz_warmup_init_mbtoken,
             dyn_bsz=args.train.dyn_bsz,
             dyn_bsz_runtime=args.train.dyn_bsz_runtime,
+            dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             seed=args.train.seed,
             collate_fn=self.collate_fn,

--- a/veomni/trainer/base_rl_trainer.py
+++ b/veomni/trainer/base_rl_trainer.py
@@ -65,6 +65,7 @@ class BaseRLTrainer(BaseTrainer):
             bsz_warmup_init_mbtoken=args.train.bsz_warmup_init_mbtoken,
             dyn_bsz=args.train.dyn_bsz,
             dyn_bsz_runtime=args.train.dyn_bsz_runtime,
+            dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             seed=args.train.seed,
             build_collate_fn=False,

--- a/veomni/trainer/base_rl_trainer.py
+++ b/veomni/trainer/base_rl_trainer.py
@@ -66,6 +66,7 @@ class BaseRLTrainer(BaseTrainer):
             dyn_bsz=args.train.dyn_bsz,
             dyn_bsz_runtime=args.train.dyn_bsz_runtime,
             dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
+            dyn_bsz_physical_overflow_ratio=args.train.dyn_bsz_physical_overflow_ratio,
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             seed=args.train.seed,
             build_collate_fn=False,

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -375,6 +375,7 @@ class DiTTrainer:
                 dyn_bsz=args.train.dyn_bsz,
                 dyn_bsz_runtime=args.train.dyn_bsz_runtime,
                 dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
+                dyn_bsz_physical_overflow_ratio=args.train.dyn_bsz_physical_overflow_ratio,
                 dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
                 num_workers=args.data.dataloader.num_workers,
                 drop_last=args.data.dataloader.drop_last,

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -374,6 +374,7 @@ class DiTTrainer:
                 bsz_warmup_init_mbtoken=args.train.bsz_warmup_init_mbtoken,
                 dyn_bsz=args.train.dyn_bsz,
                 dyn_bsz_runtime=args.train.dyn_bsz_runtime,
+                dyn_bsz_count_mode=args.train.dyn_bsz_count_mode,
                 dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
                 num_workers=args.data.dataloader.num_workers,
                 drop_last=args.data.dataloader.drop_last,


### PR DESCRIPTION
## Summary

Add a new `train.dyn_bsz_count_mode` switch (`"total"` | `"effective"`, default `"total"`, fully backward compatible). When set to `"effective"`, dynamic batching seals a micro-batch by **effective tokens** (`labels != IGNORE_INDEX`) instead of total `attention_mask` tokens.

This addresses a long-standing imbalance in SFT / DPO / multimodal pipelines: sequence packing already evens out the **wall-clock compute** across DP ranks, but it does **not** even out the **effective-token count**. Prompt-heavy samples can starve some DP ranks of gradient signal while others train on dense supervision, inflating gradient variance and loss noise even though the global loss reduction is mathematically correct.

## Motivation

### Status quo (`total` mode, current default)

- `DynBszBuffer` / `TextBatchingStrategy` / `DynamicBatchingSizeDataset` all measure per-sample length via `attention_mask.sum()`.
- A micro-batch is sealed once `Σ attention_mask >= micro_batch_size * max_seq_len`.
- Total tokens per DP rank (≈ wall-clock compute) are naturally balanced.
- **However, the effective-token count (loss-mask=1) can differ by tens of times across DP ranks**, e.g.:
  - Rank A: long system prompt + short reply → effective ≈ 200
  - Rank B: pure pre-training long doc → effective ≈ 7900
  - Rank C: many short multi-turn dialogs → effective ≈ 4000

`mean_global_loss` (`veomni/utils/loss_utils.py:54`) already reduces loss with a global effective-token weighting, so the **loss value is correct**. But the per-step gradient signal-to-noise ratio still differs by tens of times across ranks, hurting effective convergence rate.

### New `effective` mode

- Per-sample length becomes `(labels != IGNORE_INDEX).sum()`.
- A micro-batch is sealed once the **effective-token sum** crosses the budget.
- DP-rank effective gradient signal becomes balanced; gradient variance becomes more stable.
- Trade-off: the actual packed sequence may be slightly longer than `max_seq_len` (prompt tokens occupy extra physical space).

## Design

| Counting scheme | Meaning | When to use |
|---|---|---|
| `attention_mask.sum()` | Tokens that participate in attention | Pre-training / CPT, latency-sensitive setups |
| `(labels != IGNORE_INDEX).sum()` | Tokens that contribute to the loss | SFT, DPO, multimodal, prompt-heavy data |

### What this PR explicitly does NOT do

- **No cross-DP all-to-all redistribution.** Sequence packing already balances compute time for text LLMs; adding a runtime redistribute would cost more in communication than it saves. This change only swaps the "is the micro-batch ready?" predicate — zero extra communication.
- **No default behaviour change.** `dyn_bsz_count_mode` defaults to `"total"`; existing configs are unaffected.
- **No change to loss normalization.** `mean_global_loss` is already correct; left untouched.

## Changes

### New argument

- `veomni/arguments/arguments_types.py`: `TrainingArguments.dyn_bsz_count_mode: Literal["total", "effective"] = "total"`

### Data layer

- `veomni/data/dataset.py`
  - Add a top-level `IGNORE_INDEX` import (avoid per-call import on the hot path).
  - New `get_length_by_labels_fn(sample)`: counts via `labels != IGNORE_INDEX`; gracefully falls back to `attention_mask` when `labels` is missing.
  - New `get_length_fn_by_count_mode(count_mode)`: mode → length-callable selector.
- `veomni/data/dynamic_batching.py`
  - `DynBszBuffer.__init__` now accepts an optional `get_length_fn`; default behaviour unchanged (still uses `attention_mask`).
  - `TextBatchingStrategy.__init__` forwards `get_length_fn` into its internal buffer.
- `veomni/data/data_loader.py`
  - `build_native_dataloader` adds the new `dyn_bsz_count_mode` argument.
  - Both `main` and `worker` dyn_bsz runtimes now use the same length callable.

### Trainer plumbing

- `veomni/trainer/base.py`
- `veomni/trainer/base_rl_trainer.py`
- `veomni/trainer/dit_trainer.py`

Each forwards `dyn_bsz_count_mode=args.train.dyn_bsz_count_mode` to `build_dataloader` / `build_native_dataloader`.

## Backward Compatibility

- Default `count_mode="total"` is bit-for-bit equivalent to the pre-change code path.
- `DynBszBuffer.__init__`'s new parameter defaults to `None`; external callers constructing the buffer directly are not broken.
- No existing YAML config needs updating.

## Usage

```yaml
train:
  dyn_bsz: true
  dyn_bsz_count_mode: effective   # new; defaults to "total"
```

Or via CLI:

```bash
--train.dyn_bsz_count_mode=effective
```

### Recommended setting

| Scenario | Recommended |
|---|---|
| Pre-training / CPT | `total` |
| SFT with stable prompt-to-response ratio | `total` |
| SFT with highly variable prompt length (multi-turn history / long system prompt) | `effective` |
| DPO / preference alignment | `effective` |
| Multimodal SFT (vision tokens are not in the loss) | `effective` |
| NPU / strong wall-clock-balance requirement | `total` |


## Testing

- All edited files pass `python3 -m ast.parse` syntactic sanity check.
- Both `total` and 'effective' mode test existing on: `tests/data/test_dataloader.py`, `tests/data/test_dynamic_batching_dataset.py`, `tests/data/test_multisource_dataset.py`.
