### PR TITLE
[model] feat: add LTX-2.3 source code

### DIFF
--- a/veomni/models/diffusers/ltx2_3/ltx_core/__init__.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/__init__.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+_ltx_core_parent = str(Path(__file__).resolve().parent.parent)
+if _ltx_core_parent not in sys.path:
+    sys.path.insert(0, _ltx_core_parent)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/components/patchifiers.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/components/patchifiers.py
@@ -1,0 +1,235 @@
+import math
+from typing import Optional, Tuple
+
+import einops
+import torch
+
+from ltx_core.components.protocols import Patchifier
+from ltx_core.types import AudioLatentShape, SpatioTemporalScaleFactors, VideoLatentShape
+
+
+class VideoLatentPatchifier(Patchifier):
+    def __init__(self, patch_size: int):
+        self._patch_size = (
+            1,
+            patch_size,
+            patch_size,
+        )
+
+    @property
+    def patch_size(self) -> Tuple[int, int, int]:
+        return self._patch_size
+
+    def get_token_count(self, tgt_shape: VideoLatentShape) -> int:
+        return math.prod(tgt_shape.to_torch_shape()[2:]) // math.prod(self._patch_size)
+
+    def patchify(
+        self,
+        latents: torch.Tensor,
+    ) -> torch.Tensor:
+        latents = einops.rearrange(
+            latents,
+            "b c (f p1) (h p2) (w p3) -> b (f h w) (c p1 p2 p3)",
+            p1=self._patch_size[0],
+            p2=self._patch_size[1],
+            p3=self._patch_size[2],
+        )
+
+        return latents
+
+    def unpatchify(
+        self,
+        latents: torch.Tensor,
+        output_shape: VideoLatentShape,
+    ) -> torch.Tensor:
+        assert self._patch_size[0] == 1
+
+        patch_grid_frames = output_shape.frames // self._patch_size[0]
+        patch_grid_height = output_shape.height // self._patch_size[1]
+        patch_grid_width = output_shape.width // self._patch_size[2]
+
+        latents = einops.rearrange(
+            latents,
+            "b (f h w) (c p q) -> b c f (h p) (w q)",
+            f=patch_grid_frames,
+            h=patch_grid_height,
+            w=patch_grid_width,
+            p=self._patch_size[1],
+            q=self._patch_size[2],
+        )
+
+        return latents
+
+    def get_patch_grid_bounds(
+        self,
+        output_shape: AudioLatentShape | VideoLatentShape,
+        device: Optional[torch.device] = None,
+    ) -> torch.Tensor:
+        if not isinstance(output_shape, VideoLatentShape):
+            raise ValueError("VideoLatentPatchifier expects VideoLatentShape when computing coordinates")
+
+        frames = output_shape.frames
+        height = output_shape.height
+        width = output_shape.width
+        batch_size = output_shape.batch
+
+        assert frames > 0
+        assert height > 0
+        assert width > 0
+        assert batch_size > 0
+
+        grid_coords = torch.meshgrid(
+            torch.arange(start=0, end=frames, step=self._patch_size[0], device=device),
+            torch.arange(start=0, end=height, step=self._patch_size[1], device=device),
+            torch.arange(start=0, end=width, step=self._patch_size[2], device=device),
+            indexing="ij",
+        )
+
+        patch_starts = torch.stack(grid_coords, dim=0)
+
+        patch_size_delta = torch.tensor(
+            self._patch_size,
+            device=patch_starts.device,
+            dtype=patch_starts.dtype,
+        ).view(3, 1, 1, 1)
+
+        patch_ends = patch_starts + patch_size_delta
+
+        latent_coords = torch.stack((patch_starts, patch_ends), dim=-1)
+
+        latent_coords = einops.repeat(
+            latent_coords,
+            "c f h w bounds -> b c (f h w) bounds",
+            b=batch_size,
+            bounds=2,
+        )
+
+        return latent_coords
+
+
+def get_pixel_coords(
+    latent_coords: torch.Tensor,
+    scale_factors: SpatioTemporalScaleFactors,
+    causal_fix: bool = False,
+) -> torch.Tensor:
+    broadcast_shape = [1] * latent_coords.ndim
+    broadcast_shape[1] = -1
+    scale_tensor = torch.tensor(
+        [scale_factors.time, scale_factors.height, scale_factors.width],
+        device=latent_coords.device,
+    ).view(*broadcast_shape)
+
+    pixel_coords = latent_coords * scale_tensor
+
+    if causal_fix:
+        pixel_coords[:, 0, ...] = (pixel_coords[:, 0, ...] + 1 - scale_factors.time).clamp(min=0)
+
+    return pixel_coords
+
+
+class AudioPatchifier(Patchifier):
+    def __init__(
+        self,
+        patch_size: int,
+        sample_rate: int = 16000,
+        hop_length: int = 160,
+        audio_latent_downsample_factor: int = 4,
+        is_causal: bool = True,
+        shift: int = 0,
+    ):
+        self.hop_length = hop_length
+        self.sample_rate = sample_rate
+        self.audio_latent_downsample_factor = audio_latent_downsample_factor
+        self.is_causal = is_causal
+        self.shift = shift
+        self._patch_size = (1, patch_size, patch_size)
+
+    @property
+    def patch_size(self) -> Tuple[int, int, int]:
+        return self._patch_size
+
+    def get_token_count(self, tgt_shape: AudioLatentShape) -> int:
+        return tgt_shape.frames
+
+    def _get_audio_latent_time_in_sec(
+        self,
+        start_latent: int,
+        end_latent: int,
+        dtype: torch.dtype,
+        device: Optional[torch.device] = None,
+    ) -> torch.Tensor:
+        if device is None:
+            device = torch.device("cpu")
+
+        audio_latent_frame = torch.arange(start_latent, end_latent, dtype=dtype, device=device)
+
+        audio_mel_frame = audio_latent_frame * self.audio_latent_downsample_factor
+
+        if self.is_causal:
+            causal_offset = 1
+            audio_mel_frame = (audio_mel_frame + causal_offset - self.audio_latent_downsample_factor).clip(min=0)
+
+        return audio_mel_frame * self.hop_length / self.sample_rate
+
+    def _compute_audio_timings(
+        self,
+        batch_size: int,
+        num_steps: int,
+        device: Optional[torch.device] = None,
+    ) -> torch.Tensor:
+        resolved_device = device
+        if resolved_device is None:
+            resolved_device = torch.device("cpu")
+
+        start_timings = self._get_audio_latent_time_in_sec(
+            self.shift,
+            num_steps + self.shift,
+            torch.float32,
+            resolved_device,
+        )
+        start_timings = start_timings.unsqueeze(0).expand(batch_size, -1).unsqueeze(1)
+
+        end_timings = self._get_audio_latent_time_in_sec(
+            self.shift + 1,
+            num_steps + self.shift + 1,
+            torch.float32,
+            resolved_device,
+        )
+        end_timings = end_timings.unsqueeze(0).expand(batch_size, -1).unsqueeze(1)
+
+        return torch.stack([start_timings, end_timings], dim=-1)
+
+    def patchify(
+        self,
+        audio_latents: torch.Tensor,
+    ) -> torch.Tensor:
+        audio_latents = einops.rearrange(
+            audio_latents,
+            "b c t f -> b t (c f)",
+        )
+
+        return audio_latents
+
+    def unpatchify(
+        self,
+        audio_latents: torch.Tensor,
+        output_shape: AudioLatentShape,
+    ) -> torch.Tensor:
+        audio_latents = einops.rearrange(
+            audio_latents,
+            "b t (c f) -> b c t f",
+            c=output_shape.channels,
+            f=output_shape.mel_bins,
+        )
+
+        return audio_latents
+
+    def get_patch_grid_bounds(
+        self,
+        output_shape: AudioLatentShape | VideoLatentShape,
+        device: Optional[torch.device] = None,
+    ) -> torch.Tensor:
+        if not isinstance(output_shape, AudioLatentShape):
+            raise ValueError("AudioPatchifier expects AudioLatentShape when computing coordinates")
+
+        return self._compute_audio_timings(output_shape.batch, output_shape.frames, device)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/components/protocols.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/components/protocols.py
@@ -1,0 +1,45 @@
+from typing import Protocol, Tuple
+
+import torch
+
+from ltx_core.types import AudioLatentShape, VideoLatentShape
+
+
+class Patchifier(Protocol):
+    def patchify(
+        self,
+        latents: torch.Tensor,
+    ) -> torch.Tensor: ...
+
+    def unpatchify(
+        self,
+        latents: torch.Tensor,
+        output_shape: AudioLatentShape | VideoLatentShape,
+    ) -> torch.Tensor: ...
+
+    @property
+    def patch_size(self) -> Tuple[int, int, int]: ...
+
+    def get_patch_grid_bounds(
+        self,
+        output_shape: AudioLatentShape | VideoLatentShape,
+        device: torch.device | None = None,
+    ) -> torch.Tensor: ...
+
+
+class SchedulerProtocol(Protocol):
+    def execute(self, steps: int, **kwargs) -> torch.FloatTensor: ...
+
+
+class GuiderProtocol(Protocol):
+    scale: float
+
+    def delta(self, cond: torch.Tensor, uncond: torch.Tensor) -> torch.Tensor: ...
+
+    def enabled(self) -> bool: ...
+
+
+class DiffusionStepProtocol(Protocol):
+    def step(
+        self, sample: torch.Tensor, denoised_sample: torch.Tensor, sigmas: torch.Tensor, step_index: int, **kwargs
+    ) -> torch.Tensor: ...

