### PR TITLE
[ops, perf]: Add npu cross entropy fast path to accelerate chunk logp computation in RL scenarios

### DIFF
--- a/patchgen-pkg/patchgen/_normalize.py
+++ b/patchgen-pkg/patchgen/_normalize.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import Optional
 
 
 DEFAULT_IGNORE = ("E402", "B007")
@@ -47,7 +46,7 @@ DEFAULT_IGNORE = ("E402", "B007")
 def ruff_fix_and_format(
     path: Path,
     *,
-    extra_ignore: Optional[tuple[str, ...]] = None,
+    extra_ignore: tuple[str, ...] | None = None,
     isolated: bool = False,
 ) -> None:
     """Run ``ruff check --fix`` + ``ruff format`` on *path*.

--- a/patchgen-pkg/patchgen/check_patchgen.py
+++ b/patchgen-pkg/patchgen/check_patchgen.py
@@ -30,7 +30,7 @@ import difflib
 import sys
 import tempfile
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable
 
 from ._normalize import ruff_fix_and_format
 from .codegen import ModelingCodeGenerator, load_patch_config_module
@@ -50,7 +50,7 @@ def check_config(
     fix: bool = False,
     ruff_extra_ignore: tuple[str, ...] = (),
     ruff_isolated: bool = False,
-    search_roots: Optional[list[Path]] = None,
+    search_roots: list[Path] | None = None,
 ) -> bool:
     """Check a single config for drift.
 
@@ -147,7 +147,7 @@ def run_check(
     discovery: DiscoveryConfig,
     *,
     fix: bool = False,
-    configs: Optional[list[str]] = None,
+    configs: list[str] | None = None,
 ) -> int:
     """Run a drift check across ``configs`` (or auto-discover via ``discovery``).
 
@@ -183,7 +183,7 @@ def run_check(
     return 1
 
 
-def _build_parser(prog_name: Optional[str] = None) -> argparse.ArgumentParser:
+def _build_parser(prog_name: str | None = None) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog=prog_name,
         description="Check patchgen generated files for drift",
@@ -198,8 +198,8 @@ def _build_parser(prog_name: Optional[str] = None) -> argparse.ArgumentParser:
 
 def build_cli(
     discovery: DiscoveryConfig,
-    prog_name: Optional[str] = None,
-) -> Callable[[Optional[list[str]]], int]:
+    prog_name: str | None = None,
+) -> Callable[[list[str] | None], int]:
     """Return a ``main()``-shaped callable that runs a drift check rooted at
     ``discovery``.
 
@@ -208,7 +208,7 @@ def build_cli(
     """
     parser = _build_parser(prog_name=prog_name)
 
-    def _main(argv: Optional[list[str]] = None) -> int:
+    def _main(argv: list[str] | None = None) -> int:
         args = parser.parse_args(argv)
         return run_check(discovery, fix=args.fix)
 

--- a/patchgen-pkg/patchgen/cli.py
+++ b/patchgen-pkg/patchgen/cli.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Optional
+
 
 try:
     import tomllib  # py>=3.11
@@ -42,7 +42,7 @@ from . import DiscoveryConfig, build_check_cli, build_run_codegen_cli
 _PROG = "patchgen"
 
 
-def _find_pyproject_with_section(start: Path) -> Optional[tuple[Path, dict]]:
+def _find_pyproject_with_section(start: Path) -> tuple[Path, dict] | None:
     """Walk up from ``start`` looking for a ``pyproject.toml`` containing a
     ``[tool.patchgen]`` table. Returns ``(pyproject_path, section_dict)`` or
     ``None``.
@@ -96,7 +96,7 @@ def _load_discovery() -> DiscoveryConfig:
     return _discovery_from_section(section, pyproject_path.parent)
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     argv = sys.argv[1:] if argv is None else list(argv)
     discovery = _load_discovery()
     if "--check" in argv:

--- a/patchgen-pkg/patchgen/run_codegen.py
+++ b/patchgen-pkg/patchgen/run_codegen.py
@@ -27,7 +27,7 @@ import difflib
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable
 
 from ._normalize import ruff_fix_and_format
 from .codegen import CodegenError, ModelingCodeGenerator, load_patch_config_module
@@ -57,7 +57,7 @@ class DiscoveryConfig:
 
     search_root: Path
     package_prefix: str
-    legacy_patches_prefix: Optional[str] = None
+    legacy_patches_prefix: str | None = None
     ruff_extra_ignore: tuple[str, ...] = ()
     ruff_isolated: bool = False  # pass --isolated to ruff (line-length 88, no project config)
 
@@ -205,15 +205,15 @@ def print_config_summary(config: PatchConfig) -> None:
 
 def run_codegen(
     patch_module: str,
-    output_dir: Optional[Path],
+    output_dir: Path | None,
     config_name: str = "config",
     dry_run: bool = False,
     save_diff: bool = False,
     verbose: bool = False,
     ruff_extra_ignore: tuple[str, ...] = (),
     ruff_isolated: bool = False,
-    discovery: Optional[DiscoveryConfig] = None,
-) -> Optional[str]:
+    discovery: DiscoveryConfig | None = None,
+) -> str | None:
     """
     Run code generation for a patch configuration.
 
@@ -332,7 +332,7 @@ def run_codegen(
         return None
 
 
-def _build_parser(prog_name: Optional[str] = None) -> argparse.ArgumentParser:
+def _build_parser(prog_name: str | None = None) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog=prog_name,
         description="Modeling Code Generator - Generate patched HuggingFace modeling code",
@@ -466,8 +466,8 @@ def _run_with_discovery(
 
 def build_cli(
     discovery: DiscoveryConfig,
-    prog_name: Optional[str] = None,
-) -> Callable[[Optional[list[str]]], int]:
+    prog_name: str | None = None,
+) -> Callable[[list[str] | None], int]:
     """Return a ``main()``-shaped callable that runs the run_codegen CLI
     rooted at ``discovery``.
 
