### PR TITLE
[ops] feat: stream all2all chunks to reduce FusedMoe with EP memory

### DIFF
--- a/veomni/distributed/moe/__init__.py
+++ b/veomni/distributed/moe/__init__.py
@@ -13,7 +13,15 @@
 # limitations under the License.
 
 
-from .moe_layer import EPGroupGemm, EPMergedFc1GroupGemm, preprocess, token_pre_all2all, tokens_post_all2all
+from .moe_layer import (
+    EPGroupGemm,
+    EPMergedFc1GroupGemm,
+    EPMergedFc1PostAllToAllGroupGemm,
+    preprocess,
+    token_pre_all2all,
+    tokens_post_all2all,
+)
+from .moe_utils import build_routing_map
 
 
 __all__ = [
@@ -22,4 +30,6 @@ __all__ = [
     "tokens_post_all2all",
     "EPGroupGemm",
     "EPMergedFc1GroupGemm",
+    "EPMergedFc1PostAllToAllGroupGemm",
+    "build_routing_map",
 ]

--- a/veomni/distributed/moe/moe_layer.py
+++ b/veomni/distributed/moe/moe_layer.py
@@ -283,15 +283,16 @@ def _weighted_unpermute_forward(
     output: torch.Tensor,
 ):
     hidden_dim = output.size(-1)
-    output.zero_()
+    fp32_output = torch.zeros(output.shape, device=output.device, dtype=torch.float32)
     for start in range(0, tokens.size(0), _UNPERMUTE_CHUNK_SIZE):
         end = min(start + _UNPERMUTE_CHUNK_SIZE, tokens.size(0))
         chunk_mapping = permutation_mapping[start:end]
-        output.scatter_add_(
+        fp32_output.scatter_add_(
             0,
             chunk_mapping.unsqueeze(1).expand(-1, hidden_dim),
-            (tokens[start:end] * tokens_weight[start:end].unsqueeze(-1)).to(output.dtype),
+            (tokens[start:end] * tokens_weight[start:end].unsqueeze(-1)).float(),
         )
+    output.copy_(fp32_output.to(output.dtype))
     return output
 
 
@@ -404,6 +405,8 @@ class EPMergedFc1PostAllToAllGroupGemm(torch.autograd.Function):
         hidden_chunk_size = ctx.hidden_chunk_size
         intermediate_dim = fc1_1_2_weight.shape[1] // 2
         fc2_weight_grad_arg_start = 17
+        if grad_output.dtype != permute_tokens.dtype:
+            grad_output = grad_output.to(permute_tokens.dtype)
 
         grad_routing_weights = torch.zeros_like(routing_weights) if ctx.needs_input_grad[1] else None
         grad_tokens_weight = torch.zeros_like(tokens_weight) if grad_routing_weights is not None else None
@@ -462,6 +465,8 @@ class EPMergedFc1PostAllToAllGroupGemm(torch.autograd.Function):
                 ctx.expert_output_splits,
                 ctx.unpermute_order,
             )
+            if grad_expert_full.dtype != permute_tokens.dtype:
+                grad_expert_full = grad_expert_full.to(permute_tokens.dtype)
 
             grad_fc2_weight_chunk = fc2_weight_grads[chunk_idx]
             for token_start, token_end in _iter_token_chunks(permute_tokens.shape[0]):
@@ -539,7 +544,7 @@ class EPMergedFc1PostAllToAllGroupGemm(torch.autograd.Function):
                 )
                 grad_tokens_weight.add_((grad_local * local_output).sum(dim=-1).to(tokens_weight.dtype))
 
-        grad_permute_tokens = permute_tokens
+        grad_permute_tokens = torch.empty_like(permute_tokens)
         for token_start, token_end in _iter_token_chunks(permute_tokens.shape[0]):
             chunk_cumsum = _chunk_cumsum(cumsum, token_start, token_end)
             permute_tokens_chunk = permute_tokens[token_start:token_end].clone()

--- a/veomni/distributed/moe/moe_layer.py
+++ b/veomni/distributed/moe/moe_layer.py
@@ -20,22 +20,148 @@ import torch.distributed as dist
 
 from ...utils.import_utils import is_torch_npu_available
 from .comm import all_to_all
-from .moe_utils import generate_weights_idx, permute, sort_chunks_by_idxs, unpermute
+from .moe_utils import (
+    generate_weights_idx,
+    get_permutation_mapping,
+    get_permuted_tokens_weight,
+    inverse_sort_chunks_by_idxs,
+    sort_chunks_by_idxs,
+    unpermute,
+)
 
 
 if not is_torch_npu_available():
