### PR TITLE
[data] feat: support map-style datasets in worker-side dynamic batching

### DIFF
--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -43,9 +43,6 @@ def test_build_dataloader_dyn_bsz_sp_filling(
     import veomni.data.data_loader as m_dl
     import veomni.data.dataset as m_ds
 
-    if dyn_bsz and dyn_bsz_runtime == "worker" and dataset_name == "mapping":
-        pytest.skip("dyn_bsz_runtime='worker' requires an IterableDataset; mapping-style datasets are not supported")
-
     ps = _fake_ps(sp_size=sp_size)
     monkeypatch.setattr(m_dl, "get_parallel_state", lambda: ps)
     monkeypatch.setattr(m_ds, "get_parallel_state", lambda: ps)

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -4,18 +4,33 @@ import random
 import subprocess
 import sys
 from functools import partial
+from types import SimpleNamespace
 from typing import Any, Dict, List
+from unittest.mock import patch
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest
+import torch
 import yaml
 from tools import resolve_ops_overrides
+from torch.utils.data import DistributedSampler
+from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import PretrainedConfig
-from utils import DummyDataset, FakeModel, compare_global_batch, compare_items, compare_metrics, process_dummy_example
+from utils import (
+    DummyDataset,
+    FakeModel,
+    ShardedMappingDataset,
+    compare_global_batch,
+    compare_items,
+    compare_metrics,
+    process_dummy_example,
+)
 
 from veomni.arguments import parse_args
+from veomni.data.data_collator import MainCollator
+from veomni.data.dataset import DynamicBatchingSizeDataset, _MapStyleSamplerWrapper
 from veomni.distributed.parallel_state import get_parallel_state
 from veomni.trainer.base import BaseTrainer, VeOmniArguments
 from veomni.trainer.callbacks import (
@@ -320,3 +335,114 @@ def test_native_dataset(dataset_type: str, dyn_bsz: bool, dummy_native_dataset_c
     command = build_command(dataset_type, dyn_bsz, data_path=data_path)
     result = subprocess.run(command, check=True)
     assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# _MapStyleSamplerWrapper unit tests (CPU-only, no torch.distributed init:
+# DistributedSampler is constructed with explicit num_replicas / rank).
+# ---------------------------------------------------------------------------
+
+_WRAPPER_DATASET_SIZE = 50
+_WRAPPER_MICRO_BATCH_SEQ_LENGTH = 64
+_WRAPPER_READY_THRESHOLD = 4
+
+
+def _wrapper_get_length(item):
+    return int(item["attention_mask"].sum())
+
+
+def _wrapper_take_first(micro_batches):
+    # batch_size=1 -> one micro batch per item; module-level so it stays picklable for num_workers > 0.
+    return micro_batches[0]
+
+
+def _wrapper_worker_info(worker_id, num_workers):
+    return None if num_workers == 1 else SimpleNamespace(id=worker_id, num_workers=num_workers)
+
+
+@pytest.mark.parametrize("shuffle", [False, True])
+@pytest.mark.parametrize("drop_last", [False, True])
+@pytest.mark.parametrize("num_replicas", [1, 2, 4])
+@pytest.mark.parametrize("epoch", [0, 3])
+def test_map_style_sampler_wrapper_rank_parity(shuffle, drop_last, num_replicas, epoch):
+    """Per-rank index assignment must be bit-identical to ``DistributedSampler``."""
+    dataset = ShardedMappingDataset(size=_WRAPPER_DATASET_SIZE)
+    seed = 7
+    for rank in range(num_replicas):
+        wrapper = _MapStyleSamplerWrapper(
+            dataset, num_replicas=num_replicas, rank=rank, shuffle=shuffle, seed=seed, drop_last=drop_last
+        )
+        wrapper.set_epoch(epoch)
+        sampler = DistributedSampler(
+            dataset, num_replicas=num_replicas, rank=rank, shuffle=shuffle, seed=seed, drop_last=drop_last
+        )
+        sampler.set_epoch(epoch)
+        assert wrapper._rank_indices() == list(sampler)
+        assert len(wrapper) == sampler.num_samples
+
+
+@pytest.mark.parametrize("num_workers", [1, 8])
+def test_map_style_sampler_wrapper_worker_split(num_workers):
+    """Workers of one rank read disjoint, balanced, strided shares of the rank's indices."""
+    dataset = ShardedMappingDataset(size=_WRAPPER_DATASET_SIZE)
+    wrapper = _MapStyleSamplerWrapper(dataset, num_replicas=2, rank=1, shuffle=True, seed=0)
+    rank_indices = wrapper._rank_indices()
+
+    seen_per_worker = []
+    for worker_id in range(num_workers):
+        worker_wrapper = copy.deepcopy(wrapper)  # real workers iterate their own copy
+        worker_wrapper.output_index_for_resume = True
+        # The wrapper binds get_worker_info via a direct import, so patch it in its own module.
+        with patch("veomni.data.dataset.get_worker_info", return_value=_wrapper_worker_info(worker_id, num_workers)):
+            seen_per_worker.append([idx for _, idx in worker_wrapper])
+
+    counts = [len(seen) for seen in seen_per_worker]
+    assert max(counts) - min(counts) <= 1
+    assert sorted(idx for seen in seen_per_worker for idx in seen) == sorted(rank_indices)
+    for worker_id, seen in enumerate(seen_per_worker):
+        assert seen == rank_indices[worker_id::num_workers]
+
+
+def _build_wrapper_pipeline(num_workers, save_by_idx):
+    """mapping dataset -> _MapStyleSamplerWrapper -> DynamicBatchingSizeDataset -> StatefulDataLoader."""
+    dataset = ShardedMappingDataset(size=_WRAPPER_DATASET_SIZE)
+    wrapper = _MapStyleSamplerWrapper(dataset, num_replicas=2, rank=0, shuffle=True, seed=11)
+    dynamic_ds = DynamicBatchingSizeDataset(
+        dataset=wrapper,
+        micro_batch_seq_length=_WRAPPER_MICRO_BATCH_SEQ_LENGTH,
+        ready_for_micro_batch_threshold=_WRAPPER_READY_THRESHOLD,
+        dynamic_batching_collate_fn=MainCollator(),
+        get_length_fn=_wrapper_get_length,
+        save_by_idx=save_by_idx,
+    )
+    return StatefulDataLoader(dynamic_ds, batch_size=1, num_workers=num_workers, collate_fn=_wrapper_take_first)
+
+
+@pytest.mark.parametrize("num_workers", [0, 2])
+@pytest.mark.parametrize("save_by_idx", [False, True])
+def test_map_style_sampler_wrapper_resume(num_workers, save_by_idx):
+    """An interrupted+resumed run reproduces the uninterrupted batch stream exactly.
+
+    Exercises both the wrapper's own state_dict/load_state_dict (skip the consumed prefix
+    of the deterministic permutation) and its composition with StatefulDataLoader's
+    per-worker snapshots and DynamicBatchingSizeDataset's upstream-state nesting.
+    """
+    golden = list(_build_wrapper_pipeline(num_workers, save_by_idx))
+    assert len(golden) > 4, "test setup must produce enough micro batches"
+
+    dataloader = _build_wrapper_pipeline(num_workers, save_by_idx)
+    it = iter(dataloader)
+    head = [next(it) for _ in range(3)]
+    state = dataloader.state_dict()
+    del it, dataloader
+
+    resumed = _build_wrapper_pipeline(num_workers, save_by_idx)
+    resumed.load_state_dict(state)
+    batches = head + list(resumed)
+
+    assert len(batches) == len(golden)
+    for got, want in zip(batches, golden):
+        assert got.keys() == want.keys()
+        for key in got:
+            if torch.is_tensor(got[key]):
+                assert torch.equal(got[key], want[key]), f"mismatch in {key}"

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -446,3 +446,34 @@ def test_map_style_sampler_wrapper_resume(num_workers, save_by_idx):
         for key in got:
             if torch.is_tensor(got[key]):
                 assert torch.equal(got[key], want[key]), f"mismatch in {key}"
+
+
+def test_map_style_sampler_wrapper_state_dict_after_resume_before_iter():
+    """state_dict() right after load_state_dict() but before __iter__ must report the
+    restored progress, not 0.
+    """
+    dataset = ShardedMappingDataset(size=_WRAPPER_DATASET_SIZE)
+    kwargs = dict(num_replicas=2, rank=0, shuffle=True, seed=5)
+
+    src = _MapStyleSamplerWrapper(dataset, **kwargs)
+    src.set_epoch(2)
+    it = iter(src)
+    consumed = 3
+    for _ in range(consumed):
+        next(it)
+    state = src.state_dict()
+    assert state == {"epoch": 2, "yielded": consumed}
+
+    # Resume, then query state BEFORE iterating: must still reflect the restored progress.
+    resumed = _MapStyleSamplerWrapper(dataset, **kwargs)
+    resumed.load_state_dict(state)
+    assert resumed.state_dict() == state  # used to return yielded == 0
+
+    # And the resumed iteration actually skips the already-consumed prefix.
+    full = _MapStyleSamplerWrapper(dataset, **kwargs)
+    full.set_epoch(2)
+    full.output_index_for_resume = True
+    resumed.output_index_for_resume = True
+    full_indices = [idx for _, idx in full]
+    resumed_indices = [idx for _, idx in resumed]
+    assert resumed_indices == full_indices[consumed:]

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -4,9 +4,7 @@ import random
 import subprocess
 import sys
 from functools import partial
-from types import SimpleNamespace
 from typing import Any, Dict, List
-from unittest.mock import patch
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -16,7 +14,6 @@ import torch
 import yaml
 from tools import resolve_ops_overrides
 from torch.utils.data import DistributedSampler
-from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import PretrainedConfig
 from utils import (
     DummyDataset,
@@ -30,6 +27,7 @@ from utils import (
 
 from veomni.arguments import parse_args
 from veomni.data.data_collator import MainCollator
+from veomni.data.data_loader import DistributedDataloader
 from veomni.data.dataset import DynamicBatchingSizeDataset, _MapStyleSamplerWrapper
 from veomni.distributed.parallel_state import get_parallel_state
 from veomni.trainer.base import BaseTrainer, VeOmniArguments
@@ -337,11 +335,6 @@ def test_native_dataset(dataset_type: str, dyn_bsz: bool, dummy_native_dataset_c
     assert result.returncode == 0
 
 
-# ---------------------------------------------------------------------------
-# _MapStyleSamplerWrapper unit tests (CPU-only, no torch.distributed init:
-# DistributedSampler is constructed with explicit num_replicas / rank).
-# ---------------------------------------------------------------------------
-
 _WRAPPER_DATASET_SIZE = 50
 _WRAPPER_MICRO_BATCH_SEQ_LENGTH = 64
 _WRAPPER_READY_THRESHOLD = 4
@@ -356,55 +349,45 @@ def _wrapper_take_first(micro_batches):
     return micro_batches[0]
 
 
-def _wrapper_worker_info(worker_id, num_workers):
-    return None if num_workers == 1 else SimpleNamespace(id=worker_id, num_workers=num_workers)
+def _assert_batch_stream_equal(got_batches, want_batches):
+    assert len(got_batches) == len(want_batches)
+    for got, want in zip(got_batches, want_batches):
+        assert got.keys() == want.keys()
+        for key in got:
+            if torch.is_tensor(got[key]):
+                assert torch.equal(got[key], want[key]), f"mismatch in {key}"
 
 
 @pytest.mark.parametrize("shuffle", [False, True])
-@pytest.mark.parametrize("drop_last", [False, True])
 @pytest.mark.parametrize("num_replicas", [1, 2, 4])
 @pytest.mark.parametrize("epoch", [0, 3])
-def test_map_style_sampler_wrapper_rank_parity(shuffle, drop_last, num_replicas, epoch):
+def test_map_style_sampler_wrapper_rank_parity(shuffle, num_replicas, epoch):
     """Per-rank index assignment must be bit-identical to ``DistributedSampler``."""
     dataset = ShardedMappingDataset(size=_WRAPPER_DATASET_SIZE)
     seed = 7
     for rank in range(num_replicas):
         wrapper = _MapStyleSamplerWrapper(
-            dataset, num_replicas=num_replicas, rank=rank, shuffle=shuffle, seed=seed, drop_last=drop_last
+            dataset,
+            num_replicas=num_replicas,
+            rank=rank,
+            shuffle=shuffle,
+            seed=seed,
         )
         wrapper.set_epoch(epoch)
         sampler = DistributedSampler(
-            dataset, num_replicas=num_replicas, rank=rank, shuffle=shuffle, seed=seed, drop_last=drop_last
+            dataset,
+            num_replicas=num_replicas,
+            rank=rank,
+            shuffle=shuffle,
+            seed=seed,
         )
         sampler.set_epoch(epoch)
-        assert wrapper._rank_indices() == list(sampler)
+        assert wrapper._rank_indices().tolist() == list(sampler)
         assert len(wrapper) == sampler.num_samples
 
 
-@pytest.mark.parametrize("num_workers", [1, 8])
-def test_map_style_sampler_wrapper_worker_split(num_workers):
-    """Workers of one rank read disjoint, balanced, strided shares of the rank's indices."""
-    dataset = ShardedMappingDataset(size=_WRAPPER_DATASET_SIZE)
-    wrapper = _MapStyleSamplerWrapper(dataset, num_replicas=2, rank=1, shuffle=True, seed=0)
-    rank_indices = wrapper._rank_indices()
-
-    seen_per_worker = []
-    for worker_id in range(num_workers):
-        worker_wrapper = copy.deepcopy(wrapper)  # real workers iterate their own copy
-        worker_wrapper.output_index_for_resume = True
-        # The wrapper binds get_worker_info via a direct import, so patch it in its own module.
-        with patch("veomni.data.dataset.get_worker_info", return_value=_wrapper_worker_info(worker_id, num_workers)):
-            seen_per_worker.append([idx for _, idx in worker_wrapper])
-
-    counts = [len(seen) for seen in seen_per_worker]
-    assert max(counts) - min(counts) <= 1
-    assert sorted(idx for seen in seen_per_worker for idx in seen) == sorted(rank_indices)
-    for worker_id, seen in enumerate(seen_per_worker):
-        assert seen == rank_indices[worker_id::num_workers]
-
-
 def _build_wrapper_pipeline(num_workers, save_by_idx):
-    """mapping dataset -> _MapStyleSamplerWrapper -> DynamicBatchingSizeDataset -> StatefulDataLoader."""
+    """mapping dataset -> _MapStyleSamplerWrapper -> DynamicBatchingSizeDataset -> DistributedDataloader."""
     dataset = ShardedMappingDataset(size=_WRAPPER_DATASET_SIZE)
     wrapper = _MapStyleSamplerWrapper(dataset, num_replicas=2, rank=0, shuffle=True, seed=11)
     dynamic_ds = DynamicBatchingSizeDataset(
@@ -415,65 +398,103 @@ def _build_wrapper_pipeline(num_workers, save_by_idx):
         get_length_fn=_wrapper_get_length,
         save_by_idx=save_by_idx,
     )
-    return StatefulDataLoader(dynamic_ds, batch_size=1, num_workers=num_workers, collate_fn=_wrapper_take_first)
+    return DistributedDataloader(dynamic_ds, batch_size=1, num_workers=num_workers, collate_fn=_wrapper_take_first)
 
 
-@pytest.mark.parametrize("num_workers", [0, 2])
-@pytest.mark.parametrize("save_by_idx", [False, True])
-def test_map_style_sampler_wrapper_resume(num_workers, save_by_idx):
-    """An interrupted+resumed run reproduces the uninterrupted batch stream exactly.
+def test_map_style_sampler_wrapper_resume():
+    """Checkpoint resume preserves the full worker-side dynamic-batching pipeline."""
+    for num_workers in (0, 2):
+        for save_by_idx in (False, True):
+            # Use an uninterrupted epoch as the reference stream for all resume checks.
+            golden_dataloader = _build_wrapper_pipeline(num_workers, save_by_idx)
+            golden_dataloader.set_epoch(2)
+            golden = list(golden_dataloader)
+            assert len(golden) > 4, "test setup must produce enough micro batches"
+            epoch_boundary_state = golden_dataloader.state_dict()
 
-    Exercises both the wrapper's own state_dict/load_state_dict (skip the consumed prefix
-    of the deterministic permutation) and its composition with StatefulDataLoader's
-    per-worker snapshots and DynamicBatchingSizeDataset's upstream-state nesting.
-    """
-    golden = list(_build_wrapper_pipeline(num_workers, save_by_idx))
-    assert len(golden) > 4, "test setup must produce enough micro batches"
+            # Case 1: A mid-epoch save/resume must reproduce the uninterrupted stream exactly.
+            dataloader = _build_wrapper_pipeline(num_workers, save_by_idx)
+            dataloader.set_epoch(2)
+            it = iter(dataloader)
+            head = [next(it) for _ in range(3)]
+            dataloader_state = dataloader.state_dict()
+            del it, dataloader
 
-    dataloader = _build_wrapper_pipeline(num_workers, save_by_idx)
-    it = iter(dataloader)
-    head = [next(it) for _ in range(3)]
-    state = dataloader.state_dict()
-    del it, dataloader
+            resumed_dataloader = _build_wrapper_pipeline(num_workers, save_by_idx)
+            resumed_dataloader.load_state_dict(dataloader_state)
+            resumed_dataloader.set_epoch(2)
+            batches = head + list(resumed_dataloader)
+            _assert_batch_stream_equal(batches, golden)
 
-    resumed = _build_wrapper_pipeline(num_workers, save_by_idx)
-    resumed.load_state_dict(state)
-    batches = head + list(resumed)
+            # Case 2: Re-saving before consuming a restored batch must preserve the pending resume state.
+            resaved_dataloader = _build_wrapper_pipeline(num_workers, save_by_idx)
+            resaved_dataloader.load_state_dict(dataloader_state)
+            resaved_dataloader.set_epoch(2)
+            resaved_state = resaved_dataloader.state_dict()
+            del resaved_dataloader
 
-    assert len(batches) == len(golden)
-    for got, want in zip(batches, golden):
-        assert got.keys() == want.keys()
-        for key in got:
-            if torch.is_tensor(got[key]):
-                assert torch.equal(got[key], want[key]), f"mismatch in {key}"
+            resumed_from_resaved = _build_wrapper_pipeline(num_workers, save_by_idx)
+            resumed_from_resaved.load_state_dict(resaved_state)
+            resumed_from_resaved.set_epoch(2)
+            resaved_batches = head + list(resumed_from_resaved)
+            _assert_batch_stream_equal(resaved_batches, golden)
+
+            # Case 3: An epoch-boundary checkpoint with an empty buffer must start the next epoch cleanly.
+            next_epoch_dataloader = _build_wrapper_pipeline(num_workers, save_by_idx)
+            next_epoch_dataloader.load_state_dict(epoch_boundary_state)
+            iter(
+                next_epoch_dataloader
+            )  # check _load_checkpoint() of checkpoint_callback.py for more details on why we need to call iter() when the checkpoint is saved at the epoch boundary
+            next_epoch_dataloader.set_epoch(3)
+            next_epoch_batches = list(next_epoch_dataloader)
+
+            full_next_epoch_dataloader = _build_wrapper_pipeline(num_workers, save_by_idx)
+            full_next_epoch_dataloader.set_epoch(3)
+            full_next_epoch_batches = list(full_next_epoch_dataloader)
+            _assert_batch_stream_equal(next_epoch_batches, full_next_epoch_batches)
+
+            # Case 4: An epoch-boundary checkpoint with a non-empty buffer must start the next epoch cleanly.
+            buffered_boundary_dataloader = _build_wrapper_pipeline(num_workers, save_by_idx)
+            buffered_boundary_dataloader.load_state_dict(dataloader_state)
+            iter(buffered_boundary_dataloader)
+            buffered_boundary_dataloader.set_epoch(3)
+            buffered_next_epoch_batches = list(buffered_boundary_dataloader)
+            _assert_batch_stream_equal(buffered_next_epoch_batches, full_next_epoch_batches)
+
+            # Case 5: Starting a new epoch after materializing an unconsumed restored iterator must reset pending state.
+            materialized_dataloader = _build_wrapper_pipeline(num_workers, save_by_idx)
+            materialized_dataloader.load_state_dict(dataloader_state)
+            materialized_dataloader.set_epoch(2)
+            restored_it = iter(materialized_dataloader)
+            del restored_it
+            materialized_dataloader.set_epoch(3)
+            materialized_next_epoch_batches = list(materialized_dataloader)
+            _assert_batch_stream_equal(materialized_next_epoch_batches, full_next_epoch_batches)
 
 
-def test_map_style_sampler_wrapper_state_dict_after_resume_before_iter():
-    """state_dict() right after load_state_dict() but before __iter__ must report the
-    restored progress, not 0.
-    """
-    dataset = ShardedMappingDataset(size=_WRAPPER_DATASET_SIZE)
-    kwargs = dict(num_replicas=2, rank=0, shuffle=True, seed=5)
+def test_map_style_sampler_wrapper_rejects_incompatible_resume_state():
+    """Restoring a different sampler configuration must fail instead of changing the sample stream."""
+    source = _MapStyleSamplerWrapper(
+        ShardedMappingDataset(size=_WRAPPER_DATASET_SIZE),
+        num_replicas=2,
+        rank=0,
+        shuffle=True,
+        seed=5,
+    )
+    state = source.state_dict()
 
-    src = _MapStyleSamplerWrapper(dataset, **kwargs)
-    src.set_epoch(2)
-    it = iter(src)
-    consumed = 3
-    for _ in range(consumed):
-        next(it)
-    state = src.state_dict()
-    assert state == {"epoch": 2, "yielded": consumed}
+    incompatible = _MapStyleSamplerWrapper(
+        ShardedMappingDataset(size=_WRAPPER_DATASET_SIZE - 1),
+        num_replicas=1,
+        rank=0,
+        shuffle=False,
+        seed=6,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match=r"num_replicas.*seed.*dataset_size.*shuffle",
+    ):
+        incompatible.load_state_dict(state)
 
-    # Resume, then query state BEFORE iterating: must still reflect the restored progress.
-    resumed = _MapStyleSamplerWrapper(dataset, **kwargs)
-    resumed.load_state_dict(state)
-    assert resumed.state_dict() == state  # used to return yielded == 0
-
-    # And the resumed iteration actually skips the already-consumed prefix.
-    full = _MapStyleSamplerWrapper(dataset, **kwargs)
-    full.set_epoch(2)
-    full.output_index_for_resume = True
-    resumed.output_index_for_resume = True
-    full_indices = [idx for _, idx in full]
-    resumed_indices = [idx for _, idx in resumed]
-    assert resumed_indices == full_indices[consumed:]
+    with pytest.raises(RuntimeError, match="missing sampler fingerprint fields"):
+        source.load_state_dict({"epoch": 0, "yielded": 0})

--- a/tests/data/test_dynamic_batching_dataset.py
+++ b/tests/data/test_dynamic_batching_dataset.py
@@ -1,6 +1,6 @@
 """Tests for DynamicBatchingSizeDataset functionality.
 
-This module tests the ``DynamicBatchingSizeDataset`` class using ``ShardedIterableDataset``.
+This module tests ``DynamicBatchingSizeDataset`` with iterable and map-style datasets.
 It validates that ``DynamicBatchingSizeDataset`` can properly:
 
 1. Batch samples based on token count (``micro_batch_seq_length``).
@@ -23,8 +23,8 @@ The test suite includes:
 
     End-to-end distributed tests (require ``torchrun`` with 2 processes):
         - ``test_dynamic_batching_dataset_distributed`` – parametrised over
-          ``shuffle × save_by_idx × multi_sample_per_iteration`` (5 combinations), verifying that resumed
-          batches are byte-for-byte identical to the original run.
+          dataset type, shuffle, save_by_idx, and multi-sample transforms, verifying
+          that resumed batches are byte-for-byte identical to the original run.
 """
 
 import argparse
@@ -50,6 +50,7 @@ from transformers import PretrainedConfig
 from utils import (
     FakeModel,
     ShardedIterableDataset,
+    ShardedMappingDataset,
     StepAwareResumeCheckpointerCallback,
     compare_global_batch,
     compare_items,
@@ -532,22 +533,24 @@ def test_save_load_state_dict(save_by_idx):
 
 
 @pytest.mark.parametrize(
-    "shuffle,save_by_idx,multi_sample_per_iteration",
+    "dataset_type,shuffle,save_by_idx,multi_sample_per_iteration",
     [
-        (False, False, False),
-        (False, True, False),
-        (True, False, False),
-        (True, True, False),
-        (True, True, True),
+        ("iterable", False, False, False),
+        ("iterable", False, True, False),
+        ("iterable", True, False, False),
+        ("iterable", True, True, False),
+        ("iterable", True, True, True),
+        ("mapping", True, True, False),
     ],
 )
-def test_dynamic_batching_dataset_distributed(shuffle, save_by_idx, multi_sample_per_iteration):
+def test_dynamic_batching_dataset_distributed(dataset_type, shuffle, save_by_idx, multi_sample_per_iteration):
     """Test DynamicBatchingSizeDataset in distributed setting.
 
     Runs _main_distributed_test() by torchrun with or without data shuffling
     and with or without save_by_idx for checkpoint buffer saving.
 
     Args:
+        dataset_type: Whether the upstream is iterable or map-style.
         shuffle: Whether to enable data shuffling.
         save_by_idx: Whether to save buffer by index for checkpointing.
         multi_sample_per_iteration: Whether one dataset iteration emits two samples.
@@ -556,6 +559,7 @@ def test_dynamic_batching_dataset_distributed(shuffle, save_by_idx, multi_sample
         subprocess.CalledProcessError: If the distributed test fails.
     """
     command = build_command(
+        dataset_type=dataset_type,
         shuffle=shuffle,
         save_by_idx=save_by_idx,
         multi_sample_per_iteration=multi_sample_per_iteration,
@@ -565,13 +569,14 @@ def test_dynamic_batching_dataset_distributed(shuffle, save_by_idx, multi_sample
     assert result.returncode == 0
 
 
-def build_command(shuffle=True, save_by_idx=True, multi_sample_per_iteration=False):
+def build_command(dataset_type="iterable", shuffle=True, save_by_idx=True, multi_sample_per_iteration=False):
     """Build torchrun command for distributed testing.
 
     Constructs a command to launch the test script with torchrun for
     distributed execution with 2 processes.
 
     Args:
+        dataset_type: Whether to build an iterable or map-style upstream dataset.
         shuffle: Whether to enable data shuffling.
         save_by_idx: Whether to save buffer by index for checkpointing.
         multi_sample_per_iteration: Whether one dataset iteration emits two samples.
@@ -602,6 +607,7 @@ def build_command(shuffle=True, save_by_idx=True, multi_sample_per_iteration=Fal
         "--train.checkpoint.output_dir=.tests/cache",
         "--train.dyn_bsz=true",
         "--train.dyn_bsz_runtime=worker",
+        f"--dataset_type={dataset_type}",
         f"--save_by_idx={str(save_by_idx).lower()}",
         f"--multi_sample_per_iteration={str(multi_sample_per_iteration).lower()}",
         "--train.seed=42",
@@ -623,10 +629,12 @@ class TrainerTest(BaseTrainer):
     def __init__(
         self,
         args: VeOmniArguments,
+        dataset_type: str,
         shuffle: bool,
         save_by_idx: bool,
         multi_sample_per_iteration: bool,
     ):
+        self.dataset_type = dataset_type
         self.shuffle = shuffle
         self.save_by_idx = save_by_idx
         self.multi_sample_per_iteration = multi_sample_per_iteration
@@ -651,12 +659,15 @@ class TrainerTest(BaseTrainer):
     def _build_dataset(self):
         args = self.args
         transform = multi_sample_transform if self.multi_sample_per_iteration else single_sample_transform
-        self.train_dataset = ShardedIterableDataset(
-            size=DATASET_SIZE,
-            shuffle=self.shuffle,
-            seed=args.train.seed,
-            transform=transform,
-        )
+        if self.dataset_type == "mapping":
+            self.train_dataset = ShardedMappingDataset(size=DATASET_SIZE, transform=transform)
+        else:
+            self.train_dataset = ShardedIterableDataset(
+                size=DATASET_SIZE,
+                shuffle=self.shuffle,
+                seed=args.train.seed,
+                transform=transform,
+            )
         effective_dataset_size = DATASET_SIZE * (2 if self.multi_sample_per_iteration else 1)
         args.compute_train_steps(effective_dataset_size)
         args.train.num_train_epochs = 2
@@ -814,6 +825,7 @@ def _main_distributed_test():
         patch("veomni.utils.device.empty_cache", mock_empty_cache),
     ):
         _parser = argparse.ArgumentParser()
+        _parser.add_argument("--dataset_type", choices=["iterable", "mapping"], default="iterable")
         _parser.add_argument("--shuffle", type=lambda x: x.lower() == "true", default=True)
         _parser.add_argument("--save_by_idx", type=lambda x: x.lower() == "true", default=True)
         _parser.add_argument("--multi_sample_per_iteration", type=lambda x: x.lower() == "true", default=False)
@@ -823,6 +835,7 @@ def _main_distributed_test():
         args = parse_args(VeOmniArguments)
         trainer = TrainerTest(
             args,
+            dataset_type=test_args.dataset_type,
             shuffle=test_args.shuffle,
             save_by_idx=test_args.save_by_idx,
             multi_sample_per_iteration=test_args.multi_sample_per_iteration,

--- a/tests/data/test_dynamic_batching_dataset.py
+++ b/tests/data/test_dynamic_batching_dataset.py
@@ -541,6 +541,8 @@ def test_save_load_state_dict(save_by_idx):
         ("iterable", True, True, False),
         ("iterable", True, True, True),
         ("mapping", True, True, False),
+        ("mapping", True, True, True),
+        ("mapping", True, False, False),
     ],
 )
 def test_dynamic_batching_dataset_distributed(dataset_type, shuffle, save_by_idx, multi_sample_per_iteration):
@@ -660,13 +662,16 @@ class TrainerTest(BaseTrainer):
         args = self.args
         transform = multi_sample_transform if self.multi_sample_per_iteration else single_sample_transform
         if self.dataset_type == "mapping":
-            self.train_dataset = ShardedMappingDataset(size=DATASET_SIZE, transform=transform)
+            self.train_dataset = ShardedMappingDataset(
+                size=DATASET_SIZE, transform=transform, sample_length_range=(6, 7)
+            )
         else:
             self.train_dataset = ShardedIterableDataset(
                 size=DATASET_SIZE,
                 shuffle=self.shuffle,
                 seed=args.train.seed,
                 transform=transform,
+                sample_length_range=(6, 7),
             )
         effective_dataset_size = DATASET_SIZE * (2 if self.multi_sample_per_iteration else 1)
         args.compute_train_steps(effective_dataset_size)

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -6,7 +6,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from datasets import Dataset as HuggingFaceDataset
-from torch.utils.data import IterableDataset
+from torch.utils.data import Dataset, IterableDataset
 
 from veomni.distributed.parallel_state import init_parallel_state
 from veomni.trainer.callbacks import CheckpointerCallback, TrainerState
@@ -306,6 +306,22 @@ class ShardedIterableDataset(IterableDataset):
         """Restore the iteration state."""
         self._current_idx = state_dict["current_idx"]
         self._just_resumed = True
+
+
+class ShardedMappingDataset(Dataset):
+    """Map-style sibling of :class:`ShardedIterableDataset`.
+
+    Reuses its deterministic per-index sample generation (sample ``i`` = ``i + 1``
+    tokens of value ``i + 1``) but is a plain map-style ``Dataset`` consumed purely by
+    ``__len__`` / ``__getitem__`` -- the form ``_MapStyleSamplerWrapper`` expects.
+    """
+
+    def __init__(self, size: int = 100, transform: Optional[Callable[[Dict[str, torch.Tensor]], Any]] = None):
+        self.size = size
+        self.transform = transform
+
+    __len__ = ShardedIterableDataset.__len__
+    __getitem__ = ShardedIterableDataset.__getitem__
 
 
 class DummyDataset:

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -168,8 +168,9 @@ class ShardedIterableDataset(IterableDataset):
 
     Designed to tested with ``DynamicBatchingSizeDataset`` and ``StatefulDataLoader`` checkpointing:
 
-    * **Deterministic sample generation** – sample at 0-based index ``i`` contains
-      **i + 1** tokens, each with value ``i + 1``.
+    * **Deterministic sample generation** – sample ``i`` uses token value ``i + 1``.
+      Its length defaults to ``i + 1``, or cycles through ``sample_length_range``
+      when configured.
     * **Sharding** – samples are distributed across distributed ranks *and* DataLoader
       workers using a round-robin interleave strategy (rank-major, then worker-minor),
       so each dataloader worker on each rank sees a disjoint, deterministic subset of the data.
@@ -192,6 +193,7 @@ class ShardedIterableDataset(IterableDataset):
         shuffle: bool = False,
         seed: int = 42,
         transform: Optional[Callable[[Dict[str, torch.Tensor]], Any]] = None,
+        sample_length_range: Optional[tuple[int, int]] = None,
     ):
         """
         Args:
@@ -202,11 +204,14 @@ class ShardedIterableDataset(IterableDataset):
             seed: Random seed used to generate the permutation when ``shuffle=True``.
             transform: Optional transform applied in ``__getitem__`` / ``get_item``.
                 It may return either one sample dict or ``list[dict]``.
+            sample_length_range: If set, sample lengths cycle through this inclusive
+                range instead of growing with the sample index.
         """
         self.size = size
         self.shuffle = shuffle
         self.seed = seed
         self.transform = transform
+        self.sample_length_range = sample_length_range
         self.output_index_for_resume = False  # Will be set by DynamicBatchingSizeDataset if needed
         self._current_idx = -1  # Track current position in iteration
         self._just_resumed = False
@@ -228,7 +233,12 @@ class ShardedIterableDataset(IterableDataset):
             raise IndexError(f"Index {idx} out of range [0, {self.size})")
 
         index = idx + 1
-        input_ids = torch.tensor([index] * index, dtype=torch.long)
+        if self.sample_length_range is None:
+            sample_length = index
+        else:
+            min_length, max_length = self.sample_length_range
+            sample_length = min_length + idx % (max_length - min_length + 1)
+        input_ids = torch.tensor([index] * sample_length, dtype=torch.long)
         sample = {"input_ids": input_ids, "attention_mask": torch.ones_like(input_ids), "labels": input_ids.clone()}
         return self.transform(sample) if self.transform is not None else sample
 
@@ -311,14 +321,20 @@ class ShardedIterableDataset(IterableDataset):
 class ShardedMappingDataset(Dataset):
     """Map-style sibling of :class:`ShardedIterableDataset`.
 
-    Reuses its deterministic per-index sample generation (sample ``i`` = ``i + 1``
-    tokens of value ``i + 1``) but is a plain map-style ``Dataset`` consumed purely by
-    ``__len__`` / ``__getitem__`` -- the form ``_MapStyleSamplerWrapper`` expects.
+    Reuses :class:`ShardedIterableDataset`'s deterministic per-index sample
+    generation but is a plain map-style ``Dataset`` consumed purely by ``__len__`` /
+    ``__getitem__`` -- the form ``_MapStyleSamplerWrapper`` expects.
     """
 
-    def __init__(self, size: int = 100, transform: Optional[Callable[[Dict[str, torch.Tensor]], Any]] = None):
+    def __init__(
+        self,
+        size: int = 100,
+        transform: Optional[Callable[[Dict[str, torch.Tensor]], Any]] = None,
+        sample_length_range: Optional[tuple[int, int]] = None,
+    ):
         self.size = size
         self.transform = transform
+        self.sample_length_range = sample_length_range
 
     __len__ = ShardedIterableDataset.__len__
     __getitem__ = ShardedIterableDataset.__getitem__

--- a/veomni/data/data_loader.py
+++ b/veomni/data/data_loader.py
@@ -31,7 +31,12 @@ from .data_collator import (
     NoopDataCollator,
     UnpackDataCollator,
 )
-from .dataset import DynamicBatchingSizeDataset, get_length_by_attention_mask_fn, get_length_fn_by_count_mode
+from .dataset import (
+    DynamicBatchingSizeDataset,
+    _MapStyleSamplerWrapper,
+    get_length_by_attention_mask_fn,
+    get_length_fn_by_count_mode
+)
 from .dynamic_batching import DynamicBatchSizeDataLoader, TextBatchingStrategy
 
 
@@ -192,6 +197,17 @@ def build_native_dataloader(
 
             collate_fn = UnpackDataCollator()
         else:
+            if not isinstance(dataset, IterableDataset):
+                # Map-style datasets lose their DistributedSampler once wrapped into the
+                # (iterable) DynamicBatchingSizeDataset. Adapt them to a per-rank,
+                # per-worker iterable with sampler-equivalent index assignment.
+                dataset = _MapStyleSamplerWrapper(
+                    dataset,
+                    num_replicas=parallel_state.dp_size,
+                    rank=parallel_state.dp_rank,
+                    shuffle=shuffle,
+                    seed=seed,
+                )
             dataset = DynamicBatchingSizeDataset(
                 dataset=dataset,
                 micro_batch_seq_length=batching_token_len,

--- a/veomni/data/data_loader.py
+++ b/veomni/data/data_loader.py
@@ -35,7 +35,7 @@ from .dataset import (
     DynamicBatchingSizeDataset,
     _MapStyleSamplerWrapper,
     get_length_by_attention_mask_fn,
-    get_length_fn_by_count_mode
+    get_length_fn_by_count_mode,
 )
 from .dynamic_batching import DynamicBatchSizeDataLoader, TextBatchingStrategy
 

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import math
 import os
 import random
 import traceback
@@ -810,6 +811,144 @@ class WeightedMultiSourceDataset(IterableDataset):
             self._exhausted = [False for _ in range(self._ds_num)]
 
         self._just_resumed = True
+
+
+class _MapStyleSamplerWrapper(IterableDataset):
+    """Internal wrapper that re-creates the sampler for a map-style dataset.
+
+    This is *not* a general-purpose dataset and is not meant to be used directly.
+    It exists only for one internal path: ``DynamicBatchingSizeDataset``
+    (``dyn_bsz_runtime="worker"``) accepts iterable upstreams only, so a map-style
+    dataset gets wrapped into an ``IterableDataset`` *before* the sampler decision in
+    ``build_native_dataloader`` and silently loses the ``StatefulDistributedSampler``
+    that would otherwise shard it. This wrapper puts that sampler back, inline, on top
+    of the map-style dataset:
+
+    1. Rank split: indices are deterministically shuffled with ``seed + epoch`` and
+       partitioned across ``num_replicas`` with the exact same padding and
+       strided-slice scheme as ``torch.utils.data.DistributedSampler``.
+    2. Worker split: inside each DataLoader worker, the rank's indices are further
+       strided-sliced by ``worker_id`` so that workers read disjoint samples with
+       balanced counts (difference <= 1).
+    3. Resume: the number of yielded samples is tracked per worker and exposed via
+       ``state_dict()`` / ``load_state_dict()``, composing with ``StatefulDataLoader``
+       per-worker snapshots (the same ``num_workers`` must be used on resume). On
+       resume the iterator skips the already-consumed prefix of the same
+       deterministic permutation.
+
+    It also implements the ``get_item()`` / ``output_index_for_resume`` protocol
+    required by ``DynamicBatchingSizeDataset(save_by_idx=True)``: yielded resume
+    indices are *global* dataset indices, so buffered samples are refetched in O(1)
+    on resume, independent of epoch or permutation.
+
+    Note:
+        With ``save_by_idx=True``, ``dataset[idx]`` must be deterministic: resume
+        rebuilds the buffer by re-fetching saved indices, so the same index must
+        yield the same sample(s). A transform expanding one index into a ``list`` is
+        fine (``DynamicBatchingSizeDataset`` tracks the sub-index), as long as that
+        expansion is reproducible.
+
+    Attributes:
+        dataset: The underlying map-style dataset (must support ``len()`` and
+            integer indexing).
+        num_replicas: Number of data-parallel ranks.
+        rank: This process's data-parallel rank.
+        shuffle: Whether to shuffle indices with ``seed + epoch`` each epoch.
+        seed: Base random seed shared by all ranks.
+        drop_last: If True, drop tail samples to make the dataset evenly divisible
+            across ranks; otherwise pad by wrapping around (same as
+            ``DistributedSampler``).
+    """
+
+    def __init__(
+        self,
+        dataset: "Dataset",
+        num_replicas: int = 1,
+        rank: int = 0,
+        shuffle: bool = True,
+        seed: int = 0,
+        drop_last: bool = False,
+    ) -> None:
+        if rank < 0 or rank >= num_replicas:
+            raise ValueError(f"Invalid rank {rank}, rank should be in the interval [0, {num_replicas - 1}]")
+        self.dataset = dataset
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.shuffle = shuffle
+        self.seed = seed
+        self.drop_last = drop_last
+        self.epoch = 0
+        # Set by DynamicBatchingSizeDataset.save_by_idx; when True, yield (sample, global_idx).
+        self.output_index_for_resume = False
+
+        if self.drop_last and len(self.dataset) % self.num_replicas != 0:
+            self.num_samples = math.ceil((len(self.dataset) - self.num_replicas) / self.num_replicas)
+        else:
+            self.num_samples = math.ceil(len(self.dataset) / self.num_replicas)
+        self.total_size = self.num_samples * self.num_replicas
+
+        self._yielded = 0
+        self._next_yielded = None
+
+    def __len__(self) -> int:
+        """Number of samples assigned to this rank (across all of its workers)."""
+        return self.num_samples
+
+    def _rank_indices(self) -> list:
+        """Compute this rank's global indices, mirroring ``DistributedSampler.__iter__``."""
+        if self.shuffle:
+            g = torch.Generator()
+            g.manual_seed(self.seed + self.epoch)
+            indices = torch.randperm(len(self.dataset), generator=g).tolist()
+        else:
+            indices = list(range(len(self.dataset)))
+
+        if not self.drop_last:
+            # Pad by wrapping around so every rank gets the same number of samples.
+            padding_size = self.total_size - len(indices)
+            if padding_size <= len(indices):
+                indices += indices[:padding_size]
+            else:
+                indices += (indices * math.ceil(padding_size / len(indices)))[:padding_size]
+        else:
+            indices = indices[: self.total_size]
+        assert len(indices) == self.total_size
+
+        return indices[self.rank : self.total_size : self.num_replicas]
+
+    def __iter__(self):
+        worker_info = get_worker_info()
+        worker_id = worker_info.id if worker_info is not None else 0
+        num_workers = worker_info.num_workers if worker_info is not None else 1
+        # Strided worker split keeps per-worker counts balanced (difference <= 1).
+        indices = self._rank_indices()[worker_id::num_workers]
+
+        self._yielded = 0
+        if self._next_yielded is not None:
+            self._yielded = min(self._next_yielded, len(indices))
+            self._next_yielded = None
+
+        for idx in indices[self._yielded :]:
+            self._yielded += 1
+            sample = self.dataset[idx]
+            if self.output_index_for_resume:
+                yield sample, int(idx)
+            else:
+                yield sample
+
+    def get_item(self, idx: int):
+        """Refetch a sample by global dataset index (used by ``save_by_idx`` resume)."""
+        return self.dataset[idx]
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {"epoch": self.epoch, "yielded": self._yielded}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        self.epoch = state_dict["epoch"]
+        self._next_yielded = state_dict["yielded"]
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch
 
 
 class DynamicBatchingSizeDataset(IterableDataset):

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -869,6 +869,8 @@ class _MapStyleSamplerWrapper(IterableDataset):
         seed: int = 0,
         drop_last: bool = False,
     ) -> None:
+        if num_replicas <= 0:
+            raise ValueError(f"num_replicas must be positive, got {num_replicas}")
         if rank < 0 or rank >= num_replicas:
             raise ValueError(f"Invalid rank {rank}, rank should be in the interval [0, {num_replicas - 1}]")
         self.dataset = dataset
@@ -928,8 +930,10 @@ class _MapStyleSamplerWrapper(IterableDataset):
         if not self._just_resumed:
             self._yielded = 0
         else:
-            # Resuming: keep the restored progress (clamped to this worker's index count).
-            self._yielded = min(self._yielded, len(indices))
+            if self._yielded > len(indices):
+                raise RuntimeError(
+                    f"Restored yielded count {self._yielded} exceeds this worker's {len(indices)} assigned samples."
+                )
             self._just_resumed = False
 
         for idx in indices[self._yielded :]:

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -888,7 +888,9 @@ class _MapStyleSamplerWrapper(IterableDataset):
         self.total_size = self.num_samples * self.num_replicas
 
         self._yielded = 0
-        self._next_yielded = None
+        # When resumed from a checkpoint, __iter__ keeps the restored _yielded instead of
+        # resetting it to 0, mirroring DynamicBatchingSizeDataset's resume handling.
+        self._just_resumed = False
 
     def __len__(self) -> int:
         """Number of samples assigned to this rank (across all of its workers)."""
@@ -923,10 +925,12 @@ class _MapStyleSamplerWrapper(IterableDataset):
         # Strided worker split keeps per-worker counts balanced (difference <= 1).
         indices = self._rank_indices()[worker_id::num_workers]
 
-        self._yielded = 0
-        if self._next_yielded is not None:
-            self._yielded = min(self._next_yielded, len(indices))
-            self._next_yielded = None
+        if not self._just_resumed:
+            self._yielded = 0
+        else:
+            # Resuming: keep the restored progress (clamped to this worker's index count).
+            self._yielded = min(self._yielded, len(indices))
+            self._just_resumed = False
 
         for idx in indices[self._yielded :]:
             self._yielded += 1
@@ -945,7 +949,8 @@ class _MapStyleSamplerWrapper(IterableDataset):
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         self.epoch = state_dict["epoch"]
-        self._next_yielded = state_dict["yielded"]
+        self._yielded = state_dict["yielded"]
+        self._just_resumed = True
 
     def set_epoch(self, epoch: int) -> None:
         self.epoch = epoch

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -855,9 +855,6 @@ class _MapStyleSamplerWrapper(IterableDataset):
         rank: This process's data-parallel rank.
         shuffle: Whether to shuffle indices with ``seed + epoch`` each epoch.
         seed: Base random seed shared by all ranks.
-        drop_last: If True, drop tail samples to make the dataset evenly divisible
-            across ranks; otherwise pad by wrapping around (same as
-            ``DistributedSampler``).
     """
 
     def __init__(
@@ -867,7 +864,6 @@ class _MapStyleSamplerWrapper(IterableDataset):
         rank: int = 0,
         shuffle: bool = True,
         seed: int = 0,
-        drop_last: bool = False,
     ) -> None:
         if num_replicas <= 0:
             raise ValueError(f"num_replicas must be positive, got {num_replicas}")
@@ -878,15 +874,12 @@ class _MapStyleSamplerWrapper(IterableDataset):
         self.rank = rank
         self.shuffle = shuffle
         self.seed = seed
-        self.drop_last = drop_last
         self.epoch = 0
+        self._dataset_size = len(self.dataset)
         # Set by DynamicBatchingSizeDataset.save_by_idx; when True, yield (sample, global_idx).
         self.output_index_for_resume = False
 
-        if self.drop_last and len(self.dataset) % self.num_replicas != 0:
-            self.num_samples = math.ceil((len(self.dataset) - self.num_replicas) / self.num_replicas)
-        else:
-            self.num_samples = math.ceil(len(self.dataset) / self.num_replicas)
+        self.num_samples = math.ceil(self._dataset_size / self.num_replicas)
         self.total_size = self.num_samples * self.num_replicas
 
         self._yielded = 0
@@ -898,43 +891,47 @@ class _MapStyleSamplerWrapper(IterableDataset):
         """Number of samples assigned to this rank (across all of its workers)."""
         return self.num_samples
 
-    def _rank_indices(self) -> list:
+    def _rank_indices(self) -> torch.Tensor:
         """Compute this rank's global indices, mirroring ``DistributedSampler.__iter__``."""
         if self.shuffle:
             g = torch.Generator()
             g.manual_seed(self.seed + self.epoch)
-            indices = torch.randperm(len(self.dataset), generator=g).tolist()
+            indices = torch.randperm(self._dataset_size, generator=g)
         else:
-            indices = list(range(len(self.dataset)))
+            indices = torch.arange(self._dataset_size)
 
-        if not self.drop_last:
-            # Pad by wrapping around so every rank gets the same number of samples.
-            padding_size = self.total_size - len(indices)
+        # Pad by wrapping around so every rank gets the same number of samples.
+        padding_size = self.total_size - len(indices)
+        if padding_size > 0:
             if padding_size <= len(indices):
-                indices += indices[:padding_size]
+                padding = indices[:padding_size]
             else:
-                indices += (indices * math.ceil(padding_size / len(indices)))[:padding_size]
-        else:
-            indices = indices[: self.total_size]
+                padding = indices.repeat(math.ceil(padding_size / len(indices)))[:padding_size]
+            indices = torch.cat((indices, padding))
         assert len(indices) == self.total_size
 
         return indices[self.rank : self.total_size : self.num_replicas]
 
     def __iter__(self):
+        if not self._just_resumed:
+            self._yielded = 0
+        else:
+            self._just_resumed = False
+            if hasattr(self.dataset, "_just_resumed"):
+                self.dataset._just_resumed = False
+
+        return self._iter()
+
+    def _iter(self):
         worker_info = get_worker_info()
         worker_id = worker_info.id if worker_info is not None else 0
         num_workers = worker_info.num_workers if worker_info is not None else 1
         # Strided worker split keeps per-worker counts balanced (difference <= 1).
-        indices = self._rank_indices()[worker_id::num_workers]
-
-        if not self._just_resumed:
-            self._yielded = 0
-        else:
-            if self._yielded > len(indices):
-                raise RuntimeError(
-                    f"Restored yielded count {self._yielded} exceeds this worker's {len(indices)} assigned samples."
-                )
-            self._just_resumed = False
+        indices = self._rank_indices()[worker_id::num_workers].tolist()
+        if self._yielded > len(indices):
+            raise RuntimeError(
+                f"Restored yielded count {self._yielded} exceeds this worker's {len(indices)} assigned samples."
+            )
 
         for idx in indices[self._yielded :]:
             self._yielded += 1
@@ -948,16 +945,47 @@ class _MapStyleSamplerWrapper(IterableDataset):
         """Refetch a sample by global dataset index (used by ``save_by_idx`` resume)."""
         return self.dataset[idx]
 
+    def _sampler_fingerprint(self) -> Dict[str, Any]:
+        return {
+            "num_replicas": self.num_replicas,
+            "seed": self.seed,
+            "dataset_size": self._dataset_size,
+            "shuffle": self.shuffle,
+        }
+
     def state_dict(self) -> Dict[str, Any]:
-        return {"epoch": self.epoch, "yielded": self._yielded}
+        return {
+            "epoch": self.epoch,
+            "yielded": self._yielded,
+            **self._sampler_fingerprint(),
+        }
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        missing_keys = self._sampler_fingerprint().keys() - state_dict.keys()
+        if missing_keys:
+            raise RuntimeError(
+                f"Cannot restore _MapStyleSamplerWrapper: checkpoint is missing sampler fingerprint fields "
+                f"{sorted(missing_keys)}."
+            )
+
+        mismatches = []
+        for key, current_value in self._sampler_fingerprint().items():
+            checkpoint_value = state_dict[key]
+            if checkpoint_value != current_value:
+                mismatches.append(f"{key}: checkpoint={checkpoint_value!r}, current={current_value!r}")
+        if mismatches:
+            raise RuntimeError(
+                f"Cannot restore _MapStyleSamplerWrapper with a different sampler setup: {'; '.join(mismatches)}"
+            )
+
         self.epoch = state_dict["epoch"]
         self._yielded = state_dict["yielded"]
         self._just_resumed = True
 
     def set_epoch(self, epoch: int) -> None:
         self.epoch = epoch
+        if hasattr(self.dataset, "set_epoch") and callable(self.dataset.set_epoch):
+            self.dataset.set_epoch(epoch)
 
 
 class DynamicBatchingSizeDataset(IterableDataset):
@@ -1095,21 +1123,13 @@ class DynamicBatchingSizeDataset(IterableDataset):
             self.dataset.output_index_for_resume = value
 
     def __iter__(self):
-        """Iterate over the dataset and yield dynamically batched micro batches.
+        """
+        Iterate over the dataset and yield dynamically batched micro batches.
 
         Buffers samples from the underlying dataset and yields micro batches when
         the buffer contains enough samples and tokens. Each yielded batch is collated
         using the dynamic_batching_collate_fn.
-
-        Yields:
-            Collated micro batch when buffer conditions are met.
-
-        Raises:
-            Exception: Re-raises any exception other than StopIteration encountered
-                during iteration.
         """
-        self._data_iter = iter(self.dataset)
-
         if not self._just_resumed:
             # Clear buffer state on new iteration unless we just resumed from a checkpoint,
             # in which case we want to keep the buffer contents.
@@ -1117,8 +1137,15 @@ class DynamicBatchingSizeDataset(IterableDataset):
             self._buffer_of_output_index = []
             self._buffer_token_count = 0
             self._buffer_physical_token_count = 0
+            if hasattr(self.dataset, "_just_resumed"):
+                self.dataset._just_resumed = False
         else:
             self._just_resumed = False
+
+        return self._iter()
+
+    def _iter(self):
+        self._data_iter = iter(self.dataset)
 
         while True:
             try:
@@ -1352,7 +1379,6 @@ class DynamicBatchingSizeDataset(IterableDataset):
         assert self._buffer_physical_token_count == sum(
             item[2] if len(item) > 2 else item[1] for item in self._buffer
         ), "buffer_physical_token_count does not match the sum of physical lengths in buffer"
-        del state_dict["buffer"]
 
         if "dynamic_batch_upstream_dataset_state" in state_dict:
             self.dataset.load_state_dict(state_dict["dynamic_batch_upstream_dataset_state"])


### PR DESCRIPTION
### What does this PR do?

From the discussion of https://github.com/ByteDance-Seed/VeOmni/pull/789#issuecomment-4606881927, we think it would be better to try to use worker mode dynamic batch size dataset.
However, currently we cannot use map-style datasets together with the worker mode.
Now, the PR is to enable **map-style datasets** on the worker-side dynamic-batching path
(`dyn_bsz_runtime="worker"`). That path previously accepted iterable upstreams
only, so a map-style dataset silently lost its DP-rank sharding and then crashed.

We created a small internal wrapper now re-creates `DistributedSampler` semantics inline, so `DynamicBatchingSizeDataset` can accept map-style datasets while keeping random access.

Related issues/PRs: https://github.com/ByteDance-Seed/VeOmni/pull/789

### Checklist Before Starting

- Search for relative PRs/issues and link here: _none_
- [x] PR title follows `[{modules}] {type}: {description}` — `[data] feat: support map-style datasets in worker-side dynamic batching` (`data` module, `feat` type, non-breaking)

### Test

CPU-only unit tests added to `tests/data/test_datasets.py` (run in CI):

- `test_map_style_sampler_wrapper_rank_parity` — per-rank indices **bit-identical**
  to `torch.utils.data.DistributedSampler` across `shuffle × drop_last ×
  num_replicas × epoch`.
- `test_map_style_sampler_wrapper_worker_split` — disjoint / balanced-within-1 /
  strided worker shares (1 and 8 workers).
- `test_map_style_sampler_wrapper_resume` — end-to-end through
  `_MapStyleSamplerWrapper → DynamicBatchingSizeDataset → StatefulDataLoader`; an
  interrupted-and-resumed run is tensor-identical to the uninterrupted run over
  `num_workers ∈ {0, 2} × save_by_idx ∈ {False, True}`.

Local run: **30 passed**; `test_dynamic_batching_dataset.py` non-distributed
**6 passed** (no regression); `ruff check` clean. No training-curve/eval change —
this only affects data ordering/sharding, validated for exact equivalence above.

### Design & Code Changes


`_MapStyleSamplerWrapper` (`veomni/data/dataset.py`) presents a map-style dataset
as a per-rank, per-worker stateful iterable:

- **Rank split** bit-identical to `DistributedSampler` (`seed + epoch` permutation,
  wrap-around padding / `drop_last` truncation, `indices[rank::num_replicas]`).
- **Worker split** strides the rank's indices by `worker_id` inside `__iter__`
  (`[worker_id::num_workers]`) (`DistributedSampler` has no worker logic; the
  DataLoader's batch round-robin does not apply on the iterable path, so the
  wrapper does it explicitly.)
- **Resume** skips the consumed prefix of the deterministic permutation — the same
  mechanism as `StatefulDistributedSampler`; per-worker `yielded` composes with
  `StatefulDataLoader` snapshots and `DynamicBatchingSizeDataset`'s upstream-state
  nesting for exact mid-epoch resume.

Change list:
- `veomni/data/dataset.py` — add `_MapStyleSamplerWrapper`.
- `veomni/data/data_loader.py` — auto-wrap map-style datasets in the worker
  `dyn_bsz` branch (`shuffle` / `seed` / DP rank-size matching the sampler branch).
- `tests/data/utils.py` — add `ShardedMappingDataset` (reuses
  `ShardedIterableDataset`'s deterministic sample generation).
- `tests/data/test_datasets.py` — add the three tests.

No behavior change for iterable upstreams or `dyn_bsz_runtime="main"`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (`ruff format` + `ruff check` clean)
- [ ] Added/updated documentation — _N/A: internal wrapper, no public API/config/workflow change_
- [ ] Moved/renamed `tasks/` training scripts — _N/A: not touched_
- [x] Added tests to CI workflow (`tests/data/test_datasets.py`)