### PR TITLE
[dist] fix: correct FSDP2 grad norm reduction

### DIFF
--- a/tests/utils/test_fsdp2_clip_grad_norm.py
+++ b/tests/utils/test_fsdp2_clip_grad_norm.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 
-from veomni.distributed.fsdp2.clip_grad_norm import _fsdp_grad_norm_reduce_groups
+import torch
+
+from veomni.distributed.fsdp2.clip_grad_norm import _fsdp_grad_norm_reduce_groups, _local_pth_sum
 
 
 def _parallel_state(*, dp_mode: str = "fsdp2", dp_replicate_enabled: bool = False, dp_shard_size: int = 1):
@@ -29,3 +31,17 @@ def test_fsdp_grad_norm_reduce_groups_skip_non_fsdp2_modes():
     ps = _parallel_state(dp_mode="ddp")
 
     assert _fsdp_grad_norm_reduce_groups(ps) == []
+
+
+def test_local_pth_sum_skips_missing_grads_and_accumulates_in_fp32():
+    p1 = torch.nn.Parameter(torch.tensor([1.0, -2.0]))
+    p2 = torch.nn.Parameter(torch.tensor([3.0]))
+    p3 = torch.nn.Parameter(torch.tensor([5.0]))
+    p1.grad = torch.tensor([3.0, 4.0])
+    p2.grad = None
+    p3.grad = torch.tensor([12.0])
+
+    actual = _local_pth_sum([p1, p2, p3], p=2.0)
+
+    assert actual.dtype == torch.float32
+    assert torch.equal(actual.cpu(), torch.tensor(169.0))

--- a/tests/utils/test_fsdp2_clip_grad_norm.py
+++ b/tests/utils/test_fsdp2_clip_grad_norm.py
@@ -9,12 +9,20 @@ from veomni.distributed.fsdp2.clip_grad_norm import _fsdp_grad_norm_reduce_group
 clip_grad_norm_module = importlib.import_module("veomni.distributed.fsdp2.clip_grad_norm")
 
 
-def _parallel_state(*, dp_mode: str = "fsdp2", dp_replicate_enabled: bool = False, dp_shard_size: int = 1):
+def _parallel_state(
+    *,
+    dp_mode: str = "fsdp2",
+    dp_replicate_enabled: bool = False,
+    dp_shard_size: int = 1,
+    dp_shard_sp_enabled: bool = False,
+):
     return SimpleNamespace(
         dp_mode=dp_mode,
         dp_replicate_enabled=dp_replicate_enabled,
         dp_shard_size=dp_shard_size,
+        dp_shard_sp_enabled=dp_shard_sp_enabled,
         dp_shard_group=object(),
+        dp_shard_sp_group=object(),
         fsdp_group=object(),
     )
 
@@ -29,6 +37,18 @@ def test_fsdp_grad_norm_reduce_groups_use_shard_group_for_hsdp():
     ps = _parallel_state(dp_replicate_enabled=True, dp_shard_size=4)
 
     assert _fsdp_grad_norm_reduce_groups(ps) == [("fsdp_shard", ps.dp_shard_group)]
+
+
+def test_fsdp_grad_norm_reduce_groups_include_sp_for_hsdp_sp():
+    ps = _parallel_state(dp_replicate_enabled=True, dp_shard_size=4, dp_shard_sp_enabled=True)
+
+    assert _fsdp_grad_norm_reduce_groups(ps) == [("fsdp_shard_sp", ps.dp_shard_sp_group)]
+
+
+def test_fsdp_grad_norm_reduce_groups_include_sp_for_replicated_sp_only_sharding():
+    ps = _parallel_state(dp_replicate_enabled=True, dp_shard_size=1, dp_shard_sp_enabled=True)
+
+    assert _fsdp_grad_norm_reduce_groups(ps) == [("fsdp_shard_sp", ps.dp_shard_sp_group)]
 
 
 def test_fsdp_grad_norm_reduce_groups_skip_replicated_unsharded_fsdp2():
@@ -53,6 +73,24 @@ def test_local_pth_sum_skips_missing_grads_and_accumulates_in_fp32(monkeypatch):
     p3.grad = torch.tensor([12.0])
 
     actual = _local_pth_sum([p1, p2, p3], p=2.0)
