### PR TITLE
[data, model] fix: coalesce qwen3.5 pad cu-seqlens for GDN

### DIFF
--- a/tests/data/test_collators.py
+++ b/tests/data/test_collators.py
@@ -170,4 +170,27 @@ def test_seqcls_collator_pad_to_length_sp_enabled(monkeypatch, features_two_samp
     assert out["max_length_k"] == exp_max_length
 
 
+def test_packing_collator_clamps_linear_attn_tail_padding_length(monkeypatch, features_two_samples):
+    import veomni.data.data_collator as m
+
+    monkeypatch.setattr(m, "get_parallel_state", lambda: _fake_ps(sp_enabled=True))
+    monkeypatch.setattr(m.PackingCollator, "pad_batch_to_length", lambda _, batch: batch)
+
+    token_labels = [
+        {
+            **features_two_samples[0],
+            "labels": torch.tensor([2, 3, 4], dtype=torch.long),
+        },
+        {
+            **features_two_samples[1],
+            "labels": torch.tensor([1, 2], dtype=torch.long),
+        },
+    ]
+    collator = m.PackingCollator(pad_to_length=4)
+
+    out = collator(token_labels)
+
+    assert m._LINEAR_ATTN_TAIL_PADDING_LENGTH not in out
+
+
 # TODO: add omni data ci test

--- a/tests/data/test_prepare_fa_kwargs.py
+++ b/tests/data/test_prepare_fa_kwargs.py
@@ -1,6 +1,9 @@
 import torch
 
-from veomni.utils.seqlen_pos_transform_utils import prepare_fa_kwargs_from_position_ids
+from veomni.utils.seqlen_pos_transform_utils import (
+    coalesce_tail_padding_cu_seqlens,
+    prepare_fa_kwargs_from_position_ids,
+)
 
 
 def make_pos_ids_concat(lengths):
@@ -78,7 +81,48 @@ def test_random_batch():
     assert max_q == expected_max and max_k == expected_max
 
 
+def test_linear_attn_cu_seqlens_coalesces_tail_padding():
+    real_lengths = [4, 3]
+    tail_padding_length = 3
+    pos = torch.cat(
+        (
+            make_pos_ids_concat(real_lengths),
+            torch.zeros(tail_padding_length, dtype=torch.long),
+        )
+    ).unsqueeze(0)
+
+    (cu_seq_lens_q, _), _ = prepare_fa_kwargs_from_position_ids(pos)
+    linear_attn_cu_seq_lens_q = coalesce_tail_padding_cu_seqlens(cu_seq_lens_q, tail_padding_length)
+
+    # FlashAttention still sees the zero-padded tail exactly as encoded by position_ids.
+    assert torch.equal(cu_seq_lens_q, torch.tensor([0, 4, 7, 8, 9, 10], dtype=torch.int32))
+    # Linear-attention kernels see one independent padding segment instead of one segment per pad token.
+    assert torch.equal(linear_attn_cu_seq_lens_q, torch.tensor([0, 4, 7, 10], dtype=torch.int32))
+
+
+def test_linear_attn_cu_seqlens_preserves_real_one_token_sequence():
+    real_lengths = [4, 1]
+    tail_padding_length = 3
+    pos = torch.cat(
+        (
+            make_pos_ids_concat(real_lengths),
+            torch.zeros(tail_padding_length, dtype=torch.long),
+        )
+    ).unsqueeze(0)
+
+    (cu_seq_lens_q, _), _ = prepare_fa_kwargs_from_position_ids(pos)
+    linear_attn_cu_seq_lens_q = coalesce_tail_padding_cu_seqlens(cu_seq_lens_q, tail_padding_length)
+
+    assert torch.equal(cu_seq_lens_q, torch.tensor([0, 4, 5, 6, 7, 8], dtype=torch.int32))
+    assert torch.equal(linear_attn_cu_seq_lens_q, torch.tensor([0, 4, 5, 8], dtype=torch.int32))
+
+
 if __name__ == "__main__":
     run_test("basic", test_basic)
     run_test("randomized", test_randomized)
     run_test("large_random_batch_stress", test_random_batch)
+    run_test("linear_attn_cu_seqlens_coalesces_tail_padding", test_linear_attn_cu_seqlens_coalesces_tail_padding)
+    run_test(
+        "linear_attn_cu_seqlens_preserves_real_one_token_sequence",
+        test_linear_attn_cu_seqlens_preserves_real_one_token_sequence,
+    )

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -26,7 +26,11 @@ from ..distributed.parallel_state import get_parallel_state
 from ..distributed.sequence_parallel import gather_outputs
 from ..utils import logging
 from ..utils.constants import IGNORE_INDEX, MODALITY
-from ..utils.seqlen_pos_transform_utils import prepare_fa_kwargs_from_position_ids, valid_seqlens_from_cu_seqlens
+from ..utils.seqlen_pos_transform_utils import (
+    coalesce_tail_padding_cu_seqlens,
+    prepare_fa_kwargs_from_position_ids,
+    valid_seqlens_from_cu_seqlens,
+)
 
 
 # A model-provided hook that derives ``multimodal_metadata`` from a packed +
@@ -40,9 +44,12 @@ MetadataCollateFunc = Callable[[Dict[str, Any], Dict[str, int]], None]
 
 logger = logging.get_logger(__name__)
 
+_LINEAR_ATTN_TAIL_PADDING_LENGTH = "_linear_attn_tail_padding_length"
+
 
 def add_flash_attention_kwargs_from_position_ids(
     batch: Dict[str, "torch.Tensor"],
+    linear_attn_tail_padding_length: int = 0,
 ) -> Tuple["torch.Tensor", "torch.Tensor", "torch.Tensor", "torch.Tensor"]:
     """
     Calculate and add Flash Attention kwargs (cu_seq_lens and max_length) from position_ids.
@@ -55,7 +62,11 @@ def add_flash_attention_kwargs_from_position_ids(
 
     Args:
         batch: The batch dictionary containing position_ids. Will be modified in-place to add
-               cu_seq_lens_q, cu_seq_lens_k, max_length_q, and max_length_k.
+               cu_seq_lens_q, cu_seq_lens_k, max_length_q, max_length_k, and
+               linear_attn_cu_seq_lens_q.
+        linear_attn_tail_padding_length: Number of known padding tokens appended at the tail by
+               collators. These are kept in FlashAttention cu-seqlens but coalesced into one segment
+               for linear-attention kernels that compile or allocate per segment.
 
     Returns:
         Tuple of (cu_seq_lens_q, cu_seq_lens_k, max_length_q, max_length_k) for additional use.
@@ -69,6 +80,10 @@ def add_flash_attention_kwargs_from_position_ids(
     batch["cu_seq_lens_k"] = cu_seq_lens_k
     batch["max_length_q"] = max_length_q
     batch["max_length_k"] = max_length_k
+    batch["linear_attn_cu_seq_lens_q"] = coalesce_tail_padding_cu_seqlens(
+        cu_seq_lens_q,
+        linear_attn_tail_padding_length,
+    )
 
     return cu_seq_lens_q, cu_seq_lens_k, max_length_q, max_length_k
 
@@ -263,11 +278,13 @@ class PackingCollator(DataCollator):
                 if pack_dim == -1:
                     batch[key] = batch[key].unsqueeze(0)
 
+        linear_attn_tail_padding_length = 0
         if self.pad_to_length:
+            linear_attn_tail_padding_length = max(0, self.pad_to_length - batch["input_ids"].shape[-1])
             batch = self.pad_batch_to_length(batch)
 
         if not self.sp_enabled:
-            add_flash_attention_kwargs_from_position_ids(batch)
+            add_flash_attention_kwargs_from_position_ids(batch, linear_attn_tail_padding_length)
             # No SP downstream → no sp-pad. Hand the packed batch to the
             # model-provided hook (if any), which derives ``multimodal_metadata``
             # from the packed ``*_grid_thw`` tensors using its own config. When
@@ -275,6 +292,8 @@ class PackingCollator(DataCollator):
             # the hook sees the SP-padded batch + per-modality pad counts.
             if self.metadata_collate_func is not None:
                 self.metadata_collate_func(batch, {"pixel_values": 0, "pixel_values_videos": 0})
+        elif linear_attn_tail_padding_length:
+            batch[_LINEAR_ATTN_TAIL_PADDING_LENGTH] = linear_attn_tail_padding_length
         return batch
 
 
@@ -340,6 +359,8 @@ class SequenceParallelCollator(DataCollator):
             labels = F.pad(labels, (0, 1), "constant", IGNORE_INDEX)
             batch["labels"] = labels
 
+        linear_attn_tail_padding_length = int(batch.pop(_LINEAR_ATTN_TAIL_PADDING_LENGTH, 0))
+
         # Track sp_pad sizes for pixel_values{,_videos} so the ViT metadata
         # ``cu_seqlens`` can be extended with the sp-pad tail entry (mirrors
         # how the text-side cu_seq_lens picks up sp-pad via the position_ids==0
@@ -367,12 +388,14 @@ class SequenceParallelCollator(DataCollator):
                 post_pad_len = len(batch[key]) if isinstance(batch[key], list) else batch[key].size(pack_dim)
                 if key in vit_sp_pad:
                     vit_sp_pad[key] = post_pad_len - pre_pad_len
+                if key == "position_ids":
+                    linear_attn_tail_padding_length += post_pad_len - pre_pad_len
 
             if sp_slice and key != "position_ids":  # position_ids should be sp sliced after precompute fa kwargs
                 # sp slice
                 batch[key] = self.sp_slice(key, batch[key], dim=pack_dim)
 
-        add_flash_attention_kwargs_from_position_ids(batch)
+        add_flash_attention_kwargs_from_position_ids(batch, linear_attn_tail_padding_length)
 
         batch["position_ids"] = self.sp_slice(
             "position_ids", batch["position_ids"], dim=self.collate_infos["position_ids"].pack_dim

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
@@ -674,7 +674,7 @@
 
 
  class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
-@@ -774,19 +1081,29 @@
+@@ -774,19 +1081,30 @@
          attention_mask: torch.Tensor | None = None,
          position_ids: torch.LongTensor | None = None,
          past_key_values: Cache | None = None,
@@ -691,21 +691,22 @@
 +            "cu_seq_lens_q must be provided to support varlen Flash Linear Attention, varlen Conv1D,"
 +            "and to remove the full Flash Attention CPU-GPU sync."
 +        )
++        linear_attn_cu_seq_lens_q = kwargs.pop("linear_attn_cu_seq_lens_q", cu_seq_lens_q)
 +
          # Token Mixer
          if self.layer_type == "linear_attention":
-+            # Modification: pass cu_seq_lens_q through to Qwen3_5GatedDeltaNet.forward.
++            # Modification: pass linear-attention cu_seqlens through to Qwen3_5GatedDeltaNet.forward.
              hidden_states = self.linear_attn(
                  hidden_states=hidden_states,
                  cache_params=past_key_values,
 +                cache_position=cache_position,
                  attention_mask=attention_mask,
 -                **kwargs,
-+                cu_seq_lens_q=cu_seq_lens_q,
++                cu_seq_lens_q=linear_attn_cu_seq_lens_q,
              )
          elif self.layer_type == "full_attention":
              # Self Attention
-@@ -795,6 +1112,7 @@
+@@ -795,6 +1113,7 @@
                  attention_mask=attention_mask,
                  position_ids=position_ids,
                  past_key_values=past_key_values,
@@ -713,7 +714,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -806,7 +1124,6 @@
+@@ -806,7 +1125,6 @@
          hidden_states = self.post_attention_layernorm(hidden_states)
          hidden_states = self.mlp(hidden_states)
          hidden_states = residual + hidden_states
@@ -721,7 +722,7 @@
          return hidden_states
 
 
-@@ -902,6 +1219,12 @@
+@@ -902,6 +1220,12 @@
      return q_embed, k_embed
 
 
@@ -734,7 +735,7 @@
  class Qwen3_5VisionAttention(nn.Module):
      def __init__(self, config: Qwen3_5VisionConfig) -> None:
          super().__init__()
-@@ -935,13 +1258,18 @@
+@@ -935,13 +1259,18 @@
          key_states = key_states.transpose(0, 1).unsqueeze(0)
          value_states = value_states.transpose(0, 1).unsqueeze(0)
 
@@ -756,7 +757,7 @@
              attn_output, _ = attention_interface(
                  self,
                  query_states,
-@@ -958,6 +1286,9 @@
+@@ -958,6 +1287,9 @@
                  **kwargs,
              )
          else:
@@ -766,7 +767,7 @@
              # Other implementations: Process each chunk separately
              lengths = cu_seqlens[1:] - cu_seqlens[:-1]
              splits = [
-@@ -1019,6 +1350,12 @@
+@@ -1019,6 +1351,12 @@
          return hidden_states
 
 
@@ -779,7 +780,7 @@
  class Qwen3_5VisionModel(Qwen3_5PreTrainedModel):
      config: Qwen3_5VisionConfig
      input_modalities = ("image", "video")
-@@ -1054,28 +1391,127 @@
+@@ -1054,28 +1392,127 @@
 
          self.post_init()
 
@@ -927,7 +928,7 @@
 
      @merge_with_config_defaults
      @capture_outputs
-@@ -1090,25 +1526,147 @@
+@@ -1090,25 +1527,147 @@
          Returns:
              `torch.Tensor`: hidden_states.
          """
@@ -1087,7 +1088,7 @@
 
          for blk in self.blocks:
              hidden_states = blk(
-@@ -1124,6 +1682,36 @@
+@@ -1124,6 +1683,36 @@
              last_hidden_state=hidden_states,
              pooler_output=merged_hidden_states,
          )
@@ -1124,7 +1125,7 @@
 
 
  @auto_docstring(
-@@ -1148,6 +1736,12 @@
+@@ -1148,6 +1737,12 @@
      hidden_states: tuple[torch.FloatTensor] | None = None
      attentions: tuple[torch.FloatTensor] | None = None
      rope_deltas: torch.LongTensor | None = None
@@ -1137,7 +1138,7 @@
 
 
  class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
-@@ -1233,19 +1827,42 @@
+@@ -1233,19 +1828,42 @@
              past_key_values=past_key_values,
          )
 
@@ -1191,7 +1192,7 @@
 
 
  @auto_docstring
-@@ -1441,64 +2058,43 @@
+@@ -1441,64 +2059,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1281,7 +1282,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1564,13 +2160,18 @@
+@@ -1564,13 +2161,18 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1300,7 +1301,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1578,29 +2179,169 @@
+@@ -1578,29 +2180,169 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1480,7 +1481,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1610,6 +2351,18 @@
+@@ -1610,6 +2352,18 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1499,7 +1500,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1617,6 +2370,7 @@
+@@ -1617,6 +2371,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1507,7 +1508,7 @@
              **kwargs,
          )
 