@@ -478,7 +478,7 @@ def build_cli(
     """
     parser = _build_parser(prog_name=prog_name)
 
-    def _main(argv: Optional[list[str]] = None) -> int:
+    def _main(argv: list[str] | None = None) -> int:
         args = parser.parse_args(argv)
         return _run_with_discovery(args, discovery, parser)
 

--- a/tests/ops/test_npu_chunk_logprobs.py
+++ b/tests/ops/test_npu_chunk_logprobs.py
@@ -1,0 +1,140 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manual check for the NPU fused CE fast path.
+
+Run with:
+    python tests/ops/test_npu_chunk_logprobs.py --device npu
+
+This script compares the NPU fused CE helper against the old
+log_softmax+gather fallback. It is kept as a manual check because reliable
+timing requires an NPU runtime and explicit synchronization.
+"""
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from veomni.ops.kernels.cross_entropy.chunk_logprobs import (  # noqa: E402
+    _NPU_CE_AVAILABLE,
+    _per_token_log_probs_from_logits_npu,
+)
+
+
+def old_log_softmax_gather(logits: torch.Tensor, labels: torch.Tensor, ignore_index: int) -> torch.Tensor:
+    # This is the pre-optimization fallback path: it materializes a full
+    # [tokens, vocab] log-prob tensor, then gathers target-token logprobs.
+    mask = labels != ignore_index
+    safe_labels = labels.clamp(min=0).unsqueeze(-1)
+    log_probs = logits.log_softmax(dim=-1).gather(-1, safe_labels).squeeze(-1)
+    return torch.where(mask, log_probs, torch.zeros_like(log_probs))
+
+
+def run_npu_cross_entropy_fast_path_check() -> None:
+    """Compare the NPU fused CE path with the original PyTorch fallback."""
+    parser = argparse.ArgumentParser(description="Compare NPU CE fast path against log_softmax+gather.")
+    parser.add_argument("--device", default="npu", choices=["npu", "cpu"], help="Device used for generated tensors.")
+    parser.add_argument("--tokens", type=int, default=2048, help="Number of token rows, i.e. N in [N, V].")
+    parser.add_argument("--vocab", type=int, default=151936, help="Vocabulary size, i.e. V in [N, V].")
+    parser.add_argument("--dtype", default="float32", choices=["float32", "float16", "bfloat16"], help="Logits dtype.")
+    parser.add_argument("--warmup", type=int, default=5, help="Warmup iterations.")
+    parser.add_argument("--iters", type=int, default=20, help="Timed iterations.")
+    parser.add_argument("--ignore-index", type=int, default=-100, help="Ignored label value.")
+    parser.add_argument("--ignore-ratio", type=float, default=0.01, help="Fraction of labels set to ignore-index.")
+    args = parser.parse_args()
+
+    dtype = getattr(torch, args.dtype)
+    device = torch.device(args.device)
+    if args.device == "npu" and (not _NPU_CE_AVAILABLE or not hasattr(torch, "npu") or not torch.npu.is_available()):
+        raise RuntimeError(
+            "NPU manual check requested, but torch_npu.npu_cross_entropy_loss or an NPU device is unavailable."
+        )
+
+    def synchronize() -> None:
+        if device.type == "npu":
+            torch.npu.synchronize()
+
+    def new_npu_fused_ce(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        return _per_token_log_probs_from_logits_npu(logits, labels, args.ignore_index)
+
+    torch.manual_seed(2026)
+    logits = torch.randn(args.tokens, args.vocab, device=device, dtype=dtype)
+    labels = torch.randint(0, args.vocab, (args.tokens,), device=device, dtype=torch.long)
+    if args.ignore_ratio > 0:
+        ignore_mask = torch.rand(args.tokens, device=device) < args.ignore_ratio
+        labels = labels.masked_fill(ignore_mask, args.ignore_index)
+
+    # Precision check uses fp32 comparison. For fp16/bf16 inputs, the two kernels
+    # may differ slightly because their internal reductions are implemented
+    # differently, so report both absolute and relative error.
+    with torch.no_grad():
+        old_out = old_log_softmax_gather(logits, labels, args.ignore_index)
+        if device.type == "npu":
+            new_out = new_npu_fused_ce(logits, labels)
+        else:
+            print("[WARN] CPU has no torch_npu fast path; comparing the fallback against itself.")
+            new_out = old_log_softmax_gather(logits, labels, args.ignore_index)
+        synchronize()
+
+        old_f32 = old_out.float()
+        new_f32 = new_out.float()
+        abs_diff = (new_f32 - old_f32).abs()
+        rel_diff = abs_diff / old_f32.abs().clamp_min(1e-12)
+        ignored = labels == args.ignore_index
+
+    def time_path(name: str, fn) -> float:
+        with torch.no_grad():
+            for _ in range(args.warmup):
+                fn(logits, labels)
+            synchronize()
+
+            start = time.perf_counter()
+            for _ in range(args.iters):
+                fn(logits, labels)
+            synchronize()
+            elapsed_ms = (time.perf_counter() - start) * 1000.0 / args.iters
+            print(f"[TIME] {name}: {elapsed_ms:.3f} ms/iter")
+            return elapsed_ms
+
+    print("========== NPU CE Fast Path Check ==========")
+    print(f"device={device}, dtype={args.dtype}, tokens={args.tokens}, vocab={args.vocab}")
+    print(f"ignore_index={args.ignore_index}, ignore_ratio={args.ignore_ratio}, ignored_tokens={ignored.sum().item()}")
+    print(f"[PRECISION] max_abs_diff={abs_diff.max().item():.8e}")
+    print(f"[PRECISION] mean_abs_diff={abs_diff.mean().item():.8e}")
+    print(f"[PRECISION] max_rel_diff={rel_diff.max().item():.8e}")
+    print(f"[PRECISION] mean_rel_diff={rel_diff.mean().item():.8e}")
+    if ignored.any():
+        print(f"[PRECISION] ignored_old_max_abs={old_f32[ignored].abs().max().item():.8e}")
+        print(f"[PRECISION] ignored_new_max_abs={new_f32[ignored].abs().max().item():.8e}")
+
+    old_ms = time_path(
+        "old log_softmax+gather",
+        lambda logits, labels: old_log_softmax_gather(logits, labels, args.ignore_index),
+    )
+    if device.type == "npu":
+        new_ms = time_path("new torch_npu.npu_cross_entropy_loss", new_npu_fused_ce)
+        print(f"[SPEEDUP] old/new = {old_ms / new_ms:.3f}x")
+    else:
+        print("[SPEEDUP] skipped because CPU cannot run the NPU fused CE kernel.")
+
+
+if __name__ == "__main__":
+    run_npu_cross_entropy_fast_path_check()

--- a/tests/ops/test_npu_chunk_logprobs.py
+++ b/tests/ops/test_npu_chunk_logprobs.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 import torch
 
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))

