### PR TITLE
[config] fix: auto-resolve ops defaults to NPU-compatible

### DIFF
--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -14,7 +14,7 @@
 
 import math
 import os
-from dataclasses import dataclass, field
+from dataclasses import MISSING, dataclass, field, fields
 from pathlib import Path
 from typing import Dict, List, Literal, Optional
 
@@ -731,6 +731,16 @@ _NPU_REQUIRED: Dict[str, frozenset] = {
     "moe_implementation": frozenset({"fused_npu"}),
 }
 
+_NPU_DEFAULT_FALLBACK: Dict[str, str] = {
+    "rms_norm_implementation": "npu",
+    "rotary_pos_emb_implementation": "npu",
+    "rotary_pos_emb_vision_implementation": "npu",
+    "swiglu_mlp_implementation": "eager",
+    "load_balancing_loss_implementation": "eager",
+    "cross_entropy_loss_implementation": "npu",
+    "moe_implementation": "fused_npu",
+}
+
 
 @dataclass
 class OpsImplementationConfig:
@@ -882,7 +892,32 @@ class OpsImplementationConfig:
             )
             self.moe_implementation = resolved
 
+        self._apply_npu_default_fallback()
         self._validate_implementations()
+
+    def _apply_npu_default_fallback(self):
+        """Auto-resolve GPU-only defaults to NPU-compatible alternatives.
+
+        When running on NPU, fields still at their GPU default are silently
+        swapped to the NPU fallback from ``_NPU_DEFAULT_FALLBACK``. Explicit
+        user overrides (non-default values) are left untouched and will be
+        caught by ``_validate_implementations`` if unsupported.
+        """
+        from ..utils.import_utils import is_torch_npu_available
+
+        if not is_torch_npu_available():
+            return
+
+        gpu_defaults = {f.name: f.default for f in fields(self) if f.default is not MISSING}
+        for field_name, npu_value in _NPU_DEFAULT_FALLBACK.items():
+            if field_name not in gpu_defaults:
+                continue
+            current = getattr(self, field_name)
+            if current == gpu_defaults[field_name]:
+                setattr(self, field_name, npu_value)
+                logger.info_rank0(
+                    f"{field_name}: auto-resolved GPU default {current!r} -> {npu_value!r} on Ascend NPU."
+                )
 
     def _validate_implementations(self):
         """Fail fast on hardware/op mismatch at config-parse time.


### PR DESCRIPTION

### What does this PR do?

> Add _NPU_DEFAULT_FALLBACK mapping and _apply_npu_default_fallback() to OpsImplementationConfig. When running on NPU, GPU-only default op implementations (e.g., rms_norm, rotary_pos_emb, swiglu_mlp, cross_entropy_loss, moe) are automatically resolved to NPU-compatible alternatives. Explicit user overrides are left untouched and still validated by _validate_implementations.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Verified on both NPU and GPU — Qwen3 can start training and complete 3 epochs using the repo's default config.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