-@@ -1624,6 +2378,12 @@
+@@ -1624,6 +2379,12 @@
              **outputs,
              rope_deltas=self.rope_deltas,
          )
@@ -1520,7 +1521,7 @@
 
 
  @auto_docstring
-@@ -1654,10 +2414,13 @@
+@@ -1654,10 +2415,13 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
@@ -1534,7 +1535,7 @@
          labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
              Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
              config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
-@@ -1686,21 +2449,50 @@
+@@ -1686,21 +2450,50 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -1589,7 +1590,7 @@
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
-@@ -1740,6 +2532,41 @@
+@@ -1740,6 +2533,41 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1631,7 +1632,7 @@
  class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1796,57 +2623,10 @@
+@@ -1796,57 +2624,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1691,7 +1692,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1857,27 +2637,54 @@
+@@ -1857,27 +2638,54 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1752,7 +1753,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2103,6 +2910,24 @@
+@@ -2103,6 +2911,24 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
@@ -1094,16 +1094,17 @@ class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
             "cu_seq_lens_q must be provided to support varlen Flash Linear Attention, varlen Conv1D,"
             "and to remove the full Flash Attention CPU-GPU sync."
         )
+        linear_attn_cu_seq_lens_q = kwargs.pop("linear_attn_cu_seq_lens_q", cu_seq_lens_q)
 
         # Token Mixer
         if self.layer_type == "linear_attention":