--- a/veomni/ops/kernels/cross_entropy/chunk_logprobs.py
+++ b/veomni/ops/kernels/cross_entropy/chunk_logprobs.py
@@ -90,6 +90,7 @@ try:
 except ImportError:
     _NPU_CE_AVAILABLE = False
 
+
 def _per_token_log_probs_from_logits_npu(
     logits: torch.Tensor,
     labels: torch.Tensor,
@@ -112,6 +113,7 @@ def _per_token_log_probs_from_logits_npu(
         ignore_index=ignore_index,
     )
     return -loss.view(*batch_shape)
+
 
 def _per_token_log_probs_from_logits(
     logits: torch.Tensor,

--- a/veomni/ops/kernels/cross_entropy/chunk_logprobs.py
+++ b/veomni/ops/kernels/cross_entropy/chunk_logprobs.py
@@ -83,6 +83,35 @@ try:
 except ImportError:
     _FA_CE_AVAILABLE = False
 
+try:
+    import torch_npu as _torch_npu
+
+    _NPU_CE_AVAILABLE = hasattr(_torch_npu, "npu_cross_entropy_loss")
+except ImportError:
+    _NPU_CE_AVAILABLE = False
+
+def _per_token_log_probs_from_logits_npu(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    ignore_index: int,
+) -> torch.Tensor:
+    """Per-token log-probs through Ascend's fused cross-entropy kernel.
+
+    ``npu_cross_entropy_loss`` fuses log_softmax and NLL loss on NPU, avoiding
+    the explicit ``[chunk, vocab]`` log-prob tensor produced by the PyTorch
+    fallback. The custom autograd Function below still owns backward, so this
+    path is used only as an NPU-friendly forward primitive.
+    """
+    batch_shape = logits.shape[:-1]
+    logits_2d = logits.reshape(-1, logits.shape[-1])
+    labels_1d = labels.reshape(-1).to(torch.int64)
+    loss, _, _, _ = _torch_npu.npu_cross_entropy_loss(
+        logits_2d,
+        labels_1d,
+        reduction="none",
+        ignore_index=ignore_index,
+    )
+    return -loss.view(*batch_shape)
 
 def _per_token_log_probs_from_logits(
     logits: torch.Tensor,
@@ -100,6 +129,9 @@ def _per_token_log_probs_from_logits(
     positions internally, the negation is then ``-0.0`` which compares
     equal to ``0.0``).
     """
+    if _NPU_CE_AVAILABLE and logits.device.type == "npu":
+        return _per_token_log_probs_from_logits_npu(logits, labels, ignore_index)
+
     if _FA_CE_AVAILABLE:
         per_token_nll = _fa_cross_entropy_loss(logits, labels, ignore_index=ignore_index)[0]
         return -per_token_nll


### PR DESCRIPTION
### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

As title.


### Checklist Before Starting

- Search for relative PRs/issues and link here: https://github.com/ByteDance-Seed/VeOmni/pulls?q=is%3Apr+is%3Aopen+NPU+cross+entropy
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

Run `python tests/ops/test_npu_chunk_logprobs.py --device npu --dtype float32`

<img width="966" height="362" alt="image" src="https://github.com/user-attachments/assets/688d8620-ffa4-4903-b7c9-6b4c9831fd54" />

Results in deferent chunksize. I manually adjusted the chunksize to investigate performance under various scenarios. The left graph corresponds to 3072, while the right graph uses the default value of 1024:

In the left figure, the red line represents the original method and the purple line stands for the method with NPU operators replaced;
In the right figure, the yellow line represents the original method and the red line stands for the method with NPU operators replaced.
<img width="1666" height="544" alt="image" src="https://github.com/user-attachments/assets/55cd4207-634a-4949-94b6-b49676a62a98" />


### API and Usage Example

> Show API changes and usage examples if applicable.

It will automatically detect whether the device is NPU and then perform replacement.

### Design & Code Changes

> High-level design description and specific change list.

<img width="1280" height="554" alt="image" src="https://github.com/user-attachments/assets/5786ddf7-cf58-4952-9923-8c7ddcedd5f1" />

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