+
+    assert actual.dtype == torch.float32
+    assert torch.equal(actual.cpu(), torch.tensor(169.0))
+
+
+def test_local_pth_sum_falls_back_without_foreach_support(monkeypatch):
+    monkeypatch.setattr(clip_grad_norm_module, "_has_foreach_support", lambda tensors, device: False)
+
+    def fail_foreach_norm(*args, **kwargs):
+        raise AssertionError("foreach path should not be used")
+
+    monkeypatch.setattr(torch, "_foreach_norm", fail_foreach_norm)
+    p1 = torch.nn.Parameter(torch.tensor([1.0, -2.0]))
+    p2 = torch.nn.Parameter(torch.tensor([3.0]))
+    p1.grad = torch.tensor([3.0, 4.0])
+    p2.grad = torch.tensor([12.0])
+
+    actual = _local_pth_sum([p1, p2], p=2.0)
 
     assert actual.dtype == torch.float32
     assert torch.equal(actual.cpu(), torch.tensor(169.0))

--- a/tests/utils/test_fsdp2_clip_grad_norm.py
+++ b/tests/utils/test_fsdp2_clip_grad_norm.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+
+from veomni.distributed.fsdp2.clip_grad_norm import _fsdp_grad_norm_reduce_groups
+
+
+def _parallel_state(*, dp_mode: str = "fsdp2", dp_replicate_enabled: bool = False, dp_shard_size: int = 1):
+    return SimpleNamespace(
+        dp_mode=dp_mode,
+        dp_replicate_enabled=dp_replicate_enabled,
+        dp_shard_size=dp_shard_size,
+        dp_shard_group=object(),
+        fsdp_group=object(),
+    )
+
+
+def test_fsdp_grad_norm_reduce_groups_use_fsdp_group_for_plain_fsdp2():
+    ps = _parallel_state()
+
+    assert _fsdp_grad_norm_reduce_groups(ps) == [("fsdp", ps.fsdp_group)]
+
+
+def test_fsdp_grad_norm_reduce_groups_use_shard_group_for_hsdp():
+    ps = _parallel_state(dp_replicate_enabled=True, dp_shard_size=4)
+
+    assert _fsdp_grad_norm_reduce_groups(ps) == [("fsdp_shard", ps.dp_shard_group)]
+
+
+def test_fsdp_grad_norm_reduce_groups_skip_non_fsdp2_modes():
+    ps = _parallel_state(dp_mode="ddp")
+
+    assert _fsdp_grad_norm_reduce_groups(ps) == []

--- a/tests/utils/test_fsdp2_clip_grad_norm.py
+++ b/tests/utils/test_fsdp2_clip_grad_norm.py
@@ -80,6 +80,7 @@ def test_local_pth_sum_skips_missing_grads_and_accumulates_in_fp32(monkeypatch):
 
 def test_local_pth_sum_falls_back_without_foreach_support(monkeypatch):
     monkeypatch.setattr(clip_grad_norm_module, "_has_foreach_support", lambda tensors, device: False)
+    monkeypatch.setattr(clip_grad_norm_module, "_device_has_foreach_support", lambda device: False)
 
     def fail_foreach_norm(*args, **kwargs):
         raise AssertionError("foreach path should not be used")

--- a/tests/utils/test_fsdp2_clip_grad_norm.py
+++ b/tests/utils/test_fsdp2_clip_grad_norm.py
@@ -1,8 +1,12 @@
+import importlib
 from types import SimpleNamespace
 
 import torch
 
 from veomni.distributed.fsdp2.clip_grad_norm import _fsdp_grad_norm_reduce_groups, _local_pth_sum
+
+
+clip_grad_norm_module = importlib.import_module("veomni.distributed.fsdp2.clip_grad_norm")
 
 
 def _parallel_state(*, dp_mode: str = "fsdp2", dp_replicate_enabled: bool = False, dp_shard_size: int = 1):
@@ -27,13 +31,20 @@ def test_fsdp_grad_norm_reduce_groups_use_shard_group_for_hsdp():
     assert _fsdp_grad_norm_reduce_groups(ps) == [("fsdp_shard", ps.dp_shard_group)]
 
 
+def test_fsdp_grad_norm_reduce_groups_skip_replicated_unsharded_fsdp2():
+    ps = _parallel_state(dp_replicate_enabled=True, dp_shard_size=1)
+
+    assert _fsdp_grad_norm_reduce_groups(ps) == []
+
+
 def test_fsdp_grad_norm_reduce_groups_skip_non_fsdp2_modes():
     ps = _parallel_state(dp_mode="ddp")
 
     assert _fsdp_grad_norm_reduce_groups(ps) == []
 
 