-            # Modification: pass cu_seq_lens_q through to Qwen3_5GatedDeltaNet.forward.
+            # Modification: pass linear-attention cu_seqlens through to Qwen3_5GatedDeltaNet.forward.
             hidden_states = self.linear_attn(
                 hidden_states=hidden_states,
                 cache_params=past_key_values,
                 cache_position=cache_position,
                 attention_mask=attention_mask,
-                cu_seq_lens_q=cu_seq_lens_q,
+                cu_seq_lens_q=linear_attn_cu_seq_lens_q,
             )
         elif self.layer_type == "full_attention":
             # Self Attention

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
@@ -687,7 +687,7 @@
 
 
  class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
-@@ -774,19 +1046,29 @@
+@@ -774,19 +1046,30 @@
          attention_mask: torch.Tensor | None = None,
          position_ids: torch.LongTensor | None = None,
          past_key_values: Cache | None = None,
@@ -704,21 +704,22 @@
 +            "cu_seq_lens_q must be provided to support varlen Flash Linear Attention, varlen Conv1D,"
 +            "and to remove the full Flash Attention CPU-NPU sync."
 +        )
++        linear_attn_cu_seq_lens_q = kwargs.pop("linear_attn_cu_seq_lens_q", cu_seq_lens_q)
 +
          # Token Mixer
          if self.layer_type == "linear_attention":
