### PR TITLE
[model] fix: patched forward docstrings for transformers 5.9

### DIFF
--- a/veomni/models/transformers/qwen2_5_omni/generated/patched_modeling_qwen2_5_omni_gpu.diff
+++ b/veomni/models/transformers/qwen2_5_omni/generated/patched_modeling_qwen2_5_omni_gpu.diff
@@ -1354,7 +1354,7 @@
 
      def get_placeholder_mask(
          self,
-@@ -1875,133 +2373,202 @@
+@@ -1875,133 +2373,204 @@
          special_audio_mask = special_audio_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
          return special_image_mask, special_video_mask, special_audio_mask
 
@@ -1429,6 +1429,8 @@
 -    ) -> tuple | Qwen2_5OmniThinkerCausalLMOutputWithPast:
 +    ) -> tuple | Qwen2_5OmniThinkerCausalLMOutputWithLogProbs:
          r"""
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
@@ -1641,7 +1643,7 @@
                      audio_feature_lengths,
                      video_second_per_grid,
                  )
-@@ -2009,11 +2576,16 @@
+@@ -2009,11 +2578,16 @@
                  self.rope_deltas = rope_deltas
              else:
                  batch_size, seq_length = input_ids.shape
@@ -1659,7 +1661,7 @@
 
          outputs = self.model(
              attention_mask=attention_mask,
-@@ -2021,27 +2593,61 @@
+@@ -2021,27 +2595,61 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -1731,7 +1733,7 @@
 
      def prepare_inputs_for_generation(
          self,
-@@ -2090,860 +2696,54 @@
+@@ -2090,860 +2698,54 @@
 
          return model_inputs
 
@@ -2640,7 +2642,7 @@
 
 
  # Modified from Llama with a different rotate function, will fixed in next release
-@@ -2980,708 +2780,10 @@
+@@ -2980,708 +2782,10 @@
      return q_embed, k_embed
 
 
@@ -3353,7 +3355,7 @@
 
 
  ############################
-@@ -3708,22 +2810,74 @@
+@@ -3708,22 +2812,74 @@
          "Qwen2_5OmniToken2WavModel",
      ]
 
@@ -3438,7 +3440,7 @@
 
      def load_speakers(self, path):
          check_torch_load_is_safe()
-@@ -3785,244 +2939,71 @@
+@@ -3785,244 +2941,71 @@
 
          return model
 

--- a/veomni/models/transformers/qwen2_5_omni/generated/patched_modeling_qwen2_5_omni_gpu.py
+++ b/veomni/models/transformers/qwen2_5_omni/generated/patched_modeling_qwen2_5_omni_gpu.py
@@ -2426,6 +2426,8 @@ class Qwen2_5OmniThinkerForConditionalGeneration(Qwen2_5OmniPreTrainedModelForCo
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen2_5OmniThinkerCausalLMOutputWithLogProbs:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen2_5_omni/qwen2_5_omni_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen2_5_omni/qwen2_5_omni_gpu_patch_gen_config.py
@@ -1110,6 +1110,8 @@ def qwen2_5_omni_thinker_forward_patched(
     **kwargs: Unpack[TransformersKwargs],
 ) -> tuple | Qwen2_5OmniThinkerCausalLMOutputWithLogProbs:
     r"""
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices describing the positions of the input sequence tokens in the cache.
     image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
         The temporal, height and width of feature shape of each image in LLM.
     video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.diff
+++ b/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.diff
@@ -398,7 +398,7 @@
  class Qwen2_5_VLVisionBlock(GradientCheckpointingLayer):
      def __init__(self, config, attn_implementation: str = "sdpa") -> None:
          super().__init__()
-@@ -299,24 +547,29 @@
+@@ -299,24 +547,37 @@
          self.attn = Qwen2_5_VLVisionAttention(config=config)
          self.mlp = Qwen2_5_VLMLP(config, bias=True)
 
@@ -419,12 +419,16 @@
          position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
          **kwargs,
      ) -> torch.Tensor:
--        r"""
--        cu_seqlens (`torch.Tensor`):
+         r"""
+         cu_seqlens (`torch.Tensor`):
 -            Cumulative sequence lengths used for packed variable-length attention in Flash Attention kernels.
--        rotary_pos_emb (`torch.Tensor`, *optional*):
++            Cumulative sequence lengths for variable-length vision attention.
++        max_seqlen (`int`):
++            Maximum per-image or per-video sequence length in the packed vision batch.
+         rotary_pos_emb (`torch.Tensor`, *optional*):
 -            Precomputed rotary positional embeddings applied to the vision attention query/key states.
--        """
++            Precomputed rotary position embeddings for vision attention.
+         """
          hidden_states = hidden_states + self.attn(
              self.norm1(hidden_states),
              cu_seqlens=cu_seqlens,
@@ -434,7 +438,7 @@
              rotary_pos_emb=rotary_pos_emb,
              position_embeddings=position_embeddings,
              **kwargs,
-@@ -346,6 +599,12 @@
+@@ -346,6 +607,12 @@
              init.copy_(module.inv_freq, inv_freq)
 
 
@@ -447,7 +451,7 @@
  class Qwen2_5_VisionTransformerPretrainedModel(Qwen2_5_VLPreTrainedModel):
      config: Qwen2_5_VLVisionConfig
      _no_split_modules = ["Qwen2_5_VLVisionBlock"]
-@@ -407,66 +666,248 @@
+@@ -407,66 +674,248 @@
          )
          return window_index, cu_window_seqlens.tolist()
 
@@ -722,7 +726,7 @@
 
 
  @auto_docstring(
-@@ -891,6 +1332,12 @@
+@@ -891,6 +1340,12 @@
              last_hidden_state=hidden_states,
              past_key_values=past_key_values,
          )
@@ -735,7 +739,7 @@
 
 
  @auto_docstring
-@@ -1100,13 +1547,20 @@
+@@ -1100,13 +1555,20 @@
              The temporal, height and width of feature shape of each video in LLM.
          """
          pixel_values_videos = pixel_values_videos.type(self.visual.dtype)
@@ -761,7 +765,7 @@
      @accepts_precomputed_kwargs(modality="image")
      @can_return_tuple
      @auto_docstring
-@@ -1123,52 +1577,28 @@
+@@ -1123,52 +1585,28 @@
              The temporal, height and width of feature shape of each image in LLM.
          """
          pixel_values = pixel_values.type(self.visual.dtype)
@@ -828,7 +832,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1219,6 +1649,25 @@
+@@ -1219,6 +1657,25 @@
              position_ids = None
          return position_ids
 
@@ -854,7 +858,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1229,12 +1678,15 @@
+@@ -1229,16 +1686,21 @@
          past_key_values: Cache | None = None,
          inputs_embeds: torch.FloatTensor | None = None,
          use_cache: bool | None = None,
@@ -871,7 +875,13 @@
          second_per_grid_ts: torch.Tensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen2_5_VLModelOutputWithPast:
-@@ -1248,27 +1700,142 @@
+         r"""
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
+         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+             The temporal, height and width of feature shape of each image in LLM.
+         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
+@@ -1248,27 +1710,142 @@
          second_per_grid_ts (`torch.Tensor` of shape `(num_videos)`, *optional*):
              The time interval (in seconds) for each grid along the temporal dimension in the 3D position IDs.
          """
