### PR TITLE
[trainer] fix: skip NCCL destroy on normal trainer exit

### DIFF
--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -27,6 +27,7 @@ Features:
 """
 
 import json
+import os
 import queue
 import threading
 import warnings
@@ -67,6 +68,7 @@ from ..utils.device import (
     get_device_type,
     get_dist_comm_backend,
     get_torch_device,
+    is_nccl_backend,
     synchronize,
 )
 from ..utils.loss_utils import count_loss_token, mean_global_loss
@@ -747,8 +749,21 @@ class BaseTrainer(Stateful, ABC):
         self.on_step_end(loss=total_loss, loss_dict=total_loss_dict, grad_norm=grad_norm)
 
     def destroy_distributed(self):
+        if not dist.is_available() or not dist.is_initialized():
+            return
+
+        backend = dist.get_backend()
         helper.empty_cache()
         dist.barrier()
+
+        if is_nccl_backend(backend) and os.getenv("VEOMNI_DESTROY_NCCL_ON_EXIT", "0") != "1":
+            logger.info_rank0(
+                "Skipping explicit NCCL process-group destroy on normal trainer exit. "
+                "Set VEOMNI_DESTROY_NCCL_ON_EXIT=1 to restore the previous teardown behavior."
+            )
+            return
+
+        synchronize()
         dist.destroy_process_group()
 
     def train(self):

--- a/veomni/utils/device.py
+++ b/veomni/utils/device.py
@@ -100,9 +100,9 @@ def set_device(device: torch.types.Device) -> None:
     get_torch_device().set_device(device)
 
 
-def is_nccl_backend() -> bool:
+def is_nccl_backend(backend: str | None = None) -> bool:
     """Check if the distributed communication backend is NCCL."""
-    return get_dist_comm_backend() == "nccl"
+    return (backend or get_dist_comm_backend()) == "nccl"
 
 
 def is_hccl_backend() -> bool:


### PR DESCRIPTION
## Summary

Skip explicit NCCL process-group destruction during normal trainer shutdown by default.

Some distributed NCCL runs can complete training successfully and then fail during explicit process-group teardown after NCCL communicator destruction. This change keeps the existing cache cleanup and final barrier, but avoids the explicit NCCL destroy call on normal NCCL exit.

An escape hatch is kept for debugging or compatibility:

```bash
VEOMNI_DESTROY_NCCL_ON_EXIT=1
```

Non-NCCL backends and explicit NCCL destroy opt-in still synchronize before using the explicit destroy path.

## Validation

- Pre-commit hooks passed on commit.
- Ran distributed NCCL/FSDP2 smoke validation with checkpoint save enabled.
- Verified variants covering skip-destroy without final synchronize and skip-destroy with cache cleanup in the skip path.
- Verified the validation run completed training, saved checkpoints, printed the NCCL destroy skip message, and exited with code 0.