-+            # Modification: pass cu_seq_lens_q through to Qwen3_5GatedDeltaNet.forward.
++            # Modification: pass linear-attention cu_seqlens through to Qwen3_5GatedDeltaNet.forward.
              hidden_states = self.linear_attn(
                  hidden_states=hidden_states,
                  cache_params=past_key_values,
 +                cache_position=cache_position,
                  attention_mask=attention_mask,
 -                **kwargs,
-+                cu_seq_lens_q=cu_seq_lens_q,
++                cu_seq_lens_q=linear_attn_cu_seq_lens_q,
              )
          elif self.layer_type == "full_attention":
              # Self Attention
-@@ -795,6 +1077,7 @@
+@@ -795,6 +1078,7 @@
                  attention_mask=attention_mask,
                  position_ids=position_ids,
                  past_key_values=past_key_values,
@@ -726,7 +727,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -806,7 +1089,6 @@
+@@ -806,7 +1090,6 @@
          hidden_states = self.post_attention_layernorm(hidden_states)
          hidden_states = self.mlp(hidden_states)
          hidden_states = residual + hidden_states
@@ -734,7 +735,7 @@
          return hidden_states
 
 
-@@ -888,9 +1170,16 @@
+@@ -888,9 +1171,16 @@
          return x
 
 
@@ -751,7 +752,7 @@
      orig_q_dtype = q.dtype
      orig_k_dtype = k.dtype
      q, k = q.float(), k.float()
-@@ -1019,6 +1308,12 @@
+@@ -1019,6 +1309,12 @@
          return hidden_states
 
 
@@ -764,7 +765,7 @@
  class Qwen3_5VisionModel(Qwen3_5PreTrainedModel):
      config: Qwen3_5VisionConfig
      input_modalities = ("image", "video")
-@@ -1054,28 +1349,127 @@
+@@ -1054,28 +1350,127 @@
 
          self.post_init()
 
@@ -912,7 +913,7 @@
 
      @merge_with_config_defaults
      @capture_outputs