--- a/veomni/models/diffusers/ltx2_3/ltx_core/guidance/perturbations.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/guidance/perturbations.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+from enum import Enum
+
+import torch
+from torch._prims_common import DeviceLikeType
+
+
+class PerturbationType(Enum):
+    """Types of attention perturbations for STG (Spatio-Temporal Guidance)."""
+
+    SKIP_A2V_CROSS_ATTN = "skip_a2v_cross_attn"
+    SKIP_V2A_CROSS_ATTN = "skip_v2a_cross_attn"
+    SKIP_VIDEO_SELF_ATTN = "skip_video_self_attn"
+    SKIP_AUDIO_SELF_ATTN = "skip_audio_self_attn"
+
+
+@dataclass(frozen=True)
+class Perturbation:
+    """A single perturbation specifying which attention type to skip and in which blocks."""
+
+    type: PerturbationType
+    blocks: list[int] | None  # None means all blocks
+
+    def is_perturbed(self, perturbation_type: PerturbationType, block: int) -> bool:
+        if self.type != perturbation_type:
+            return False
+
+        if self.blocks is None:
+            return True
+
+        return block in self.blocks
+
+
+@dataclass(frozen=True)
+class PerturbationConfig:
+    """Configuration holding a list of perturbations for a single sample."""
+
+    perturbations: list[Perturbation] | None
+
+    def is_perturbed(self, perturbation_type: PerturbationType, block: int) -> bool:
+        if self.perturbations is None:
+            return False
+
+        return any(perturbation.is_perturbed(perturbation_type, block) for perturbation in self.perturbations)
+
+    @staticmethod
+    def empty() -> "PerturbationConfig":
+        return PerturbationConfig([])
+
+
+@dataclass(frozen=True)
+class BatchedPerturbationConfig:
+    """Perturbation configurations for a batch, with utilities for generating attention masks."""
+
+    perturbations: list[PerturbationConfig]
+
+    def mask(
+        self, perturbation_type: PerturbationType, block: int, device: DeviceLikeType, dtype: torch.dtype
+    ) -> torch.Tensor:
+        mask = torch.ones((len(self.perturbations),), device=device, dtype=dtype)
+        for batch_idx, perturbation in enumerate(self.perturbations):
+            if perturbation.is_perturbed(perturbation_type, block):
+                mask[batch_idx] = 0
+
+        return mask
+
+    def mask_like(self, perturbation_type: PerturbationType, block: int, values: torch.Tensor) -> torch.Tensor:
+        mask = self.mask(perturbation_type, block, values.device, values.dtype)
+        return mask.view(mask.numel(), *([1] * len(values.shape[1:])))
+
+    def any_in_batch(self, perturbation_type: PerturbationType, block: int) -> bool:
+        return any(perturbation.is_perturbed(perturbation_type, block) for perturbation in self.perturbations)
+
+    def all_in_batch(self, perturbation_type: PerturbationType, block: int) -> bool:
+        return all(perturbation.is_perturbed(perturbation_type, block) for perturbation in self.perturbations)
+
+    @staticmethod
+    def empty(batch_size: int) -> "BatchedPerturbationConfig":
+        return BatchedPerturbationConfig([PerturbationConfig.empty() for _ in range(batch_size)])

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/common/normalization.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/common/normalization.py
@@ -1,0 +1,31 @@
+from enum import Enum
+
+import torch
+from torch import nn
+
+
+class NormType(Enum):
+    GROUP = "group"
+    PIXEL = "pixel"
+
+
+class PixelNorm(nn.Module):
+    def __init__(self, dim: int = 1, eps: float = 1e-8) -> None:
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        mean_sq = torch.mean(x**2, dim=self.dim, keepdim=True)
+        rms = torch.sqrt(mean_sq + self.eps)
+        return x / rms
+
+
+def build_normalization_layer(
+    in_channels: int, *, num_groups: int = 32, normtype: NormType = NormType.GROUP
+) -> nn.Module:
+    if normtype == NormType.GROUP:
+        return torch.nn.GroupNorm(num_groups=num_groups, num_channels=in_channels, eps=1e-6, affine=True)
+    if normtype == NormType.PIXEL:
+        return PixelNorm(dim=1, eps=1e-6)
+    raise ValueError(f"Invalid normalization type: {normtype}")

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/model_protocol.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/model_protocol.py
@@ -1,0 +1,11 @@
+from typing import Protocol, TypeVar
+
+
+ModelType = TypeVar("ModelType")
+
+
+class ModelConfigurator(Protocol[ModelType]):
+    """Protocol for model loader classes that instantiates models from a configuration dictionary."""
+
+    @classmethod
+    def from_config(cls, config: dict) -> ModelType: ...

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/__init__.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/__init__.py
@@ -1,0 +1,9 @@
+from ltx_core.model.transformer.modality import Modality
+from ltx_core.model.transformer.model import LTXModel, X0Model
+
+
+__all__ = [
+    "Modality",
+    "LTXModel",
+    "X0Model",
+]

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/adaln.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/adaln.py
@@ -1,0 +1,46 @@
+from typing import Optional, Tuple
+
+import torch
+
+from ltx_core.model.transformer.timestep_embedding import PixArtAlphaCombinedTimestepSizeEmbeddings
+
+
+# Number of AdaLN modulation parameters per transformer block.
+# Base: 2 params (shift + scale) x 3 norms (self-attn, feed-forward, output).
+ADALN_NUM_BASE_PARAMS = 6
+# Cross-attention AdaLN adds 3 more (scale, shift, gate) for the CA norm.
+ADALN_NUM_CROSS_ATTN_PARAMS = 3
+
+
+def adaln_embedding_coefficient(cross_attention_adaln: bool) -> int:
+    """Total number of AdaLN parameters per block."""
+    return ADALN_NUM_BASE_PARAMS + (ADALN_NUM_CROSS_ATTN_PARAMS if cross_attention_adaln else 0)
+
+
+class AdaLayerNormSingle(torch.nn.Module):
+    r"""
+    Norm layer adaptive layer norm single (adaLN-single).
+    As proposed in PixArt-Alpha (see: https://arxiv.org/abs/2310.00426; Section 2.3).
+    Parameters:
+        embedding_dim (`int`): The size of each embedding vector.
+        use_additional_conditions (`bool`): To use additional conditions for normalization or not.
+    """
+
+    def __init__(self, embedding_dim: int, embedding_coefficient: int = 6):
+        super().__init__()
+
+        self.emb = PixArtAlphaCombinedTimestepSizeEmbeddings(
+            embedding_dim,
+            size_emb_dim=embedding_dim // 3,
+        )
+
+        self.silu = torch.nn.SiLU()
+        self.linear = torch.nn.Linear(embedding_dim, embedding_coefficient * embedding_dim, bias=True)
+
+    def forward(
+        self,
+        timestep: torch.Tensor,
+        hidden_dtype: Optional[torch.dtype] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        embedded_timestep = self.emb(timestep, hidden_dtype=hidden_dtype)
+        return self.linear(self.silu(embedded_timestep)), embedded_timestep

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/attention.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/attention.py
@@ -1,0 +1,549 @@
+import functools
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol
+
+import torch
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+from ltx_core.model.transformer.ops import (
+    GatedAttentionCallable,
+    PreAttentionCallable,
+    PytorchGatedAttention,
+    PytorchPreAttention,
+)
+from ltx_core.model.transformer.rope import LTXRopeType
+from veomni.utils.device import IS_CUDA_AVAILABLE, get_device_type, get_gpu_compute_capability
+
+
+logger = logging.getLogger(__name__)
+
+
+def _torch_default_sdpa_priority() -> list[SDPBackend]:
+    """Fetch torch's current default SDPA priority order at runtime.
+    Used as the default for ``PytorchAttention`` so the wrapper-always
+    code path matches torch's native dispatch order without hard-coding it
+    (which would drift if torch updates the default).
+    ``torch._C._get_sdp_priority_order`` is a private API; we accept that
+    risk because the project pins ``torch`` in the lockfile, so any
+    rename/removal surfaces on a controlled torch bump rather than silently.
+    """
+    return [SDPBackend(p) for p in torch._C._get_sdp_priority_order()]
+
+
+memory_efficient_attention = None
+flash_attn_interface = None
+flash_attn_4_func = None
+try:
+    from xformers.ops import memory_efficient_attention
+except ImportError:
+    memory_efficient_attention = None
+try:
+    # FlashAttention3 and XFormersAttention cannot be used together
+    if memory_efficient_attention is None:
+        import flash_attn_interface
+except ImportError:
+    flash_attn_interface = None
+try:
+    from flash_attn.cute import flash_attn_func as flash_attn_4_func
+except ImportError:
+    flash_attn_4_func = None
+
+
+class AttentionCallable(Protocol):
+    """Unmasked attention. Backends without a mask kernel (FA3/FA4) implement only
+    this protocol; backends that support masks too (Pytorch/SDPA, xFormers) are
+    structurally usable here and as :class:`MaskedAttentionCallable`."""
+
+    def __call__(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, heads: int) -> torch.Tensor: ...
+
+
+class MaskedAttentionCallable(Protocol):
+    """Masked attention. Mask is required (not optional) -- the caller has already
+    decided this is the masked path and chosen a backend that can serve it. Used
+    by :class:`Attention` when its forward receives a non-None ``mask``."""
+
+    def __call__(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, heads: int, mask: torch.Tensor
+    ) -> torch.Tensor: ...
+
+
+class PytorchAttention(AttentionCallable):
+    def __init__(self, priority: list[SDPBackend] | None = None) -> None:
+        # priority=None -> snapshot torch's default SDPA priority at construction.
+        # Always passed through ``sdpa_kernel(..., set_priority=True)`` so the
+        # call site is uniform regardless of how the priority was chosen.
+        self._priority = priority if priority is not None else _torch_default_sdpa_priority()
+
+    @property
+    def label(self) -> str:
+        """Human-readable identifier (used in the AUTOMATIC selection log).
+        Encodes the SDPA priority list so a single-backend pin reads differently
+        from the full-priority dispatcher walk."""
+        return f"SDPA[{'>'.join(b.name for b in self._priority)}]"
+
+    def __call__(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, heads: int, mask: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        b, _, dim_head = q.shape
+        dim_head //= heads
+        q, k, v = (t.view(b, -1, heads, dim_head).transpose(1, 2) for t in (q, k, v))
+
+        if mask is not None:
+            # add a batch dimension if there isn't already one
+            if mask.ndim == 2:
+                mask = mask.unsqueeze(0)
+            # add a heads dimension if there isn't already one
+            if mask.ndim == 3:
+                mask = mask.unsqueeze(1)
+
+        with sdpa_kernel(self._priority, set_priority=True):
+            out = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False
+            )
+        out = out.transpose(1, 2).reshape(b, -1, heads * dim_head)
+        return out
+
+
+class XFormersAttention(AttentionCallable):
+    label = "xFormers"
+
+    def __call__(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        heads: int,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if memory_efficient_attention is None:
+            raise RuntimeError("XFormersAttention was selected but `xformers` is not installed.")
+
+        b, _, dim_head = q.shape
+        dim_head //= heads
+
+        # xformers expects [B, M, H, K]
+        q, k, v = (t.view(b, -1, heads, dim_head) for t in (q, k, v))
+
+        if mask is not None:
+            # add a singleton batch dimension
+            if mask.ndim == 2:
+                mask = mask.unsqueeze(0)
+            # add a singleton heads dimension
+            if mask.ndim == 3:
+                mask = mask.unsqueeze(1)
+            # pad to a multiple of 8
+            pad = 8 - mask.shape[-1] % 8
+            # the xformers docs says that it's allowed to have a mask of shape (1, Nq, Nk)
+            # but when using separated heads, the shape has to be (B, H, Nq, Nk)
+            # in flux, this matrix ends up being over 1GB
+            # here, we create a mask with the same batch/head size as the input mask (potentially singleton or full)
+            mask_out = torch.empty(
+                [mask.shape[0], mask.shape[1], q.shape[1], mask.shape[-1] + pad], dtype=q.dtype, device=q.device
+            )
+
+            mask_out[..., : mask.shape[-1]] = mask
+            # doesn't this remove the padding again??
+            mask = mask_out[..., : mask.shape[-1]]
+            mask = mask.expand(b, heads, -1, -1)
+
+        out = memory_efficient_attention(q.to(v.dtype), k.to(v.dtype), v, attn_bias=mask, p=0.0)
+        out = out.reshape(b, -1, heads * dim_head)
+        return out
+
+
+class FlashAttention3(AttentionCallable):
+    label = "FlashAttention3"
+
+    def __call__(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        heads: int,
+    ) -> torch.Tensor:
+        if flash_attn_interface is None:
+            raise RuntimeError("FlashAttention3 was selected but `FlashAttention3` is not installed.")
+
+        b, _, dim_head = q.shape
+        dim_head //= heads
+
+        q, k, v = (t.view(b, -1, heads, dim_head) for t in (q, k, v))
+
+        out = flash_attn_interface.flash_attn_func(q.to(v.dtype), k.to(v.dtype), v)
+        out = out.reshape(b, -1, heads * dim_head)
+        return out
+
+
+class FlashAttention4(AttentionCallable):
+    label = "FlashAttention4"
+
+    def __call__(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        heads: int,
+    ) -> torch.Tensor:
+        if flash_attn_4_func is None:
+            raise RuntimeError("FlashAttention4 was selected but `flash-attn-4` is not installed.")
+
+        b, _, dim_head = q.shape
+        dim_head //= heads
+
+        q, k, v = (t.view(b, -1, heads, dim_head) for t in (q, k, v))
+
+        out, _ = flash_attn_4_func(q.to(v.dtype), k.to(v.dtype), v)
+        out = out.reshape(b, -1, heads * dim_head)
+        return out
+
+
+# --- Automatic selection -----------------------------------------------------
+# AUTOMATIC inspects installed extras and the GPU arch and returns the fastest
+# usable callable for each path. The selection runs once per process (cached)
+# and logs the resulting label once. The unmasked and masked picks are
+# independent: each calls its own helper and may end up on different backends
+# (e.g. FA3 unmasked + xFormers masked on H100).
+
+
+def _sdpa_can_use(backend: SDPBackend, *, with_mask: bool) -> bool:
+    """Ask torch whether *backend* can run with the given mask shape.
+    ``MATH`` is the universal SDPA fallback (pure PyTorch ops, no kernel
+    requirements) so it returns True everywhere, CPU included. The other
+    backends use ``torch.backends.<accel>.can_use_*`` capability checks (no GPU
+    compute, no synchronization) and are False without an accelerator. The probe shapes
+    are small but realistic enough to surface constraints (head dim, dtype)
+    that the per-backend rules care about.
+    """
+    if backend is SDPBackend.MATH:
+        return True
+    if not IS_CUDA_AVAILABLE:
+        return False
+    _device = get_device_type()
+    _accel_backend = getattr(torch.backends, _device)
+    q = torch.empty(1, 4, 128, 64, device=_device, dtype=torch.bfloat16)
+    k = torch.empty(1, 4, 128, 64, device=_device, dtype=torch.bfloat16)
+    v = torch.empty(1, 4, 128, 64, device=_device, dtype=torch.bfloat16)
+    mask = torch.zeros(1, 4, 128, 128, device=_device, dtype=torch.bfloat16) if with_mask else None
+    params = _accel_backend.SDPAParams(q, k, v, mask, 0.0, False, False)
+    if backend is SDPBackend.CUDNN_ATTENTION:
+        return _accel_backend.can_use_cudnn_attention(params, debug=False)
+    if backend is SDPBackend.FLASH_ATTENTION:
+        return _accel_backend.can_use_flash_attention(params, debug=False)
+    if backend is SDPBackend.EFFICIENT_ATTENTION:
+        return _accel_backend.can_use_efficient_attention(params, debug=False)
+    return False
+
+
+_SDPA_FULL_PRIORITY: tuple[SDPBackend, ...] = (
+    SDPBackend.CUDNN_ATTENTION,
+    SDPBackend.FLASH_ATTENTION,
+    SDPBackend.EFFICIENT_ATTENTION,
+    SDPBackend.MATH,
+)
+
+
+def _sdpa_full_priority() -> PytorchAttention:
+    """Hand SDPA the full backend priority order; let torch's dispatcher pick at call time.
+    ``sdpa_kernel(_SDPA_FULL_PRIORITY, set_priority=True)`` enables all four
+    backends and orders them; torch then walks the order at call time and picks
+    the first backend whose ``can_use_*`` check passes for the actual
+    shapes/dtype/mask. FLASH is rejected automatically when a mask is present;
+    CUDNN may be rejected under deterministic mode; MATH is the universal
+    fallback. Probing per-backend usability up front from generic probe shapes
+    cannot anticipate the variety of real call sites (e.g. broadcast key-only
+    masks, large head dim), so we defer the choice to the dispatcher.
+    """
+    return PytorchAttention(priority=list(_SDPA_FULL_PRIORITY))
+
+
+def _select_primary_attention() -> AttentionCallable:
+    """Pick the fastest unmasked attention based on installed extras and GPU arch.
+    Priority by arch:
+    - Hopper (sm_90, H100): FA3 / xFormers (mutually exclusive at import) > FA4 > SDPA.
+    - Datacenter Blackwell (sm_100, B200): FA4 > SDPA. FA4 is intentionally *not*
+      picked on consumer Blackwell (sm_120) -- known regressions in newer
+      FA4 betas; users who want it on sm_120 must opt in explicitly.
+    - Everywhere else (Ada, Ampere, CPU): SDPA with the full backend priority
+      list -- torch's runtime dispatcher picks the best fit at call time.
+    """
+    _compute_cap = get_gpu_compute_capability()
+    if _compute_cap > 0:
+        major = _compute_cap // 10
+        if major == 9:
+            if flash_attn_interface is not None:
+                return FlashAttention3()
+            if memory_efficient_attention is not None:
+                return XFormersAttention()
+            if flash_attn_4_func is not None:
+                return FlashAttention4()
+        if major == 10 and flash_attn_4_func is not None:
+            return FlashAttention4()
+    return _sdpa_full_priority()
+
+
+def _select_masked_attention() -> MaskedAttentionCallable:
+    """Pick a mask-aware attention. Prefers xFormers when installed; else SDPA with
+    the full priority list (the dispatcher rejects FLASH automatically when a
+    mask is present and walks past it)."""
+    if memory_efficient_attention is not None:
+        return XFormersAttention()
+    return _sdpa_full_priority()
+
+
+@functools.cache
+def automatic_attention() -> AttentionCallable:
+    """Cached AUTOMATIC pick for the unmasked path. Logs the chosen label once
+    per process."""
+    fn = _select_primary_attention()
+    logger.info("Automatic attention selected: %s", fn.label)
+    return fn
+
+
+@functools.cache
+def automatic_masked_attention() -> MaskedAttentionCallable:
+    """Cached AUTOMATIC pick for the masked path. Logs the chosen label once
+    per process."""
+    fn = _select_masked_attention()
+    logger.info("Automatic masked attention selected: %s", fn.label)
+    return fn
+
+
+def _resolve_sdpa_variant(backend: SDPBackend, name: str, *, with_mask: bool) -> PytorchAttention:
+    """Build a single-backend ``PytorchAttention`` pin, raising if the backend
+    can't actually serve the call on this machine. Used by both
+    :meth:`AttentionFunction.to_callable` and :meth:`MaskedAttentionFunction.to_callable`;
+    ``with_mask`` differs between the two so the capability check considers
+    the protocol the caller intends to use. Not used for ``MATH`` -- MATH is
+    the universal fallback and would falsely fail the CUDA-only probe on CPU.
+    """
+    if not _sdpa_can_use(backend, with_mask=with_mask):
+        raise RuntimeError(
+            f"{name} selected but the SDPA {backend.name} backend is not usable on this machine "
+            "(either no CUDA, the backend rejected the probe shapes, or "
+            "torch.use_deterministic_algorithms(True) excluded it)."
+        )
+    return PytorchAttention(priority=[backend])
+
+
+class AttentionFunction(Enum):
+    PYTORCH = "pytorch"
+    XFORMERS = "xformers"
+    FLASH_ATTENTION_3 = "flash_attention_3"
+    FLASH_ATTENTION_4 = "flash_attention_4"
+    SDPA_CUDNN = "sdpa_cudnn"
+    SDPA_FLASH = "sdpa_flash"
+    SDPA_EFFICIENT = "sdpa_efficient"
+    SDPA_MATH = "sdpa_math"
+    # Pick the fastest unmasked backend for the current GPU/extras combo; see
+    # :func:`automatic_attention`. Default for :class:`AttentionOps`.
+    AUTOMATIC = "automatic"
+
+    def to_callable(self) -> AttentionCallable:  # noqa: PLR0911
+        """Resolve to a concrete callable. Use this at module init time so that
+        torch.compile can trace through the attention call without graph breaks.
+        Every non-AUTOMATIC variant raises :class:`RuntimeError` when the backend
+        isn't usable on this machine -- missing package or SDPA backend rejected
+        on this hardware (e.g. cuDNN under ``torch.use_deterministic_algorithms``).
+        Opting in means "this kernel or fail loudly". ``AUTOMATIC`` returns the
+        cached :func:`automatic_attention` instance so the once-per-process log
+        fires only on the first resolution.
+        """
+        match self:
+            case AttentionFunction.AUTOMATIC:
+                return automatic_attention()
+            case AttentionFunction.PYTORCH:
+                return PytorchAttention()
+            case AttentionFunction.XFORMERS:
+                if memory_efficient_attention is None:
+                    raise RuntimeError("AttentionFunction.XFORMERS selected but `xformers` is not installed.")
+                return XFormersAttention()
+            case AttentionFunction.FLASH_ATTENTION_3:
+                if flash_attn_interface is None:
+                    raise RuntimeError(
+                        "AttentionFunction.FLASH_ATTENTION_3 selected but `flash-attn-3` is not installed."
+                    )
+                return FlashAttention3()
+            case AttentionFunction.FLASH_ATTENTION_4:
+                if flash_attn_4_func is None:
+                    raise RuntimeError(
+                        "AttentionFunction.FLASH_ATTENTION_4 selected but `flash-attn-4` is not installed."
+                    )
+                return FlashAttention4()
+            case AttentionFunction.SDPA_MATH:
+                return PytorchAttention(priority=[SDPBackend.MATH])
+            case AttentionFunction.SDPA_CUDNN:
+                return _resolve_sdpa_variant(
+                    SDPBackend.CUDNN_ATTENTION, "AttentionFunction.SDPA_CUDNN", with_mask=False
+                )
+            case AttentionFunction.SDPA_FLASH:
+                return _resolve_sdpa_variant(
+                    SDPBackend.FLASH_ATTENTION, "AttentionFunction.SDPA_FLASH", with_mask=False
+                )
+            case AttentionFunction.SDPA_EFFICIENT:
+                return _resolve_sdpa_variant(
+                    SDPBackend.EFFICIENT_ATTENTION, "AttentionFunction.SDPA_EFFICIENT", with_mask=False
+                )
+
+
+class MaskedAttentionFunction(Enum):
+    """Backends usable on the masked path. Mirrors :class:`AttentionFunction` minus
+    the variants the torch SDPA dispatcher (or the wrapped kernel) rejects with a
+    mask: ``SDPA_FLASH`` -- FLASH kernel cannot serve an additive ``attn_mask``;
+    ``FLASH_ATTENTION_3``/``FLASH_ATTENTION_4`` -- neither has a mask kernel at all.
+    Keeping them out makes "this backend cannot mask" a type error, not a runtime one."""
+
+    PYTORCH = "pytorch"
+    XFORMERS = "xformers"
+    SDPA_CUDNN = "sdpa_cudnn"
+    SDPA_EFFICIENT = "sdpa_efficient"
+    SDPA_MATH = "sdpa_math"
+    # Pick the fastest mask-capable backend for the current extras combo; see
+    # :func:`automatic_masked_attention`. Default for the masked slot of
+    # :class:`AttentionOps`.
+    AUTOMATIC = "automatic"
+
+    def to_callable(self) -> MaskedAttentionCallable:
+        """Resolve to a concrete masked callable. Same backend classes as
+        :meth:`AttentionFunction.to_callable`; the protocol returned just exposes
+        the masked call signature.
+        Non-AUTOMATIC variants raise :class:`RuntimeError` when the backend isn't
+        usable for the masked path on this machine. SDPA probes run with
+        ``with_mask=True`` so the capability check considers the protocol the
+        caller will actually use."""
+        match self:
+            case MaskedAttentionFunction.AUTOMATIC:
+                return automatic_masked_attention()
+            case MaskedAttentionFunction.PYTORCH:
+                return PytorchAttention()
+            case MaskedAttentionFunction.XFORMERS:
+                if memory_efficient_attention is None:
+                    raise RuntimeError("MaskedAttentionFunction.XFORMERS selected but `xformers` is not installed.")
+                return XFormersAttention()
+            case MaskedAttentionFunction.SDPA_MATH:
+                return PytorchAttention(priority=[SDPBackend.MATH])
+            case MaskedAttentionFunction.SDPA_CUDNN:
+                return _resolve_sdpa_variant(
+                    SDPBackend.CUDNN_ATTENTION, "MaskedAttentionFunction.SDPA_CUDNN", with_mask=True
+                )
+            case MaskedAttentionFunction.SDPA_EFFICIENT:
+                return _resolve_sdpa_variant(
+                    SDPBackend.EFFICIENT_ATTENTION, "MaskedAttentionFunction.SDPA_EFFICIENT", with_mask=True
+                )
+
+
+@dataclass(frozen=True)
+class AttentionOps:
+    """Pluggable callables consumed by :class:`Attention`."""
+
+    attention_function: AttentionCallable = field(default_factory=lambda: AttentionFunction.AUTOMATIC.to_callable())
+    masked_attention_function: MaskedAttentionCallable = field(
+        default_factory=lambda: MaskedAttentionFunction.AUTOMATIC.to_callable()
+    )
+    preattention_function: PreAttentionCallable = field(default_factory=PytorchPreAttention)
+    gated_attention_function: GatedAttentionCallable = field(default_factory=PytorchGatedAttention)
+
+
+class Attention(torch.nn.Module):
+    def __init__(
+        self,
+        query_dim: int,
+        context_dim: int | None = None,
+        heads: int = 8,
+        dim_head: int = 64,
+        norm_eps: float = 1e-6,
+        rope_type: LTXRopeType = LTXRopeType.SPLIT,
+        ops: AttentionOps | None = None,
+        apply_gated_attention: bool = False,
+    ) -> None:
+        super().__init__()
+        if ops is None:
+            ops = AttentionOps()
+        self.rope_type = rope_type
+        self.attention_function = ops.attention_function
+        self.masked_attention_function = ops.masked_attention_function
+        self.preattention_function = ops.preattention_function
+        self.gated_attention_function = ops.gated_attention_function
+
+        inner_dim = dim_head * heads
+        context_dim = query_dim if context_dim is None else context_dim
+
+        self.heads = heads
+        self.dim_head = dim_head
+
+        self.q_norm = torch.nn.RMSNorm(inner_dim, eps=norm_eps)
+        self.k_norm = torch.nn.RMSNorm(inner_dim, eps=norm_eps)
+
+        self.to_q = torch.nn.Linear(query_dim, inner_dim, bias=True)
+        self.to_k = torch.nn.Linear(context_dim, inner_dim, bias=True)
+        self.to_v = torch.nn.Linear(context_dim, inner_dim, bias=True)
+
+        # Optional per-head gating
+        if apply_gated_attention:
+            self.to_gate_logits = torch.nn.Linear(query_dim, heads, bias=True)
+        else:
+            self.to_gate_logits = None
+
+        self.to_out = torch.nn.Sequential(torch.nn.Linear(inner_dim, query_dim, bias=True), torch.nn.Identity())
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        context: torch.Tensor | None = None,
+        mask: torch.Tensor | None = None,
+        pe: torch.Tensor | None = None,
+        k_pe: torch.Tensor | None = None,
+        perturbation_mask: torch.Tensor | None = None,
+        all_perturbed: bool = False,
+    ) -> torch.Tensor:
+        """Multi-head attention with optional RoPE, perturbation masking, and per-head gating.
+        When ``perturbation_mask`` is all zeros, the expensive query/key path
+        (linear projections, RMSNorm, RoPE) is skipped entirely and only the
+        value projection is used as a pass-through.
+        Args:
+            x: Query input tensor of shape ``(B, T, query_dim)``.
+            context: Key/value context tensor of shape ``(B, S, context_dim)``.
+                Falls back to ``x`` (self-attention) when *None*.
+            mask: Optional attention mask. Interpretation depends on the attention
+                backend (additive bias for xformers/PyTorch SDPA). A non-None
+                ``mask`` routes to ``masked_attention_function``; ``None`` keeps
+                the unmasked path.
+            pe: Rotary positional embeddings applied to both ``q`` and ``k``.
+            k_pe: Separate rotary positional embeddings for ``k`` only. When
+                *None*, ``pe`` is reused for keys.
+            perturbation_mask: Optional mask in ``[0, 1]`` that
+                blends the attention output with the raw value projection:
+                ``out = attn_out * mask + v * (1 - mask)``.
+                **1** keeps the full attention output, **0** bypasses attention
+                and passes the value projection through unchanged.
+                *None* or all-ones means standard attention; all-zeros skips
+                the query/key path entirely for efficiency.
+            all_perturbed: Whether all perturbations are active for this block.
+        Returns:
+            Output tensor of shape ``(B, T, query_dim)``.
+        """
+        context = x if context is None else context
+        use_attention = not all_perturbed
+
+        v = self.to_v(context)
+
+        if not use_attention:
+            out = v
+        else:
+            q = self.to_q(x)
+            k = self.to_k(context)
+            q, k = self.preattention_function(q, k, self, mask, pe, k_pe)
+            if mask is None:
+                out = self.attention_function(q, k, v, self.heads)  # (B, T, H*D)
+            else:
+                out = self.masked_attention_function(q, k, v, self.heads, mask)
+
+            if perturbation_mask is not None:
+                out = out * perturbation_mask + v * (1 - perturbation_mask)
+
+        # Apply per-head gating if enabled
+        if self.to_gate_logits is not None:
+            out = self.gated_attention_function(x, out, self)
+
+        return self.to_out(out)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/feed_forward.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/feed_forward.py
@@ -1,0 +1,15 @@
+import torch
+
+from ltx_core.model.transformer.gelu_approx import GELUApprox
+
+
+class FeedForward(torch.nn.Module):
+    def __init__(self, dim: int, dim_out: int, mult: int = 4) -> None:
+        super().__init__()
+        inner_dim = int(dim * mult)
+        project_in = GELUApprox(dim, inner_dim)
+
+        self.net = torch.nn.Sequential(project_in, torch.nn.Identity(), torch.nn.Linear(inner_dim, dim_out))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/gelu_approx.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/gelu_approx.py
@@ -1,0 +1,10 @@
+import torch
+
+
+class GELUApprox(torch.nn.Module):
+    def __init__(self, dim_in: int, dim_out: int) -> None:
+        super().__init__()
+        self.proj = torch.nn.Linear(dim_in, dim_out)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.gelu(self.proj(x), approximate="tanh")

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/modality.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/modality.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class Modality:
+    """
+    Input data for a single modality (video or audio) in the transformer.
+    Bundles the latent tokens, timestep embeddings, positional information,
+    and text conditioning context for processing by the diffusion transformer.
+    Attributes:
+        latent: Patchified latent tokens, shape ``(B, T, D)`` where *B* is
+            the batch size, *T* is the total number of tokens (noisy +
+            conditioning), and *D* is the input dimension.
+        timesteps: Per-token timestep embeddings, shape ``(B, T)``.
+        positions: Per-token patch coordinates used to build the RoPE
+            frequencies. With the default ``use_middle_indices_grid=True``,
+            shape is ``(B, n_pos_dims, T, 2)`` where ``n_pos_dims=3`` for
+            video (time, height, width) and ``n_pos_dims=1`` for audio
+            (time); the last dim of size 2 holds the ``[start, end)``
+            index bounds of each patch, and RoPE is evaluated at the
+            *middle* of that range -- hence the flag name. Taking the
+            patch midpoint produces a smoother and more accurate
+            positional signal than indexing by the patch's start when
+            patches span more than one spatial / temporal unit.
+            When ``use_middle_indices_grid=False``, the legacy 3-D form
+            ``(B, n_pos_dims, T)`` of integer positional indices is
+            accepted instead and used as-is (no midpoint derivation).
+        context: Text conditioning embeddings from the prompt encoder.
+        enabled: Whether this modality is active in the current forward pass.
+        context_mask: Optional mask for the text context tokens.
+        attention_mask: Optional 2-D self-attention mask, shape ``(B, T, T)``.
+            Values in ``[0, 1]`` where ``1`` = full attention and ``0`` = no
+            attention. ``None`` means unrestricted (full) attention between
+            all tokens. Built incrementally by conditioning items; see
+            :class:`~ltx_core.conditioning.types.attention_strength_wrapper.ConditioningItemAttentionStrengthWrapper`.
+    """
+
+    latent: (
+        torch.Tensor
+    )  # Shape: (B, T, D) where B is the batch size, T is the number of tokens, and D is input dimension
+    sigma: torch.Tensor  # Shape: (B,). Current sigma value, used for cross-attention timestep calculation.
+    timesteps: torch.Tensor  # Shape: (B, T) where T is the number of timesteps
+    # Shape: (B, n_pos_dims, T, 2) by default (use_middle_indices_grid=True);
+    # n_pos_dims=3 for video, 1 for audio; last dim holds [start, end) patch bounds.
+    # Legacy form (B, n_pos_dims, T) when use_middle_indices_grid=False.
+    positions: torch.Tensor
+    context: torch.Tensor
+    enabled: bool = True
+    context_mask: torch.Tensor | None = None
+    attention_mask: torch.Tensor | None = None
+
+    def split(self, sizes: list[int]) -> list[Modality]:
+        """Split along the batch dimension into chunks of the given sizes."""
+        n = len(sizes)
+        split_fields: dict[str, list[torch.Tensor | None] | list[bool]] = {}
+        for f in dataclasses.fields(self):
+            value = getattr(self, f.name)
+            if isinstance(value, torch.Tensor):
+                split_fields[f.name] = list(value.split(sizes, dim=0))
+            elif value is None or isinstance(value, bool):
+                split_fields[f.name] = [value] * n
+            else:
+                raise TypeError(f"Cannot split field {f.name!r}: unsupported type {type(value)}")
+        return [Modality(**{name: parts[i] for name, parts in split_fields.items()}) for i in range(n)]

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/model.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/model.py
@@ -1,0 +1,447 @@
+from enum import Enum
+
+import torch
+
+from ltx_core.guidance.perturbations import BatchedPerturbationConfig, PerturbationType
+from ltx_core.model.transformer.adaln import AdaLayerNormSingle, adaln_embedding_coefficient
+from ltx_core.model.transformer.modality import Modality
+from ltx_core.model.transformer.rope import LTXRopeType
+from ltx_core.model.transformer.transformer import (
+    DEFAULT_TRANSFORMER_OPS,
+    BasicAVTransformerBlock,
+    TransformerConfig,
+    TransformerOpsConfig,
+)
+from ltx_core.model.transformer.transformer_args import (
+    BlockPerturbationsProcessor,
+    MultiModalTransformerArgsPreprocessor,
+    TransformerArgs,
+    TransformerArgsPreprocessor,
+)
+from ltx_core.utils import to_denoised
+
+
+class LTXModelType(Enum):
+    AudioVideo = "ltx av model"
+    VideoOnly = "ltx video only model"
+    AudioOnly = "ltx audio only model"
+
+    def is_video_enabled(self) -> bool:
+        return self in (LTXModelType.AudioVideo, LTXModelType.VideoOnly)
+
+    def is_audio_enabled(self) -> bool:
+        return self in (LTXModelType.AudioVideo, LTXModelType.AudioOnly)
+
+
+class LTXModel(torch.nn.Module):
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        model_type: LTXModelType = LTXModelType.AudioVideo,
+        num_attention_heads: int = 32,
+        attention_head_dim: int = 128,
+        in_channels: int = 128,
+        out_channels: int = 128,
+        num_layers: int = 48,
+        cross_attention_dim: int = 4096,
+        norm_eps: float = 1e-06,
+        ops: TransformerOpsConfig = DEFAULT_TRANSFORMER_OPS,
+        positional_embedding_theta: float = 10000.0,
+        positional_embedding_max_pos: list[int] | None = None,
+        timestep_scale_multiplier: int = 1000,
+        use_middle_indices_grid: bool = True,
+        audio_num_attention_heads: int = 32,
+        audio_attention_head_dim: int = 64,
+        audio_in_channels: int = 128,
+        audio_out_channels: int = 128,
+        audio_cross_attention_dim: int = 2048,
+        audio_positional_embedding_max_pos: list[int] | None = None,
+        av_ca_timestep_scale_multiplier: int = 1,
+        rope_type: LTXRopeType = LTXRopeType.SPLIT,
+        double_precision_rope: bool = False,
+        apply_gated_attention: bool = False,
+        caption_projection: torch.nn.Module | None = None,
+        audio_caption_projection: torch.nn.Module | None = None,
+        cross_attention_adaln: bool = False,
+    ):
+        super().__init__()
+        self.gradient_checkpointing = False
+        self.cross_attention_adaln = cross_attention_adaln
+        self.use_middle_indices_grid = use_middle_indices_grid
+        self.rope_type = rope_type
+        self.double_precision_rope = double_precision_rope
+        self.timestep_scale_multiplier = timestep_scale_multiplier
+        self.positional_embedding_theta = positional_embedding_theta
+        self.model_type = model_type
+        cross_pe_max_pos = None
+        if model_type.is_video_enabled():
+            if positional_embedding_max_pos is None:
+                positional_embedding_max_pos = [20, 2048, 2048]
+            self.positional_embedding_max_pos = positional_embedding_max_pos
+            self.num_attention_heads = num_attention_heads
+            self.inner_dim = num_attention_heads * attention_head_dim
+            self._init_video(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                norm_eps=norm_eps,
+                caption_projection=caption_projection,
+            )
+
+        if model_type.is_audio_enabled():
+            if audio_positional_embedding_max_pos is None:
+                audio_positional_embedding_max_pos = [20]
+            self.audio_positional_embedding_max_pos = audio_positional_embedding_max_pos
+            self.audio_num_attention_heads = audio_num_attention_heads
+            self.audio_inner_dim = self.audio_num_attention_heads * audio_attention_head_dim
+            self._init_audio(
+                in_channels=audio_in_channels,
+                out_channels=audio_out_channels,
+                norm_eps=norm_eps,
+                caption_projection=audio_caption_projection,
+            )
+
+        if model_type.is_video_enabled() and model_type.is_audio_enabled():
+            cross_pe_max_pos = max(self.positional_embedding_max_pos[0], self.audio_positional_embedding_max_pos[0])
+            self.av_ca_timestep_scale_multiplier = av_ca_timestep_scale_multiplier
+            self.audio_cross_attention_dim = audio_cross_attention_dim
+            self._init_audio_video(num_scale_shift_values=4)
+
+        self._init_preprocessors(cross_pe_max_pos)
+        self._init_transformer_blocks(
+            num_layers=num_layers,
+            attention_head_dim=attention_head_dim if model_type.is_video_enabled() else 0,
+            cross_attention_dim=cross_attention_dim,
+            audio_attention_head_dim=audio_attention_head_dim if model_type.is_audio_enabled() else 0,
+            audio_cross_attention_dim=audio_cross_attention_dim,
+            norm_eps=norm_eps,
+            ops=ops,
+            apply_gated_attention=apply_gated_attention,
+        )
+        self.block_input_processor = BlockPerturbationsProcessor()
+
+    @property
+    def _adaln_embedding_coefficient(self) -> int:
+        return adaln_embedding_coefficient(self.cross_attention_adaln)
+
+    def _init_video(
+        self,
+        in_channels: int,
+        out_channels: int,
+        norm_eps: float,
+        caption_projection: torch.nn.Module | None = None,
+    ) -> None:
+        self.patchify_proj = torch.nn.Linear(in_channels, self.inner_dim, bias=True)
+        if caption_projection is not None:
+            self.caption_projection = caption_projection
+
+        self.adaln_single = AdaLayerNormSingle(self.inner_dim, embedding_coefficient=self._adaln_embedding_coefficient)
+
+        self.prompt_adaln_single = (
+            AdaLayerNormSingle(self.inner_dim, embedding_coefficient=2) if self.cross_attention_adaln else None
+        )
+
+        self.scale_shift_table = torch.nn.Parameter(torch.empty(2, self.inner_dim))
+        self.norm_out = torch.nn.LayerNorm(self.inner_dim, elementwise_affine=False, eps=norm_eps)
+        self.proj_out = torch.nn.Linear(self.inner_dim, out_channels)
+
+    def _init_audio(
+        self,
+        in_channels: int,
+        out_channels: int,
+        norm_eps: float,
+        caption_projection: torch.nn.Module | None = None,
+    ) -> None:
+        self.audio_patchify_proj = torch.nn.Linear(in_channels, self.audio_inner_dim, bias=True)
+        if caption_projection is not None:
+            self.audio_caption_projection = caption_projection
+
+        self.audio_adaln_single = AdaLayerNormSingle(
+            self.audio_inner_dim,
+            embedding_coefficient=self._adaln_embedding_coefficient,
+        )
+
+        self.audio_prompt_adaln_single = (
+            AdaLayerNormSingle(self.audio_inner_dim, embedding_coefficient=2) if self.cross_attention_adaln else None
+        )
+
+        self.audio_scale_shift_table = torch.nn.Parameter(torch.empty(2, self.audio_inner_dim))
+        self.audio_norm_out = torch.nn.LayerNorm(self.audio_inner_dim, elementwise_affine=False, eps=norm_eps)
+        self.audio_proj_out = torch.nn.Linear(self.audio_inner_dim, out_channels)
+
+    def _init_audio_video(
+        self,
+        num_scale_shift_values: int,
+    ) -> None:
+        self.av_ca_video_scale_shift_adaln_single = AdaLayerNormSingle(
+            self.inner_dim,
+            embedding_coefficient=num_scale_shift_values,
+        )
+
+        self.av_ca_audio_scale_shift_adaln_single = AdaLayerNormSingle(
+            self.audio_inner_dim,
+            embedding_coefficient=num_scale_shift_values,
+        )
+
+        self.av_ca_a2v_gate_adaln_single = AdaLayerNormSingle(
+            self.inner_dim,
+            embedding_coefficient=1,
+        )
+
+        self.av_ca_v2a_gate_adaln_single = AdaLayerNormSingle(
+            self.audio_inner_dim,
+            embedding_coefficient=1,
+        )
+
+    def _init_preprocessors(
+        self,
+        cross_pe_max_pos: int | None = None,
+    ) -> None:
+        if self.model_type.is_video_enabled() and self.model_type.is_audio_enabled():
+            self.video_args_preprocessor = MultiModalTransformerArgsPreprocessor(
+                patchify_proj=self.patchify_proj,
+                adaln=self.adaln_single,
+                cross_scale_shift_adaln=self.av_ca_video_scale_shift_adaln_single,
+                cross_gate_adaln=self.av_ca_a2v_gate_adaln_single,
+                inner_dim=self.inner_dim,
+                max_pos=self.positional_embedding_max_pos,
+                num_attention_heads=self.num_attention_heads,
+                cross_pe_max_pos=cross_pe_max_pos,
+                use_middle_indices_grid=self.use_middle_indices_grid,
+                audio_cross_attention_dim=self.audio_cross_attention_dim,
+                timestep_scale_multiplier=self.timestep_scale_multiplier,
+                double_precision_rope=self.double_precision_rope,
+                positional_embedding_theta=self.positional_embedding_theta,
+                rope_type=self.rope_type,
+                av_ca_timestep_scale_multiplier=self.av_ca_timestep_scale_multiplier,
+                caption_projection=getattr(self, "caption_projection", None),
+                prompt_adaln=getattr(self, "prompt_adaln_single", None),
+            )
+            self.audio_args_preprocessor = MultiModalTransformerArgsPreprocessor(
+                patchify_proj=self.audio_patchify_proj,
+                adaln=self.audio_adaln_single,
+                cross_scale_shift_adaln=self.av_ca_audio_scale_shift_adaln_single,
+                cross_gate_adaln=self.av_ca_v2a_gate_adaln_single,
+                inner_dim=self.audio_inner_dim,
+                max_pos=self.audio_positional_embedding_max_pos,
+                num_attention_heads=self.audio_num_attention_heads,
+                cross_pe_max_pos=cross_pe_max_pos,
+                use_middle_indices_grid=self.use_middle_indices_grid,
+                audio_cross_attention_dim=self.audio_cross_attention_dim,
+                timestep_scale_multiplier=self.timestep_scale_multiplier,
+                double_precision_rope=self.double_precision_rope,
+                positional_embedding_theta=self.positional_embedding_theta,
+                rope_type=self.rope_type,
+                av_ca_timestep_scale_multiplier=self.av_ca_timestep_scale_multiplier,
+                caption_projection=getattr(self, "audio_caption_projection", None),
+                prompt_adaln=getattr(self, "audio_prompt_adaln_single", None),
+            )
+        elif self.model_type.is_video_enabled():
+            self.video_args_preprocessor = TransformerArgsPreprocessor(
+                patchify_proj=self.patchify_proj,
+                adaln=self.adaln_single,
+                inner_dim=self.inner_dim,
+                max_pos=self.positional_embedding_max_pos,
+                num_attention_heads=self.num_attention_heads,
+                use_middle_indices_grid=self.use_middle_indices_grid,
+                timestep_scale_multiplier=self.timestep_scale_multiplier,
+                double_precision_rope=self.double_precision_rope,
+                positional_embedding_theta=self.positional_embedding_theta,
+                rope_type=self.rope_type,
+                caption_projection=getattr(self, "caption_projection", None),
+                prompt_adaln=getattr(self, "prompt_adaln_single", None),
+            )
+        elif self.model_type.is_audio_enabled():
+            self.audio_args_preprocessor = TransformerArgsPreprocessor(
+                patchify_proj=self.audio_patchify_proj,
+                adaln=self.audio_adaln_single,
+                inner_dim=self.audio_inner_dim,
+                max_pos=self.audio_positional_embedding_max_pos,
+                num_attention_heads=self.audio_num_attention_heads,
+                use_middle_indices_grid=self.use_middle_indices_grid,
+                timestep_scale_multiplier=self.timestep_scale_multiplier,
+                double_precision_rope=self.double_precision_rope,
+                positional_embedding_theta=self.positional_embedding_theta,
+                rope_type=self.rope_type,
+                caption_projection=getattr(self, "audio_caption_projection", None),
+                prompt_adaln=getattr(self, "audio_prompt_adaln_single", None),
+            )
+
+    def _init_transformer_blocks(
+        self,
+        num_layers: int,
+        attention_head_dim: int,
+        cross_attention_dim: int,
+        audio_attention_head_dim: int,
+        audio_cross_attention_dim: int,
+        norm_eps: float,
+        ops: TransformerOpsConfig,
+        apply_gated_attention: bool,
+    ) -> None:
+        video_config = (
+            TransformerConfig(
+                dim=self.inner_dim,
+                heads=self.num_attention_heads,
+                d_head=attention_head_dim,
+                context_dim=cross_attention_dim,
+                apply_gated_attention=apply_gated_attention,
+                cross_attention_adaln=self.cross_attention_adaln,
+            )
+            if self.model_type.is_video_enabled()
+            else None
+        )
+        audio_config = (
+            TransformerConfig(
+                dim=self.audio_inner_dim,
+                heads=self.audio_num_attention_heads,
+                d_head=audio_attention_head_dim,
+                context_dim=audio_cross_attention_dim,
+                apply_gated_attention=apply_gated_attention,
+                cross_attention_adaln=self.cross_attention_adaln,
+            )
+            if self.model_type.is_audio_enabled()
+            else None
+        )
+        self.transformer_blocks = torch.nn.ModuleList(
+            [
+                BasicAVTransformerBlock(
+                    video=video_config,
+                    audio=audio_config,
+                    rope_type=self.rope_type,
+                    norm_eps=norm_eps,
+                    ops=ops,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+    def set_gradient_checkpointing(self, enable: bool) -> None:
+        self.gradient_checkpointing = enable
+
+    def _process_transformer_blocks(
+        self,
+        video: TransformerArgs | None,
+        audio: TransformerArgs | None,
+        perturbations: BatchedPerturbationConfig | None,
+    ) -> tuple[TransformerArgs | None, TransformerArgs | None]:
+        if perturbations is None:
+            batch_size = (video or audio).x.shape[0]
+            perturbations = BatchedPerturbationConfig.empty(batch_size)
+
+        for block_idx, block in enumerate(self.transformer_blocks):
+            if video is not None:
+                video = self.block_input_processor(
+                    video,
+                    perturbations,
+                    block_idx,
+                    self_attn_type=PerturbationType.SKIP_VIDEO_SELF_ATTN,
+                    cross_attn_type=PerturbationType.SKIP_A2V_CROSS_ATTN,
+                )
+            if audio is not None:
+                audio = self.block_input_processor(
+                    audio,
+                    perturbations,
+                    block_idx,
+                    self_attn_type=PerturbationType.SKIP_AUDIO_SELF_ATTN,
+                    cross_attn_type=PerturbationType.SKIP_V2A_CROSS_ATTN,
+                )
+
+            if self.gradient_checkpointing and self.training:
+                video, audio = torch.utils.checkpoint.checkpoint(
+                    block,
+                    video,
+                    audio,
+                    use_reentrant=False,
+                )
+            else:
+                video, audio = block(video=video, audio=audio)
+
+        return video, audio
+
+    def _process_output(
+        self,
+        scale_shift_table: torch.Tensor,
+        norm_out: torch.nn.LayerNorm,
+        proj_out: torch.nn.Linear,
+        x: torch.Tensor,
+        embedded_timestep: torch.Tensor,
+    ) -> torch.Tensor:
+        scale_shift_values = (
+            scale_shift_table[None, None].to(device=x.device, dtype=x.dtype) + embedded_timestep[:, :, None]
+        )
+        shift, scale = scale_shift_values[:, :, 0], scale_shift_values[:, :, 1]
+
+        x = norm_out(x)
+        x = x * (1 + scale) + shift
+        x = proj_out(x)
+        return x
+
+    def forward(
+        self, video: Modality | None, audio: Modality | None, perturbations: BatchedPerturbationConfig
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not self.model_type.is_video_enabled() and video is not None:
+            raise ValueError("Video is not enabled for this model")
+        if not self.model_type.is_audio_enabled() and audio is not None:
+            raise ValueError("Audio is not enabled for this model")
+
+        video_args = self.video_args_preprocessor.prepare(video, audio) if video is not None else None
+        audio_args = self.audio_args_preprocessor.prepare(audio, video) if audio is not None else None
+        video_out, audio_out = self._process_transformer_blocks(
+            video=video_args,
+            audio=audio_args,
+            perturbations=perturbations,
+        )
+
+        vx = (
+            self._process_output(
+                self.scale_shift_table, self.norm_out, self.proj_out, video_out.x, video_out.embedded_timestep
+            )
+            if video_out is not None
+            else None
+        )
+        ax = (
+            self._process_output(
+                self.audio_scale_shift_table,
+                self.audio_norm_out,
+                self.audio_proj_out,
+                audio_out.x,
+                audio_out.embedded_timestep,
+            )
+            if audio_out is not None
+            else None
+        )
+        return vx, ax
+
+
+class LegacyX0Model(torch.nn.Module):
+    def __init__(self, velocity_model: LTXModel):
+        super().__init__()
+        self.velocity_model = velocity_model
+
+    def forward(
+        self,
+        video: Modality | None,
+        audio: Modality | None,
+        perturbations: BatchedPerturbationConfig,
+        sigma: float,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        vx, ax = self.velocity_model(video, audio, perturbations)
+        denoised_video = to_denoised(video.latent, vx, sigma) if vx is not None else None
+        denoised_audio = to_denoised(audio.latent, ax, sigma) if ax is not None else None
+        return denoised_video, denoised_audio
+
+
+class X0Model(torch.nn.Module):
+    def __init__(self, velocity_model: LTXModel):
+        super().__init__()
+        self.velocity_model = velocity_model
+
+    def forward(
+        self,
+        video: Modality | None,
+        audio: Modality | None,
+        perturbations: BatchedPerturbationConfig,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        vx, ax = self.velocity_model(video, audio, perturbations)
+        denoised_video = to_denoised(video.latent, vx, video.timesteps) if vx is not None else None
+        denoised_audio = to_denoised(audio.latent, ax, audio.timesteps) if ax is not None else None
+        return denoised_video, denoised_audio

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/model_configurator.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/model_configurator.py
@@ -1,0 +1,153 @@
+import torch
+
+from ltx_core.loader.sd_ops import SDOps
+from ltx_core.model.model_protocol import ModelConfigurator
+from ltx_core.model.transformer.model import LTXModel, LTXModelType
+from ltx_core.model.transformer.rope import LTXRopeType
+from ltx_core.model.transformer.text_projection import create_caption_projection
+from ltx_core.model.transformer.transformer import DEFAULT_TRANSFORMER_OPS, TransformerOpsConfig
+from ltx_core.utils import check_config_value
+
+
+class LTXModelConfigurator(ModelConfigurator[LTXModel]):
+    """
+    Configurator for LTX model.
+    Used to create an LTX model from a configuration dictionary.
+    """
+
+    @classmethod
+    def from_config(cls, config: dict, ops: TransformerOpsConfig = DEFAULT_TRANSFORMER_OPS) -> LTXModel:
+        # Build caption projections for 19B models (projection handled in transformer).
+        caption_projection, audio_caption_projection = _build_caption_projections(config, is_av=True)
+
+        config = config.get("transformer", {})
+
+        check_config_value(config, "dropout", 0.0)
+        check_config_value(config, "attention_bias", True)
+        check_config_value(config, "num_vector_embeds", None)
+        check_config_value(config, "activation_fn", "gelu-approximate")
+        check_config_value(config, "num_embeds_ada_norm", 1000)
+        check_config_value(config, "use_linear_projection", False)
+        check_config_value(config, "only_cross_attention", False)
+        check_config_value(config, "cross_attention_norm", True)
+        check_config_value(config, "double_self_attention", False)
+        check_config_value(config, "upcast_attention", False)
+        check_config_value(config, "standardization_norm", "rms_norm")
+        check_config_value(config, "norm_elementwise_affine", False)
+        check_config_value(config, "qk_norm", "rms_norm")
+        check_config_value(config, "positional_embedding_type", "rope")
+        check_config_value(config, "use_audio_video_cross_attention", True)
+        check_config_value(config, "share_ff", False)
+        check_config_value(config, "av_cross_ada_norm", True)
+        check_config_value(config, "use_middle_indices_grid", True)
+        check_config_value(config, "num_attention_heads", config.get("audio_num_attention_heads", float("nan")))
+
+        return LTXModel(
+            model_type=LTXModelType.AudioVideo,
+            num_attention_heads=config.get("num_attention_heads", 32),
+            attention_head_dim=config.get("attention_head_dim", 128),
+            in_channels=config.get("in_channels", 128),
+            out_channels=config.get("out_channels", 128),
+            num_layers=config.get("num_layers", 48),
+            cross_attention_dim=config.get("cross_attention_dim", 4096),
+            norm_eps=config.get("norm_eps", 1e-06),
+            ops=ops,
+            positional_embedding_theta=config.get("positional_embedding_theta", 10000.0),
+            positional_embedding_max_pos=config.get("positional_embedding_max_pos", [20, 2048, 2048]),
+            timestep_scale_multiplier=config.get("timestep_scale_multiplier", 1000),
+            use_middle_indices_grid=config.get("use_middle_indices_grid", True),
+            audio_num_attention_heads=config.get("audio_num_attention_heads", 32),
+            audio_attention_head_dim=config.get("audio_attention_head_dim", 64),
+            audio_in_channels=config.get("audio_in_channels", 128),
+            audio_out_channels=config.get("audio_out_channels", 128),
+            audio_cross_attention_dim=config.get("audio_cross_attention_dim", 2048),
+            audio_positional_embedding_max_pos=config.get("audio_positional_embedding_max_pos", [20]),
+            av_ca_timestep_scale_multiplier=config.get("av_ca_timestep_scale_multiplier", 1),
+            rope_type=LTXRopeType(config.get("rope_type", "split")),
+            double_precision_rope=config.get("frequencies_precision", False) == "float64",
+            apply_gated_attention=config.get("apply_gated_attention", False),
+            caption_projection=caption_projection,
+            audio_caption_projection=audio_caption_projection,
+            cross_attention_adaln=config.get("cross_attention_adaln", False),
+        )
+
+
+class LTXVideoOnlyModelConfigurator(ModelConfigurator[LTXModel]):
+    """
+    Configurator for LTX video only model.
+    Used to create an LTX video only model from a configuration dictionary.
+    """
+
+    @classmethod
+    def from_config(cls, config: dict, ops: TransformerOpsConfig = DEFAULT_TRANSFORMER_OPS) -> LTXModel:
+        # Build caption projection for 19B model (projection handled in transformer).
+        caption_projection, _ = _build_caption_projections(config, is_av=False)
+
+        config = config.get("transformer", {})
+
+        check_config_value(config, "dropout", 0.0)
+        check_config_value(config, "attention_bias", True)
+        check_config_value(config, "num_vector_embeds", None)
+        check_config_value(config, "activation_fn", "gelu-approximate")
+        check_config_value(config, "num_embeds_ada_norm", 1000)
+        check_config_value(config, "use_linear_projection", False)
+        check_config_value(config, "only_cross_attention", False)
+        check_config_value(config, "cross_attention_norm", True)
+        check_config_value(config, "double_self_attention", False)
+        check_config_value(config, "upcast_attention", False)
+        check_config_value(config, "standardization_norm", "rms_norm")
+        check_config_value(config, "norm_elementwise_affine", False)
+        check_config_value(config, "qk_norm", "rms_norm")
+        check_config_value(config, "positional_embedding_type", "rope")
+        check_config_value(config, "use_middle_indices_grid", True)
+
+        return LTXModel(
+            model_type=LTXModelType.VideoOnly,
+            num_attention_heads=config.get("num_attention_heads", 32),
+            attention_head_dim=config.get("attention_head_dim", 128),
+            in_channels=config.get("in_channels", 128),
+            out_channels=config.get("out_channels", 128),
+            num_layers=config.get("num_layers", 48),
+            cross_attention_dim=config.get("cross_attention_dim", 4096),
+            norm_eps=config.get("norm_eps", 1e-06),
+            ops=ops,
+            positional_embedding_theta=config.get("positional_embedding_theta", 10000.0),
+            positional_embedding_max_pos=config.get("positional_embedding_max_pos", [20, 2048, 2048]),
+            timestep_scale_multiplier=config.get("timestep_scale_multiplier", 1000),
+            use_middle_indices_grid=config.get("use_middle_indices_grid", True),
+            rope_type=LTXRopeType(config.get("rope_type", "split")),
+            double_precision_rope=config.get("frequencies_precision", False) == "float64",
+            apply_gated_attention=config.get("apply_gated_attention", False),
+            caption_projection=caption_projection,
+            cross_attention_adaln=config.get("cross_attention_adaln", False),
+        )
+
+
+def _build_caption_projections(
+    config: dict,
+    is_av: bool,
+) -> tuple[torch.nn.Module | None, torch.nn.Module | None]:
+    """Build caption projections for the transformer when projection is NOT in the text encoder.
+    19B models: projection is in the transformer (caption_proj_before_connector=False).
+    22B models: projection is in the text encoder, so no projections are created here.
+    Args:
+        config: Full model config dict (must contain "transformer" key).
+        is_av: Whether this is an audio-video model. When False, audio projection is skipped.
+    Returns:
+        Tuple of (video_caption_projection, audio_caption_projection), both None for 22B models.
+    """
+    transformer_config = config.get("transformer", {})
+    if transformer_config.get("caption_proj_before_connector", False):
+        return None, None
+
+    with torch.device("meta"):
+        caption_projection = create_caption_projection(transformer_config)
+        audio_caption_projection = create_caption_projection(transformer_config, audio=True) if is_av else None
+    return caption_projection, audio_caption_projection
+
+
+LTXV_MODEL_COMFY_RENAMING_MAP = (
+    SDOps("LTXV_MODEL_COMFY_PREFIX_MAP")
+    .with_matching(prefix="model.diffusion_model.")
+    .with_replacement("model.diffusion_model.", "")
+)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/ops.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/ops.py
@@ -1,0 +1,106 @@
+from typing import List, Protocol
+
+import torch
+from torch import nn
+
+from ltx_core.model.transformer.rope import apply_rotary_emb
+from ltx_core.utils import rms_norm
+
+
+class PreAttentionCallable(Protocol):
+    def __call__(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        attn_module: nn.Module,
+        mask: torch.Tensor | None,
+        pe: torch.Tensor | None,
+        k_pe: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]: ...
+
+
+class PytorchPreAttention(PreAttentionCallable):
+    def __call__(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        attn_module: nn.Module,
+        mask: torch.Tensor | None,  # noqa: ARG002
+        pe: torch.Tensor | None,
+        k_pe: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        q = attn_module.q_norm(q)
+        k = attn_module.k_norm(k)
+        if pe is not None:
+            q = apply_rotary_emb(q, pe, attn_module.rope_type)
+            k = apply_rotary_emb(k, pe if k_pe is None else k_pe, attn_module.rope_type)
+        return q, k
+
+
+class AdaZeroCallable(Protocol):
+    def __call__(
+        self,
+        x: torch.Tensor,
+        eps: float,
+        scale: torch.Tensor,
+        shift: torch.Tensor,
+    ) -> torch.Tensor: ...
+
+
+class PytorchAdaZeroFunction(AdaZeroCallable):
+    def __call__(
+        self,
+        x: torch.Tensor,
+        eps: float,
+        scale: torch.Tensor,
+        shift: torch.Tensor,
+    ) -> torch.Tensor:
+        return rms_norm(x, eps=eps) * (1 + scale) + shift
+
+
+class PostSACallable(Protocol):
+    def __call__(
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        norm_weights: torch.Tensor | None,
+        eps: float,
+        gate: torch.Tensor,
+    ) -> List[torch.Tensor]: ...
+
+
+class PytorchPostSAFunction(PostSACallable):
+    def __call__(
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        norm_weights: torch.Tensor | None,
+        eps: float,
+        gate: torch.Tensor,
+    ) -> List[torch.Tensor]:
+        x_fma = x + y * gate
+        return x_fma, rms_norm(x_fma, norm_weights, eps=eps)
+
+
+class GatedAttentionCallable(Protocol):
+    def __call__(
+        self,
+        x: torch.Tensor,
+        attn_out: torch.Tensor,
+        attn_module: nn.Module,
+    ) -> torch.Tensor: ...
+
+
+class PytorchGatedAttention(GatedAttentionCallable):
+    def __call__(
+        self,
+        x: torch.Tensor,
+        attn_out: torch.Tensor,
+        attn_module: nn.Module,
+    ) -> torch.Tensor:
+        gate_logits = attn_module.to_gate_logits(x)  # (B, T, H)
+        b, t, _ = attn_out.shape
+        out = attn_out.view(b, t, attn_module.heads, attn_module.dim_head)
+        gates = 2.0 * torch.sigmoid(gate_logits)  # (B, T, H)
+        out = out * gates.unsqueeze(-1)  # (B, T, H, D) * (B, T, H, 1)
+        return out.view(b, t, attn_module.heads * attn_module.dim_head)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/rope.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/rope.py
@@ -1,0 +1,222 @@
+import functools
+import math
+from enum import Enum
+from typing import Callable, Tuple
+
+import numpy as np
+import torch
+from einops import rearrange
+
+
+class LTXRopeType(Enum):
+    INTERLEAVED = "interleaved"
+    SPLIT = "split"
+
+
+def apply_rotary_emb(
+    input_tensor: torch.Tensor,
+    freqs_cis: Tuple[torch.Tensor, torch.Tensor],
+    rope_type: LTXRopeType = LTXRopeType.SPLIT,
+) -> torch.Tensor:
+    if rope_type == LTXRopeType.INTERLEAVED:
+        # Note: INTERLEAVED rope is a legacy mode. Prefer SPLIT instead.
+        return apply_interleaved_rotary_emb(input_tensor, *freqs_cis)
+    elif rope_type == LTXRopeType.SPLIT:
+        return apply_split_rotary_emb(input_tensor, *freqs_cis)
+    else:
+        raise ValueError(f"Invalid rope type: {rope_type}")
+
+
+def apply_interleaved_rotary_emb(
+    input_tensor: torch.Tensor, cos_freqs: torch.Tensor, sin_freqs: torch.Tensor
+) -> torch.Tensor:
+    t_dup = rearrange(input_tensor, "... (d r) -> ... d r", r=2)
+    t1, t2 = t_dup.unbind(dim=-1)
+    t_dup = torch.stack((-t2, t1), dim=-1)
+    input_tensor_rot = rearrange(t_dup, "... d r -> ... (d r)")
+
+    out = input_tensor * cos_freqs + input_tensor_rot * sin_freqs
+
+    return out
+
+
+def apply_split_rotary_emb(
+    input_tensor: torch.Tensor, cos_freqs: torch.Tensor, sin_freqs: torch.Tensor
+) -> torch.Tensor:
+    if sin_freqs.shape != cos_freqs.shape:
+        raise ValueError(
+            f"apply_split_rotary_emb: sin_freqs.shape {tuple(sin_freqs.shape)} must equal "
+            f"cos_freqs.shape {tuple(cos_freqs.shape)}."
+        )
+    needs_reshape = input_tensor.ndim != 4 and cos_freqs.ndim == 4
+    if needs_reshape:
+        b_freq = cos_freqs.shape[0]
+        h = cos_freqs.shape[1]
+        b_in = input_tensor.shape[0]
+        if b_freq not in (1, b_in):
+            raise ValueError(
+                f"apply_split_rotary_emb: cos_freqs batch ({b_freq}) must be 1 "
+                f"(broadcast) or equal input_tensor batch ({b_in})."
+            )
+        # `unflatten` only touches the last dim, keeping the batch and seq dims as
+        # the input tensor's own symbolic ints under torch.compile. `reshape(b_in,
+        # t, h, -1)` would have forced Dynamo to specialise those dims because it
+        # cannot prove `b_in == cos_freqs.shape[0]` and `seq == t` across tensors.
+        input_tensor = input_tensor.unflatten(-1, (h, -1)).transpose(1, 2)
+
+    split_input = rearrange(input_tensor, "... (d r) -> ... d r", d=2)
+    first_half_input = split_input[..., :1, :]
+    second_half_input = split_input[..., 1:, :]
+
+    output = split_input * cos_freqs.unsqueeze(-2)
+    first_half_output = output[..., :1, :]
+    second_half_output = output[..., 1:, :]
+
+    first_half_output.addcmul_(-sin_freqs.unsqueeze(-2), second_half_input)
+    second_half_output.addcmul_(sin_freqs.unsqueeze(-2), first_half_input)
+
+    output = rearrange(output, "... d r -> ... (d r)")
+    if needs_reshape:
+        # `transpose(1, 2).flatten(-2)` keeps the batch and seq dims symbolic; using
+        # `reshape(b_in, t, -1)` would force Dynamo to specialise both axes.
+        output = output.transpose(1, 2).flatten(-2)
+
+    return output
+
+
+@functools.lru_cache(maxsize=5)
+def generate_freq_grid_np(
+    positional_embedding_theta: float, positional_embedding_max_pos_count: int, inner_dim: int
+) -> torch.Tensor:
+    theta = positional_embedding_theta
+    start = 1
+    end = theta
+
+    n_elem = 2 * positional_embedding_max_pos_count
+    pow_indices = np.power(
+        theta,
+        np.linspace(
+            np.log(start) / np.log(theta),
+            np.log(end) / np.log(theta),
+            inner_dim // n_elem,
+            dtype=np.float64,
+        ),
+    )
+    return torch.tensor(pow_indices * math.pi / 2, dtype=torch.float32)
+
+
+@functools.lru_cache(maxsize=5)
+def generate_freq_grid_pytorch(
+    positional_embedding_theta: float, positional_embedding_max_pos_count: int, inner_dim: int
+) -> torch.Tensor:
+    theta = positional_embedding_theta
+    start = 1
+    end = theta
+    n_elem = 2 * positional_embedding_max_pos_count
+
+    indices = theta ** (
+        torch.linspace(
+            math.log(start, theta),
+            math.log(end, theta),
+            inner_dim // n_elem,
+            dtype=torch.float32,
+        )
+    )
+    indices = indices.to(dtype=torch.float32)
+
+    indices = indices * math.pi / 2
+
+    return indices
+
+
+def get_fractional_positions(indices_grid: torch.Tensor, max_pos: list[int]) -> torch.Tensor:
+    n_pos_dims = indices_grid.shape[1]
+    assert n_pos_dims == len(max_pos), (
+        f"Number of position dimensions ({n_pos_dims}) must match max_pos length ({len(max_pos)})"
+    )
+    fractional_positions = torch.stack(
+        [indices_grid[:, i] / max_pos[i] for i in range(n_pos_dims)],
+        dim=-1,
+    )
+    return fractional_positions
+
+
+def generate_freqs(
+    indices: torch.Tensor, indices_grid: torch.Tensor, max_pos: list[int], use_middle_indices_grid: bool
+) -> torch.Tensor:
+    if use_middle_indices_grid:
+        assert len(indices_grid.shape) == 4
+        assert indices_grid.shape[-1] == 2
+        indices_grid_start, indices_grid_end = indices_grid[..., 0], indices_grid[..., 1]
+        indices_grid = (indices_grid_start + indices_grid_end) / 2.0
+    elif len(indices_grid.shape) == 4:
+        indices_grid = indices_grid[..., 0]
+
+    fractional_positions = get_fractional_positions(indices_grid, max_pos)
+    indices = indices.to(device=fractional_positions.device)
+
+    freqs = (indices * (fractional_positions.unsqueeze(-1) * 2 - 1)).transpose(-1, -2).flatten(2)
+    return freqs
+
+
+def split_freqs_cis(freqs: torch.Tensor, pad_size: int, num_attention_heads: int) -> tuple[torch.Tensor, torch.Tensor]:
+    cos_freq = freqs.cos()
+    sin_freq = freqs.sin()
+
+    if pad_size != 0:
+        cos_padding = torch.ones_like(cos_freq[:, :, :pad_size])
+        sin_padding = torch.zeros_like(sin_freq[:, :, :pad_size])
+
+        cos_freq = torch.concatenate([cos_padding, cos_freq], axis=-1)
+        sin_freq = torch.concatenate([sin_padding, sin_freq], axis=-1)
+
+    # Reshape freqs to be compatible with multi-head attention
+    b = cos_freq.shape[0]
+    t = cos_freq.shape[1]
+
+    cos_freq = cos_freq.reshape(b, t, num_attention_heads, -1)
+    sin_freq = sin_freq.reshape(b, t, num_attention_heads, -1)
+
+    cos_freq = torch.swapaxes(cos_freq, 1, 2)  # (B,H,T,D//2)
+    sin_freq = torch.swapaxes(sin_freq, 1, 2)  # (B,H,T,D//2)
+    return cos_freq, sin_freq
+
+
+def interleaved_freqs_cis(freqs: torch.Tensor, pad_size: int) -> tuple[torch.Tensor, torch.Tensor]:
+    cos_freq = freqs.cos().repeat_interleave(2, dim=-1)
+    sin_freq = freqs.sin().repeat_interleave(2, dim=-1)
+    if pad_size != 0:
+        cos_padding = torch.ones_like(cos_freq[:, :, :pad_size])
+        sin_padding = torch.zeros_like(cos_freq[:, :, :pad_size])
+        cos_freq = torch.cat([cos_padding, cos_freq], dim=-1)
+        sin_freq = torch.cat([sin_padding, sin_freq], dim=-1)
+    return cos_freq, sin_freq
+
+
+def precompute_freqs_cis(
+    indices_grid: torch.Tensor,
+    dim: int,
+    out_dtype: torch.dtype,
+    theta: float = 10000.0,
+    max_pos: list[int] | None = None,
+    use_middle_indices_grid: bool = False,
+    num_attention_heads: int = 32,
+    rope_type: LTXRopeType = LTXRopeType.SPLIT,
+    freq_grid_generator: Callable[[float, int, int, torch.device], torch.Tensor] = generate_freq_grid_pytorch,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if max_pos is None:
+        max_pos = [20, 2048, 2048]
+
+    indices = freq_grid_generator(theta, indices_grid.shape[1], dim)
+    freqs = generate_freqs(indices, indices_grid, max_pos, use_middle_indices_grid)
+
+    if rope_type == LTXRopeType.SPLIT:
+        expected_freqs = dim // 2
+        current_freqs = freqs.shape[-1]
+        pad_size = expected_freqs - current_freqs
+        cos_freq, sin_freq = split_freqs_cis(freqs, pad_size, num_attention_heads)
+    else:
+        # 2 because of cos and sin by 3 for (t, x, y), 1 for temporal only
+        n_elem = 2 * indices_grid.shape[1]
+        cos_freq, sin_freq = interleaved_freqs_cis(freqs, dim % n_elem)
+    return cos_freq.to(out_dtype), sin_freq.to(out_dtype)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/text_projection.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/text_projection.py
@@ -1,0 +1,38 @@
+import torch
+
+
+class PixArtAlphaTextProjection(torch.nn.Module):
+    """
+    Projects caption embeddings using dual linear layers.
+    Flow: linear_1 → activation → linear_2
+    Adapted from https://github.com/PixArt-alpha/PixArt-alpha/blob/master/diffusion/model/nets/PixArt_blocks.py
+    """
+
+    def __init__(self, in_features: int, hidden_size: int, out_features: int | None = None, act_fn: str = "gelu_tanh"):
+        super().__init__()
+        if out_features is None:
+            out_features = hidden_size
+        self.linear_1 = torch.nn.Linear(in_features=in_features, out_features=hidden_size, bias=True)
+        if act_fn == "gelu_tanh":
+            self.act_1 = torch.nn.GELU(approximate="tanh")
+        elif act_fn == "silu":
+            self.act_1 = torch.nn.SiLU()
+        else:
+            raise ValueError(f"Unknown activation function: {act_fn}")
+        self.linear_2 = torch.nn.Linear(in_features=hidden_size, out_features=out_features, bias=True)
+
+    def forward(self, caption: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.linear_1(caption)
+        hidden_states = self.act_1(hidden_states)
+        hidden_states = self.linear_2(hidden_states)
+        return hidden_states
+
+
+def create_caption_projection(transformer_config: dict, audio: bool = False) -> PixArtAlphaTextProjection:
+    """Create a caption projection for the transformer (V1/19B only)."""
+    caption_channels = transformer_config["caption_channels"]
+    if audio:
+        inner_dim = transformer_config["audio_num_attention_heads"] * transformer_config["audio_attention_head_dim"]
+    else:
+        inner_dim = transformer_config["num_attention_heads"] * transformer_config["attention_head_dim"]
+    return PixArtAlphaTextProjection(in_features=caption_channels, hidden_size=inner_dim)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/timestep_embedding.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/timestep_embedding.py
@@ -1,0 +1,145 @@
+import math
+
+import torch
+
+
+def get_timestep_embedding(
+    timesteps: torch.Tensor,
+    embedding_dim: int,
+    flip_sin_to_cos: bool = False,
+    downscale_freq_shift: float = 1,
+    scale: float = 1,
+    max_period: int = 10000,
+) -> torch.Tensor:
+    """
+    This matches the implementation in Denoising Diffusion Probabilistic Models: Create sinusoidal timestep embeddings.
+    Args
+        timesteps (torch.Tensor):
+            a 1-D Tensor of N indices, one per batch element. These may be fractional.
+        embedding_dim (int):
+            the dimension of the output.
+        flip_sin_to_cos (bool):
+            Whether the embedding order should be `cos, sin` (if True) or `sin, cos` (if False)
+        downscale_freq_shift (float):
+            Controls the delta between frequencies between dimensions
+        scale (float):
+            Scaling factor applied to the embeddings.
+        max_period (int):
+            Controls the maximum frequency of the embeddings
+    Returns
+        torch.Tensor: an [N x dim] Tensor of positional embeddings.
+    """
+    assert len(timesteps.shape) == 1, "Timesteps should be a 1d-array"
+
+    half_dim = embedding_dim // 2
+    exponent = -math.log(max_period) * torch.arange(
+        start=0, end=half_dim, dtype=torch.float32, device=timesteps.device
+    )
+    exponent = exponent / (half_dim - downscale_freq_shift)
+
+    emb = torch.exp(exponent)
+    emb = timesteps[:, None].float() * emb[None, :]
+
+    # scale embeddings
+    emb = scale * emb
+
+    # concat sine and cosine embeddings
+    emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=-1)
+
+    # flip sine and cosine embeddings
+    if flip_sin_to_cos:
+        emb = torch.cat([emb[:, half_dim:], emb[:, :half_dim]], dim=-1)
+
+    # zero pad
+    if embedding_dim % 2 == 1:
+        emb = torch.nn.functional.pad(emb, (0, 1, 0, 0))
+    return emb
+
+
+class TimestepEmbedding(torch.nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        time_embed_dim: int,
+        out_dim: int | None = None,
+        post_act_fn: str | None = None,
+        cond_proj_dim: int | None = None,
+        sample_proj_bias: bool = True,
+    ):
+        super().__init__()
+
+        self.linear_1 = torch.nn.Linear(in_channels, time_embed_dim, sample_proj_bias)
+
+        if cond_proj_dim is not None:
+            self.cond_proj = torch.nn.Linear(cond_proj_dim, in_channels, bias=False)
+        else:
+            self.cond_proj = None
+
+        self.act = torch.nn.SiLU()
+        time_embed_dim_out = out_dim if out_dim is not None else time_embed_dim
+
+        self.linear_2 = torch.nn.Linear(time_embed_dim, time_embed_dim_out, sample_proj_bias)
+
+        if post_act_fn is None:
+            self.post_act = None
+
+    def forward(self, sample: torch.Tensor, condition: torch.Tensor | None = None) -> torch.Tensor:
+        if condition is not None:
+            sample = sample + self.cond_proj(condition)
+        sample = self.linear_1(sample)
+
+        if self.act is not None:
+            sample = self.act(sample)
+
+        sample = self.linear_2(sample)
+
+        if self.post_act is not None:
+            sample = self.post_act(sample)
+        return sample
+
+
+class Timesteps(torch.nn.Module):
+    def __init__(self, num_channels: int, flip_sin_to_cos: bool, downscale_freq_shift: float, scale: int = 1):
+        super().__init__()
+        self.num_channels = num_channels
+        self.flip_sin_to_cos = flip_sin_to_cos
+        self.downscale_freq_shift = downscale_freq_shift
+        self.scale = scale
+
+    def forward(self, timesteps: torch.Tensor) -> torch.Tensor:
+        t_emb = get_timestep_embedding(
+            timesteps,
+            self.num_channels,
+            flip_sin_to_cos=self.flip_sin_to_cos,
+            downscale_freq_shift=self.downscale_freq_shift,
+            scale=self.scale,
+        )
+        return t_emb
+
+
+class PixArtAlphaCombinedTimestepSizeEmbeddings(torch.nn.Module):
+    """
+    For PixArt-Alpha.
+    Reference:
+    https://github.com/PixArt-alpha/PixArt-alpha/blob/0f55e922376d8b797edd44d25d0e7464b260dcab/diffusion/model/nets/PixArtMS.py#L164C9-L168C29
+    """
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        size_emb_dim: int,
+    ):
+        super().__init__()
+
+        self.outdim = size_emb_dim
+        self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
+        self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
+
+    def forward(
+        self,
+        timestep: torch.Tensor,
+        hidden_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        timesteps_proj = self.time_proj(timestep)
+        timesteps_emb = self.timestep_embedder(timesteps_proj.to(dtype=hidden_dtype))  # (N, D)
+        return timesteps_emb

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/transformer.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/transformer.py
@@ -1,0 +1,443 @@
+from dataclasses import dataclass, field, replace
+
+import torch
+
+from ltx_core.model.transformer.adaln import adaln_embedding_coefficient
+from ltx_core.model.transformer.attention import (
+    Attention,
+    AttentionCallable,
+    AttentionFunction,
+    AttentionOps,
+    MaskedAttentionCallable,
+    MaskedAttentionFunction,
+)
+from ltx_core.model.transformer.feed_forward import FeedForward
+from ltx_core.model.transformer.ops import (
+    AdaZeroCallable,
+    GatedAttentionCallable,
+    PostSACallable,
+    PreAttentionCallable,
+    PytorchAdaZeroFunction,
+    PytorchGatedAttention,
+    PytorchPostSAFunction,
+    PytorchPreAttention,
+)
+from ltx_core.model.transformer.rope import LTXRopeType
+from ltx_core.model.transformer.transformer_args import TransformerArgs
+from ltx_core.utils import rms_norm
+
+
+@dataclass
+class TransformerConfig:
+    dim: int
+    heads: int
+    d_head: int
+    context_dim: int
+    apply_gated_attention: bool = False
+    cross_attention_adaln: bool = False
+
+
+@dataclass(frozen=True)
+class TransformerOpsConfig:
+    """Pluggable ops for :class:`BasicAVTransformerBlock`.
+    Use :meth:`from_functions` to construct from enum values or partial overrides
+    without spelling out a full :class:`AttentionOps`.
+    """
+
+    attention_ops: AttentionOps = field(default_factory=AttentionOps)
+    ada_zero_function: AdaZeroCallable = field(default_factory=PytorchAdaZeroFunction)
+    post_sa_function: PostSACallable = field(default_factory=PytorchPostSAFunction)
+
+    @classmethod
+    def from_functions(
+        cls,
+        attention: AttentionFunction | AttentionCallable = AttentionFunction.AUTOMATIC,
+        masked_attention: MaskedAttentionFunction | MaskedAttentionCallable = MaskedAttentionFunction.AUTOMATIC,
+        preattention: PreAttentionCallable | None = None,
+        gated_attention: GatedAttentionCallable | None = None,
+        ada_zero: AdaZeroCallable | None = None,
+        post_sa: PostSACallable | None = None,
+    ) -> "TransformerOpsConfig":
+        """Build a config from individual functions or enums. Each *None* slot
+        falls back to the standard PyTorch implementation."""
+        attention_callable = attention.to_callable() if isinstance(attention, AttentionFunction) else attention
+        masked_callable = (
+            masked_attention.to_callable()
+            if isinstance(masked_attention, MaskedAttentionFunction)
+            else masked_attention
+        )
+        attention_ops = AttentionOps(
+            attention_function=attention_callable,
+            masked_attention_function=masked_callable,
+            preattention_function=preattention if preattention is not None else PytorchPreAttention(),
+            gated_attention_function=(gated_attention if gated_attention is not None else PytorchGatedAttention()),
+        )
+        return cls(
+            attention_ops=attention_ops,
+            ada_zero_function=ada_zero if ada_zero is not None else PytorchAdaZeroFunction(),
+            post_sa_function=post_sa if post_sa is not None else PytorchPostSAFunction(),
+        )
+
+
+# Frozen, so safe to share as a default argument across callers that want the
+# stock PyTorch ops without explicit construction.
+DEFAULT_TRANSFORMER_OPS = TransformerOpsConfig()
+
+
+class BasicAVTransformerBlock(torch.nn.Module):
+    def __init__(
+        self,
+        video: TransformerConfig | None = None,
+        audio: TransformerConfig | None = None,
+        rope_type: LTXRopeType = LTXRopeType.SPLIT,
+        norm_eps: float = 1e-6,
+        ops: TransformerOpsConfig | None = None,
+    ):
+        super().__init__()
+
+        if ops is None:
+            ops = TransformerOpsConfig()
+        self.ada_zero_function = ops.ada_zero_function
+        self.post_sa_function = ops.post_sa_function
+        if video is not None:
+            self.attn1 = Attention(
+                query_dim=video.dim,
+                heads=video.heads,
+                dim_head=video.d_head,
+                context_dim=None,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                ops=ops.attention_ops,
+                apply_gated_attention=video.apply_gated_attention,
+            )
+            self.attn2 = Attention(
+                query_dim=video.dim,
+                context_dim=video.context_dim,
+                heads=video.heads,
+                dim_head=video.d_head,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                ops=ops.attention_ops,
+                apply_gated_attention=video.apply_gated_attention,
+            )
+            self.ff = FeedForward(video.dim, dim_out=video.dim)
+            video_sst_size = adaln_embedding_coefficient(video.cross_attention_adaln)
+            self.scale_shift_table = torch.nn.Parameter(torch.empty(video_sst_size, video.dim))
+
+        if audio is not None:
+            self.audio_attn1 = Attention(
+                query_dim=audio.dim,
+                heads=audio.heads,
+                dim_head=audio.d_head,
+                context_dim=None,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                ops=ops.attention_ops,
+                apply_gated_attention=audio.apply_gated_attention,
+            )
+            self.audio_attn2 = Attention(
+                query_dim=audio.dim,
+                context_dim=audio.context_dim,
+                heads=audio.heads,
+                dim_head=audio.d_head,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                ops=ops.attention_ops,
+                apply_gated_attention=audio.apply_gated_attention,
+            )
+            self.audio_ff = FeedForward(audio.dim, dim_out=audio.dim)
+            audio_sst_size = adaln_embedding_coefficient(audio.cross_attention_adaln)
+            self.audio_scale_shift_table = torch.nn.Parameter(torch.empty(audio_sst_size, audio.dim))
+
+        if audio is not None and video is not None:
+            # Q: Video, K,V: Audio
+            self.audio_to_video_attn = Attention(
+                query_dim=video.dim,
+                context_dim=audio.dim,
+                heads=audio.heads,
+                dim_head=audio.d_head,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                ops=ops.attention_ops,
+                apply_gated_attention=video.apply_gated_attention,
+            )
+
+            # Q: Audio, K,V: Video
+            self.video_to_audio_attn = Attention(
+                query_dim=audio.dim,
+                context_dim=video.dim,
+                heads=audio.heads,
+                dim_head=audio.d_head,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                ops=ops.attention_ops,
+                apply_gated_attention=audio.apply_gated_attention,
+            )
+
+            self.scale_shift_table_a2v_ca_audio = torch.nn.Parameter(torch.empty(5, audio.dim))
+            self.scale_shift_table_a2v_ca_video = torch.nn.Parameter(torch.empty(5, video.dim))
+
+        self.cross_attention_adaln = (video is not None and video.cross_attention_adaln) or (
+            audio is not None and audio.cross_attention_adaln
+        )
+
+        if self.cross_attention_adaln and video is not None:
+            self.prompt_scale_shift_table = torch.nn.Parameter(torch.empty(2, video.dim))
+        if self.cross_attention_adaln and audio is not None:
+            self.audio_prompt_scale_shift_table = torch.nn.Parameter(torch.empty(2, audio.dim))
+
+        self.norm_eps = norm_eps
+
+    def get_ada_values(
+        self, scale_shift_table: torch.Tensor, batch_size: int, timestep: torch.Tensor, indices: slice
+    ) -> tuple[torch.Tensor, ...]:
+        num_ada_params = scale_shift_table.shape[0]
+
+        ada_values = (
+            scale_shift_table[indices].unsqueeze(0).unsqueeze(0).to(device=timestep.device, dtype=timestep.dtype)
+            + timestep.reshape(batch_size, timestep.shape[1], num_ada_params, -1)[:, :, indices, :]
+        ).unbind(dim=2)
+        return ada_values
+
+    def get_av_ca_ada_values(
+        self,
+        scale_shift_table: torch.Tensor,
+        batch_size: int,
+        scale_shift_timestep: torch.Tensor,
+        gate_timestep: torch.Tensor,
+        scale_shift_indices: slice,
+        num_scale_shift_values: int = 4,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        scale_shift_ada_values = self.get_ada_values(
+            scale_shift_table[:num_scale_shift_values, :], batch_size, scale_shift_timestep, scale_shift_indices
+        )
+        gate_ada_values = self.get_ada_values(
+            scale_shift_table[num_scale_shift_values:, :], batch_size, gate_timestep, slice(None, None)
+        )
+
+        scale, shift = (t.squeeze(2) for t in scale_shift_ada_values)
+        (gate,) = (t.squeeze(2) for t in gate_ada_values)
+
+        return scale, shift, gate
+
+    def _apply_text_cross_attention(
+        self,
+        x: torch.Tensor,
+        context: torch.Tensor,
+        attn: AttentionCallable,
+        scale_shift_table: torch.Tensor,
+        prompt_scale_shift_table: torch.Tensor | None,
+        timestep: torch.Tensor,
+        prompt_timestep: torch.Tensor | None,
+        context_mask: torch.Tensor | None,
+        cross_attention_adaln: bool = False,
+    ) -> torch.Tensor:
+        """Apply text cross-attention, with optional AdaLN modulation."""
+        if cross_attention_adaln:
+            shift_q, scale_q, gate = self.get_ada_values(scale_shift_table, x.shape[0], timestep, slice(6, 9))
+            return apply_cross_attention_adaln(
+                x,
+                context,
+                attn,
+                shift_q,
+                scale_q,
+                gate,
+                prompt_scale_shift_table,
+                prompt_timestep,
+                context_mask,
+                self.norm_eps,
+            )
+        return attn(rms_norm(x, eps=self.norm_eps), context=context, mask=context_mask)
+
+    def forward(  # noqa: PLR0915
+        self,
+        video: TransformerArgs | None,
+        audio: TransformerArgs | None,
+    ) -> tuple[TransformerArgs | None, TransformerArgs | None]:
+        if video is None and audio is None:
+            raise ValueError("At least one of video or audio must be provided")
+
+        vx = video.x if video is not None else None
+        ax = audio.x if audio is not None else None
+
+        run_vx = video is not None and video.enabled and vx.numel() > 0
+        run_ax = audio is not None and audio.enabled and ax.numel() > 0
+
+        run_a2v = run_vx and (audio is not None and ax.numel() > 0)
+        run_v2a = run_ax and (video is not None and vx.numel() > 0)
+
+        if run_vx:
+            vshift_msa, vscale_msa, vgate_msa = self.get_ada_values(
+                self.scale_shift_table, vx.shape[0], video.timesteps, slice(0, 3)
+            )
+            norm_vx = self.ada_zero_function(vx, self.norm_eps, vscale_msa, vshift_msa)
+            del vshift_msa, vscale_msa
+
+            vx_msa_out = self.attn1(
+                norm_vx,
+                pe=video.positional_embeddings,
+                mask=video.self_attention_mask,
+                perturbation_mask=video.self_attn_perturbation_mask,
+                all_perturbed=video.self_attn_all_perturbed,
+            )
+            vx = vx + vx_msa_out * vgate_msa
+            del vgate_msa, norm_vx, vx_msa_out
+            vx = vx + self._apply_text_cross_attention(
+                vx,
+                video.context,
+                self.attn2,
+                self.scale_shift_table,
+                getattr(self, "prompt_scale_shift_table", None),
+                video.timesteps,
+                video.prompt_timestep,
+                video.context_mask,
+                cross_attention_adaln=self.cross_attention_adaln,
+            )
+
+        if run_ax:
+            ashift_msa, ascale_msa, agate_msa = self.get_ada_values(
+                self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(0, 3)
+            )
+
+            norm_ax = self.ada_zero_function(ax, self.norm_eps, ascale_msa, ashift_msa)
+            del ashift_msa, ascale_msa
+            ax_msa_out = self.audio_attn1(
+                norm_ax,
+                pe=audio.positional_embeddings,
+                mask=audio.self_attention_mask,
+                perturbation_mask=audio.self_attn_perturbation_mask,
+                all_perturbed=audio.self_attn_all_perturbed,
+            )
+            ax = ax + ax_msa_out * agate_msa
+            del agate_msa, norm_ax, ax_msa_out
+            ax = ax + self._apply_text_cross_attention(
+                ax,
+                audio.context,
+                self.audio_attn2,
+                self.audio_scale_shift_table,
+                getattr(self, "audio_prompt_scale_shift_table", None),
+                audio.timesteps,
+                audio.prompt_timestep,
+                audio.context_mask,
+                cross_attention_adaln=self.cross_attention_adaln,
+            )
+
+        # Audio - Video cross attention.
+        if run_a2v or run_v2a:
+            # Snapshot vx/ax before A2V mutates vx; V2A's video keys/values must
+            # use the pre-A2V state so direction order doesn't bias the result.
+            vx_pre_av = vx
+            ax_pre_av = ax
+            if run_a2v and not video.cross_attn_skip_all:
+                scale_ca_video_a2v, shift_ca_video_a2v, gate_out_a2v = self.get_av_ca_ada_values(
+                    self.scale_shift_table_a2v_ca_video,
+                    vx.shape[0],
+                    video.cross_scale_shift_timestep,
+                    video.cross_gate_timestep,
+                    slice(0, 2),
+                )
+                a2v_vx_scaled = self.ada_zero_function(
+                    vx_pre_av, self.norm_eps, scale_ca_video_a2v, shift_ca_video_a2v
+                )
+                del scale_ca_video_a2v, shift_ca_video_a2v
+
+                scale_ca_audio_a2v, shift_ca_audio_a2v, _ = self.get_av_ca_ada_values(
+                    self.scale_shift_table_a2v_ca_audio,
+                    ax.shape[0],
+                    audio.cross_scale_shift_timestep,
+                    audio.cross_gate_timestep,
+                    slice(0, 2),
+                )
+                a2v_ax_scaled = self.ada_zero_function(
+                    ax_pre_av, self.norm_eps, scale_ca_audio_a2v, shift_ca_audio_a2v
+                )
+                del scale_ca_audio_a2v, shift_ca_audio_a2v
+                vx = vx + (
+                    self.audio_to_video_attn(
+                        a2v_vx_scaled,
+                        context=a2v_ax_scaled,
+                        pe=video.cross_positional_embeddings,
+                        k_pe=audio.cross_positional_embeddings,
+                    )
+                    * gate_out_a2v
+                    * video.cross_attn_perturbation_mask
+                )
+                del gate_out_a2v, a2v_vx_scaled, a2v_ax_scaled
+
+            if run_v2a and not audio.cross_attn_skip_all:
+                scale_ca_audio_v2a, shift_ca_audio_v2a, gate_out_v2a = self.get_av_ca_ada_values(
+                    self.scale_shift_table_a2v_ca_audio,
+                    ax.shape[0],
+                    audio.cross_scale_shift_timestep,
+                    audio.cross_gate_timestep,
+                    slice(2, 4),
+                )
+                v2a_ax_scaled = self.ada_zero_function(
+                    ax_pre_av, self.norm_eps, scale_ca_audio_v2a, shift_ca_audio_v2a
+                )
+                del scale_ca_audio_v2a, shift_ca_audio_v2a
+                scale_ca_video_v2a, shift_ca_video_v2a, _ = self.get_av_ca_ada_values(
+                    self.scale_shift_table_a2v_ca_video,
+                    vx.shape[0],
+                    video.cross_scale_shift_timestep,
+                    video.cross_gate_timestep,
+                    slice(2, 4),
+                )
+                v2a_vx_scaled = self.ada_zero_function(
+                    vx_pre_av, self.norm_eps, scale_ca_video_v2a, shift_ca_video_v2a
+                )
+                del scale_ca_video_v2a, shift_ca_video_v2a
+                ax = ax + (
+                    self.video_to_audio_attn(
+                        v2a_ax_scaled,
+                        context=v2a_vx_scaled,
+                        pe=audio.cross_positional_embeddings,
+                        k_pe=video.cross_positional_embeddings,
+                    )
+                    * gate_out_v2a
+                    * audio.cross_attn_perturbation_mask
+                )
+                del gate_out_v2a, v2a_vx_scaled, v2a_ax_scaled
+            del vx_pre_av, ax_pre_av
+
+        if run_vx:
+            vshift_mlp, vscale_mlp, vgate_mlp = self.get_ada_values(
+                self.scale_shift_table, vx.shape[0], video.timesteps, slice(3, 6)
+            )
+            vx_scaled = self.ada_zero_function(vx, self.norm_eps, vscale_mlp, vshift_mlp)
+            vx = vx + self.ff(vx_scaled) * vgate_mlp
+
+            del vshift_mlp, vscale_mlp, vgate_mlp, vx_scaled
+
+        if run_ax:
+            ashift_mlp, ascale_mlp, agate_mlp = self.get_ada_values(
+                self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(3, 6)
+            )
+            ax_scaled = self.ada_zero_function(ax, self.norm_eps, ascale_mlp, ashift_mlp)
+            ax = ax + self.audio_ff(ax_scaled) * agate_mlp
+
+            del ashift_mlp, ascale_mlp, agate_mlp, ax_scaled
+
+        return replace(video, x=vx) if video is not None else None, replace(audio, x=ax) if audio is not None else None
+
+
+def apply_cross_attention_adaln(
+    x: torch.Tensor,
+    context: torch.Tensor,
+    attn: AttentionCallable,
+    q_shift: torch.Tensor,
+    q_scale: torch.Tensor,
+    q_gate: torch.Tensor,
+    prompt_scale_shift_table: torch.Tensor,
+    prompt_timestep: torch.Tensor,
+    context_mask: torch.Tensor | None = None,
+    norm_eps: float = 1e-6,
+) -> torch.Tensor:
+    batch_size = x.shape[0]
+    shift_kv, scale_kv = (
+        prompt_scale_shift_table[None, None].to(device=x.device, dtype=x.dtype)
+        + prompt_timestep.reshape(batch_size, prompt_timestep.shape[1], 2, -1)
+    ).unbind(dim=2)
+    attn_input = rms_norm(x, eps=norm_eps) * (1 + q_scale) + q_shift
+    encoder_hidden_states = context * (1 + scale_kv) + shift_kv
+    return attn(attn_input, context=encoder_hidden_states, mask=context_mask) * q_gate

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/transformer_args.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/transformer/transformer_args.py
@@ -1,0 +1,353 @@
+from dataclasses import dataclass, replace
+
+import torch
+
+from ltx_core.guidance.perturbations import BatchedPerturbationConfig, PerturbationType
+from ltx_core.model.transformer.adaln import AdaLayerNormSingle
+from ltx_core.model.transformer.modality import Modality
+from ltx_core.model.transformer.rope import (
+    LTXRopeType,
+    generate_freq_grid_np,
+    generate_freq_grid_pytorch,
+    precompute_freqs_cis,
+)
+
+
+@dataclass(frozen=True)
+class TransformerArgs:
+    x: torch.Tensor
+    context: torch.Tensor
+    context_mask: torch.Tensor
+    timesteps: torch.Tensor
+    embedded_timestep: torch.Tensor
+    positional_embeddings: tuple[torch.Tensor, torch.Tensor]
+    cross_positional_embeddings: tuple[torch.Tensor, torch.Tensor] | None
+    cross_scale_shift_timestep: torch.Tensor | None
+    cross_gate_timestep: torch.Tensor | None
+    enabled: bool
+    prompt_timestep: torch.Tensor | None = None
+    self_attention_mask: torch.Tensor | None = (
+        None  # Additive log-space self-attention bias (B, 1, T, T), None = full attention
+    )
+    # Per-block perturbation state, precomputed by `LTXModel._process_transformer_blocks`
+    # so the block forward needs no per-block identity. The bool shortcuts
+    # (`*_all_perturbed`, `cross_attn_skip_all`) are Python bools that Dynamo specialises
+    # on — fine because they're stable across denoising steps for a fixed perturbation
+    # config.
+    self_attn_perturbation_mask: torch.Tensor | None = None
+    self_attn_all_perturbed: bool = False
+    cross_attn_perturbation_mask: torch.Tensor | None = None
+    cross_attn_skip_all: bool = False
+
+
+class BlockPerturbationsProcessor:
+    """Per-block preparation of ``TransformerArgs``.
+    The base implementation returns a copy of ``args`` with this block's
+    precomputed perturbation flags and masks attached. Subclasses can layer in
+    operations that must run on each block's inputs but stay outside the
+    compile boundary -- e.g. ``torch._dynamo.mark_dynamic`` for
+    shape-polymorphic block compilation (see ``compiling.py``). Swapping the
+    processor on an ``LTXModel`` instance is how compile transforms opt in to
+    such behaviour without baking it into the model's forward.
+    ``self_attn_perturbation_mask`` is None when all or none of the batch is
+    perturbed (the attention call can take the shortcut path). ``cross_attn_*``
+    is None when every sample skips the cross-attention entirely.
+    """
+
+    def __call__(
+        self,
+        args: "TransformerArgs",
+        perturbations: BatchedPerturbationConfig,
+        block_idx: int,
+        self_attn_type: PerturbationType,
+        cross_attn_type: PerturbationType,
+    ) -> "TransformerArgs":
+        device, dtype = args.x.device, args.x.dtype
+
+        all_self = perturbations.all_in_batch(self_attn_type, block_idx)
+        any_self = perturbations.any_in_batch(self_attn_type, block_idx)
+        self_mask: torch.Tensor | None = None
+        if any_self and not all_self:
+            self_mask = perturbations.mask(self_attn_type, block_idx, device, dtype).view(-1, 1, 1)
+
+        all_cross = perturbations.all_in_batch(cross_attn_type, block_idx)
+        cross_mask: torch.Tensor | None = None
+        if not all_cross:
+            cross_mask = perturbations.mask(cross_attn_type, block_idx, device, dtype).view(-1, 1, 1)
+
+        return replace(
+            args,
+            self_attn_perturbation_mask=self_mask,
+            self_attn_all_perturbed=all_self,
+            cross_attn_perturbation_mask=cross_mask,
+            cross_attn_skip_all=all_cross,
+        )
+
+
+class TransformerArgsPreprocessor:
+    def __init__(  # noqa: PLR0913
+        self,
+        patchify_proj: torch.nn.Linear,
+        adaln: AdaLayerNormSingle,
+        inner_dim: int,
+        max_pos: list[int],
+        num_attention_heads: int,
+        use_middle_indices_grid: bool,
+        timestep_scale_multiplier: int,
+        double_precision_rope: bool,
+        positional_embedding_theta: float,
+        rope_type: LTXRopeType,
+        caption_projection: torch.nn.Module | None = None,
+        prompt_adaln: AdaLayerNormSingle | None = None,
+    ) -> None:
+        self.patchify_proj = patchify_proj
+        self.adaln = adaln
+        self.inner_dim = inner_dim
+        self.max_pos = max_pos
+        self.num_attention_heads = num_attention_heads
+        self.use_middle_indices_grid = use_middle_indices_grid
+        self.timestep_scale_multiplier = timestep_scale_multiplier
+        self.double_precision_rope = double_precision_rope
+        self.positional_embedding_theta = positional_embedding_theta
+        self.rope_type = rope_type
+        self.caption_projection = caption_projection
+        self.prompt_adaln = prompt_adaln
+
+    def _prepare_timestep(
+        self, timestep: torch.Tensor, adaln: AdaLayerNormSingle, batch_size: int, hidden_dtype: torch.dtype
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Prepare timestep embeddings."""
+        timestep_scaled = timestep * self.timestep_scale_multiplier
+        timestep, embedded_timestep = adaln(
+            timestep_scaled.flatten(),
+            hidden_dtype=hidden_dtype,
+        )
+        # Second dimension is 1 or number of tokens (if timestep_per_token)
+        timestep = timestep.view(batch_size, -1, timestep.shape[-1])
+        embedded_timestep = embedded_timestep.view(batch_size, -1, embedded_timestep.shape[-1])
+
+        return timestep, embedded_timestep
+
+    def _prepare_context(
+        self,
+        context: torch.Tensor,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        """Prepare context for transformer blocks."""
+        if self.caption_projection is not None:
+            context = self.caption_projection(context)
+        batch_size = x.shape[0]
+        return context.view(batch_size, -1, x.shape[-1])
+
+    def _prepare_attention_mask(
+        self, attention_mask: torch.Tensor | None, x_dtype: torch.dtype
+    ) -> torch.Tensor | None:
+        """Prepare attention mask."""
+        if attention_mask is None or torch.is_floating_point(attention_mask):
+            return attention_mask
+
+        return (attention_mask - 1).to(x_dtype).reshape(
+            (attention_mask.shape[0], 1, -1, attention_mask.shape[-1])
+        ) * torch.finfo(x_dtype).max
+
+    def _prepare_self_attention_mask(
+        self, attention_mask: torch.Tensor | None, x_dtype: torch.dtype
+    ) -> torch.Tensor | None:
+        """Prepare self-attention mask by converting [0,1] values to additive log-space bias.
+        Input shape: 3D ``(B, T_q, T_k)`` with values in [0, 1]. The dense form
+        is ``(B, T, T)``; broadcastable forms like ``(1, 1, T)`` (key-only
+        padding) or ``(B, 1, T)`` are also valid and yield a correspondingly
+        broadcastable output.
+        Output shape: ``(B, 1, T_q, T_k)`` (heads dim inserted) with 0.0 for
+        full attention and a large negative value for masked positions.
+        Positions with attention_mask <= 0 are fully masked (mapped to the dtype's minimum
+        representable value). Strictly positive entries are converted via log-space for
+        smooth attenuation, with small values clamped for numerical stability.
+        Returns None if input is None (no masking).
+        """
+        if attention_mask is None:
+            return None
+
+        # Convert [0, 1] attention mask to additive log-space bias:
+        #   1.0 -> log(1.0) = 0.0  (no bias, full attention)
+        #   0.0 -> finfo.min        (fully masked)
+        finfo = torch.finfo(x_dtype)
+        eps = finfo.tiny
+
+        bias = torch.full_like(attention_mask, finfo.min, dtype=x_dtype)
+        positive = attention_mask > 0
+        if positive.any():
+            bias[positive] = torch.log(attention_mask[positive].clamp(min=eps)).to(x_dtype)
+
+        return bias.unsqueeze(1)  # (B, 1, T_q, T_k) for head broadcast
+
+    def _prepare_positional_embeddings(
+        self,
+        positions: torch.Tensor,
+        inner_dim: int,
+        max_pos: list[int],
+        use_middle_indices_grid: bool,
+        num_attention_heads: int,
+        x_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Prepare positional embeddings."""
+        freq_grid_generator = generate_freq_grid_np if self.double_precision_rope else generate_freq_grid_pytorch
+        pe = precompute_freqs_cis(
+            positions,
+            dim=inner_dim,
+            out_dtype=x_dtype,
+            theta=self.positional_embedding_theta,
+            max_pos=max_pos,
+            use_middle_indices_grid=use_middle_indices_grid,
+            num_attention_heads=num_attention_heads,
+            rope_type=self.rope_type,
+            freq_grid_generator=freq_grid_generator,
+        )
+        return pe
+
+    def prepare(
+        self,
+        modality: Modality,
+        cross_modality: Modality | None = None,  # noqa: ARG002
+    ) -> TransformerArgs:
+        x = self.patchify_proj(modality.latent)
+        batch_size = x.shape[0]
+        timestep, embedded_timestep = self._prepare_timestep(
+            modality.timesteps, self.adaln, batch_size, modality.latent.dtype
+        )
+        prompt_timestep = None
+        if self.prompt_adaln is not None:
+            prompt_timestep, _ = self._prepare_timestep(
+                modality.sigma, self.prompt_adaln, batch_size, modality.latent.dtype
+            )
+        context = self._prepare_context(modality.context, x)
+        attention_mask = self._prepare_attention_mask(modality.context_mask, modality.latent.dtype)
+        pe = self._prepare_positional_embeddings(
+            positions=modality.positions,
+            inner_dim=self.inner_dim,
+            max_pos=self.max_pos,
+            use_middle_indices_grid=self.use_middle_indices_grid,
+            num_attention_heads=self.num_attention_heads,
+            x_dtype=modality.latent.dtype,
+        )
+        self_attention_mask = self._prepare_self_attention_mask(modality.attention_mask, modality.latent.dtype)
+        return TransformerArgs(
+            x=x,
+            context=context,
+            context_mask=attention_mask,
+            timesteps=timestep,
+            embedded_timestep=embedded_timestep,
+            positional_embeddings=pe,
+            cross_positional_embeddings=None,
+            cross_scale_shift_timestep=None,
+            cross_gate_timestep=None,
+            enabled=modality.enabled,
+            prompt_timestep=prompt_timestep,
+            self_attention_mask=self_attention_mask,
+        )
+
+
+class MultiModalTransformerArgsPreprocessor:
+    def __init__(  # noqa: PLR0913
+        self,
+        patchify_proj: torch.nn.Linear,
+        adaln: AdaLayerNormSingle,
+        cross_scale_shift_adaln: AdaLayerNormSingle,
+        cross_gate_adaln: AdaLayerNormSingle,
+        inner_dim: int,
+        max_pos: list[int],
+        num_attention_heads: int,
+        cross_pe_max_pos: int,
+        use_middle_indices_grid: bool,
+        audio_cross_attention_dim: int,
+        timestep_scale_multiplier: int,
+        double_precision_rope: bool,
+        positional_embedding_theta: float,
+        rope_type: LTXRopeType,
+        av_ca_timestep_scale_multiplier: int,
+        caption_projection: torch.nn.Module | None = None,
+        prompt_adaln: AdaLayerNormSingle | None = None,
+    ) -> None:
+        self.simple_preprocessor = TransformerArgsPreprocessor(
+            patchify_proj=patchify_proj,
+            adaln=adaln,
+            inner_dim=inner_dim,
+            max_pos=max_pos,
+            num_attention_heads=num_attention_heads,
+            use_middle_indices_grid=use_middle_indices_grid,
+            timestep_scale_multiplier=timestep_scale_multiplier,
+            double_precision_rope=double_precision_rope,
+            positional_embedding_theta=positional_embedding_theta,
+            rope_type=rope_type,
+            caption_projection=caption_projection,
+            prompt_adaln=prompt_adaln,
+        )
+        self.cross_scale_shift_adaln = cross_scale_shift_adaln
+        self.cross_gate_adaln = cross_gate_adaln
+        self.cross_pe_max_pos = cross_pe_max_pos
+        self.audio_cross_attention_dim = audio_cross_attention_dim
+        self.av_ca_timestep_scale_multiplier = av_ca_timestep_scale_multiplier
+
+    def prepare(
+        self,
+        modality: Modality,
+        cross_modality: Modality | None = None,
+    ) -> TransformerArgs:
+        transformer_args = self.simple_preprocessor.prepare(modality)
+        if cross_modality is None:
+            return transformer_args
+
+        if cross_modality.sigma.numel() > 1:
+            if cross_modality.sigma.shape[0] != modality.timesteps.shape[0]:
+                raise ValueError("Cross modality sigma must have the same batch size as the modality")
+            if cross_modality.sigma.ndim != 1:
+                raise ValueError("Cross modality sigma must be a 1D tensor")
+
+        cross_pe = self.simple_preprocessor._prepare_positional_embeddings(
+            positions=modality.positions[:, 0:1, :],
+            inner_dim=self.audio_cross_attention_dim,
+            max_pos=[self.cross_pe_max_pos],
+            use_middle_indices_grid=True,
+            num_attention_heads=self.simple_preprocessor.num_attention_heads,
+            x_dtype=modality.latent.dtype,
+        )
+
+        cross_scale_shift_timestep, cross_gate_timestep = self._prepare_cross_attention_timestep(
+            modality_timesteps=modality.timesteps,
+            cross_modality_sigma=cross_modality.sigma,
+            timestep_scale_multiplier=self.simple_preprocessor.timestep_scale_multiplier,
+            batch_size=transformer_args.x.shape[0],
+            hidden_dtype=modality.latent.dtype,
+        )
+
+        return replace(
+            transformer_args,
+            cross_positional_embeddings=cross_pe,
+            cross_scale_shift_timestep=cross_scale_shift_timestep,
+            cross_gate_timestep=cross_gate_timestep,
+        )
+
+    def _prepare_cross_attention_timestep(
+        self,
+        modality_timesteps: torch.Tensor,
+        cross_modality_sigma: torch.Tensor,
+        timestep_scale_multiplier: int,
+        batch_size: int,
+        hidden_dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Prepare A-V cross-attention AdaLN inputs."""
+        av_ca_factor = self.av_ca_timestep_scale_multiplier / timestep_scale_multiplier
+
+        scale_shift_timestep, _ = self.cross_scale_shift_adaln(
+            (modality_timesteps * timestep_scale_multiplier).flatten(),
+            hidden_dtype=hidden_dtype,
+        )
+        scale_shift_timestep = scale_shift_timestep.view(batch_size, -1, scale_shift_timestep.shape[-1])
+
+        gate_noise_timestep, _ = self.cross_gate_adaln(
+            (cross_modality_sigma * timestep_scale_multiplier * av_ca_factor).flatten(),
+            hidden_dtype=hidden_dtype,
+        )
+        gate_noise_timestep = gate_noise_timestep.view(batch_size, -1, gate_noise_timestep.shape[-1])
+
+        return scale_shift_timestep, gate_noise_timestep

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/__init__.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/__init__.py
@@ -1,0 +1,21 @@
+from ltx_core.model.video_vae.model_configurator import (
+    VideoDecoderConfigurator,
+    VideoEncoderConfigurator,
+    load_video_decoder,
+    load_video_encoder,
+)
+from ltx_core.model.video_vae.tiling import SpatialTilingConfig, TemporalTilingConfig, TilingConfig
+from ltx_core.model.video_vae.video_vae import VideoDecoder, VideoEncoder
+
+
+__all__ = [
+    "SpatialTilingConfig",
+    "TemporalTilingConfig",
+    "TilingConfig",
+    "VideoDecoder",
+    "VideoDecoderConfigurator",
+    "VideoEncoder",
+    "VideoEncoderConfigurator",
+    "load_video_decoder",
+    "load_video_encoder",
+]

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/convolution.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/convolution.py
@@ -1,0 +1,303 @@
+from typing import Tuple, Union
+
+import torch
+from einops import rearrange
+from torch import nn
+from torch.nn import functional as F
+
+from ltx_core.model.video_vae.enums import PaddingModeType
+
+
+def make_conv_nd(  # noqa: PLR0913
+    dims: Union[int, Tuple[int, int]],
+    in_channels: int,
+    out_channels: int,
+    kernel_size: int,
+    stride: int = 1,
+    padding: int = 0,
+    dilation: int = 1,
+    groups: int = 1,
+    bias: bool = True,
+    causal: bool = False,
+    spatial_padding_mode: PaddingModeType = PaddingModeType.ZEROS,
+    temporal_padding_mode: PaddingModeType = PaddingModeType.ZEROS,
+) -> nn.Module:
+    if not (spatial_padding_mode == temporal_padding_mode or causal):
+        raise NotImplementedError("spatial and temporal padding modes must be equal")
+    if dims == 2:
+        return nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+            padding_mode=spatial_padding_mode.value,
+        )
+    elif dims == 3:
+        if causal:
+            return CausalConv3d(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                kernel_size=kernel_size,
+                stride=stride,
+                dilation=dilation,
+                groups=groups,
+                bias=bias,
+                spatial_padding_mode=spatial_padding_mode,
+            )
+        return nn.Conv3d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+            padding_mode=spatial_padding_mode.value,
+        )
+    elif dims == (2, 1):
+        return DualConv3d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            bias=bias,
+            padding_mode=spatial_padding_mode.value,
+        )
+    else:
+        raise ValueError(f"unsupported dimensions: {dims}")
+
+
+def make_linear_nd(
+    dims: int,
+    in_channels: int,
+    out_channels: int,
+    bias: bool = True,
+) -> nn.Module:
+    if dims == 2:
+        return nn.Conv2d(in_channels=in_channels, out_channels=out_channels, kernel_size=1, bias=bias)
+    elif dims in (3, (2, 1)):
+        return nn.Conv3d(in_channels=in_channels, out_channels=out_channels, kernel_size=1, bias=bias)
+    else:
+        raise ValueError(f"unsupported dimensions: {dims}")
+
+
+class DualConv3d(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: Union[int, Tuple[int, int, int]] = 1,
+        padding: Union[int, Tuple[int, int, int]] = 0,
+        dilation: Union[int, Tuple[int, int, int]] = 1,
+        groups: int = 1,
+        bias: bool = True,
+        padding_mode: str = "zeros",
+    ) -> None:
+        super(DualConv3d, self).__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.padding_mode = padding_mode
+        if isinstance(kernel_size, int):
+            kernel_size = (kernel_size, kernel_size, kernel_size)
+        if kernel_size == (1, 1, 1):
+            raise ValueError("kernel_size must be greater than 1. Use make_linear_nd instead.")
+        if isinstance(stride, int):
+            stride = (stride, stride, stride)
+        if isinstance(padding, int):
+            padding = (padding, padding, padding)
+        if isinstance(dilation, int):
+            dilation = (dilation, dilation, dilation)
+
+        self.groups = groups
+        self.bias = bias
+
+        intermediate_channels = out_channels if in_channels < out_channels else in_channels
+
+        self.weight1 = nn.Parameter(
+            torch.Tensor(
+                intermediate_channels,
+                in_channels // groups,
+                1,
+                kernel_size[1],
+                kernel_size[2],
+            )
+        )
+        self.stride1 = (1, stride[1], stride[2])
+        self.padding1 = (0, padding[1], padding[2])
+        self.dilation1 = (1, dilation[1], dilation[2])
+        if bias:
+            self.bias1 = nn.Parameter(torch.Tensor(intermediate_channels))
+        else:
+            self.register_parameter("bias1", None)
+
+        self.weight2 = nn.Parameter(torch.Tensor(out_channels, intermediate_channels // groups, kernel_size[0], 1, 1))
+        self.stride2 = (stride[0], 1, 1)
+        self.padding2 = (padding[0], 0, 0)
+        self.dilation2 = (dilation[0], 1, 1)
+        if bias:
+            self.bias2 = nn.Parameter(torch.Tensor(out_channels))
+        else:
+            self.register_parameter("bias2", None)
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        nn.init.kaiming_uniform_(self.weight1, a=torch.sqrt(5))
+        nn.init.kaiming_uniform_(self.weight2, a=torch.sqrt(5))
+        if self.bias:
+            fan_in1, _ = nn.init._calculate_fan_in_and_fan_out(self.weight1)
+            bound1 = 1 / torch.sqrt(fan_in1)
+            nn.init.uniform_(self.bias1, -bound1, bound1)
+            fan_in2, _ = nn.init._calculate_fan_in_and_fan_out(self.weight2)
+            bound2 = 1 / torch.sqrt(fan_in2)
+            nn.init.uniform_(self.bias2, -bound2, bound2)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        use_conv3d: bool = False,
+        skip_time_conv: bool = False,
+    ) -> torch.Tensor:
+        if use_conv3d:
+            return self.forward_with_3d(x=x, skip_time_conv=skip_time_conv)
+        else:
+            return self.forward_with_2d(x=x, skip_time_conv=skip_time_conv)
+
+    def forward_with_3d(self, x: torch.Tensor, skip_time_conv: bool = False) -> torch.Tensor:
+        x = F.conv3d(
+            x,
+            self.weight1,
+            self.bias1,
+            self.stride1,
+            self.padding1,
+            self.dilation1,
+            self.groups,
+            padding_mode=self.padding_mode,
+        )
+
+        if skip_time_conv:
+            return x
+
+        x = F.conv3d(
+            x,
+            self.weight2,
+            self.bias2,
+            self.stride2,
+            self.padding2,
+            self.dilation2,
+            self.groups,
+            padding_mode=self.padding_mode,
+        )
+
+        return x
+
+    def forward_with_2d(self, x: torch.Tensor, skip_time_conv: bool = False) -> torch.Tensor:
+        b, _, _, h, w = x.shape
+
+        x = rearrange(x, "b c d h w -> (b d) c h w")
+        weight1 = self.weight1.squeeze(2)
+        stride1 = (self.stride1[1], self.stride1[2])
+        padding1 = (self.padding1[1], self.padding1[2])
+        dilation1 = (self.dilation1[1], self.dilation1[2])
+        x = F.conv2d(
+            x,
+            weight1,
+            self.bias1,
+            stride1,
+            padding1,
+            dilation1,
+            self.groups,
+            padding_mode=self.padding_mode,
+        )
+
+        _, _, h, w = x.shape
+
+        if skip_time_conv:
+            x = rearrange(x, "(b d) c h w -> b c d h w", b=b)
+            return x
+
+        x = rearrange(x, "(b d) c h w -> (b h w) c d", b=b)
+
+        weight2 = self.weight2.squeeze(-1).squeeze(-1)
+        stride2 = self.stride2[0]
+        padding2 = self.padding2[0]
+        dilation2 = self.dilation2[0]
+        x = F.conv1d(
+            x,
+            weight2,
+            self.bias2,
+            stride2,
+            padding2,
+            dilation2,
+            self.groups,
+            padding_mode=self.padding_mode,
+        )
+        x = rearrange(x, "(b h w) c d -> b c d h w", b=b, h=h, w=w)
+
+        return x
+
+    @property
+    def weight(self) -> torch.Tensor:
+        return self.weight2
+
+
+class CausalConv3d(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int = 3,
+        stride: Union[int, Tuple[int]] = 1,
+        dilation: int = 1,
+        groups: int = 1,
+        bias: bool = True,
+        spatial_padding_mode: PaddingModeType = PaddingModeType.ZEROS,
+    ) -> None:
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+
+        kernel_size = (kernel_size, kernel_size, kernel_size)
+        self.time_kernel_size = kernel_size[0]
+
+        dilation = (dilation, 1, 1)
+
+        height_pad = kernel_size[1] // 2
+        width_pad = kernel_size[2] // 2
+        padding = (0, height_pad, width_pad)
+
+        self.conv = nn.Conv3d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            dilation=dilation,
+            padding=padding,
+            padding_mode=spatial_padding_mode.value,
+            groups=groups,
+            bias=bias,
+        )
+
+    def forward(self, x: torch.Tensor, causal: bool = True) -> torch.Tensor:
+        if causal:
+            first_frame_pad = x[:, :, :1, :, :].repeat((1, 1, self.time_kernel_size - 1, 1, 1))
+            x = torch.concatenate((first_frame_pad, x), dim=2)
+        else:
+            first_frame_pad = x[:, :, :1, :, :].repeat((1, 1, (self.time_kernel_size - 1) // 2, 1, 1))
+            last_frame_pad = x[:, :, -1:, :, :].repeat((1, 1, (self.time_kernel_size - 1) // 2, 1, 1))
+            x = torch.concatenate((first_frame_pad, x, last_frame_pad), dim=2)
+        x = self.conv(x)
+        return x
+
+    @property
+    def weight(self) -> torch.Tensor:
+        return self.conv.weight

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/enums.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/enums.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class NormLayerType(Enum):
+    GROUP_NORM = "group_norm"
+    PIXEL_NORM = "pixel_norm"
+
+
+class LogVarianceType(Enum):
+    PER_CHANNEL = "per_channel"
+    UNIFORM = "uniform"
+    CONSTANT = "constant"
+    NONE = "none"
+
+
+class PaddingModeType(Enum):
+    ZEROS = "zeros"
+    REFLECT = "reflect"
+    REPLICATE = "replicate"
+    CIRCULAR = "circular"

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/model_configurator.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/model_configurator.py
@@ -1,0 +1,151 @@
+import json
+from pathlib import Path
+
+import safetensors
+import torch
+
+from ltx_core.model.video_vae.enums import LogVarianceType, NormLayerType, PaddingModeType
+from ltx_core.model.video_vae.video_vae import VideoDecoder, VideoEncoder
+
+
+class VideoEncoderConfigurator:
+    @classmethod
+    def from_config(cls, config: dict) -> VideoEncoder:
+        config = config.get("vae", {})
+        convolution_dimensions = config.get("dims", 3)
+        in_channels = config.get("in_channels", 3)
+        latent_channels = config.get("latent_channels", 128)
+        spatial_padding_mode = PaddingModeType(config.get("spatial_padding_mode", "zeros"))
+        encoder_blocks = config.get("encoder_blocks", [])
+        patch_size = config.get("patch_size", 4)
+        norm_layer_str = config.get("norm_layer", "pixel_norm")
+        latent_log_var_str = config.get("latent_log_var", "uniform")
+
+        return VideoEncoder(
+            convolution_dimensions=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=latent_channels,
+            encoder_blocks=[tuple(b) for b in encoder_blocks],
+            patch_size=patch_size,
+            norm_layer=NormLayerType(norm_layer_str),
+            latent_log_var=LogVarianceType(latent_log_var_str),
+            encoder_spatial_padding_mode=spatial_padding_mode,
+        )
+
+
+class VideoDecoderConfigurator:
+    @classmethod
+    def from_config(cls, config: dict) -> VideoDecoder:
+        config = config.get("vae", {})
+        convolution_dimensions = config.get("dims", 3)
+        latent_channels = config.get("latent_channels", 128)
+        spatial_padding_mode = PaddingModeType(config.get("spatial_padding_mode", "reflect"))
+        out_channels = config.get("out_channels", 3)
+        decoder_blocks = config.get("decoder_blocks", [])
+        patch_size = config.get("patch_size", 4)
+        norm_layer_str = config.get("norm_layer", "pixel_norm")
+        causal = config.get("causal_decoder", False)
+        timestep_conditioning = config.get("timestep_conditioning", True)
+        base_channels = config.get("decoder_base_channels", 128)
+
+        return VideoDecoder(
+            convolution_dimensions=convolution_dimensions,
+            in_channels=latent_channels,
+            out_channels=out_channels,
+            decoder_blocks=[tuple(b) for b in decoder_blocks],
+            patch_size=patch_size,
+            norm_layer=NormLayerType(norm_layer_str),
+            causal=causal,
+            timestep_conditioning=timestep_conditioning,
+            decoder_spatial_padding_mode=spatial_padding_mode,
+            base_channels=base_channels,
+        )
+
+
+VAE_ENCODER_KEY_PREFIXES = ("vae.encoder.", "vae.per_channel_statistics.")
+VAE_DECODER_KEY_PREFIXES = ("vae.decoder.", "vae.per_channel_statistics.")
+
+
+def _load_safetensors_config(path: str) -> dict:
+    path_obj = Path(path)
+    if path_obj.is_dir():
+        safetensor_files = list(path_obj.rglob("*.safetensors"))
+        if not safetensor_files:
+            raise FileNotFoundError(f"No safetensors files found in {path}")
+        path = str(safetensor_files[0])
+
+    with safetensors.safe_open(path, framework="pt") as f:
+        meta = f.metadata()
+        if meta is None or "config" not in meta:
+            return {}
+        return json.loads(meta["config"])
+
+
+def _load_filtered_state_dict(
+    path: str,
+    key_prefixes: tuple[str, ...],
+    device: torch.device | None = None,
+) -> dict:
+    path_obj = Path(path)
+    if path_obj.is_dir():
+        safetensor_files = list(path_obj.rglob("*.safetensors"))
+    else:
+        safetensor_files = [path_obj]
+
+    sd = {}
+    device = device or torch.device("cpu")
+    for shard_path in safetensor_files:
+        with safetensors.safe_open(str(shard_path), framework="pt", device=str(device)) as f:
+            for name in f.keys():
+                if any(name.startswith(prefix) for prefix in key_prefixes):
+                    new_name = name
+                    for prefix in key_prefixes:
+                        if name.startswith(prefix):
+                            new_name = name[len(prefix) :]
+                            break
+                    sd[new_name] = f.get_tensor(name).to(device=device)
+    return sd
+
+
+def load_video_encoder(
+    checkpoint_path: str,
+    device: torch.device | str = "cpu",
+    dtype: torch.dtype = torch.bfloat16,
+    meta_init: bool = False,
+) -> VideoEncoder:
+    if isinstance(device, str):
+        device = torch.device(device)
+
+    config = _load_safetensors_config(checkpoint_path)
+    encoder = VideoEncoderConfigurator.from_config(config)
+
+    if not meta_init:
+        sd = _load_filtered_state_dict(checkpoint_path, VAE_ENCODER_KEY_PREFIXES, device)
+        if dtype is not None:
+            sd = {k: v.to(dtype=dtype) for k, v in sd.items()}
+        encoder.load_state_dict(sd, strict=False, assign=True)
+        encoder = encoder.to(device=device)
+
+    return encoder
+
+
+def load_video_decoder(
+    checkpoint_path: str,
+    device: torch.device | str = "cpu",
+    dtype: torch.dtype = torch.bfloat16,
+    meta_init: bool = False,
+) -> VideoDecoder:
+    if isinstance(device, str):
+        device = torch.device(device)
+
+    config = _load_safetensors_config(checkpoint_path)
+    decoder = VideoDecoderConfigurator.from_config(config)
+
+    if not meta_init:
+        sd = _load_filtered_state_dict(checkpoint_path, VAE_DECODER_KEY_PREFIXES, device)
+        if dtype is not None:
+            sd = {k: v.to(dtype=dtype) for k, v in sd.items()}
+        decoder.load_state_dict(sd, strict=False, assign=True)
+        decoder = decoder.to(device=device)
+
+    return decoder

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/normalization.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/normalization.py
@@ -1,0 +1,4 @@
+from ltx_core.model.common.normalization import PixelNorm, build_normalization_layer
+
+
+__all__ = ["PixelNorm", "build_normalization_layer"]

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/ops.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/ops.py
@@ -1,0 +1,57 @@
+import torch
+from einops import rearrange
+from torch import nn
+
+
+def patchify(x: torch.Tensor, patch_size_hw: int, patch_size_t: int = 1) -> torch.Tensor:
+    if patch_size_hw == 1 and patch_size_t == 1:
+        return x
+    if x.dim() == 4:
+        x = rearrange(x, "b c (h q) (w r) -> b (c r q) h w", q=patch_size_hw, r=patch_size_hw)
+    elif x.dim() == 5:
+        x = rearrange(
+            x,
+            "b c (f p) (h q) (w r) -> b (c p r q) f h w",
+            p=patch_size_t,
+            q=patch_size_hw,
+            r=patch_size_hw,
+        )
+    else:
+        raise ValueError(f"Invalid input shape: {x.shape}")
+
+    return x
+
+
+def unpatchify(x: torch.Tensor, patch_size_hw: int, patch_size_t: int = 1) -> torch.Tensor:
+    if patch_size_hw == 1 and patch_size_t == 1:
+        return x
+
+    if x.dim() == 4:
+        x = rearrange(x, "b (c r q) h w -> b c (h q) (w r)", q=patch_size_hw, r=patch_size_hw)
+    elif x.dim() == 5:
+        x = rearrange(
+            x,
+            "b (c p r q) f h w -> b c (f p) (h q) (w r)",
+            p=patch_size_t,
+            q=patch_size_hw,
+            r=patch_size_hw,
+        )
+
+    return x
+
+
+class PerChannelStatistics(nn.Module):
+    def __init__(self, latent_channels: int = 128):
+        super().__init__()
+        self.register_buffer("std-of-means", torch.empty(latent_channels))
+        self.register_buffer("mean-of-means", torch.empty(latent_channels))
+
+    def un_normalize(self, x: torch.Tensor) -> torch.Tensor:
+        return (x * self.get_buffer("std-of-means").view(1, -1, 1, 1, 1).to(x)) + self.get_buffer(
+            "mean-of-means"
+        ).view(1, -1, 1, 1, 1).to(x)
+
+    def normalize(self, x: torch.Tensor) -> torch.Tensor:
+        return (x - self.get_buffer("mean-of-means").view(1, -1, 1, 1, 1).to(x)) / self.get_buffer(
+            "std-of-means"
+        ).view(1, -1, 1, 1, 1).to(x)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/resnet.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/resnet.py
@@ -1,0 +1,243 @@
+from typing import Optional, Tuple, Union
+
+import torch
+from torch import nn
+
+from ltx_core.model.common.normalization import PixelNorm
+from ltx_core.model.transformer.timestep_embedding import PixArtAlphaCombinedTimestepSizeEmbeddings
+from ltx_core.model.video_vae.convolution import make_conv_nd, make_linear_nd
+from ltx_core.model.video_vae.enums import NormLayerType, PaddingModeType
+
+
+class ResnetBlock3D(nn.Module):
+    def __init__(
+        self,
+        dims: Union[int, Tuple[int, int]],
+        in_channels: int,
+        out_channels: Optional[int] = None,
+        dropout: float = 0.0,
+        groups: int = 32,
+        eps: float = 1e-6,
+        norm_layer: NormLayerType = NormLayerType.PIXEL_NORM,
+        inject_noise: bool = False,
+        timestep_conditioning: bool = False,
+        spatial_padding_mode: PaddingModeType = PaddingModeType.ZEROS,
+    ):
+        super().__init__()
+        self.in_channels = in_channels
+        out_channels = in_channels if out_channels is None else out_channels
+        self.out_channels = out_channels
+        self.inject_noise = inject_noise
+
+        if norm_layer == NormLayerType.GROUP_NORM:
+            self.norm1 = nn.GroupNorm(num_groups=groups, num_channels=in_channels, eps=eps, affine=True)
+        elif norm_layer == NormLayerType.PIXEL_NORM:
+            self.norm1 = PixelNorm()
+
+        self.non_linearity = nn.SiLU()
+
+        self.conv1 = make_conv_nd(
+            dims,
+            in_channels,
+            out_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+
+        if inject_noise:
+            self.per_channel_scale1 = nn.Parameter(torch.zeros((in_channels, 1, 1)))
+
+        if norm_layer == NormLayerType.GROUP_NORM:
+            self.norm2 = nn.GroupNorm(num_groups=groups, num_channels=out_channels, eps=eps, affine=True)
+        elif norm_layer == NormLayerType.PIXEL_NORM:
+            self.norm2 = PixelNorm()
+
+        self.dropout = torch.nn.Dropout(dropout)
+
+        self.conv2 = make_conv_nd(
+            dims,
+            out_channels,
+            out_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+
+        if inject_noise:
+            self.per_channel_scale2 = nn.Parameter(torch.zeros((in_channels, 1, 1)))
+
+        self.conv_shortcut = (
+            make_linear_nd(dims=dims, in_channels=in_channels, out_channels=out_channels)
+            if in_channels != out_channels
+            else nn.Identity()
+        )
+
+        self.norm3 = (
+            nn.GroupNorm(num_groups=1, num_channels=in_channels, eps=eps, affine=True)
+            if in_channels != out_channels
+            else nn.Identity()
+        )
+
+        self.timestep_conditioning = timestep_conditioning
+
+        if timestep_conditioning:
+            self.scale_shift_table = nn.Parameter(torch.zeros(4, in_channels))
+
+    def _feed_spatial_noise(
+        self,
+        hidden_states: torch.Tensor,
+        per_channel_scale: torch.Tensor,
+        generator: Optional[torch.Generator] = None,
+    ) -> torch.Tensor:
+        spatial_shape = hidden_states.shape[-2:]
+        device = hidden_states.device
+        dtype = hidden_states.dtype
+
+        spatial_noise = torch.randn(spatial_shape, device=device, dtype=dtype, generator=generator)[None]
+        scaled_noise = (spatial_noise * per_channel_scale)[None, :, None, ...]
+        hidden_states = hidden_states + scaled_noise
+
+        return hidden_states
+
+    def forward(
+        self,
+        input_tensor: torch.Tensor,
+        causal: bool = True,
+        timestep: Optional[torch.Tensor] = None,
+        generator: Optional[torch.Generator] = None,
+    ) -> torch.Tensor:
+        hidden_states = input_tensor
+        batch_size = hidden_states.shape[0]
+
+        hidden_states = self.norm1(hidden_states)
+        if self.timestep_conditioning:
+            if timestep is None:
+                raise ValueError("'timestep' parameter must be provided when 'timestep_conditioning' is True")
+            ada_values = self.scale_shift_table[None, ..., None, None, None].to(
+                device=hidden_states.device, dtype=hidden_states.dtype
+            ) + timestep.reshape(
+                batch_size,
+                4,
+                -1,
+                timestep.shape[-3],
+                timestep.shape[-2],
+                timestep.shape[-1],
+            )
+            shift1, scale1, shift2, scale2 = ada_values.unbind(dim=1)
+
+            hidden_states = hidden_states * (1 + scale1) + shift1
+
+        hidden_states = self.non_linearity(hidden_states)
+
+        hidden_states = self.conv1(hidden_states, causal=causal)
+
+        if self.inject_noise:
+            hidden_states = self._feed_spatial_noise(
+                hidden_states,
+                self.per_channel_scale1.to(device=hidden_states.device, dtype=hidden_states.dtype),
+                generator=generator,
+            )
+
+        hidden_states = self.norm2(hidden_states)
+
+        if self.timestep_conditioning:
+            hidden_states = hidden_states * (1 + scale2) + shift2
+
+        hidden_states = self.non_linearity(hidden_states)
+
+        hidden_states = self.dropout(hidden_states)
+
+        hidden_states = self.conv2(hidden_states, causal=causal)
+
+        if self.inject_noise:
+            hidden_states = self._feed_spatial_noise(
+                hidden_states,
+                self.per_channel_scale2.to(device=hidden_states.device, dtype=hidden_states.dtype),
+                generator=generator,
+            )
+
+        input_tensor = self.norm3(input_tensor)
+
+        batch_size = input_tensor.shape[0]
+
+        input_tensor = self.conv_shortcut(input_tensor)
+
+        output_tensor = input_tensor + hidden_states
+
+        return output_tensor
+
+
+class UNetMidBlock3D(nn.Module):
+    def __init__(
+        self,
+        dims: Union[int, Tuple[int, int]],
+        in_channels: int,
+        dropout: float = 0.0,
+        num_layers: int = 1,
+        resnet_eps: float = 1e-6,
+        resnet_groups: int = 32,
+        norm_layer: NormLayerType = NormLayerType.GROUP_NORM,
+        inject_noise: bool = False,
+        timestep_conditioning: bool = False,
+        spatial_padding_mode: PaddingModeType = PaddingModeType.ZEROS,
+    ):
+        super().__init__()
+        resnet_groups = resnet_groups if resnet_groups is not None else min(in_channels // 4, 32)
+
+        self.timestep_conditioning = timestep_conditioning
+
+        if timestep_conditioning:
+            self.time_embedder = PixArtAlphaCombinedTimestepSizeEmbeddings(
+                embedding_dim=in_channels * 4, size_emb_dim=0
+            )
+
+        self.res_blocks = nn.ModuleList(
+            [
+                ResnetBlock3D(
+                    dims=dims,
+                    in_channels=in_channels,
+                    out_channels=in_channels,
+                    eps=resnet_eps,
+                    groups=resnet_groups,
+                    dropout=dropout,
+                    norm_layer=norm_layer,
+                    inject_noise=inject_noise,
+                    timestep_conditioning=timestep_conditioning,
+                    spatial_padding_mode=spatial_padding_mode,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        causal: bool = True,
+        timestep: Optional[torch.Tensor] = None,
+        generator: Optional[torch.Generator] = None,
+    ) -> torch.Tensor:
+        timestep_embed = None
+        if self.timestep_conditioning:
+            if timestep is None:
+                raise ValueError("'timestep' parameter must be provided when 'timestep_conditioning' is True")
+            batch_size = hidden_states.shape[0]
+            timestep_embed = self.time_embedder(
+                timestep=timestep.flatten(),
+                hidden_dtype=hidden_states.dtype,
+            )
+            timestep_embed = timestep_embed.view(batch_size, timestep_embed.shape[-1], 1, 1, 1)
+
+        for resnet in self.res_blocks:
+            hidden_states = resnet(
+                hidden_states,
+                causal=causal,
+                timestep=timestep_embed,
+                generator=generator,
+            )
+
+        return hidden_states

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/sampling.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/sampling.py
@@ -1,0 +1,120 @@
+import math
+from typing import Tuple, Union
+
+import torch
+from einops import rearrange
+from torch import nn
+
+from .convolution import make_conv_nd
+from .enums import PaddingModeType
+
+
+class SpaceToDepthDownsample(nn.Module):
+    def __init__(
+        self,
+        dims: Union[int, Tuple[int, int]],
+        in_channels: int,
+        out_channels: int,
+        stride: Tuple[int, int, int],
+        spatial_padding_mode: PaddingModeType = PaddingModeType.ZEROS,
+    ):
+        super().__init__()
+        self.stride = stride
+        self.group_size = in_channels * math.prod(stride) // out_channels
+        self.conv = make_conv_nd(
+            dims=dims,
+            in_channels=in_channels,
+            out_channels=out_channels // math.prod(stride),
+            kernel_size=3,
+            stride=1,
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        causal: bool = True,
+    ) -> torch.Tensor:
+        if self.stride[0] == 2:
+            x = torch.cat([x[:, :, :1, :, :], x], dim=2)
+
+        x_in = rearrange(
+            x,
+            "b c (d p1) (h p2) (w p3) -> b (c p1 p2 p3) d h w",
+            p1=self.stride[0],
+            p2=self.stride[1],
+            p3=self.stride[2],
+        )
+        x_in = rearrange(x_in, "b (c g) d h w -> b c g d h w", g=self.group_size)
+        x_in = x_in.mean(dim=2)
+
+        x = self.conv(x, causal=causal)
+        x = rearrange(
+            x,
+            "b c (d p1) (h p2) (w p3) -> b (c p1 p2 p3) d h w",
+            p1=self.stride[0],
+            p2=self.stride[1],
+            p3=self.stride[2],
+        )
+
+        x = x + x_in
+
+        return x
+
+
+class DepthToSpaceUpsample(nn.Module):
+    def __init__(
+        self,
+        dims: int | Tuple[int, int],
+        in_channels: int,
+        stride: Tuple[int, int, int],
+        residual: bool = False,
+        out_channels_reduction_factor: int = 1,
+        spatial_padding_mode: PaddingModeType = PaddingModeType.ZEROS,
+    ):
+        super().__init__()
+        self.stride = stride
+        self.out_channels = math.prod(stride) * in_channels // out_channels_reduction_factor
+        self.conv = make_conv_nd(
+            dims=dims,
+            in_channels=in_channels,
+            out_channels=self.out_channels,
+            kernel_size=3,
+            stride=1,
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+        self.residual = residual
+        self.out_channels_reduction_factor = out_channels_reduction_factor
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        causal: bool = True,
+    ) -> torch.Tensor:
+        if self.residual:
+            x_in = rearrange(
+                x,
+                "b (c p1 p2 p3) d h w -> b c (d p1) (h p2) (w p3)",
+                p1=self.stride[0],
+                p2=self.stride[1],
+                p3=self.stride[2],
+            )
+            num_repeat = math.prod(self.stride) // self.out_channels_reduction_factor
+            x_in = x_in.repeat(1, num_repeat, 1, 1, 1)
+            if self.stride[0] == 2:
+                x_in = x_in[:, :, 1:, :, :]
+        x = self.conv(x, causal=causal)
+        x = rearrange(
+            x,
+            "b (c p1 p2 p3) d h w -> b c (d p1) (h p2) (w p3)",
+            p1=self.stride[0],
+            p2=self.stride[1],
+            p3=self.stride[2],
+        )
+        if self.stride[0] == 2:
+            x = x[:, :, 1:, :, :]
+        if self.residual:
+            x = x + x_in
+        return x

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/tiling.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/tiling.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SpatialTilingConfig:
+    tile_size_in_pixels: int
+    tile_overlap_in_pixels: int = 0
+
+    def __post_init__(self) -> None:
+        if self.tile_size_in_pixels < 64:
+            raise ValueError(f"tile_size_in_pixels must be at least 64, got {self.tile_size_in_pixels}")
+        if self.tile_size_in_pixels % 32 != 0:
+            raise ValueError(f"tile_size_in_pixels must be divisible by 32, got {self.tile_size_in_pixels}")
+        if self.tile_overlap_in_pixels % 32 != 0:
+            raise ValueError(f"tile_overlap_in_pixels must be divisible by 32, got {self.tile_overlap_in_pixels}")
+        if self.tile_overlap_in_pixels >= self.tile_size_in_pixels:
+            raise ValueError(
+                f"Overlap must be less than tile size, got {self.tile_overlap_in_pixels} and {self.tile_size_in_pixels}"
+            )
+
+
+@dataclass(frozen=True)
+class TemporalTilingConfig:
+    tile_size_in_frames: int
+    tile_overlap_in_frames: int = 0
+
+    def __post_init__(self) -> None:
+        if self.tile_size_in_frames < 16:
+            raise ValueError(f"tile_size_in_frames must be at least 16, got {self.tile_size_in_frames}")
+        if self.tile_size_in_frames % 8 != 0:
+            raise ValueError(f"tile_size_in_frames must be divisible by 8, got {self.tile_size_in_frames}")
+        if self.tile_overlap_in_frames % 8 != 0:
+            raise ValueError(f"tile_overlap_in_frames must be divisible by 8, got {self.tile_overlap_in_frames}")
+        if self.tile_overlap_in_frames >= self.tile_size_in_frames:
+            raise ValueError(
+                f"Overlap must be less than tile size, got {self.tile_overlap_in_frames} and {self.tile_size_in_frames}"
+            )
+
+
+@dataclass(frozen=True)
+class TilingConfig:
+    spatial_config: SpatialTilingConfig | None = None
+    temporal_config: TemporalTilingConfig | None = None
+
+    @classmethod
+    def default(cls) -> "TilingConfig":
+        return cls(
+            spatial_config=SpatialTilingConfig(tile_size_in_pixels=768, tile_overlap_in_pixels=64),
+            temporal_config=TemporalTilingConfig(tile_size_in_frames=80, tile_overlap_in_frames=24),
+        )

--- a/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/video_vae.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/model/video_vae/video_vae.py
@@ -1,0 +1,493 @@
+import logging
+from typing import Any, List, Tuple
+
+import torch
+from torch import nn
+
+from ltx_core.model.common.normalization import PixelNorm
+from ltx_core.model.transformer.timestep_embedding import PixArtAlphaCombinedTimestepSizeEmbeddings
+from ltx_core.model.video_vae.convolution import make_conv_nd
+from ltx_core.model.video_vae.enums import LogVarianceType, NormLayerType, PaddingModeType
+from ltx_core.model.video_vae.ops import PerChannelStatistics, patchify, unpatchify
+from ltx_core.model.video_vae.resnet import ResnetBlock3D, UNetMidBlock3D
+from ltx_core.model.video_vae.sampling import DepthToSpaceUpsample, SpaceToDepthDownsample
+from ltx_core.types import SpatioTemporalScaleFactors
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _make_encoder_block(
+    block_name: str,
+    block_config: dict[str, Any],
+    in_channels: int,
+    convolution_dimensions: int,
+    norm_layer: NormLayerType,
+    norm_num_groups: int,
+    spatial_padding_mode: PaddingModeType,
+) -> Tuple[nn.Module, int]:
+    out_channels = in_channels
+
+    if block_name == "res_x":
+        block = UNetMidBlock3D(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            num_layers=block_config["num_layers"],
+            resnet_eps=1e-6,
+            resnet_groups=norm_num_groups,
+            norm_layer=norm_layer,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "res_x_y":
+        out_channels = in_channels * block_config.get("multiplier", 2)
+        block = ResnetBlock3D(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            eps=1e-6,
+            groups=norm_num_groups,
+            norm_layer=norm_layer,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "compress_time":
+        block = make_conv_nd(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=(2, 1, 1),
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "compress_space":
+        block = make_conv_nd(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=(1, 2, 2),
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "compress_all":
+        block = make_conv_nd(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=(2, 2, 2),
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "compress_all_x_y":
+        out_channels = in_channels * block_config.get("multiplier", 2)
+        block = make_conv_nd(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=(2, 2, 2),
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "compress_space_res":
+        out_channels = in_channels * block_config.get("multiplier", 2)
+        block = SpaceToDepthDownsample(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            stride=(1, 2, 2),
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "compress_time_res":
+        out_channels = in_channels * block_config.get("multiplier", 2)
+        block = SpaceToDepthDownsample(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            stride=(2, 1, 1),
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "compress_all_res":
+        out_channels = in_channels * block_config.get("multiplier", 2)
+        block = SpaceToDepthDownsample(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            stride=(2, 2, 2),
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    else:
+        raise ValueError(f"unknown block: {block_name}")
+
+    return block, out_channels
+
+
+class VideoEncoder(nn.Module):
+    _DEFAULT_NORM_NUM_GROUPS = 32
+
+    def __init__(
+        self,
+        convolution_dimensions: int = 3,
+        in_channels: int = 3,
+        out_channels: int = 128,
+        encoder_blocks: List[Tuple[str, int]] | List[Tuple[str, dict[str, Any]]] = [],  # noqa: B006
+        patch_size: int = 4,
+        norm_layer: NormLayerType = NormLayerType.PIXEL_NORM,
+        latent_log_var: LogVarianceType = LogVarianceType.UNIFORM,
+        encoder_spatial_padding_mode: PaddingModeType = PaddingModeType.ZEROS,
+    ):
+        super().__init__()
+
+        self.patch_size = patch_size
+        self.norm_layer = norm_layer
+        self.latent_channels = out_channels
+        self.latent_log_var = latent_log_var
+        self._norm_num_groups = self._DEFAULT_NORM_NUM_GROUPS
+
+        self.per_channel_statistics = PerChannelStatistics(latent_channels=out_channels)
+
+        in_channels = in_channels * patch_size**2
+        feature_channels = out_channels
+
+        self.conv_in = make_conv_nd(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=feature_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            causal=True,
+            spatial_padding_mode=encoder_spatial_padding_mode,
+        )
+
+        self.down_blocks = nn.ModuleList([])
+
+        for block_name, block_params in encoder_blocks:
+            block_config = {"num_layers": block_params} if isinstance(block_params, int) else block_params
+
+            block, feature_channels = _make_encoder_block(
+                block_name=block_name,
+                block_config=block_config,
+                in_channels=feature_channels,
+                convolution_dimensions=convolution_dimensions,
+                norm_layer=norm_layer,
+                norm_num_groups=self._norm_num_groups,
+                spatial_padding_mode=encoder_spatial_padding_mode,
+            )
+
+            self.down_blocks.append(block)
+
+        if norm_layer == NormLayerType.GROUP_NORM:
+            self.conv_norm_out = nn.GroupNorm(
+                num_channels=feature_channels, num_groups=self._norm_num_groups, eps=1e-6
+            )
+        elif norm_layer == NormLayerType.PIXEL_NORM:
+            self.conv_norm_out = PixelNorm()
+
+        self.conv_act = nn.SiLU()
+
+        conv_out_channels = out_channels
+        if latent_log_var == LogVarianceType.PER_CHANNEL:
+            conv_out_channels *= 2
+        elif latent_log_var in {LogVarianceType.UNIFORM, LogVarianceType.CONSTANT}:
+            conv_out_channels += 1
+        elif latent_log_var != LogVarianceType.NONE:
+            raise ValueError(f"Invalid latent_log_var: {latent_log_var}")
+
+        self.conv_out = make_conv_nd(
+            dims=convolution_dimensions,
+            in_channels=feature_channels,
+            out_channels=conv_out_channels,
+            kernel_size=3,
+            padding=1,
+            causal=True,
+            spatial_padding_mode=encoder_spatial_padding_mode,
+        )
+
+    def forward(self, sample: torch.Tensor) -> torch.Tensor:
+        frames_count = sample.shape[2]
+        if ((frames_count - 1) % 8) != 0:
+            frames_to_crop = (frames_count - 1) % 8
+            logger.warning(
+                "Invalid number of frames %s for encode; cropping last %s frames to satisfy 1 + 8*k.",
+                frames_count,
+                frames_to_crop,
+            )
+            sample = sample[:, :, :-frames_to_crop, ...]
+
+        sample = patchify(sample, patch_size_hw=self.patch_size, patch_size_t=1)
+        sample = self.conv_in(sample)
+
+        for down_block in self.down_blocks:
+            sample = down_block(sample)
+
+        sample = self.conv_norm_out(sample)
+        sample = self.conv_act(sample)
+        sample = self.conv_out(sample)
+
+        if self.latent_log_var == LogVarianceType.UNIFORM:
+            if sample.shape[1] < 2:
+                raise ValueError(
+                    f"Invalid channel count for UNIFORM mode: expected at least 2 channels "
+                    f"(N means + 1 logvar), got {sample.shape[1]}"
+                )
+
+            means = sample[:, :-1, ...]
+            logvar = sample[:, -1:, ...]
+
+            num_channels = means.shape[1]
+            repeat_shape = [1, num_channels] + [1] * (sample.ndim - 2)
+            repeated_logvar = logvar.repeat(*repeat_shape)
+
+            sample = torch.cat([means, repeated_logvar], dim=1)
+        elif self.latent_log_var == LogVarianceType.CONSTANT:
+            sample = sample[:, :-1, ...]
+            approx_ln_0 = -30
+            sample = torch.cat(
+                [sample, torch.ones_like(sample, device=sample.device) * approx_ln_0],
+                dim=1,
+            )
+
+        means, _ = torch.chunk(sample, 2, dim=1)
+        return self.per_channel_statistics.normalize(means)
+
+
+def _make_decoder_block(
+    block_name: str,
+    block_config: dict[str, Any],
+    in_channels: int,
+    convolution_dimensions: int,
+    norm_layer: NormLayerType,
+    timestep_conditioning: bool,
+    norm_num_groups: int,
+    spatial_padding_mode: PaddingModeType,
+) -> Tuple[nn.Module, int]:
+    out_channels = in_channels
+    if block_name == "res_x":
+        block = UNetMidBlock3D(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            num_layers=block_config["num_layers"],
+            resnet_eps=1e-6,
+            resnet_groups=norm_num_groups,
+            norm_layer=norm_layer,
+            inject_noise=block_config.get("inject_noise", False),
+            timestep_conditioning=timestep_conditioning,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "res_x_y":
+        out_channels = in_channels // block_config.get("multiplier", 2)
+        block = ResnetBlock3D(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            eps=1e-6,
+            groups=norm_num_groups,
+            norm_layer=norm_layer,
+            inject_noise=block_config.get("inject_noise", False),
+            timestep_conditioning=False,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "compress_time":
+        out_channels = in_channels // block_config.get("multiplier", 1)
+        block = DepthToSpaceUpsample(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            stride=(2, 1, 1),
+            out_channels_reduction_factor=block_config.get("multiplier", 1),
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "compress_space":
+        out_channels = in_channels // block_config.get("multiplier", 1)
+        block = DepthToSpaceUpsample(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            stride=(1, 2, 2),
+            out_channels_reduction_factor=block_config.get("multiplier", 1),
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "compress_all":
+        out_channels = in_channels // block_config.get("multiplier", 1)
+        block = DepthToSpaceUpsample(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            stride=(2, 2, 2),
+            residual=block_config.get("residual", False),
+            out_channels_reduction_factor=block_config.get("multiplier", 1),
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    else:
+        raise ValueError(f"unknown block: {block_name}")
+
+    return block, out_channels
+
+
+class VideoDecoder(nn.Module):
+    _DEFAULT_NORM_NUM_GROUPS = 32
+
+    def __init__(
+        self,
+        convolution_dimensions: int = 3,
+        in_channels: int = 128,
+        out_channels: int = 3,
+        decoder_blocks: List[Tuple[str, int | dict]] = [],  # noqa: B006
+        patch_size: int = 4,
+        norm_layer: NormLayerType = NormLayerType.PIXEL_NORM,
+        causal: bool = False,
+        timestep_conditioning: bool = False,
+        decoder_spatial_padding_mode: PaddingModeType = PaddingModeType.REFLECT,
+        base_channels: int = 128,
+    ):
+        super().__init__()
+
+        self.video_downscale_factors = SpatioTemporalScaleFactors(
+            time=8,
+            height=32,
+            width=32,
+        )
+
+        self.patch_size = patch_size
+        out_channels = out_channels * patch_size**2
+        self.causal = causal
+        self.timestep_conditioning = timestep_conditioning
+        self._norm_num_groups = self._DEFAULT_NORM_NUM_GROUPS
+
+        self.per_channel_statistics = PerChannelStatistics(latent_channels=in_channels)
+
+        self.decode_noise_scale = 0.025
+        self.decode_timestep = 0.05
+
+        feature_channels = base_channels * 8
+
+        self.conv_in = make_conv_nd(
+            dims=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=feature_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            causal=True,
+            spatial_padding_mode=decoder_spatial_padding_mode,
+        )
+
+        self.up_blocks = nn.ModuleList([])
+
+        for block_name, block_params in list(reversed(decoder_blocks)):
+            block_config = {"num_layers": block_params} if isinstance(block_params, int) else block_params
+
+            block, feature_channels = _make_decoder_block(
+                block_name=block_name,
+                block_config=block_config,
+                in_channels=feature_channels,
+                convolution_dimensions=convolution_dimensions,
+                norm_layer=norm_layer,
+                timestep_conditioning=timestep_conditioning,
+                norm_num_groups=self._norm_num_groups,
+                spatial_padding_mode=decoder_spatial_padding_mode,
+            )
+
+            self.up_blocks.append(block)
+
+        if norm_layer == NormLayerType.GROUP_NORM:
+            self.conv_norm_out = nn.GroupNorm(
+                num_channels=feature_channels, num_groups=self._norm_num_groups, eps=1e-6
+            )
+        elif norm_layer == NormLayerType.PIXEL_NORM:
+            self.conv_norm_out = PixelNorm()
+
+        self.conv_act = nn.SiLU()
+        self.conv_out = make_conv_nd(
+            dims=convolution_dimensions,
+            in_channels=feature_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            padding=1,
+            causal=True,
+            spatial_padding_mode=decoder_spatial_padding_mode,
+        )
+
+        if timestep_conditioning:
+            self.timestep_scale_multiplier = nn.Parameter(torch.tensor(1000.0))
+            self.last_time_embedder = PixArtAlphaCombinedTimestepSizeEmbeddings(
+                embedding_dim=feature_channels * 2, size_emb_dim=0
+            )
+            self.last_scale_shift_table = nn.Parameter(torch.empty(2, feature_channels))
+
+    def forward(
+        self,
+        sample: torch.Tensor,
+        timestep: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        batch_size = sample.shape[0]
+        output_dtype = sample.dtype
+        weights_dtype = next(self.parameters()).dtype
+        sample = sample.to(weights_dtype)
+
+        if self.timestep_conditioning:
+            noise = (
+                torch.randn(
+                    sample.size(),
+                    generator=generator,
+                    dtype=sample.dtype,
+                    device=sample.device,
+                )
+                * self.decode_noise_scale
+            )
+
+            sample = noise + (1.0 - self.decode_noise_scale) * sample
+
+        sample = self.per_channel_statistics.un_normalize(sample)
+
+        if timestep is None and self.timestep_conditioning:
+            timestep = torch.full((batch_size,), self.decode_timestep, device=sample.device, dtype=sample.dtype)
+
+        sample = self.conv_in(sample, causal=self.causal)
+
+        scaled_timestep = None
+        if self.timestep_conditioning:
+            if timestep is None:
+                raise ValueError("'timestep' parameter must be provided when 'timestep_conditioning' is True")
+            scaled_timestep = timestep * self.timestep_scale_multiplier.to(sample)
+
+        for up_block in self.up_blocks:
+            if isinstance(up_block, UNetMidBlock3D):
+                block_kwargs = {
+                    "causal": self.causal,
+                    "timestep": scaled_timestep if self.timestep_conditioning else None,
+                    "generator": generator,
+                }
+                sample = up_block(sample, **block_kwargs)
+            elif isinstance(up_block, ResnetBlock3D):
+                sample = up_block(sample, causal=self.causal, generator=generator)
+            else:
+                sample = up_block(sample, causal=self.causal)
+
+        sample = self.conv_norm_out(sample)
+
+        if self.timestep_conditioning:
+            embedded_timestep = self.last_time_embedder(
+                timestep=scaled_timestep.flatten(),
+                hidden_dtype=sample.dtype,
+            )
+            embedded_timestep = embedded_timestep.view(batch_size, embedded_timestep.shape[-1], 1, 1, 1)
+            ada_values = self.last_scale_shift_table[None, ..., None, None, None].to(
+                device=sample.device, dtype=sample.dtype
+            ) + embedded_timestep.reshape(
+                batch_size,
+                2,
+                -1,
+                embedded_timestep.shape[-3],
+                embedded_timestep.shape[-2],
+                embedded_timestep.shape[-1],
+            )
+            shift, scale = ada_values.unbind(dim=1)
+            sample = sample * (1 + scale) + shift
+
+        sample = self.conv_act(sample)
+        sample = self.conv_out(sample, causal=self.causal)
+
+        sample = unpatchify(sample, patch_size_hw=self.patch_size, patch_size_t=1)
+
+        return sample.to(output_dtype)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/__init__.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/__init__.py
@@ -1,0 +1,1 @@
+"""CLIP/text encoder model components."""

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/__init__.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/__init__.py
@@ -1,0 +1,24 @@
+"""Gemma text encoder components."""
+
+from ltx_core.text_encoders.gemma.embeddings_processor import (
+    EmbeddingsProcessor,
+    EmbeddingsProcessorOutput,
+    convert_to_additive_mask,
+)
+from ltx_core.text_encoders.gemma.encoders.base_encoder import (
+    GemmaTextEncoder,
+)
+from ltx_core.text_encoders.gemma.encoders.encoder_configurator import (
+    EMBEDDINGS_PROCESSOR_KEY_REMAP,
+    build_embeddings_processor,
+)
+
+
+__all__ = [
+    "EMBEDDINGS_PROCESSOR_KEY_REMAP",
+    "EmbeddingsProcessor",
+    "EmbeddingsProcessorOutput",
+    "GemmaTextEncoder",
+    "build_embeddings_processor",
+    "convert_to_additive_mask",
+]

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/config.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/config.py
@@ -1,0 +1,75 @@
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass
+class Gemma3RopeScaling:
+    factor: float = 8.0
+    rope_type: str = "linear"
+
+
+@dataclass
+class Gemma3TextConfig:
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    attn_logit_softcapping: float | None = None
+    cache_implementation: str = "hybrid"
+    final_logit_softcapping: float | None = None
+    head_dim: int = 256
+    hidden_activation: str = "gelu_pytorch_tanh"
+    hidden_size: int = 3840
+    initializer_range: float = 0.02
+    intermediate_size: int = 15360
+    max_position_embeddings: int = 131072
+    model_type: str = "gemma3_text"
+    num_attention_heads: int = 16
+    num_hidden_layers: int = 48
+    num_key_value_heads: int = 8
+    query_pre_attn_scalar: int = 256
+    rms_norm_eps: float = 1e-06
+    rope_local_base_freq: int = 10000
+    rope_scaling: Gemma3RopeScaling = field(default_factory=Gemma3RopeScaling)
+    rope_theta: int = 1000000
+    sliding_window: int = 1024
+    sliding_window_pattern: int = 6
+    torch_dtype: str = "float32"
+    use_cache: bool = True
+    vocab_size: int = 262208
+
+
+@dataclass
+class Gemma3VisionConfig:
+    attention_dropout: float = 0.0
+    hidden_act: str = "gelu_pytorch_tanh"
+    hidden_size: int = 1152
+    image_size: int = 896
+    intermediate_size: int = 4304
+    layer_norm_eps: float = 1e-06
+    model_type: str = "siglip_vision_model"
+    num_attention_heads: int = 16
+    num_channels: int = 3
+    num_hidden_layers: int = 27
+    patch_size: int = 14
+    torch_dtype: str = "float32"
+    vision_use_head: bool = False
+
+
+@dataclass
+class Gemma3ConfigData:
+    architectures: list[str] = field(default_factory=lambda: ["Gemma3ForConditionalGeneration"])
+    boi_token_index: int = 255999
+    eoi_token_index: int = 256000
+    eos_token_id: list[int] = field(default_factory=lambda: [1, 106])
+    image_token_index: int = 262144
+    initializer_range: float = 0.02
+    mm_tokens_per_image: int = 256
+    model_type: str = "gemma3"
+    text_config: Gemma3TextConfig = field(default_factory=Gemma3TextConfig)
+    torch_dtype: str = "bfloat16"
+    transformers_version: str = "4.51.0"
+    vision_config: Gemma3VisionConfig = field(default_factory=Gemma3VisionConfig)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+GEMMA3_CONFIG_FOR_LTX = Gemma3ConfigData()

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/embeddings_connector.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/embeddings_connector.py
@@ -1,0 +1,228 @@
+import torch
+
+from ltx_core.model.transformer.attention import Attention
+from ltx_core.model.transformer.feed_forward import FeedForward
+from ltx_core.model.transformer.rope import (
+    LTXRopeType,
+    generate_freq_grid_np,
+    generate_freq_grid_pytorch,
+    precompute_freqs_cis,
+)
+from ltx_core.utils import rms_norm
+
+
+class _BasicTransformerBlock1D(torch.nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        heads: int,
+        dim_head: int,
+        rope_type: LTXRopeType = LTXRopeType.SPLIT,
+        apply_gated_attention: bool = False,
+    ):
+        super().__init__()
+
+        self.attn1 = Attention(
+            query_dim=dim,
+            heads=heads,
+            dim_head=dim_head,
+            rope_type=rope_type,
+            apply_gated_attention=apply_gated_attention,
+        )
+
+        self.ff = FeedForward(
+            dim,
+            dim_out=dim,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        additive_attention_mask: torch.Tensor | None = None,
+        pe: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        norm_hidden_states = rms_norm(hidden_states)
+        norm_hidden_states = norm_hidden_states.squeeze(1)
+
+        attn_output = self.attn1(norm_hidden_states, mask=additive_attention_mask, pe=pe)
+
+        hidden_states = attn_output + hidden_states
+        if hidden_states.ndim == 4:
+            hidden_states = hidden_states.squeeze(1)
+
+        norm_hidden_states = rms_norm(hidden_states)
+        ff_output = self.ff(norm_hidden_states)
+
+        hidden_states = ff_output + hidden_states
+        if hidden_states.ndim == 4:
+            hidden_states = hidden_states.squeeze(1)
+
+        return hidden_states
+
+
+class Embeddings1DConnector(torch.nn.Module):
+    """Applies 1D transformer processing to sequential embeddings with RoPE and learnable registers."""
+
+    _supports_gradient_checkpointing = True
+
+    def __init__(
+        self,
+        attention_head_dim: int = 128,
+        num_attention_heads: int = 30,
+        num_layers: int = 2,
+        positional_embedding_theta: float = 10000.0,
+        positional_embedding_max_pos: list[int] | None = None,
+        causal_temporal_positioning: bool = False,
+        num_learnable_registers: int | None = 128,
+        rope_type: LTXRopeType = LTXRopeType.SPLIT,
+        double_precision_rope: bool = False,
+        apply_gated_attention: bool = False,
+    ):
+        super().__init__()
+        self.num_attention_heads = num_attention_heads
+        self.inner_dim = num_attention_heads * attention_head_dim
+        self.causal_temporal_positioning = causal_temporal_positioning
+        self.positional_embedding_theta = positional_embedding_theta
+        self.positional_embedding_max_pos = (
+            positional_embedding_max_pos if positional_embedding_max_pos is not None else [1]
+        )
+        self.rope_type = rope_type
+        self.double_precision_rope = double_precision_rope
+        self.transformer_1d_blocks = torch.nn.ModuleList(
+            [
+                _BasicTransformerBlock1D(
+                    dim=self.inner_dim,
+                    heads=num_attention_heads,
+                    dim_head=attention_head_dim,
+                    rope_type=rope_type,
+                    apply_gated_attention=apply_gated_attention,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+        self.num_learnable_registers = num_learnable_registers
+        if self.num_learnable_registers:
+            self.learnable_registers = torch.nn.Parameter(
+                torch.rand(self.num_learnable_registers, self.inner_dim, dtype=torch.bfloat16) * 2.0 - 1.0
+            )
+
+    def _replace_padded_with_learnable_registers(
+        self, hidden_states: torch.Tensor, additive_attention_mask: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size, seq_len, _ = hidden_states.shape
+
+        assert seq_len % self.num_learnable_registers == 0
+
+        registers = self.learnable_registers.repeat(seq_len // self.num_learnable_registers, 1).to(
+            device=hidden_states.device, dtype=hidden_states.dtype
+        )
+        registers = registers.unsqueeze(0).expand(batch_size, -1, -1)
+        binary_mask = additive_attention_mask[:, 0, 0, :].unsqueeze(-1) >= 0
+        binary_mask = binary_mask.to(hidden_states.dtype)
+        hidden_states = binary_mask * hidden_states + (1 - binary_mask) * registers
+
+        return hidden_states, torch.zeros_like(additive_attention_mask)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        additive_attention_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Forward pass of Embeddings1DConnector.
+
+        Args:
+            hidden_states: (B, S, D) input embeddings.
+            additive_attention_mask: optional additive mask of shape (B, 1, 1, S).
+
+        Returns:
+            (hidden_states, additive_attention_mask)
+        """
+        self.to(hidden_states.device)
+
+        if self.num_learnable_registers:
+            hidden_states, additive_attention_mask = self._replace_padded_with_learnable_registers(
+                hidden_states, additive_attention_mask
+            )
+
+        indices_grid = torch.arange(hidden_states.shape[1], dtype=torch.float32, device=hidden_states.device)
+        indices_grid = indices_grid[None, None, :].expand(hidden_states.shape[0], -1, -1)
+        freq_grid_generator = generate_freq_grid_np if self.double_precision_rope else generate_freq_grid_pytorch
+        freqs_cis = precompute_freqs_cis(
+            indices_grid=indices_grid,
+            dim=self.inner_dim,
+            out_dtype=hidden_states.dtype,
+            theta=self.positional_embedding_theta,
+            max_pos=self.positional_embedding_max_pos,
+            num_attention_heads=self.num_attention_heads,
+            rope_type=self.rope_type,
+            freq_grid_generator=freq_grid_generator,
+        )
+
+        for block in self.transformer_1d_blocks:
+            hidden_states = block(hidden_states, additive_attention_mask=additive_attention_mask, pe=freqs_cis)
+
+        hidden_states = rms_norm(hidden_states)
+
+        return hidden_states, additive_attention_mask
+
+
+class Embeddings1DConnectorConfigurator:
+    """Configurator for video embeddings connector."""
+
+    @classmethod
+    def from_config(cls, config: dict) -> Embeddings1DConnector:
+        transformer_config = config.get("transformer", {})
+        rope_type = LTXRopeType(transformer_config.get("rope_type", "split"))
+        double_precision_rope = transformer_config.get("frequencies_precision", False) == "float64"
+        pe_max_pos = transformer_config.get("connector_positional_embedding_max_pos", [1])
+
+        num_attention_heads = transformer_config.get("connector_num_attention_heads", 30)
+        attention_head_dim = transformer_config.get("connector_attention_head_dim", 128)
+        num_layers = transformer_config.get("connector_num_layers", 2)
+
+        connector = Embeddings1DConnector(
+            num_attention_heads=num_attention_heads,
+            attention_head_dim=attention_head_dim,
+            num_layers=num_layers,
+            positional_embedding_max_pos=pe_max_pos,
+            rope_type=rope_type,
+            double_precision_rope=double_precision_rope,
+            apply_gated_attention=transformer_config.get("connector_apply_gated_attention", False),
+        )
+        return connector
+
+
+class AudioEmbeddings1DConnectorConfigurator:
+    """Configurator for audio embeddings connector with separate dimension settings."""
+
+    @classmethod
+    def from_config(cls, config: dict) -> Embeddings1DConnector:
+        transformer_config = config.get("transformer", {})
+        rope_type = LTXRopeType(transformer_config.get("rope_type", "split"))
+        double_precision_rope = transformer_config.get("frequencies_precision", False) == "float64"
+        pe_max_pos = transformer_config.get("connector_positional_embedding_max_pos", [1])
+
+        num_attention_heads = transformer_config.get(
+            "audio_connector_num_attention_heads",
+            transformer_config.get("connector_num_attention_heads", 30),
+        )
+        attention_head_dim = transformer_config.get(
+            "audio_connector_attention_head_dim",
+            transformer_config.get("connector_attention_head_dim", 128),
+        )
+        num_layers = transformer_config.get(
+            "audio_connector_num_layers",
+            transformer_config.get("connector_num_layers", 2),
+        )
+
+        connector = Embeddings1DConnector(
+            num_attention_heads=num_attention_heads,
+            attention_head_dim=attention_head_dim,
+            num_layers=num_layers,
+            positional_embedding_max_pos=pe_max_pos,
+            rope_type=rope_type,
+            double_precision_rope=double_precision_rope,
+            apply_gated_attention=transformer_config.get("connector_apply_gated_attention", False),
+        )
+        return connector

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/embeddings_processor.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/embeddings_processor.py
@@ -1,0 +1,93 @@
+from typing import NamedTuple
+
+import torch
+from torch import nn
+
+from ltx_core.text_encoders.gemma.embeddings_connector import Embeddings1DConnector
+
+
+class EmbeddingsProcessorOutput(NamedTuple):
+    video_encoding: torch.Tensor
+    audio_encoding: torch.Tensor | None
+    attention_mask: torch.Tensor
+
+
+def convert_to_additive_mask(attention_mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Convert binary attention mask to additive form for transformer masking."""
+    return (attention_mask.to(torch.int64) - 1).to(dtype).reshape(
+        (attention_mask.shape[0], 1, -1, attention_mask.shape[-1])
+    ) * torch.finfo(dtype).max
+
+
+def _compute_right_pad_order(additive_mask: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute the index permutation that places valid tokens before pads in each row."""
+    binary = (additive_mask[:, 0, 0, :] >= 0).to(torch.int32)
+    sort_idx = torch.argsort(binary, dim=-1, descending=True, stable=True)
+    new_binary = torch.gather(binary, 1, sort_idx)
+    new_additive = (new_binary.to(additive_mask.dtype) - 1) * torch.finfo(additive_mask.dtype).max
+    return sort_idx, new_additive[:, None, None, :]
+
+
+def _apply_right_pad_order(features: torch.Tensor, sort_idx: torch.Tensor) -> torch.Tensor:
+    """Apply a precomputed right-pad permutation to features."""
+    return torch.gather(features, 1, sort_idx.unsqueeze(-1).expand_as(features))
+
+
+def _to_binary_mask(encoded_mask: torch.Tensor, lead_shape: tuple[int, int]) -> torch.Tensor:
+    """Convert connector output mask to a binary (0/1) mask shaped (B, S, 1)."""
+    return (encoded_mask < 0.000001).to(torch.int64).reshape([lead_shape[0], lead_shape[1], 1])
+
+
+class EmbeddingsProcessor(nn.Module):
+    """Wraps feature extractor + video connector + optional audio connector."""
+
+    def __init__(
+        self,
+        *,
+        feature_extractor: nn.Module | None = None,
+        video_connector: Embeddings1DConnector,
+        audio_connector: Embeddings1DConnector | None = None,
+    ):
+        super().__init__()
+        self.feature_extractor = feature_extractor
+        self.video_connector = video_connector
+        self.audio_connector = audio_connector
+
+    def create_embeddings(
+        self,
+        video_features: torch.Tensor,
+        audio_features: torch.Tensor | None,
+        additive_attention_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+        if self.audio_connector is not None and audio_features is None:
+            raise ValueError("Audio connector is configured but no audio features were provided.")
+        if self.audio_connector is None and audio_features is not None:
+            raise ValueError("Audio features were provided but no audio connector is configured.")
+
+        sort_idx, mask_for_connector = _compute_right_pad_order(additive_attention_mask)
+        video_features = _apply_right_pad_order(video_features, sort_idx)
+        video_encoded, video_mask = self.video_connector(video_features, mask_for_connector)
+        binary_mask = _to_binary_mask(video_mask, video_encoded.shape[:2])
+        video_encoded = video_encoded * binary_mask
+
+        audio_encoded = None
+        if self.audio_connector is not None:
+            audio_features = _apply_right_pad_order(audio_features, sort_idx)
+            audio_encoded, _ = self.audio_connector(audio_features, mask_for_connector)
+
+        return video_encoded, audio_encoded, binary_mask.squeeze(-1)
+
+    def process_hidden_states(
+        self,
+        hidden_states: tuple[torch.Tensor, ...],
+        attention_mask: torch.Tensor,
+        padding_side: str = "left",
+    ) -> EmbeddingsProcessorOutput:
+        """Full pipeline: feature extraction -> connectors -> final embeddings."""
+        if self.feature_extractor is None:
+            raise ValueError("feature_extractor is required for process_hidden_states()")
+
+        video_feats, audio_feats = self.feature_extractor(hidden_states, attention_mask, padding_side)
+        additive_mask = convert_to_additive_mask(attention_mask, video_feats.dtype)
+        video_enc, audio_enc, binary_mask = self.create_embeddings(video_feats, audio_feats, additive_mask)
+        return EmbeddingsProcessorOutput(video_enc, audio_enc, binary_mask)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/encoders/base_encoder.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/encoders/base_encoder.py
@@ -1,0 +1,94 @@
+import logging
+import os
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+import torch
+from ltx_core.text_encoders.gemma.tokenizer import LTXVGemmaTokenizer
+from transformers import Gemma3ForConditionalGeneration
+
+from veomni.utils.device import IS_CUDA_AVAILABLE
+
+
+class GemmaTextEncoder(torch.nn.Module):
+    """Pure Gemma text encoder — runs the LLM and returns raw hidden states."""
+
+    def __init__(
+        self,
+        model: Gemma3ForConditionalGeneration | None = None,
+        tokenizer: LTXVGemmaTokenizer | None = None,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        super().__init__()
+        self.model = model
+        self.tokenizer = tokenizer
+        self._dtype = dtype
+
+    def encode(
+        self,
+        text: str,
+        padding_side: str = "left",  # noqa: ARG002
+    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        """Run Gemma LLM and return raw hidden states + attention mask."""
+        token_pairs = self.tokenizer.tokenize_with_weights(text)["gemma"]
+        input_ids = torch.tensor([[t[0] for t in token_pairs]], device=self.model.device)
+        attention_mask = torch.tensor([[w[1] for w in token_pairs]], device=self.model.device)
+        outputs = self.model.model(input_ids=input_ids, attention_mask=attention_mask, output_hidden_states=True)
+        hidden_states = outputs.hidden_states
+        del outputs
+        return hidden_states, attention_mask
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_path: str,
+        tokenizer_path: str | None = None,
+        max_length: int = 1024,
+        device: torch.device | str | int | None = None,
+    ):
+        """Load Gemma text encoder from pretrained weights in 8-bit precision."""
+        from transformers import BitsAndBytesConfig
+
+        gemma_path = _find_gemma_subpath(model_path, "model*.safetensors")
+        tokenizer_path = _find_gemma_subpath(tokenizer_path or model_path, "tokenizer.model")
+
+        # Pin the entire model to a single device. `device_map="auto"` collides on cuda:0
+        # in multi-process launches because every rank picks the same default device.
+        device_map: str | dict[str, int | str | torch.device]
+        if device is not None:
+            device_map = {"": device}
+        elif IS_CUDA_AVAILABLE:
+            device_map = {"": int(os.environ.get("LOCAL_RANK", "0"))}
+        else:
+            device_map = "auto"
+
+        quantization_config = BitsAndBytesConfig(load_in_8bit=True)
+        with _suppress_accelerate_memory_warnings():
+            model = Gemma3ForConditionalGeneration.from_pretrained(
+                gemma_path,
+                quantization_config=quantization_config,
+                torch_dtype=torch.bfloat16,
+                device_map=device_map,
+                local_files_only=True,
+            )
+        tokenizer = LTXVGemmaTokenizer(tokenizer_path, max_length=max_length)
+        return cls(model=model, tokenizer=tokenizer, dtype=torch.bfloat16)
+
+
+def _find_gemma_subpath(root_path: str | Path, pattern: str) -> str:
+    matches = list(Path(root_path).rglob(pattern))
+    if not matches:
+        raise FileNotFoundError(f"No files matching pattern '{pattern}' found under {root_path}")
+    return str(matches[0].parent)
+
+
+@contextmanager
+def _suppress_accelerate_memory_warnings() -> Generator[None, None, None]:
+    accelerate_logger = logging.getLogger("accelerate.utils.modeling")
+    old_level = accelerate_logger.level
+    accelerate_logger.setLevel(logging.WARNING)
+    try:
+        yield
+    finally:
+        accelerate_logger.setLevel(old_level)

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/encoders/encoder_configurator.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/encoders/encoder_configurator.py
@@ -1,0 +1,82 @@
+import torch
+from ltx_core.text_encoders.gemma.config import GEMMA3_CONFIG_FOR_LTX
+from ltx_core.text_encoders.gemma.embeddings_connector import (
+    AudioEmbeddings1DConnectorConfigurator,
+    Embeddings1DConnectorConfigurator,
+)
+from ltx_core.text_encoders.gemma.embeddings_processor import EmbeddingsProcessor
+from ltx_core.text_encoders.gemma.feature_extractor import (
+    FeatureExtractorV1,
+    FeatureExtractorV2,
+)
+
+
+_V2_EXPECTED_CONFIG = {
+    "caption_proj_before_connector": True,
+    "caption_projection_first_linear": False,
+    "caption_proj_input_norm": False,
+    "caption_projection_second_linear": False,
+}
+
+
+def _create_feature_extractor(transformer_config: dict) -> torch.nn.Module:
+    """Select and create the appropriate feature extractor based on config."""
+    gemma_text_config = GEMMA3_CONFIG_FOR_LTX.text_config
+    embedding_dim = gemma_text_config.hidden_size
+    num_layers = gemma_text_config.num_hidden_layers + 1
+    flat_dim = embedding_dim * num_layers
+
+    overlapping_keys = transformer_config.keys() & _V2_EXPECTED_CONFIG.keys()
+    if not overlapping_keys:
+        aggregate_embed = torch.nn.Linear(flat_dim, embedding_dim, bias=False)
+        return FeatureExtractorV1(aggregate_embed=aggregate_embed, is_av=True)
+
+    missing_keys = _V2_EXPECTED_CONFIG.keys() - overlapping_keys
+    if missing_keys:
+        raise NotImplementedError("Partial V2 config — missing keys: " + ", ".join(sorted(missing_keys)))
+
+    unexpected_value_keys = {k for k in overlapping_keys if transformer_config[k] != _V2_EXPECTED_CONFIG[k]}
+    if unexpected_value_keys:
+        raise NotImplementedError(
+            "Unknown config: "
+            + ", ".join(
+                f"{k}={transformer_config[k]!r} (expected {_V2_EXPECTED_CONFIG[k]!r})" for k in unexpected_value_keys
+            )
+        )
+
+    video_inner_dim = transformer_config["num_attention_heads"] * transformer_config["attention_head_dim"]
+    audio_inner_dim = transformer_config["audio_num_attention_heads"] * transformer_config["audio_attention_head_dim"]
+    return FeatureExtractorV2(
+        video_aggregate_embed=torch.nn.Linear(flat_dim, video_inner_dim, bias=True),
+        embedding_dim=embedding_dim,
+        audio_aggregate_embed=torch.nn.Linear(flat_dim, audio_inner_dim, bias=True),
+    )
+
+
+def build_embeddings_processor(config: dict, with_feature_extractor: bool = False) -> EmbeddingsProcessor:
+    """Build EmbeddingsProcessor from model config.
+
+    Args:
+        config: Model config dict (must contain 'transformer' key with connector params).
+        with_feature_extractor: If True, also creates the feature extractor (for precompute).
+    """
+    transformer_config = config.get("transformer", {})
+
+    video_connector = Embeddings1DConnectorConfigurator.from_config(config)
+    audio_connector = AudioEmbeddings1DConnectorConfigurator.from_config(config)
+    feature_extractor = _create_feature_extractor(transformer_config) if with_feature_extractor else None
+
+    return EmbeddingsProcessor(
+        video_connector=video_connector,
+        audio_connector=audio_connector,
+        feature_extractor=feature_extractor,
+    )
+
+
+EMBEDDINGS_PROCESSOR_KEY_REMAP = {
+    "text_embedding_projection.aggregate_embed.": "feature_extractor.aggregate_embed.",
+    "text_embedding_projection.video_aggregate_embed.": "feature_extractor.video_aggregate_embed.",
+    "text_embedding_projection.audio_aggregate_embed.": "feature_extractor.audio_aggregate_embed.",
+    "model.diffusion_model.video_embeddings_connector.": "video_connector.",
+    "model.diffusion_model.audio_embeddings_connector.": "audio_connector.",
+}

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/encoders/prompts/gemma_i2v_system_prompt.txt
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/encoders/prompts/gemma_i2v_system_prompt.txt
@@ -1,0 +1,30 @@
+You are a Creative Assistant writing concise, action-focused image-to-video prompts. Given an image (first frame) and user Raw Input Prompt, generate a prompt to guide video generation from that image.
+
+#### Guidelines:
+- Analyze the Image: Identify Subject, Setting, Elements, Style and Mood.
+- Follow user Raw Input Prompt: Include all requested motion, actions, camera movements, audio, and details. If in conflict with the image, prioritize user request while maintaining visual consistency (describe transition from image to user's scene).
+- Describe only changes from the image: Don't reiterate established visual details. Inaccurate descriptions may cause scene cuts.
+- Active language: Use present-progressive verbs ("is walking," "speaking"). If no action specified, describe natural movements.
+- Chronological flow: Use temporal connectors ("as," "then," "while").
+- Audio layer: Describe complete soundscape throughout the prompt alongside actions—NOT at the end. Align audio intensity with action tempo. Include natural background audio, ambient sounds, effects, speech or music (when requested). Be specific (e.g., "soft footsteps on tile") not vague (e.g., "ambient sound").
+- Speech (only when requested): Provide exact words in quotes with character's visual/voice characteristics (e.g., "The tall man speaks in a low, gravelly voice"), language if not English and accent if relevant. If general conversation mentioned without text, generate contextual quoted dialogue. (i.e., "The man is talking" input -> the output should include exact spoken words, like: "The man is talking in an excited voice saying: 'You won't believe what I just saw!' His hands gesture expressively as he speaks, eyebrows raised with enthusiasm. The ambient sound of a quiet room underscores his animated speech.")
+- Style: Include visual style at beginning: "Style: <style>, <rest of prompt>." If unclear, omit to avoid conflicts.
+- Visual and audio only: Describe only what is seen and heard. NO smell, taste, or tactile sensations.
+- Restrained language: Avoid dramatic terms. Use mild, natural, understated phrasing.
+
+#### Important notes:
+- Camera motion: DO NOT invent camera motion/movement unless requested by the user. Make sure to include camera motion only if specified in the input.
+- Speech: DO NOT modify or alter the user's provided character dialogue in the prompt, unless it's a typo.
+- No timestamps or cuts: DO NOT use timestamps or describe scene cuts unless explicitly requested.
+- Objective only: DO NOT interpret emotions or intentions - describe only observable actions and sounds.
+- Format: DO NOT use phrases like "The scene opens with..." / "The video starts...". Start directly with Style (optional) and chronological scene description.
+- Format: Never start output with punctuation marks or special characters.
+- DO NOT invent dialogue unless the user mentions speech/talking/singing/conversation.
+- Your performance is CRITICAL. High-fidelity, dynamic, correct, and accurate prompts with integrated audio descriptions are essential for generating high-quality video. Your goal is flawless execution of these rules.
+
+#### Output Format (Strict):
+- Single concise paragraph in natural English. NO titles, headings, prefaces, sections, code fences, or Markdown.
+- If unsafe/invalid, return original user prompt. Never ask questions or clarifications.
+
+#### Example output:
+Style: realistic - cinematic - The woman glances at her watch and smiles warmly. She speaks in a cheerful, friendly voice, "I think we're right on time!" In the background, a café barista prepares drinks at the counter. The barista calls out in a clear, upbeat tone, "Two cappuccinos ready!" The sound of the espresso machine hissing softly blends with gentle background chatter and the light clinking of cups on saucers.

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/encoders/prompts/gemma_t2v_system_prompt.txt
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/encoders/prompts/gemma_t2v_system_prompt.txt
@@ -1,0 +1,40 @@
+You are a Creative Assistant. Given a user's raw input prompt describing a scene or concept, expand it into a detailed video generation prompt with specific visuals and integrated audio to guide a text-to-video model.
+
+#### Guidelines
+- Strictly follow all aspects of the user's raw input: include every element requested (style, visuals, motions, actions, camera movement, audio).
+    - If the input is vague, invent concrete details: lighting, textures, materials, scene settings, etc.
+        - For characters: describe gender, clothing, hair, expressions. DO NOT invent unrequested characters.
+- Use active language: present-progressive verbs ("is walking," "speaking"). If no action specified, describe natural movements.
+- Maintain chronological flow: use temporal connectors ("as," "then," "while").
+- Audio layer: Describe complete soundscape (background audio, ambient sounds, SFX, speech/music when requested). Integrate sounds chronologically alongside actions. Be specific (e.g., "soft footsteps on tile"), not vague (e.g., "ambient sound is present").
+- Speech (only when requested):
+    - For ANY speech-related input (talking, conversation, singing, etc.), ALWAYS include exact words in quotes with voice characteristics (e.g., "The man says in an excited voice: 'You won't believe what I just saw!'").
+    - Specify language if not English and accent if relevant.
+- Style: Include visual style at the beginning: "Style: <style>, <rest of prompt>." Default to cinematic-realistic if unspecified. Omit if unclear.
+- Visual and audio only: NO non-visual/auditory senses (smell, taste, touch).
+- Restrained language: Avoid dramatic/exaggerated terms. Use mild, natural phrasing.
+    - Colors: Use plain terms ("red dress"), not intensified ("vibrant blue," "bright red").
+    - Lighting: Use neutral descriptions ("soft overhead light"), not harsh ("blinding light").
+    - Facial features: Use delicate modifiers for subtle features (i.e., "subtle freckles").
+
+#### Important notes:
+- Analyze the user's raw input carefully. In cases of FPV or POV, exclude the description of the subject whose POV is requested.
+- Camera motion: DO NOT invent camera motion unless requested by the user.
+- Speech: DO NOT modify user-provided character dialogue unless it's a typo.
+- No timestamps or cuts: DO NOT use timestamps or describe scene cuts unless explicitly requested.
+- Format: DO NOT use phrases like "The scene opens with...". Start directly with Style (optional) and chronological scene description.
+- Format: DO NOT start your response with special characters.
+- DO NOT invent dialogue unless the user mentions speech/talking/singing/conversation.
+- If the user's raw input prompt is highly detailed, chronological and in the requested format: DO NOT make major edits or introduce new elements. Add/enhance audio descriptions if missing.
+
+#### Output Format (Strict):
+- Single continuous paragraph in natural language (English).
+- NO titles, headings, prefaces, code fences, or Markdown.
+- If unsafe/invalid, return original user prompt. Never ask questions or clarifications.
+
+Your output quality is CRITICAL. Generate visually rich, dynamic prompts with integrated audio for high-quality video generation.
+
+#### Example
+Input: "A woman at a coffee shop talking on the phone"
+Output:
+Style: realistic with cinematic lighting. In a medium close-up, a woman in her early 30s with shoulder-length brown hair sits at a small wooden table by the window. She wears a cream-colored turtleneck sweater, holding a white ceramic coffee cup in one hand and a smartphone to her ear with the other. Ambient cafe sounds fill the space—espresso machine hiss, quiet conversations, gentle clinking of cups. The woman listens intently, nodding slightly, then takes a sip of her coffee and sets it down with a soft clink. Her face brightens into a warm smile as she speaks in a clear, friendly voice, 'That sounds perfect! I'd love to meet up this weekend. How about Saturday afternoon?' She laughs softly—a genuine chuckle—and shifts in her chair. Behind her, other patrons move subtly in and out of focus. 'Great, I'll see you then,' she concludes cheerfully, lowering the phone.

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/feature_extractor.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/feature_extractor.py
@@ -1,0 +1,107 @@
+import math
+
+import torch
+from einops import rearrange
+from torch import nn
+
+
+def _norm_and_concat_padded_batch(
+    encoded_text: torch.Tensor,
+    attention_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Normalize and flatten multi-layer hidden states, respecting padding."""
+    b, _, d, l = encoded_text.shape  # noqa: E741
+    eps = 1e-6
+
+    sequence_lengths = attention_mask.sum(dim=-1)
+    mask = rearrange(attention_mask.bool(), "b t -> b t 1 1")
+
+    masked = encoded_text.masked_fill(~mask, 0.0)
+    denom = (sequence_lengths * d).view(b, 1, 1, 1)
+    mean = masked.sum(dim=(1, 2), keepdim=True) / (denom + eps)
+
+    x_min = encoded_text.masked_fill(~mask, float("inf")).amin(dim=(1, 2), keepdim=True)
+    x_max = encoded_text.masked_fill(~mask, float("-inf")).amax(dim=(1, 2), keepdim=True)
+    range_ = x_max - x_min
+
+    normed = 8 * (encoded_text - mean) / (range_ + eps)
+    normed = normed.reshape(b, -1, d * l)
+
+    mask_flattened = rearrange(mask, "b t 1 1 -> b t 1").expand(-1, -1, d * l)
+    return normed.masked_fill(~mask_flattened, 0.0)
+
+
+def norm_and_concat_per_token_rms(
+    encoded_text: torch.Tensor,
+    attention_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Per-token RMSNorm normalization for V2 models."""
+    B, T, D, L = encoded_text.shape  # noqa: N806
+    variance = torch.mean(encoded_text**2, dim=2, keepdim=True)
+    normed = encoded_text * torch.rsqrt(variance + 1e-6)
+    normed = normed.reshape(B, T, D * L)
+    mask_3d = attention_mask.bool().unsqueeze(-1)
+    return torch.where(mask_3d, normed, torch.zeros_like(normed))
+
+
+def _rescale_norm(x: torch.Tensor, target_dim: int, source_dim: int) -> torch.Tensor:
+    """Rescale normalization: x * sqrt(target_dim / source_dim)."""
+    return x * math.sqrt(target_dim / source_dim)
+
+
+class FeatureExtractorV1(nn.Module):
+    """19B: per-segment norm -> aggregate_embed -> 3840"""
+
+    def __init__(self, aggregate_embed: nn.Module, is_av: bool = False):
+        super().__init__()
+        self.aggregate_embed = aggregate_embed
+        self.is_av = is_av
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        padding_side: str = "left",  # noqa: ARG002
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        self.to(hidden_states.device if isinstance(hidden_states, torch.Tensor) else hidden_states[0].device)
+        encoded = torch.stack(hidden_states, dim=-1) if isinstance(hidden_states, (list, tuple)) else hidden_states
+        dtype = encoded.dtype
+        device = encoded.device
+        normed = _norm_and_concat_padded_batch(encoded, attention_mask)
+        features = self.aggregate_embed(normed.to(device=device, dtype=dtype))
+        if self.is_av:
+            return features, features
+        return features, None
+
+
+class FeatureExtractorV2(nn.Module):
+    """22B: per-token RMS norm -> rescale -> dual aggregate embeds"""
+
+    def __init__(
+        self,
+        video_aggregate_embed: nn.Linear,
+        embedding_dim: int,
+        audio_aggregate_embed: nn.Linear | None = None,
+    ):
+        super().__init__()
+        self.video_aggregate_embed = video_aggregate_embed
+        self.audio_aggregate_embed = audio_aggregate_embed
+        self.embedding_dim = embedding_dim
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        padding_side: str = "left",  # noqa: ARG002
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        self.to(hidden_states.device if isinstance(hidden_states, torch.Tensor) else hidden_states[0].device)
+        encoded = torch.stack(hidden_states, dim=-1) if isinstance(hidden_states, (list, tuple)) else hidden_states
+        normed = norm_and_concat_per_token_rms(encoded, attention_mask)
+        normed = normed.to(device=encoded.device, dtype=encoded.dtype)
+        v_dim = self.video_aggregate_embed.out_features
+        video = self.video_aggregate_embed(_rescale_norm(normed, v_dim, self.embedding_dim))
+        audio = None
+        if self.audio_aggregate_embed is not None:
+            a_dim = self.audio_aggregate_embed.out_features
+            audio = self.audio_aggregate_embed(_rescale_norm(normed, a_dim, self.embedding_dim))
+        return video, audio

--- a/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/tokenizer.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/text_encoders/gemma/tokenizer.py
@@ -1,0 +1,40 @@
+from enum import Enum
+
+from transformers import AutoTokenizer
+
+
+class PaddingSide(str, Enum):
+    LEFT = "left"
+    RIGHT = "right"
+
+
+class LTXVGemmaTokenizer:
+    """Tokenizer wrapper for Gemma models compatible with LTXV processes."""
+
+    def __init__(self, tokenizer_path: str, max_length: int = 256, padding_side: PaddingSide = PaddingSide.LEFT):
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_path, local_files_only=True, model_max_length=max_length
+        )
+        self.tokenizer.padding_side = padding_side.value
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.max_length = max_length
+
+    def tokenize_with_weights(self, text: str, return_word_ids: bool = False) -> dict[str, list[tuple[int, int]]]:
+        text = text.strip()
+        encoded = self.tokenizer(
+            text,
+            padding="max_length",
+            max_length=self.max_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+        input_ids = encoded.input_ids
+        attention_mask = encoded.attention_mask
+        tuples = [
+            (token_id, attn, i) for i, (token_id, attn) in enumerate(zip(input_ids[0], attention_mask[0], strict=True))
+        ]
+        out = {"gemma": tuples}
+        if not return_word_ids:
+            out = {k: [(t, w) for t, w, _ in v] for k, v in out.items()}
+        return out

--- a/veomni/models/diffusers/ltx2_3/ltx_core/types.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/types.py
@@ -1,0 +1,168 @@
+from dataclasses import dataclass, replace
+from typing import NamedTuple
+
+import torch
+
+
+class VideoPixelShape(NamedTuple):
+    batch: int
+    frames: int
+    height: int
+    width: int
+    fps: float
+
+
+class SpatioTemporalScaleFactors(NamedTuple):
+    time: int
+    height: int
+    width: int
+
+    @classmethod
+    def default(cls) -> "SpatioTemporalScaleFactors":
+        return cls(time=8, height=32, width=32)
+
+
+VIDEO_SCALE_FACTORS = SpatioTemporalScaleFactors.default()
+
+
+class VideoLatentShape(NamedTuple):
+    batch: int
+    channels: int
+    frames: int
+    height: int
+    width: int
+
+    def to_torch_shape(self) -> torch.Size:
+        return torch.Size([self.batch, self.channels, self.frames, self.height, self.width])
+
+    @staticmethod
+    def from_torch_shape(shape: torch.Size) -> "VideoLatentShape":
+        return VideoLatentShape(
+            batch=shape[0],
+            channels=shape[1],
+            frames=shape[2],
+            height=shape[3],
+            width=shape[4],
+        )
+
+    def token_count(self) -> int:
+        return self.frames * self.height * self.width
+
+    def mask_shape(self) -> "VideoLatentShape":
+        return self._replace(channels=1)
+
+    @staticmethod
+    def from_pixel_shape(
+        shape: VideoPixelShape,
+        latent_channels: int = 128,
+        scale_factors: SpatioTemporalScaleFactors = VIDEO_SCALE_FACTORS,
+    ) -> "VideoLatentShape":
+        frames = (shape.frames - 1) // scale_factors.time + 1
+        height = shape.height // scale_factors.height
+        width = shape.width // scale_factors.width
+
+        return VideoLatentShape(
+            batch=shape.batch,
+            channels=latent_channels,
+            frames=frames,
+            height=height,
+            width=width,
+        )
+
+    def upscale(self, scale_factors: SpatioTemporalScaleFactors = VIDEO_SCALE_FACTORS) -> "VideoLatentShape":
+        return self._replace(
+            channels=3,
+            frames=(self.frames - 1) * scale_factors.time + 1,
+            height=self.height * scale_factors.height,
+            width=self.width * scale_factors.width,
+        )
+
+
+class AudioLatentShape(NamedTuple):
+    batch: int
+    channels: int
+    frames: int
+    mel_bins: int
+
+    def to_torch_shape(self) -> torch.Size:
+        return torch.Size([self.batch, self.channels, self.frames, self.mel_bins])
+
+    def token_count(self) -> int:
+        return self.frames
+
+    def mask_shape(self) -> "AudioLatentShape":
+        return self._replace(channels=1, mel_bins=1)
+
+    @staticmethod
+    def from_torch_shape(shape: torch.Size) -> "AudioLatentShape":
+        return AudioLatentShape(
+            batch=shape[0],
+            channels=shape[1],
+            frames=shape[2],
+            mel_bins=shape[3],
+        )
+
+    @staticmethod
+    def from_duration(
+        batch: int,
+        duration: float,
+        channels: int = 8,
+        mel_bins: int = 16,
+        sample_rate: int = 16000,
+        hop_length: int = 160,
+        audio_latent_downsample_factor: int = 4,
+    ) -> "AudioLatentShape":
+        latents_per_second = float(sample_rate) / float(hop_length) / float(audio_latent_downsample_factor)
+
+        return AudioLatentShape(
+            batch=batch,
+            channels=channels,
+            frames=round(duration * latents_per_second),
+            mel_bins=mel_bins,
+        )
+
+    @staticmethod
+    def from_video_pixel_shape(
+        shape: VideoPixelShape,
+        channels: int = 8,
+        mel_bins: int = 16,
+        sample_rate: int = 16000,
+        hop_length: int = 160,
+        audio_latent_downsample_factor: int = 4,
+    ) -> "AudioLatentShape":
+        return AudioLatentShape.from_duration(
+            batch=shape.batch,
+            duration=float(shape.frames) / float(shape.fps),
+            channels=channels,
+            mel_bins=mel_bins,
+            sample_rate=sample_rate,
+            hop_length=hop_length,
+            audio_latent_downsample_factor=audio_latent_downsample_factor,
+        )
+
+
+@dataclass(frozen=True)
+class Audio:
+    waveform: torch.Tensor
+    sampling_rate: int
+
+    def to(self, **kwargs: object) -> "Audio":
+        return replace(self, waveform=self.waveform.to(**kwargs))
+
+
+@dataclass(frozen=True)
+class LatentState:
+    latent: torch.Tensor
+    denoise_mask: torch.Tensor
+    positions: torch.Tensor
+    clean_latent: torch.Tensor
+    attention_mask: torch.Tensor | None = None
+
+    def clone(self) -> "LatentState":
+        return LatentState(
+            latent=self.latent.clone(),
+            denoise_mask=self.denoise_mask.clone(),
+            positions=self.positions.clone(),
+            clean_latent=self.clean_latent.clone(),
+            attention_mask=self.attention_mask.clone() if self.attention_mask is not None else None,
+        )

--- a/veomni/models/diffusers/ltx2_3/ltx_core/utils.py
+++ b/veomni/models/diffusers/ltx2_3/ltx_core/utils.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+def rms_norm(x: torch.Tensor, weight: torch.Tensor | None = None, eps: float = 1e-6) -> torch.Tensor:
+    """Root-mean-square (RMS) normalize `x` over its last dimension.
+    Thin wrapper around `torch.nn.functional.rms_norm` that infers the normalized
+    shape and forwards `weight` and `eps`.
+    """
+    return torch.nn.functional.rms_norm(x, (x.shape[-1],), weight=weight, eps=eps)
+
+
+def check_config_value(config: dict, key: str, expected: Any) -> None:  # noqa: ANN401
+    actual = config.get(key)
+    if actual != expected:
+        raise ValueError(f"Config value {key} is {actual}, expected {expected}")
+
+
+def to_velocity(
+    sample: torch.Tensor,
+    sigma: float | torch.Tensor,
+    denoised_sample: torch.Tensor,
+    calc_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """
+    Convert the sample and its denoised version to velocity.
+    Returns:
+        Velocity
+    """
+    if isinstance(sigma, torch.Tensor):
+        sigma = sigma.to(calc_dtype).item()
+    if sigma == 0:
+        raise ValueError("Sigma can't be 0.0")
+    return ((sample.to(calc_dtype) - denoised_sample.to(calc_dtype)) / sigma).to(sample.dtype)
+
+
+def to_denoised(
+    sample: torch.Tensor,
+    velocity: torch.Tensor,
+    sigma: float | torch.Tensor,
+    calc_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """
+    Convert the sample and its denoising velocity to denoised sample.
+    Returns:
+        Denoised sample
+    """
+    if isinstance(sigma, torch.Tensor):
+        sigma = sigma.to(calc_dtype)
+    return (sample.to(calc_dtype) - velocity.to(calc_dtype) * sigma).to(sample.dtype)
+
+
+def find_matching_file(root_path: str, pattern: str) -> Path:
+    """
+    Recursively search for files matching a glob pattern and return the first match.
+    """
+    matches = list(Path(root_path).rglob(pattern))
+    if not matches:
+        raise FileNotFoundError(f"No files matching pattern '{pattern}' found under {root_path}")
+    return matches[0]


### PR DESCRIPTION
### What does this PR do?

> Add LTX-2.3 source code

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Only add LTX-2.3 source code, no functional changes is involved.

### API and Usage Example

> NA

### Design & Code Changes

> Migrate the source code of LTX-2.3 into VeOmni.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
