### PR TITLE
[model, ci] fix: GPT-OSS e2e parametrization

### DIFF
--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -210,6 +210,7 @@ deepseek_v4_text_smoke_test_cases = [
         _DEFAULT_RTOL,
         _DEFAULT_ATOL,
         None,  # max_sp_size
+        None,  # max_ep_size
         marks=_gpt_oss_fa4_quack_skip,
     ),
 ]


### PR DESCRIPTION
## Summary
- Add the missing `max_ep_size=None` argument to the GPT-OSS text smoke test case.
- Keep this as a standalone CI fix so the DSA integration can stack on top separately.

## Validation
- `uv run --frozen pytest --collect-only -q tests/e2e/test_e2e_parallel.py`
- `ruff format --check tests/e2e/test_e2e_parallel.py`
- `ruff check tests/e2e/test_e2e_parallel.py`
- `modelchef-review` verdict: safe