-@@ -1090,25 +1484,147 @@
+@@ -1090,25 +1485,147 @@
          Returns:
              `torch.Tensor`: hidden_states.
          """
@@ -1072,7 +1073,7 @@
 
          for blk in self.blocks:
              hidden_states = blk(
-@@ -1124,6 +1640,36 @@
+@@ -1124,6 +1641,36 @@
              last_hidden_state=hidden_states,
              pooler_output=merged_hidden_states,
          )
@@ -1109,7 +1110,7 @@
 
 
  @auto_docstring(
-@@ -1148,6 +1694,12 @@
+@@ -1148,6 +1695,12 @@
      hidden_states: tuple[torch.FloatTensor] | None = None
      attentions: tuple[torch.FloatTensor] | None = None
      rope_deltas: torch.LongTensor | None = None
@@ -1122,7 +1123,7 @@
 
 
  class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
-@@ -1233,19 +1785,42 @@
+@@ -1233,19 +1786,42 @@
              past_key_values=past_key_values,
          )
 
@@ -1176,7 +1177,7 @@
 
 
  @auto_docstring
-@@ -1441,64 +2016,43 @@
+@@ -1441,64 +2017,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1266,7 +1267,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1564,13 +2118,18 @@
+@@ -1564,13 +2119,18 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1285,7 +1286,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1578,29 +2137,169 @@
+@@ -1578,29 +2138,169 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1465,7 +1466,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1610,6 +2309,18 @@
+@@ -1610,6 +2310,18 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1484,7 +1485,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1617,6 +2328,7 @@
+@@ -1617,6 +2329,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1492,7 +1493,7 @@
              **kwargs,
          )
 
-@@ -1624,6 +2336,12 @@
+@@ -1624,6 +2337,12 @@
              **outputs,
              rope_deltas=self.rope_deltas,
          )
@@ -1505,7 +1506,7 @@
 
 
  @auto_docstring
-@@ -1654,10 +2372,13 @@
+@@ -1654,10 +2373,13 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
@@ -1519,7 +1520,7 @@
          labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
              Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
              config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
-@@ -1686,21 +2407,50 @@
+@@ -1686,21 +2408,50 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -1574,7 +1575,7 @@
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
-@@ -1740,6 +2490,31 @@
+@@ -1740,6 +2491,31 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1606,7 +1607,7 @@
  class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1796,57 +2571,10 @@
+@@ -1796,57 +2572,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1666,7 +1667,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1857,27 +2585,54 @@
+@@ -1857,27 +2586,54 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1727,7 +1728,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2103,6 +2858,24 @@
+@@ -2103,6 +2859,24 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
@@ -1059,16 +1059,17 @@ class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
             "cu_seq_lens_q must be provided to support varlen Flash Linear Attention, varlen Conv1D,"
             "and to remove the full Flash Attention CPU-NPU sync."
         )
+        linear_attn_cu_seq_lens_q = kwargs.pop("linear_attn_cu_seq_lens_q", cu_seq_lens_q)
 
         # Token Mixer
         if self.layer_type == "linear_attention":
-            # Modification: pass cu_seq_lens_q through to Qwen3_5GatedDeltaNet.forward.
+            # Modification: pass linear-attention cu_seqlens through to Qwen3_5GatedDeltaNet.forward.
             hidden_states = self.linear_attn(
                 hidden_states=hidden_states,
                 cache_params=past_key_values,
                 cache_position=cache_position,
                 attention_mask=attention_mask,
-                cu_seq_lens_q=cu_seq_lens_q,
+                cu_seq_lens_q=linear_attn_cu_seq_lens_q,
             )
         elif self.layer_type == "full_attention":
             # Self Attention

--- a/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
@@ -574,16 +574,17 @@ def qwen3_5_decoder_layer_forward_patched(
         "cu_seq_lens_q must be provided to support varlen Flash Linear Attention, varlen Conv1D,"
         "and to remove the full Flash Attention CPU-GPU sync."
     )
+    linear_attn_cu_seq_lens_q = kwargs.pop("linear_attn_cu_seq_lens_q", cu_seq_lens_q)
 
     # Token Mixer
     if self.layer_type == "linear_attention":
-        # Modification: pass cu_seq_lens_q through to Qwen3_5GatedDeltaNet.forward.
+        # Modification: pass linear-attention cu_seqlens through to Qwen3_5GatedDeltaNet.forward.
         hidden_states = self.linear_attn(
             hidden_states=hidden_states,
             cache_params=past_key_values,
             cache_position=cache_position,
             attention_mask=attention_mask,
-            cu_seq_lens_q=cu_seq_lens_q,
+            cu_seq_lens_q=linear_attn_cu_seq_lens_q,
         )
     elif self.layer_type == "full_attention":
         # Self Attention

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
@@ -773,7 +773,7 @@
      def forward(
          self,
          hidden_states: torch.Tensor,
-@@ -853,19 +1210,29 @@
+@@ -853,19 +1210,30 @@
          attention_mask: torch.Tensor | None = None,
          position_ids: torch.LongTensor | None = None,
          past_key_values: Cache | None = None,
@@ -790,21 +790,22 @@
 +            "cu_seq_lens_q must be provided to support varlen Flash Linear Attention, varlen Conv1D,"
 +            "and to remove the full Flash Attention CPU-GPU sync."
 +        )
++        linear_attn_cu_seq_lens_q = kwargs.pop("linear_attn_cu_seq_lens_q", cu_seq_lens_q)
 +
          # Token Mixer
          if self.layer_type == "linear_attention":
-+            # Modification: pass cu_seq_lens_q through to Qwen3_5MoeGatedDeltaNet.forward.
++            # Modification: pass linear-attention cu_seqlens through to Qwen3_5MoeGatedDeltaNet.forward.
              hidden_states = self.linear_attn(
                  hidden_states=hidden_states,
                  cache_params=past_key_values,
 +                cache_position=cache_position,
                  attention_mask=attention_mask,
 -                **kwargs,
-+                cu_seq_lens_q=cu_seq_lens_q,
++                cu_seq_lens_q=linear_attn_cu_seq_lens_q,
              )
          elif self.layer_type == "full_attention":
              # Self Attention
-@@ -874,6 +1241,7 @@
+@@ -874,6 +1242,7 @@
                  attention_mask=attention_mask,
                  position_ids=position_ids,
                  past_key_values=past_key_values,
@@ -812,7 +813,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -888,7 +1256,6 @@
+@@ -888,7 +1257,6 @@
          if isinstance(hidden_states, tuple):
              hidden_states, _ = hidden_states
          hidden_states = residual + hidden_states
@@ -820,7 +821,7 @@
          return hidden_states
 
 
-@@ -990,6 +1357,12 @@
+@@ -990,6 +1358,12 @@
      return q_embed, k_embed
 
 
@@ -833,7 +834,7 @@
  class Qwen3_5MoeVisionAttention(nn.Module):
      def __init__(self, config: Qwen3_5MoeVisionConfig) -> None:
          super().__init__()
-@@ -1023,13 +1396,18 @@
+@@ -1023,13 +1397,18 @@
          key_states = key_states.transpose(0, 1).unsqueeze(0)
          value_states = value_states.transpose(0, 1).unsqueeze(0)
 
@@ -855,7 +856,7 @@
              attn_output, _ = attention_interface(
                  self,
                  query_states,
-@@ -1046,6 +1424,9 @@
+@@ -1046,6 +1425,9 @@
                  **kwargs,
              )
          else:
@@ -865,7 +866,7 @@
              # Other implementations: Process each chunk separately
              lengths = cu_seqlens[1:] - cu_seqlens[:-1]
              splits = [
-@@ -1107,6 +1488,12 @@
+@@ -1107,6 +1489,12 @@
          return hidden_states
 
 
@@ -878,7 +879,7 @@
  class Qwen3_5MoeVisionModel(Qwen3_5MoePreTrainedModel):
      config: Qwen3_5MoeVisionConfig
      input_modalities = ("image", "video")
-@@ -1142,28 +1529,127 @@
+@@ -1142,28 +1530,127 @@
 
          self.post_init()
 
@@ -1026,7 +1027,7 @@
 
      @merge_with_config_defaults
      @capture_outputs
-@@ -1178,25 +1664,147 @@
+@@ -1178,25 +1665,147 @@
          Returns:
              `torch.Tensor`: hidden_states.
          """
