### PR TITLE
[ci, lora] test: add LoRA save/load case to NPU unit tests

### DIFF
--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -179,3 +179,9 @@ jobs:
       - name: Run utils tests
         run: |
           uv run --frozen pytest -v -s -x tests/utils/test_count_flops.py
+      - name: Run LoRA save/load test
+        # peft ships under the `npu` extra, so the earlier
+        # `uv sync --extra npu --group dev` step already installs it — no extra
+        # sync needed here.
+        run: |
+          uv run --frozen pytest -v -s -x tests/lora/test_lora_trainer_saveload.py

--- a/tests/lora/test_lora_trainer_saveload.py
+++ b/tests/lora/test_lora_trainer_saveload.py
@@ -1,5 +1,6 @@
 """
 LoRA checkpoint save/load test using BaseTrainer + toy Qwen3 model (FSDP2).
+Runs on both GPU and NPU CI (the NPU unit-test workflow runs this too).
 
 Flow:
   1. Train 3 steps with LoRA adapter.


### PR DESCRIPTION
## What
Run `tests/lora/test_lora_trainer_saveload.py` in the NPU unit test workflow so LoRA adapter save/load is covered on Ascend (previously GPU-only).

## Why
NPU had no LoRA coverage. peft already ships under the `npu` extra, so no extra sync step is needed (mirrors the GPU workflow).

## Changes
- `.github/workflows/npu_unit_tests.yml`: run the LoRA save/load test.
- `tests/lora/test_lora_trainer_saveload.py`: note in the module docstring that this test now runs on both GPU and NPU CI.

No toy-config ops overrides are needed: #863 auto-resolves GPU-default ops to NPU-compatible values at config-parse time (`moe_implementation` → `fused_npu`, `load_balancing_loss_implementation` → `eager` on Ascend).

