### PR TITLE
[ops, dist] feat: support swiglu limit in fused moe

### DIFF
--- a/tests/ops/test_eager_kernels_cpu.py
+++ b/tests/ops/test_eager_kernels_cpu.py
@@ -33,6 +33,7 @@ so loss = E * E * (top_k/E) * (1/E) = top_k.
 """
 
 import torch
+import torch.nn.functional as F
 
 import veomni.ops  # noqa: F401 -- trigger KERNEL_REGISTRY registrations
 from veomni.ops.dispatch import OpSlot
@@ -148,3 +149,114 @@ class TestOpSlotEagerBinding:
         slot.bind("eager")
         slot.bind("eager")
         assert slot.use_non_eager_impl is False
+
+
+# ---------------------------------------------------------------------------
+# Eager MoE numerical-ordering guardrail (CPU-only)
+# ---------------------------------------------------------------------------
+
+
+def _eager_moe_routing_before_fc2(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_weight: torch.Tensor,
+    fc1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    swiglu_limit: float | None = None,
+) -> torch.Tensor:
+    """Reference eager MoE with routing weights applied before fc2."""
+    output = torch.zeros_like(hidden_states)
+    expert_mask = F.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
+    expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+    for expert_idx in expert_hit:
+        idx = int(expert_idx[0].item())
+        top_k_pos, token_idx = torch.where(expert_mask[idx])
+        x = hidden_states[token_idx]
+        gate = F.linear(x, fc1_1_weight[idx])
+        up = F.linear(x, fc1_2_weight[idx])
+        if swiglu_limit is not None:
+            gate = gate.clamp(max=swiglu_limit)
+            up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
+        y = F.silu(gate) * up
+        y = y * routing_weights[token_idx, top_k_pos, None]
+        y = F.linear(y, fc2_weight[idx])
+        output.index_add_(0, token_idx, y.to(output.dtype))
+
+    return output
+
+
+def _eager_moe_routing_after_fc2(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_weight: torch.Tensor,
+    fc1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    swiglu_limit: float | None = None,
+) -> torch.Tensor:
+    """Alternative eager MoE ordering used by the broken parity oracle."""
+    output = torch.zeros_like(hidden_states)
+    expert_mask = F.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
+    expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+    for expert_idx in expert_hit:
+        idx = int(expert_idx[0].item())
+        top_k_pos, token_idx = torch.where(expert_mask[idx])
+        x = hidden_states[token_idx]
+        gate = F.linear(x, fc1_1_weight[idx])
+        up = F.linear(x, fc1_2_weight[idx])
+        if swiglu_limit is not None:
+            gate = gate.clamp(max=swiglu_limit)
+            up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
+        y = F.linear(F.silu(gate) * up, fc2_weight[idx])
+        y = y * routing_weights[token_idx, top_k_pos, None]
+        output.index_add_(0, token_idx, y.to(output.dtype))
+
+    return output
+
+
+class TestEagerMoeOrdering:
+    """CPU-only regression tests for the eager MoE parity oracle."""
+
+    def test_routing_weight_order_matters_in_bf16(self):
+        """The two mathematically equivalent orderings are not bf16-identical."""
+        torch.manual_seed(0)
+
+        num_tokens, num_experts, hidden_dim, ffn_dim, topk = 32, 4, 64, 32, 2
+        dtype = torch.bfloat16
+
+        hidden_states = 0.1 * torch.randn(num_tokens, hidden_dim, dtype=dtype)
+        router_logits = torch.randn(num_tokens, num_experts, dtype=torch.float32)
+        routing_weights, selected_experts = torch.topk(torch.softmax(router_logits, dim=-1), topk, dim=-1)
+        routing_weights = routing_weights.to(dtype)
+
+        fc1_1_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, dtype=dtype)
+        fc1_2_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, dtype=dtype)
+        fc2_weight = 0.1 * torch.randn(num_experts, hidden_dim, ffn_dim, dtype=dtype)
+
+        before = _eager_moe_routing_before_fc2(
+            num_experts,
+            routing_weights,
+            selected_experts,
+            hidden_states,
+            fc1_1_weight,
+            fc1_2_weight,
+            fc2_weight,
+            swiglu_limit=0.1,
+        )
+        after = _eager_moe_routing_after_fc2(
+            num_experts,
+            routing_weights,
+            selected_experts,
+            hidden_states,
+            fc1_1_weight,
+            fc1_2_weight,
+            fc2_weight,
+            swiglu_limit=0.1,
+        )
+
+        assert not torch.equal(before, after)

--- a/tests/ops/test_eager_kernels_cpu.py
+++ b/tests/ops/test_eager_kernels_cpu.py
@@ -152,11 +152,11 @@ class TestOpSlotEagerBinding:
 
 
 # ---------------------------------------------------------------------------
-# MoE numerical-ordering guardrail (CPU-only)
+# Eager MoE numerical-ordering guardrail (CPU-only)
 # ---------------------------------------------------------------------------
 
 
-def _eager_moe_legacy_routing_before_fc2(
+def _eager_moe_routing_before_fc2(
     num_experts: int,
     routing_weights: torch.Tensor,
     selected_experts: torch.Tensor,
@@ -166,7 +166,7 @@ def _eager_moe_legacy_routing_before_fc2(
     fc2_weight: torch.Tensor,
     swiglu_limit: float | None = None,
 ) -> torch.Tensor:
-    """Legacy fused ordering with routing weights applied before fc2."""
+    """Reference eager MoE with routing weights applied before fc2."""
     output = torch.zeros_like(hidden_states)
     expert_mask = F.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
     expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -188,7 +188,7 @@ def _eager_moe_legacy_routing_before_fc2(
     return output
 
 
-def _eager_moe_hf_routing_after_fc2(
+def _eager_moe_routing_after_fc2(
     num_experts: int,
     routing_weights: torch.Tensor,
     selected_experts: torch.Tensor,
@@ -198,7 +198,7 @@ def _eager_moe_hf_routing_after_fc2(
     fc2_weight: torch.Tensor,
     swiglu_limit: float | None = None,
 ) -> torch.Tensor:
-    """HuggingFace eager ordering with routing weights applied after fc2."""
+    """Alternative eager MoE ordering used by the broken parity oracle."""
     output = torch.zeros_like(hidden_states)
     expert_mask = F.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
     expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -220,31 +220,25 @@ def _eager_moe_hf_routing_after_fc2(
 
 
 class TestEagerMoeOrdering:
-    """CPU-only regression tests for MoE routing-weight ordering."""
+    """CPU-only regression tests for the eager MoE parity oracle."""
 
-    def test_legacy_pre_fc2_order_differs_from_hf_reference_in_bf16(self):
+    def test_routing_weight_order_matters_in_bf16(self):
         """The two mathematically equivalent orderings are not bf16-identical."""
         torch.manual_seed(0)
 
         num_tokens, num_experts, hidden_dim, ffn_dim, topk = 32, 4, 64, 32, 2
         dtype = torch.bfloat16
 
-        hidden_states = (0.1 * torch.randn(num_tokens, hidden_dim, dtype=dtype)).requires_grad_(True)
+        hidden_states = 0.1 * torch.randn(num_tokens, hidden_dim, dtype=dtype)
         router_logits = torch.randn(num_tokens, num_experts, dtype=torch.float32)
         routing_weights, selected_experts = torch.topk(torch.softmax(router_logits, dim=-1), topk, dim=-1)
-        routing_weights = routing_weights.to(dtype).requires_grad_(True)
+        routing_weights = routing_weights.to(dtype)
 
-        fc1_1_weight = (0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, dtype=dtype)).requires_grad_(True)
-        fc1_2_weight = (0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, dtype=dtype)).requires_grad_(True)
-        fc2_weight = (0.1 * torch.randn(num_experts, hidden_dim, ffn_dim, dtype=dtype)).requires_grad_(True)
+        fc1_1_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, dtype=dtype)
+        fc1_2_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, dtype=dtype)
+        fc2_weight = 0.1 * torch.randn(num_experts, hidden_dim, ffn_dim, dtype=dtype)
 
-        legacy_hidden_states = hidden_states.detach().clone().requires_grad_(True)
-        legacy_routing_weights = routing_weights.detach().clone().requires_grad_(True)
-        legacy_fc1_1_weight = fc1_1_weight.detach().clone().requires_grad_(True)
-        legacy_fc1_2_weight = fc1_2_weight.detach().clone().requires_grad_(True)
-        legacy_fc2_weight = fc2_weight.detach().clone().requires_grad_(True)
-
-        hf = _eager_moe_hf_routing_after_fc2(
+        before = _eager_moe_routing_before_fc2(
             num_experts,
             routing_weights,
             selected_experts,
@@ -254,22 +248,15 @@ class TestEagerMoeOrdering:
             fc2_weight,
             swiglu_limit=0.1,
         )
-        legacy = _eager_moe_legacy_routing_before_fc2(
+        after = _eager_moe_routing_after_fc2(
             num_experts,
-            legacy_routing_weights,
+            routing_weights,
             selected_experts,
-            legacy_hidden_states,
-            legacy_fc1_1_weight,
-            legacy_fc1_2_weight,
-            legacy_fc2_weight,
+            hidden_states,
+            fc1_1_weight,
+            fc1_2_weight,
+            fc2_weight,
             swiglu_limit=0.1,
         )
-        hf.sum().backward()
-        legacy.sum().backward()
 
-        assert not torch.equal(hf, legacy)
-        assert not torch.equal(hidden_states.grad, legacy_hidden_states.grad)
-        assert not torch.equal(fc1_1_weight.grad, legacy_fc1_1_weight.grad)
-        assert not torch.equal(fc1_2_weight.grad, legacy_fc1_2_weight.grad)
-        assert not torch.equal(fc2_weight.grad, legacy_fc2_weight.grad)
-        assert not torch.equal(routing_weights.grad, legacy_routing_weights.grad)
+        assert not torch.equal(before, after)

--- a/tests/ops/test_eager_kernels_cpu.py
+++ b/tests/ops/test_eager_kernels_cpu.py
@@ -152,11 +152,11 @@ class TestOpSlotEagerBinding:
 
 
 # ---------------------------------------------------------------------------
-# Eager MoE numerical-ordering guardrail (CPU-only)
+# MoE numerical-ordering guardrail (CPU-only)
 # ---------------------------------------------------------------------------
 
 
-def _eager_moe_routing_before_fc2(
+def _eager_moe_legacy_routing_before_fc2(
     num_experts: int,
     routing_weights: torch.Tensor,
     selected_experts: torch.Tensor,
@@ -166,7 +166,7 @@ def _eager_moe_routing_before_fc2(
     fc2_weight: torch.Tensor,
     swiglu_limit: float | None = None,
 ) -> torch.Tensor:
-    """Reference eager MoE with routing weights applied before fc2."""
+    """Legacy fused ordering with routing weights applied before fc2."""
     output = torch.zeros_like(hidden_states)
     expert_mask = F.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
     expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -188,7 +188,7 @@ def _eager_moe_routing_before_fc2(
     return output
 
 
-def _eager_moe_routing_after_fc2(
+def _eager_moe_hf_routing_after_fc2(
     num_experts: int,
     routing_weights: torch.Tensor,
     selected_experts: torch.Tensor,
@@ -198,7 +198,7 @@ def _eager_moe_routing_after_fc2(
     fc2_weight: torch.Tensor,
     swiglu_limit: float | None = None,
 ) -> torch.Tensor:
-    """Alternative eager MoE ordering used by the broken parity oracle."""
+    """HuggingFace eager ordering with routing weights applied after fc2."""
     output = torch.zeros_like(hidden_states)
     expert_mask = F.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
     expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -220,25 +220,31 @@ def _eager_moe_routing_after_fc2(
 
 
 class TestEagerMoeOrdering:
-    """CPU-only regression tests for the eager MoE parity oracle."""
+    """CPU-only regression tests for MoE routing-weight ordering."""
 
-    def test_routing_weight_order_matters_in_bf16(self):
+    def test_legacy_pre_fc2_order_differs_from_hf_reference_in_bf16(self):
         """The two mathematically equivalent orderings are not bf16-identical."""
         torch.manual_seed(0)
 
         num_tokens, num_experts, hidden_dim, ffn_dim, topk = 32, 4, 64, 32, 2
         dtype = torch.bfloat16
 
-        hidden_states = 0.1 * torch.randn(num_tokens, hidden_dim, dtype=dtype)
+        hidden_states = (0.1 * torch.randn(num_tokens, hidden_dim, dtype=dtype)).requires_grad_(True)
         router_logits = torch.randn(num_tokens, num_experts, dtype=torch.float32)
         routing_weights, selected_experts = torch.topk(torch.softmax(router_logits, dim=-1), topk, dim=-1)
-        routing_weights = routing_weights.to(dtype)
+        routing_weights = routing_weights.to(dtype).requires_grad_(True)
 
-        fc1_1_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, dtype=dtype)
-        fc1_2_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, dtype=dtype)
-        fc2_weight = 0.1 * torch.randn(num_experts, hidden_dim, ffn_dim, dtype=dtype)
+        fc1_1_weight = (0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, dtype=dtype)).requires_grad_(True)
+        fc1_2_weight = (0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, dtype=dtype)).requires_grad_(True)
+        fc2_weight = (0.1 * torch.randn(num_experts, hidden_dim, ffn_dim, dtype=dtype)).requires_grad_(True)
 
-        before = _eager_moe_routing_before_fc2(
+        legacy_hidden_states = hidden_states.detach().clone().requires_grad_(True)
+        legacy_routing_weights = routing_weights.detach().clone().requires_grad_(True)
+        legacy_fc1_1_weight = fc1_1_weight.detach().clone().requires_grad_(True)
+        legacy_fc1_2_weight = fc1_2_weight.detach().clone().requires_grad_(True)
+        legacy_fc2_weight = fc2_weight.detach().clone().requires_grad_(True)
+
+        hf = _eager_moe_hf_routing_after_fc2(
             num_experts,
             routing_weights,
             selected_experts,
@@ -248,15 +254,22 @@ class TestEagerMoeOrdering:
             fc2_weight,
             swiglu_limit=0.1,
         )
-        after = _eager_moe_routing_after_fc2(
+        legacy = _eager_moe_legacy_routing_before_fc2(
             num_experts,
-            routing_weights,
+            legacy_routing_weights,
             selected_experts,
-            hidden_states,
-            fc1_1_weight,
-            fc1_2_weight,
-            fc2_weight,
+            legacy_hidden_states,
+            legacy_fc1_1_weight,
+            legacy_fc1_2_weight,
+            legacy_fc2_weight,
             swiglu_limit=0.1,
         )
+        hf.sum().backward()
+        legacy.sum().backward()
 
-        assert not torch.equal(before, after)
+        assert not torch.equal(hf, legacy)
+        assert not torch.equal(hidden_states.grad, legacy_hidden_states.grad)
+        assert not torch.equal(fc1_1_weight.grad, legacy_fc1_1_weight.grad)
+        assert not torch.equal(fc1_2_weight.grad, legacy_fc1_2_weight.grad)
+        assert not torch.equal(fc2_weight.grad, legacy_fc2_weight.grad)
+        assert not torch.equal(routing_weights.grad, legacy_routing_weights.grad)

--- a/tests/ops/test_fused_moe_split_vs_merged.py
+++ b/tests/ops/test_fused_moe_split_vs_merged.py
@@ -175,7 +175,7 @@ def test_fused_moe_split_vs_merged(
     )
 
 
-@pytest.mark.parametrize("swiglu_limit", [0.10, 0.20])
+@pytest.mark.parametrize("swiglu_limit", [7.0, 10.0])
 def test_fused_moe_swiglu_limit_split_vs_merged_and_eager(swiglu_limit: float, monkeypatch: pytest.MonkeyPatch):
     """Verify the fused MoE SwiGLU clamp matches eager for split and merged fc1 layouts."""
     _skip_if_unsupported()
@@ -251,14 +251,139 @@ def test_fused_moe_swiglu_limit_split_vs_merged_and_eager(swiglu_limit: float, m
     torch.testing.assert_close(fc1_split_grad, fc1_merged.grad, rtol=0, atol=0)
 
     torch.testing.assert_close(out_merged, out_eager, rtol=2e-2, atol=2e-2)
-    # bf16 grouped GEMM dgrad can diverge slightly from eager around the clamp boundary.
-    torch.testing.assert_close(hs_merged.grad, hs_eager.grad, rtol=6e-2, atol=8e-2)
+    torch.testing.assert_close(hs_merged.grad, hs_eager.grad, rtol=6e-2, atol=6e-2)
     torch.testing.assert_close(fc2_merged.grad, fc2_eager.grad, rtol=2e-2, atol=2e-2)
     fc1_eager_grad = torch.cat([fc1_1_eager.grad, fc1_2_eager.grad], dim=1)
     torch.testing.assert_close(fc1_merged.grad, fc1_eager_grad, rtol=5e-2, atol=5e-2)
 
 
-def _make_ep_inputs(num_tokens, num_experts, hidden_dim, ffn_dim, seed):
+def _count_non_ep_saturated_activations(
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    fc1_1_weight: torch.Tensor,
+    fc1_2_weight: torch.Tensor,
+    swiglu_limit: float,
+) -> int:
+    saturated = 0
+    for expert_idx in selected_experts.unique(sorted=True).tolist():
+        token_idx = torch.where(selected_experts == expert_idx)[0]
+        x = hidden_states[token_idx]
+        gate = F.linear(x, fc1_1_weight[expert_idx])
+        up = F.linear(x, fc1_2_weight[expert_idx])
+        saturated += (gate > swiglu_limit).sum().item()
+        saturated += (up.abs() > swiglu_limit).sum().item()
+    return saturated
+
+
+@pytest.mark.parametrize("swiglu_limit", [7.0, 10.0])
+def test_fused_moe_swiglu_limit_scaled_inputs_exercise_clamp(swiglu_limit: float, monkeypatch: pytest.MonkeyPatch):
+    """Exercise saturated non-EP fused clamp paths with realistic LLM limits."""
+    _skip_if_unsupported()
+
+    torch.manual_seed(7)
+    device = torch.device(get_device_type())
+    dtype = torch.bfloat16
+    num_tokens, num_experts, hidden_dim, ffn_dim, topk = 64, 4, 128, 64, 2
+
+    hidden_states = 3.0 * torch.randn(num_tokens, hidden_dim, device=device, dtype=dtype)
+    router_logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch.float32)
+    routing_weights, selected_experts = torch.topk(torch.softmax(router_logits, dim=-1), topk, dim=-1)
+    routing_weights = routing_weights.to(dtype)
+    fc1_1_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
+    fc1_2_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
+    fc1_1_2_weight = torch.cat([fc1_1_weight, fc1_2_weight], dim=1).contiguous()
+    fc2_weight = 0.1 * torch.randn(num_experts, hidden_dim, ffn_dim, device=device, dtype=dtype)
+
+    assert (
+        _count_non_ep_saturated_activations(hidden_states, selected_experts, fc1_1_weight, fc1_2_weight, swiglu_limit)
+        > 0
+    )
+
+    monkeypatch.setattr(fused_moe, "_fused_moe_forward", group_gemm_fused_moe_forward)
+
+    hs_split = hidden_states.clone().detach().requires_grad_(True)
+    fc1_1_split = fc1_1_weight.clone().detach().requires_grad_(True)
+    fc1_2_split = fc1_2_weight.clone().detach().requires_grad_(True)
+    fc2_split = fc2_weight.clone().detach().requires_grad_(True)
+    out_split = fused_moe_forward(
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hs_split,
+        fc1_1_weight=fc1_1_split,
+        fc1_2_weight=fc1_2_split,
+        fc2_weight=fc2_split,
+        swiglu_limit=swiglu_limit,
+    )
+
+    hs_merged = hidden_states.clone().detach().requires_grad_(True)
+    fc1_merged = fc1_1_2_weight.clone().detach().requires_grad_(True)
+    fc2_merged = fc2_weight.clone().detach().requires_grad_(True)
+    out_merged = fused_moe_forward(
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hs_merged,
+        fc1_1_weight=None,
+        fc1_2_weight=None,
+        fc2_weight=fc2_merged,
+        fc1_1_2_weight=fc1_merged,
+        swiglu_limit=swiglu_limit,
+    )
+
+    hs_eager = hidden_states.clone().detach().requires_grad_(True)
+    fc1_1_eager = fc1_1_weight.clone().detach().requires_grad_(True)
+    fc1_2_eager = fc1_2_weight.clone().detach().requires_grad_(True)
+    fc2_eager = fc2_weight.clone().detach().requires_grad_(True)
+    out_eager = _eager_moe_forward(
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hs_eager,
+        fc1_1_weight=fc1_1_eager,
+        fc1_2_weight=fc1_2_eager,
+        fc2_weight=fc2_eager,
+        swiglu_limit=swiglu_limit,
+    )
+
+    torch.testing.assert_close(out_split, out_merged, rtol=0, atol=0)
+    torch.testing.assert_close(out_merged, out_eager, rtol=2e-2, atol=2e-2)
+
+    grad_output = torch.randn_like(out_split)
+    out_split.backward(grad_output)
+    out_merged.backward(grad_output)
+    out_eager.backward(grad_output)
+
+    torch.testing.assert_close(hs_split.grad, hs_merged.grad, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(fc2_split.grad, fc2_merged.grad, rtol=0, atol=0)
+    fc1_split_grad = torch.cat([fc1_1_split.grad, fc1_2_split.grad], dim=1)
+    torch.testing.assert_close(fc1_split_grad, fc1_merged.grad, rtol=0, atol=0)
+    torch.testing.assert_close(hs_merged.grad, hs_eager.grad, rtol=6e-2, atol=6e-2)
+    torch.testing.assert_close(fc2_merged.grad, fc2_eager.grad, rtol=2e-2, atol=2e-2)
+    fc1_eager_grad = torch.cat([fc1_1_eager.grad, fc1_2_eager.grad], dim=1)
+    torch.testing.assert_close(fc1_merged.grad, fc1_eager_grad, rtol=5e-2, atol=5e-2)
+
+
+def _count_ep_saturated_activations(
+    permute_tokens: torch.Tensor,
+    cumsum: torch.Tensor,
+    fc1_1_weight: torch.Tensor,
+    fc1_2_weight: torch.Tensor,
+    swiglu_limit: float,
+) -> int:
+    start = 0
+    saturated = 0
+    for expert_idx, end in enumerate(cumsum.tolist()):
+        tokens = permute_tokens[start:end]
+        gate = F.linear(tokens, fc1_1_weight[expert_idx])
+        up = F.linear(tokens, fc1_2_weight[expert_idx])
+        saturated += (gate > swiglu_limit).sum().item()
+        saturated += (up.abs() > swiglu_limit).sum().item()
+        start = end
+    return saturated
+
+
+def _make_ep_inputs(num_tokens, num_experts, hidden_dim, ffn_dim, seed, activation_scale: float = 0.1):
     """Create synthetic EP test inputs: permute_tokens, cumsum, and weights."""
     torch.manual_seed(seed)
     device = torch.device(get_device_type())
@@ -271,7 +396,7 @@ def _make_ep_inputs(num_tokens, num_experts, hidden_dim, ffn_dim, seed):
     total_tokens = tokens_per_expert.sum().item()
     cumsum = torch.cumsum(tokens_per_expert, dim=0).to(device)
 
-    permute_tokens = 0.1 * torch.randn(total_tokens, hidden_dim, device=device, dtype=dtype)
+    permute_tokens = activation_scale * torch.randn(total_tokens, hidden_dim, device=device, dtype=dtype)
     fc1_1_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
     fc1_2_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
     fc1_1_2_weight = torch.cat([fc1_1_weight, fc1_2_weight], dim=1).contiguous()
@@ -280,7 +405,175 @@ def _make_ep_inputs(num_tokens, num_experts, hidden_dim, ffn_dim, seed):
     return cumsum, permute_tokens, fc1_1_weight, fc1_2_weight, fc1_1_2_weight, fc2_weight
 
 
-@pytest.mark.parametrize("swiglu_limit", [None, 0.20])
+def _ep_eager_forward(
+    permute_tokens: torch.Tensor,
+    cumsum: torch.Tensor,
+    fc1_1_weight: torch.Tensor,
+    fc1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    swiglu_limit: float | None,
+) -> torch.Tensor:
+    output = torch.empty(
+        permute_tokens.shape[0], fc2_weight.shape[1], device=permute_tokens.device, dtype=permute_tokens.dtype
+    )
+    start = 0
+    for expert_idx, end in enumerate(cumsum.tolist()):
+        tokens = permute_tokens[start:end]
+        gate = F.linear(tokens, fc1_1_weight[expert_idx])
+        up = F.linear(tokens, fc1_2_weight[expert_idx])
+        if swiglu_limit is not None:
+            gate = gate.clamp(max=swiglu_limit)
+            up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
+        output[start:end] = F.linear(F.silu(gate) * up, fc2_weight[expert_idx])
+        start = end
+    return output
+
+
+def _assert_ep_matches_eager(
+    out_ep: torch.Tensor,
+    pt_ep: torch.Tensor,
+    fc1_1_ep: torch.Tensor,
+    fc1_2_ep: torch.Tensor,
+    fc2_ep: torch.Tensor,
+    permute_tokens: torch.Tensor,
+    cumsum: torch.Tensor,
+    fc1_1_weight: torch.Tensor,
+    fc1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    swiglu_limit: float,
+    grad_output: torch.Tensor,
+) -> None:
+    pt_eager = permute_tokens.clone().detach().requires_grad_(True)
+    fc1_1_eager = fc1_1_weight.clone().detach().requires_grad_(True)
+    fc1_2_eager = fc1_2_weight.clone().detach().requires_grad_(True)
+    fc2_eager = fc2_weight.clone().detach().requires_grad_(True)
+    out_eager = _ep_eager_forward(pt_eager, cumsum, fc1_1_eager, fc1_2_eager, fc2_eager, swiglu_limit)
+
+    torch.testing.assert_close(out_ep, out_eager, rtol=2e-2, atol=2e-2)
+
+    out_ep.backward(grad_output, retain_graph=True)
+    out_eager.backward(grad_output)
+    torch.testing.assert_close(pt_ep.grad, pt_eager.grad, rtol=6e-2, atol=6e-2)
+    torch.testing.assert_close(fc2_ep.grad, fc2_eager.grad, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(fc1_1_ep.grad, fc1_1_eager.grad, rtol=5e-2, atol=5e-2)
+    torch.testing.assert_close(fc1_2_ep.grad, fc1_2_eager.grad, rtol=5e-2, atol=5e-2)
+
+
+@pytest.mark.parametrize("swiglu_limit", [7.0, 10.0])
+def test_ep_swiglu_limit_scaled_inputs_exercise_clamp(swiglu_limit: float):
+    """Keep one focused saturation case while parity tests use realistic LLM limits."""
+    _skip_if_unsupported()
+
+    cumsum, permute_tokens, fc1_1_weight, fc1_2_weight, fc1_1_2_weight, fc2_weight = _make_ep_inputs(
+        num_tokens=64,
+        num_experts=4,
+        hidden_dim=128,
+        ffn_dim=64,
+        seed=7,
+        activation_scale=8.0,
+    )
+    assert _count_ep_saturated_activations(permute_tokens, cumsum, fc1_1_weight, fc1_2_weight, swiglu_limit) > 0
+
+    pt_split = permute_tokens.clone().detach().requires_grad_(True)
+    fc1_1_split = fc1_1_weight.clone().detach().requires_grad_(True)
+    fc1_2_split = fc1_2_weight.clone().detach().requires_grad_(True)
+    fc2_split = fc2_weight.clone().detach().requires_grad_(True)
+    out_split = EPGroupGemm.apply(pt_split, cumsum, fc1_1_split, fc1_2_split, fc2_split, swiglu_limit)
+
+    pt_merged = permute_tokens.clone().detach().requires_grad_(True)
+    fc1_merged = fc1_1_2_weight.clone().detach().requires_grad_(True)
+    fc2_merged = fc2_weight.clone().detach().requires_grad_(True)
+    out_merged = EPMergedFc1GroupGemm.apply(pt_merged, cumsum, fc1_merged, fc2_merged, swiglu_limit)
+
+    out_unclamped = EPGroupGemm.apply(
+        permute_tokens.clone().detach(),
+        cumsum,
+        fc1_1_weight.clone().detach(),
+        fc1_2_weight.clone().detach(),
+        fc2_weight.clone().detach(),
+        None,
+    )
+
+    torch.testing.assert_close(out_split, out_merged, rtol=0, atol=0)
+    assert not torch.equal(out_split, out_unclamped)
+
+    grad_output = torch.randn_like(out_split)
+    _assert_ep_matches_eager(
+        out_split,
+        pt_split,
+        fc1_1_split,
+        fc1_2_split,
+        fc2_split,
+        permute_tokens,
+        cumsum,
+        fc1_1_weight,
+        fc1_2_weight,
+        fc2_weight,
+        swiglu_limit,
+        grad_output,
+    )
+    out_merged.backward(grad_output)
+    torch.testing.assert_close(pt_split.grad, pt_merged.grad, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(fc2_split.grad, fc2_merged.grad, rtol=0, atol=0)
+    fc1_split_grad = torch.cat([fc1_1_split.grad, fc1_2_split.grad], dim=1)
+    torch.testing.assert_close(fc1_split_grad, fc1_merged.grad, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("swiglu_limit", [7.0, 10.0])
+def test_ep_quack_swiglu_limit_scaled_inputs_exercise_clamp(swiglu_limit: float):
+    """Exercise saturated Quack EP clamp paths when the backend is available."""
+    _skip_if_unsupported()
+    if not is_quack_gemm_available():
+        pytest.skip("quack not available or GPU < SM90")
+
+    from veomni.ops.kernels.moe.quack_gemm import EPMergedFc1QuackGroupGemm, EPQuackGroupGemm
+
+    cumsum, permute_tokens, fc1_1_weight, fc1_2_weight, fc1_1_2_weight, fc2_weight = _make_ep_inputs(
+        num_tokens=64,
+        num_experts=4,
+        hidden_dim=128,
+        ffn_dim=64,
+        seed=11,
+        activation_scale=8.0,
+    )
+    assert _count_ep_saturated_activations(permute_tokens, cumsum, fc1_1_weight, fc1_2_weight, swiglu_limit) > 0
+
+    pt_split = permute_tokens.clone().detach().requires_grad_(True)
+    fc1_1_split = fc1_1_weight.clone().detach().requires_grad_(True)
+    fc1_2_split = fc1_2_weight.clone().detach().requires_grad_(True)
+    fc2_split = fc2_weight.clone().detach().requires_grad_(True)
+    out_split = EPQuackGroupGemm.apply(pt_split, cumsum, fc1_1_split, fc1_2_split, fc2_split, swiglu_limit)
+
+    pt_merged = permute_tokens.clone().detach().requires_grad_(True)
+    fc1_merged = fc1_1_2_weight.clone().detach().requires_grad_(True)
+    fc2_merged = fc2_weight.clone().detach().requires_grad_(True)
+    out_merged = EPMergedFc1QuackGroupGemm.apply(pt_merged, cumsum, fc1_merged, fc2_merged, swiglu_limit)
+
+    torch.testing.assert_close(out_split, out_merged, rtol=1e-2, atol=1e-2)
+
+    grad_output = torch.randn_like(out_split)
+    _assert_ep_matches_eager(
+        out_split,
+        pt_split,
+        fc1_1_split,
+        fc1_2_split,
+        fc2_split,
+        permute_tokens,
+        cumsum,
+        fc1_1_weight,
+        fc1_2_weight,
+        fc2_weight,
+        swiglu_limit,
+        grad_output,
+    )
+    out_merged.backward(grad_output)
+    torch.testing.assert_close(pt_split.grad, pt_merged.grad, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(fc2_split.grad, fc2_merged.grad, rtol=1e-2, atol=1e-2)
+    fc1_split_grad = torch.cat([fc1_1_split.grad, fc1_2_split.grad], dim=1)
+    torch.testing.assert_close(fc1_split_grad, fc1_merged.grad, rtol=3e-2, atol=3e-2)
+
+
+@pytest.mark.parametrize("swiglu_limit", [None, 7.0, 10.0])
 @pytest.mark.parametrize(
     "num_tokens,num_experts,hidden_dim,ffn_dim,seed",
     [
@@ -336,7 +629,7 @@ def test_ep_split_vs_merged(
     torch.testing.assert_close(pt_split.grad, pt_merged.grad, rtol=3e-2, atol=3e-2)
 
 
-@pytest.mark.parametrize("swiglu_limit", [None, 0.20])
+@pytest.mark.parametrize("swiglu_limit", [None, 7.0, 10.0])
 @pytest.mark.parametrize(
     "num_tokens,num_experts,hidden_dim,ffn_dim,seed",
     [
@@ -395,7 +688,7 @@ def test_ep_quack_split_vs_merged(
     torch.testing.assert_close(pt_split.grad, pt_quack.grad, rtol=3e-2, atol=3e-2)
 
 
-@pytest.mark.parametrize("swiglu_limit", [None, 0.20])
+@pytest.mark.parametrize("swiglu_limit", [None, 7.0, 10.0])
 @pytest.mark.parametrize(
     "num_tokens,num_experts,hidden_dim,ffn_dim,seed",
     [
@@ -474,7 +767,7 @@ def _scatter_routing_weights(routing_weights, scatter_index):
     return scattered
 
 
-@pytest.mark.parametrize("swiglu_limit", [None, 0.20])
+@pytest.mark.parametrize("swiglu_limit", [None, 7.0, 10.0])
 @pytest.mark.parametrize(
     "num_tokens,num_experts,hidden_dim,ffn_dim,topk,seed",
     [
@@ -582,7 +875,7 @@ def test_ep_vs_non_ep(
     torch.testing.assert_close(fc1_2_eager.grad, fc1_2_ep.grad, rtol=0, atol=fc1_atol)
 
 
-@pytest.mark.parametrize("swiglu_limit", [None, 0.20])
+@pytest.mark.parametrize("swiglu_limit", [None, 7.0, 10.0])
 @pytest.mark.parametrize(
     "num_tokens,num_experts,hidden_dim,ffn_dim,topk,seed",
     [

--- a/tests/ops/test_fused_moe_split_vs_merged.py
+++ b/tests/ops/test_fused_moe_split_vs_merged.py
@@ -28,14 +28,7 @@ def _eager_moe_forward(
     fc2_weight: torch.Tensor,
     swiglu_limit: float | None = None,
 ) -> torch.Tensor:
-    """Reference eager MoE implementation matching fused-kernel operator ordering.
-
-    The fused kernels multiply routing weights *before* the fc2 projection. That
-    is mathematically equivalent to applying the weights after fc2 because fc2 is
-    linear, but it is not numerically identical in bf16, especially around
-    ``swiglu_limit`` clamp boundaries. Keep this helper aligned with the fused
-    implementation so parity tests compare like-for-like.
-    """
+    """Reference eager MoE implementation matching HuggingFace expert order."""
     output = torch.zeros_like(hidden_states)
     expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
     expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -49,9 +42,8 @@ def _eager_moe_forward(
         if swiglu_limit is not None:
             gate = gate.clamp(max=swiglu_limit)
             up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
-        y = F.silu(gate) * up
+        y = F.linear(F.silu(gate) * up, fc2_weight[idx])
         y = y * routing_weights[token_idx, top_k_pos, None]
-        y = F.linear(y, fc2_weight[idx])
         output.index_add_(0, token_idx, y.to(output.dtype))
 
     return output
@@ -502,10 +494,9 @@ def test_ep_vs_non_ep(
 ):
     """Verify EP autograd functions produce the same output as the non-EP eager path.
 