@@ -1186,7 +1187,7 @@
 
          for blk in self.blocks:
              hidden_states = blk(
-@@ -1212,6 +1820,36 @@
+@@ -1212,6 +1821,36 @@
              last_hidden_state=hidden_states,
              pooler_output=merged_hidden_states,
          )
@@ -1223,7 +1224,7 @@
 
 
  @auto_docstring(
-@@ -1268,6 +1906,37 @@
+@@ -1268,6 +1907,37 @@
      rope_deltas: torch.LongTensor | None = None
      router_logits: tuple[torch.FloatTensor] | None = None
      aux_loss: torch.FloatTensor | None = None
@@ -1261,7 +1262,7 @@
 
 
  class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
-@@ -1353,19 +2022,42 @@
+@@ -1353,19 +2023,42 @@
              past_key_values=past_key_values,
          )
 
@@ -1315,7 +1316,7 @@
 
 
  @auto_docstring
-@@ -1376,7 +2068,19 @@
+@@ -1376,7 +2069,19 @@
      config: Qwen3_5MoeConfig
      _no_split_modules = ["Qwen3_5MoeDecoderLayer", "Qwen3_5MoeVisionBlock"]
 
@@ -1335,7 +1336,7 @@
          super().__init__(config)
          self.visual = Qwen3_5MoeVisionModel._from_config(config.vision_config)
          self.language_model = Qwen3_5MoeTextModel._from_config(config.text_config)
-@@ -1561,64 +2265,43 @@
+@@ -1561,64 +2266,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1425,7 +1426,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1684,6 +2367,7 @@
+@@ -1684,6 +2368,7 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1433,7 +1434,7 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5MoeModelOutputWithPast:
          r"""
-@@ -1691,6 +2375,10 @@
+@@ -1691,6 +2376,10 @@
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
@@ -1444,7 +1445,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1698,29 +2386,170 @@
+@@ -1698,29 +2387,170 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1625,7 +1626,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1730,6 +2559,17 @@
+@@ -1730,6 +2560,17 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1643,7 +1644,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1737,6 +2577,7 @@
+@@ -1737,6 +2578,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1651,7 +1652,7 @@
              **kwargs,
          )
 
-@@ -1828,6 +2669,12 @@
+@@ -1828,6 +2670,12 @@
      return overall_loss * num_experts
 
 
@@ -1664,7 +1665,7 @@
  @auto_docstring
  class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -1848,6 +2695,7 @@
+@@ -1848,6 +2696,7 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -1672,7 +1673,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1860,14 +2708,17 @@
+@@ -1860,14 +2709,17 @@
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
          output_router_logits: bool | None = None,
@@ -1691,7 +1692,7 @@
 
          Example:
 
-@@ -1899,30 +2750,70 @@
+@@ -1899,30 +2751,70 @@
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
              output_router_logits=output_router_logits,
@@ -1774,7 +1775,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1930,7 +2821,14 @@
+@@ -1930,7 +2822,14 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
@@ -1790,7 +1791,7 @@
 
 
  class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMixin):
-@@ -1977,6 +2875,7 @@
+@@ -1977,6 +2876,7 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1798,7 +1799,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1990,105 +2889,93 @@
+@@ -1990,105 +2890,93 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1959,7 +1960,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2314,6 +3201,30 @@
+@@ -2314,6 +3202,30 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -1223,16 +1223,17 @@ class Qwen3_5MoeDecoderLayer(GradientCheckpointingLayer):
             "cu_seq_lens_q must be provided to support varlen Flash Linear Attention, varlen Conv1D,"
             "and to remove the full Flash Attention CPU-GPU sync."
         )
+        linear_attn_cu_seq_lens_q = kwargs.pop("linear_attn_cu_seq_lens_q", cu_seq_lens_q)
 
         # Token Mixer
         if self.layer_type == "linear_attention":
-            # Modification: pass cu_seq_lens_q through to Qwen3_5MoeGatedDeltaNet.forward.
+            # Modification: pass linear-attention cu_seqlens through to Qwen3_5MoeGatedDeltaNet.forward.
             hidden_states = self.linear_attn(
                 hidden_states=hidden_states,
                 cache_params=past_key_values,
                 cache_position=cache_position,
                 attention_mask=attention_mask,
-                cu_seq_lens_q=cu_seq_lens_q,
+                cu_seq_lens_q=linear_attn_cu_seq_lens_q,
             )
         elif self.layer_type == "full_attention":
             # Self Attention

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
@@ -794,7 +794,7 @@
      def forward(
          self,
          hidden_states: torch.Tensor,
-@@ -853,19 +1184,29 @@
+@@ -853,19 +1184,30 @@
          attention_mask: torch.Tensor | None = None,
          position_ids: torch.LongTensor | None = None,
          past_key_values: Cache | None = None,
@@ -811,21 +811,22 @@
 +            "cu_seq_lens_q must be provided to support varlen Flash Linear Attention, varlen Conv1D,"
 +            "and to remove the full Flash Attention CPU-GPU sync."
 +        )
++        linear_attn_cu_seq_lens_q = kwargs.pop("linear_attn_cu_seq_lens_q", cu_seq_lens_q)
 +
          # Token Mixer
          if self.layer_type == "linear_attention":
-+            # Modification: pass cu_seq_lens_q through to Qwen3_5MoeGatedDeltaNet.forward.
++            # Modification: pass linear-attention cu_seqlens through to Qwen3_5MoeGatedDeltaNet.forward.
              hidden_states = self.linear_attn(
                  hidden_states=hidden_states,
                  cache_params=past_key_values,
 +                cache_position=cache_position,
                  attention_mask=attention_mask,
 -                **kwargs,
-+                cu_seq_lens_q=cu_seq_lens_q,
++                cu_seq_lens_q=linear_attn_cu_seq_lens_q,
              )
          elif self.layer_type == "full_attention":
              # Self Attention
-@@ -874,6 +1215,7 @@
+@@ -874,6 +1216,7 @@
                  attention_mask=attention_mask,
                  position_ids=position_ids,
                  past_key_values=past_key_values,
@@ -833,7 +834,7 @@
                  position_embeddings=position_embeddings,
                  **kwargs,
              )
-@@ -888,7 +1230,6 @@
+@@ -888,7 +1231,6 @@
          if isinstance(hidden_states, tuple):
              hidden_states, _ = hidden_states
          hidden_states = residual + hidden_states
@@ -841,7 +842,7 @@
          return hidden_states
 
 
-@@ -976,9 +1317,16 @@
+@@ -976,9 +1318,16 @@
          return x
 
 
@@ -858,7 +859,7 @@
      orig_q_dtype = q.dtype
      orig_k_dtype = k.dtype
      q, k = q.float(), k.float()
-@@ -1107,6 +1455,12 @@
+@@ -1107,6 +1456,12 @@
          return hidden_states
 
 
@@ -871,7 +872,7 @@
  class Qwen3_5MoeVisionModel(Qwen3_5MoePreTrainedModel):
      config: Qwen3_5MoeVisionConfig
      input_modalities = ("image", "video")
-@@ -1142,28 +1496,127 @@
+@@ -1142,28 +1497,127 @@
 
          self.post_init()
 
@@ -1019,7 +1020,7 @@
 
      @merge_with_config_defaults
      @capture_outputs
-@@ -1178,25 +1631,147 @@
+@@ -1178,25 +1632,147 @@
          Returns:
              `torch.Tensor`: hidden_states.
          """
