### PR TITLE
[lora] fix: support PEFT LoRA on fused MoE experts

### DIFF
--- a/docs/key_features/lora.md
+++ b/docs/key_features/lora.md
@@ -42,9 +42,10 @@ model:
 | `rank` | int | Rank of the decomposition matrices A and B |
 | `alpha` | int | LoRA scaling factor; effective scale = `alpha / rank` |
 | `lora_modules` | list[str] | Target linear layer name substrings (matched against module FQNs) |
-| `lora_adapter` | str (optional) | Path to a saved adapter directory to resume from |
+| `lora_adapter` | str (optional) | Path to a saved HF/PEFT adapter directory to load before training |
 
-For **resume training**, add the `lora_adapter` key pointing to the saved adapter directory:
+To continue from a saved HF/PEFT adapter rather than a DCP training checkpoint,
+add the `lora_adapter` key pointing to the saved adapter directory:
 
 ```yaml
 model:
@@ -55,6 +56,10 @@ model:
     lora_adapter: ./exp/my_run/global_step_500   # HF adapter dir to resume from
 ```
 
+For exact training-state resume, including optimizer, scheduler, dataloader state,
+RNG state, and global step, use `train.checkpoint.load_path` instead. See
+[`lora_resume`](#lora_resume-qwen3-moe-dcp-training-state-resume).
+
 ---
 
 ## 2. LoRA Initialization in BaseTrainer
@@ -63,6 +68,8 @@ LoRA wrapping happens in `BaseTrainer._setup_lora()`, called from `_freeze_model
 
 ```python
 # veomni/trainer/base.py
+
+from ..utils.lora_utils import build_peft_lora_targets
 
 def _setup_lora(self):
     lora_config = self.args.model.lora_config
@@ -80,11 +87,15 @@ def _setup_lora(self):
     else:
         # From scratch: wrap with LoraConfig
         from peft import LoraConfig, get_peft_model
-        peft_cfg = LoraConfig(
-            r=lora_config["rank"],
-            lora_alpha=lora_config["alpha"],
-            target_modules=lora_config["lora_modules"],
-        )
+        target_modules, target_parameters = build_peft_lora_targets(self.model, lora_config)
+        peft_kwargs = {
+            "r": lora_config["rank"],
+            "lora_alpha": lora_config["alpha"],
+            "target_modules": target_modules,
+        }
+        if target_parameters:
+            peft_kwargs["target_parameters"] = target_parameters
+        peft_cfg = LoraConfig(**peft_kwargs)
         self.model = get_peft_model(self.model, peft_cfg)
 ```
 
@@ -129,8 +140,9 @@ infix (e.g. `lora_A.weight`), whereas the live model stores them as
 ### DCP checkpoint (training state)
 
 `CheckpointerCallback._save_checkpoint` saves the full distributed state (model + optimizer +
-extra state) via PyTorch DCP. For LoRA training this includes both base-model parameters
-**and** adapter parameters; the optimizer state only covers the trainable adapter parameters.
+extra state) via PyTorch DCP. For LoRA training, the model state is saved with
+`trainable_only=True`, so it contains adapter parameters only rather than frozen
+base-model parameters; the optimizer state covers the trainable adapter parameters.
 
 ### HF LoRA adapter (inference artifact)
 
@@ -258,7 +270,7 @@ bash train.sh tasks/train_text.py configs/text/qwen3_lora.yaml \
     --train.wandb.enable true
 ```
 
-To resume from a saved adapter:
+To resume from the latest DCP training checkpoint:
 
 ```shell
 bash train.sh tasks/train_text.py configs/text/qwen3_lora.yaml \
@@ -268,7 +280,192 @@ bash train.sh tasks/train_text.py configs/text/qwen3_lora.yaml \
     --train.checkpoint.load_path auto          # auto-picks latest DCP checkpoint
 ```
 
-### 5.3 Qwen-Image LoRA (DiT, FSDP2)
+### 5.3 Qwen3-MoE fused expert LoRA (LLM, PEFT target_parameters)
+
+Qwen3-MoE stores expert MLP weights as fused parameters instead of ordinary
+`gate_proj`, `up_proj`, and `down_proj` `Linear` modules. VeOmni lets users keep
+the standard semantic LoRA config; the Qwen3-MoE model registration maps those
+semantic MLP targets to PEFT `target_parameters` for:
+
+```text
+model.layers.*.mlp.experts.gate_up_proj
+model.layers.*.mlp.experts.down_proj
+```
+
+The attention projections remain regular PEFT `target_modules`.
+
+#### lora_train: train and save the fused-MoE adapter
+
+Start from [`configs/text/qwen3-moe.yaml`](../../configs/text/qwen3-moe.yaml)
+so the data, optimizer, FSDP2, and fused-MoE operator settings stay aligned with
+the standard Qwen3-MoE training recipe. Add the LoRA block and enable HF adapter
+saving, for example:
+
+```yaml
+model:
+  model_path: /path/to/Qwen3-30B-A3B-Instruct-2507
+  ops_implementation:
+    attn_implementation: flash_attention_2
+    moe_implementation: fused_triton
+  lora_config:
+    rank: 1024
+    alpha: 2048
+    lora_modules:
+      - q_proj
+      - k_proj
+      - v_proj
+      - o_proj
+      - gate_proj
+      - up_proj
+      - down_proj
+
+data:
+  train_path: /path/to/sft_data
+  data_type: conversation
+  chat_template: chatml
+  max_seq_len: 2048
+  train_size: 750000
+  text_keys: messages
+  dyn_bsz_buffer_size: 200
+
+train:
+  init_device: meta
+  accelerator:
+    fsdp_config:
+      fsdp_mode: fsdp2
+  gradient_checkpointing:
+    enable: true
+  global_batch_size: 8
+  micro_batch_size: 1
+  optimizer:
+    type: adamw
+    lr: 1.0e-4
+    lr_decay_style: cosine
+    max_grad_norm: 1.0
+  num_train_epochs: 1
+  checkpoint:
+    output_dir: ./exp/qwen3_moe_lora
+    manager: dcp
+    save_hf_weights: true
+    save_epochs: 1
+```
+
+Launch it with path-specific overrides:
+
+```shell
+NPROC_PER_NODE=8
+
+bash train.sh tasks/train_text.py configs/text/qwen3_moe_lora.yaml \
+    --model.model_path /path/to/Qwen3-30B-A3B-Instruct-2507 \
+    --data.train_path /path/to/sft_data \
+    --train.global_batch_size 8 \
+    --train.micro_batch_size 1 \
+    --train.checkpoint.output_dir ./exp/qwen3_moe_lora \
+    --train.checkpoint.save_hf_weights true \
+    --train.num_train_epochs 1
+```
+
+The HF/PEFT adapter is saved under:
+
+```text
+./exp/qwen3_moe_lora/global_step_N/
+├── adapter_config.json
+└── adapter_model.bin
+```
+
+For fused-MoE LoRA, `adapter_config.json` should keep dense attention modules
+in `target_modules` and list fused expert parameters in `target_parameters`.
+A 48-layer Qwen3-MoE run with LoRA on `q/k/v/o/gate/up/down` saves LoRA-only
+adapter tensors:
+
+```text
+total adapter tensors: 576
+fused expert LoRA tensors: 192
+non-LoRA tensors: 0
+```
+
+#### lora_resume: Qwen3-MoE DCP training-state resume
+
+Use the DCP checkpoint under `checkpoints/global_step_N` when resuming an
+interrupted training run. This restores the training state, not just the HF
+adapter weights.
+
+```shell
+bash train.sh tasks/train_text.py configs/text/qwen3_moe_lora.yaml \
+    --model.model_path /path/to/Qwen3-30B-A3B-Instruct-2507 \
+    --data.train_path /path/to/sft_data \
+    --train.checkpoint.output_dir ./exp/qwen3_moe_lora \
+    --train.checkpoint.load_path ./exp/qwen3_moe_lora/checkpoints/global_step_5 \
+    --train.checkpoint.save_hf_weights true \
+    --train.num_train_epochs 3
+```
+
+Expected resume evidence in the logs:
+
+```text
+Loaded checkpoint from ./exp/qwen3_moe_lora/checkpoints/global_step_5
+Start step: 0. Train steps: 5. Start epoch: 1. Train epochs: 3.
+```
+
+After resume, later adapter saves should keep the same LoRA-only fused-MoE
+format. In the validation run, `global_step_5`, `global_step_10`, and
+`global_step_15` each had:
+
+```text
+total=576, fused=192, non_lora=0
+```
+
+#### lora_inference: load or merge the trained adapter
+
+The saved adapter can be loaded directly with PEFT:
+
+```python
+import torch
+from peft import PeftModel
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+base_model_path = "/path/to/Qwen3-30B-A3B-Instruct-2507"
+adapter_path = "./exp/qwen3_moe_lora/global_step_15"
+
+tokenizer = AutoTokenizer.from_pretrained(base_model_path, trust_remote_code=True)
+base_model = AutoModelForCausalLM.from_pretrained(
+    base_model_path,
+    dtype=torch.bfloat16,
+    device_map="auto",
+    trust_remote_code=True,
+)
+model = PeftModel.from_pretrained(base_model, adapter_path)
+model.eval()
+
+inputs = tokenizer("Hello, my name is", return_tensors="pt")
+inputs = {key: value.to(next(model.parameters()).device) for key, value in inputs.items()}
+
+with torch.no_grad():
+    outputs = model(**inputs)
+print(outputs.logits.shape)
+```
+
+Loaded fused expert LoRA parameter names include the adapter name, for example
+`.lora_A.default.weight`, while saved adapter keys omit it. This is standard PEFT
+adapter-name remapping.
+
+To produce a merged model without LoRA modules:
+
+```python
+merged = model.merge_and_unload()
+merged.eval()
+
+num_lora_params = sum(1 for name, _ in merged.named_parameters() if "lora_" in name)
+print(num_lora_params)  # expected: 0
+```
+
+PEFT may warn that `Qwen3MoeExperts` is an unsupported layer type. Validate the
+merged model for your deployment path; in the Qwen3-MoE smoke test, direct
+adapter loading, `merge_and_unload()`, forward, and generation completed
+successfully, and representative fused expert base tensors changed after merge,
+confirming that the LoRA delta was folded into `gate_up_proj` and `down_proj`.
+
+### 5.4 Qwen-Image LoRA (DiT, FSDP2)
 
 Config: [`configs/dit/qwen_image_lora.yaml`](../../configs/dit/qwen_image_lora.yaml)
 
@@ -316,7 +513,7 @@ bash train.sh tasks/train_dit.py configs/dit/qwen_image_lora.yaml \
     --train.num_train_epochs 3
 ```
 
-`HFLoraCkptCallback` writes the trained adapter to `${output_dir}/global_step_${step}/{adapter_config.json, adapter_model.{bin,safetensors}}`, which is the standard PEFT format consumable by `PeftModel.from_pretrained` and `diffusers`' `pipeline.transformer.load_lora_adapter` (the adapter keys carry the `base_model.model.` prefix expected by `peft`).
+`HFLoraCkptCallback` writes the trained adapter to `${output_dir}/global_step_${step}/{adapter_config.json, adapter_model.bin}`, which is the standard PEFT format consumable by `PeftModel.from_pretrained` and `diffusers`' `pipeline.transformer.load_lora_adapter` (the adapter keys carry the `base_model.model.` prefix expected by `peft`).
 
 ---
 

--- a/tests/utils/test_lora_utils.py
+++ b/tests/utils/test_lora_utils.py
@@ -1,0 +1,34 @@
+import torch
+import torch.nn as nn
+
+from veomni.utils.lora_utils import build_lora_key_overrides
+
+
+class _TargetParameterPeftModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.base_model = nn.Module()
+        self.base_model.model = nn.Module()
+        self.base_model.model.model = nn.Module()
+        self.base_model.model.model.layers = nn.ModuleList([nn.Module()])
+        experts = nn.Module()
+        experts.base_layer = nn.Module()
+        experts.base_layer.gate_up_proj = nn.Parameter(torch.empty(2, 4, 3))
+        experts.base_layer.register_buffer("down_proj", torch.empty(2, 3, 4))
+        experts.lora_A = nn.ParameterDict({"default": nn.Parameter(torch.empty(2, 1))})
+        self.base_model.model.model.layers[0].mlp = nn.Module()
+        self.base_model.model.model.layers[0].mlp.experts = experts
+
+
+def test_build_lora_key_overrides_handles_target_parameters_base_layer():
+    model = _TargetParameterPeftModel()
+
+    overrides = build_lora_key_overrides(model)
+
+    assert overrides["model.layers.0.mlp.experts.gate_up_proj"] == (
+        "base_model.model.model.layers.0.mlp.experts.base_layer.gate_up_proj"
+    )
+    assert overrides["model.layers.0.mlp.experts.down_proj"] == (
+        "base_model.model.model.layers.0.mlp.experts.base_layer.down_proj"
+    )
+    assert "model.layers.0.mlp.experts.lora_A.default" not in overrides

--- a/tests/utils/test_lora_utils.py
+++ b/tests/utils/test_lora_utils.py
@@ -1,7 +1,8 @@
+import pytest
 import torch
 import torch.nn as nn
 
-from veomni.utils.lora_utils import build_lora_key_overrides
+from veomni.utils.lora_utils import build_lora_key_overrides, build_peft_lora_targets, convert_fused_moe_lora_targets
 
 
 class _TargetParameterPeftModel(nn.Module):
@@ -20,6 +21,40 @@ class _TargetParameterPeftModel(nn.Module):
         self.base_model.model.model.layers[0].mlp.experts = experts
 
 
+class _DenseModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList([nn.Module()])
+        self.model.layers[0].mlp = nn.Module()
+        self.model.layers[0].mlp.gate_proj = nn.Linear(4, 8, bias=False)
+        self.model.layers[0].mlp.up_proj = nn.Linear(4, 8, bias=False)
+        self.model.layers[0].mlp.down_proj = nn.Linear(8, 4, bias=False)
+        self.model.layers[0].custom = nn.Parameter(torch.empty(2, 2))
+
+
+class _FusedMoeModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList([nn.Module()])
+        self.model.layers[0].self_attn = nn.Module()
+        self.model.layers[0].self_attn.q_proj = nn.Linear(4, 4, bias=False)
+        self.model.layers[0].mlp = nn.Module()
+        self.model.layers[0].mlp.experts = nn.Module()
+        self.model.layers[0].mlp.experts.gate_up_proj = nn.Parameter(torch.empty(2, 8, 4))
+        self.model.layers[0].mlp.experts.down_proj = nn.Parameter(torch.empty(2, 4, 8))
+
+
+def _convert_test_fused_moe_lora_targets(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "model.layers.*.mlp.experts.gate_up_proj",
+        "model.layers.*.mlp.experts.down_proj",
+    )
+
+
 def test_build_lora_key_overrides_handles_target_parameters_base_layer():
     model = _TargetParameterPeftModel()
 
@@ -32,3 +67,58 @@ def test_build_lora_key_overrides_handles_target_parameters_base_layer():
         "base_model.model.model.layers.0.mlp.experts.base_layer.down_proj"
     )
     assert "model.layers.0.mlp.experts.lora_A.default" not in overrides
+
+
+def test_build_peft_lora_targets_keeps_dense_modules_with_explicit_parameters():
+    model = _DenseModel()
+    lora_config = {
+        "lora_modules": ["gate_proj", "up_proj", "down_proj"],
+        "target_parameters": ["model.layers.0.custom"],
+    }
+
+    target_modules, target_parameters = build_peft_lora_targets(model, lora_config)
+
+    assert target_modules == ["gate_proj", "up_proj", "down_proj"]
+    assert target_parameters == ["model.layers.0.custom"]
+
+
+def test_build_peft_lora_targets_uses_model_owned_fused_mapping():
+    model = _FusedMoeModel()
+    model._convert_lora_targets_to_parameters = _convert_test_fused_moe_lora_targets
+    lora_config = {
+        "lora_modules": ["q_proj", "gate_proj", "up_proj", "down_proj"],
+    }
+
+    target_modules, target_parameters = build_peft_lora_targets(model, lora_config)
+
+    assert target_modules == ["q_proj"]
+    assert target_parameters == [
+        "model.layers.0.mlp.experts.down_proj",
+        "model.layers.0.mlp.experts.gate_up_proj",
+    ]
+
+
+def test_build_peft_lora_targets_merges_explicit_parameters_with_fused_mapping():
+    model = _FusedMoeModel()
+    model.extra = nn.Parameter(torch.empty(1))
+    model._convert_lora_targets_to_parameters = _convert_test_fused_moe_lora_targets
+    lora_config = {
+        "lora_modules": ["q_proj", "gate_proj"],
+        "target_parameters": ["extra"],
+    }
+
+    target_modules, target_parameters = build_peft_lora_targets(model, lora_config)
+
+    assert target_modules == ["q_proj"]
+    assert target_parameters == ["extra", "model.layers.0.mlp.experts.gate_up_proj"]
+
+
+def test_build_peft_lora_targets_rejects_unmatched_parameter_pattern():
+    model = _DenseModel()
+    lora_config = {
+        "lora_modules": ["gate_proj"],
+        "target_parameters": ["missing.parameter"],
+    }
+
+    with pytest.raises(ValueError, match="missing.parameter"):
+        build_peft_lora_targets(model, lora_config)

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -332,7 +332,14 @@ def load_model_weights(
 
         lora_key_overrides = build_lora_key_overrides(model)
 
+    def _map_peft_key(name: str) -> str:
+        if not is_peft_model:
+            return name
+        return lora_key_overrides.get(name, "base_model.model." + name)
+
     converter = get_checkpoint_tensor_converter(model)
+    if converter is None and is_peft_model and hasattr(model, "get_base_model"):
+        converter = get_checkpoint_tensor_converter(model.get_base_model())
     state_dict_iterators = _load_state_dict(weights_path)
 
     def _dispatch_kv(name: str, tensor: "torch.Tensor") -> None:
@@ -349,19 +356,17 @@ def load_model_weights(
     ):
         for name, tensor in state_dict_iterator:
             name = _convert_weight_key(name, model)
-            if is_peft_model:
-                name = lora_key_overrides.get(name, "base_model.model." + name)
             converted = maybe_convert_checkpoint_tensor(name, tensor, converter)
             if converted is None:
                 continue
-            _dispatch_kv(converted.name, converted.tensor)
+            _dispatch_kv(_map_peft_key(converted.name), converted.tensor)
 
         del state_dict_iterator
         empty_cache()
 
     if converter is not None:
         for result in converter.finalize():
-            _dispatch_kv(result.name, result.tensor)
+            _dispatch_kv(_map_peft_key(result.name), result.tensor)
 
     if is_peft_model and adapter_path:
         # load peft lora weights if adapter_path is provided, else, init lora model weights in post_process_after_weight_loading
@@ -425,7 +430,14 @@ def rank0_load_and_broadcast_weights(
 
         lora_key_overrides = build_lora_key_overrides(model)
 
+    def _map_peft_key(name: str) -> str:
+        if not is_peft_model:
+            return name
+        return lora_key_overrides.get(name, "base_model.model." + name)
+
     converter = get_checkpoint_tensor_converter(model)
+    if converter is None and is_peft_model and hasattr(model, "get_base_model"):
+        converter = get_checkpoint_tensor_converter(model.get_base_model())
     global_rank = get_parallel_state().global_rank
     torch_device = _get_communication_device(init_device)
 
@@ -669,12 +681,10 @@ def rank0_load_and_broadcast_weights(
                     try:
                         key, tensor = next(iterator)  # type: ignore[arg-type]
                         key = _convert_weight_key(key, model)
-                        if is_peft_model:
-                            key = lora_key_overrides.get(key, "base_model.model." + key)
                         converted = maybe_convert_checkpoint_tensor(key, tensor, converter)
                         if converted is None:
                             continue
-                        key, tensor = converted.name, converted.tensor
+                        key, tensor = _map_peft_key(converted.name), converted.tensor
                         logger.info_rank0(f"loading {key=}")
                         if torch.count_nonzero(tensor) == 0:
                             logger.warning_rank0(
@@ -732,7 +742,8 @@ def rank0_load_and_broadcast_weights(
         for i in range(fin_count):
             if global_rank == 0:
                 result = finalized[i]
-                metadata = BroadcastMetadata(False, result.name, result.tensor.shape, result.tensor.dtype)
+                name = _map_peft_key(result.name)
+                metadata = BroadcastMetadata(False, name, result.tensor.shape, result.tensor.dtype)
                 tensor = result.tensor
             else:
                 metadata = BroadcastMetadata(False, None, None, None)

--- a/veomni/models/transformers/qwen3_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_moe/__init__.py
@@ -12,7 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from ....utils.device import IS_NPU_AVAILABLE
+from ....utils.lora_utils import convert_fused_moe_lora_targets
 from ...loader import MODELING_REGISTRY
+
+
+def _convert_qwen3_moe_wrapped_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "model.layers.*.mlp.experts.gate_up_proj",
+        "model.layers.*.mlp.experts.down_proj",
+    )
+
+
+def _convert_qwen3_moe_model_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "layers.*.mlp.experts.gate_up_proj",
+        "layers.*.mlp.experts.down_proj",
+    )
 
 
 @MODELING_REGISTRY.register("qwen3_moe")
@@ -45,6 +64,12 @@ def register_qwen3_moe_modeling(architecture: str):
     ):
         model_cls._create_checkpoint_tensor_converter = staticmethod(create_qwen3_moe_checkpoint_tensor_converter)
         model_cls._convert_fqn_to_index_mapping = staticmethod(convert_qwen3_moe_fqn_to_index_mapping)
+        model_cls._convert_lora_targets_to_parameters = staticmethod(
+            _convert_qwen3_moe_wrapped_lora_targets_to_parameters
+        )
+    Qwen3MoeModel._convert_lora_targets_to_parameters = staticmethod(
+        _convert_qwen3_moe_model_lora_targets_to_parameters
+    )
 
     if "ForCausalLM" in architecture:
         return Qwen3MoeForCausalLM

--- a/veomni/models/transformers/qwen3_omni_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_omni_moe/__init__.py
@@ -11,7 +11,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from ....utils.lora_utils import convert_fused_moe_lora_targets
 from ...loader import MODEL_CONFIG_REGISTRY, MODEL_PROCESSOR_REGISTRY, MODELING_REGISTRY
+
+
+def _convert_qwen3_omni_moe_wrapped_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "thinker.model.layers.*.mlp.experts.gate_up_proj",
+        "thinker.model.layers.*.mlp.experts.down_proj",
+    )
+
+
+def _convert_qwen3_omni_moe_thinker_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "model.layers.*.mlp.experts.gate_up_proj",
+        "model.layers.*.mlp.experts.down_proj",
+    )
+
+
+def _convert_qwen3_omni_moe_text_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "layers.*.mlp.experts.gate_up_proj",
+        "layers.*.mlp.experts.down_proj",
+    )
 
 
 @MODEL_CONFIG_REGISTRY.register("qwen3_omni_moe")
@@ -57,6 +85,15 @@ def register_qwen3_omni_moe_modeling(architecture: str):
     ):
         model_cls._create_checkpoint_tensor_converter = staticmethod(create_qwen3_omni_moe_checkpoint_tensor_converter)
         model_cls._convert_fqn_to_index_mapping = staticmethod(convert_qwen3_omni_moe_fqn_to_index_mapping)
+    Qwen3OmniMoeForConditionalGeneration._convert_lora_targets_to_parameters = staticmethod(
+        _convert_qwen3_omni_moe_wrapped_lora_targets_to_parameters
+    )
+    Qwen3OmniMoeThinkerForConditionalGeneration._convert_lora_targets_to_parameters = staticmethod(
+        _convert_qwen3_omni_moe_thinker_lora_targets_to_parameters
+    )
+    Qwen3OmniMoeThinkerTextModel._convert_lora_targets_to_parameters = staticmethod(
+        _convert_qwen3_omni_moe_text_lora_targets_to_parameters
+    )
 
     if "ThinkerTextModel" in architecture:
         return Qwen3OmniMoeThinkerTextModel

--- a/veomni/models/transformers/qwen3_vl_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_vl_moe/__init__.py
@@ -12,7 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from ....utils.device import IS_NPU_AVAILABLE
+from ....utils.lora_utils import convert_fused_moe_lora_targets
 from ...loader import MODELING_REGISTRY
+
+
+def _convert_qwen3_vl_moe_wrapped_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "model.language_model.layers.*.mlp.experts.gate_up_proj",
+        "model.language_model.layers.*.mlp.experts.down_proj",
+    )
+
+
+def _convert_qwen3_vl_moe_model_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "language_model.layers.*.mlp.experts.gate_up_proj",
+        "language_model.layers.*.mlp.experts.down_proj",
+    )
+
+
+def _convert_qwen3_vl_moe_text_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "layers.*.mlp.experts.gate_up_proj",
+        "layers.*.mlp.experts.down_proj",
+    )
 
 
 @MODELING_REGISTRY.register("qwen3_vl_moe")
@@ -34,6 +62,15 @@ def register_qwen3_vl_moe_modeling(architecture: str):
 
     for model_cls in (Qwen3VLMoeForConditionalGeneration, Qwen3VLMoeModel, Qwen3VLMoeTextModel):
         model_cls._create_checkpoint_tensor_converter = staticmethod(create_qwen3_vl_moe_checkpoint_tensor_converter)
+    Qwen3VLMoeForConditionalGeneration._convert_lora_targets_to_parameters = staticmethod(
+        _convert_qwen3_vl_moe_wrapped_lora_targets_to_parameters
+    )
+    Qwen3VLMoeModel._convert_lora_targets_to_parameters = staticmethod(
+        _convert_qwen3_vl_moe_model_lora_targets_to_parameters
+    )
+    Qwen3VLMoeTextModel._convert_lora_targets_to_parameters = staticmethod(
+        _convert_qwen3_vl_moe_text_lora_targets_to_parameters
+    )
 
     if "ForConditionalGeneration" in architecture:
         return Qwen3VLMoeForConditionalGeneration

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -34,6 +34,7 @@ import warnings
 from abc import ABC
 from collections import defaultdict
 from dataclasses import asdict
+from fnmatch import fnmatch
 from typing import Any, Callable, Dict, List
 
 import torch
@@ -88,6 +89,48 @@ from .callbacks import (
 
 
 logger = logging.get_logger(__name__)
+
+
+_FUSED_MOE_TARGET_MODULES = {"gate_proj", "up_proj", "down_proj"}
+
+
+def _expand_parameter_patterns(model: torch.nn.Module, patterns: list[str]) -> list[str]:
+    parameter_names = [name for name, _param in model.named_parameters()]
+    expanded: list[str] = []
+    for pattern in patterns:
+        if any(ch in pattern for ch in "*?["):
+            matches = [name for name in parameter_names if fnmatch(name, pattern)]
+        else:
+            matches = [name for name in parameter_names if name == pattern or name.endswith(f".{pattern}")]
+        if not matches:
+            raise ValueError(f"LoRA target parameter pattern did not match any parameter: {pattern}")
+        expanded.extend(matches)
+    return sorted(set(expanded))
+
+
+def _build_peft_lora_targets(model: torch.nn.Module, lora_config: dict[str, Any]) -> tuple[list[str], list[str]]:
+    lora_modules = list(lora_config["lora_modules"])
+
+    target_parameter_patterns = list(lora_config.get("target_parameters") or [])
+    if target_parameter_patterns:
+        target_modules = [name for name in lora_modules if name not in _FUSED_MOE_TARGET_MODULES]
+        target_parameters = _expand_parameter_patterns(model, target_parameter_patterns)
+    else:
+        parameter_names = [name for name, _param in model.named_parameters()]
+        has_fused_gate_up = any(name.endswith(".mlp.experts.gate_up_proj") for name in parameter_names)
+        has_fused_down = any(name.endswith(".mlp.experts.down_proj") for name in parameter_names)
+        target_modules = list(lora_modules)
+        if has_fused_gate_up and {"gate_proj", "up_proj"} & set(lora_modules):
+            target_parameter_patterns.append("*.mlp.experts.gate_up_proj")
+            target_modules = [name for name in target_modules if name not in {"gate_proj", "up_proj"}]
+        if has_fused_down and "down_proj" in lora_modules:
+            target_parameter_patterns.append("*.mlp.experts.down_proj")
+            target_modules = [name for name in target_modules if name != "down_proj"]
+        target_parameters = (
+            _expand_parameter_patterns(model, target_parameter_patterns) if target_parameter_patterns else []
+        )
+
+    return target_modules, target_parameters
 
 
 class BackgroundPrefetcher:
@@ -405,11 +448,19 @@ class BaseTrainer(Stateful, ABC):
             logger.info_rank0("Initialising LoRA adapter from scratch.")
             from peft import LoraConfig, get_peft_model
 
-            peft_cfg = LoraConfig(
-                r=lora_config["rank"],
-                lora_alpha=lora_config["alpha"],
-                target_modules=lora_config["lora_modules"],
+            target_modules, target_parameters = _build_peft_lora_targets(self.model, lora_config)
+            logger.info_rank0(
+                f"Using PEFT target_parameters for fused MoE LoRA: {len(target_parameters)} parameter(s), "
+                f"first={target_parameters[0] if target_parameters else '<none>'}."
             )
+            peft_kwargs = {
+                "r": lora_config["rank"],
+                "lora_alpha": lora_config["alpha"],
+                "target_modules": target_modules,
+            }
+            if target_parameters:
+                peft_kwargs["target_parameters"] = target_parameters
+            peft_cfg = LoraConfig(**peft_kwargs)
             logger.info_rank0(f"LoraConfig: {peft_cfg.to_dict()}.")
             self.model = get_peft_model(self.model, peft_cfg)
 

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -110,15 +110,19 @@ def _expand_parameter_patterns(model: torch.nn.Module, patterns: list[str]) -> l
 
 def _build_peft_lora_targets(model: torch.nn.Module, lora_config: dict[str, Any]) -> tuple[list[str], list[str]]:
     lora_modules = list(lora_config["lora_modules"])
+    parameter_names = [name for name, _param in model.named_parameters()]
+    has_fused_gate_up = any(name.endswith(".mlp.experts.gate_up_proj") for name in parameter_names)
+    has_fused_down = any(name.endswith(".mlp.experts.down_proj") for name in parameter_names)
 
     target_parameter_patterns = list(lora_config.get("target_parameters") or [])
     if target_parameter_patterns:
-        target_modules = [name for name in lora_modules if name not in _FUSED_MOE_TARGET_MODULES]
+        target_modules = list(lora_modules)
+        if has_fused_gate_up:
+            target_modules = [name for name in target_modules if name not in {"gate_proj", "up_proj"}]
+        if has_fused_down:
+            target_modules = [name for name in target_modules if name != "down_proj"]
         target_parameters = _expand_parameter_patterns(model, target_parameter_patterns)
     else:
-        parameter_names = [name for name, _param in model.named_parameters()]
-        has_fused_gate_up = any(name.endswith(".mlp.experts.gate_up_proj") for name in parameter_names)
-        has_fused_down = any(name.endswith(".mlp.experts.down_proj") for name in parameter_names)
         target_modules = list(lora_modules)
         if has_fused_gate_up and {"gate_proj", "up_proj"} & set(lora_modules):
             target_parameter_patterns.append("*.mlp.experts.gate_up_proj")

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -34,7 +34,6 @@ import warnings
 from abc import ABC
 from collections import defaultdict
 from dataclasses import asdict
-from fnmatch import fnmatch
 from typing import Any, Callable, Dict, List
 
 import torch
@@ -72,6 +71,7 @@ from ..utils.device import (
     is_nccl_backend,
     synchronize,
 )
+from ..utils.lora_utils import build_peft_lora_targets
 from ..utils.loss_utils import count_loss_token, mean_global_loss
 from ..utils.model_utils import pretty_print_trainable_parameters
 from .callbacks import (
@@ -89,52 +89,6 @@ from .callbacks import (
 
 
 logger = logging.get_logger(__name__)
-
-
-_FUSED_MOE_TARGET_MODULES = {"gate_proj", "up_proj", "down_proj"}
-
-
-def _expand_parameter_patterns(model: torch.nn.Module, patterns: list[str]) -> list[str]:
-    parameter_names = [name for name, _param in model.named_parameters()]
-    expanded: list[str] = []
-    for pattern in patterns:
-        if any(ch in pattern for ch in "*?["):
-            matches = [name for name in parameter_names if fnmatch(name, pattern)]
-        else:
-            matches = [name for name in parameter_names if name == pattern or name.endswith(f".{pattern}")]
-        if not matches:
-            raise ValueError(f"LoRA target parameter pattern did not match any parameter: {pattern}")
-        expanded.extend(matches)
-    return sorted(set(expanded))
-
-
-def _build_peft_lora_targets(model: torch.nn.Module, lora_config: dict[str, Any]) -> tuple[list[str], list[str]]:
-    lora_modules = list(lora_config["lora_modules"])
-    parameter_names = [name for name, _param in model.named_parameters()]
-    has_fused_gate_up = any(name.endswith(".mlp.experts.gate_up_proj") for name in parameter_names)
-    has_fused_down = any(name.endswith(".mlp.experts.down_proj") for name in parameter_names)
-
-    target_parameter_patterns = list(lora_config.get("target_parameters") or [])
-    if target_parameter_patterns:
-        target_modules = list(lora_modules)
-        if has_fused_gate_up:
-            target_modules = [name for name in target_modules if name not in {"gate_proj", "up_proj"}]
-        if has_fused_down:
-            target_modules = [name for name in target_modules if name != "down_proj"]
-        target_parameters = _expand_parameter_patterns(model, target_parameter_patterns)
-    else:
-        target_modules = list(lora_modules)
-        if has_fused_gate_up and {"gate_proj", "up_proj"} & set(lora_modules):
-            target_parameter_patterns.append("*.mlp.experts.gate_up_proj")
-            target_modules = [name for name in target_modules if name not in {"gate_proj", "up_proj"}]
-        if has_fused_down and "down_proj" in lora_modules:
-            target_parameter_patterns.append("*.mlp.experts.down_proj")
-            target_modules = [name for name in target_modules if name != "down_proj"]
-        target_parameters = (
-            _expand_parameter_patterns(model, target_parameter_patterns) if target_parameter_patterns else []
-        )
-
-    return target_modules, target_parameters
 
 
 class BackgroundPrefetcher:
@@ -452,9 +406,9 @@ class BaseTrainer(Stateful, ABC):
             logger.info_rank0("Initialising LoRA adapter from scratch.")
             from peft import LoraConfig, get_peft_model
 
-            target_modules, target_parameters = _build_peft_lora_targets(self.model, lora_config)
+            target_modules, target_parameters = build_peft_lora_targets(self.model, lora_config)
             logger.info_rank0(
-                f"Using PEFT target_parameters for fused MoE LoRA: {len(target_parameters)} parameter(s), "
+                f"Using PEFT target_parameters for LoRA: {len(target_parameters)} parameter(s), "
                 f"first={target_parameters[0] if target_parameters else '<none>'}."
             )
             peft_kwargs = {

--- a/veomni/utils/lora_utils.py
+++ b/veomni/utils/lora_utils.py
@@ -49,19 +49,24 @@ def build_lora_key_overrides(model: "nn.Module") -> "Dict[str, str]":
         A ``{checkpoint_key: model_fqn}`` dict for every LoRA layer's
         parameters and buffers.  Empty dict if the model has no LoRA layers.
     """
-    from typing import Dict
-
     overrides: Dict[str, str] = {}
-    for fqn, module in model.named_modules():
-        if not hasattr(module, "base_layer"):
-            continue
-        inner = fqn[len("base_model.model.") :] if fqn.startswith("base_model.model.") else fqn
-        inner_dot = inner + ("." if inner else "")
-        wrap_dot = fqn + ("." if fqn else "") + "base_layer."
-        for pname, _ in module.base_layer.named_parameters():
-            overrides[inner_dot + pname] = wrap_dot + pname
-        for bname, _ in module.base_layer.named_buffers():
-            overrides[inner_dot + bname] = wrap_dot + bname
+    adapter_parts = {"lora_A", "lora_B", "lora_embedding_A", "lora_embedding_B"}
+
+    def add_override(fqn: str) -> None:
+        if not fqn.startswith("base_model.model."):
+            return
+        inner = fqn[len("base_model.model.") :]
+        parts = inner.split(".")
+        if "base_layer" not in parts or any(part in adapter_parts for part in parts):
+            return
+
+        checkpoint_key = ".".join(part for part in parts if part != "base_layer")
+        overrides[checkpoint_key] = fqn
+
+    for fqn, _param in model.named_parameters():
+        add_override(fqn)
+    for fqn, _buffer in model.named_buffers():
+        add_override(fqn)
     return overrides
 
 
@@ -116,8 +121,8 @@ def load_lora_model_weights(
 
     adapter_name = _read_adapter_name(adapter_path)
     raw_sd = load_peft_weights(adapter_path, device=init_device)
-    for name, tensor in raw_sd.items():
-        name = _remap_adapter_key(name, adapter_name)
+    adapter_sd = {_remap_adapter_key(name, adapter_name): tensor for name, tensor in raw_sd.items()}
+    for name, tensor in adapter_sd.items():
         _dispatch_parameter(model, name, tensor, dtensor_factory)
         if parameter_names_to_load is not None:
             parameter_names_to_load.discard(name)

--- a/veomni/utils/lora_utils.py
+++ b/veomni/utils/lora_utils.py
@@ -14,6 +14,7 @@
 
 import os
 import time
+from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Any, Callable, Dict, Literal, Optional, Union
 
 import torch
@@ -29,6 +30,71 @@ if TYPE_CHECKING:
     from transformers import PreTrainedModel
 
 logger = logging.get_logger(__name__)
+
+
+def _unwrap_model_for_lora_targets(model: "nn.Module") -> "nn.Module":
+    if hasattr(model, "get_base_model"):
+        return model.get_base_model()
+    return model
+
+
+def _expand_parameter_patterns(model: "nn.Module", patterns: list[str]) -> list[str]:
+    parameter_names = [name for name, _param in model.named_parameters()]
+    expanded: list[str] = []
+    for pattern in patterns:
+        if any(ch in pattern for ch in "*?["):
+            matches = [name for name in parameter_names if fnmatch(name, pattern)]
+        else:
+            matches = [name for name in parameter_names if name == pattern or name.endswith(f".{pattern}")]
+        if not matches:
+            raise ValueError(f"LoRA target parameter pattern did not match any parameter: {pattern}")
+        expanded.extend(matches)
+    return sorted(set(expanded))
+
+
+def convert_fused_moe_lora_targets(
+    lora_modules: list[str],
+    target_parameter_patterns: list[str],
+    gate_up_proj_pattern: str,
+    down_proj_pattern: str,
+) -> tuple[list[str], list[str]]:
+    """Map semantic MLP LoRA module names to fused MoE expert parameters."""
+    target_modules = list(lora_modules)
+    target_parameter_patterns = list(target_parameter_patterns)
+    if {"gate_proj", "up_proj"} & set(target_modules):
+        target_parameter_patterns.append(gate_up_proj_pattern)
+        target_modules = [name for name in target_modules if name not in {"gate_proj", "up_proj"}]
+    if "down_proj" in target_modules:
+        target_parameter_patterns.append(down_proj_pattern)
+        target_modules = [name for name in target_modules if name != "down_proj"]
+    return target_modules, target_parameter_patterns
+
+
+def build_peft_lora_targets(model: "nn.Module", lora_config: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """Build PEFT LoRA module and parameter targets.
+
+    Models with fused parameters can provide ``_convert_lora_targets_to_parameters``
+    to translate semantic module names (for example ``gate_proj``) to physical
+    parameter patterns owned by that model.
+    """
+    model = _unwrap_model_for_lora_targets(model)
+    lora_modules = list(lora_config["lora_modules"])
+    target_parameter_patterns = list(lora_config.get("target_parameters") or [])
+
+    converter = getattr(model, "_convert_lora_targets_to_parameters", None)
+    if converter is not None:
+        if not callable(converter):
+            logger.warning_rank0("Ignore invalid `_convert_lora_targets_to_parameters`: not callable.")
+            target_modules = lora_modules
+        else:
+            target_modules, target_parameter_patterns = converter(model, lora_modules, target_parameter_patterns)
+    else:
+        target_modules = lora_modules
+
+    target_parameters = (
+        _expand_parameter_patterns(model, target_parameter_patterns) if target_parameter_patterns else []
+    )
+    return target_modules, target_parameters
 
 
 def build_lora_key_overrides(model: "nn.Module") -> "Dict[str, str]":


### PR DESCRIPTION
### What does this PR do?

Fix PEFT LoRA setup and base weight loading for VeOmni fused MoE expert parameters.

With a standard LoRA config such as `lora_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]`, Qwen3-MoE previously only attached LoRA to attention projections. The MLP targets were missed because VeOmni stores MoE expert MLP weights as fused parameters (`gate_up_proj` and `down_proj`) rather than ordinary `gate_proj` / `up_proj` / `down_proj` `Linear` modules.

This PR keeps the community PEFT path and lets fused MoE model families map semantic MLP LoRA targets to PEFT `target_parameters` through a model-owned hook. It also fixes base checkpoint loading for PEFT-wrapped fused MoE models by applying VeOmni checkpoint tensor conversion before PEFT key remapping, so HF per-expert weights land in the wrapped fused base parameters.

### Checklist Before Starting

- Search for relative PRs/issues and link here: Related PR: #758
- This PR is narrower than #758: it does not add VeOmni-native MoE-LoRA kernels, EP-specific adapter variants, or a custom MoE-LoRA wrapper.
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))

### Test

- `ruff check veomni/trainer/base.py veomni/models/module_utils.py veomni/utils/lora_utils.py veomni/models/transformers/qwen3_moe/__init__.py veomni/models/transformers/qwen3_vl_moe/__init__.py veomni/models/transformers/qwen3_omni_moe/__init__.py tests/utils/test_lora_utils.py`
- `ruff format --check veomni/trainer/base.py veomni/models/module_utils.py veomni/utils/lora_utils.py veomni/models/transformers/qwen3_moe/__init__.py veomni/models/transformers/qwen3_vl_moe/__init__.py veomni/models/transformers/qwen3_omni_moe/__init__.py tests/utils/test_lora_utils.py`
- `python -m compileall veomni/trainer/base.py veomni/models/module_utils.py veomni/utils/lora_utils.py veomni/models/transformers/qwen3_moe/__init__.py veomni/models/transformers/qwen3_vl_moe/__init__.py veomni/models/transformers/qwen3_omni_moe/__init__.py tests/utils/test_lora_utils.py`
- `make quality`
- Attempted `python -m pytest tests/utils/test_lora_utils.py`, but the local shell environment uses an incompatible torch/transformers stack (`torch==2.3.0`; transformers import fails during collection with `NameError: name 'nn' is not defined`). The test should be run in the project uv environment.

Observed Qwen3-MoE LoRA behavior with the same config:

- Before this fix, trainable parameters only included attention LoRA (`self_attn.{q,k,v,o}_proj.lora_A/B`) and no MLP LoRA parameters.
- After this fix, trainable parameters include fused expert MLP LoRA entries under `mlp.experts...lora_A/B`.

### API and Usage Example

No config change is required. Existing PEFT LoRA configs can continue to specify MLP targets in the usual module form:

```yaml
lora_modules:
  - q_proj
  - k_proj
  - v_proj
  - o_proj
  - gate_proj
  - up_proj
  - down_proj