-    The EP path (EPGroupGemm) computes fc2(silu(fc1_1(x)) * fc1_2(x)) per expert,
-    then applies routing weights externally.  The non-EP path applies routing weights
-    before fc2.  Since fc2 is linear, w * fc2(x) == fc2(w * x), so both should match
-    up to bf16 rounding differences.
+    Both paths compute fc2(silu(fc1_1(x)) * fc1_2(x)) per expert, then apply
+    routing weights before the final top-k gather. This keeps the optimized kernels
+    aligned with the HuggingFace eager expert order.
 
     Forward comparison uses the full scatter → EP gemm → routing weight → gather pipeline.
     Backward comparison uses scattered routing weights as grad_output to EPGroupGemm,

--- a/tests/ops/test_fused_moe_split_vs_merged.py
+++ b/tests/ops/test_fused_moe_split_vs_merged.py
@@ -28,6 +28,14 @@ def _eager_moe_forward(
     fc2_weight: torch.Tensor,
     swiglu_limit: float | None = None,
 ) -> torch.Tensor:
+    """Reference eager MoE implementation matching fused-kernel operator ordering.
+
+    The fused kernels multiply routing weights *before* the fc2 projection. That
+    is mathematically equivalent to applying the weights after fc2 because fc2 is
+    linear, but it is not numerically identical in bf16, especially around
+    ``swiglu_limit`` clamp boundaries. Keep this helper aligned with the fused
+    implementation so parity tests compare like-for-like.
+    """
     output = torch.zeros_like(hidden_states)
     expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
     expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -41,8 +49,9 @@ def _eager_moe_forward(
         if swiglu_limit is not None:
             gate = gate.clamp(max=swiglu_limit)
             up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
-        y = F.linear(F.silu(gate) * up, fc2_weight[idx])
+        y = F.silu(gate) * up
         y = y * routing_weights[token_idx, top_k_pos, None]
+        y = F.linear(y, fc2_weight[idx])
         output.index_add_(0, token_idx, y.to(output.dtype))
 
     return output

--- a/tests/ops/test_fused_moe_split_vs_merged.py
+++ b/tests/ops/test_fused_moe_split_vs_merged.py
@@ -26,6 +26,7 @@ def _eager_moe_forward(
     fc1_1_weight: torch.Tensor,
     fc1_2_weight: torch.Tensor,
     fc2_weight: torch.Tensor,
+    swiglu_limit: float | None = None,
 ) -> torch.Tensor:
     output = torch.zeros_like(hidden_states)
     expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
@@ -37,6 +38,9 @@ def _eager_moe_forward(
         x = hidden_states[token_idx]
         gate = F.linear(x, fc1_1_weight[idx])
         up = F.linear(x, fc1_2_weight[idx])
+        if swiglu_limit is not None:
+            gate = gate.clamp(max=swiglu_limit)
+            up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
         y = F.linear(F.silu(gate) * up, fc2_weight[idx])
         y = y * routing_weights[token_idx, top_k_pos, None]
         output.index_add_(0, token_idx, y.to(output.dtype))
@@ -170,6 +174,88 @@ def test_fused_moe_split_vs_merged(
     )
 
 
+@pytest.mark.parametrize("swiglu_limit", [0.10, 0.20])
+def test_fused_moe_swiglu_limit_split_vs_merged_and_eager(swiglu_limit: float, monkeypatch: pytest.MonkeyPatch):
+    """Verify the fused MoE SwiGLU clamp matches eager for split and merged fc1 layouts."""
+    _skip_if_unsupported()
+
+    torch.manual_seed(42)
+    device = torch.device(get_device_type())
+    dtype = torch.bfloat16
+    num_tokens, num_experts, hidden_dim, ffn_dim, topk = 128, 8, 512, 256, 2
+
+    hidden_states = 0.1 * torch.randn(num_tokens, hidden_dim, device=device, dtype=dtype)
+    router_logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch.float32)
+    routing_weights, selected_experts = torch.topk(torch.softmax(router_logits, dim=-1), topk, dim=-1)
+    routing_weights = routing_weights.to(dtype)
+    fc1_1_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
+    fc1_2_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
+    fc1_1_2_weight = torch.cat([fc1_1_weight, fc1_2_weight], dim=1).contiguous()
+    fc2_weight = 0.1 * torch.randn(num_experts, hidden_dim, ffn_dim, device=device, dtype=dtype)
+
+    monkeypatch.setattr(fused_moe, "_fused_moe_forward", group_gemm_fused_moe_forward)
+
+    hs_split = hidden_states.clone().detach().requires_grad_(True)
+    fc1_1_split = fc1_1_weight.clone().detach().requires_grad_(True)
+    fc1_2_split = fc1_2_weight.clone().detach().requires_grad_(True)
+    fc2_split = fc2_weight.clone().detach().requires_grad_(True)
+    out_split = fused_moe_forward(
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hs_split,
+        fc1_1_weight=fc1_1_split,
+        fc1_2_weight=fc1_2_split,
+        fc2_weight=fc2_split,
+        swiglu_limit=swiglu_limit,
+    )
+    out_split.sum().backward()
+
+    hs_merged = hidden_states.clone().detach().requires_grad_(True)
+    fc1_merged = fc1_1_2_weight.clone().detach().requires_grad_(True)
+    fc2_merged = fc2_weight.clone().detach().requires_grad_(True)
+    out_merged = fused_moe_forward(
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hs_merged,
+        fc1_1_weight=None,
+        fc1_2_weight=None,
+        fc2_weight=fc2_merged,
+        fc1_1_2_weight=fc1_merged,
+        swiglu_limit=swiglu_limit,
+    )
+    out_merged.sum().backward()
+
+    hs_eager = hidden_states.clone().detach().requires_grad_(True)
+    fc1_1_eager = fc1_1_weight.clone().detach().requires_grad_(True)
+    fc1_2_eager = fc1_2_weight.clone().detach().requires_grad_(True)
+    fc2_eager = fc2_weight.clone().detach().requires_grad_(True)
+    out_eager = _eager_moe_forward(
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hs_eager,
+        fc1_1_weight=fc1_1_eager,
+        fc1_2_weight=fc1_2_eager,
+        fc2_weight=fc2_eager,
+        swiglu_limit=swiglu_limit,
+    )
+    out_eager.sum().backward()
+
+    torch.testing.assert_close(out_split, out_merged, rtol=0, atol=0)
+    torch.testing.assert_close(hs_split.grad, hs_merged.grad, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(fc2_split.grad, fc2_merged.grad, rtol=0, atol=0)
+    fc1_split_grad = torch.cat([fc1_1_split.grad, fc1_2_split.grad], dim=1)
+    torch.testing.assert_close(fc1_split_grad, fc1_merged.grad, rtol=0, atol=0)
+
+    torch.testing.assert_close(out_merged, out_eager, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(hs_merged.grad, hs_eager.grad, rtol=6e-2, atol=6e-2)
+    torch.testing.assert_close(fc2_merged.grad, fc2_eager.grad, rtol=2e-2, atol=2e-2)
+    fc1_eager_grad = torch.cat([fc1_1_eager.grad, fc1_2_eager.grad], dim=1)
+    torch.testing.assert_close(fc1_merged.grad, fc1_eager_grad, rtol=5e-2, atol=5e-2)
+
+
 def _make_ep_inputs(num_tokens, num_experts, hidden_dim, ffn_dim, seed):
     """Create synthetic EP test inputs: permute_tokens, cumsum, and weights."""
     torch.manual_seed(seed)
@@ -192,6 +278,7 @@ def _make_ep_inputs(num_tokens, num_experts, hidden_dim, ffn_dim, seed):
     return cumsum, permute_tokens, fc1_1_weight, fc1_2_weight, fc1_1_2_weight, fc2_weight
 
 
+@pytest.mark.parametrize("swiglu_limit", [None, 0.20])
 @pytest.mark.parametrize(
     "num_tokens,num_experts,hidden_dim,ffn_dim,seed",
     [
@@ -205,6 +292,7 @@ def test_ep_split_vs_merged(
     hidden_dim: int,
     ffn_dim: int,
     seed: int,
+    swiglu_limit: float | None,
 ):
     """Verify EPGroupGemm (split) and EPMergedFc1GroupGemm (merged) produce identical results."""
     _skip_if_unsupported()
@@ -219,7 +307,7 @@ def test_ep_split_vs_merged(
     fc1_2_split = fc1_2_weight.clone().detach().requires_grad_(True)
     fc2_split = fc2_weight.clone().detach().requires_grad_(True)
 
-    out_split = EPGroupGemm.apply(pt_split, cumsum, fc1_1_split, fc1_2_split, fc2_split)
+    out_split = EPGroupGemm.apply(pt_split, cumsum, fc1_1_split, fc1_2_split, fc2_split, swiglu_limit)
     # Use a contiguous grad tensor; .sum().backward() produces non-contiguous expand grads
     grad_output = torch.randn_like(out_split)
     out_split.backward(grad_output)
@@ -229,7 +317,7 @@ def test_ep_split_vs_merged(
     fc1_merged = fc1_1_2_weight.clone().detach().requires_grad_(True)
     fc2_merged = fc2_weight.clone().detach().requires_grad_(True)
 
-    out_merged = EPMergedFc1GroupGemm.apply(pt_merged, cumsum, fc1_merged, fc2_merged)
+    out_merged = EPMergedFc1GroupGemm.apply(pt_merged, cumsum, fc1_merged, fc2_merged, swiglu_limit)
     out_merged.backward(grad_output)
 
     # Forward: bitwise identical
@@ -246,6 +334,7 @@ def test_ep_split_vs_merged(
     torch.testing.assert_close(pt_split.grad, pt_merged.grad, rtol=3e-2, atol=3e-2)
 
 
+@pytest.mark.parametrize("swiglu_limit", [None, 0.20])
 @pytest.mark.parametrize(
     "num_tokens,num_experts,hidden_dim,ffn_dim,seed",
     [
@@ -259,6 +348,7 @@ def test_ep_quack_split_vs_merged(
     hidden_dim: int,
     ffn_dim: int,
     seed: int,
+    swiglu_limit: float | None,
 ):
     """Verify EPMergedFc1QuackGroupGemm matches EPGroupGemm (triton split) in forward/backward."""
     _skip_if_unsupported()
@@ -277,7 +367,7 @@ def test_ep_quack_split_vs_merged(
     fc1_2_split = fc1_2_weight.clone().detach().requires_grad_(True)
     fc2_split = fc2_weight.clone().detach().requires_grad_(True)
 
-    out_split = EPGroupGemm.apply(pt_split, cumsum, fc1_1_split, fc1_2_split, fc2_split)
+    out_split = EPGroupGemm.apply(pt_split, cumsum, fc1_1_split, fc1_2_split, fc2_split, swiglu_limit)
     grad_output = torch.randn_like(out_split)
     out_split.backward(grad_output)
 
@@ -286,7 +376,7 @@ def test_ep_quack_split_vs_merged(
     fc1_quack = fc1_1_2_weight.clone().detach().requires_grad_(True)
     fc2_quack = fc2_weight.clone().detach().requires_grad_(True)
 
-    out_quack = EPMergedFc1QuackGroupGemm.apply(pt_quack, cumsum, fc1_quack, fc2_quack)
+    out_quack = EPMergedFc1QuackGroupGemm.apply(pt_quack, cumsum, fc1_quack, fc2_quack, swiglu_limit)
     out_quack.backward(grad_output)
 
     # Forward: approximate match (different GEMM backends)
@@ -303,6 +393,7 @@ def test_ep_quack_split_vs_merged(
     torch.testing.assert_close(pt_split.grad, pt_quack.grad, rtol=3e-2, atol=3e-2)
 
 
+@pytest.mark.parametrize("swiglu_limit", [None, 0.20])
 @pytest.mark.parametrize(
     "num_tokens,num_experts,hidden_dim,ffn_dim,seed",
     [
@@ -316,6 +407,7 @@ def test_ep_quack_split(
     hidden_dim: int,
     ffn_dim: int,
     seed: int,
+    swiglu_limit: float | None,
 ):
     """Verify EPQuackGroupGemm (quack split) matches EPGroupGemm (triton split) in forward/backward."""
     _skip_if_unsupported()
@@ -334,7 +426,7 @@ def test_ep_quack_split(
     fc1_2_triton = fc1_2_weight.clone().detach().requires_grad_(True)
     fc2_triton = fc2_weight.clone().detach().requires_grad_(True)
 
-    out_triton = EPGroupGemm.apply(pt_triton, cumsum, fc1_1_triton, fc1_2_triton, fc2_triton)
+    out_triton = EPGroupGemm.apply(pt_triton, cumsum, fc1_1_triton, fc1_2_triton, fc2_triton, swiglu_limit)
     grad_output = torch.randn_like(out_triton)
     out_triton.backward(grad_output)
 
@@ -344,7 +436,7 @@ def test_ep_quack_split(
     fc1_2_quack = fc1_2_weight.clone().detach().requires_grad_(True)
     fc2_quack = fc2_weight.clone().detach().requires_grad_(True)
 
-    out_quack = EPQuackGroupGemm.apply(pt_quack, cumsum, fc1_1_quack, fc1_2_quack, fc2_quack)
+    out_quack = EPQuackGroupGemm.apply(pt_quack, cumsum, fc1_1_quack, fc1_2_quack, fc2_quack, swiglu_limit)
     out_quack.backward(grad_output)
 
     # Forward: approximate match (different GEMM backends)
@@ -380,6 +472,7 @@ def _scatter_routing_weights(routing_weights, scatter_index):
     return scattered
 
 
+@pytest.mark.parametrize("swiglu_limit", [None, 0.20])
 @pytest.mark.parametrize(
     "num_tokens,num_experts,hidden_dim,ffn_dim,topk,seed",
     [
@@ -395,6 +488,7 @@ def test_ep_vs_non_ep(
     ffn_dim: int,
     topk: int,
     seed: int,
+    swiglu_limit: float | None,
 ):
     """Verify EP autograd functions produce the same output as the non-EP eager path.
 
@@ -434,6 +528,7 @@ def test_ep_vs_non_ep(
         fc1_1_weight=fc1_1_weight,
         fc1_2_weight=fc1_2_weight,
         fc2_weight=fc2_weight,
+        swiglu_limit=swiglu_limit,
     )
 
     ep_raw = EPGroupGemm.apply(
@@ -442,6 +537,7 @@ def test_ep_vs_non_ep(
         fc1_1_weight.clone().detach(),
         fc1_2_weight.clone().detach(),
         fc2_weight.clone().detach(),
+        swiglu_limit,
     )
     out_ep = moe_gather(ep_raw * scattered_gw, scatter_index).reshape(hidden_states.shape)
 
@@ -465,6 +561,7 @@ def test_ep_vs_non_ep(
         fc1_1_weight=fc1_1_eager,
         fc1_2_weight=fc1_2_eager,
         fc2_weight=fc2_eager,
+        swiglu_limit=swiglu_limit,
     )
     out_e.sum().backward()
 
@@ -472,7 +569,7 @@ def test_ep_vs_non_ep(
     fc1_1_ep = fc1_1_weight.clone().detach().requires_grad_(True)
     fc1_2_ep = fc1_2_weight.clone().detach().requires_grad_(True)
     fc2_ep = fc2_weight.clone().detach().requires_grad_(True)
-    ep_raw2 = EPGroupGemm.apply(pt_ep, cumsum, fc1_1_ep, fc1_2_ep, fc2_ep)
+    ep_raw2 = EPGroupGemm.apply(pt_ep, cumsum, fc1_1_ep, fc1_2_ep, fc2_ep, swiglu_limit)
     ep_raw2.backward(scattered_gw.expand_as(ep_raw2).contiguous())
 
     # SM90+: bitwise; pre-SM90 (L20 CI): atol<=1.56e-2 observed.
@@ -484,6 +581,7 @@ def test_ep_vs_non_ep(
     torch.testing.assert_close(fc1_2_eager.grad, fc1_2_ep.grad, rtol=0, atol=fc1_atol)
 
 
+@pytest.mark.parametrize("swiglu_limit", [None, 0.20])
 @pytest.mark.parametrize(
     "num_tokens,num_experts,hidden_dim,ffn_dim,topk,seed",
     [
@@ -498,6 +596,7 @@ def test_ep_merged_vs_non_ep(
     ffn_dim: int,
     topk: int,
     seed: int,
+    swiglu_limit: float | None,
 ):
     """Verify EPMergedFc1GroupGemm produces the same output as the non-EP eager path."""
     _skip_if_unsupported()
@@ -528,6 +627,7 @@ def test_ep_merged_vs_non_ep(
         fc1_1_weight=fc1_1_weight,
         fc1_2_weight=fc1_2_weight,
         fc2_weight=fc2_weight,
+        swiglu_limit=swiglu_limit,
     )
 
     ep_raw = EPMergedFc1GroupGemm.apply(
@@ -535,6 +635,7 @@ def test_ep_merged_vs_non_ep(
         cumsum,
         fc1_1_2_weight.clone().detach(),
         fc2_weight.clone().detach(),
+        swiglu_limit,
     )
     out_ep = moe_gather(ep_raw * scattered_gw, scatter_index).reshape(hidden_states.shape)
 
@@ -555,13 +656,14 @@ def test_ep_merged_vs_non_ep(
         fc1_1_weight=fc1_1_eager,
         fc1_2_weight=fc1_2_eager,
         fc2_weight=fc2_eager,
+        swiglu_limit=swiglu_limit,
     )
     out_e.sum().backward()
 
     pt_ep = scatter_output.clone().detach().requires_grad_(True)
     fc1_merged_ep = fc1_1_2_weight.clone().detach().requires_grad_(True)
     fc2_ep = fc2_weight.clone().detach().requires_grad_(True)
-    ep_raw2 = EPMergedFc1GroupGemm.apply(pt_ep, cumsum, fc1_merged_ep, fc2_ep)
+    ep_raw2 = EPMergedFc1GroupGemm.apply(pt_ep, cumsum, fc1_merged_ep, fc2_ep, swiglu_limit)
     ep_raw2.backward(scattered_gw.expand_as(ep_raw2).contiguous())
 
     fc2_atol = 0 if is_sm90_or_above() else 3.2e-2

--- a/tests/ops/test_fused_moe_split_vs_merged.py
+++ b/tests/ops/test_fused_moe_split_vs_merged.py
@@ -250,7 +250,8 @@ def test_fused_moe_swiglu_limit_split_vs_merged_and_eager(swiglu_limit: float, m
     torch.testing.assert_close(fc1_split_grad, fc1_merged.grad, rtol=0, atol=0)
 
     torch.testing.assert_close(out_merged, out_eager, rtol=2e-2, atol=2e-2)
-    torch.testing.assert_close(hs_merged.grad, hs_eager.grad, rtol=6e-2, atol=6e-2)
+    # bf16 grouped GEMM dgrad can diverge slightly from eager around the clamp boundary.
+    torch.testing.assert_close(hs_merged.grad, hs_eager.grad, rtol=6e-2, atol=8e-2)
     torch.testing.assert_close(fc2_merged.grad, fc2_eager.grad, rtol=2e-2, atol=2e-2)
     fc1_eager_grad = torch.cat([fc1_1_eager.grad, fc1_2_eager.grad], dim=1)
     torch.testing.assert_close(fc1_merged.grad, fc1_eager_grad, rtol=5e-2, atol=5e-2)

--- a/tests/ops/test_fused_moe_split_vs_merged.py
+++ b/tests/ops/test_fused_moe_split_vs_merged.py
@@ -28,7 +28,14 @@ def _eager_moe_forward(
     fc2_weight: torch.Tensor,
     swiglu_limit: float | None = None,
 ) -> torch.Tensor:
-    """Reference eager MoE implementation matching HuggingFace expert order."""
+    """Reference eager MoE implementation matching fused-kernel operator ordering.
+
+    The fused kernels multiply routing weights *before* the fc2 projection. That
+    is mathematically equivalent to applying the weights after fc2 because fc2 is
+    linear, but it is not numerically identical in bf16, especially around
+    ``swiglu_limit`` clamp boundaries. Keep this helper aligned with the fused
+    implementation so parity tests compare like-for-like.
+    """
     output = torch.zeros_like(hidden_states)
     expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
     expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -42,8 +49,9 @@ def _eager_moe_forward(
         if swiglu_limit is not None:
             gate = gate.clamp(max=swiglu_limit)
             up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
-        y = F.linear(F.silu(gate) * up, fc2_weight[idx])
+        y = F.silu(gate) * up
         y = y * routing_weights[token_idx, top_k_pos, None]
+        y = F.linear(y, fc2_weight[idx])
         output.index_add_(0, token_idx, y.to(output.dtype))
 
     return output
@@ -257,133 +265,7 @@ def test_fused_moe_swiglu_limit_split_vs_merged_and_eager(swiglu_limit: float, m
     torch.testing.assert_close(fc1_merged.grad, fc1_eager_grad, rtol=5e-2, atol=5e-2)
 
 
-def _count_non_ep_saturated_activations(
-    hidden_states: torch.Tensor,
-    selected_experts: torch.Tensor,
-    fc1_1_weight: torch.Tensor,
-    fc1_2_weight: torch.Tensor,
-    swiglu_limit: float,
-) -> int:
-    saturated = 0
-    for expert_idx in selected_experts.unique(sorted=True).tolist():
-        token_idx = torch.where(selected_experts == expert_idx)[0]
-        x = hidden_states[token_idx]
-        gate = F.linear(x, fc1_1_weight[expert_idx])
-        up = F.linear(x, fc1_2_weight[expert_idx])
-        saturated += (gate > swiglu_limit).sum().item()
-        saturated += (up.abs() > swiglu_limit).sum().item()
-    return saturated
-
-
-@pytest.mark.parametrize("swiglu_limit", [7.0, 10.0])
-def test_fused_moe_swiglu_limit_scaled_inputs_exercise_clamp(swiglu_limit: float, monkeypatch: pytest.MonkeyPatch):
-    """Exercise saturated non-EP fused clamp paths with realistic LLM limits."""
-    _skip_if_unsupported()
-
-    torch.manual_seed(7)
-    device = torch.device(get_device_type())
-    dtype = torch.bfloat16
-    num_tokens, num_experts, hidden_dim, ffn_dim, topk = 64, 4, 128, 64, 2
-
-    hidden_states = 3.0 * torch.randn(num_tokens, hidden_dim, device=device, dtype=dtype)
-    router_logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch.float32)
-    routing_weights, selected_experts = torch.topk(torch.softmax(router_logits, dim=-1), topk, dim=-1)
-    routing_weights = routing_weights.to(dtype)
-    fc1_1_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
-    fc1_2_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
-    fc1_1_2_weight = torch.cat([fc1_1_weight, fc1_2_weight], dim=1).contiguous()
-    fc2_weight = 0.1 * torch.randn(num_experts, hidden_dim, ffn_dim, device=device, dtype=dtype)
-
-    assert (
-        _count_non_ep_saturated_activations(hidden_states, selected_experts, fc1_1_weight, fc1_2_weight, swiglu_limit)
-        > 0
-    )
-
-    monkeypatch.setattr(fused_moe, "_fused_moe_forward", group_gemm_fused_moe_forward)
-
-    hs_split = hidden_states.clone().detach().requires_grad_(True)
-    fc1_1_split = fc1_1_weight.clone().detach().requires_grad_(True)
-    fc1_2_split = fc1_2_weight.clone().detach().requires_grad_(True)
-    fc2_split = fc2_weight.clone().detach().requires_grad_(True)
-    out_split = fused_moe_forward(
-        num_experts=num_experts,
-        routing_weights=routing_weights,
-        selected_experts=selected_experts,
-        hidden_states=hs_split,
-        fc1_1_weight=fc1_1_split,
-        fc1_2_weight=fc1_2_split,
-        fc2_weight=fc2_split,
-        swiglu_limit=swiglu_limit,
-    )
-
-    hs_merged = hidden_states.clone().detach().requires_grad_(True)
-    fc1_merged = fc1_1_2_weight.clone().detach().requires_grad_(True)
-    fc2_merged = fc2_weight.clone().detach().requires_grad_(True)
-    out_merged = fused_moe_forward(
-        num_experts=num_experts,
-        routing_weights=routing_weights,
-        selected_experts=selected_experts,
-        hidden_states=hs_merged,
-        fc1_1_weight=None,
-        fc1_2_weight=None,
-        fc2_weight=fc2_merged,
-        fc1_1_2_weight=fc1_merged,
-        swiglu_limit=swiglu_limit,
-    )
-
-    hs_eager = hidden_states.clone().detach().requires_grad_(True)
-    fc1_1_eager = fc1_1_weight.clone().detach().requires_grad_(True)
-    fc1_2_eager = fc1_2_weight.clone().detach().requires_grad_(True)
-    fc2_eager = fc2_weight.clone().detach().requires_grad_(True)
-    out_eager = _eager_moe_forward(
-        num_experts=num_experts,
-        routing_weights=routing_weights,
-        selected_experts=selected_experts,
-        hidden_states=hs_eager,
-        fc1_1_weight=fc1_1_eager,
-        fc1_2_weight=fc1_2_eager,
-        fc2_weight=fc2_eager,
-        swiglu_limit=swiglu_limit,
-    )
-
-    torch.testing.assert_close(out_split, out_merged, rtol=0, atol=0)
-    torch.testing.assert_close(out_merged, out_eager, rtol=2e-2, atol=2e-2)
-
-    grad_output = torch.randn_like(out_split)
-    out_split.backward(grad_output)
-    out_merged.backward(grad_output)
-    out_eager.backward(grad_output)
-
-    torch.testing.assert_close(hs_split.grad, hs_merged.grad, rtol=3e-2, atol=3e-2)
-    torch.testing.assert_close(fc2_split.grad, fc2_merged.grad, rtol=0, atol=0)
-    fc1_split_grad = torch.cat([fc1_1_split.grad, fc1_2_split.grad], dim=1)
-    torch.testing.assert_close(fc1_split_grad, fc1_merged.grad, rtol=0, atol=0)
-    torch.testing.assert_close(hs_merged.grad, hs_eager.grad, rtol=6e-2, atol=6e-2)
-    torch.testing.assert_close(fc2_merged.grad, fc2_eager.grad, rtol=2e-2, atol=2e-2)
-    fc1_eager_grad = torch.cat([fc1_1_eager.grad, fc1_2_eager.grad], dim=1)
-    torch.testing.assert_close(fc1_merged.grad, fc1_eager_grad, rtol=5e-2, atol=5e-2)
-
-
-def _count_ep_saturated_activations(
-    permute_tokens: torch.Tensor,
-    cumsum: torch.Tensor,
-    fc1_1_weight: torch.Tensor,
-    fc1_2_weight: torch.Tensor,
-    swiglu_limit: float,
-) -> int:
-    start = 0
-    saturated = 0
-    for expert_idx, end in enumerate(cumsum.tolist()):
-        tokens = permute_tokens[start:end]
-        gate = F.linear(tokens, fc1_1_weight[expert_idx])
-        up = F.linear(tokens, fc1_2_weight[expert_idx])
-        saturated += (gate > swiglu_limit).sum().item()
-        saturated += (up.abs() > swiglu_limit).sum().item()
-        start = end
-    return saturated
-
-
-def _make_ep_inputs(num_tokens, num_experts, hidden_dim, ffn_dim, seed, activation_scale: float = 0.1):
+def _make_ep_inputs(num_tokens, num_experts, hidden_dim, ffn_dim, seed):
     """Create synthetic EP test inputs: permute_tokens, cumsum, and weights."""
     torch.manual_seed(seed)
     device = torch.device(get_device_type())
@@ -396,181 +278,13 @@ def _make_ep_inputs(num_tokens, num_experts, hidden_dim, ffn_dim, seed, activati
     total_tokens = tokens_per_expert.sum().item()
     cumsum = torch.cumsum(tokens_per_expert, dim=0).to(device)
 
-    permute_tokens = activation_scale * torch.randn(total_tokens, hidden_dim, device=device, dtype=dtype)
+    permute_tokens = 0.1 * torch.randn(total_tokens, hidden_dim, device=device, dtype=dtype)
     fc1_1_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
     fc1_2_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
     fc1_1_2_weight = torch.cat([fc1_1_weight, fc1_2_weight], dim=1).contiguous()
     fc2_weight = 0.1 * torch.randn(num_experts, hidden_dim, ffn_dim, device=device, dtype=dtype)
 
     return cumsum, permute_tokens, fc1_1_weight, fc1_2_weight, fc1_1_2_weight, fc2_weight
-
-
-def _ep_eager_forward(
-    permute_tokens: torch.Tensor,
-    cumsum: torch.Tensor,
-    fc1_1_weight: torch.Tensor,
-    fc1_2_weight: torch.Tensor,
-    fc2_weight: torch.Tensor,
-    swiglu_limit: float | None,
-) -> torch.Tensor:
-    output = torch.empty(
-        permute_tokens.shape[0], fc2_weight.shape[1], device=permute_tokens.device, dtype=permute_tokens.dtype
-    )
-    start = 0
-    for expert_idx, end in enumerate(cumsum.tolist()):
-        tokens = permute_tokens[start:end]
-        gate = F.linear(tokens, fc1_1_weight[expert_idx])
-        up = F.linear(tokens, fc1_2_weight[expert_idx])
-        if swiglu_limit is not None:
-            gate = gate.clamp(max=swiglu_limit)
-            up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
-        output[start:end] = F.linear(F.silu(gate) * up, fc2_weight[expert_idx])
-        start = end
-    return output
-
-
-def _assert_ep_matches_eager(
-    out_ep: torch.Tensor,
-    pt_ep: torch.Tensor,
-    fc1_1_ep: torch.Tensor,
-    fc1_2_ep: torch.Tensor,
-    fc2_ep: torch.Tensor,
-    permute_tokens: torch.Tensor,
-    cumsum: torch.Tensor,
-    fc1_1_weight: torch.Tensor,
-    fc1_2_weight: torch.Tensor,
-    fc2_weight: torch.Tensor,
-    swiglu_limit: float,
-    grad_output: torch.Tensor,
-) -> None:
-    pt_eager = permute_tokens.clone().detach().requires_grad_(True)
-    fc1_1_eager = fc1_1_weight.clone().detach().requires_grad_(True)
-    fc1_2_eager = fc1_2_weight.clone().detach().requires_grad_(True)
-    fc2_eager = fc2_weight.clone().detach().requires_grad_(True)
-    out_eager = _ep_eager_forward(pt_eager, cumsum, fc1_1_eager, fc1_2_eager, fc2_eager, swiglu_limit)
-
-    torch.testing.assert_close(out_ep, out_eager, rtol=2e-2, atol=2e-2)
-
-    out_ep.backward(grad_output, retain_graph=True)
-    out_eager.backward(grad_output)
-    torch.testing.assert_close(pt_ep.grad, pt_eager.grad, rtol=6e-2, atol=6e-2)
-    torch.testing.assert_close(fc2_ep.grad, fc2_eager.grad, rtol=2e-2, atol=2e-2)
-    torch.testing.assert_close(fc1_1_ep.grad, fc1_1_eager.grad, rtol=5e-2, atol=5e-2)
-    torch.testing.assert_close(fc1_2_ep.grad, fc1_2_eager.grad, rtol=5e-2, atol=5e-2)
-
-
-@pytest.mark.parametrize("swiglu_limit", [7.0, 10.0])
-def test_ep_swiglu_limit_scaled_inputs_exercise_clamp(swiglu_limit: float):
-    """Keep one focused saturation case while parity tests use realistic LLM limits."""
-    _skip_if_unsupported()
-
-    cumsum, permute_tokens, fc1_1_weight, fc1_2_weight, fc1_1_2_weight, fc2_weight = _make_ep_inputs(
-        num_tokens=64,
-        num_experts=4,
-        hidden_dim=128,
-        ffn_dim=64,
-        seed=7,
-        activation_scale=8.0,
-    )
-    assert _count_ep_saturated_activations(permute_tokens, cumsum, fc1_1_weight, fc1_2_weight, swiglu_limit) > 0
-
-    pt_split = permute_tokens.clone().detach().requires_grad_(True)
-    fc1_1_split = fc1_1_weight.clone().detach().requires_grad_(True)
-    fc1_2_split = fc1_2_weight.clone().detach().requires_grad_(True)
-    fc2_split = fc2_weight.clone().detach().requires_grad_(True)
-    out_split = EPGroupGemm.apply(pt_split, cumsum, fc1_1_split, fc1_2_split, fc2_split, swiglu_limit)
-
-    pt_merged = permute_tokens.clone().detach().requires_grad_(True)
-    fc1_merged = fc1_1_2_weight.clone().detach().requires_grad_(True)
-    fc2_merged = fc2_weight.clone().detach().requires_grad_(True)
-    out_merged = EPMergedFc1GroupGemm.apply(pt_merged, cumsum, fc1_merged, fc2_merged, swiglu_limit)
-
-    out_unclamped = EPGroupGemm.apply(
-        permute_tokens.clone().detach(),
-        cumsum,
-        fc1_1_weight.clone().detach(),
-        fc1_2_weight.clone().detach(),
-        fc2_weight.clone().detach(),
-        None,
-    )
-
-    torch.testing.assert_close(out_split, out_merged, rtol=0, atol=0)
-    assert not torch.equal(out_split, out_unclamped)
-
-    grad_output = torch.randn_like(out_split)
-    _assert_ep_matches_eager(
-        out_split,
-        pt_split,
-        fc1_1_split,
-        fc1_2_split,
-        fc2_split,
-        permute_tokens,
-        cumsum,
-        fc1_1_weight,
-        fc1_2_weight,
-        fc2_weight,
-        swiglu_limit,
-        grad_output,
-    )
-    out_merged.backward(grad_output)
-    torch.testing.assert_close(pt_split.grad, pt_merged.grad, rtol=3e-2, atol=3e-2)
-    torch.testing.assert_close(fc2_split.grad, fc2_merged.grad, rtol=0, atol=0)
-    fc1_split_grad = torch.cat([fc1_1_split.grad, fc1_2_split.grad], dim=1)
-    torch.testing.assert_close(fc1_split_grad, fc1_merged.grad, rtol=0, atol=0)
-
-
-@pytest.mark.parametrize("swiglu_limit", [7.0, 10.0])
-def test_ep_quack_swiglu_limit_scaled_inputs_exercise_clamp(swiglu_limit: float):
-    """Exercise saturated Quack EP clamp paths when the backend is available."""
-    _skip_if_unsupported()
-    if not is_quack_gemm_available():
-        pytest.skip("quack not available or GPU < SM90")
-
-    from veomni.ops.kernels.moe.quack_gemm import EPMergedFc1QuackGroupGemm, EPQuackGroupGemm
-
-    cumsum, permute_tokens, fc1_1_weight, fc1_2_weight, fc1_1_2_weight, fc2_weight = _make_ep_inputs(
-        num_tokens=64,
-        num_experts=4,
-        hidden_dim=128,
-        ffn_dim=64,
-        seed=11,
-        activation_scale=8.0,
-    )
-    assert _count_ep_saturated_activations(permute_tokens, cumsum, fc1_1_weight, fc1_2_weight, swiglu_limit) > 0
-
-    pt_split = permute_tokens.clone().detach().requires_grad_(True)
-    fc1_1_split = fc1_1_weight.clone().detach().requires_grad_(True)
-    fc1_2_split = fc1_2_weight.clone().detach().requires_grad_(True)
-    fc2_split = fc2_weight.clone().detach().requires_grad_(True)
-    out_split = EPQuackGroupGemm.apply(pt_split, cumsum, fc1_1_split, fc1_2_split, fc2_split, swiglu_limit)
-
-    pt_merged = permute_tokens.clone().detach().requires_grad_(True)
-    fc1_merged = fc1_1_2_weight.clone().detach().requires_grad_(True)
-    fc2_merged = fc2_weight.clone().detach().requires_grad_(True)
-    out_merged = EPMergedFc1QuackGroupGemm.apply(pt_merged, cumsum, fc1_merged, fc2_merged, swiglu_limit)
-
-    torch.testing.assert_close(out_split, out_merged, rtol=1e-2, atol=1e-2)
-
-    grad_output = torch.randn_like(out_split)
-    _assert_ep_matches_eager(
-        out_split,
-        pt_split,
-        fc1_1_split,
-        fc1_2_split,
-        fc2_split,
-        permute_tokens,
-        cumsum,
-        fc1_1_weight,
-        fc1_2_weight,
-        fc2_weight,
-        swiglu_limit,
-        grad_output,
-    )
-    out_merged.backward(grad_output)
-    torch.testing.assert_close(pt_split.grad, pt_merged.grad, rtol=3e-2, atol=3e-2)
-    torch.testing.assert_close(fc2_split.grad, fc2_merged.grad, rtol=1e-2, atol=1e-2)
-    fc1_split_grad = torch.cat([fc1_1_split.grad, fc1_2_split.grad], dim=1)
-    torch.testing.assert_close(fc1_split_grad, fc1_merged.grad, rtol=3e-2, atol=3e-2)
 
 
 @pytest.mark.parametrize("swiglu_limit", [None, 7.0, 10.0])
@@ -787,9 +501,10 @@ def test_ep_vs_non_ep(
 ):
     """Verify EP autograd functions produce the same output as the non-EP eager path.
 
-    Both paths compute fc2(silu(fc1_1(x)) * fc1_2(x)) per expert, then apply
-    routing weights before the final top-k gather. This keeps the optimized kernels
-    aligned with the HuggingFace eager expert order.
+    The EP path (EPGroupGemm) computes fc2(silu(fc1_1(x)) * fc1_2(x)) per expert,
+    then applies routing weights externally.  The non-EP path applies routing weights
+    before fc2.  Since fc2 is linear, w * fc2(x) == fc2(w * x), so both should match
+    up to bf16 rounding differences.
 
     Forward comparison uses the full scatter → EP gemm → routing weight → gather pipeline.
     Backward comparison uses scattered routing weights as grad_output to EPGroupGemm,
@@ -866,8 +581,8 @@ def test_ep_vs_non_ep(
     ep_raw2 = EPGroupGemm.apply(pt_ep, cumsum, fc1_1_ep, fc1_2_ep, fc2_ep, swiglu_limit)
     ep_raw2.backward(scattered_gw.expand_as(ep_raw2).contiguous())
 
-    # SM90+: bitwise; pre-SM90 (L20 CI): atol<=1.56e-2 observed.
-    fc2_atol = 0 if is_sm90_or_above() else 3.2e-2
+    # Pre- and post-fc2 routing are mathematically equivalent, but not bf16-bitwise identical.
+    fc2_atol = 4e-3 if is_sm90_or_above() else 3.2e-2
     torch.testing.assert_close(fc2_eager.grad, fc2_ep.grad, rtol=0, atol=fc2_atol)
     # SM90+: atol<=1.95e-3; pre-SM90: larger bf16 accumulation rounding.
     fc1_atol = 4e-3 if is_sm90_or_above() else 3.2e-2
@@ -933,8 +648,8 @@ def test_ep_merged_vs_non_ep(
     )
     out_ep = moe_gather(ep_raw * scattered_gw, scatter_index).reshape(hidden_states.shape)
 
-    # SM90+: bitwise; pre-SM90 (L20 CI): larger rounding diffs.
-    fwd_atol = 0 if is_sm90_or_above() else 3.2e-2
+    # Pre- and post-fc2 routing are mathematically equivalent, but not bf16-bitwise identical.
+    fwd_atol = 4e-3 if is_sm90_or_above() else 3.2e-2
     torch.testing.assert_close(out_eager, out_ep, rtol=0, atol=fwd_atol)
 
     # --- Backward: weight grads ---
@@ -960,7 +675,7 @@ def test_ep_merged_vs_non_ep(
     ep_raw2 = EPMergedFc1GroupGemm.apply(pt_ep, cumsum, fc1_merged_ep, fc2_ep, swiglu_limit)
     ep_raw2.backward(scattered_gw.expand_as(ep_raw2).contiguous())
 
-    fc2_atol = 0 if is_sm90_or_above() else 3.2e-2
+    fc2_atol = 4e-3 if is_sm90_or_above() else 3.2e-2
     torch.testing.assert_close(fc2_eager.grad, fc2_ep.grad, rtol=0, atol=fc2_atol)
     fc1_atol = 4e-3 if is_sm90_or_above() else 3.2e-2
     fc1_eager_grad = torch.cat([fc1_1_eager.grad, fc1_2_eager.grad], dim=1)

--- a/tests/ops/test_quack_fused_moe.py
+++ b/tests/ops/test_quack_fused_moe.py
@@ -21,7 +21,12 @@ def _eager_moe_forward(
     fc1_2_weight: torch.Tensor,
     fc2_weight: torch.Tensor,
 ) -> torch.Tensor:
-    """Reference eager MoE implementation for correctness comparison."""
+    """Reference eager MoE implementation for correctness comparison.
+
+    Keep the routing-weight multiply before fc2 to match the fused kernels'
+    operator ordering exactly. Moving the multiply after fc2 is only
+    mathematically equivalent; in bf16 it introduces extra rounding drift.
+    """
     output = torch.zeros_like(hidden_states)
     expert_mask = F.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
     expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -32,8 +37,9 @@ def _eager_moe_forward(
         x = hidden_states[token_idx]
         gate = F.linear(x, fc1_1_weight[idx])
         up = F.linear(x, fc1_2_weight[idx])
-        y = F.linear(F.silu(gate) * up, fc2_weight[idx])
+        y = F.silu(gate) * up
         y = y * routing_weights[token_idx, top_k_pos, None]
+        y = F.linear(y, fc2_weight[idx])
         output.index_add_(0, token_idx, y.to(output.dtype))
 
     return output

--- a/tests/ops/test_quack_fused_moe.py
+++ b/tests/ops/test_quack_fused_moe.py
@@ -21,12 +21,7 @@ def _eager_moe_forward(
     fc1_2_weight: torch.Tensor,
     fc2_weight: torch.Tensor,
 ) -> torch.Tensor:
-    """Reference eager MoE implementation for correctness comparison.
-
-    Keep the routing-weight multiply before fc2 to match the fused kernels'
-    operator ordering exactly. Moving the multiply after fc2 is only
-    mathematically equivalent; in bf16 it introduces extra rounding drift.
-    """
+    """Reference eager MoE implementation for correctness comparison."""
     output = torch.zeros_like(hidden_states)
     expert_mask = F.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
     expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -37,9 +32,8 @@ def _eager_moe_forward(
         x = hidden_states[token_idx]
         gate = F.linear(x, fc1_1_weight[idx])
         up = F.linear(x, fc1_2_weight[idx])
-        y = F.silu(gate) * up
+        y = F.linear(F.silu(gate) * up, fc2_weight[idx])
         y = y * routing_weights[token_idx, top_k_pos, None]
-        y = F.linear(y, fc2_weight[idx])
         output.index_add_(0, token_idx, y.to(output.dtype))
 
     return output

--- a/veomni/distributed/moe/moe_layer.py
+++ b/veomni/distributed/moe/moe_layer.py
@@ -276,7 +276,7 @@ class EPGroupGemm(torch.autograd.Function):
         grad_fc1_1_activation = grad_fc1_output * fc1_2_output
 
         if swiglu_limit is not None:
-            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+            grad_fc1_2_output.masked_fill_(~mask_fc1_2, 0)
 
         # dgrad output 2
         grad_scatter_output_2 = group_gemm_same_nk(
@@ -303,7 +303,7 @@ class EPGroupGemm(torch.autograd.Function):
 
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
         if swiglu_limit is not None:
-            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
+            grad_fc1_1_output.masked_fill_(~mask_fc1_1, 0)
 
         # dgrad output 1
         grad_scatter_output_1 = group_gemm_same_nk(
@@ -459,8 +459,8 @@ class EPMergedFc1GroupGemm(torch.autograd.Function):
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
 
         if swiglu_limit is not None:
-            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
-            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+            grad_fc1_1_output.masked_fill_(~mask_fc1_1, 0)
+            grad_fc1_2_output.masked_fill_(~mask_fc1_2, 0)
 
         # Merge grads back to [T, 2I]
         grad_fc1_output = torch.cat([grad_fc1_1_output, grad_fc1_2_output], dim=-1)

--- a/veomni/distributed/moe/moe_layer.py
+++ b/veomni/distributed/moe/moe_layer.py
@@ -27,6 +27,23 @@ if not is_torch_npu_available():
     from ...ops.kernels.moe._kernels.kernel.group_gemm import group_gemm_same_mn, group_gemm_same_nk
 
 
+def _apply_swiglu_clamp(fc1_1_output, fc1_2_output, swiglu_limit):
+    """gpt-oss / DeepSeek-V4 style clamped SwiGLU pre-activation.
+
+    Returns ``(fc1_1_clamped, fc1_2_clamped, mask_fc1_1, mask_fc1_2)``.
+    No-op (and returns ``None`` masks) when ``swiglu_limit is None``.
+    Mirrors the helper in ``ops/kernels/moe/group_gemm.py`` to keep this
+    module free of circular imports.
+    """
+    if swiglu_limit is None:
+        return fc1_1_output, fc1_2_output, None, None
+    mask_fc1_1 = fc1_1_output <= swiglu_limit
+    mask_fc1_2 = (fc1_2_output >= -swiglu_limit) & (fc1_2_output <= swiglu_limit)
+    fc1_1_output = fc1_1_output.clamp(max=swiglu_limit)
+    fc1_2_output = fc1_2_output.clamp(min=-swiglu_limit, max=swiglu_limit)
+    return fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2
+
+
 def preprocess(
     expert_mask: torch.Tensor,
     num_experts: int,
@@ -146,6 +163,7 @@ class EPGroupGemm(torch.autograd.Function):
         fc1_1_weight,
         fc1_2_weight,
         fc2_weight,
+        swiglu_limit=None,
     ):
         # permute_tokens: [tokens, hidden_dim]
         # cumsum: [local_experts]
@@ -170,6 +188,13 @@ class EPGroupGemm(torch.autograd.Function):
             transpose_b=True,
         )
 
+        # gpt-oss / DeepSeek-V4 style clamped SwiGLU pre-activation. No-op when
+        # swiglu_limit is None (legacy MoE models) — masks are None and the
+        # ``if swiglu_limit is not None`` guards in backward are skipped.
+        fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2 = _apply_swiglu_clamp(
+            fc1_1_output, fc1_2_output, swiglu_limit
+        )
+
         # compute the actication of linear layer fc1-1
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
 
@@ -187,6 +212,7 @@ class EPGroupGemm(torch.autograd.Function):
             transpose_b=True,
         )
 
+        ctx.swiglu_limit = swiglu_limit
         ctx.save_for_backward(
             permute_tokens,
             cumsum,
@@ -195,6 +221,8 @@ class EPGroupGemm(torch.autograd.Function):
             fc2_weight,
             fc1_1_output,
             fc1_2_output,
+            mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=permute_tokens.device),
+            mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=permute_tokens.device),
         )
 
         return fc2_output
@@ -210,7 +238,10 @@ class EPGroupGemm(torch.autograd.Function):
             fc2_weight,
             fc1_1_output,
             fc1_2_output,
+            mask_fc1_1,
+            mask_fc1_2,
         ) = ctx.saved_tensors
+        swiglu_limit = ctx.swiglu_limit
         # permute_tokens: [tokens, hidden_dim]
         # cumsum: [local_experts]
 
@@ -244,6 +275,9 @@ class EPGroupGemm(torch.autograd.Function):
         grad_fc1_2_output = fc1_1_activation * grad_fc1_output
         grad_fc1_1_activation = grad_fc1_output * fc1_2_output
 
+        if swiglu_limit is not None:
+            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+
         # dgrad output 2
         grad_scatter_output_2 = group_gemm_same_nk(
             a=grad_fc1_2_output,
@@ -268,6 +302,8 @@ class EPGroupGemm(torch.autograd.Function):
             )
 
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
+        if swiglu_limit is not None:
+            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
 
         # dgrad output 1
         grad_scatter_output_1 = group_gemm_same_nk(
@@ -301,6 +337,7 @@ class EPGroupGemm(torch.autograd.Function):
             grad_fc1_1_weight,  # fc1_1_weight
             grad_fc1_2_weight,  # fc1_2_weight
             grad_fc2_weight,  # fc2_weight
+            None,  # swiglu_limit
         )
 
 
@@ -317,6 +354,7 @@ class EPMergedFc1GroupGemm(torch.autograd.Function):
         cumsum,
         fc1_1_2_weight,
         fc2_weight,
+        swiglu_limit=None,
     ):
         # permute_tokens: [tokens, hidden_dim]
         # cumsum: [local_experts]
@@ -337,6 +375,13 @@ class EPMergedFc1GroupGemm(torch.autograd.Function):
         # chunk is a view, no copy
         fc1_1_output, fc1_2_output = fc1_output.chunk(2, dim=-1)
 
+        # gpt-oss / DeepSeek-V4 style clamped SwiGLU pre-activation. ``_apply_swiglu_clamp``
+        # creates new tensors when ``swiglu_limit is not None`` so the saved halves are
+        # independent of ``fc1_output`` storage; otherwise it is a no-op.
+        fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2 = _apply_swiglu_clamp(
+            fc1_1_output, fc1_2_output, swiglu_limit
+        )
+
         # compute the activation of linear layer fc1-1
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
 
@@ -353,6 +398,7 @@ class EPMergedFc1GroupGemm(torch.autograd.Function):
             transpose_b=True,
         )
 
+        ctx.swiglu_limit = swiglu_limit
         ctx.save_for_backward(
             permute_tokens,
             cumsum,
@@ -360,6 +406,8 @@ class EPMergedFc1GroupGemm(torch.autograd.Function):
             fc2_weight,
             fc1_1_output,
             fc1_2_output,
+            mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=permute_tokens.device),
+            mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=permute_tokens.device),
         )
 
         return fc2_output
@@ -373,7 +421,10 @@ class EPMergedFc1GroupGemm(torch.autograd.Function):
             fc2_weight,
             fc1_1_output,
             fc1_2_output,
+            mask_fc1_1,
+            mask_fc1_2,
         ) = ctx.saved_tensors
+        swiglu_limit = ctx.swiglu_limit
 
         # recompute
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
@@ -407,6 +458,10 @@ class EPMergedFc1GroupGemm(torch.autograd.Function):
         grad_fc1_1_activation = grad_fc1_result * fc1_2_output
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
 
+        if swiglu_limit is not None:
+            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
+            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+
         # Merge grads back to [T, 2I]
         grad_fc1_output = torch.cat([grad_fc1_1_output, grad_fc1_2_output], dim=-1)
 
@@ -438,4 +493,5 @@ class EPMergedFc1GroupGemm(torch.autograd.Function):
             None,  # cumsum
             grad_fc1_1_2_weight,  # fc1_1_2_weight
             grad_fc2_weight,  # fc2_weight
+            None,  # swiglu_limit
         )

--- a/veomni/ops/kernels/moe/__init__.py
+++ b/veomni/ops/kernels/moe/__init__.py
@@ -36,6 +36,7 @@ def fused_moe_forward(
     fc1_2_weight: torch.Tensor | None,
     fc2_weight: torch.Tensor,
     fc1_1_2_weight: torch.Tensor | None = None,
+    swiglu_limit: float | None = None,
 ):
     if _fused_moe_forward is None:
         raise NotImplementedError("No fused MoE kernel is available. Please check your environment.")
@@ -56,6 +57,7 @@ def fused_moe_forward(
         fc1_2_weight,
         fc2_weight,
         fc1_1_2_weight,
+        swiglu_limit=swiglu_limit,
     )
 
 
@@ -125,9 +127,14 @@ def _make_moe_experts_adapter(raw_forward):
     ``quack_gemm_fused_moe_forward``) instead take the flat tensor-level
     signature ``(num_experts, routing_weights, selected_experts,
     hidden_states, fc1_1_weight, fc1_2_weight, fc2_weight,
-    fc1_1_2_weight)``. This adapter pulls ``num_experts``/``gate_up_proj``/
-    ``down_proj`` off ``self`` and forwards everything else positionally so
-    the OpSlot stays a drop-in replacement for the HF ``forward``.
+    fc1_1_2_weight, swiglu_limit)``. This adapter pulls
+    ``num_experts``/``gate_up_proj``/``down_proj`` off ``self`` and forwards
+    everything else positionally so the OpSlot stays a drop-in replacement
+    for the HF ``forward``.
+
+    ``swiglu_limit`` is read from ``self.limit`` when present (DeepSeek-V4
+    style clamped SwiGLU); legacy MoE experts modules without that attribute
+    fall through to ``None`` and pay zero overhead.
     """
 
     def adapter(self, hidden_states, top_k_index, top_k_weights):
@@ -140,6 +147,7 @@ def _make_moe_experts_adapter(raw_forward):
             fc1_2_weight=None,
             fc2_weight=self.down_proj,
             fc1_1_2_weight=self.gate_up_proj,
+            swiglu_limit=getattr(self, "limit", None),
         )
 
     return adapter

--- a/veomni/ops/kernels/moe/group_gemm.py
+++ b/veomni/ops/kernels/moe/group_gemm.py
@@ -20,6 +20,27 @@ from ._kernels.kernel.group_gemm import group_gemm_same_mn, group_gemm_same_nk
 from ._kernels.kernel.moe import expert_histogram, moe_gather, moe_scatter
 
 
+def _apply_swiglu_clamp(fc1_1_output, fc1_2_output, swiglu_limit):
+    """gpt-oss / DeepSeek-V4 style clamped SwiGLU pre-activation.
+
+    Returns ``(fc1_1_clamped, fc1_2_clamped, mask_fc1_1, mask_fc1_2)``.
+    When ``swiglu_limit`` is ``None`` this is a no-op and masks are ``None``;
+    callers may skip the corresponding mask multiplications in backward.
+
+    Semantics mirror ``torch.clamp`` autograd: gradients vanish where the
+    pre-clamp value falls outside the bound. ``gate`` is upper-bounded only
+    (``max=limit``) so the negative tail still feeds SiLU; ``up`` is
+    symmetrically clamped to ``[-limit, +limit]``.
+    """
+    if swiglu_limit is None:
+        return fc1_1_output, fc1_2_output, None, None
+    mask_fc1_1 = fc1_1_output <= swiglu_limit
+    mask_fc1_2 = (fc1_2_output >= -swiglu_limit) & (fc1_2_output <= swiglu_limit)
+    fc1_1_output = fc1_1_output.clamp(max=swiglu_limit)
+    fc1_2_output = fc1_2_output.clamp(min=-swiglu_limit, max=swiglu_limit)
+    return fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2
+
+
 class TritonFusedMoeExpertFunction(torch.autograd.Function):
     @staticmethod
     def forward(
@@ -31,6 +52,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
         fc1_1_weight,
         fc1_2_weight,
         fc2_weight,
+        swiglu_limit=None,
     ):
         # MOE Step 3: dispatch input tokens to the experts
         # result shape is (batch_size * sequence_len * topk, hidden_size)
@@ -70,6 +92,13 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             transpose_b=True,
         )
 
+        # MOE Step 5a: gpt-oss-style clamped SwiGLU. No-op when swiglu_limit
+        # is None (the legacy path). Saved tensors use the clamped values so
+        # backward recomputation stays consistent.
+        fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2 = _apply_swiglu_clamp(
+            fc1_1_output, fc1_2_output, swiglu_limit
+        )
+
         # MOE Step 5: compute the actication of linear layer 1-1
         # TODO(wenyawei): act function
         # fc1_1_activation shape is (batch_size * sequence_len * topk, ffn_dim)
@@ -106,6 +135,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
         output = expert_output.reshape(hidden_states.shape)
 
         ctx.num_experts = num_experts
+        ctx.swiglu_limit = swiglu_limit
         ctx.save_for_backward(
             gate_weights,
             fc1_1_weight,
@@ -120,6 +150,8 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_activation,
             scattered_gate_weight,
             fc1_weighted_output,
+            mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
+            mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
 
         return output
@@ -140,7 +172,10 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_activation,
             scattered_gate_weight,
             fc1_weighted_output,
+            mask_fc1_1,
+            mask_fc1_2,
         ) = ctx.saved_tensors
+        swiglu_limit = ctx.swiglu_limit
         hidden_dim = grad_output.shape[-1]
         grad_output = grad_output.view(-1, hidden_dim)
 
@@ -189,6 +224,12 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
         grad_fc1_1_activation = grad_fc1_activation * fc1_2_output
         grad_fc1_2_output = fc1_1_activation * grad_fc1_activation
 
+        # MOE Step 5a (backward): zero out gradients in the saturated SwiGLU
+        # clamp regions; mirrors ``torch.clamp`` autograd. No-op when
+        # ``swiglu_limit`` is None (mask tensors are placeholders).
+        if swiglu_limit is not None:
+            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+
         # MOE Step 6
         # grad_scatter_output_2 = torch.empty_like(scatter_output)
 
@@ -217,6 +258,8 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
 
         # MOE Step 5
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
+        if swiglu_limit is not None:
+            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
 
         # MOE Step 4
         # grad_scatter_output_1 = torch.empty_like(scatter_output)
@@ -263,6 +306,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             grad_fc1_1_weight,  # fc1_1_weight
             grad_fc1_2_weight,  # fc1_2_weight
             grad_fc2_weight,  # fc2_weight
+            None,  # swiglu_limit
         )
 
 
@@ -282,6 +326,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
         hidden_states,
         fc1_1_2_weight,
         fc2_weight,
+        swiglu_limit=None,
     ):
         splits = expert_histogram(expert_index, num_experts)
         scatter_index = expert_index.flatten().argsort(stable=True).argsort().int().view(expert_index.shape)
@@ -301,6 +346,14 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
 
         # chunk is a view, no copy
         fc1_1_output, fc1_2_output = fc1_output.chunk(2, dim=-1)
+
+        # gpt-oss-style clamped SwiGLU pre-activation. ``_apply_swiglu_clamp``
+        # creates new tensors when ``swiglu_limit is not None`` (so the saved
+        # halves are independent of the underlying ``fc1_output`` storage);
+        # otherwise it returns the original views and is a no-op.
+        fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2 = _apply_swiglu_clamp(
+            fc1_1_output, fc1_2_output, swiglu_limit
+        )
 
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_activation = fc1_1_activation * fc1_2_output
@@ -324,6 +377,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
         output = expert_output.reshape(hidden_states.shape)
 
         ctx.num_experts = num_experts
+        ctx.swiglu_limit = swiglu_limit
         ctx.save_for_backward(
             gate_weights,
             fc1_1_2_weight,
@@ -337,6 +391,8 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_activation,
             scattered_gate_weight,
             fc1_weighted_output,
+            mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
+            mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
 
         return output
@@ -356,7 +412,10 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_activation,
             scattered_gate_weight,
             fc1_weighted_output,
+            mask_fc1_1,
+            mask_fc1_2,
         ) = ctx.saved_tensors
+        swiglu_limit = ctx.swiglu_limit
         hidden_dim = grad_output.shape[-1]
         grad_output = grad_output.view(-1, hidden_dim)
 
@@ -404,6 +463,11 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
         # MOE Step 5
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
 
+        # Step 5a (backward): zero out gradients in saturated SwiGLU clamp regions.
+        if swiglu_limit is not None:
+            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
+            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+
         # Merge grad_fc1_1_output and grad_fc1_2_output back to [T, 2I]
         grad_fc1_output = torch.cat([grad_fc1_1_output, grad_fc1_2_output], dim=-1)
 
@@ -441,6 +505,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             grad_hidden_states,  # hidden_states
             grad_fc1_1_2_weight,  # fc1_1_2_weight
             grad_fc2_weight,  # fc2_weight
+            None,  # swiglu_limit
         )
 
 
@@ -453,6 +518,7 @@ def group_gemm_fused_moe_forward(
     fc1_2_weight: torch.Tensor | None,
     fc2_weight: torch.Tensor,
     fc1_1_2_weight: torch.Tensor | None = None,
+    swiglu_limit: float | None = None,
 ):
     """Triton grouped-gemm fused MoE forward pass.
 
@@ -463,6 +529,11 @@ def group_gemm_fused_moe_forward(
       merged weights are provided, or ``TritonFusedMoeExpertFunction`` when split
       weights are provided.  No format conversion is performed.
     - EP path: always resolves to split format for ``EPGroupGemm``.
+
+    ``swiglu_limit``: gpt-oss / DeepSeek-V4 style clamp on the SwiGLU
+    pre-activations (``gate.clamp(max=L)``, ``up.clamp(min=-L, max=L)``).
+    ``None`` disables the clamp (default, zero overhead — used by every legacy
+    MoE model).
     """
     if get_parallel_state().ep_enabled:
         if fc1_1_2_weight is not None:
@@ -498,6 +569,7 @@ def group_gemm_fused_moe_forward(
                 cumsum,
                 fc1_1_2_weight,
                 fc2_weight,
+                swiglu_limit,
             )
         else:
             final_permute_tokens = EPGroupGemm.apply(
@@ -506,6 +578,7 @@ def group_gemm_fused_moe_forward(
                 fc1_1_weight,
                 fc1_2_weight,
                 fc2_weight,
+                swiglu_limit,
             )
 
         # unpermute with routing_weight
@@ -533,6 +606,7 @@ def group_gemm_fused_moe_forward(
                 hidden_states,
                 fc1_1_2_weight,
                 fc2_weight,
+                swiglu_limit,
             )
         else:
             if fc1_1_weight is None or fc1_2_weight is None:
@@ -545,5 +619,6 @@ def group_gemm_fused_moe_forward(
                 fc1_1_weight,
                 fc1_2_weight,
                 fc2_weight,
+                swiglu_limit,
             )
     return final_hidden_states

--- a/veomni/ops/kernels/moe/group_gemm.py
+++ b/veomni/ops/kernels/moe/group_gemm.py
@@ -107,10 +107,20 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
         # MOE Step 7: compute final result of linear layer 1
         fc1_activation = fc1_1_activation * fc1_2_output
 
-        # MOE Step 8: compute linear layer 2
+        # MOE Step 8: compute the weighted linear layer 1 result
+        # MOE Step 8-1: compute scattered_gate_weight, shape is (batch_size * sequence_len * topk)
+        reshaped_gate_weight = gate_weights.reshape(-1, 1)
+        scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
+        scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
+
+        # MOE Step 8-2: multiply activate with scattered_gate_weight
+        # fc1_weighted_output shape is (batch_size * sequence_len * topk, ffn_dim)
+        fc1_weighted_output = fc1_activation * scattered_gate_weight
+
+        # MOE Step 9: compute linear layer 2
         # result shape is (batch_size * sequence_len * topk, hidden_size)
         fc2_output = group_gemm_same_nk(
-            a=fc1_activation,
+            a=fc1_weighted_output,
             b=fc2_weight,
             cumsum_M=cumsum_t,
             max_M=scatter_output.shape[0],
@@ -118,15 +128,8 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             transpose_b=True,
         )
 
-        # MOE Step 9: apply routing weights after fc2, matching HuggingFace eager
-        # experts and common fused-MoE implementations.
-        reshaped_gate_weight = gate_weights.reshape(-1, 1)
-        scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
-        scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
-        fc2_weighted_output = fc2_output * scattered_gate_weight
-
-        # MOE Step 10: gather the final token result by averaging the topk token results
-        expert_output = moe_gather(fc2_weighted_output, scatter_index)
+        # MOE Step 10: gather the final token result by averaging the top-k token results
+        expert_output = moe_gather(fc2_output, scatter_index)
 
         # reshape the output with input shape
         output = expert_output.reshape(hidden_states.shape)
@@ -146,7 +149,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc2_output,
+            fc1_weighted_output,
             mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
             mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
@@ -168,7 +171,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc2_output,
+            fc1_weighted_output,
             mask_fc1_1,
             mask_fc1_2,
         ) = ctx.saved_tensors
@@ -179,16 +182,11 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
         # MOE Step 10
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
 
-        # MOE Step 9: routing weights are applied after fc2.
-        grad_weighted_fc2_output = grad_fc2_output
-        grad_fc2_output = grad_weighted_fc2_output * scattered_gate_weight
-        grad_scattered_gate_weight = torch.sum(fc2_output * grad_weighted_fc2_output, dim=-1)
-        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
-        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
+        # MOE Step 9
+        # grad_fc1_weighted_output = torch.empty_like(fc1_weighted_output)
 
-        # MOE Step 8
         # dgrad
-        grad_fc1_activation = group_gemm_same_nk(
+        grad_fc1_weighted_output = group_gemm_same_nk(
             a=grad_fc2_output,
             b=fc2_weight,
             cumsum_M=cumsum_t,
@@ -202,13 +200,22 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             grad_fc2_weight = torch.empty_like(fc2_weight)
             group_gemm_same_mn(
                 a=grad_fc2_output,
-                b=fc1_activation,
+                b=fc1_weighted_output,
                 c=grad_fc2_weight,
                 cumsum_K=cumsum_t,
                 max_K=grad_output.shape[0],
                 transpose_a=True,
                 transpose_b=False,
             )
+
+        # MOE Step 8
+        # MOE Step 8-2
+        grad_fc1_activation = grad_fc1_weighted_output * scattered_gate_weight
+
+        # MOE Step 8-1
+        grad_scattered_gate_weight = torch.sum(fc1_activation * grad_fc1_weighted_output, dim=-1)
+        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
+        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
         # recompute during backward
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
@@ -351,8 +358,14 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_activation = fc1_1_activation * fc1_2_output
 
+        reshaped_gate_weight = gate_weights.reshape(-1, 1)
+        scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
+        scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
+
+        fc1_weighted_output = fc1_activation * scattered_gate_weight
+
         fc2_output = group_gemm_same_nk(
-            a=fc1_activation,
+            a=fc1_weighted_output,
             b=fc2_weight,
             cumsum_M=cumsum_t,
             max_M=scatter_output.shape[0],
@@ -360,12 +373,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             transpose_b=True,
         )
 
-        reshaped_gate_weight = gate_weights.reshape(-1, 1)
-        scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
-        scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
-        fc2_weighted_output = fc2_output * scattered_gate_weight
-
-        expert_output = moe_gather(fc2_weighted_output, scatter_index)
+        expert_output = moe_gather(fc2_output, scatter_index)
         output = expert_output.reshape(hidden_states.shape)
 
         ctx.num_experts = num_experts
@@ -382,7 +390,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc2_output,
+            fc1_weighted_output,
             mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
             mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
@@ -403,7 +411,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc2_output,
+            fc1_weighted_output,
             mask_fc1_1,
             mask_fc1_2,
         ) = ctx.saved_tensors
@@ -414,15 +422,8 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
         # MOE Step 10
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
 
-        # MOE Step 9: routing weights are applied after fc2.
-        grad_weighted_fc2_output = grad_fc2_output
-        grad_fc2_output = grad_weighted_fc2_output * scattered_gate_weight
-        grad_scattered_gate_weight = torch.sum(fc2_output * grad_weighted_fc2_output, dim=-1)
-        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
-        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
-
-        # MOE Step 8 - dgrad
-        grad_fc1_activation = group_gemm_same_nk(
+        # MOE Step 9 - dgrad
+        grad_fc1_weighted_output = group_gemm_same_nk(
             a=grad_fc2_output,
             b=fc2_weight,
             cumsum_M=cumsum_t,
@@ -430,19 +431,27 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             transpose_b=False,
         )
 
-        # MOE Step 8 - wgrad
+        # MOE Step 9 - wgrad
         grad_fc2_weight = None
         if fc2_weight.requires_grad:
             grad_fc2_weight = torch.empty_like(fc2_weight)
             group_gemm_same_mn(
                 a=grad_fc2_output,
-                b=fc1_activation,
+                b=fc1_weighted_output,
                 c=grad_fc2_weight,
                 cumsum_K=cumsum_t,
                 max_K=grad_output.shape[0],
                 transpose_a=True,
                 transpose_b=False,
             )
+
+        # MOE Step 8-2
+        grad_fc1_activation = grad_fc1_weighted_output * scattered_gate_weight
+
+        # MOE Step 8-1
+        grad_scattered_gate_weight = torch.sum(fc1_activation * grad_fc1_weighted_output, dim=-1)
+        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
+        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
         # recompute during backward
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)

--- a/veomni/ops/kernels/moe/group_gemm.py
+++ b/veomni/ops/kernels/moe/group_gemm.py
@@ -107,20 +107,10 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
         # MOE Step 7: compute final result of linear layer 1
         fc1_activation = fc1_1_activation * fc1_2_output
 
-        # MOE Step 8: compute the the weighted linear layer 1 result
-        # MOE Step 8-1: compute scattered_gate_weight, shape is (batch_size * sequence_len * topk)
-        reshaped_gate_weight = gate_weights.reshape(-1, 1)
-        scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
-        scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
-
-        # MOE Step 8-2: multiply activate with scattered_gate_weight
-        # fc1_weighted_output shape is (batch_size * sequence_len * topk, ffn_dim)
-        fc1_weighted_output = fc1_activation * scattered_gate_weight
-
-        # MOE Step 9: compute linear layer 2
+        # MOE Step 8: compute linear layer 2
         # result shape is (batch_size * sequence_len * topk, hidden_size)
         fc2_output = group_gemm_same_nk(
-            a=fc1_weighted_output,
+            a=fc1_activation,
             b=fc2_weight,
             cumsum_M=cumsum_t,
             max_M=scatter_output.shape[0],
@@ -128,8 +118,15 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             transpose_b=True,
         )
 
-        # MOE Step 10: gather the final token result by averate the the topk token results
-        expert_output = moe_gather(fc2_output, scatter_index)
+        # MOE Step 9: apply routing weights after fc2, matching HuggingFace eager
+        # experts and common fused-MoE implementations.
+        reshaped_gate_weight = gate_weights.reshape(-1, 1)
+        scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
+        scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
+        fc2_weighted_output = fc2_output * scattered_gate_weight
+
+        # MOE Step 10: gather the final token result by averaging the topk token results
+        expert_output = moe_gather(fc2_weighted_output, scatter_index)
 
         # reshape the output with input shape
         output = expert_output.reshape(hidden_states.shape)
@@ -149,7 +146,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc1_weighted_output,
+            fc2_output,
             mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
             mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
@@ -171,7 +168,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc1_weighted_output,
+            fc2_output,
             mask_fc1_1,
             mask_fc1_2,
         ) = ctx.saved_tensors
@@ -182,11 +179,16 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
         # MOE Step 10
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
 
-        # MOE Step 9
-        # grad_fc1_weighted_output = torch.empty_like(fc1_weighted_output)
+        # MOE Step 9: routing weights are applied after fc2.
+        grad_weighted_fc2_output = grad_fc2_output
+        grad_fc2_output = grad_weighted_fc2_output * scattered_gate_weight
+        grad_scattered_gate_weight = torch.sum(fc2_output * grad_weighted_fc2_output, dim=-1)
+        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
+        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
+        # MOE Step 8
         # dgrad
-        grad_fc1_weighted_output = group_gemm_same_nk(
+        grad_fc1_activation = group_gemm_same_nk(
             a=grad_fc2_output,
             b=fc2_weight,
             cumsum_M=cumsum_t,
@@ -200,22 +202,13 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             grad_fc2_weight = torch.empty_like(fc2_weight)
             group_gemm_same_mn(
                 a=grad_fc2_output,
-                b=fc1_weighted_output,
+                b=fc1_activation,
                 c=grad_fc2_weight,
                 cumsum_K=cumsum_t,
                 max_K=grad_output.shape[0],
                 transpose_a=True,
                 transpose_b=False,
             )
-
-        # MOE Step 8
-        # MOE Step 8-2
-        grad_fc1_activation = grad_fc1_weighted_output * scattered_gate_weight
-
-        # MOE Step 8-1
-        grad_scattered_gate_weight = torch.sum(fc1_activation * grad_fc1_weighted_output, dim=-1)
-        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
-        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
         # recompute during backward
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
@@ -358,14 +351,8 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_activation = fc1_1_activation * fc1_2_output
 
-        reshaped_gate_weight = gate_weights.reshape(-1, 1)
-        scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
-        scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
-
-        fc1_weighted_output = fc1_activation * scattered_gate_weight
-
         fc2_output = group_gemm_same_nk(
-            a=fc1_weighted_output,
+            a=fc1_activation,
             b=fc2_weight,
             cumsum_M=cumsum_t,
             max_M=scatter_output.shape[0],
@@ -373,7 +360,12 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             transpose_b=True,
         )
 
-        expert_output = moe_gather(fc2_output, scatter_index)
+        reshaped_gate_weight = gate_weights.reshape(-1, 1)
+        scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
+        scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
+        fc2_weighted_output = fc2_output * scattered_gate_weight
+
+        expert_output = moe_gather(fc2_weighted_output, scatter_index)
         output = expert_output.reshape(hidden_states.shape)
 
         ctx.num_experts = num_experts
@@ -390,7 +382,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc1_weighted_output,
+            fc2_output,
             mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
             mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
@@ -411,7 +403,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc1_weighted_output,
+            fc2_output,
             mask_fc1_1,
             mask_fc1_2,
         ) = ctx.saved_tensors
@@ -422,8 +414,15 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
         # MOE Step 10
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
 
-        # MOE Step 9 - dgrad
-        grad_fc1_weighted_output = group_gemm_same_nk(
+        # MOE Step 9: routing weights are applied after fc2.
+        grad_weighted_fc2_output = grad_fc2_output
+        grad_fc2_output = grad_weighted_fc2_output * scattered_gate_weight
+        grad_scattered_gate_weight = torch.sum(fc2_output * grad_weighted_fc2_output, dim=-1)
+        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
+        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
+
+        # MOE Step 8 - dgrad
+        grad_fc1_activation = group_gemm_same_nk(
             a=grad_fc2_output,
             b=fc2_weight,
             cumsum_M=cumsum_t,
@@ -431,27 +430,19 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             transpose_b=False,
         )
 
-        # MOE Step 9 - wgrad
+        # MOE Step 8 - wgrad
         grad_fc2_weight = None
         if fc2_weight.requires_grad:
             grad_fc2_weight = torch.empty_like(fc2_weight)
             group_gemm_same_mn(
                 a=grad_fc2_output,
-                b=fc1_weighted_output,
+                b=fc1_activation,
                 c=grad_fc2_weight,
                 cumsum_K=cumsum_t,
                 max_K=grad_output.shape[0],
                 transpose_a=True,
                 transpose_b=False,
             )
-
-        # MOE Step 8-2
-        grad_fc1_activation = grad_fc1_weighted_output * scattered_gate_weight
-
-        # MOE Step 8-1
-        grad_scattered_gate_weight = torch.sum(fc1_activation * grad_fc1_weighted_output, dim=-1)
-        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
-        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
         # recompute during backward
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)

--- a/veomni/ops/kernels/moe/group_gemm.py
+++ b/veomni/ops/kernels/moe/group_gemm.py
@@ -228,7 +228,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
         # clamp regions; mirrors ``torch.clamp`` autograd. No-op when
         # ``swiglu_limit`` is None (mask tensors are placeholders).
         if swiglu_limit is not None:
-            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+            grad_fc1_2_output.masked_fill_(~mask_fc1_2, 0)
 
         # MOE Step 6
         # grad_scatter_output_2 = torch.empty_like(scatter_output)
@@ -259,7 +259,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
         # MOE Step 5
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
         if swiglu_limit is not None:
-            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
+            grad_fc1_1_output.masked_fill_(~mask_fc1_1, 0)
 
         # MOE Step 4
         # grad_scatter_output_1 = torch.empty_like(scatter_output)
@@ -465,8 +465,8 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
 
         # Step 5a (backward): zero out gradients in saturated SwiGLU clamp regions.
         if swiglu_limit is not None:
-            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
-            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+            grad_fc1_1_output.masked_fill_(~mask_fc1_1, 0)
+            grad_fc1_2_output.masked_fill_(~mask_fc1_2, 0)
 
         # Merge grad_fc1_1_output and grad_fc1_2_output back to [T, 2I]
         grad_fc1_output = torch.cat([grad_fc1_1_output, grad_fc1_2_output], dim=-1)

--- a/veomni/ops/kernels/moe/npu_group_gemm.py
+++ b/veomni/ops/kernels/moe/npu_group_gemm.py
@@ -216,7 +216,11 @@ def npu_fused_moe_forward(
     fc1_2_weight: torch.Tensor | None,
     fc2_weight: torch.Tensor,
     fc1_1_2_weight: torch.Tensor | None = None,
+    swiglu_limit: float | None = None,
 ):
+    if swiglu_limit is not None:
+        raise NotImplementedError("NPU fused MoE does not support swiglu_limit clamp semantics.")
+
     if get_parallel_state().ep_enabled:
         final_hidden_states = npu_ep_fused_moe_forward(
             num_experts,

--- a/veomni/ops/kernels/moe/quack_gemm.py
+++ b/veomni/ops/kernels/moe/quack_gemm.py
@@ -99,20 +99,22 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_activation = fc1_1_activation * fc1_2_output
 
-        # fc2: input is already expert-sorted, no A_idx needed
-        fc2_output = gemm(fc1_activation, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
-
-        # Apply routing weights after fc2, matching HuggingFace eager experts and
-        # common fused-MoE implementations. A_idx alone cannot replace
-        # scatter_index here because it lacks the topk-slot index needed to
-        # address gate_weights[T, topk].
+        # Apply routing weights.
+        # Note: A_idx alone cannot replace scatter_index here because A_idx only
+        # carries token indices (sorted_order // topk) but not the topk-slot index,
+        # so it cannot address into gate_weights[T, topk] without extra bookkeeping.
         reshaped_gate_weight = gate_weights.reshape(-1, 1)
         scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
         scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
-        fc2_weighted_output = fc2_output * scattered_gate_weight
+
+        fc1_weighted_output = fc1_activation * scattered_gate_weight
+
+        # fc2: input is already expert-sorted, no A_idx needed
+        fc2_output = gemm(fc1_weighted_output, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
 
         # Gather output tokens back to original order
-        expert_output = moe_gather(fc2_weighted_output, scatter_index)
+        expert_output = moe_gather(fc2_output, scatter_index)
+        del fc2_output
         output = expert_output.reshape(hidden_states.shape)
 
         ctx.num_experts = num_experts
@@ -129,7 +131,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc2_output,
+            fc1_weighted_output,
             mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
             mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
@@ -150,7 +152,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc2_output,
+            fc1_weighted_output,
             mask_fc1_1,
             mask_fc1_2,
         ) = ctx.saved_tensors
@@ -161,25 +163,27 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         # Step 10: scatter grad to expert-sorted order
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
 
-        # Step 9: routing weights are applied after fc2.
-        grad_weighted_fc2_output = grad_fc2_output
-        grad_fc2_output = grad_weighted_fc2_output * scattered_gate_weight
-        grad_scattered_gate_weight = torch.sum(fc2_output * grad_weighted_fc2_output, dim=-1)
-        del fc2_output, grad_weighted_fc2_output, scattered_gate_weight
-        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
-        del grad_scattered_gate_weight
-        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
+        # Step 9 dgrad: grad @ fc2_weight (original layout [E, H, I] is already [K, N] for quack)
+        grad_fc1_weighted_output = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
 
-        # Step 8 dgrad: grad @ fc2_weight (original layout [E, H, I] is already [K, N] for quack)
-        grad_fc1_activation = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
-
-        # Step 8 wgrad: grad_fc2_output.T @ fc1_activation → [E, H, I]
+        # Step 9 wgrad: grad_fc2_output.T @ fc1_weighted_output → [E, H, I]
         # cu_seqlens_k mode: A=[M, total_K] @ B=[total_K, N] → [L, M, N] per expert group.
         # Pass .T view (not .T.contiguous()) — quack varlen_k requires A to be m-major.
         grad_fc2_weight = None
         if fc2_weight.requires_grad:
-            grad_fc2_weight = gemm(grad_fc2_output.T, fc1_activation, cu_seqlens_k=cu_seqlens_m)
+            grad_fc2_weight = gemm(grad_fc2_output.T, fc1_weighted_output, cu_seqlens_k=cu_seqlens_m)
+        del fc1_weighted_output
+
+        # Step 8-2: routing weight backward
+        grad_fc1_activation = grad_fc1_weighted_output * scattered_gate_weight
+        del scattered_gate_weight
+
+        # Step 8-1: gate weight backward
+        grad_scattered_gate_weight = torch.sum(fc1_activation * grad_fc1_weighted_output, dim=-1)
         del fc1_activation
+        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
+        del grad_scattered_gate_weight
+        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
         # Recompute SiLU activation
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
@@ -275,14 +279,16 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_activation = fc1_1_activation * fc1_2_output
 
-        fc2_output = gemm(fc1_activation, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
-
         reshaped_gate_weight = gate_weights.reshape(-1, 1)
         scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
         scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
-        fc2_weighted_output = fc2_output * scattered_gate_weight
 
-        expert_output = moe_gather(fc2_weighted_output, scatter_index)
+        fc1_weighted_output = fc1_activation * scattered_gate_weight
+
+        fc2_output = gemm(fc1_weighted_output, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
+
+        expert_output = moe_gather(fc2_output, scatter_index)
+        del fc2_output
         output = expert_output.reshape(hidden_states.shape)
 
         ctx.num_experts = num_experts
@@ -298,7 +304,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc2_output,
+            fc1_weighted_output,
             mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
             mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
@@ -318,7 +324,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc2_output,
+            fc1_weighted_output,
             mask_fc1_1,
             mask_fc1_2,
         ) = ctx.saved_tensors
@@ -329,25 +335,27 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         # Step 10
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
 
-        # Step 9: routing weights are applied after fc2.
-        grad_weighted_fc2_output = grad_fc2_output
-        grad_fc2_output = grad_weighted_fc2_output * scattered_gate_weight
-        grad_scattered_gate_weight = torch.sum(fc2_output * grad_weighted_fc2_output, dim=-1)
-        del fc2_output, grad_weighted_fc2_output, scattered_gate_weight
-        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
-        del grad_scattered_gate_weight
-        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
+        # Step 9 dgrad
+        grad_fc1_weighted_output = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
 
-        # Step 8 dgrad
-        grad_fc1_activation = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
-
-        # Step 8 wgrad: grad_fc2_output.T @ fc1_activation → [E, H, I]
+        # Step 9 wgrad: grad_fc2_output.T @ fc1_weighted_output → [E, H, I]
         # cu_seqlens_k mode: A=[M, total_K] @ B=[total_K, N] → [L, M, N] per expert group.
         # Pass .T view (not .T.contiguous()) — quack varlen_k requires A to be m-major.
         grad_fc2_weight = None
         if fc2_weight.requires_grad:
-            grad_fc2_weight = gemm(grad_fc2_output.T, fc1_activation, cu_seqlens_k=cu_seqlens_m)
+            grad_fc2_weight = gemm(grad_fc2_output.T, fc1_weighted_output, cu_seqlens_k=cu_seqlens_m)
+        del fc1_weighted_output
+
+        # Step 8-2
+        grad_fc1_activation = grad_fc1_weighted_output * scattered_gate_weight
+        del scattered_gate_weight
+
+        # Step 8-1
+        grad_scattered_gate_weight = torch.sum(fc1_activation * grad_fc1_weighted_output, dim=-1)
         del fc1_activation
+        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
+        del grad_scattered_gate_weight
+        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
         # Recompute
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)

--- a/veomni/ops/kernels/moe/quack_gemm.py
+++ b/veomni/ops/kernels/moe/quack_gemm.py
@@ -30,6 +30,7 @@ from quack.gemm_interface import gemm
 from ....distributed.moe import preprocess, token_pre_all2all, tokens_post_all2all
 from ....distributed.parallel_state import get_parallel_state
 from ._kernels.kernel.moe import expert_histogram, moe_gather, moe_scatter
+from .group_gemm import _apply_swiglu_clamp
 
 
 def _build_moe_indices(expert_index: torch.Tensor, num_experts: int):
@@ -72,6 +73,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         fc1_1_weight,
         fc1_2_weight,
         fc2_weight,
+        swiglu_limit=None,
     ):
         cu_seqlens_m, A_idx, scatter_index = _build_moe_indices(expert_index, num_experts)
 
@@ -87,6 +89,11 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
 
         # fc1_2: [T*topk, I]
         fc1_2_output = gemm(hidden_states, fc1_2_w_t, cu_seqlens_m=cu_seqlens_m, A_idx=A_idx)
+
+        # gpt-oss / DeepSeek-V4 style clamped SwiGLU pre-activation.
+        fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2 = _apply_swiglu_clamp(
+            fc1_1_output, fc1_2_output, swiglu_limit
+        )
 
         # SiLU activation + gate multiply
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
@@ -111,6 +118,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         output = expert_output.reshape(hidden_states.shape)
 
         ctx.num_experts = num_experts
+        ctx.swiglu_limit = swiglu_limit
         ctx.save_for_backward(
             gate_weights,
             fc1_1_weight,
@@ -124,6 +132,8 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_activation,
             scattered_gate_weight,
             fc1_weighted_output,
+            mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
+            mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
 
         return output
@@ -143,7 +153,10 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_activation,
             scattered_gate_weight,
             fc1_weighted_output,
+            mask_fc1_1,
+            mask_fc1_2,
         ) = ctx.saved_tensors
+        swiglu_limit = ctx.swiglu_limit
         hidden_dim = grad_output.shape[-1]
         grad_output = grad_output.view(-1, hidden_dim)
 
@@ -181,12 +194,17 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         grad_fc1_2_output = fc1_1_activation * grad_fc1_activation
         del grad_fc1_activation, fc1_1_activation
 
+        if swiglu_limit is not None:
+            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+
         # Step 6 dgrad: fc1_2_weight [E, I, H] is already [K, N] for quack
         grad_scatter_output_2 = gemm(grad_fc1_2_output, fc1_2_weight, cu_seqlens_m=cu_seqlens_m)
 
         # Step 5: SiLU backward
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
         del fc1_1_output
+        if swiglu_limit is not None:
+            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
 
         # Step 4 dgrad: fc1_1_weight [E, I, H] is already [K, N] for quack
         grad_scatter_output_1 = gemm(grad_fc1_1_output, fc1_1_weight, cu_seqlens_m=cu_seqlens_m)
@@ -220,6 +238,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
             grad_fc1_1_weight,  # fc1_1_weight
             grad_fc1_2_weight,  # fc1_2_weight
             grad_fc2_weight,  # fc2_weight
+            None,  # swiglu_limit
         )
 
 
@@ -235,6 +254,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         hidden_states,
         fc1_1_2_weight,
         fc2_weight,
+        swiglu_limit=None,
     ):
         cu_seqlens_m, A_idx, scatter_index = _build_moe_indices(expert_index, num_experts)
 
@@ -248,6 +268,13 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         fc1_output = gemm(hidden_states, fc1_1_2_w_t, cu_seqlens_m=cu_seqlens_m, A_idx=A_idx)
 
         fc1_1_output, fc1_2_output = fc1_output.chunk(2, dim=-1)
+
+        # gpt-oss / DeepSeek-V4 style clamped SwiGLU pre-activation. ``_apply_swiglu_clamp``
+        # creates new tensors when ``swiglu_limit is not None`` so the saved halves are
+        # independent of ``fc1_output`` storage; otherwise it is a no-op.
+        fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2 = _apply_swiglu_clamp(
+            fc1_1_output, fc1_2_output, swiglu_limit
+        )
 
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_activation = fc1_1_activation * fc1_2_output
@@ -265,6 +292,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         output = expert_output.reshape(hidden_states.shape)
 
         ctx.num_experts = num_experts
+        ctx.swiglu_limit = swiglu_limit
         ctx.save_for_backward(
             gate_weights,
             fc1_1_2_weight,
@@ -277,6 +305,8 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_activation,
             scattered_gate_weight,
             fc1_weighted_output,
+            mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
+            mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
 
         return output
@@ -295,7 +325,10 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_activation,
             scattered_gate_weight,
             fc1_weighted_output,
+            mask_fc1_1,
+            mask_fc1_2,
         ) = ctx.saved_tensors
+        swiglu_limit = ctx.swiglu_limit
         hidden_dim = grad_output.shape[-1]
         grad_output = grad_output.view(-1, hidden_dim)
 
@@ -337,6 +370,10 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
         del fc1_1_output
 
+        if swiglu_limit is not None:
+            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
+            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+
         # Merge grads back to [T, 2I]
         grad_fc1_output = torch.cat([grad_fc1_1_output, grad_fc1_2_output], dim=-1)
         del grad_fc1_1_output, grad_fc1_2_output
@@ -364,6 +401,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
             grad_hidden_states,  # hidden_states
             grad_fc1_1_2_weight,  # fc1_1_2_weight
             grad_fc2_weight,  # fc2_weight
+            None,  # swiglu_limit
         )
 
 
@@ -384,6 +422,7 @@ class EPQuackGroupGemm(torch.autograd.Function):
         fc1_1_weight,
         fc1_2_weight,
         fc2_weight,
+        swiglu_limit=None,
     ):
         cu_seqlens_m = _cumsum_to_cu_seqlens(cumsum)
 
@@ -394,11 +433,16 @@ class EPQuackGroupGemm(torch.autograd.Function):
         fc1_1_output = gemm(permute_tokens, fc1_1_w_t, cu_seqlens_m=cu_seqlens_m)
         fc1_2_output = gemm(permute_tokens, fc1_2_w_t, cu_seqlens_m=cu_seqlens_m)
 
+        fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2 = _apply_swiglu_clamp(
+            fc1_1_output, fc1_2_output, swiglu_limit
+        )
+
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_result = fc1_1_activation * fc1_2_output
 
         fc2_output = gemm(fc1_result, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
 
+        ctx.swiglu_limit = swiglu_limit
         ctx.save_for_backward(
             permute_tokens,
             cumsum,
@@ -407,6 +451,8 @@ class EPQuackGroupGemm(torch.autograd.Function):
             fc2_weight,
             fc1_1_output,
             fc1_2_output,
+            mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=permute_tokens.device),
+            mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=permute_tokens.device),
         )
 
         return fc2_output
@@ -421,7 +467,10 @@ class EPQuackGroupGemm(torch.autograd.Function):
             fc2_weight,
             fc1_1_output,
             fc1_2_output,
+            mask_fc1_1,
+            mask_fc1_2,
         ) = ctx.saved_tensors
+        swiglu_limit = ctx.swiglu_limit
 
         cu_seqlens_m = _cumsum_to_cu_seqlens(cumsum)
 
@@ -443,6 +492,9 @@ class EPQuackGroupGemm(torch.autograd.Function):
         grad_fc1_1_activation = grad_fc1_result * fc1_2_output
         del fc1_1_activation
 
+        if swiglu_limit is not None:
+            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+
         # dgrad fc1_2
         grad_scatter_output_2 = gemm(grad_fc1_2_output, fc1_2_weight, cu_seqlens_m=cu_seqlens_m)
 
@@ -454,6 +506,8 @@ class EPQuackGroupGemm(torch.autograd.Function):
 
         # silu backward
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
+        if swiglu_limit is not None:
+            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
 
         # dgrad fc1_1
         grad_scatter_output_1 = gemm(grad_fc1_1_output, fc1_1_weight, cu_seqlens_m=cu_seqlens_m)
@@ -473,6 +527,7 @@ class EPQuackGroupGemm(torch.autograd.Function):
             grad_fc1_1_weight,  # fc1_1_weight
             grad_fc1_2_weight,  # fc1_2_weight
             grad_fc2_weight,  # fc2_weight
+            None,  # swiglu_limit
         )
 
 
@@ -486,6 +541,7 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
         cumsum,
         fc1_1_2_weight,
         fc2_weight,
+        swiglu_limit=None,
     ):
         assert fc1_1_2_weight.shape[1] % 2 == 0, (
             f"Merged fc1_1_2_weight dim 1 must be even, got {fc1_1_2_weight.shape[1]}"
@@ -501,12 +557,17 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
         # chunk is a view, no copy
         fc1_1_output, fc1_2_output = fc1_output.chunk(2, dim=-1)
 
+        fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2 = _apply_swiglu_clamp(
+            fc1_1_output, fc1_2_output, swiglu_limit
+        )
+
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_result = fc1_1_activation * fc1_2_output
 
         # fc2
         fc2_output = gemm(fc1_result, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
 
+        ctx.swiglu_limit = swiglu_limit
         ctx.save_for_backward(
             permute_tokens,
             cumsum,
@@ -514,6 +575,8 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
             fc2_weight,
             fc1_1_output,
             fc1_2_output,
+            mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=permute_tokens.device),
+            mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=permute_tokens.device),
         )
 
         return fc2_output
@@ -527,7 +590,10 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
             fc2_weight,
             fc1_1_output,
             fc1_2_output,
+            mask_fc1_1,
+            mask_fc1_2,
         ) = ctx.saved_tensors
+        swiglu_limit = ctx.swiglu_limit
 
         cu_seqlens_m = _cumsum_to_cu_seqlens(cumsum)
 
@@ -552,6 +618,10 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
         del fc1_1_output
 
+        if swiglu_limit is not None:
+            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
+            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+
         # Merge grads back to [T, 2I]
         grad_fc1_output = torch.cat([grad_fc1_1_output, grad_fc1_2_output], dim=-1)
         del grad_fc1_1_output, grad_fc1_2_output
@@ -570,6 +640,7 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
             None,  # cumsum
             grad_fc1_1_2_weight,  # fc1_1_2_weight
             grad_fc2_weight,  # fc2_weight
+            None,  # swiglu_limit
         )
 
 
@@ -582,11 +653,15 @@ def quack_gemm_fused_moe_forward(
     fc1_2_weight: torch.Tensor | None,
     fc2_weight: torch.Tensor,
     fc1_1_2_weight: torch.Tensor | None = None,
+    swiglu_limit: float | None = None,
 ):
     """Quack GEMM fused MoE forward pass.
 
     Same interface as ``group_gemm_fused_moe_forward``. Supports both split
     and merged fc1 weight layouts, including EP (Expert Parallelism).
+
+    ``swiglu_limit``: gpt-oss / DeepSeek-V4 style clamp on SwiGLU
+    pre-activations. ``None`` disables the clamp (default, zero overhead).
     """
     if get_parallel_state().ep_enabled:
         if fc1_1_2_weight is not None:
@@ -622,6 +697,7 @@ def quack_gemm_fused_moe_forward(
                 cumsum,
                 fc1_1_2_weight,
                 fc2_weight,
+                swiglu_limit,
             )
         else:
             final_permute_tokens = EPQuackGroupGemm.apply(
@@ -630,6 +706,7 @@ def quack_gemm_fused_moe_forward(
                 fc1_1_weight,
                 fc1_2_weight,
                 fc2_weight,
+                swiglu_limit,
             )
 
         final_hidden_states = tokens_post_all2all(
@@ -657,6 +734,7 @@ def quack_gemm_fused_moe_forward(
             hidden_states,
             fc1_1_2_weight,
             fc2_weight,
+            swiglu_limit,
         )
     else:
         if fc1_1_weight is None or fc1_2_weight is None:
@@ -669,4 +747,5 @@ def quack_gemm_fused_moe_forward(
             fc1_1_weight,
             fc1_2_weight,
             fc2_weight,
+            swiglu_limit,
         )

--- a/veomni/ops/kernels/moe/quack_gemm.py
+++ b/veomni/ops/kernels/moe/quack_gemm.py
@@ -99,22 +99,20 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_activation = fc1_1_activation * fc1_2_output
 
-        # Apply routing weights.
-        # Note: A_idx alone cannot replace scatter_index here because A_idx only
-        # carries token indices (sorted_order // topk) but not the topk-slot index,
-        # so it cannot address into gate_weights[T, topk] without extra bookkeeping.
+        # fc2: input is already expert-sorted, no A_idx needed
+        fc2_output = gemm(fc1_activation, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
+
+        # Apply routing weights after fc2, matching HuggingFace eager experts and
+        # common fused-MoE implementations. A_idx alone cannot replace
+        # scatter_index here because it lacks the topk-slot index needed to
+        # address gate_weights[T, topk].
         reshaped_gate_weight = gate_weights.reshape(-1, 1)
         scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
         scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
-
-        fc1_weighted_output = fc1_activation * scattered_gate_weight
-
-        # fc2: input is already expert-sorted, no A_idx needed
-        fc2_output = gemm(fc1_weighted_output, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
+        fc2_weighted_output = fc2_output * scattered_gate_weight
 
         # Gather output tokens back to original order
-        expert_output = moe_gather(fc2_output, scatter_index)
-        del fc2_output
+        expert_output = moe_gather(fc2_weighted_output, scatter_index)
         output = expert_output.reshape(hidden_states.shape)
 
         ctx.num_experts = num_experts
@@ -131,7 +129,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc1_weighted_output,
+            fc2_output,
             mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
             mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
@@ -152,7 +150,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc1_weighted_output,
+            fc2_output,
             mask_fc1_1,
             mask_fc1_2,
         ) = ctx.saved_tensors
@@ -163,27 +161,25 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         # Step 10: scatter grad to expert-sorted order
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
 
-        # Step 9 dgrad: grad @ fc2_weight (original layout [E, H, I] is already [K, N] for quack)
-        grad_fc1_weighted_output = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
+        # Step 9: routing weights are applied after fc2.
+        grad_weighted_fc2_output = grad_fc2_output
+        grad_fc2_output = grad_weighted_fc2_output * scattered_gate_weight
+        grad_scattered_gate_weight = torch.sum(fc2_output * grad_weighted_fc2_output, dim=-1)
+        del fc2_output, grad_weighted_fc2_output, scattered_gate_weight
+        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
+        del grad_scattered_gate_weight
+        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
-        # Step 9 wgrad: grad_fc2_output.T @ fc1_weighted_output → [E, H, I]
+        # Step 8 dgrad: grad @ fc2_weight (original layout [E, H, I] is already [K, N] for quack)
+        grad_fc1_activation = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
+
+        # Step 8 wgrad: grad_fc2_output.T @ fc1_activation → [E, H, I]
         # cu_seqlens_k mode: A=[M, total_K] @ B=[total_K, N] → [L, M, N] per expert group.
         # Pass .T view (not .T.contiguous()) — quack varlen_k requires A to be m-major.
         grad_fc2_weight = None
         if fc2_weight.requires_grad:
-            grad_fc2_weight = gemm(grad_fc2_output.T, fc1_weighted_output, cu_seqlens_k=cu_seqlens_m)
-        del fc1_weighted_output
-
-        # Step 8-2: routing weight backward
-        grad_fc1_activation = grad_fc1_weighted_output * scattered_gate_weight
-        del scattered_gate_weight
-
-        # Step 8-1: gate weight backward
-        grad_scattered_gate_weight = torch.sum(fc1_activation * grad_fc1_weighted_output, dim=-1)
+            grad_fc2_weight = gemm(grad_fc2_output.T, fc1_activation, cu_seqlens_k=cu_seqlens_m)
         del fc1_activation
-        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
-        del grad_scattered_gate_weight
-        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
         # Recompute SiLU activation
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
@@ -279,16 +275,14 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_activation = fc1_1_activation * fc1_2_output
 
+        fc2_output = gemm(fc1_activation, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
+
         reshaped_gate_weight = gate_weights.reshape(-1, 1)
         scattered_gate_weight = torch.empty_like(reshaped_gate_weight)
         scattered_gate_weight[scatter_index.flatten()] = reshaped_gate_weight
+        fc2_weighted_output = fc2_output * scattered_gate_weight
 
-        fc1_weighted_output = fc1_activation * scattered_gate_weight
-
-        fc2_output = gemm(fc1_weighted_output, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
-
-        expert_output = moe_gather(fc2_output, scatter_index)
-        del fc2_output
+        expert_output = moe_gather(fc2_weighted_output, scatter_index)
         output = expert_output.reshape(hidden_states.shape)
 
         ctx.num_experts = num_experts
@@ -304,7 +298,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc1_weighted_output,
+            fc2_output,
             mask_fc1_1 if mask_fc1_1 is not None else torch.empty(0, device=hidden_states.device),
             mask_fc1_2 if mask_fc1_2 is not None else torch.empty(0, device=hidden_states.device),
         )
@@ -324,7 +318,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
             fc1_2_output,
             fc1_activation,
             scattered_gate_weight,
-            fc1_weighted_output,
+            fc2_output,
             mask_fc1_1,
             mask_fc1_2,
         ) = ctx.saved_tensors
@@ -335,27 +329,25 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         # Step 10
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
 
-        # Step 9 dgrad
-        grad_fc1_weighted_output = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
+        # Step 9: routing weights are applied after fc2.
+        grad_weighted_fc2_output = grad_fc2_output
+        grad_fc2_output = grad_weighted_fc2_output * scattered_gate_weight
+        grad_scattered_gate_weight = torch.sum(fc2_output * grad_weighted_fc2_output, dim=-1)
+        del fc2_output, grad_weighted_fc2_output, scattered_gate_weight
+        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
+        del grad_scattered_gate_weight
+        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
-        # Step 9 wgrad: grad_fc2_output.T @ fc1_weighted_output → [E, H, I]
+        # Step 8 dgrad
+        grad_fc1_activation = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
+
+        # Step 8 wgrad: grad_fc2_output.T @ fc1_activation → [E, H, I]
         # cu_seqlens_k mode: A=[M, total_K] @ B=[total_K, N] → [L, M, N] per expert group.
         # Pass .T view (not .T.contiguous()) — quack varlen_k requires A to be m-major.
         grad_fc2_weight = None
         if fc2_weight.requires_grad:
-            grad_fc2_weight = gemm(grad_fc2_output.T, fc1_weighted_output, cu_seqlens_k=cu_seqlens_m)
-        del fc1_weighted_output
-
-        # Step 8-2
-        grad_fc1_activation = grad_fc1_weighted_output * scattered_gate_weight
-        del scattered_gate_weight
-
-        # Step 8-1
-        grad_scattered_gate_weight = torch.sum(fc1_activation * grad_fc1_weighted_output, dim=-1)
+            grad_fc2_weight = gemm(grad_fc2_output.T, fc1_activation, cu_seqlens_k=cu_seqlens_m)
         del fc1_activation
-        grad_gate_weight = grad_scattered_gate_weight[scatter_index.flatten()]
-        del grad_scattered_gate_weight
-        grad_gate_weight = grad_gate_weight.reshape(gate_weights.shape)
 
         # Recompute
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)

--- a/veomni/ops/kernels/moe/quack_gemm.py
+++ b/veomni/ops/kernels/moe/quack_gemm.py
@@ -195,7 +195,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         del grad_fc1_activation, fc1_1_activation
 
         if swiglu_limit is not None:
-            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+            grad_fc1_2_output.masked_fill_(~mask_fc1_2, 0)
 
         # Step 6 dgrad: fc1_2_weight [E, I, H] is already [K, N] for quack
         grad_scatter_output_2 = gemm(grad_fc1_2_output, fc1_2_weight, cu_seqlens_m=cu_seqlens_m)
@@ -204,7 +204,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
         del fc1_1_output
         if swiglu_limit is not None:
-            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
+            grad_fc1_1_output.masked_fill_(~mask_fc1_1, 0)
 
         # Step 4 dgrad: fc1_1_weight [E, I, H] is already [K, N] for quack
         grad_scatter_output_1 = gemm(grad_fc1_1_output, fc1_1_weight, cu_seqlens_m=cu_seqlens_m)
@@ -371,8 +371,8 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         del fc1_1_output
 
         if swiglu_limit is not None:
-            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
-            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+            grad_fc1_1_output.masked_fill_(~mask_fc1_1, 0)
+            grad_fc1_2_output.masked_fill_(~mask_fc1_2, 0)
 
         # Merge grads back to [T, 2I]
         grad_fc1_output = torch.cat([grad_fc1_1_output, grad_fc1_2_output], dim=-1)
@@ -493,7 +493,7 @@ class EPQuackGroupGemm(torch.autograd.Function):
         del fc1_1_activation
 
         if swiglu_limit is not None:
-            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+            grad_fc1_2_output.masked_fill_(~mask_fc1_2, 0)
 
         # dgrad fc1_2
         grad_scatter_output_2 = gemm(grad_fc1_2_output, fc1_2_weight, cu_seqlens_m=cu_seqlens_m)
@@ -507,7 +507,7 @@ class EPQuackGroupGemm(torch.autograd.Function):
         # silu backward
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
         if swiglu_limit is not None:
-            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
+            grad_fc1_1_output.masked_fill_(~mask_fc1_1, 0)
 
         # dgrad fc1_1
         grad_scatter_output_1 = gemm(grad_fc1_1_output, fc1_1_weight, cu_seqlens_m=cu_seqlens_m)
@@ -619,8 +619,8 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
         del fc1_1_output
 
         if swiglu_limit is not None:
-            grad_fc1_1_output = grad_fc1_1_output * mask_fc1_1
-            grad_fc1_2_output = grad_fc1_2_output * mask_fc1_2
+            grad_fc1_1_output.masked_fill_(~mask_fc1_1, 0)
+            grad_fc1_2_output.masked_fill_(~mask_fc1_2, 0)
 
         # Merge grads back to [T, 2I]
         grad_fc1_output = torch.cat([grad_fc1_1_output, grad_fc1_2_output], dim=-1)


### PR DESCRIPTION
### What does this PR do?

> This PR adds optional `swiglu_limit` support to VeOmni fused MoE experts.
> The new path implements DeepSeek-V4 / gpt-oss style clamped SwiGLU pre-activation in Triton group-gemm, Quack GEMM, and EP group-gemm paths, while preserving `swiglu_limit=None` as the legacy no-op path.
> NPU fused MoE keeps signature compatibility for the new keyword and explicitly rejects non-`None` clamps because the GPU validation/report for this change was GPU-only.

### Checklist Before Starting

- Search for relative PRs/issues and link here: related to DeepSeek-V4 support in #840.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

Local checks on this branch:

```bash
python -m compileall -q \
  veomni/distributed/moe/moe_layer.py \
  veomni/ops/kernels/moe/__init__.py \
  veomni/ops/kernels/moe/group_gemm.py \
  veomni/ops/kernels/moe/quack_gemm.py \
  veomni/ops/kernels/moe/npu_group_gemm.py

ruff check \
  veomni/distributed/moe/moe_layer.py \
  veomni/ops/kernels/moe/__init__.py \
  veomni/ops/kernels/moe/group_gemm.py \
  veomni/ops/kernels/moe/quack_gemm.py \
  veomni/ops/kernels/moe/npu_group_gemm.py
# All checks passed!

ruff format --check \
  veomni/distributed/moe/moe_layer.py \
  veomni/ops/kernels/moe/__init__.py \
  veomni/ops/kernels/moe/group_gemm.py \
  veomni/ops/kernels/moe/quack_gemm.py \
  veomni/ops/kernels/moe/npu_group_gemm.py
# 5 files already formatted

make quality
# ruff check tasks tests veomni docs: All checks passed!
# ruff format --check tasks tests veomni docs: 458 files already formatted
```

Attempted local ops pytest, but this local environment does not have Triton installed:

```bash
pytest tests/ops/test_fused_moe_split_vs_merged.py -q
# ERROR collecting tests/ops/test_fused_moe_split_vs_merged.py
# ModuleNotFoundError: No module named 'triton'
```

GPU validation report included with the submitted change:

#### Environment

- Hardware: NVIDIA H20 (SM90, single-card 97 GiB)
- Backend: Triton group-gemm (`is_fused_moe_available=True`); Quack not installed; NPU unavailable
- dtype: bfloat16
- Exported patch: `deepseek_v4_swiglu_limit_gpu.diff`

#### Unit / model patch tests

| Test | Result |
|---|---|
| `tests/ops/test_fused_moe_split_vs_merged.py` | **9 passed, 4 skipped** (Quack cases skipped) |
| `tests/models/test_models_patch.py::test_models_patch_fwd_bwd[deepseek_v4]` | **passed** (HF eager ↔ VeOmni fused-MoE+clamp numerically aligned) |

Before making `swiglu_limit` optional on the autograd Functions, direct legacy calls such as `EPGroupGemm.apply(...)` failed with `TypeError: forward() missing 1 required positional argument: 'swiglu_limit'`. After the fix, existing split/merged MoE tests pass.

#### `swiglu_limit` numerical correctness

`None` path no-op check: `fused(None)` vs `fused(L=1e9)` forward relative error is **0.00e+00**, confirming the legacy path is unchanged.

Clamp correctness (`T=256, E=8, H=512, I=256, topk=2`, relative error):

| swiglu_limit | Saturation ratio | fwd | hidden_grad | gate_up_grad | down_grad |
|---|---:|---:|---:|---:|---:|
| None | - | 6.96e-03 | 4.58e-03 | 3.81e-03 | 4.46e-03 |
| 0.3 | 18% | 6.50e-03 | 6.16e-03 | 5.71e-03 | 2.79e-03 |
| 0.1 | 66% | 8.54e-03 | 5.71e-03 | 4.82e-03 | 3.88e-03 |

Even with 66% saturated activations, forward and all three gradient paths stay below `1e-2` relative error, which is within normal bf16 GEMM tolerance. This validates both forward clamp semantics and backward gradient masking.

DeepSeek-V4 real-shape eager vs fused (`L=10`) forward relative error: **7.05e-03**.

#### Performance comparison

DeepSeek-V4 MoE requires clamped SwiGLU. Before this change, VeOmni fused kernels did not support clamp, so DeepSeek-V4 had to use eager MoE (`DeepseekV4Experts.forward` Python per-expert loop + `_apply_gate` clamp). After this change, fused MoE applies the same `swiglu_limit=10.0` clamp inside Triton group-gemm.

| Shape | Before: eager fwd+bwd | After: fused fwd+bwd | Speedup | Activation memory saved |
|---|---:|---:|---:|---:|
| **V4-full** `T=2048, H=7168, I=2048, E=256, topk=8` | 6678.88 ms | 74.20 ms | **90.0x** | 13.7 GiB |
| `T=512, E=64, H=2048, I=1408, topk=6` | 102.80 ms | 3.96 ms | 26.0x | 644 MiB |
| `T=1024, E=32, H=2048, I=1024, topk=8` | 28.13 ms | 3.65 ms | 7.7x | 113 MiB |

Peak memory on the V4-full shape: eager **58311.7 MiB** → fused **44596.2 MiB**.

Conclusion from the report:

- Full DeepSeek-V4 shape gets ~90x speedup and saves 13.7 GiB activation memory.
- Gains grow with expert count and shape size; this makes DeepSeek-V4 training practical compared with the eager Python per-expert loop.
- Legacy models with `swiglu_limit=None` have zero semantic overhead; fused `None` path and pre-change HEAD differ by <0.2% runtime noise on V4 shape.

### API and Usage Example

`swiglu_limit` is optional and defaults to `None`:

```python
from veomni.ops import fused_moe_forward

output = fused_moe_forward(
    num_experts=num_experts,
    routing_weights=top_k_weights,
    selected_experts=top_k_index,
    hidden_states=hidden_states,
    fc1_1_weight=None,
    fc1_2_weight=None,
    fc2_weight=down_proj,
    fc1_1_2_weight=gate_up_proj,
    swiglu_limit=10.0,
)
```

For `OpSlot`-based expert modules, the adapter reads `self.limit` when present and passes it as `swiglu_limit`; legacy expert modules without `limit` continue to pass `None`.

### Design & Code Changes

> - Adds clamped SwiGLU helper logic for `gate.clamp(max=L)` and `up.clamp(min=-L, max=L)`.
> - Applies the clamp before SwiGLU activation in Triton group-gemm split/merged paths.
> - Applies the same clamp and backward saturation masks in EP group-gemm split/merged paths.
> - Applies the same API and mask handling in Quack split/merged and EP paths.
> - Extends `fused_moe_forward(..., swiglu_limit=None)` and the MoE OpSlot adapter.
> - Keeps backward compatibility by making every new autograd Function argument default to `None`.
> - Keeps NPU fused MoE compatible with the new keyword for `None`, and raises clearly for unsupported non-`None` clamp semantics.