@@ -1179,7 +1180,7 @@
 
          for blk in self.blocks:
              hidden_states = blk(
-@@ -1212,6 +1787,36 @@
+@@ -1212,6 +1788,36 @@
              last_hidden_state=hidden_states,
              pooler_output=merged_hidden_states,
          )
@@ -1216,7 +1217,7 @@
 
 
  @auto_docstring(
-@@ -1268,6 +1873,37 @@
+@@ -1268,6 +1874,37 @@
      rope_deltas: torch.LongTensor | None = None
      router_logits: tuple[torch.FloatTensor] | None = None
      aux_loss: torch.FloatTensor | None = None
@@ -1254,7 +1255,7 @@
 
 
  class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
-@@ -1353,19 +1989,42 @@
+@@ -1353,19 +1990,42 @@
              past_key_values=past_key_values,
          )
 
@@ -1308,7 +1309,7 @@
 
 
  @auto_docstring
-@@ -1376,7 +2035,19 @@
+@@ -1376,7 +2036,19 @@
      config: Qwen3_5MoeConfig
      _no_split_modules = ["Qwen3_5MoeDecoderLayer", "Qwen3_5MoeVisionBlock"]
 
@@ -1328,7 +1329,7 @@
          super().__init__(config)
          self.visual = Qwen3_5MoeVisionModel._from_config(config.vision_config)
          self.language_model = Qwen3_5MoeTextModel._from_config(config.text_config)