```

For fused MoE models, each model family maps `gate_proj` / `up_proj` / `down_proj` internally to PEFT `target_parameters` for its own fused expert parameter layout.

### Design & Code Changes

- Keep `BaseTrainer` generic: LoRA setup calls `build_peft_lora_targets()` and does not contain Qwen3-specific FQNs.
- Add shared LoRA target construction in `lora_utils`, including wildcard parameter expansion, explicit `target_parameters`, and a reusable fused MoE semantic-to-physical target helper.
- Add a model-owned `_convert_lora_targets_to_parameters` hook convention for fused parameter layouts.
- Register Qwen3-MoE, Qwen3-VL-MoE, and Qwen3-Omni-MoE hooks in their model package `__init__.py` files next to existing converter/registration wiring.
- Keep ordinary `target_modules` for non-fused/dense layers, avoiding accidental removal of dense MLP LoRA targets.
- Load base checkpoints through VeOmni's checkpoint tensor converter before applying PEFT key remapping.
- Extend LoRA key overrides to discover PEFT `target_parameters` base-layer paths from actual parameters and buffers.
- Add focused unit coverage for target construction and PEFT target-parameter `base_layer` key override mapping.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks listed above
- [x] Added/updated documentation: not needed; user-facing LoRA config is unchanged
- [x] If `tasks/` training scripts were moved or renamed: N/A
- [x] Added tests to CI workflow (or explained why not feasible): added focused unit tests; no workflow change needed