@@ -1024,7 +1034,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1279,6 +1846,15 @@
+@@ -1279,6 +1856,15 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1040,7 +1050,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1287,16 +1863,21 @@
+@@ -1287,16 +1873,21 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -1063,7 +1073,7 @@
 
 
  @auto_docstring(
-@@ -1328,6 +1909,12 @@
+@@ -1328,6 +1919,12 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1076,7 +1086,7 @@
  class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1370,6 +1957,16 @@
+@@ -1370,6 +1967,16 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1093,7 +1103,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1381,21 +1978,19 @@
+@@ -1381,21 +1988,21 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
@@ -1116,10 +1126,12 @@
 -            Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
 -            config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
 -            (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
-@@ -1404,79 +1999,76 @@
+@@ -1404,79 +2011,76 @@
              The rope index difference between sequence length and multimodal rope.
          second_per_grid_ts (`torch.Tensor` of shape `(num_videos)`, *optional*):
              The time interval (in seconds) for each grid along the temporal dimension in the 3D position IDs.
@@ -1245,7 +1257,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1696,5 +2288,44 @@
+@@ -1696,5 +2300,44 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.py
+++ b/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.py
@@ -564,6 +564,14 @@ class Qwen2_5_VLVisionBlock(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         **kwargs,
     ) -> torch.Tensor:
+        r"""
+        cu_seqlens (`torch.Tensor`):
+            Cumulative sequence lengths for variable-length vision attention.
+        max_seqlen (`int`):
+            Maximum per-image or per-video sequence length in the packed vision batch.
+        rotary_pos_emb (`torch.Tensor`, *optional*):
+            Precomputed rotary position embeddings for vision attention.
+        """
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
             cu_seqlens=cu_seqlens,
@@ -1691,6 +1699,8 @@ class Qwen2_5_VLModel(Qwen2_5_VLPreTrainedModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen2_5_VLModelOutputWithPast:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
@@ -1991,6 +2001,8 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPreTrainedModel, GenerationMi
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen2_5_VLCausalLMOutputWithLogProbs:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen2_5vl/qwen2_5_vl_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen2_5vl/qwen2_5_vl_gpu_patch_gen_config.py
@@ -195,6 +195,14 @@ def qwen2_5_vl_vision_block_forward_patched(
     position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
     **kwargs,
 ) -> torch.Tensor:
+    r"""
+    cu_seqlens (`torch.Tensor`):
+        Cumulative sequence lengths for variable-length vision attention.
+    max_seqlen (`int`):
+        Maximum per-image or per-video sequence length in the packed vision batch.
+    rotary_pos_emb (`torch.Tensor`, *optional*):
+        Precomputed rotary position embeddings for vision attention.
+    """
     hidden_states = hidden_states + self.attn(
         self.norm1(hidden_states),
         cu_seqlens=cu_seqlens,
@@ -581,6 +589,8 @@ def qwen2_5_vl_model_forward_patched(
     **kwargs: Unpack[TransformersKwargs],
 ) -> tuple | Qwen2_5_VLModelOutputWithPast:
     r"""
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices describing the positions of the input sequence tokens in the cache.
     image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
         The temporal, height and width of feature shape of each image in LLM.
     video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
@@ -886,6 +896,8 @@ def qwen2_5_vl_for_conditional_generation_forward_patched(
     **kwargs: Unpack[TransformersKwargs],
 ) -> tuple | Qwen2_5_VLCausalLMOutputWithLogProbs:
     r"""
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices describing the positions of the input sequence tokens in the cache.
     image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
         The temporal, height and width of feature shape of each image in LLM.
     video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen2_vl/generated/patched_modeling_qwen2_vl_gpu.diff
+++ b/veomni/models/transformers/qwen2_vl/generated/patched_modeling_qwen2_vl_gpu.diff
@@ -455,7 +455,7 @@
 
          return vision_outputs
 
-@@ -1204,12 +1449,15 @@
+@@ -1204,15 +1449,20 @@
          past_key_values: Cache | None = None,
          inputs_embeds: torch.FloatTensor | None = None,
          use_cache: bool | None = None,
@@ -472,7 +472,12 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen2VLModelOutputWithPast:
          r"""
-@@ -1220,27 +1468,107 @@
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
+         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+             The temporal, height and width of feature shape of each image in LLM.
+         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
+@@ -1220,27 +1470,107 @@
          rope_deltas (`torch.LongTensor` of shape `(batch_size, )`, *optional*):
              The rope index difference between sequence length and multimodal rope.
          """
@@ -590,7 +595,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1250,6 +1578,10 @@
+@@ -1250,6 +1580,10 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -601,7 +606,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1258,15 +1590,27 @@
+@@ -1258,15 +1592,27 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -630,7 +635,7 @@
 
 
  class Qwen2VLForConditionalGeneration(Qwen2VLPreTrainedModel, GenerationMixin):
-@@ -1320,97 +1664,96 @@
+@@ -1320,97 +1666,98 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
@@ -652,6 +657,8 @@
 -            Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
 -            config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
 -            (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
@@ -779,7 +786,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1628,5 +1971,46 @@
+@@ -1628,5 +1975,46 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen2_vl/generated/patched_modeling_qwen2_vl_gpu.py
+++ b/veomni/models/transformers/qwen2_vl/generated/patched_modeling_qwen2_vl_gpu.py
@@ -1461,6 +1461,8 @@ class Qwen2VLModel(Qwen2VLPreTrainedModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen2VLModelOutputWithPast:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
@@ -1676,6 +1678,8 @@ class Qwen2VLForConditionalGeneration(Qwen2VLPreTrainedModel, GenerationMixin):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen2VLCausalLMOutputWithLogProbs:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen2_vl/qwen2_vl_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen2_vl/qwen2_vl_gpu_patch_gen_config.py
@@ -380,6 +380,8 @@ def qwen2vl_model_forward_patched(
     **kwargs: Unpack[TransformersKwargs],
 ) -> tuple | Qwen2VLModelOutputWithPast:
     r"""
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices describing the positions of the input sequence tokens in the cache.
     image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
         The temporal, height and width of feature shape of each image in LLM.
     video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
@@ -679,6 +681,8 @@ def qwen2vl_for_conditional_generation_forward_patched(
     **kwargs: Unpack[TransformersKwargs],
 ) -> tuple | Qwen2VLCausalLMOutputWithLogProbs:
     r"""
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices describing the positions of the input sequence tokens in the cache.
     image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
         The temporal, height and width of feature shape of each image in LLM.
     video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
@@ -1281,7 +1281,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1564,6 +2160,7 @@
+@@ -1564,13 +2160,18 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1289,7 +1289,9 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5ModelOutputWithPast:
          r"""
-@@ -1571,6 +2168,8 @@
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
+         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
@@ -1298,7 +1300,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1578,29 +2177,169 @@
+@@ -1578,29 +2179,169 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1478,7 +1480,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1610,6 +2349,18 @@
+@@ -1610,6 +2351,18 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1497,7 +1499,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1617,6 +2368,7 @@
+@@ -1617,6 +2370,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1505,7 +1507,7 @@
              **kwargs,
          )
 
-@@ -1624,6 +2376,12 @@
+@@ -1624,6 +2378,12 @@
              **outputs,
              rope_deltas=self.rope_deltas,
          )
@@ -1518,7 +1520,7 @@
 
 
  @auto_docstring
-@@ -1654,6 +2412,7 @@
+@@ -1654,10 +2414,13 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
@@ -1526,7 +1528,13 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> CausalLMOutputWithPast:
-@@ -1686,21 +2445,50 @@
+         r"""
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
+         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+             Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
+             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+@@ -1686,21 +2449,50 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -1581,7 +1589,7 @@
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
-@@ -1740,6 +2528,41 @@
+@@ -1740,6 +2532,41 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1623,7 +1631,7 @@
  class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1796,57 +2619,10 @@
+@@ -1796,57 +2623,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1683,7 +1691,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1857,27 +2633,54 @@
+@@ -1857,27 +2637,54 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1744,7 +1752,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2103,6 +2906,24 @@
+@@ -2103,6 +2910,24 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
@@ -2164,6 +2164,8 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen3_5ModelOutputWithPast:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
@@ -2417,6 +2419,8 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         **kwargs: Unpack[TransformersKwargs],
     ) -> CausalLMOutputWithPast:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
@@ -1266,7 +1266,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1564,6 +2118,7 @@
+@@ -1564,13 +2118,18 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1274,7 +1274,9 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5ModelOutputWithPast:
          r"""
-@@ -1571,6 +2126,8 @@
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
+         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
@@ -1283,7 +1285,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1578,29 +2135,169 @@
+@@ -1578,29 +2137,169 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1463,7 +1465,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1610,6 +2307,18 @@
+@@ -1610,6 +2309,18 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1482,7 +1484,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1617,6 +2326,7 @@
+@@ -1617,6 +2328,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1490,7 +1492,7 @@
              **kwargs,
          )
 
-@@ -1624,6 +2334,12 @@
+@@ -1624,6 +2336,12 @@
              **outputs,
              rope_deltas=self.rope_deltas,
          )
@@ -1503,7 +1505,7 @@
 
 
  @auto_docstring
-@@ -1654,6 +2370,7 @@
+@@ -1654,10 +2372,13 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
@@ -1511,7 +1513,13 @@
          logits_to_keep: int | torch.Tensor = 0,
          **kwargs: Unpack[TransformersKwargs],
      ) -> CausalLMOutputWithPast:
-@@ -1686,21 +2403,50 @@
+         r"""
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
+         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+             Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
+             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+@@ -1686,21 +2407,50 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -1566,7 +1574,7 @@
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
-@@ -1740,6 +2486,31 @@
+@@ -1740,6 +2490,31 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1598,7 +1606,7 @@
  class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1796,57 +2567,10 @@
+@@ -1796,57 +2571,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1658,7 +1666,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1857,27 +2581,54 @@
+@@ -1857,27 +2585,54 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1719,7 +1727,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2103,6 +2854,24 @@
+@@ -2103,6 +2858,24 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
@@ -2122,6 +2122,8 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen3_5ModelOutputWithPast:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
@@ -2375,6 +2377,8 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         **kwargs: Unpack[TransformersKwargs],
     ) -> CausalLMOutputWithPast:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored

--- a/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
@@ -1107,6 +1107,8 @@ def qwen3_5_model_forward(
     **kwargs: Unpack[TransformersKwargs],
 ) -> tuple | Qwen3_5ModelOutputWithPast:
     r"""
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices describing the positions of the input sequence tokens in the cache.
     image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
         The temporal, height and width of feature shape of each image in LLM.
     video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
@@ -1338,6 +1340,8 @@ def qwen3_5_forcausallm_forward_patched(
     **kwargs: Unpack[TransformersKwargs],
 ) -> CausalLMOutputWithPast:
     r"""
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices describing the positions of the input sequence tokens in the cache.
     labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
         Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
         config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
@@ -1433,16 +1433,18 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5MoeModelOutputWithPast:
          r"""
-@@ -1691,6 +2375,8 @@
+@@ -1691,6 +2375,10 @@
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
 +        mm_token_type_ids (`torch.IntTensor` of shape `(batch_size, sequence_length)`, *optional*):
 +            Token type IDs for multimodal inputs.
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices depicting the position of the input sequence tokens in the sequence.
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1698,29 +2384,170 @@
+@@ -1698,29 +2386,170 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1623,7 +1625,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1730,6 +2557,17 @@
+@@ -1730,6 +2559,17 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1641,7 +1643,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1737,6 +2575,7 @@
+@@ -1737,6 +2577,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1649,7 +1651,7 @@
              **kwargs,
          )
 
-@@ -1828,6 +2667,12 @@
+@@ -1828,6 +2669,12 @@
      return overall_loss * num_experts
 
 
@@ -1662,7 +1664,7 @@
  @auto_docstring
  class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -1848,6 +2693,7 @@
+@@ -1848,6 +2695,7 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -1670,7 +1672,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1860,9 +2706,10 @@
+@@ -1860,14 +2708,17 @@
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
          output_router_logits: bool | None = None,
@@ -1682,7 +1684,14 @@
          r"""
          labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
              Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
-@@ -1899,30 +2746,70 @@
+             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+             (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices depicting the position of the input sequence tokens in the sequence.
+
+         Example:
+
+@@ -1899,30 +2750,70 @@
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
              output_router_logits=output_router_logits,
@@ -1765,7 +1774,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1930,7 +2817,14 @@
+@@ -1930,7 +2821,14 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
@@ -1781,7 +1790,7 @@
 
 
  class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMixin):
-@@ -1977,6 +2871,7 @@
+@@ -1977,6 +2875,7 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1789,7 +1798,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1990,105 +2885,93 @@
+@@ -1990,105 +2889,93 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1950,7 +1959,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2314,6 +3197,30 @@
+@@ -2314,6 +3201,30 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -2377,6 +2377,8 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
             The temporal, height and width of feature shape of each video in LLM.
         mm_token_type_ids (`torch.IntTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Token type IDs for multimodal inputs.
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices depicting the position of the input sequence tokens in the sequence.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -2715,6 +2717,8 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
             Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
             (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices depicting the position of the input sequence tokens in the sequence.
 
         Example:
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
@@ -1426,16 +1426,18 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5MoeModelOutputWithPast:
          r"""
-@@ -1691,6 +2342,8 @@
+@@ -1691,6 +2342,10 @@
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
 +        mm_token_type_ids (`torch.IntTensor` of shape `(batch_size, sequence_length)`, *optional*):
 +            Token type IDs for multimodal inputs.
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices depicting the position of the input sequence tokens in the sequence.
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1698,29 +2351,170 @@
+@@ -1698,29 +2353,170 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1616,7 +1618,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1730,6 +2524,17 @@
+@@ -1730,6 +2526,17 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1634,7 +1636,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1737,6 +2542,7 @@
+@@ -1737,6 +2544,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1642,7 +1644,7 @@
              **kwargs,
          )
 
-@@ -1828,6 +2634,12 @@
+@@ -1828,6 +2636,12 @@
      return overall_loss * num_experts
 
 
@@ -1655,7 +1657,7 @@
  @auto_docstring
  class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -1848,6 +2660,7 @@
+@@ -1848,6 +2662,7 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -1663,7 +1665,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1860,9 +2673,10 @@
+@@ -1860,14 +2675,17 @@
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
          output_router_logits: bool | None = None,
@@ -1675,7 +1677,14 @@
          r"""
          labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
              Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
-@@ -1899,30 +2713,70 @@
+             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+             (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices depicting the position of the input sequence tokens in the sequence.
+
+         Example:
+
+@@ -1899,30 +2717,70 @@
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
              output_router_logits=output_router_logits,
@@ -1758,7 +1767,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1930,7 +2784,14 @@
+@@ -1930,7 +2788,14 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
@@ -1774,7 +1783,7 @@
 
 
  class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMixin):
-@@ -1977,6 +2838,7 @@
+@@ -1977,6 +2842,7 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1782,7 +1791,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1990,105 +2852,93 @@
+@@ -1990,105 +2856,93 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1943,7 +1952,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2314,6 +3164,30 @@
+@@ -2314,6 +3168,30 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -2344,6 +2344,8 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
             The temporal, height and width of feature shape of each video in LLM.
         mm_token_type_ids (`torch.IntTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Token type IDs for multimodal inputs.
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices depicting the position of the input sequence tokens in the sequence.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -2682,6 +2684,8 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
             Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
             (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices depicting the position of the input sequence tokens in the sequence.
 
         Example:
 

--- a/veomni/models/transformers/qwen3_5_moe/qwen3_5_moe_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5_moe/qwen3_5_moe_gpu_patch_gen_config.py
@@ -332,6 +332,8 @@ def qwen3_5_moe_model_forward_patched(
         The temporal, height and width of feature shape of each video in LLM.
     mm_token_type_ids (`torch.IntTensor` of shape `(batch_size, sequence_length)`, *optional*):
         Token type IDs for multimodal inputs.
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices depicting the position of the input sequence tokens in the sequence.
     """
     if (input_ids is None) ^ (inputs_embeds is not None):
         raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -872,6 +874,8 @@ def qwen3_5_moe_forcausallm_forward_patched(
         Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
         config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
         (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices depicting the position of the input sequence tokens in the sequence.
 
     Example:
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.diff
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.diff
@@ -467,7 +467,7 @@
  class Qwen3VLVisionBlock(GradientCheckpointingLayer):
      def __init__(self, config, attn_implementation: str = "sdpa") -> None:
          super().__init__()
-@@ -274,24 +586,37 @@
+@@ -274,24 +586,41 @@
          self.attn = Qwen3VLVisionAttention(config=config)
          self.mlp = Qwen3VLVisionMLP(config=config)
 
@@ -489,6 +489,8 @@
          **kwargs,
      ) -> torch.Tensor:
          r"""
++        hidden_states (`torch.Tensor`):
++            The input hidden states.
          cu_seqlens (`torch.Tensor`):
 -            Cumulative sequence lengths used for packed variable-length attention in Flash Attention kernels.
 +            Cumulative sequence lengths for variable-length vision attention.
@@ -497,6 +499,8 @@
          rotary_pos_emb (`torch.Tensor`, *optional*):
 -            Precomputed rotary positional embeddings applied to the vision attention query/key states.
 +            Precomputed rotary position embeddings for vision attention.
++        position_embeddings (`tuple[torch.Tensor, torch.Tensor]`, *optional*):
++            Precomputed rotary positional embeddings (cos, sin) for vision attention.
          """
          hidden_states = hidden_states + self.attn(
              self.norm1(hidden_states),
@@ -507,7 +511,7 @@
              rotary_pos_emb=rotary_pos_emb,
              position_embeddings=position_embeddings,
              **kwargs,
-@@ -391,6 +716,12 @@
+@@ -391,6 +720,12 @@
          return freqs_t
 
 
@@ -520,7 +524,7 @@
  @use_kernel_forward_from_hub("RMSNorm")
  class Qwen3VLTextRMSNorm(nn.Module):
      def __init__(self, hidden_size, eps: float = 1e-6) -> None:
-@@ -401,7 +732,12 @@
+@@ -401,7 +736,12 @@
          self.weight = nn.Parameter(torch.ones(hidden_size))
          self.variance_epsilon = eps
 
@@ -533,7 +537,7 @@
          input_dtype = hidden_states.dtype
          hidden_states = hidden_states.to(torch.float32)
          variance = hidden_states.pow(2).mean(-1, keepdim=True)
-@@ -412,30 +748,34 @@
+@@ -412,30 +752,34 @@
          return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
 
 
@@ -587,7 +591,7 @@
 
 
  @use_kernelized_func(apply_rotary_pos_emb)
-@@ -470,14 +810,33 @@
+@@ -470,14 +814,33 @@
              self.head_dim, eps=config.rms_norm_eps
          )  # thus post q_norm does not need reshape
 
@@ -621,7 +625,7 @@
          input_shape = hidden_states.shape[:-1]
          hidden_shape = (*input_shape, -1, self.head_dim)
 
-@@ -489,7 +848,8 @@
+@@ -489,7 +852,8 @@
          query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
          if past_key_values is not None:
@@ -631,7 +635,7 @@
 
          attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
              self.config._attn_implementation, eager_attention_forward
-@@ -619,6 +979,12 @@
+@@ -619,6 +983,12 @@
              init.copy_(module.inv_freq, inv_freq)
 
 
@@ -644,7 +648,7 @@
  class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
      config: Qwen3VLVisionConfig
      input_modalities = ("image", "video")
-@@ -665,69 +1031,246 @@
+@@ -665,69 +1035,246 @@
 
          self.post_init()
 
@@ -937,7 +941,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -739,11 +1282,94 @@
+@@ -739,11 +1286,94 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -1032,7 +1036,7 @@
 
 
  @auto_docstring(
-@@ -861,15 +1487,35 @@
+@@ -861,15 +1491,35 @@
              past_key_values=past_key_values,
          )
 
@@ -1068,7 +1072,7 @@
 
 
  @auto_docstring
-@@ -1058,6 +1704,13 @@
+@@ -1058,6 +1708,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -1082,7 +1086,7 @@
      @accepts_precomputed_kwargs(modality="image")
      @can_return_tuple
      @auto_docstring
-@@ -1066,10 +1719,8 @@
+@@ -1066,10 +1723,8 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1094,7 +1098,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          """
-@@ -1077,52 +1728,31 @@
+@@ -1077,52 +1732,31 @@
          vision_output: BaseModelOutputWithDeepstackFeatures = self.visual(
              pixel_values, grid_thw=image_grid_thw, return_dict=True, **kwargs
          )
@@ -1164,7 +1168,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1174,6 +1804,24 @@
+@@ -1174,6 +1808,24 @@
              position_ids = None
          return position_ids
 
@@ -1189,7 +1193,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1187,10 +1835,12 @@
+@@ -1187,10 +1839,12 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1203,7 +1207,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
-@@ -1202,39 +1852,172 @@
+@@ -1202,39 +1856,172 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1392,7 +1396,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1244,25 +2027,71 @@
+@@ -1244,25 +2031,71 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1469,7 +1473,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1270,13 +2099,17 @@
+@@ -1270,13 +2103,17 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1488,7 +1492,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1310,6 +2143,12 @@
+@@ -1310,6 +2147,12 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1501,7 +1505,7 @@
  class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1353,6 +2192,16 @@
+@@ -1353,6 +2196,16 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1518,7 +1522,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1366,57 +2215,10 @@
+@@ -1366,57 +2219,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1578,7 +1582,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1427,27 +2229,55 @@
+@@ -1427,27 +2233,55 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1642,7 +1646,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1673,6 +2503,47 @@
+@@ -1673,6 +2507,47 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.diff
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.diff
@@ -467,7 +467,7 @@
  class Qwen3VLVisionBlock(GradientCheckpointingLayer):
      def __init__(self, config, attn_implementation: str = "sdpa") -> None:
          super().__init__()
-@@ -274,24 +586,29 @@
+@@ -274,24 +586,37 @@
          self.attn = Qwen3VLVisionAttention(config=config)
          self.mlp = Qwen3VLVisionMLP(config=config)
 
@@ -488,12 +488,16 @@
          position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
          **kwargs,
      ) -> torch.Tensor:
--        r"""
--        cu_seqlens (`torch.Tensor`):
+         r"""
+         cu_seqlens (`torch.Tensor`):
 -            Cumulative sequence lengths used for packed variable-length attention in Flash Attention kernels.
--        rotary_pos_emb (`torch.Tensor`, *optional*):
++            Cumulative sequence lengths for variable-length vision attention.
++        max_seqlen (`int`):
++            Maximum per-image or per-video sequence length in the packed vision batch.
+         rotary_pos_emb (`torch.Tensor`, *optional*):
 -            Precomputed rotary positional embeddings applied to the vision attention query/key states.
--        """
++            Precomputed rotary position embeddings for vision attention.
+         """
          hidden_states = hidden_states + self.attn(
              self.norm1(hidden_states),
              cu_seqlens=cu_seqlens,
@@ -503,7 +507,7 @@
              rotary_pos_emb=rotary_pos_emb,
              position_embeddings=position_embeddings,
              **kwargs,
-@@ -391,6 +708,12 @@
+@@ -391,6 +716,12 @@
          return freqs_t
 
 
@@ -516,7 +520,7 @@
  @use_kernel_forward_from_hub("RMSNorm")
  class Qwen3VLTextRMSNorm(nn.Module):
      def __init__(self, hidden_size, eps: float = 1e-6) -> None:
-@@ -401,7 +724,12 @@
+@@ -401,7 +732,12 @@
          self.weight = nn.Parameter(torch.ones(hidden_size))
          self.variance_epsilon = eps
 
@@ -529,7 +533,7 @@
          input_dtype = hidden_states.dtype
          hidden_states = hidden_states.to(torch.float32)
          variance = hidden_states.pow(2).mean(-1, keepdim=True)
-@@ -412,30 +740,34 @@
+@@ -412,30 +748,34 @@
          return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
 
 
@@ -583,7 +587,7 @@
 
 
  @use_kernelized_func(apply_rotary_pos_emb)
-@@ -470,14 +802,33 @@
+@@ -470,14 +810,33 @@
              self.head_dim, eps=config.rms_norm_eps
          )  # thus post q_norm does not need reshape
 
@@ -617,7 +621,7 @@
          input_shape = hidden_states.shape[:-1]
          hidden_shape = (*input_shape, -1, self.head_dim)
 
-@@ -489,7 +840,8 @@
+@@ -489,7 +848,8 @@
          query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
          if past_key_values is not None:
@@ -627,7 +631,7 @@
 
          attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
              self.config._attn_implementation, eager_attention_forward
-@@ -619,6 +971,12 @@
+@@ -619,6 +979,12 @@
              init.copy_(module.inv_freq, inv_freq)
 
 
@@ -640,7 +644,7 @@
  class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
      config: Qwen3VLVisionConfig
      input_modalities = ("image", "video")
-@@ -665,69 +1023,246 @@
+@@ -665,69 +1031,246 @@
 
          self.post_init()
 
@@ -933,7 +937,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -739,11 +1274,94 @@
+@@ -739,11 +1282,94 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -1028,7 +1032,7 @@
 
 
  @auto_docstring(
-@@ -861,15 +1479,35 @@
+@@ -861,15 +1487,35 @@
              past_key_values=past_key_values,
          )
 
@@ -1064,7 +1068,7 @@
 
 
  @auto_docstring
-@@ -1058,6 +1696,13 @@
+@@ -1058,6 +1704,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -1078,7 +1082,7 @@
      @accepts_precomputed_kwargs(modality="image")
      @can_return_tuple
      @auto_docstring
-@@ -1066,10 +1711,8 @@
+@@ -1066,10 +1719,8 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1090,7 +1094,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          """
-@@ -1077,52 +1720,31 @@
+@@ -1077,52 +1728,31 @@
          vision_output: BaseModelOutputWithDeepstackFeatures = self.visual(
              pixel_values, grid_thw=image_grid_thw, return_dict=True, **kwargs
          )
@@ -1160,7 +1164,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1174,6 +1796,24 @@
+@@ -1174,6 +1804,24 @@
              position_ids = None
          return position_ids
 
@@ -1185,7 +1189,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1187,7 +1827,7 @@
+@@ -1187,10 +1835,12 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1194,7 +1198,12 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLModelOutputWithPast:
          r"""
-@@ -1202,39 +1842,172 @@
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
+         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+             The temporal, height and width of feature shape of each image in LLM.
+         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
+@@ -1202,39 +1852,172 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1383,7 +1392,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1244,25 +2017,71 @@
+@@ -1244,25 +2027,71 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1460,7 +1469,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1270,13 +2089,17 @@
+@@ -1270,13 +2099,17 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1479,7 +1488,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1310,6 +2133,12 @@
+@@ -1310,6 +2143,12 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1492,7 +1501,7 @@
  class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1353,6 +2182,16 @@
+@@ -1353,6 +2192,16 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1509,7 +1518,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1366,57 +2205,10 @@
+@@ -1366,57 +2215,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1569,7 +1578,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1427,27 +2219,55 @@
+@@ -1427,27 +2229,55 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1633,7 +1642,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1673,6 +2493,47 @@
+@@ -1673,6 +2503,47 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.py
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.py
@@ -604,12 +604,16 @@ class Qwen3VLVisionBlock(GradientCheckpointingLayer):
         **kwargs,
     ) -> torch.Tensor:
         r"""
+        hidden_states (`torch.Tensor`):
+            The input hidden states.
         cu_seqlens (`torch.Tensor`):
             Cumulative sequence lengths for variable-length vision attention.
         max_seqlen (`int`):
             Maximum per-image or per-video sequence length in the packed vision batch.
         rotary_pos_emb (`torch.Tensor`, *optional*):
             Precomputed rotary position embeddings for vision attention.
+        position_embeddings (`tuple[torch.Tensor, torch.Tensor]`, *optional*):
+            Precomputed rotary positional embeddings (cos, sin) for vision attention.
         """
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.py
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_gpu.py
@@ -603,6 +603,14 @@ class Qwen3VLVisionBlock(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         **kwargs,
     ) -> torch.Tensor:
+        r"""
+        cu_seqlens (`torch.Tensor`):
+            Cumulative sequence lengths for variable-length vision attention.
+        max_seqlen (`int`):
+            Maximum per-image or per-video sequence length in the packed vision batch.
+        rotary_pos_emb (`torch.Tensor`, *optional*):
+            Precomputed rotary position embeddings for vision attention.
+        """
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
             cu_seqlens=cu_seqlens,
@@ -1831,6 +1839,8 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen3VLModelOutputWithPast:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.diff
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.diff
@@ -467,7 +467,7 @@
  class Qwen3VLVisionBlock(GradientCheckpointingLayer):
      def __init__(self, config, attn_implementation: str = "sdpa") -> None:
          super().__init__()
-@@ -274,24 +586,37 @@
+@@ -274,24 +586,41 @@
          self.attn = Qwen3VLVisionAttention(config=config)
          self.mlp = Qwen3VLVisionMLP(config=config)
 
@@ -489,6 +489,8 @@
          **kwargs,
      ) -> torch.Tensor:
          r"""
++        hidden_states (`torch.Tensor`):
++            The input hidden states.
          cu_seqlens (`torch.Tensor`):
 -            Cumulative sequence lengths used for packed variable-length attention in Flash Attention kernels.
 +            Cumulative sequence lengths for variable-length vision attention.
@@ -497,6 +499,8 @@
          rotary_pos_emb (`torch.Tensor`, *optional*):
 -            Precomputed rotary positional embeddings applied to the vision attention query/key states.
 +            Precomputed rotary position embeddings for vision attention.
++        position_embeddings (`tuple[torch.Tensor, torch.Tensor]`, *optional*):
++            Precomputed rotary positional embeddings (cos, sin) for vision attention.
          """
          hidden_states = hidden_states + self.attn(
              self.norm1(hidden_states),
@@ -507,7 +511,7 @@
              rotary_pos_emb=rotary_pos_emb,
              position_embeddings=position_embeddings,
              **kwargs,
-@@ -391,6 +716,12 @@
+@@ -391,6 +720,12 @@
          return freqs_t
 
 
@@ -520,7 +524,7 @@
  @use_kernel_forward_from_hub("RMSNorm")
  class Qwen3VLTextRMSNorm(nn.Module):
      def __init__(self, hidden_size, eps: float = 1e-6) -> None:
-@@ -401,7 +732,12 @@
+@@ -401,7 +736,12 @@
          self.weight = nn.Parameter(torch.ones(hidden_size))
          self.variance_epsilon = eps
 
@@ -533,7 +537,7 @@
          input_dtype = hidden_states.dtype
          hidden_states = hidden_states.to(torch.float32)
          variance = hidden_states.pow(2).mean(-1, keepdim=True)
-@@ -412,30 +748,34 @@
+@@ -412,30 +752,34 @@
          return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
 
 
@@ -587,7 +591,7 @@
 
 
  @use_kernelized_func(apply_rotary_pos_emb)
-@@ -470,14 +810,33 @@
+@@ -470,14 +814,33 @@
              self.head_dim, eps=config.rms_norm_eps
          )  # thus post q_norm does not need reshape
 
@@ -621,7 +625,7 @@
          input_shape = hidden_states.shape[:-1]
          hidden_shape = (*input_shape, -1, self.head_dim)
 
-@@ -489,7 +848,8 @@
+@@ -489,7 +852,8 @@
          query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
          if past_key_values is not None:
@@ -631,7 +635,7 @@
 
          attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
              self.config._attn_implementation, eager_attention_forward
-@@ -619,6 +979,12 @@
+@@ -619,6 +983,12 @@
              init.copy_(module.inv_freq, inv_freq)
 
 
@@ -644,7 +648,7 @@
  class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
      config: Qwen3VLVisionConfig
      input_modalities = ("image", "video")
-@@ -665,69 +1031,246 @@
+@@ -665,69 +1035,246 @@
 
          self.post_init()
 
@@ -937,7 +941,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -739,11 +1282,94 @@
+@@ -739,11 +1286,94 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -1032,7 +1036,7 @@
 
 
  @auto_docstring(
-@@ -861,15 +1487,35 @@
+@@ -861,15 +1491,35 @@
              past_key_values=past_key_values,
          )
 
@@ -1068,7 +1072,7 @@
 
 
  @auto_docstring
-@@ -1058,6 +1704,13 @@
+@@ -1058,6 +1708,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -1082,7 +1086,7 @@
      @accepts_precomputed_kwargs(modality="image")
      @can_return_tuple
      @auto_docstring
-@@ -1066,10 +1719,8 @@
+@@ -1066,10 +1723,8 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1094,7 +1098,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          """
-@@ -1077,52 +1728,31 @@
+@@ -1077,52 +1732,31 @@
          vision_output: BaseModelOutputWithDeepstackFeatures = self.visual(
              pixel_values, grid_thw=image_grid_thw, return_dict=True, **kwargs
          )
@@ -1164,7 +1168,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1174,6 +1804,24 @@
+@@ -1174,6 +1808,24 @@
              position_ids = None
          return position_ids
 
@@ -1189,7 +1193,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1187,10 +1835,12 @@
+@@ -1187,10 +1839,12 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1203,7 +1207,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
-@@ -1202,39 +1852,172 @@
+@@ -1202,39 +1856,172 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1392,7 +1396,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1244,25 +2027,71 @@
+@@ -1244,25 +2031,71 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1469,7 +1473,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1270,13 +2099,17 @@
+@@ -1270,13 +2103,17 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1488,7 +1492,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1310,6 +2143,12 @@
+@@ -1310,6 +2147,12 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1501,7 +1505,7 @@
  class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1353,6 +2192,16 @@
+@@ -1353,6 +2196,16 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1518,7 +1522,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1366,57 +2215,10 @@
+@@ -1366,57 +2219,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1578,7 +1582,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1427,27 +2229,55 @@
+@@ -1427,27 +2233,55 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1642,7 +1646,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1673,6 +2503,47 @@
+@@ -1673,6 +2507,47 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.diff
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.diff
@@ -467,7 +467,7 @@
  class Qwen3VLVisionBlock(GradientCheckpointingLayer):
      def __init__(self, config, attn_implementation: str = "sdpa") -> None:
          super().__init__()
-@@ -274,24 +586,29 @@
+@@ -274,24 +586,37 @@
          self.attn = Qwen3VLVisionAttention(config=config)
          self.mlp = Qwen3VLVisionMLP(config=config)
 
@@ -488,12 +488,16 @@
          position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
          **kwargs,
      ) -> torch.Tensor:
--        r"""
--        cu_seqlens (`torch.Tensor`):
+         r"""
+         cu_seqlens (`torch.Tensor`):
 -            Cumulative sequence lengths used for packed variable-length attention in Flash Attention kernels.
--        rotary_pos_emb (`torch.Tensor`, *optional*):
++            Cumulative sequence lengths for variable-length vision attention.
++        max_seqlen (`int`):
++            Maximum per-image or per-video sequence length in the packed vision batch.
+         rotary_pos_emb (`torch.Tensor`, *optional*):
 -            Precomputed rotary positional embeddings applied to the vision attention query/key states.
--        """
++            Precomputed rotary position embeddings for vision attention.
+         """
          hidden_states = hidden_states + self.attn(
              self.norm1(hidden_states),
              cu_seqlens=cu_seqlens,
@@ -503,7 +507,7 @@
              rotary_pos_emb=rotary_pos_emb,
              position_embeddings=position_embeddings,
              **kwargs,
-@@ -391,6 +708,12 @@
+@@ -391,6 +716,12 @@
          return freqs_t
 
 
@@ -516,7 +520,7 @@
  @use_kernel_forward_from_hub("RMSNorm")
  class Qwen3VLTextRMSNorm(nn.Module):
      def __init__(self, hidden_size, eps: float = 1e-6) -> None:
-@@ -401,7 +724,12 @@
+@@ -401,7 +732,12 @@
          self.weight = nn.Parameter(torch.ones(hidden_size))
          self.variance_epsilon = eps
 
@@ -529,7 +533,7 @@
          input_dtype = hidden_states.dtype
          hidden_states = hidden_states.to(torch.float32)
          variance = hidden_states.pow(2).mean(-1, keepdim=True)
-@@ -412,30 +740,34 @@
+@@ -412,30 +748,34 @@
          return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
 
 
@@ -583,7 +587,7 @@
 
 
  @use_kernelized_func(apply_rotary_pos_emb)
-@@ -470,14 +802,33 @@
+@@ -470,14 +810,33 @@
              self.head_dim, eps=config.rms_norm_eps
          )  # thus post q_norm does not need reshape
 
@@ -617,7 +621,7 @@
          input_shape = hidden_states.shape[:-1]
          hidden_shape = (*input_shape, -1, self.head_dim)
 
-@@ -489,7 +840,8 @@
+@@ -489,7 +848,8 @@
          query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
          if past_key_values is not None:
@@ -627,7 +631,7 @@
 
          attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
              self.config._attn_implementation, eager_attention_forward
-@@ -619,6 +971,12 @@
+@@ -619,6 +979,12 @@
              init.copy_(module.inv_freq, inv_freq)
 
 
@@ -640,7 +644,7 @@
  class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
      config: Qwen3VLVisionConfig
      input_modalities = ("image", "video")
-@@ -665,69 +1023,246 @@
+@@ -665,69 +1031,246 @@
 
          self.post_init()
 
@@ -933,7 +937,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -739,11 +1274,94 @@
+@@ -739,11 +1282,94 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -1028,7 +1032,7 @@
 
 
  @auto_docstring(
-@@ -861,15 +1479,35 @@
+@@ -861,15 +1487,35 @@
              past_key_values=past_key_values,
          )
 
@@ -1064,7 +1068,7 @@
 
 
  @auto_docstring
-@@ -1058,6 +1696,13 @@
+@@ -1058,6 +1704,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -1078,7 +1082,7 @@
      @accepts_precomputed_kwargs(modality="image")
      @can_return_tuple
      @auto_docstring
-@@ -1066,10 +1711,8 @@
+@@ -1066,10 +1719,8 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1090,7 +1094,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          """
-@@ -1077,52 +1720,31 @@
+@@ -1077,52 +1728,31 @@
          vision_output: BaseModelOutputWithDeepstackFeatures = self.visual(
              pixel_values, grid_thw=image_grid_thw, return_dict=True, **kwargs
          )
@@ -1160,7 +1164,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1174,6 +1796,24 @@
+@@ -1174,6 +1804,24 @@
              position_ids = None
          return position_ids
 
@@ -1185,7 +1189,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1187,7 +1827,7 @@
+@@ -1187,10 +1835,12 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1194,7 +1198,12 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLModelOutputWithPast:
          r"""
-@@ -1202,39 +1842,172 @@
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
+         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+             The temporal, height and width of feature shape of each image in LLM.
+         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
+@@ -1202,39 +1852,172 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1383,7 +1392,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1244,25 +2017,71 @@
+@@ -1244,25 +2027,71 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1460,7 +1469,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1270,13 +2089,17 @@
+@@ -1270,13 +2099,17 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1479,7 +1488,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1310,6 +2133,12 @@
+@@ -1310,6 +2143,12 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1492,7 +1501,7 @@
  class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1353,6 +2182,16 @@
+@@ -1353,6 +2192,16 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1509,7 +1518,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1366,57 +2205,10 @@
+@@ -1366,57 +2215,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1569,7 +1578,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1427,27 +2219,55 @@
+@@ -1427,27 +2229,55 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1633,7 +1642,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1673,6 +2493,47 @@
+@@ -1673,6 +2503,47 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.py
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.py
@@ -604,12 +604,16 @@ class Qwen3VLVisionBlock(GradientCheckpointingLayer):
         **kwargs,
     ) -> torch.Tensor:
         r"""
+        hidden_states (`torch.Tensor`):
+            The input hidden states.
         cu_seqlens (`torch.Tensor`):
             Cumulative sequence lengths for variable-length vision attention.
         max_seqlen (`int`):
             Maximum per-image or per-video sequence length in the packed vision batch.
         rotary_pos_emb (`torch.Tensor`, *optional*):
             Precomputed rotary position embeddings for vision attention.
+        position_embeddings (`tuple[torch.Tensor, torch.Tensor]`, *optional*):
+            Precomputed rotary positional embeddings (cos, sin) for vision attention.
         """
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),

--- a/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.py
+++ b/veomni/models/transformers/qwen3_vl/generated/patched_modeling_qwen3_vl_npu.py
@@ -603,6 +603,14 @@ class Qwen3VLVisionBlock(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         **kwargs,
     ) -> torch.Tensor:
+        r"""
+        cu_seqlens (`torch.Tensor`):
+            Cumulative sequence lengths for variable-length vision attention.
+        max_seqlen (`int`):
+            Maximum per-image or per-video sequence length in the packed vision batch.
+        rotary_pos_emb (`torch.Tensor`, *optional*):
+            Precomputed rotary position embeddings for vision attention.
+        """
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
             cu_seqlens=cu_seqlens,
@@ -1831,6 +1839,8 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen3VLModelOutputWithPast:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen3_vl/qwen3_vl_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_vl/qwen3_vl_gpu_patch_gen_config.py
@@ -487,12 +487,16 @@ def qwen3_vl_vision_block_forward_patched(
     **kwargs,
 ) -> torch.Tensor:
     r"""
+    hidden_states (`torch.Tensor`):
+        The input hidden states.
     cu_seqlens (`torch.Tensor`):
         Cumulative sequence lengths for variable-length vision attention.
     max_seqlen (`int`):
         Maximum per-image or per-video sequence length in the packed vision batch.
     rotary_pos_emb (`torch.Tensor`, *optional*):
         Precomputed rotary position embeddings for vision attention.
+    position_embeddings (`tuple[torch.Tensor, torch.Tensor]`, *optional*):
+        Precomputed rotary positional embeddings (cos, sin) for vision attention.
     """
     hidden_states = hidden_states + self.attn(
         self.norm1(hidden_states),

--- a/veomni/models/transformers/qwen3_vl/qwen3_vl_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_vl/qwen3_vl_gpu_patch_gen_config.py
@@ -486,6 +486,14 @@ def qwen3_vl_vision_block_forward_patched(
     position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
     **kwargs,
 ) -> torch.Tensor:
+    r"""
+    cu_seqlens (`torch.Tensor`):
+        Cumulative sequence lengths for variable-length vision attention.
+    max_seqlen (`int`):
+        Maximum per-image or per-video sequence length in the packed vision batch.
+    rotary_pos_emb (`torch.Tensor`, *optional*):
+        Precomputed rotary position embeddings for vision attention.
+    """
     hidden_states = hidden_states + self.attn(
         self.norm1(hidden_states),
         cu_seqlens=cu_seqlens,
@@ -1041,6 +1049,8 @@ def qwen3_vl_model_forward_patched(
     **kwargs: Unpack[TransformersKwargs],
 ) -> tuple | Qwen3VLModelOutputWithPast:
     r"""
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices describing the positions of the input sequence tokens in the cache.
     image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
         The temporal, height and width of feature shape of each image in LLM.
     video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.diff
@@ -656,7 +656,7 @@
  class Qwen3VLMoeVisionBlock(GradientCheckpointingLayer):
      def __init__(self, config, attn_implementation: str = "sdpa") -> None:
          super().__init__()
-@@ -528,24 +920,37 @@
+@@ -528,24 +920,41 @@
          self.attn = Qwen3VLMoeVisionAttention(config=config)
          self.mlp = Qwen3VLMoeVisionMLP(config=config)
 
@@ -678,6 +678,8 @@
          **kwargs,
      ) -> torch.Tensor:
          r"""
++        hidden_states (`torch.Tensor`):
++            The input hidden states.
          cu_seqlens (`torch.Tensor`):
 -            Cumulative sequence lengths used for packed variable-length attention in Flash Attention kernels.
 +            Cumulative sequence lengths for variable-length vision attention.
@@ -686,6 +688,8 @@
          rotary_pos_emb (`torch.Tensor`, *optional*):
 -            Precomputed rotary positional embeddings applied to the vision attention query/key states.
 +            Precomputed rotary position embeddings for vision attention.
++        position_embeddings (`tuple[torch.Tensor, torch.Tensor]`, *optional*):
++            Precomputed rotary positional embeddings (cos, sin) for vision attention.
          """
          hidden_states = hidden_states + self.attn(
              self.norm1(hidden_states),
@@ -696,7 +700,7 @@
              rotary_pos_emb=rotary_pos_emb,
              position_embeddings=position_embeddings,
              **kwargs,
-@@ -601,6 +1006,12 @@
+@@ -601,6 +1010,12 @@
          return x
 
 
@@ -709,7 +713,7 @@
  class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
      config: Qwen3VLMoeVisionConfig
      input_modalities = ("image", "video")
-@@ -648,69 +1059,246 @@
+@@ -648,69 +1063,246 @@
 
          self.post_init()
 
@@ -1002,7 +1006,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -722,11 +1310,88 @@
+@@ -722,11 +1314,88 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -1091,7 +1095,7 @@
 
 
  class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
-@@ -818,6 +1483,12 @@
+@@ -818,6 +1487,12 @@
              idx = slice(offset, length, 3)
              freqs_t[..., idx] = freqs[dim, ..., idx]
          return freqs_t
@@ -1104,7 +1108,7 @@
 
 
  @auto_docstring(
-@@ -935,9 +1606,23 @@
+@@ -935,9 +1610,23 @@
              past_key_values=past_key_values,
          )
 
@@ -1128,7 +1132,7 @@
          visual_pos_masks = visual_pos_masks.to(hidden_states.device)
          visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
          hidden_states = hidden_states.clone()
-@@ -1000,6 +1685,12 @@
+@@ -1000,6 +1689,12 @@
      rope_deltas: torch.LongTensor | None = None
      router_logits: tuple[torch.FloatTensor] | None = None
      aux_loss: torch.FloatTensor | None = None
@@ -1141,7 +1145,7 @@
 
 
  @auto_docstring
-@@ -1188,6 +1879,13 @@
+@@ -1188,6 +1883,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -1155,7 +1159,7 @@
      @accepts_precomputed_kwargs(modality="image")
      @can_return_tuple
      @auto_docstring
-@@ -1196,10 +1894,8 @@
+@@ -1196,10 +1898,8 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1167,7 +1171,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          """
-@@ -1207,52 +1903,31 @@
+@@ -1207,52 +1907,31 @@
          vision_output: BaseModelOutputWithDeepstackFeatures = self.visual(
              pixel_values, grid_thw=image_grid_thw, return_dict=True, **kwargs
          )
@@ -1237,7 +1241,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1304,6 +1979,16 @@
+@@ -1304,6 +1983,16 @@
              position_ids = None
          return position_ids
 
@@ -1254,7 +1258,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1317,10 +2002,12 @@
+@@ -1317,10 +2006,12 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1268,7 +1272,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
-@@ -1332,39 +2019,167 @@
+@@ -1332,39 +2023,167 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1452,7 +1456,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1374,25 +2189,63 @@
+@@ -1374,25 +2193,63 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1521,7 +1525,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1400,13 +2253,18 @@
+@@ -1400,13 +2257,18 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1541,7 +1545,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1491,6 +2349,12 @@
+@@ -1491,6 +2353,12 @@
 
      overall_loss = torch.sum(tokens_per_expert * router_prob_per_expert.unsqueeze(0))
      return overall_loss * num_experts
@@ -1554,7 +1558,7 @@
 
 
  class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMixin):
-@@ -1536,6 +2400,14 @@
+@@ -1536,6 +2404,14 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1569,7 +1573,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1549,100 +2421,87 @@
+@@ -1549,100 +2425,87 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1730,7 +1734,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1650,7 +2509,8 @@
+@@ -1650,7 +2513,8 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
@@ -1740,7 +1744,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1876,6 +2736,59 @@
+@@ -1876,6 +2740,59 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.diff
@@ -656,7 +656,7 @@
  class Qwen3VLMoeVisionBlock(GradientCheckpointingLayer):
      def __init__(self, config, attn_implementation: str = "sdpa") -> None:
          super().__init__()
-@@ -528,24 +920,29 @@
+@@ -528,24 +920,37 @@
          self.attn = Qwen3VLMoeVisionAttention(config=config)
          self.mlp = Qwen3VLMoeVisionMLP(config=config)
 
@@ -677,12 +677,16 @@
          position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
          **kwargs,
      ) -> torch.Tensor:
--        r"""
--        cu_seqlens (`torch.Tensor`):
+         r"""
+         cu_seqlens (`torch.Tensor`):
 -            Cumulative sequence lengths used for packed variable-length attention in Flash Attention kernels.
--        rotary_pos_emb (`torch.Tensor`, *optional*):
++            Cumulative sequence lengths for variable-length vision attention.
++        max_seqlen (`int`):
++            Maximum per-image or per-video sequence length in the packed vision batch.
+         rotary_pos_emb (`torch.Tensor`, *optional*):
 -            Precomputed rotary positional embeddings applied to the vision attention query/key states.
--        """
++            Precomputed rotary position embeddings for vision attention.
+         """
          hidden_states = hidden_states + self.attn(
              self.norm1(hidden_states),
              cu_seqlens=cu_seqlens,
@@ -692,7 +696,7 @@
              rotary_pos_emb=rotary_pos_emb,
              position_embeddings=position_embeddings,
              **kwargs,
-@@ -601,6 +998,12 @@
+@@ -601,6 +1006,12 @@
          return x
 
 
@@ -705,7 +709,7 @@
  class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
      config: Qwen3VLMoeVisionConfig
      input_modalities = ("image", "video")
-@@ -648,69 +1051,246 @@
+@@ -648,69 +1059,246 @@
 
          self.post_init()
 
@@ -998,7 +1002,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -722,11 +1302,88 @@
+@@ -722,11 +1310,88 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -1087,7 +1091,7 @@
 
 
  class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
-@@ -818,6 +1475,12 @@
+@@ -818,6 +1483,12 @@
              idx = slice(offset, length, 3)
              freqs_t[..., idx] = freqs[dim, ..., idx]
          return freqs_t
@@ -1100,7 +1104,7 @@
 
 
  @auto_docstring(
-@@ -935,9 +1598,23 @@
+@@ -935,9 +1606,23 @@
              past_key_values=past_key_values,
          )
 
@@ -1124,7 +1128,7 @@
          visual_pos_masks = visual_pos_masks.to(hidden_states.device)
          visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
          hidden_states = hidden_states.clone()
-@@ -1000,6 +1677,12 @@
+@@ -1000,6 +1685,12 @@
      rope_deltas: torch.LongTensor | None = None
      router_logits: tuple[torch.FloatTensor] | None = None
      aux_loss: torch.FloatTensor | None = None
@@ -1137,7 +1141,7 @@
 
 
  @auto_docstring
-@@ -1188,6 +1871,13 @@
+@@ -1188,6 +1879,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -1151,7 +1155,7 @@
      @accepts_precomputed_kwargs(modality="image")
      @can_return_tuple
      @auto_docstring
-@@ -1196,10 +1886,8 @@
+@@ -1196,10 +1894,8 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1163,7 +1167,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          """
-@@ -1207,52 +1895,31 @@
+@@ -1207,52 +1903,31 @@
          vision_output: BaseModelOutputWithDeepstackFeatures = self.visual(
              pixel_values, grid_thw=image_grid_thw, return_dict=True, **kwargs
          )
@@ -1233,7 +1237,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1304,6 +1971,16 @@
+@@ -1304,6 +1979,16 @@
              position_ids = None
          return position_ids
 
@@ -1250,7 +1254,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1317,7 +1994,7 @@
+@@ -1317,10 +2002,12 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1259,7 +1263,12 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLMoeModelOutputWithPast:
          r"""
-@@ -1332,39 +2009,167 @@
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
+         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+             The temporal, height and width of feature shape of each image in LLM.
+         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
+@@ -1332,39 +2019,167 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1443,7 +1452,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1374,25 +2179,63 @@
+@@ -1374,25 +2189,63 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1512,7 +1521,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1400,13 +2243,18 @@
+@@ -1400,13 +2253,18 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1532,7 +1541,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1491,6 +2339,12 @@
+@@ -1491,6 +2349,12 @@
 
      overall_loss = torch.sum(tokens_per_expert * router_prob_per_expert.unsqueeze(0))
      return overall_loss * num_experts
@@ -1545,7 +1554,7 @@
 
 
  class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMixin):
-@@ -1536,6 +2390,14 @@
+@@ -1536,6 +2400,14 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1560,7 +1569,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1549,100 +2411,87 @@
+@@ -1549,100 +2421,87 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1721,7 +1730,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1650,7 +2499,8 @@
+@@ -1650,7 +2509,8 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
@@ -1731,7 +1740,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1876,6 +2726,59 @@
+@@ -1876,6 +2736,59 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.py
@@ -937,6 +937,14 @@ class Qwen3VLMoeVisionBlock(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         **kwargs,
     ) -> torch.Tensor:
+        r"""
+        cu_seqlens (`torch.Tensor`):
+            Cumulative sequence lengths for variable-length vision attention.
+        max_seqlen (`int`):
+            Maximum per-image or per-video sequence length in the packed vision batch.
+        rotary_pos_emb (`torch.Tensor`, *optional*):
+            Precomputed rotary position embeddings for vision attention.
+        """
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
             cu_seqlens=cu_seqlens,
@@ -1998,6 +2006,8 @@ class Qwen3VLMoeModel(Qwen3VLMoePreTrainedModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen3VLMoeModelOutputWithPast:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_gpu.py
@@ -938,12 +938,16 @@ class Qwen3VLMoeVisionBlock(GradientCheckpointingLayer):
         **kwargs,
     ) -> torch.Tensor:
         r"""
+        hidden_states (`torch.Tensor`):
+            The input hidden states.
         cu_seqlens (`torch.Tensor`):
             Cumulative sequence lengths for variable-length vision attention.
         max_seqlen (`int`):
             Maximum per-image or per-video sequence length in the packed vision batch.
         rotary_pos_emb (`torch.Tensor`, *optional*):
             Precomputed rotary position embeddings for vision attention.
+        position_embeddings (`tuple[torch.Tensor, torch.Tensor]`, *optional*):
+            Precomputed rotary positional embeddings (cos, sin) for vision attention.
         """
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.diff
@@ -656,7 +656,7 @@
  class Qwen3VLMoeVisionBlock(GradientCheckpointingLayer):
      def __init__(self, config, attn_implementation: str = "sdpa") -> None:
          super().__init__()
-@@ -528,24 +920,37 @@
+@@ -528,24 +920,41 @@
          self.attn = Qwen3VLMoeVisionAttention(config=config)
          self.mlp = Qwen3VLMoeVisionMLP(config=config)
 
@@ -678,6 +678,8 @@
          **kwargs,
      ) -> torch.Tensor:
          r"""
++        hidden_states (`torch.Tensor`):
++            The input hidden states.
          cu_seqlens (`torch.Tensor`):
 -            Cumulative sequence lengths used for packed variable-length attention in Flash Attention kernels.
 +            Cumulative sequence lengths for variable-length vision attention.
@@ -686,6 +688,8 @@
          rotary_pos_emb (`torch.Tensor`, *optional*):
 -            Precomputed rotary positional embeddings applied to the vision attention query/key states.
 +            Precomputed rotary position embeddings for vision attention.
++        position_embeddings (`tuple[torch.Tensor, torch.Tensor]`, *optional*):
++            Precomputed rotary positional embeddings (cos, sin) for vision attention.
          """
          hidden_states = hidden_states + self.attn(
              self.norm1(hidden_states),
@@ -696,7 +700,7 @@
              rotary_pos_emb=rotary_pos_emb,
              position_embeddings=position_embeddings,
              **kwargs,
-@@ -601,6 +1006,12 @@
+@@ -601,6 +1010,12 @@
          return x
 
 
@@ -709,7 +713,7 @@
  class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
      config: Qwen3VLMoeVisionConfig
      input_modalities = ("image", "video")
-@@ -648,69 +1059,246 @@
+@@ -648,69 +1063,246 @@
 
          self.post_init()
 
@@ -1002,7 +1006,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -722,11 +1310,88 @@
+@@ -722,11 +1314,88 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -1091,7 +1095,7 @@
 
 
  class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
-@@ -818,6 +1483,12 @@
+@@ -818,6 +1487,12 @@
              idx = slice(offset, length, 3)
              freqs_t[..., idx] = freqs[dim, ..., idx]
          return freqs_t
@@ -1104,7 +1108,7 @@
 
 
  @auto_docstring(
-@@ -935,9 +1606,23 @@
+@@ -935,9 +1610,23 @@
              past_key_values=past_key_values,
          )
 
@@ -1128,7 +1132,7 @@
          visual_pos_masks = visual_pos_masks.to(hidden_states.device)
          visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
          hidden_states = hidden_states.clone()
-@@ -1000,6 +1685,12 @@
+@@ -1000,6 +1689,12 @@
      rope_deltas: torch.LongTensor | None = None
      router_logits: tuple[torch.FloatTensor] | None = None
      aux_loss: torch.FloatTensor | None = None
@@ -1141,7 +1145,7 @@
 
 
  @auto_docstring
-@@ -1188,6 +1879,13 @@
+@@ -1188,6 +1883,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -1155,7 +1159,7 @@
      @accepts_precomputed_kwargs(modality="image")
      @can_return_tuple
      @auto_docstring
-@@ -1196,10 +1894,8 @@
+@@ -1196,10 +1898,8 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1167,7 +1171,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          """
-@@ -1207,52 +1903,31 @@
+@@ -1207,52 +1907,31 @@
          vision_output: BaseModelOutputWithDeepstackFeatures = self.visual(
              pixel_values, grid_thw=image_grid_thw, return_dict=True, **kwargs
          )
@@ -1237,7 +1241,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1304,6 +1979,16 @@
+@@ -1304,6 +1983,16 @@
              position_ids = None
          return position_ids
 
@@ -1254,7 +1258,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1317,10 +2002,12 @@
+@@ -1317,10 +2006,12 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1268,7 +1272,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
-@@ -1332,39 +2019,167 @@
+@@ -1332,39 +2023,167 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1452,7 +1456,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1374,25 +2189,63 @@
+@@ -1374,25 +2193,63 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1521,7 +1525,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1400,13 +2253,18 @@
+@@ -1400,13 +2257,18 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1541,7 +1545,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1491,6 +2349,12 @@
+@@ -1491,6 +2353,12 @@
 
      overall_loss = torch.sum(tokens_per_expert * router_prob_per_expert.unsqueeze(0))
      return overall_loss * num_experts
@@ -1554,7 +1558,7 @@
 
 
  class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMixin):
-@@ -1536,6 +2400,14 @@
+@@ -1536,6 +2404,14 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1569,7 +1573,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1549,100 +2421,87 @@
+@@ -1549,100 +2425,87 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1730,7 +1734,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1650,7 +2509,8 @@
+@@ -1650,7 +2513,8 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
@@ -1740,7 +1744,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1876,6 +2736,59 @@
+@@ -1876,6 +2740,59 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.diff
@@ -656,7 +656,7 @@
  class Qwen3VLMoeVisionBlock(GradientCheckpointingLayer):
      def __init__(self, config, attn_implementation: str = "sdpa") -> None:
          super().__init__()
-@@ -528,24 +920,29 @@
+@@ -528,24 +920,37 @@
          self.attn = Qwen3VLMoeVisionAttention(config=config)
          self.mlp = Qwen3VLMoeVisionMLP(config=config)
 
@@ -677,12 +677,16 @@
          position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
          **kwargs,
      ) -> torch.Tensor:
--        r"""
--        cu_seqlens (`torch.Tensor`):
+         r"""
+         cu_seqlens (`torch.Tensor`):
 -            Cumulative sequence lengths used for packed variable-length attention in Flash Attention kernels.
--        rotary_pos_emb (`torch.Tensor`, *optional*):
++            Cumulative sequence lengths for variable-length vision attention.
++        max_seqlen (`int`):
++            Maximum per-image or per-video sequence length in the packed vision batch.
+         rotary_pos_emb (`torch.Tensor`, *optional*):
 -            Precomputed rotary positional embeddings applied to the vision attention query/key states.
--        """
++            Precomputed rotary position embeddings for vision attention.
+         """
          hidden_states = hidden_states + self.attn(
              self.norm1(hidden_states),
              cu_seqlens=cu_seqlens,
@@ -692,7 +696,7 @@
              rotary_pos_emb=rotary_pos_emb,
              position_embeddings=position_embeddings,
              **kwargs,
-@@ -601,6 +998,12 @@
+@@ -601,6 +1006,12 @@
          return x
 
 
@@ -705,7 +709,7 @@
  class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
      config: Qwen3VLMoeVisionConfig
      input_modalities = ("image", "video")
-@@ -648,69 +1051,246 @@
+@@ -648,69 +1059,246 @@
 
          self.post_init()
 
@@ -998,7 +1002,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -722,11 +1302,88 @@
+@@ -722,11 +1310,88 @@
 
          merged_hidden_states = self.merger(hidden_states)
 
@@ -1087,7 +1091,7 @@
 
 
  class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
-@@ -818,6 +1475,12 @@
+@@ -818,6 +1483,12 @@
              idx = slice(offset, length, 3)
              freqs_t[..., idx] = freqs[dim, ..., idx]
          return freqs_t
@@ -1100,7 +1104,7 @@
 
 
  @auto_docstring(
-@@ -935,9 +1598,23 @@
+@@ -935,9 +1606,23 @@
              past_key_values=past_key_values,
          )
 
@@ -1124,7 +1128,7 @@
          visual_pos_masks = visual_pos_masks.to(hidden_states.device)
          visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
          hidden_states = hidden_states.clone()
-@@ -1000,6 +1677,12 @@
+@@ -1000,6 +1685,12 @@
      rope_deltas: torch.LongTensor | None = None
      router_logits: tuple[torch.FloatTensor] | None = None
      aux_loss: torch.FloatTensor | None = None
@@ -1137,7 +1141,7 @@
 
 
  @auto_docstring
-@@ -1188,6 +1871,13 @@
+@@ -1188,6 +1879,13 @@
          # Same implementation as for images
          return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
@@ -1151,7 +1155,7 @@
      @accepts_precomputed_kwargs(modality="image")
      @can_return_tuple
      @auto_docstring
-@@ -1196,10 +1886,8 @@
+@@ -1196,10 +1894,8 @@
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
@@ -1163,7 +1167,7 @@
          image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
              The temporal, height and width of feature shape of each image in LLM.
          """
-@@ -1207,52 +1895,31 @@
+@@ -1207,52 +1903,31 @@
          vision_output: BaseModelOutputWithDeepstackFeatures = self.visual(
              pixel_values, grid_thw=image_grid_thw, return_dict=True, **kwargs
          )
@@ -1233,7 +1237,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1304,6 +1971,16 @@
+@@ -1304,6 +1979,16 @@
              position_ids = None
          return position_ids
 
@@ -1250,7 +1254,7 @@
      @auto_docstring
      @can_return_tuple
      def forward(
-@@ -1317,7 +1994,7 @@
+@@ -1317,10 +2002,12 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1259,7 +1263,12 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3VLMoeModelOutputWithPast:
          r"""
-@@ -1332,39 +2009,167 @@
++        cache_position (`torch.LongTensor`, *optional*):
++            Indices describing the positions of the input sequence tokens in the cache.
+         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+             The temporal, height and width of feature shape of each image in LLM.
+         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
+@@ -1332,39 +2019,167 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1443,7 +1452,7 @@
              visual_pos_masks = image_mask | video_mask
              deepstack_visual_embeds = []
              image_mask_joint = image_mask[visual_pos_masks]
-@@ -1374,25 +2179,63 @@
+@@ -1374,25 +2189,63 @@
                  embed_joint[image_mask_joint, :] = img_embed
                  embed_joint[video_mask_joint, :] = vid_embed
                  deepstack_visual_embeds.append(embed_joint)
@@ -1512,7 +1521,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1400,13 +2243,18 @@
+@@ -1400,13 +2253,18 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1532,7 +1541,7 @@
              rope_deltas=self.rope_deltas,
          )
 
-@@ -1491,6 +2339,12 @@
+@@ -1491,6 +2349,12 @@
 
      overall_loss = torch.sum(tokens_per_expert * router_prob_per_expert.unsqueeze(0))
      return overall_loss * num_experts
@@ -1545,7 +1554,7 @@
 
 
  class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMixin):
-@@ -1536,6 +2390,14 @@
+@@ -1536,6 +2400,14 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1560,7 +1569,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1549,100 +2411,87 @@
+@@ -1549,100 +2421,87 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1721,7 +1730,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1650,7 +2499,8 @@
+@@ -1650,7 +2509,8 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              rope_deltas=outputs.rope_deltas,
@@ -1731,7 +1740,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -1876,6 +2726,59 @@
+@@ -1876,6 +2736,59 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.py
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.py
@@ -937,6 +937,14 @@ class Qwen3VLMoeVisionBlock(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         **kwargs,
     ) -> torch.Tensor:
+        r"""
+        cu_seqlens (`torch.Tensor`):
+            Cumulative sequence lengths for variable-length vision attention.
+        max_seqlen (`int`):
+            Maximum per-image or per-video sequence length in the packed vision batch.
+        rotary_pos_emb (`torch.Tensor`, *optional*):
+            Precomputed rotary position embeddings for vision attention.
+        """
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
             cu_seqlens=cu_seqlens,
@@ -1998,6 +2006,8 @@ class Qwen3VLMoeModel(Qwen3VLMoePreTrainedModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | Qwen3VLMoeModelOutputWithPast:
         r"""
+        cache_position (`torch.LongTensor`, *optional*):
+            Indices describing the positions of the input sequence tokens in the cache.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
             The temporal, height and width of feature shape of each image in LLM.
         video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):

--- a/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.py
+++ b/veomni/models/transformers/qwen3_vl_moe/generated/patched_modeling_qwen3_vl_moe_npu.py
@@ -938,12 +938,16 @@ class Qwen3VLMoeVisionBlock(GradientCheckpointingLayer):
         **kwargs,
     ) -> torch.Tensor:
         r"""
+        hidden_states (`torch.Tensor`):
+            The input hidden states.
         cu_seqlens (`torch.Tensor`):
             Cumulative sequence lengths for variable-length vision attention.
         max_seqlen (`int`):
             Maximum per-image or per-video sequence length in the packed vision batch.
         rotary_pos_emb (`torch.Tensor`, *optional*):
             Precomputed rotary position embeddings for vision attention.
+        position_embeddings (`tuple[torch.Tensor, torch.Tensor]`, *optional*):
+            Precomputed rotary positional embeddings (cos, sin) for vision attention.
         """
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),

--- a/veomni/models/transformers/qwen3_vl_moe/qwen3_vl_moe_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_vl_moe/qwen3_vl_moe_gpu_patch_gen_config.py
@@ -329,6 +329,8 @@ def qwen3_vl_moe_model_forward_patched(
     **kwargs: Unpack[TransformersKwargs],
 ) -> tuple | Qwen3VLMoeModelOutputWithPast:
     r"""
+    cache_position (`torch.LongTensor`, *optional*):
+        Indices describing the positions of the input sequence tokens in the cache.
     image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
         The temporal, height and width of feature shape of each image in LLM.
     video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):


### PR DESCRIPTION
## Summary
- document patched forward parameters required by Transformers 5.9 auto_docstring validation
- cover Qwen3-VL, Qwen3-VL-MoE, Qwen3.5, Qwen3.5-MoE, Qwen2.5-VL, Qwen2-VL, and Qwen2.5-Omni generated patch modules
- regenerate generated patch files through patchgen, including GPU/NPU outputs that patchgen reported stale

## Validation
- `PATH=.venv/bin:$PATH ./.venv/bin/patchgen --all --diff`
- imported affected generated modules and confirmed no auto_docstring ERROR output remains
- `PATH=.venv/bin:$PATH ./.venv/bin/patchgen --check`
- `git diff --check`