-def test_local_pth_sum_skips_missing_grads_and_accumulates_in_fp32():
+def test_local_pth_sum_skips_missing_grads_and_accumulates_in_fp32(monkeypatch):
+    monkeypatch.setattr(clip_grad_norm_module, "_LOCAL_NORM_CHUNK_SIZE", 2)
     p1 = torch.nn.Parameter(torch.tensor([1.0, -2.0]))
     p2 = torch.nn.Parameter(torch.tensor([3.0]))
     p3 = torch.nn.Parameter(torch.tensor([5.0]))

--- a/veomni/distributed/fsdp2/clip_grad_norm.py
+++ b/veomni/distributed/fsdp2/clip_grad_norm.py
@@ -4,11 +4,6 @@ from typing import List
 import torch
 import torch.distributed as dist
 from torch.distributed._tensor import DTensor
-from torch.utils._foreach_utils import (
-    _device_has_foreach_support,
-    _group_tensors_by_device_and_dtype,
-    _has_foreach_support,
-)
 
 from ...utils.device import get_device_type
 from ...utils.logging import get_logger
@@ -184,24 +179,18 @@ def _raise_if_nonfinite(total_norm: torch.Tensor, norm_type: float, error_if_non
 
 # compute local sum of param gard norm
 def _local_pth_sum(params: List[torch.nn.Parameter], p: float) -> torch.Tensor:
-    grads = [p.grad for p in params if p.grad is not None]
-    grads_local = [
-        g.to_local().detach().to(torch.float32) if isinstance(g, DTensor) else g.detach().to(torch.float32)
-        for g in grads
-    ]
-
     reduce_device = torch.device(get_device_type())
     res = torch.tensor(0.0, device=reduce_device, dtype=torch.float32)
     with torch.no_grad():
-        grouped_grads_local = _group_tensors_by_device_and_dtype([grads_local])
-        for (device, _), ([device_grads_local], _) in grouped_grads_local.items():
-            if _has_foreach_support(device_grads_local, device) or _device_has_foreach_support(device):
-                out = torch._foreach_pow_(torch._foreach_norm(device_grads_local, p), p)
-                res += torch.sum(torch.stack(out)).to(reduce_device)
-            else:
-                for grad_local in device_grads_local:
-                    gn = torch.norm(grad_local, p=p)
-                    res = res + (gn**p).to(reduce_device)
+        for param in params:
+            g = param.grad
+            if g is None:
+                continue
+            if isinstance(g, DTensor):
+                g = g.to_local()
+            g = g.detach().to(torch.float32)
+            gn = torch.norm(g, p=p)
+            res = res + (gn**p).to(reduce_device)
     return res
 
 

--- a/veomni/distributed/fsdp2/clip_grad_norm.py
+++ b/veomni/distributed/fsdp2/clip_grad_norm.py
@@ -11,6 +11,7 @@ from ..parallel_state import get_parallel_state
 
 
 logger = get_logger(__name__)
+_LOCAL_NORM_CHUNK_SIZE = 128
 
 
 def clip_grad_norm(
@@ -54,8 +55,8 @@ def _fsdp_grad_norm_reduce_groups(ps) -> List[tuple[str, dist.ProcessGroup | Non
     """
     if ps.dp_mode != "fsdp2":
         return []
-    if ps.dp_replicate_enabled and ps.dp_shard_size > 1:
-        return [("fsdp_shard", ps.dp_shard_group)]
+    if ps.dp_replicate_enabled:
+        return [("fsdp_shard", ps.dp_shard_group)] if ps.dp_shard_size > 1 else []
     return [("fsdp", ps.fsdp_group)]
 
 
@@ -181,6 +182,19 @@ def _raise_if_nonfinite(total_norm: torch.Tensor, norm_type: float, error_if_non
 def _local_pth_sum(params: List[torch.nn.Parameter], p: float) -> torch.Tensor:
     reduce_device = torch.device(get_device_type())
     res = torch.tensor(0.0, device=reduce_device, dtype=torch.float32)
+
+    chunks: dict[torch.device, list[torch.Tensor]] = {}
+
+    def flush_chunk(device: torch.device) -> None:
+        nonlocal res
+        chunk = chunks.get(device)
+        if not chunk:
+            return
+        chunk_fp32 = [g.to(torch.float32) for g in chunk]
+        norms = torch._foreach_norm(chunk_fp32, p)
+        res = res + torch.sum(torch.stack(norms).pow(p)).to(reduce_device)
+        chunk.clear()
+
     with torch.no_grad():
         for param in params:
             g = param.grad
@@ -188,9 +202,14 @@ def _local_pth_sum(params: List[torch.nn.Parameter], p: float) -> torch.Tensor:
                 continue
             if isinstance(g, DTensor):
                 g = g.to_local()
-            g = g.detach().to(torch.float32)
-            gn = torch.norm(g, p=p)
-            res = res + (gn**p).to(reduce_device)
+            g = g.detach()
+            chunk = chunks.setdefault(g.device, [])
+            chunk.append(g)
+            if len(chunk) >= _LOCAL_NORM_CHUNK_SIZE:
+                flush_chunk(g.device)
+
+        for device in list(chunks):
+            flush_chunk(device)
     return res
 
 

--- a/veomni/distributed/fsdp2/clip_grad_norm.py
+++ b/veomni/distributed/fsdp2/clip_grad_norm.py
@@ -4,7 +4,7 @@ from typing import List
 import torch
 import torch.distributed as dist
 from torch.distributed._tensor import DTensor
-from torch.utils._foreach_utils import _has_foreach_support
+from torch.utils._foreach_utils import _device_has_foreach_support, _has_foreach_support
 
 from ...utils.device import get_device_type
 from ...utils.logging import get_logger
@@ -197,11 +197,11 @@ def _local_pth_sum(params: List[torch.nn.Parameter], p: float) -> torch.Tensor:
         if not chunk:
             return
         chunk_fp32 = [g.to(torch.float32) for g in chunk]
-        if _has_foreach_support(chunk_fp32, device):
-            norms = torch._foreach_norm(chunk_fp32, p)
+        if _has_foreach_support(chunk_fp32, device) or _device_has_foreach_support(device):
+            norm_pows = torch._foreach_pow_(torch._foreach_norm(chunk_fp32, p), p)
         else:
-            norms = [torch.linalg.vector_norm(g, p) for g in chunk_fp32]
-        res = res + torch.sum(torch.stack(norms).pow(p)).to(reduce_device)
+            norm_pows = [torch.linalg.vector_norm(g, p).pow(p) for g in chunk_fp32]
+        res = res + torch.sum(torch.stack(norm_pows)).to(reduce_device)
         chunk.clear()
 
     with torch.no_grad():

--- a/veomni/distributed/fsdp2/clip_grad_norm.py
+++ b/veomni/distributed/fsdp2/clip_grad_norm.py
@@ -51,6 +51,19 @@ def clip_grad_norm(
     return grad_norm
 
 
+def _fsdp_grad_norm_reduce_groups(ps) -> List[tuple[str, dist.ProcessGroup | None]]:
+    """Process groups for FSDP2 grad-norm reduction.
+
+    Under HSDP each shard group is replicated across ``dp_replicate``; only sum
+    shard-local p-th powers across ``dp_shard``, not across replicas.
+    """
+    if ps.dp_mode != "fsdp2":
+        return []
+    if ps.dp_replicate_enabled and ps.dp_shard_size > 1:
+        return [("fsdp_shard", ps.dp_shard_group)]
+    return [("fsdp", ps.fsdp_group)]
+
+
 @torch.no_grad()
 def _cpu_offload_fsdp2_clip_grad_norm(
     model, max_norm: float, norm_type: float = 2.0, error_if_nonfinite: bool = False, foreach: bool | None = None
@@ -60,7 +73,7 @@ def _cpu_offload_fsdp2_clip_grad_norm(
     total_norm_or_pth_sum = _fsdp2_reduce_group(
         params=params,
         norm_type=norm_type,
-        reduce_groups=[("fsdp", ps.fsdp_group)],
+        reduce_groups=_fsdp_grad_norm_reduce_groups(ps),
     )
     total_norm = _finalize_total_norm(total_norm_or_pth_sum, norm_type)
     _raise_if_nonfinite(total_norm, norm_type, error_if_nonfinite)
@@ -85,7 +98,6 @@ def extra_parallel_fsdp2_clip_grad_norm(
     - Use a single global clip coefficient for both groups.
     """
     ps = get_parallel_state()
-    fsdp_group = ps.fsdp_group
     extra_parallel_group = {
         para: ps.extra_parallel_group(para) if ps.extra_parallel_enabled(para) else None
         for para in ps.extra_parallel_names
@@ -111,7 +123,7 @@ def extra_parallel_fsdp2_clip_grad_norm(
     non_extra_parallel_total = _fsdp2_reduce_group(
         params=non_extra_parallel_params,
         norm_type=norm_type,
-        reduce_groups=[("fsdp", fsdp_group)],
+        reduce_groups=_fsdp_grad_norm_reduce_groups(ps),
     )
     logger.debug_rank0(f"non_extra_parallel total grad norm: {non_extra_parallel_total}")
 

--- a/veomni/distributed/fsdp2/clip_grad_norm.py
+++ b/veomni/distributed/fsdp2/clip_grad_norm.py
@@ -4,6 +4,7 @@ from typing import List
 import torch
 import torch.distributed as dist
 from torch.distributed._tensor import DTensor
+from torch.utils._foreach_utils import _has_foreach_support
 
 from ...utils.device import get_device_type
 from ...utils.logging import get_logger
@@ -48,16 +49,19 @@ def clip_grad_norm(
 
 
 def _fsdp_grad_norm_reduce_groups(ps) -> List[tuple[str, dist.ProcessGroup | None]]:
-    """Process groups for FSDP2 grad-norm reduction.
-
-    Under HSDP each shard group is replicated across ``dp_replicate``; only sum
-    shard-local p-th powers across ``dp_shard``, not across replicas.
-    """
+    """Return process groups that own distinct FSDP gradient shards."""
     if ps.dp_mode != "fsdp2":
         return []
-    if ps.dp_replicate_enabled:
-        return [("fsdp_shard", ps.dp_shard_group)] if ps.dp_shard_size > 1 else []
-    return [("fsdp", ps.fsdp_group)]
+    if not ps.dp_replicate_enabled:
+        return [("fsdp", ps.fsdp_group)]
+    # In HSDP, replicas already hold equivalent gradients after backward; reduce
+    # only across the shard side of the FSDP mesh.
+    if ps.dp_shard_sp_enabled:
+        # When SP participates in FSDP sharding, the shard group is dp_shard_sp.
+        return [("fsdp_shard_sp", ps.dp_shard_sp_group)]
+    if ps.dp_shard_size > 1:
+        return [("fsdp_shard", ps.dp_shard_group)]
+    return []
 
 
 @torch.no_grad()
@@ -178,11 +182,13 @@ def _raise_if_nonfinite(total_norm: torch.Tensor, norm_type: float, error_if_non
         )
 
 
-# compute local sum of param gard norm
 def _local_pth_sum(params: List[torch.nn.Parameter], p: float) -> torch.Tensor:
+    """Compute the local p-th norm sum with bounded fp32 grad materialization."""
     reduce_device = torch.device(get_device_type())
     res = torch.tensor(0.0, device=reduce_device, dtype=torch.float32)
 
+    # Materializing every grad as fp32 at once can OOM on large models, so keep
+    # foreach acceleration local to bounded same-device chunks.
     chunks: dict[torch.device, list[torch.Tensor]] = {}
 
     def flush_chunk(device: torch.device) -> None:
@@ -191,7 +197,10 @@ def _local_pth_sum(params: List[torch.nn.Parameter], p: float) -> torch.Tensor:
         if not chunk:
             return
         chunk_fp32 = [g.to(torch.float32) for g in chunk]
-        norms = torch._foreach_norm(chunk_fp32, p)
+        if _has_foreach_support(chunk_fp32, device):
+            norms = torch._foreach_norm(chunk_fp32, p)
+        else:
+            norms = [torch.linalg.vector_norm(g, p) for g in chunk_fp32]
         res = res + torch.sum(torch.stack(norms).pow(p)).to(reduce_device)
         chunk.clear()
 

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -216,6 +216,11 @@ class ParallelState:
             return self.device_mesh.get_group("dp_shard")
 
     @property
+    def dp_shard_sp_group(self) -> Optional["ProcessGroup"]:
+        if self.device_mesh is not None:
+            return self.device_mesh.get_group("dp_shard_sp")
+
+    @property
     def dp_shard_rank(self) -> int:
         if self.device_mesh is not None:
             return self.device_mesh.get_local_rank("dp_shard")


### PR DESCRIPTION
## Summary

Fix two FSDP2 gradient norm issues:

- Under HSDP, reduce shard-local norm statistics over the `dp_shard` group instead of the full FSDP group. Each shard group is replicated across `dp_replicate`, so reducing over the full group over-counts the norm. For replicated but unsharded FSDP2, skip the extra norm reduction.
- Compute the local p-norm sum in bounded chunks using `torch._foreach_norm`. This avoids materializing all gradients as fp32 at once while keeping kernel-launch overhead bounded.

## Validation

```bash
.venv/bin/python -m pytest -q tests/utils/test_fsdp2_clip_grad_norm.py
```

Result:

```text
5 passed
```

```bash
.venv/bin/python -m py_compile \
  veomni/distributed/fsdp2/clip_grad_norm.py \
  tests/utils/test_fsdp2_clip_grad_norm.py
```