-    from ...ops.kernels.moe._kernels.kernel.group_gemm import group_gemm_same_mn, group_gemm_same_nk
+    from ...ops.kernels.moe._kernels.kernel.group_gemm import (
+        group_gemm_same_mn,
+        group_gemm_same_nk,
+        group_gemm_same_nk_silu_gate_up,
+    )
+
+
+_POST_ALL2ALL_HIDDEN_CHUNK_SIZE = 32
+_PRE_ALL2ALL_HIDDEN_CHUNK_SIZE = 128
+_UNPERMUTE_CHUNK_SIZE = 8192
+_EP_MERGED_GROUP_GEMM_TOKEN_CHUNK_SIZE = 2048
+
+
+def _iter_token_chunks(total_tokens: int, chunk_size: int = _EP_MERGED_GROUP_GEMM_TOKEN_CHUNK_SIZE):
+    for start in range(0, total_tokens, chunk_size):
+        end = min(start + chunk_size, total_tokens)
+        yield start, end
+
+
+def _chunk_cumsum(cumsum: torch.Tensor, start: int, end: int) -> torch.Tensor:
+    return cumsum.clamp(min=start, max=end).sub(start)
+
+
+def _all_to_all_no_autograd(
+    group: dist.ProcessGroup,
+    input: torch.Tensor,
+    output_splits: list[int],
+    input_splits: list[int],
+) -> torch.Tensor:
+    if dist.get_world_size(group=group) == 1:
+        return input
+
+    input = input.contiguous()
+    output = torch.empty((sum(output_splits), input.size(1)), dtype=input.dtype, device=input.device)
+    dist.all_to_all_single(
+        output,
+        input,
+        output_split_sizes=output_splits,
+        input_split_sizes=input_splits,
+        group=group,
+    )
+    return output
+
+
+class _TokenPreAllToAll(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        local_input_permutation_mapping: torch.Tensor,
+        num_global_tokens_per_local_expert: torch.Tensor,
+        num_experts: int,
+        input_splits: list[int],
+        output_splits: list[int],
+        ep_group: dist.ProcessGroup,
+    ) -> torch.Tensor:
+        hidden_dim = hidden_states.size(-1)
+        num_local_experts = num_experts // ep_group.size()
+        permute_order = torch.arange(num_experts).reshape(-1, num_local_experts).T.ravel().tolist()
+        split_sizes = num_global_tokens_per_local_expert.ravel()
+
+        global_permuted_hidden_states = hidden_states.new_empty((sum(output_splits), hidden_dim))
+        for start in range(0, hidden_dim, _PRE_ALL2ALL_HIDDEN_CHUNK_SIZE):
+            end = min(start + _PRE_ALL2ALL_HIDDEN_CHUNK_SIZE, hidden_dim)
+            local_permuted_hidden_states = hidden_states[:, start:end].index_select(0, local_input_permutation_mapping)
+            global_permuted_chunk = _all_to_all_no_autograd(
+                ep_group,
+                local_permuted_hidden_states,
+                output_splits,
+                input_splits,
+            )
+            sort_chunks_by_idxs(
+                global_permuted_chunk,
+                split_sizes,
+                permute_order,
+                global_permuted_hidden_states[:, start:end],
+            )
+
+        ctx.num_experts = num_experts
+        ctx.input_splits = input_splits
+        ctx.output_splits = output_splits
+        ctx.ep_group = ep_group
+        ctx.hidden_states_shape = hidden_states.shape
+        ctx.permute_order = permute_order
+        ctx.split_sizes = split_sizes
+        ctx.save_for_backward(local_input_permutation_mapping)
+        return global_permuted_hidden_states
+
+    @staticmethod
+    def backward(ctx, grad_global_permuted_hidden_states: torch.Tensor):
+        (local_input_permutation_mapping,) = ctx.saved_tensors
+        hidden_states_shape = ctx.hidden_states_shape
+        hidden_dim = hidden_states_shape[-1]
+        grad_hidden_states = torch.zeros(
+            hidden_states_shape,
+            device=grad_global_permuted_hidden_states.device,
+            dtype=grad_global_permuted_hidden_states.dtype,
+        )
+
+        for start in range(0, hidden_dim, _PRE_ALL2ALL_HIDDEN_CHUNK_SIZE):
+            end = min(start + _PRE_ALL2ALL_HIDDEN_CHUNK_SIZE, hidden_dim)
+            grad_sorted_chunk = grad_global_permuted_hidden_states[:, start:end].contiguous()
+            grad_global_permuted_chunk = inverse_sort_chunks_by_idxs(
+                grad_sorted_chunk,
+                ctx.split_sizes,
+                ctx.permute_order,
+            )
+            grad_local_permuted_chunk = _all_to_all_no_autograd(
+                ctx.ep_group,
+                grad_global_permuted_chunk,
+                ctx.input_splits,
+                ctx.output_splits,
+            )
+            grad_hidden_states[:, start:end].scatter_add_(
+                0,
+                local_input_permutation_mapping.unsqueeze(1).expand(-1, end - start),
+                grad_local_permuted_chunk,
+            )
+
+        return grad_hidden_states, None, None, None, None, None, None
 
 
 def preprocess(
-    expert_mask: torch.Tensor,
+    selected_experts: torch.Tensor,
     num_experts: int,
     ep_group: dist.ProcessGroup,
 ) -> torch.Tensor:
     ep_size = ep_group.size()
     num_local_experts = num_experts // ep_size
     rank = dist.get_rank(ep_group)
-    num_local_tokens_per_expert = expert_mask.sum(dim=(1, 2))
+    num_local_tokens_per_expert = torch.bincount(selected_experts.reshape(-1), minlength=num_experts)
 
     # [ep_size] represent the number of sum tokens in each rank
     input_splits = num_local_tokens_per_expert.reshape(ep_size, num_local_experts).sum(dim=1).tolist()