-@@ -1561,64 +2232,43 @@
+@@ -1561,64 +2233,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1418,7 +1419,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1684,6 +2334,7 @@
+@@ -1684,6 +2335,7 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1426,7 +1427,7 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5MoeModelOutputWithPast:
          r"""
-@@ -1691,6 +2342,10 @@
+@@ -1691,6 +2343,10 @@
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
@@ -1437,7 +1438,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1698,29 +2353,170 @@
+@@ -1698,29 +2354,170 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1618,7 +1619,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1730,6 +2526,17 @@
+@@ -1730,6 +2527,17 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1636,7 +1637,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1737,6 +2544,7 @@
+@@ -1737,6 +2545,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1644,7 +1645,7 @@
              **kwargs,
          )
 
-@@ -1828,6 +2636,12 @@
+@@ -1828,6 +2637,12 @@
      return overall_loss * num_experts
 
 
@@ -1657,7 +1658,7 @@
  @auto_docstring
  class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -1848,6 +2662,7 @@
+@@ -1848,6 +2663,7 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -1665,7 +1666,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1860,14 +2675,17 @@
+@@ -1860,14 +2676,17 @@
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
          output_router_logits: bool | None = None,
@@ -1684,7 +1685,7 @@
 
          Example:
 
-@@ -1899,30 +2717,70 @@
+@@ -1899,30 +2718,70 @@
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
              output_router_logits=output_router_logits,
@@ -1767,7 +1768,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1930,7 +2788,14 @@
+@@ -1930,7 +2789,14 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
@@ -1783,7 +1784,7 @@
 
 
  class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMixin):
-@@ -1977,6 +2842,7 @@
+@@ -1977,6 +2843,7 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1791,7 +1792,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1990,105 +2856,93 @@
+@@ -1990,105 +2857,93 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1952,7 +1953,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2314,6 +3168,30 @@
+@@ -2314,6 +3169,30 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -1197,16 +1197,17 @@ class Qwen3_5MoeDecoderLayer(GradientCheckpointingLayer):
             "cu_seq_lens_q must be provided to support varlen Flash Linear Attention, varlen Conv1D,"
             "and to remove the full Flash Attention CPU-GPU sync."
         )
+        linear_attn_cu_seq_lens_q = kwargs.pop("linear_attn_cu_seq_lens_q", cu_seq_lens_q)
 
         # Token Mixer
         if self.layer_type == "linear_attention":
-            # Modification: pass cu_seq_lens_q through to Qwen3_5MoeGatedDeltaNet.forward.
+            # Modification: pass linear-attention cu_seqlens through to Qwen3_5MoeGatedDeltaNet.forward.
             hidden_states = self.linear_attn(
                 hidden_states=hidden_states,
                 cache_params=past_key_values,
                 cache_position=cache_position,
                 attention_mask=attention_mask,
-                cu_seq_lens_q=cu_seq_lens_q,
+                cu_seq_lens_q=linear_attn_cu_seq_lens_q,
             )
         elif self.layer_type == "full_attention":
             # Self Attention

--- a/veomni/models/transformers/qwen3_5_moe/qwen3_5_moe_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5_moe/qwen3_5_moe_gpu_patch_gen_config.py
@@ -813,16 +813,17 @@ def qwen3_5_moe_decoder_layer_forward_patched(
         "cu_seq_lens_q must be provided to support varlen Flash Linear Attention, varlen Conv1D,"
         "and to remove the full Flash Attention CPU-GPU sync."
     )
+    linear_attn_cu_seq_lens_q = kwargs.pop("linear_attn_cu_seq_lens_q", cu_seq_lens_q)
 
     # Token Mixer
     if self.layer_type == "linear_attention":
-        # Modification: pass cu_seq_lens_q through to Qwen3_5MoeGatedDeltaNet.forward.
+        # Modification: pass linear-attention cu_seqlens through to Qwen3_5MoeGatedDeltaNet.forward.
         hidden_states = self.linear_attn(
             hidden_states=hidden_states,
             cache_params=past_key_values,
             cache_position=cache_position,
             attention_mask=attention_mask,
-            cu_seq_lens_q=cu_seq_lens_q,
+            cu_seq_lens_q=linear_attn_cu_seq_lens_q,
         )
     elif self.layer_type == "full_attention":
         # Self Attention

--- a/veomni/utils/seqlen_pos_transform_utils.py
+++ b/veomni/utils/seqlen_pos_transform_utils.py
@@ -99,6 +99,27 @@ def prepare_fa_kwargs_from_position_ids(position_ids):
     return (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k)
 
 
+def coalesce_tail_padding_cu_seqlens(cu_seqlens: torch.Tensor, tail_padding_length: int = 0) -> torch.Tensor:
+    """
+    Coalesce per-token tail padding segments into one sequence segment.
+
+    ``position_ids == 0`` marks packed sequence boundaries. When a collator pads
+    the tail with zero position ids, the FlashAttention cu-seqlens intentionally
+    contains one synthetic 1-token segment per padding token. Some linear
+    attention kernels compile or allocate per segment, so forwarding those
+    padding-only boundaries can create many unnecessary kernel shapes. This
+    helper preserves the padded tensor length while presenting the tail padding
+    as one independent segment for linear-attention style kernels.
+    """
+    if tail_padding_length <= 0:
+        return cu_seqlens
+
+    total_length = cu_seqlens[-1:]
+    real_end = torch.clamp(total_length - tail_padding_length, min=0)
+    valid_cu_seqlens = cu_seqlens[cu_seqlens <= real_end]
+    return torch.unique_consecutive(torch.cat((valid_cu_seqlens, real_end, total_length)))
+
+
 def valid_seqlens_from_cu_seqlens(cu_seqlens: torch.Tensor) -> torch.Tensor:
     """
     cu_seqlens: shape (B+1,), monotonic non-decreasing.


### PR DESCRIPTION
### What does this PR do?

Fix Qwen3.5/Qwen3.5-MoE `pad_to_length=true` with sequence parallelism for the Gated DeltaNet path.

The previous `cu_seqlens` construction could contain duplicated tail-padding boundaries after Ulysses/SP chunking. FlashAttention can tolerate zero-length or padding-only packed segments, but the GDN/linear-attention path forwards those boundaries into FLA/FlashQLA kernels. This PR coalesces known tail-padding segments for linear-attention kernels while preserving the original FlashAttention kwargs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: internal Codebase MR https://code.byted.org/data/Open-VeOmni/merge_requests/167
- PR title follows `[{modules}] {type}: {description}` format.

### Test

- `git diff --check origin/main..HEAD` passed.
- `python3 -m py_compile veomni/data/data_collator.py tests/data/test_collators.py tests/data/test_prepare_fa_kwargs.py` passed.
- Internal focused unit test on the same patch: `tests/data/test_prepare_fa_kwargs.py`: 5 passed.
- H20 2x8, Qwen3.5-9B, seq=131072, Ulysses/SP=2, `pad_to_length=true`: FlashQLA passed 120 steps and FLA completed 150/150 steps in the same JobRun.
- A100 1x8 FLA 200-step serial comparison: `pad_to_length=true` preserved training loss and reduced step-time/GPU-utilization variance.

Evidence doc: https://bytedance.larkoffice.com/docx/YOBjd4DdGopuFox4G3gczvhDndc

### API and Usage Example

No user-facing API change. Existing `--train.pad_to_length true` now works for Qwen3.5/Qwen3.5-MoE GDN paths under sequence parallelism.

### Design & Code Changes

- Add a utility to coalesce duplicated tail-padding `cu_seqlens` boundaries for linear-attention/GDN packed inputs.
- Clamp the computed linear-attention tail padding length so negative values cannot propagate into sequence-parallel padding.
- Apply the coalesced boundaries only to the Qwen3.5/Qwen3.5-MoE GDN path.
- Keep FlashAttention kwargs compatible with the existing packed-input contract.
- Regenerate patched Qwen3.5/Qwen3.5-MoE model code and patch diffs.
- Extend data/packing tests for duplicated tail-padding and negative-tail-length guard cases.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