@@ -71,7 +197,7 @@ def preprocess(
 
 def token_pre_all2all(
     hidden_states: torch.Tensor,
-    expert_mask: torch.Tensor,
+    routing_map: torch.Tensor,
     num_experts: int,
     input_splits: torch.Tensor,
     output_splits: torch.Tensor,
@@ -81,19 +207,16 @@ def token_pre_all2all(
     hidden_dim = hidden_states.size(-1)
     hidden_states = hidden_states.reshape(-1, hidden_dim)
     org_hidden_states_shape = hidden_states.shape
-    routing_map = expert_mask.sum(dim=1)
 
-    local_permuted_hidden_states, local_input_permutation_mapping = permute(hidden_states, routing_map)
-
-    global_permuted_hidden_states = all_to_all(ep_group, local_permuted_hidden_states, output_splits, input_splits)
-
-    # group tokens together by expert
-    num_local_experts = num_experts // ep_group.size()
-    permute_order = torch.arange(num_experts).reshape(-1, num_local_experts).T.ravel().tolist()
-    global_permuted_hidden_states = sort_chunks_by_idxs(
-        global_permuted_hidden_states,
-        num_global_tokens_per_local_expert.ravel(),
-        permute_order,
+    local_input_permutation_mapping = get_permutation_mapping(hidden_states.size(0), routing_map)
+    global_permuted_hidden_states = _TokenPreAllToAll.apply(
+        hidden_states,
+        local_input_permutation_mapping,
+        num_global_tokens_per_local_expert,
+        num_experts,
+        input_splits,
+        output_splits,
+        ep_group,
     )
 
     return global_permuted_hidden_states, routing_map, local_input_permutation_mapping, org_hidden_states_shape
@@ -112,29 +235,389 @@ def tokens_post_all2all(
     org_hidden_states_shape: torch.Size,
     ep_group: Optional[dist.ProcessGroup] = None,
 ) -> torch.Tensor:
-    # group tokens together by expert
     num_local_experts = num_experts // ep_group.size()
     unpermute_order = torch.arange(num_experts).reshape(num_local_experts, -1).T.ravel().tolist()
-    expert_outputs = sort_chunks_by_idxs(
-        expert_outputs,
-        num_global_tokens_per_local_expert.T.ravel(),
-        unpermute_order,
-    )
+    expert_output_splits = num_global_tokens_per_local_expert.T.ravel()
 
-    unpermute_outputs = all_to_all(ep_group, expert_outputs, input_splits, output_splits)
-
-    # [tokens, experts]
+    hidden_dim = expert_outputs.size(-1)
     weights_idx = generate_weights_idx(routing_weights, selected_experts, num_experts)
+    if hidden_dim <= _POST_ALL2ALL_HIDDEN_CHUNK_SIZE:
+        expert_outputs = sort_chunks_by_idxs(
+            expert_outputs,
+            expert_output_splits,
+            unpermute_order,
+        )
+        unpermute_outputs = all_to_all(ep_group, expert_outputs, input_splits, output_splits)
+        return unpermute(
+            unpermute_outputs,
+            weights_idx,
+            org_hidden_states_shape,
+            local_input_permutation_mapping,
+            routing_map,
+        )
 
-    unpermute_outputs = unpermute(
-        unpermute_outputs,
-        weights_idx,
-        org_hidden_states_shape,
-        local_input_permutation_mapping,
+    output = expert_outputs.new_empty(org_hidden_states_shape)
+    for start in range(0, hidden_dim, _POST_ALL2ALL_HIDDEN_CHUNK_SIZE):
+        end = min(start + _POST_ALL2ALL_HIDDEN_CHUNK_SIZE, hidden_dim)
+        expert_output_chunk = sort_chunks_by_idxs(
+            expert_outputs[:, start:end],
+            expert_output_splits,
+            unpermute_order,
+        )
+        chunk_outputs = all_to_all(ep_group, expert_output_chunk, input_splits, output_splits)
+        output[:, start:end] = unpermute(
+            chunk_outputs,
+            weights_idx,
+            torch.Size((org_hidden_states_shape[0], end - start)),
+            local_input_permutation_mapping,
+            routing_map,
+        )
+
+    return output
+
+
+def _weighted_unpermute_forward(
+    tokens: torch.Tensor,
+    tokens_weight: torch.Tensor,
+    permutation_mapping: torch.Tensor,
+    output: torch.Tensor,
+):
+    hidden_dim = output.size(-1)
+    output.zero_()
+    for start in range(0, tokens.size(0), _UNPERMUTE_CHUNK_SIZE):
+        end = min(start + _UNPERMUTE_CHUNK_SIZE, tokens.size(0))
+        chunk_mapping = permutation_mapping[start:end]
+        output.scatter_add_(
+            0,
+            chunk_mapping.unsqueeze(1).expand(-1, hidden_dim),
+            (tokens[start:end] * tokens_weight[start:end].unsqueeze(-1)).to(output.dtype),
+        )
+    return output
+
+
+def _routing_weight_indices(selected_experts: torch.Tensor, routing_map: torch.Tensor):
+    expert_indices, token_indices = routing_map.nonzero(as_tuple=True)
+    topk_match = selected_experts[token_indices] == expert_indices.unsqueeze(1)
+    topk_indices = topk_match.to(torch.int64).argmax(dim=1)
+    return token_indices, topk_indices
+
+
+class EPMergedFc1PostAllToAllGroupGemm(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        permute_tokens,
+        routing_weights,
+        selected_experts,
         routing_map,
-    )
+        local_input_permutation_mapping,
+        cumsum,
+        fc1_1_2_weight,
+        fc1_1_weight,
+        fc1_2_weight,
+        fc2_weight,
+        hidden_chunk_size: int,
+        num_experts: int,
+        input_splits,
+        output_splits,
+        num_global_tokens_per_local_expert,
+        org_hidden_states_shape,
+        ep_group,
+        *fc2_weight_chunks,
+    ):
+        del fc2_weight_chunks
+        hidden_dim = fc2_weight.shape[1]
+        num_local_experts = num_experts // ep_group.size()
+        unpermute_order = torch.arange(num_experts).reshape(num_local_experts, -1).T.ravel().tolist()
+        expert_output_splits = num_global_tokens_per_local_expert.T.ravel()
+        tokens_weight = get_permuted_tokens_weight(routing_weights, selected_experts, routing_map)
 
-    return unpermute_outputs
+        output = permute_tokens.new_empty(org_hidden_states_shape)
+        for hidden_start in range(0, hidden_dim, hidden_chunk_size):
+            hidden_end = min(hidden_start + hidden_chunk_size, hidden_dim)
+            fc2_weight_chunk = fc2_weight[:, hidden_start:hidden_end, :].contiguous()
+            expert_output_chunk = permute_tokens.new_empty((permute_tokens.shape[0], hidden_end - hidden_start))
+            for token_start, token_end in _iter_token_chunks(permute_tokens.shape[0]):
+                chunk_cumsum = _chunk_cumsum(cumsum, token_start, token_end)
+                fc1_result = group_gemm_same_nk_silu_gate_up(
+                    a=permute_tokens[token_start:token_end],
+                    b=fc1_1_2_weight,
+                    cumsum_M=chunk_cumsum,
+                    max_M=token_end - token_start,
+                )
+                expert_output_chunk[token_start:token_end].copy_(
+                    group_gemm_same_nk(
+                        a=fc1_result,
+                        b=fc2_weight_chunk,
+                        cumsum_M=chunk_cumsum,
+                        max_M=token_end - token_start,
+                        transpose_a=False,
+                        transpose_b=True,
+                    )
+                )
+
+            sorted_chunk = sort_chunks_by_idxs(expert_output_chunk, expert_output_splits, unpermute_order)
+            local_chunk = _all_to_all_no_autograd(ep_group, sorted_chunk, input_splits, output_splits)
+            _weighted_unpermute_forward(
+                local_chunk,
+                tokens_weight,
+                local_input_permutation_mapping,
+                output[:, hidden_start:hidden_end],
+            )
+
+        token_indices, topk_indices = _routing_weight_indices(selected_experts, routing_map)
+        ctx.hidden_chunk_size = hidden_chunk_size
+        ctx.num_fc2_weight_chunks = len(range(0, hidden_dim, hidden_chunk_size))
+        ctx.num_experts = num_experts
+        ctx.input_splits = input_splits
+        ctx.output_splits = output_splits
+        ctx.ep_group = ep_group
+        ctx.unpermute_order = unpermute_order
+        ctx.expert_output_splits = expert_output_splits
+        ctx.org_hidden_states_shape = org_hidden_states_shape
+        ctx.save_for_backward(
+            permute_tokens,
+            routing_weights,
+            token_indices,
+            topk_indices,
+            tokens_weight,
+            local_input_permutation_mapping,
+            cumsum,
+            fc1_1_2_weight,
+            fc2_weight,
+        )
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (
+            permute_tokens,
+            routing_weights,
+            token_indices,
+            topk_indices,
+            tokens_weight,
+            local_input_permutation_mapping,
+            cumsum,
+            fc1_1_2_weight,
+            fc2_weight,
+        ) = ctx.saved_tensors
+        hidden_chunk_size = ctx.hidden_chunk_size
+        intermediate_dim = fc1_1_2_weight.shape[1] // 2
+        fc2_weight_grad_arg_start = 17
+
+        grad_routing_weights = torch.zeros_like(routing_weights) if ctx.needs_input_grad[1] else None
+        grad_tokens_weight = torch.zeros_like(tokens_weight) if grad_routing_weights is not None else None
+
+        grad_fc1_1_weight = None
+        if ctx.needs_input_grad[7]:
+            grad_fc1_1_weight = torch.zeros(
+                (fc1_1_2_weight.shape[0], intermediate_dim, fc1_1_2_weight.shape[2]),
+                dtype=fc1_1_2_weight.dtype,
+                device=fc1_1_2_weight.device,
+            )
+
+        grad_fc1_2_weight = None
+        if ctx.needs_input_grad[8]:
+            grad_fc1_2_weight = torch.zeros(
+                (fc1_1_2_weight.shape[0], intermediate_dim, fc1_1_2_weight.shape[2]),
+                dtype=fc1_1_2_weight.dtype,
+                device=fc1_1_2_weight.device,
+            )
+
+        fc2_weight_grads = [None] * ctx.num_fc2_weight_chunks
+        for chunk_idx, hidden_start in enumerate(range(0, fc2_weight.shape[1], hidden_chunk_size)):
+            hidden_end = min(hidden_start + hidden_chunk_size, fc2_weight.shape[1])
+            if ctx.needs_input_grad[fc2_weight_grad_arg_start + chunk_idx]:
+                fc2_weight_grads[chunk_idx] = torch.zeros(
+                    (fc2_weight.shape[0], hidden_end - hidden_start, fc2_weight.shape[2]),
+                    dtype=fc2_weight.dtype,
+                    device=fc2_weight.device,
+                )
+
+        grad_fc1_result_all = torch.zeros(
+            (permute_tokens.shape[0], intermediate_dim),
+            dtype=permute_tokens.dtype,
+            device=permute_tokens.device,
+        )
+        for chunk_idx, hidden_start in enumerate(range(0, fc2_weight.shape[1], hidden_chunk_size)):
+            hidden_end = min(hidden_start + hidden_chunk_size, fc2_weight.shape[1])
+            fc2_weight_chunk = fc2_weight[:, hidden_start:hidden_end, :].contiguous()
+            grad_local = grad_output[:, hidden_start:hidden_end].index_select(0, local_input_permutation_mapping)
+
+            expert_output_chunk = (
+                permute_tokens.new_empty((permute_tokens.shape[0], hidden_end - hidden_start))
+                if grad_tokens_weight is not None
+                else None
+            )
+
+            grad_weighted_local = grad_local * tokens_weight.unsqueeze(-1)
+            grad_sorted = _all_to_all_no_autograd(
+                ctx.ep_group,
+                grad_weighted_local.contiguous(),
+                ctx.output_splits,
+                ctx.input_splits,
+            )
+            grad_expert_full = inverse_sort_chunks_by_idxs(
+                grad_sorted,
+                ctx.expert_output_splits,
+                ctx.unpermute_order,
+            )
+
+            grad_fc2_weight_chunk = fc2_weight_grads[chunk_idx]
+            for token_start, token_end in _iter_token_chunks(permute_tokens.shape[0]):
+                chunk_cumsum = _chunk_cumsum(cumsum, token_start, token_end)
+                grad_expert_chunk = grad_expert_full[token_start:token_end].contiguous()
+
+                if grad_fc2_weight_chunk is not None:
+                    fc1_result = group_gemm_same_nk_silu_gate_up(
+                        a=permute_tokens[token_start:token_end],
+                        b=fc1_1_2_weight,
+                        cumsum_M=chunk_cumsum,
+                        max_M=token_end - token_start,
+                    )
+                    if expert_output_chunk is not None:
+                        expert_output_chunk[token_start:token_end].copy_(
+                            group_gemm_same_nk(
+                                a=fc1_result,
+                                b=fc2_weight_chunk,
+                                cumsum_M=chunk_cumsum,
+                                max_M=token_end - token_start,
+                                transpose_a=False,
+                                transpose_b=True,
+                            )
+                        )
+                    group_gemm_same_mn(
+                        a=grad_expert_chunk,
+                        b=fc1_result,
+                        c=grad_fc2_weight_chunk,
+                        cumsum_K=chunk_cumsum,
+                        max_K=token_end - token_start,
+                        transpose_a=True,
+                        transpose_b=False,
+                        accumulate=True,
+                    )
+
+                elif expert_output_chunk is not None:
+                    fc1_result = group_gemm_same_nk_silu_gate_up(
+                        a=permute_tokens[token_start:token_end],
+                        b=fc1_1_2_weight,
+                        cumsum_M=chunk_cumsum,
+                        max_M=token_end - token_start,
+                    )
+                    expert_output_chunk[token_start:token_end].copy_(
+                        group_gemm_same_nk(
+                            a=fc1_result,
+                            b=fc2_weight_chunk,
+                            cumsum_M=chunk_cumsum,
+                            max_M=token_end - token_start,
+                            transpose_a=False,
+                            transpose_b=True,
+                        )
+                    )
+
+                grad_fc1_result_all[token_start:token_end].add_(
+                    group_gemm_same_nk(
+                        a=grad_expert_chunk,
+                        b=fc2_weight_chunk,
+                        cumsum_M=chunk_cumsum,
+                        max_M=token_end - token_start,
+                        transpose_b=False,
+                    )
+                )
+
+            if grad_tokens_weight is not None:
+                sorted_output = sort_chunks_by_idxs(
+                    expert_output_chunk,
+                    ctx.expert_output_splits,
+                    ctx.unpermute_order,
+                )
+                local_output = _all_to_all_no_autograd(
+                    ctx.ep_group,
+                    sorted_output,
+                    ctx.input_splits,
+                    ctx.output_splits,
+                )
+                grad_tokens_weight.add_((grad_local * local_output).sum(dim=-1).to(tokens_weight.dtype))
+
+        grad_permute_tokens = permute_tokens
+        for token_start, token_end in _iter_token_chunks(permute_tokens.shape[0]):
+            chunk_cumsum = _chunk_cumsum(cumsum, token_start, token_end)
+            permute_tokens_chunk = permute_tokens[token_start:token_end].clone()
+            grad_fc1_result = grad_fc1_result_all[token_start:token_end]
+
+            fc1_output = group_gemm_same_nk(
+                a=permute_tokens_chunk,
+                b=fc1_1_2_weight,
+                cumsum_M=chunk_cumsum,
+                max_M=token_end - token_start,
+                transpose_a=False,
+                transpose_b=True,
+            )
+            fc1_1_output, fc1_2_output = fc1_output.chunk(2, dim=-1)
+            fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
+            grad_fc1_2_output = fc1_1_activation * grad_fc1_result
+            grad_fc1_1_activation = grad_fc1_result * fc1_2_output
+            grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
+
+            if grad_fc1_1_weight is not None:
+                group_gemm_same_mn(
+                    a=grad_fc1_1_output,
+                    b=permute_tokens_chunk,
+                    c=grad_fc1_1_weight,
+                    cumsum_K=chunk_cumsum,
+                    max_K=token_end - token_start,
+                    transpose_a=True,
+                    transpose_b=False,
+                    accumulate=True,
+                )
+            if grad_fc1_2_weight is not None:
+                group_gemm_same_mn(
+                    a=grad_fc1_2_output,
+                    b=permute_tokens_chunk,
+                    c=grad_fc1_2_weight,
+                    cumsum_K=chunk_cumsum,
+                    max_K=token_end - token_start,
+                    transpose_a=True,
+                    transpose_b=False,
+                    accumulate=True,
+                )
+
+            grad_fc1_output = torch.empty_like(fc1_output)
+            grad_fc1_output[:, :intermediate_dim].copy_(grad_fc1_1_output)
+            grad_fc1_output[:, intermediate_dim:].copy_(grad_fc1_2_output)
+            grad_permute_tokens[token_start:token_end].copy_(
+                group_gemm_same_nk(
+                    a=grad_fc1_output,
+                    b=fc1_1_2_weight,
+                    cumsum_M=chunk_cumsum,
+                    max_M=token_end - token_start,
+                    transpose_b=False,
+                )
+            )
+
+        if grad_routing_weights is not None:
+            grad_routing_weights[token_indices, topk_indices] = grad_tokens_weight
+
+        return (
+            grad_permute_tokens,
+            grad_routing_weights,
+            None,
+            None,
+            None,
+            None,
+            None,
+            grad_fc1_1_weight,
+            grad_fc1_2_weight,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            *fc2_weight_grads,
+        )
 
 
 class EPGroupGemm(torch.autograd.Function):
@@ -174,7 +657,8 @@ class EPGroupGemm(torch.autograd.Function):
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
 
         # compute final result of linear layer fc1
-        fc1_output = fc1_1_activation * fc1_2_output
+        fc1_output = fc1_1_activation.mul_(fc1_2_output)
+        del fc1_1_output, fc1_2_output
 
         # weighted projection is outside this function
         # compute linear layer fc2
@@ -187,32 +671,33 @@ class EPGroupGemm(torch.autograd.Function):
             transpose_b=True,
         )
 
-        ctx.save_for_backward(
-            permute_tokens,
-            cumsum,
-            fc1_1_weight,
-            fc1_2_weight,
-            fc2_weight,
-            fc1_1_output,
-            fc1_2_output,
-        )
+        ctx.save_for_backward(permute_tokens, cumsum, fc1_1_weight, fc1_2_weight, fc2_weight)
 
         return fc2_output
 
     @staticmethod
     def backward(ctx, grad_output):
         # grad_output: [tokens, hidden_dim]
-        (
-            permute_tokens,
-            cumsum,
-            fc1_1_weight,
-            fc1_2_weight,
-            fc2_weight,
-            fc1_1_output,
-            fc1_2_output,
-        ) = ctx.saved_tensors
+        permute_tokens, cumsum, fc1_1_weight, fc1_2_weight, fc2_weight = ctx.saved_tensors
         # permute_tokens: [tokens, hidden_dim]
         # cumsum: [local_experts]
+
+        fc1_1_output = group_gemm_same_nk(
+            a=permute_tokens,
+            b=fc1_1_weight,
+            cumsum_M=cumsum,
+            max_M=permute_tokens.shape[0],
+            transpose_a=False,
+            transpose_b=True,
+        )
+        fc1_2_output = group_gemm_same_nk(
+            a=permute_tokens,
+            b=fc1_2_weight,
+            cumsum_M=cumsum,
+            max_M=permute_tokens.shape[0],
+            transpose_a=False,
+            transpose_b=True,
+        )
 
         # dgrad fc1
         grad_fc1_output = group_gemm_same_nk(
@@ -324,42 +809,32 @@ class EPMergedFc1GroupGemm(torch.autograd.Function):
             f"Merged fc1_1_2_weight dim 1 must be even, got {fc1_1_2_weight.shape[1]}"
         )
 
-        # Single fc1 gemm: output shape [T, 2I]
-        fc1_output = group_gemm_same_nk(
-            a=permute_tokens,
-            b=fc1_1_2_weight,
-            cumsum_M=cumsum,
-            max_M=permute_tokens.shape[0],
-            transpose_a=False,
-            transpose_b=True,
-        )
+        fc2_output = permute_tokens.new_empty((permute_tokens.shape[0], fc2_weight.shape[1]))
+        for start, end in _iter_token_chunks(permute_tokens.shape[0]):
+            chunk_cumsum = _chunk_cumsum(cumsum, start, end)
+            fc1_result = group_gemm_same_nk_silu_gate_up(
+                a=permute_tokens[start:end],
+                b=fc1_1_2_weight,
+                cumsum_M=chunk_cumsum,
+                max_M=end - start,
+            )
 
-        # chunk is a view, no copy
-        fc1_1_output, fc1_2_output = fc1_output.chunk(2, dim=-1)
-
-        # compute the activation of linear layer fc1-1
-        fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
-
-        # compute final result of linear layer fc1
-        fc1_result = fc1_1_activation * fc1_2_output
-
-        # compute linear layer fc2
-        fc2_output = group_gemm_same_nk(
-            a=fc1_result,
-            b=fc2_weight,
-            cumsum_M=cumsum,
-            max_M=permute_tokens.shape[0],
-            transpose_a=False,
-            transpose_b=True,
-        )
+            fc2_output[start:end].copy_(
+                group_gemm_same_nk(
+                    a=fc1_result,
+                    b=fc2_weight,
+                    cumsum_M=chunk_cumsum,
+                    max_M=end - start,
+                    transpose_a=False,
+                    transpose_b=True,
+                )
+            )
 
         ctx.save_for_backward(
             permute_tokens,
             cumsum,
             fc1_1_2_weight,
             fc2_weight,
-            fc1_1_output,
-            fc1_2_output,
         )
 
         return fc2_output
@@ -371,67 +846,88 @@ class EPMergedFc1GroupGemm(torch.autograd.Function):
             cumsum,
             fc1_1_2_weight,
             fc2_weight,
-            fc1_1_output,
-            fc1_2_output,
         ) = ctx.saved_tensors
 
-        # recompute
-        fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
-        fc1_result = fc1_1_activation * fc1_2_output
-
-        # dgrad fc2
-        grad_fc1_result = group_gemm_same_nk(
-            a=grad_output,
-            b=fc2_weight,
-            cumsum_M=cumsum,
-            max_M=grad_output.shape[0],
-            transpose_b=False,
-        )
-
-        # wgrad fc2
         grad_fc2_weight = None
         if fc2_weight.requires_grad:
             grad_fc2_weight = torch.empty_like(fc2_weight)
-            group_gemm_same_mn(
-                a=grad_output,
-                b=fc1_result,
-                c=grad_fc2_weight,
-                cumsum_K=cumsum,
-                max_K=grad_output.shape[0],
-                transpose_a=True,
-                transpose_b=False,
-            )
+            grad_fc2_weight.zero_()
 
-        # gate gradients
-        grad_fc1_2_output = fc1_1_activation * grad_fc1_result
-        grad_fc1_1_activation = grad_fc1_result * fc1_2_output
-        grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
-
-        # Merge grads back to [T, 2I]
-        grad_fc1_output = torch.cat([grad_fc1_1_output, grad_fc1_2_output], dim=-1)
-
-        # single dgrad for merged fc1
-        grad_permute_tokens = group_gemm_same_nk(
-            a=grad_fc1_output,
-            b=fc1_1_2_weight,
-            cumsum_M=cumsum,
-            max_M=grad_output.shape[0],
-            transpose_b=False,
-        )
-
-        # single wgrad for merged fc1
         grad_fc1_1_2_weight = None
         if fc1_1_2_weight.requires_grad:
             grad_fc1_1_2_weight = torch.empty_like(fc1_1_2_weight)
-            group_gemm_same_mn(
-                a=grad_fc1_output,
-                b=permute_tokens,
-                c=grad_fc1_1_2_weight,
-                cumsum_K=cumsum,
-                max_K=grad_output.shape[0],
-                transpose_a=True,
+            grad_fc1_1_2_weight.zero_()
+
+        grad_permute_tokens = torch.empty_like(permute_tokens)
+        for start, end in _iter_token_chunks(grad_output.shape[0]):
+            chunk_cumsum = _chunk_cumsum(cumsum, start, end)
+            permute_tokens_chunk = permute_tokens[start:end]
+            grad_output_chunk = grad_output[start:end]
+
+            fc1_result = group_gemm_same_nk_silu_gate_up(
+                a=permute_tokens_chunk,
+                b=fc1_1_2_weight,
+                cumsum_M=chunk_cumsum,
+                max_M=end - start,
+            )
+
+            if grad_fc2_weight is not None:
+                group_gemm_same_mn(
+                    a=grad_output_chunk,
+                    b=fc1_result,
+                    c=grad_fc2_weight,
+                    cumsum_K=chunk_cumsum,
+                    max_K=end - start,
+                    transpose_a=True,
+                    transpose_b=False,
+                    accumulate=True,
+                )
+
+            grad_fc1_result = group_gemm_same_nk(
+                a=grad_output_chunk,
+                b=fc2_weight,
+                cumsum_M=chunk_cumsum,
+                max_M=end - start,
                 transpose_b=False,
             )
+
+            fc1_output = group_gemm_same_nk(
+                a=permute_tokens_chunk,
+                b=fc1_1_2_weight,
+                cumsum_M=chunk_cumsum,
+                max_M=end - start,
+                transpose_a=False,
+                transpose_b=True,
+            )
+            fc1_1_output, fc1_2_output = fc1_output.chunk(2, dim=-1)
+            fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
+
+            grad_fc1_2_output = fc1_1_activation * grad_fc1_result
+            grad_fc1_1_activation = grad_fc1_result * fc1_2_output
+            grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
+            grad_fc1_output = torch.cat([grad_fc1_1_output, grad_fc1_2_output], dim=-1)
+
+            grad_permute_tokens[start:end].copy_(
+                group_gemm_same_nk(
+                    a=grad_fc1_output,
+                    b=fc1_1_2_weight,
+                    cumsum_M=chunk_cumsum,
+                    max_M=end - start,
+                    transpose_b=False,
+                )
+            )
+
+            if grad_fc1_1_2_weight is not None:
+                group_gemm_same_mn(
+                    a=grad_fc1_output,
+                    b=permute_tokens_chunk,
+                    c=grad_fc1_1_2_weight,
+                    cumsum_K=chunk_cumsum,
+                    max_K=end - start,
+                    transpose_a=True,
+                    transpose_b=False,
+                    accumulate=True,
+                )
 
         return (
             grad_permute_tokens,  # permute_tokens

--- a/veomni/distributed/moe/moe_utils.py
+++ b/veomni/distributed/moe/moe_utils.py
@@ -25,20 +25,42 @@ def permute(tokens: torch.Tensor, routing_map: torch.Tensor):
         routing_map (torch.Tensor): The sparse token to expert mapping, [num_experts, tokens].
 
     """
-    num_tokens, _ = tokens.shape
-    num_experts = routing_map.shape[0]
-
-    # mask [num_tokens, num_experts] -> [num_experts, num_tokens]
-    routing_map = routing_map.bool()
-
-    # Create a dense expert-to-token mapping from the sparse token-to-expert mapping
-    token_indices = torch.arange(num_tokens, device=routing_map.device).unsqueeze(0).expand(num_experts, -1)
-    sorted_indices = token_indices.masked_select(routing_map)
+    sorted_indices = get_permutation_mapping(tokens.size(0), routing_map)
 
     # use the mapping to permute the tokens
     permuted_input = tokens.index_select(0, sorted_indices)
 
     return permuted_input, sorted_indices
+
+
+def get_permutation_mapping(num_tokens: int, routing_map: torch.Tensor):
+    num_experts = routing_map.shape[0]
+    routing_map = routing_map.bool()
+    token_indices = torch.arange(num_tokens, device=routing_map.device).unsqueeze(0).expand(num_experts, -1)
+    return token_indices.masked_select(routing_map)
+
+
+def build_routing_map(selected_experts: torch.Tensor, num_experts: int) -> torch.Tensor:
+    num_tokens, top_k = selected_experts.shape
+    routing_map = torch.zeros(
+        (num_experts, num_tokens),
+        dtype=torch.bool,
+        device=selected_experts.device,
+    )
+    token_indices = torch.arange(num_tokens, device=selected_experts.device).unsqueeze(0).expand(top_k, -1)
+    routing_map[selected_experts.T.reshape(-1), token_indices.reshape(-1)] = True
+    return routing_map
+
+
+def get_permuted_tokens_weight(
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_map: torch.Tensor,
+) -> torch.Tensor:
+    expert_indices, token_indices = routing_map.nonzero(as_tuple=True)
+    topk_match = selected_experts[token_indices] == expert_indices.unsqueeze(1)
+    topk_indices = topk_match.to(torch.int64).argmax(dim=1)
+    return routing_weights[token_indices, topk_indices]
 
 
 def unpermute(
@@ -92,8 +114,48 @@ def generate_weights_idx(routing_weights: torch.Tensor, selected_experts: torch.
     return weights_idx
 
 
-def sort_chunks_by_idxs(input: torch.Tensor, split_sizes: torch.Tensor, sorted_idxs: torch.Tensor):
+def sort_chunks_by_idxs(input: torch.Tensor, split_sizes: torch.Tensor, sorted_idxs: torch.Tensor, output=None):
     """Split and sort the input tensor based on the split_sizes and sorted indices."""
-    input = torch.split(input, split_sizes.tolist(), dim=0)
-    output = torch.cat([input[i] for i in sorted_idxs], dim=0)
+    split_sizes = split_sizes.tolist()
+    if output is None:
+        output = torch.empty_like(input)
+
+    input_offsets = [0]
+    for split_size in split_sizes:
+        input_offsets.append(input_offsets[-1] + split_size)
+
+    output_offset = 0
+    for idx in sorted_idxs:
+        split_size = split_sizes[idx]
+        if split_size > 0:
+            input_start = input_offsets[idx]
+            input_end = input_start + split_size
+            output_end = output_offset + split_size
+            output[output_offset:output_end].copy_(input[input_start:input_end])
+            output_offset = output_end
+    return output
+
+
+def inverse_sort_chunks_by_idxs(
+    input: torch.Tensor, split_sizes: torch.Tensor, sorted_idxs: torch.Tensor, output=None
+):
+    """Undo sort_chunks_by_idxs for the same split sizes and sorted indices."""
+    split_sizes = split_sizes.tolist()
+    if output is None:
+        output = torch.empty_like(input)
+
+    input_offsets = [0]
+    for split_size in split_sizes:
+        input_offsets.append(input_offsets[-1] + split_size)
+
+    sorted_input_offset = 0
+    for idx in sorted_idxs:
+        split_size = split_sizes[idx]
+        if split_size > 0:
+            input_start = sorted_input_offset
+            input_end = input_start + split_size
+            output_start = input_offsets[idx]
+            output_end = output_start + split_size
+            output[output_start:output_end].copy_(input[input_start:input_end])
+            sorted_input_offset = input_end
     return output

--- a/veomni/ops/kernels/moe/_kernels/kernel/group_gemm.py
+++ b/veomni/ops/kernels/moe/_kernels/kernel/group_gemm.py
@@ -23,6 +23,7 @@ from ..utils.pretuned import algo_key_scaled, pretuned
 from .triton_utils.activation import (
     ActivationType,
     activation_fwd,
+    silu,
 )
 from .triton_utils.memory import (
     load_block_with_pred_2d,
@@ -234,6 +235,128 @@ def group_gemm_same_nk(
     return c
 
 
+@triton.heuristics(
+    values={
+        "N_ALIGNED": lambda args: args["N"] % args["BLOCK_N"] == 0,
+        "K_ALIGNED": lambda args: args["K"] % args["BLOCK_K"] == 0,
+    }
+)
+@triton.jit
+def group_gemm_same_nk_silu_gate_up_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    cumsum_M,
+    max_M,
+    total_M,  # Used for generating algo. key only.
+    G: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP: tl.constexpr,
+    N_ALIGNED: tl.constexpr,
+    K_ALIGNED: tl.constexpr,
+):
+    m, n = get_pid_mn(tl.program_id(axis=0), max_M, N, BLOCK_M, BLOCK_N, GROUP)
+    gid = tl.program_id(1).to(tl.uint64)
+    gtid_start = tl.load(cumsum_M + gid - 1, mask=gid > 0, other=0)
+    gtid_end = tl.load(cumsum_M + gid)
+    m_size = (gtid_end - gtid_start).to(tl.uint64)
+
+    if m * BLOCK_M >= m_size:
+        return
+
+    # b is a merged [G, 2N, K] tensor used as transposed B.  The first N columns
+    # are gate, and the second N columns are up.
+    a_ptr += gtid_start * K
+    b_gate_ptr = b_ptr + gid * K * (2 * N)
+    b_up_ptr = b_gate_ptr + N * K
+    c_ptr += gtid_start * N
+
+    offs_m = m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    offs_am = offs_m % m_size.to(tl.int64)
+    offs_bn = offs_n % N
+
+    blk_k = tl.arange(0, BLOCK_K)
+
+    a_ptrs = a_ptr + (offs_am[:, None] * K + blk_k[None, :])
+    b_gate_ptrs = b_gate_ptr + (blk_k[:, None] + offs_bn[None, :] * K)
+    b_up_ptrs = b_up_ptr + (blk_k[:, None] + offs_bn[None, :] * K)
+    c_ptrs = c_ptr + N * offs_m[:, None] + offs_n[None, :]
+
+    gate = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    up = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_K)):
+        a = load_with_pred_1d(a_ptrs, K_ALIGNED, blk_k[None, :] < K - k * BLOCK_K, other=0)
+        b_gate = load_with_pred_1d(b_gate_ptrs, K_ALIGNED, blk_k[:, None] < K - k * BLOCK_K, other=0)
+        b_up = load_with_pred_1d(b_up_ptrs, K_ALIGNED, blk_k[:, None] < K - k * BLOCK_K, other=0)
+
+        gate = tl.dot(a, b_gate, gate)
+        up = tl.dot(a, b_up, up)
+
+        a_ptrs += BLOCK_K
+        b_gate_ptrs += BLOCK_K
+        b_up_ptrs += BLOCK_K
+
+    gate = make_blocked(gate, c_ptr.dtype.element_ty)
+    up = make_blocked(up, c_ptr.dtype.element_ty)
+    c = silu(gate).to(c_ptr.dtype.element_ty) * up
+    store_with_pred_2d(c_ptrs, c, False, N_ALIGNED, offs_m[:, None] < m_size, offs_n[None, :] < N)
+
+
+def group_gemm_same_nk_silu_gate_up(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    cumsum_M: torch.Tensor,
+    max_M: int,
+):
+    """Grouped GEMM for merged gate/up weights.
+
+    Computes ``silu(a @ gate.T) * (a @ up.T)`` from merged ``b`` with shape
+    ``[G, 2N, K]`` without materializing the intermediate ``[T, 2N]`` tensor.
+    """
+    G, two_n, K = b.shape
+    assert two_n % 2 == 0, two_n
+    N = two_n // 2
+
+    assert a.dtype in [torch.bfloat16, torch.float16], a.dtype
+    assert b.dtype in [torch.bfloat16, torch.float16], b.dtype
+    assert a.device == b.device, f"a.device = {a.device}, b.device = {b.device}"
+    assert len(cumsum_M) == G
+    assert a.is_contiguous() and b.is_contiguous(), "Not implemented: Noncontiguous input."
+
+    c = torch.empty((a.shape[0], N), dtype=a.dtype, device=a.device)
+    with get_torch_device().device(a.device):
+        group_gemm_same_nk_silu_gate_up_kernel[
+            lambda x: (
+                triton.cdiv(max_M, x["BLOCK_M"]) * triton.cdiv(N, x["BLOCK_N"]),
+                x["G"],
+            )
+        ](
+            a_ptr=a,
+            b_ptr=b,
+            c_ptr=c,
+            cumsum_M=cumsum_M,
+            max_M=max_M,
+            total_M=a.shape[0],
+            G=G,
+            K=K,
+            N=N,
+            BLOCK_M=128,
+            BLOCK_N=128,
+            BLOCK_K=32,
+            GROUP=8,
+            num_warps=8,
+            num_stages=3,
+        )
+
+    return c
+
+
 # @triton.autotune(
 #     configs=_get_cuda_autotune_config(),
 #     key=["total_K", "M", "N"],
@@ -362,6 +485,7 @@ def group_gemm_same_mn(
     max_K: int,
     transpose_a: bool = False,
     transpose_b: bool = False,
+    accumulate: bool = False,
 ):
     G, M, N = c.shape
 
@@ -393,5 +517,5 @@ def group_gemm_same_mn(
             N=N,
             TRANSPOSE_A=transpose_a,
             TRANSPOSE_B=transpose_b,
-            ACCUMULATE_TO_C=False,
+            ACCUMULATE_TO_C=accumulate,
         )

--- a/veomni/ops/kernels/moe/group_gemm.py
+++ b/veomni/ops/kernels/moe/group_gemm.py
@@ -14,10 +14,20 @@
 
 import torch
 
-from ....distributed.moe import EPGroupGemm, EPMergedFc1GroupGemm, preprocess, token_pre_all2all, tokens_post_all2all
+from ....distributed.moe import (
+    EPGroupGemm,
+    EPMergedFc1PostAllToAllGroupGemm,
+    build_routing_map,
+    preprocess,
+    token_pre_all2all,
+    tokens_post_all2all,
+)
 from ....distributed.parallel_state import get_parallel_state
 from ._kernels.kernel.group_gemm import group_gemm_same_mn, group_gemm_same_nk
 from ._kernels.kernel.moe import expert_histogram, moe_gather, moe_scatter
+
+
+_EP_MERGED_POST_ALL2ALL_HIDDEN_CHUNK_SIZE = 128
 
 
 class TritonFusedMoeExpertFunction(torch.autograd.Function):
@@ -471,18 +481,18 @@ def group_gemm_fused_moe_forward(
         else:
             if fc1_1_weight is None or fc1_2_weight is None:
                 raise ValueError("EP requires split fc1 weights (fc1_1_weight and fc1_2_weight).")
-        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
+        routing_map = build_routing_map(selected_experts, num_experts)
         # preprocess, permute token for ep
         input_splits, output_splits, num_global_tokens_per_local_expert, num_global_sum_tokens_per_local_expert = (
             preprocess(
-                expert_mask=expert_mask,
+                selected_experts=selected_experts,
                 num_experts=num_experts,
                 ep_group=get_parallel_state().ep_group,
             )
         )
         permute_tokens, routing_map, local_input_permutation_mapping, org_hidden_states_shape = token_pre_all2all(
             hidden_states=hidden_states,
-            expert_mask=expert_mask,
+            routing_map=routing_map,
             num_experts=num_experts,
             input_splits=input_splits,
             output_splits=output_splits,
@@ -493,11 +503,33 @@ def group_gemm_fused_moe_forward(
         cumsum = torch.cumsum(num_global_sum_tokens_per_local_expert, dim=0).to(permute_tokens.device)
 
         if fc1_1_2_weight is not None:
-            final_permute_tokens = EPMergedFc1GroupGemm.apply(
+            hidden_dim = fc2_weight.shape[1]
+            intermediate_dim = fc1_1_2_weight.shape[1] // 2
+            fc1_1_weight = fc1_1_2_weight[:, :intermediate_dim, :]
+            fc1_2_weight = fc1_1_2_weight[:, intermediate_dim:, :]
+            fc2_weight_chunks = [
+                fc2_weight[:, start : start + _EP_MERGED_POST_ALL2ALL_HIDDEN_CHUNK_SIZE, :]
+                for start in range(0, hidden_dim, _EP_MERGED_POST_ALL2ALL_HIDDEN_CHUNK_SIZE)
+            ]
+            final_hidden_states = EPMergedFc1PostAllToAllGroupGemm.apply(
                 permute_tokens,
+                routing_weights,
+                selected_experts,
+                routing_map,
+                local_input_permutation_mapping,
                 cumsum,
                 fc1_1_2_weight,
+                fc1_1_weight,
+                fc1_2_weight,
                 fc2_weight,
+                _EP_MERGED_POST_ALL2ALL_HIDDEN_CHUNK_SIZE,
+                num_experts,
+                input_splits,
+                output_splits,
+                num_global_tokens_per_local_expert,
+                org_hidden_states_shape,
+                get_parallel_state().ep_group,
+                *fc2_weight_chunks,
             )
         else:
             final_permute_tokens = EPGroupGemm.apply(
@@ -508,20 +540,20 @@ def group_gemm_fused_moe_forward(
                 fc2_weight,
             )
 
-        # unpermute with routing_weight
-        final_hidden_states = tokens_post_all2all(
-            expert_outputs=final_permute_tokens,
-            routing_weights=routing_weights,
-            selected_experts=selected_experts,
-            num_experts=num_experts,
-            input_splits=input_splits,
-            output_splits=output_splits,
-            num_global_tokens_per_local_expert=num_global_tokens_per_local_expert,
-            routing_map=routing_map,
-            local_input_permutation_mapping=local_input_permutation_mapping,
-            org_hidden_states_shape=org_hidden_states_shape,
-            ep_group=get_parallel_state().ep_group,
-        )
+            # unpermute with routing_weight
+            final_hidden_states = tokens_post_all2all(
+                expert_outputs=final_permute_tokens,
+                routing_weights=routing_weights,
+                selected_experts=selected_experts,
+                num_experts=num_experts,
+                input_splits=input_splits,
+                output_splits=output_splits,
+                num_global_tokens_per_local_expert=num_global_tokens_per_local_expert,
+                routing_map=routing_map,
+                local_input_permutation_mapping=local_input_permutation_mapping,
+                org_hidden_states_shape=org_hidden_states_shape,
+                ep_group=get_parallel_state().ep_group,
+            )
     else:
         if fc1_1_2_weight is not None:
             if fc1_1_weight is not None or fc1_2_weight is not None:

--- a/veomni/ops/kernels/moe/quack_gemm.py
+++ b/veomni/ops/kernels/moe/quack_gemm.py
@@ -27,7 +27,7 @@ EP (Expert Parallelism) is supported for both split and merged fc1 weights.
 import torch
 from quack.gemm_interface import gemm
 
-from ....distributed.moe import preprocess, token_pre_all2all, tokens_post_all2all
+from ....distributed.moe import build_routing_map, preprocess, token_pre_all2all, tokens_post_all2all
 from ....distributed.parallel_state import get_parallel_state
 from ._kernels.kernel.moe import expert_histogram, moe_gather, moe_scatter
 
@@ -596,17 +596,17 @@ def quack_gemm_fused_moe_forward(
             if fc1_1_weight is None or fc1_2_weight is None:
                 raise ValueError("EP requires split fc1 weights (fc1_1_weight and fc1_2_weight).")
 
-        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
+        routing_map = build_routing_map(selected_experts, num_experts)
         input_splits, output_splits, num_global_tokens_per_local_expert, num_global_sum_tokens_per_local_expert = (
             preprocess(
-                expert_mask=expert_mask,
+                selected_experts=selected_experts,
                 num_experts=num_experts,
                 ep_group=get_parallel_state().ep_group,
             )
         )
         permute_tokens, routing_map, local_input_permutation_mapping, org_hidden_states_shape = token_pre_all2all(
             hidden_states=hidden_states,
-            expert_mask=expert_mask,
+            routing_map=routing_map,
             num_experts=num_experts,
             input_splits=input_splits,
             output_splits=output_splits,


### PR DESCRIPTION
## Summary
- stream the fused_triton EP merged-fc1 post-all2all path by hidden chunks to avoid materializing the full routed expert output
- add a fixed-meta fused grouped GEMM helper for merged gate/up weights
- keep split EP post-all2all weighting dense before unpermute and update shared routing-map callers

## Tests
- `ruff format` on changed files
- `python -m py_compile` on changed files
- focused EP merged-fc1 post-all2all correctness check
- 2-step fused_triton EP training smoke test