### PR TITLE
[trainer] feat: support HSDP for expert parallel

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -297,10 +297,10 @@ NPU validation runs at two times:
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| dp_replicate_size | `int` | `-1` | Data parallel replicate size. |
+| dp_replicate_size | `int` | `-1` | Data parallel replicate size for both dense and moe parameters. |
 | dp_shard_size | `int` | `-1` | Data parallel shard degree. |
 | tp_size | `int` | `1` | Tensor parallel size. |
-| ep_size | `int` | `1` | Expert parallel size. |
+| ep_size | `int` | `1` | Expert parallel size, should be fit into dp_shard group if HSDP enabled |
 | ep_outside | `bool` | `False` | Expert parallelism outside in EP-FSDP. |
 | pp_size | `int` | `1` | Pipeline parallel size. |
 | ulysses_size | `int` | `1` | Ulysses sequence parallel size. |

--- a/tests/checkpoints/test_trainer_saveload.py
+++ b/tests/checkpoints/test_trainer_saveload.py
@@ -249,9 +249,9 @@ if __name__ == "__main__":
     main()
 
 
-def _run_trainer_saveload_and_verify(model_name: str, ep_size: int):
-    exec_command = get_checkpoint_test_command(model_name, ep_size)
-    merge_command = get_merge_dcp_to_hf_command(model_name, ep_size)
+def _run_trainer_saveload_and_verify(model_name: str, ep_size: int, dp_replicate_size: Optional[int] = None):
+    exec_command = get_checkpoint_test_command(model_name, ep_size, dp_replicate_size=dp_replicate_size)
+    merge_command = get_merge_dcp_to_hf_command(model_name, ep_size, dp_replicate_size=dp_replicate_size)
 
     exec_result = subprocess.run(exec_command, shell=True, check=True)
     assert exec_result.returncode == 0
@@ -260,12 +260,15 @@ def _run_trainer_saveload_and_verify(model_name: str, ep_size: int):
     assert merge_result.returncode == 0
 
     assert verify_dcp_to_hf_conversion(
-        dcp_checkpoint_dir=get_checkpoint_dir(model_name, ep_size),
-        hf_checkpoint_dir=get_hf_output_dir(model_name, ep_size),
+        dcp_checkpoint_dir=get_checkpoint_dir(model_name, ep_size, dp_replicate_size),
+        hf_checkpoint_dir=get_hf_output_dir(model_name, ep_size, dp_replicate_size),
         safe_serialization=True,
-    ), f"Save and Load Checkpoint failed for `{model_name}` with ep_size `{ep_size}`"
+    ), (
+        f"Save and Load Checkpoint failed for `{model_name}` with ep_size `{ep_size}` "
+        f"and dp_replicate_size `{dp_replicate_size}`"
+    )
 
-    shutil.rmtree(get_output_dir(model_name, ep_size))
+    shutil.rmtree(get_output_dir(model_name, ep_size, dp_replicate_size))
 
 
 def _run_trainer_save_hf_safetensor(model_name: str, ep_size: int):
@@ -284,6 +287,17 @@ TEST_EP_SIZES = [1, 4, 8]
 @pytest.mark.parametrize("model_name,ep_size", [(model, ep) for model in TEST_MODELS for ep in TEST_EP_SIZES])
 def test_trainer_saveload(model_name: str, ep_size: int):
     _run_trainer_saveload_and_verify(model_name, ep_size)
+
+
+# HSDP save/load coverage on 8 GPUs: dp = (dp_replicate=2, dp_shard=4). This
+# makes the expert mesh 3D (ep_replicate, ep_fsdp, ep) and exercises the
+# 3-placement restore/drop path in the DCP checkpointer end-to-end (train ->
+# DCP save -> load -> compare golden state dicts, plus DCP->HF merge). Cases:
+#   * ep2: ep mesh (2, 2, 2) — all three dims active (ep_fsdp > 1).
+#   * ep4: ep mesh (2, 1, 4) — degenerate ep_fsdp.
+@pytest.mark.parametrize("ep_size", [2, 4])
+def test_trainer_saveload_hsdp(ep_size: int):
+    _run_trainer_saveload_and_verify("qwen3_moe", ep_size, dp_replicate_size=2)
 
 
 @pytest.mark.parametrize("ep_size", TEST_EP_SIZES)

--- a/tests/checkpoints/utils.py
+++ b/tests/checkpoints/utils.py
@@ -23,21 +23,24 @@ MODEL_CONFIGS = {
 }
 
 
-# Get some dir functions
-def get_output_dir(model_name, ep_size):
-    return f"./test_trainer_saveload_{model_name}_{ep_size}"
+# Get some dir functions.
+# ``dp_replicate_size`` is threaded into the dir name so HSDP runs
+# (dp_replicate>1) don't collide with the pure-FSDP run for the same model/ep.
+def get_output_dir(model_name, ep_size, dp_replicate_size=None):
+    suffix = f"_dpr{dp_replicate_size}" if dp_replicate_size else ""
+    return f"./test_trainer_saveload_{model_name}_{ep_size}{suffix}"
 
 
-def get_checkpoint_dir(model_name, ep_size):
-    return os.path.join(get_output_dir(model_name, ep_size), "checkpoints", "global_step_5")
+def get_checkpoint_dir(model_name, ep_size, dp_replicate_size=None):
+    return os.path.join(get_output_dir(model_name, ep_size, dp_replicate_size), "checkpoints", "global_step_5")
 
 
-def get_hf_output_dir(model_name, ep_size):
-    return os.path.join(get_output_dir(model_name, ep_size), "hf_ckpt")
+def get_hf_output_dir(model_name, ep_size, dp_replicate_size=None):
+    return os.path.join(get_output_dir(model_name, ep_size, dp_replicate_size), "hf_ckpt")
 
 
-def get_model_assets_dir(model_name, ep_size):
-    return os.path.join(get_output_dir(model_name, ep_size), "model_assets")
+def get_model_assets_dir(model_name, ep_size, dp_replicate_size=None):
+    return os.path.join(get_output_dir(model_name, ep_size, dp_replicate_size), "model_assets")
 
 
 # running command functions
@@ -45,10 +48,11 @@ def get_checkpoint_test_command(
     model_name,
     ep_size,
     save_hf_weights=False,
+    dp_replicate_size=None,
 ):
     config_path = MODEL_CONFIGS[model_name]["config_path"]
     tokenizer_path = hf_local_or_remote(MODEL_CONFIGS[model_name]["tokenizer_path"])
-    output_dir = get_output_dir(model_name, ep_size)
+    output_dir = get_output_dir(model_name, ep_size, dp_replicate_size)
     port = find_free_port()
 
     params = [
@@ -79,6 +83,12 @@ def get_checkpoint_test_command(
         "--train.checkpoint.save_async True",
         f"--train.checkpoint.save_hf_weights {save_hf_weights}",
     ]
+    # HSDP: split the FSDP dim into (dp_replicate, dp_shard). dp_shard is
+    # inferred as dp_size // dp_replicate_size by the argument resolver, and the
+    # expert mesh becomes 3D (ep_replicate, ep_fsdp, ep), exercising the
+    # 3-placement save/load path in the DCP checkpointer.
+    if dp_replicate_size is not None:
+        params.append(f"--train.accelerator.dp_replicate_size {dp_replicate_size}")
 
     exec_script = " \\\n".join(params)
 
@@ -88,10 +98,11 @@ def get_checkpoint_test_command(
 def get_merge_dcp_to_hf_command(
     model_name,
     ep_size,
+    dp_replicate_size=None,
 ):
-    checkpoint_dir = get_checkpoint_dir(model_name, ep_size)
-    hf_output_dir = get_hf_output_dir(model_name, ep_size)
-    model_assets_dir = get_model_assets_dir(model_name, ep_size)
+    checkpoint_dir = get_checkpoint_dir(model_name, ep_size, dp_replicate_size)
+    hf_output_dir = get_hf_output_dir(model_name, ep_size, dp_replicate_size)
+    model_assets_dir = get_model_assets_dir(model_name, ep_size, dp_replicate_size)
 
     params = [
         "python",

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -273,7 +273,9 @@ def main():
     dist.destroy_process_group()
 
 
-def _run_clip_grad_norm_fsdp2_test(ep_size: int, emb_size: int, cpu_offload: bool) -> None:
+def _run_clip_grad_norm_fsdp2_test(
+    ep_size: int, emb_size: int, cpu_offload: bool, dp_replicate_size: int | None = None
+) -> None:
     command = [
         "torchrun",
         "--nnodes=1",
@@ -289,6 +291,12 @@ def _run_clip_grad_norm_fsdp2_test(ep_size: int, emb_size: int, cpu_offload: boo
         "--train.init_device=meta",
         "--train.checkpoint.output_dir='debug'",
     ]
+    # HSDP: split the dp dim into (dp_replicate, dp_shard). dp_shard is inferred
+    # as dp_size // dp_replicate_size by the argument resolver. The expected
+    # total grad norm is identical to the pure-FSDP case: the clip reduces over
+    # the shard group only, so replicating over dp_replicate must NOT inflate it.
+    if dp_replicate_size is not None:
+        command.append(f"--train.accelerator.dp_replicate_size={dp_replicate_size}")
     if cpu_offload:
         command.append("--train.accelerator.fsdp_config.offload=True")
     result = subprocess.run(command, check=True)
@@ -318,6 +326,37 @@ def test_clip_grad_norm_fsdp2_emb8(cpu_offload: bool):
 @pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
 def test_clip_grad_norm_fsdp2_ep2_emb4(cpu_offload: bool):
     _run_clip_grad_norm_fsdp2_test(ep_size=2, emb_size=4, cpu_offload=cpu_offload)
+
+
+# ---------------------------------------------------------------------------
+# HSDP regression: dp = (dp_replicate=2, dp_shard=4) on 8 GPUs.
+#
+# The grad-norm reduction must skip the replicate dim for BOTH non-ExtraParallel
+# params (reduce over `dp_shard_sp`, not `dp_sp`) and ExtraParallel params
+# (reduce over `ep_fsdp`/`emb_fsdp`, not the full `*_replicate` mesh). If the
+# replicate dim leaks into the sum, the norm is inflated by sqrt(dp_replicate),
+# so these reuse the SAME expected total norm as the pure-FSDP cases above.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_clip_grad_norm_hsdp_no_extra_parallel(cpu_offload: bool):
+    _run_clip_grad_norm_fsdp2_test(ep_size=1, emb_size=1, cpu_offload=cpu_offload, dp_replicate_size=2)
+
+
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_clip_grad_norm_hsdp_ep4(cpu_offload: bool):
+    _run_clip_grad_norm_fsdp2_test(ep_size=4, emb_size=1, cpu_offload=cpu_offload, dp_replicate_size=2)
+
+
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_clip_grad_norm_hsdp_emb4(cpu_offload: bool):
+    _run_clip_grad_norm_fsdp2_test(ep_size=1, emb_size=4, cpu_offload=cpu_offload, dp_replicate_size=2)
+
+
+@pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
+def test_clip_grad_norm_hsdp_ep2_emb4(cpu_offload: bool):
+    _run_clip_grad_norm_fsdp2_test(ep_size=2, emb_size=4, cpu_offload=cpu_offload, dp_replicate_size=2)
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+import importlib.util
 import math
 import subprocess
 from dataclasses import dataclass, field
@@ -5,6 +7,7 @@ from dataclasses import dataclass, field
 import pytest
 import torch
 import torch.distributed as dist
+from packaging.version import Version
 from torch.distributed._tensor import DTensor, Shard
 
 from veomni.arguments import TrainingArguments, parse_args
@@ -25,6 +28,13 @@ from veomni.utils.device import (
 # from veomni.optim.optimizer import build_optimizer
 
 logger = helper.create_logger(__name__)
+
+
+def _torch_npu_version() -> str:
+    """Return the version of torch_npu if installed, otherwise return "0.0.0"."""
+    if importlib.util.find_spec("torch_npu") is None:
+        return None
+    return str(importlib.metadata.version("torch_npu"))
 
 
 @dataclass
@@ -344,16 +354,28 @@ def test_clip_grad_norm_hsdp_no_extra_parallel(cpu_offload: bool):
     _run_clip_grad_norm_fsdp2_test(ep_size=1, emb_size=1, cpu_offload=cpu_offload, dp_replicate_size=2)
 
 
+@pytest.mark.skipif(
+    _torch_npu_version() and Version(_torch_npu_version()) < Version("2.9.0"),
+    reason="torch_npu < 2.9.0 grad_norm with HSDP is buggy",
+)
 @pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
 def test_clip_grad_norm_hsdp_ep4(cpu_offload: bool):
     _run_clip_grad_norm_fsdp2_test(ep_size=4, emb_size=1, cpu_offload=cpu_offload, dp_replicate_size=2)
 
 
+@pytest.mark.skipif(
+    _torch_npu_version() and Version(_torch_npu_version()) < Version("2.9.0"),
+    reason="torch_npu < 2.9.0 grad_norm with HSDP is buggy",
+)
 @pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
 def test_clip_grad_norm_hsdp_emb4(cpu_offload: bool):
     _run_clip_grad_norm_fsdp2_test(ep_size=1, emb_size=4, cpu_offload=cpu_offload, dp_replicate_size=2)
 
 
+@pytest.mark.skipif(
+    _torch_npu_version() and Version(_torch_npu_version()) < Version("2.9.0"),
+    reason="torch_npu < 2.9.0 grad_norm with HSDP is buggy",
+)
 @pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
 def test_clip_grad_norm_hsdp_ep2_emb4(cpu_offload: bool):
     _run_clip_grad_norm_fsdp2_test(ep_size=2, emb_size=4, cpu_offload=cpu_offload, dp_replicate_size=2)

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -587,6 +587,7 @@ class TrainingArguments:
             )
         assert acc.tp_size == 1, "Tensor parallel size not supported yet."
         assert acc.pp_size == 1, "Pipeline parallel size not supported yet."
+        assert acc.cp_size == 1, "Context parallel size not supported yet."
 
         acc.dp_size = self.world_size // (acc.pp_size * acc.ulysses_size * acc.cp_size * acc.tp_size)
 

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -72,7 +72,10 @@ def _validate_extra_parallel_meshes(parallel_state) -> None:
         parallel_state.extra_parallel_fsdp_device_mesh[para] is not None
         and parallel_state.extra_parallel_fsdp_device_mesh[para].ndim in (2, 3)
         for para in parallel_state.extra_parallel_names
-    ), "At least one extra_parallel fsdp_device_mesh should be not None"
+    ), (
+        "At least one extra_parallel fsdp_device_mesh must carry the ExtraParallel+FSDP "
+        "composition: 2D (ep_fsdp, ep) for plain FSDP or 3D (ep_replicate, ep_fsdp, ep) for HSDP"
+    )
 
 
 def _apply_extra_parallel_dim(

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -136,10 +136,19 @@ def _apply_extra_parallel_dim(
         # ``(ep_replicate, ep_fsdp)`` for HSDP. Mirrors the mesh slicing used
         # when sharding the module in ``torch_parallelize``.
         fsdp_submesh = spec_info.para_fsdp_mesh[spec_info.para_fsdp_mesh.mesh_dim_names[:-1]]
+        # The ExtraParallel (e.g. ``ep``) dim shards the tensor along
+        # ``spec_info.placement.dim`` (dim 0 for experts), while FSDP shards it
+        # along ``spec_info.fsdp_shard_dim`` (1 by default, 0 for Muon zero-comm).
+        # These are two DIFFERENT tensor dims, so the placements must use each
+        # one explicitly instead of a fixed ``[Shard(0), Shard(1)]``.
+        ep_shard_dim = spec_info.placement.dim
+        fsdp_shard_dim = spec_info.fsdp_shard_dim
         if action == "drop":
-            tensor = drop_extra_parallel_dim(tensor, fsdp_submesh)
+            tensor = drop_extra_parallel_dim(tensor, fsdp_submesh, fsdp_shard_dim)
         else:
-            tensor = restore_extra_parallel_dim(tensor, spec_info.para_fsdp_mesh, fsdp_submesh)
+            tensor = restore_extra_parallel_dim(
+                tensor, spec_info.para_fsdp_mesh, fsdp_submesh, ep_shard_dim, fsdp_shard_dim
+            )
         state_dict[name] = tensor
 
     return state_dict
@@ -281,28 +290,33 @@ class OptimizerState(Stateful):
         )
 
 
-def drop_extra_parallel_dim(loaded_tensor: torch.Tensor, device_mesh: DeviceMesh):
+def drop_extra_parallel_dim(loaded_tensor: torch.Tensor, device_mesh: DeviceMesh, fsdp_shard_dim: int = 1):
     """
     Drop ExtraParallel dims after loading from DCP so that ExtraParallel-FSDP would not be confused.
 
     ``device_mesh`` is the FSDP sub-mesh (ExtraParallel dim already excluded):
     1D ``(ep_fsdp,)`` for plain FSDP, or 2D ``(ep_replicate, ep_fsdp)`` for HSDP.
-    The number of placements on the loaded DTensor reflects the full saved mesh:
+    ``fsdp_shard_dim`` is the tensor dim FSDP shards along (1 by default, 0 for
+    the Muon zero-comm layout). The number of placements on the loaded DTensor
+    reflects the full saved mesh:
 
     * 1 placement: pure ExtraParallel, no FSDP -> return the plain local tensor.
-    * 2 placements: ``(ep_fsdp, ep)`` -> keep FSDP ``Shard(1)`` on the 1D sub-mesh.
+    * 2 placements: ``(ep_fsdp, ep)`` -> keep FSDP ``Shard(fsdp_shard_dim)`` on
+      the 1D sub-mesh.
     * 3 placements: ``(ep_replicate, ep_fsdp, ep)`` (HSDP) -> keep
-      ``[Replicate(), Shard(1)]`` on the 2D sub-mesh.
+      ``[Replicate(), Shard(fsdp_shard_dim)]`` on the 2D sub-mesh.
     """
 
     num_placements = len(loaded_tensor.placements)
     if num_placements == 1:
         tensor_to_put = loaded_tensor.to_local()
     elif num_placements == 2:
-        tensor_to_put = DTensor.from_local(loaded_tensor._local_tensor, device_mesh=device_mesh, placements=[Shard(1)])
+        tensor_to_put = DTensor.from_local(
+            loaded_tensor._local_tensor, device_mesh=device_mesh, placements=[Shard(fsdp_shard_dim)]
+        )
     elif num_placements == 3:
         tensor_to_put = DTensor.from_local(
-            loaded_tensor._local_tensor, device_mesh=device_mesh, placements=[Replicate(), Shard(1)]
+            loaded_tensor._local_tensor, device_mesh=device_mesh, placements=[Replicate(), Shard(fsdp_shard_dim)]
         )
     else:
         raise RuntimeError(
@@ -314,38 +328,58 @@ def drop_extra_parallel_dim(loaded_tensor: torch.Tensor, device_mesh: DeviceMesh
 
 
 def restore_extra_parallel_dim(
-    orgin_tensor: torch.Tensor, fsdp_mesh: DeviceMesh, extra_parallel_fsdp_mesh: DeviceMesh
+    orgin_tensor: torch.Tensor,
+    fsdp_mesh: DeviceMesh,
+    extra_parallel_fsdp_mesh: DeviceMesh,
+    ep_shard_dim: int = 0,
+    fsdp_shard_dim: int = 1,
 ):
     """
     Restore ExtraParallel dim so that DCP can be aware about ExtraParallel ranks
 
+    The ExtraParallel (e.g. ``ep``) dim and the FSDP dim shard the tensor along
+    DIFFERENT axes: ``ep_shard_dim`` (the EP plan's ``Shard.dim``, dim 0 for
+    experts) and ``fsdp_shard_dim`` (1 by default, 0 for the Muon zero-comm
+    layout). They must be mapped to the matching mesh dims explicitly.
+
     args:
-        orgin_tensor (torch.Tensor): The orgin tensor.
+        orgin_tensor (torch.Tensor): The orgin tensor (FSDP-local shard).
         fsdp_mesh (DeviceMesh): The full ExtraParallel mesh, i.e. 2D
             ``(ep_fsdp, ep)`` for plain FSDP or 3D
             ``(ep_replicate, ep_fsdp, ep)`` for HSDP.
         extra_parallel_fsdp_mesh (DeviceMesh): The FSDP sub-mesh (ExtraParallel
             dim excluded), used for the pure-ExtraParallel (no FSDP) path.
+        ep_shard_dim (int): Tensor dim the ExtraParallel dim shards along.
+        fsdp_shard_dim (int): Tensor dim FSDP shards along.
 
+    Note:
+        When ``ep_shard_dim == fsdp_shard_dim`` (e.g. the Muon zero-comm layout
+        shards experts on dim 0 just like EP), both mesh dims split the SAME
+        tensor dim. The mesh order ``(ep_fsdp, ep)`` then composes ``ep_fsdp``
+        OUTER of ``ep``, whereas the physical layout is EP-outer / FSDP-inner,
+        so the reconstructed GLOBAL tensor is block-transposed along that dim.
+        Save->load into the SAME parallel config still round-trips correctly
+        (drop is the exact inverse); only resharding / external reads of such a
+        checkpoint see the permuted layout. Fixing this needs the EP mesh dims
+        reordered so ``ep`` precedes ``ep_fsdp`` (a parallel_state change).
     """
     assert fsdp_mesh.ndim in (2, 3), f"global_mesh.ndim must be 2 or 3, got {fsdp_mesh.ndim}"
 
     if isinstance(orgin_tensor, DTensor):
-        # ExtraParallel+FSDP2. For HSDP the leading ``ep_replicate`` dim is a
-        # replicated copy, so it maps to ``Replicate()`` while the trailing
-        # ``(ep_fsdp, ep)`` keep the same ``[Shard(0), Shard(1)]`` layout as the
-        # plain-FSDP case.
+        # ExtraParallel+FSDP2. mesh order is (ep_fsdp, ep) or, for HSDP,
+        # (ep_replicate, ep_fsdp, ep): ep_fsdp -> Shard(fsdp_shard_dim),
+        # ep -> Shard(ep_shard_dim), ep_replicate -> Replicate().
         if fsdp_mesh.ndim == 3:
-            placements = [Replicate(), Shard(0), Shard(1)]
+            placements = [Replicate(), Shard(fsdp_shard_dim), Shard(ep_shard_dim)]
         else:
-            placements = [Shard(0), Shard(1)]
+            placements = [Shard(fsdp_shard_dim), Shard(ep_shard_dim)]
         dtensor = DTensor.from_local(orgin_tensor._local_tensor, device_mesh=fsdp_mesh, placements=placements)
     elif torch.is_tensor(orgin_tensor):
         # If there is no FSDP but only ExtraParallel
         if extra_parallel_fsdp_mesh.ndim == 2:
-            placements = [Replicate(), Shard(0)]
+            placements = [Replicate(), Shard(fsdp_shard_dim)]
         else:
-            placements = [Shard(0)]
+            placements = [Shard(fsdp_shard_dim)]
         dtensor = DTensor.from_local(orgin_tensor, device_mesh=extra_parallel_fsdp_mesh, placements=placements)
     else:
         raise RuntimeError(f"origin_tensor - {orgin_tensor} is not a tensor!")

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -379,11 +379,7 @@ def restore_extra_parallel_dim(
         dtensor = DTensor.from_local(orgin_tensor._local_tensor, device_mesh=fsdp_mesh, placements=placements)
     elif torch.is_tensor(orgin_tensor):
         # If there is no FSDP but only ExtraParallel
-        if extra_parallel_fsdp_mesh.ndim == 2:
-            placements = [Replicate(), Shard(fsdp_shard_dim)]
-        else:
-            placements = [Shard(fsdp_shard_dim)]
-        dtensor = DTensor.from_local(orgin_tensor, device_mesh=extra_parallel_fsdp_mesh, placements=placements)
+        dtensor = DTensor.from_local(orgin_tensor, device_mesh=extra_parallel_fsdp_mesh, placements=[Shard(0)])
     else:
         raise RuntimeError(f"origin_tensor - {orgin_tensor} is not a tensor!")
 

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional, Union
 import torch
 import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
-from torch.distributed._tensor import DeviceMesh, DTensor, Shard
+from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard
 from torch.distributed.checkpoint import (
     FileSystemReader,
     FileSystemWriter,
@@ -55,7 +55,9 @@ def _validate_extra_parallel_meshes(parallel_state) -> None:
     """Fail-fast precondition for ExtraParallel state dict preprocessing.
 
     At least one ExtraParallel mesh must be non-None, and at least one
-    of those meshes must be 2D (the ExtraParallel + FSDP composition).
+    of those meshes must carry the ExtraParallel + FSDP composition:
+    2D ``(ep_fsdp, ep)`` for plain FSDP or 3D
+    ``(ep_replicate, ep_fsdp, ep)`` for HSDP.
     """
     extra_parallel_mesh = {
         para: parallel_state.extra_parallel_fsdp_device_mesh[para][para]
@@ -68,7 +70,7 @@ def _validate_extra_parallel_meshes(parallel_state) -> None:
     )
     assert any(
         parallel_state.extra_parallel_fsdp_device_mesh[para] is not None
-        and parallel_state.extra_parallel_fsdp_device_mesh[para].ndim == 2
+        and parallel_state.extra_parallel_fsdp_device_mesh[para].ndim in (2, 3)
         for para in parallel_state.extra_parallel_names
     ), "At least one extra_parallel fsdp_device_mesh should be not None"
 
@@ -129,7 +131,11 @@ def _apply_extra_parallel_dim(
 
         assert spec_info.para_fsdp_mesh is not None, f"ExtraParallel spec {name} must have an ExtraParallel FSDP mesh"
 
-        fsdp_submesh = spec_info.para_fsdp_mesh[f"{spec_info.para_name}_fsdp"]
+        # Drop the innermost ExtraParallel (e.g. ``ep``) dim and keep the FSDP
+        # sub-mesh: 1D ``(ep_fsdp,)`` for plain FSDP, or 2D
+        # ``(ep_replicate, ep_fsdp)`` for HSDP. Mirrors the mesh slicing used
+        # when sharding the module in ``torch_parallelize``.
+        fsdp_submesh = spec_info.para_fsdp_mesh[spec_info.para_fsdp_mesh.mesh_dim_names[:-1]]
         if action == "drop":
             tensor = drop_extra_parallel_dim(tensor, fsdp_submesh)
         else:
@@ -277,16 +283,31 @@ class OptimizerState(Stateful):
 
 def drop_extra_parallel_dim(loaded_tensor: torch.Tensor, device_mesh: DeviceMesh):
     """
-    Drop ExtraParallel dims after loading from DCP so that ExtraParallel-FSDP would not be confused
+    Drop ExtraParallel dims after loading from DCP so that ExtraParallel-FSDP would not be confused.
+
+    ``device_mesh`` is the FSDP sub-mesh (ExtraParallel dim already excluded):
+    1D ``(ep_fsdp,)`` for plain FSDP, or 2D ``(ep_replicate, ep_fsdp)`` for HSDP.
+    The number of placements on the loaded DTensor reflects the full saved mesh:
+
+    * 1 placement: pure ExtraParallel, no FSDP -> return the plain local tensor.
+    * 2 placements: ``(ep_fsdp, ep)`` -> keep FSDP ``Shard(1)`` on the 1D sub-mesh.
+    * 3 placements: ``(ep_replicate, ep_fsdp, ep)`` (HSDP) -> keep
+      ``[Replicate(), Shard(1)]`` on the 2D sub-mesh.
     """
 
-    if len(loaded_tensor.placements) == 2:
-        tensor_to_put = DTensor.from_local(loaded_tensor._local_tensor, device_mesh=device_mesh, placements=[Shard(1)])
-    elif len(loaded_tensor.placements) == 1:
+    num_placements = len(loaded_tensor.placements)
+    if num_placements == 1:
         tensor_to_put = loaded_tensor.to_local()
+    elif num_placements == 2:
+        tensor_to_put = DTensor.from_local(loaded_tensor._local_tensor, device_mesh=device_mesh, placements=[Shard(1)])
+    elif num_placements == 3:
+        tensor_to_put = DTensor.from_local(
+            loaded_tensor._local_tensor, device_mesh=device_mesh, placements=[Replicate(), Shard(1)]
+        )
     else:
         raise RuntimeError(
-            f"Expect ExtraParallel paramters from checkpoints to be DTensor with 1-dim (no FSDP) or 2-dim (ExtraParallel+FSDP), got {loaded_tensor}"
+            "Expect ExtraParallel parameters from checkpoints to be DTensor with 1-dim (no FSDP), "
+            f"2-dim (ExtraParallel+FSDP) or 3-dim (ExtraParallel+HSDP), got {loaded_tensor}"
         )
 
     return tensor_to_put
@@ -300,20 +321,32 @@ def restore_extra_parallel_dim(
 
     args:
         orgin_tensor (torch.Tensor): The orgin tensor.
-        fsdp_mesh (DeviceMesh): The extra_parallel fsdp device mesh.
-        shard (Shard): The shard info, default Shard(0).
+        fsdp_mesh (DeviceMesh): The full ExtraParallel mesh, i.e. 2D
+            ``(ep_fsdp, ep)`` for plain FSDP or 3D
+            ``(ep_replicate, ep_fsdp, ep)`` for HSDP.
+        extra_parallel_fsdp_mesh (DeviceMesh): The FSDP sub-mesh (ExtraParallel
+            dim excluded), used for the pure-ExtraParallel (no FSDP) path.
 
     """
-    assert fsdp_mesh.ndim == 2, f"global_mesh.ndim must be 2, got {fsdp_mesh.ndim}"
+    assert fsdp_mesh.ndim in (2, 3), f"global_mesh.ndim must be 2 or 3, got {fsdp_mesh.ndim}"
 
     if isinstance(orgin_tensor, DTensor):
-        # ExtraParallel+FSDP2
-        dtensor = DTensor.from_local(
-            orgin_tensor._local_tensor, device_mesh=fsdp_mesh, placements=[Shard(0), Shard(1)]
-        )
+        # ExtraParallel+FSDP2. For HSDP the leading ``ep_replicate`` dim is a
+        # replicated copy, so it maps to ``Replicate()`` while the trailing
+        # ``(ep_fsdp, ep)`` keep the same ``[Shard(0), Shard(1)]`` layout as the
+        # plain-FSDP case.
+        if fsdp_mesh.ndim == 3:
+            placements = [Replicate(), Shard(0), Shard(1)]
+        else:
+            placements = [Shard(0), Shard(1)]
+        dtensor = DTensor.from_local(orgin_tensor._local_tensor, device_mesh=fsdp_mesh, placements=placements)
     elif torch.is_tensor(orgin_tensor):
         # If there is no FSDP but only ExtraParallel
-        dtensor = DTensor.from_local(orgin_tensor, device_mesh=extra_parallel_fsdp_mesh, placements=[Shard(0)])
+        if extra_parallel_fsdp_mesh.ndim == 2:
+            placements = [Replicate(), Shard(0)]
+        else:
+            placements = [Shard(0)]
+        dtensor = DTensor.from_local(orgin_tensor, device_mesh=extra_parallel_fsdp_mesh, placements=placements)
     else:
         raise RuntimeError(f"origin_tensor - {orgin_tensor} is not a tensor!")
 

--- a/veomni/distributed/parallel_plan.py
+++ b/veomni/distributed/parallel_plan.py
@@ -33,6 +33,11 @@ class SpecInfo:
     placement: Union[Shard, Replicate]
     fqn: str
     para_fsdp_mesh: DeviceMesh
+    # Tensor dim that FSDP2 shards this param along (set in ``torch_parallelize``
+    # after the ``shard_placement_fn`` is decided: 1 by default, 0 for the
+    # Muon zero-comm layout). Used by the checkpointer to build the correct
+    # DTensor placements when (re)storing the ExtraParallel dim.
+    fsdp_shard_dim: int = 1
 
     @property
     def para_mesh(self):

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -595,14 +595,30 @@ def init_parallel_state(
         extra_parallel_sizes, extra_parallel_placement_innermost, extra_parallel_names
     ):
         if para_size > 1:
-            world_size = dist.get_world_size()
-            assert world_size % para_size == 0, f"{para_name}_size must be a factor of world_size"
-            para_fsdp_size = world_size // para_size
-            mesh = init_para_mesh_matrix(para_size=para_size, para_fsdp_size=para_fsdp_size, para_outside=para_outside)
-            extra_parallel_fsdp_device_mesh[f"{para_name}"] = DeviceMesh(
+            # TODO: drop para_outside?
+            assert not para_outside, f"{para_name} is not supported when para_outside is True."
+
+            # NOTE: Support HSDP for extra parallel. For example, world_size=1024
+            # - dense param device_mesh: (dp_replicate, dp_shard_sp)=(4, 256)
+            # - ep_size=8, expert parallel device_mesh: (ep_replicate, ep_fsdp, ep)=(4, 32, 8)
+            param_mesh_shape, para_mesh_dim_names = [], []
+            if dp_replicate_size > 1:
+                param_mesh_shape.append(dp_replicate_size)
+                para_mesh_dim_names.append(f"{para_name}_replicate")
+            dp_shard_sp_size = device_mesh["dp_shard_sp"].size()
+            assert dp_shard_sp_size % para_size == 0, (
+                f"{para_name}_size({para_size}) must be a factor of dp_shard_sp_size({dp_shard_sp_size})"
+            )
+            para_fsdp_size = dp_shard_sp_size // para_size
+            param_mesh_shape.append(para_fsdp_size)
+            param_mesh_shape.append(para_size)
+            para_mesh_dim_names.append(f"{para_name}_fsdp")
+            para_mesh_dim_names.append(para_name)
+
+            extra_parallel_fsdp_device_mesh[f"{para_name}"] = init_device_mesh(
                 device_type=device_type,
-                mesh=mesh,
-                mesh_dim_names=(para_name, f"{para_name}_fsdp"),
+                mesh_shape=param_mesh_shape,
+                mesh_dim_names=para_mesh_dim_names,
             )
 
     logger.info_rank0(f"Device mesh: {device_mesh}")

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -15,13 +15,11 @@
 
 # Adapted from https://github.com/pytorch/torchtitan/blob/main/torchtitan/distributed/parallel_dims.py
 
-import math
 import os
 from dataclasses import dataclass, field
 from functools import cached_property, wraps
 from typing import TYPE_CHECKING, Callable, Dict, Literal, Optional, Tuple
 
-import torch
 from torch import distributed as dist
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
@@ -48,29 +46,6 @@ def requires_mesh(fn: Callable) -> Callable:
         return fn(self, *args, **kwargs)
 
     return _inner
-
-
-def init_para_mesh_matrix(para_size: int, para_fsdp_size: int, para_outside: bool = False) -> "DeviceMesh":
-    """
-    Initialize the device mesh matrix for the ExtraParallel.
-    Args:
-        para_size (int): The size of the ExtraParallel.
-        para_fsdp_size (int): The size of the ExtraParallel-FSDP.
-        para_outside (bool): Whether the ExtraParallel is outside in para-fsdp group.
-    """
-    if para_outside:
-        with torch.device("cpu"):
-            mesh = torch.arange(math.prod((para_size, para_fsdp_size)), dtype=torch.int).view(
-                para_size, para_fsdp_size
-            )
-    else:
-        with torch.device("cpu"):
-            mesh = (
-                torch.arange(math.prod((para_size, para_fsdp_size)), dtype=torch.int)
-                .view(para_fsdp_size, para_size)
-                .transpose(0, 1)
-            )
-    return mesh
 
 
 @dataclass(frozen=True)

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -576,6 +576,7 @@ def init_parallel_state(
             # NOTE: Support HSDP for extra parallel. For example, world_size=1024
             # - dense param device_mesh: (dp_replicate, dp_shard_sp)=(4, 256)
             # - ep_size=8, expert parallel device_mesh: (ep_replicate, ep_fsdp, ep)=(4, 32, 8)
+            # Note that ep_size should be a factor of dp_shard_sp_size.
             param_mesh_shape, para_mesh_dim_names = [], []
             if dp_replicate_size > 1:
                 param_mesh_shape.append(dp_replicate_size)

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -262,6 +262,11 @@ def parallelize_model_fsdp2(
                     )
             para_fsdp_kwargs["shard_placement_fn"] = lambda param, _d=shard_dim_for_para: Shard(_d)
             extra_parallel_fsdp_kwargs[para] = para_fsdp_kwargs
+            # Record the FSDP shard dim on the spec_info so the checkpointer can
+            # build correct DTensor placements (EP dim vs FSDP dim) on save/load.
+            for spec_info in getattr(model, "_fqn2spec_info", {}).values():
+                if spec_info.para_name == para:
+                    spec_info.fsdp_shard_dim = shard_dim_for_para
         else:
             extra_parallel_fsdp_kwargs[para] = None
 

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -233,14 +233,19 @@ def parallelize_model_fsdp2(
     extra_parallel_fsdp_kwargs = {}
     for para in parallel_state.extra_parallel_names:
         if parallel_state.extra_parallel_enabled(para):
-            para_fsdp_mesh = parallel_state.extra_parallel_fsdp_device_mesh[para][f"{para}_fsdp"]
+            para_mesh = parallel_state.extra_parallel_fsdp_device_mesh[para]
+            para_mesh_dim_names = para_mesh.mesh_dim_names
+            # exclude para_size dimension:
+            # - (ep_fsdp, ep) -> (ep_fsdp,)
+            # - (ep_replicate, ep_fsdp, ep) -> (ep_replicate, ep_fsdp)
+            para_fsdp_mesh = para_mesh[para_mesh_dim_names[:-1]]
             para_fsdp_kwargs = dict(fsdp_kwargs)
             para_fsdp_kwargs["mesh"] = para_fsdp_mesh
             shard_dim_for_para = 1
             # Muon zero-comm needs whole experts per rank; otherwise keep the
             # default hidden-dim sharding.
             if muon_expert_zero_comm:
-                ep_fsdp_size = parallel_state.extra_parallel_fsdp_size(para)
+                ep_fsdp_size = para_mesh["ep_fsdp"].size()
                 divisible = _check_extra_parallel_dim0_divisibility(model, para, ep_fsdp_size)
                 if divisible:
                     shard_dim_for_para = 0


### PR DESCRIPTION
### What does this PR do?

Support HSDP for extra parallel. For example, world_size=1024
- dense param device_mesh: `(dp_replicate, dp_shard_sp)=(4, 256)`
- ep_size=8, expert parallel device_mesh: `(ep_replicate, ep_fsdp, ep)=(4, 32, 8)`

### Test

1. Hardware: 2*8 A100
2. Test script
```bash
#!/usr/bin/env bash
set -xeuo pipefail

# set dist args
nproc_per_node=${ARNOLD_WORKER_GPU}
export NNODES=${ARNOLD_WORKER_NUM}
export NODE_RANK=${ARNOLD_ID}
master_addr="ARNOLD_WORKER_0_HOST"
export MASTER_ADDR=${!master_addr}
master_port="ARNOLD_WORKER_0_PORT"
export master_port=${!master_port}
ports=(`echo $master_port | tr ',' ' '`)
export MASTER_PORT=${ports[0]}
echo "[nproc_per_node: ${nproc_per_node}]"
echo "[nnodes: ${NNODES}]"
echo "[node_rank: ${NODE_RANK}]"
echo "[master_addr: ${MASTER_ADDR}]"
echo "[master_port: ${MASTER_PORT}]"

# Setting 1:
# (ep_replicate, ep_fsdp, ep)=(2, 2, 4)
# dp_replicate_size=2
# dp_shard_size=8
# ep_size=4

# Setting 2:
# (ep_replicate, ep_fsdp, ep)=(2, 1, 8)
# dp_replicate_size=2
# dp_shard_size=8
# ep_size=8

# Setting 3:
# (ep_fsdp, ep)=(4, 4)
dp_replicate_size=1
dp_shard_size=16
ep_size=4

export VEOMNI_VERBOSITY=warn

bash train.sh tasks/train_text.py configs/text/qwen3.yaml \
    --model.model_path $DATA_ROOT/model/Qwen3-30B-A3B-Instruct-2507 \
    --model.ops_implementation.moe_implementation fused_triton \
    --data.train_path $DATA_ROOT/dataset/allenai/tulu-3-sft-mixture/data/train-00000-of-00006.parquet \
    --train.wandb.project wuxibin_veomni \
    --train.accelerator.fsdp_config.fsdp_mode fsdp2 \
    --train.accelerator.dp_replicate_size $dp_replicate_size \
    --train.accelerator.dp_shard_size $dp_shard_size \
    --train.accelerator.ep_size $ep_size \
    --train.init_device meta \
    --train.global_batch_size 16 \
    --train.max_steps 5 \
    --train.num_train_epochs 1
```
3. Test result
- Setting 1: (ep_replicate, ep_fsdp, ep)=(2, 2, 4)
```text
Epoch 1/1:   0%|          | 0/5 [00:12<?, ?it/s, total_loss: 1.94, foundation_loss: 1.94, grad_norm: 16.79, lr: 0.00]
Epoch 1/1:  20%|██        | 1/5 [00:12<00:50, 12.65s/it, total_loss: 1.94, foundation_loss: 1.94, grad_norm: 16.79, lr: 0.00]
Epoch 1/1:  20%|██        | 1/5 [00:15<00:50, 12.65s/it, total_loss: 1.52, foundation_loss: 1.52, grad_norm: 6.69, lr: 0.00] 
Epoch 1/1:  40%|████      | 2/5 [00:15<00:20,  6.78s/it, total_loss: 1.52, foundation_loss: 1.52, grad_norm: 6.69, lr: 0.00]
Epoch 1/1:  40%|████      | 2/5 [00:17<00:20,  6.78s/it, total_loss: 1.42, foundation_loss: 1.42, grad_norm: 2.69, lr: 0.00]
Epoch 1/1:  60%|██████    | 3/5 [00:17<00:09,  4.88s/it, total_loss: 1.42, foundation_loss: 1.42, grad_norm: 2.69, lr: 0.00]
Epoch 1/1:  60%|██████    | 3/5 [00:20<00:09,  4.88s/it, total_loss: 1.38, foundation_loss: 1.38, grad_norm: 2.90, lr: 0.00]
Epoch 1/1:  80%|████████  | 4/5 [00:20<00:03,  3.98s/it, total_loss: 1.38, foundation_loss: 1.38, grad_norm: 2.90, lr: 0.00]
Epoch 1/1:  80%|████████  | 4/5 [00:23<00:03,  3.98s/it, total_loss: 1.29, foundation_loss: 1.29, grad_norm: 1.50, lr: 0.00]
Epoch 1/1: 100%|██████████| 5/5 [00:23<00:00,  3.49s/it, total_loss: 1.29, foundation_loss: 1.29, grad_norm: 1.50, lr: 0.00]
Epoch 1/1: 100%|██████████| 5/5 [00:23<00:00,  4.63s/it, total_loss: 1.29, foundation_loss: 1.29, grad_norm: 1.50, lr: 0.00]
```
- Setting 2: (ep_replicate, ep_fsdp, ep)=(2, 1, 8)
```text
Epoch 1/1:   0%|          | 0/5 [00:15<?, ?it/s, total_loss: 1.94, foundation_loss: 1.94, grad_norm: 16.80, lr: 0.00]
Epoch 1/1:  20%|██        | 1/5 [00:15<01:03, 15.89s/it, total_loss: 1.94, foundation_loss: 1.94, grad_norm: 16.80, lr: 0.00]
Epoch 1/1:  20%|██        | 1/5 [00:18<01:03, 15.89s/it, total_loss: 1.52, foundation_loss: 1.52, grad_norm: 6.80, lr: 0.00] 
Epoch 1/1:  40%|████      | 2/5 [00:18<00:24,  8.15s/it, total_loss: 1.52, foundation_loss: 1.52, grad_norm: 6.80, lr: 0.00]
Epoch 1/1:  40%|████      | 2/5 [00:21<00:24,  8.15s/it, total_loss: 1.43, foundation_loss: 1.43, grad_norm: 2.75, lr: 0.00]
Epoch 1/1:  60%|██████    | 3/5 [00:21<00:11,  5.59s/it, total_loss: 1.43, foundation_loss: 1.43, grad_norm: 2.75, lr: 0.00]
Epoch 1/1:  60%|██████    | 3/5 [00:23<00:11,  5.59s/it, total_loss: 1.37, foundation_loss: 1.37, grad_norm: 2.93, lr: 0.00]
Epoch 1/1:  80%|████████  | 4/5 [00:23<00:04,  4.38s/it, total_loss: 1.37, foundation_loss: 1.37, grad_norm: 2.93, lr: 0.00]
Epoch 1/1:  80%|████████  | 4/5 [00:26<00:04,  4.38s/it, total_loss: 1.29, foundation_loss: 1.29, grad_norm: 1.52, lr: 0.00]
Epoch 1/1: 100%|██████████| 5/5 [00:26<00:00,  3.74s/it, total_loss: 1.29, foundation_loss: 1.29, grad_norm: 1.52, lr: 0.00]
Epoch 1/1: 100%|██████████| 5/5 [00:26<00:00,  5.26s/it, total_loss: 1.29, foundation_loss: 1.29, grad_norm: 1.52, lr: 0.00]
```
- Setting 3: (ep_fsdp, ep)=(4, 4)
```text
Epoch 1/1:   0%|          | 0/5 [00:17<?, ?it/s, total_loss: 1.94, foundation_loss: 1.94, grad_norm: 16.79, lr: 0.00]
Epoch 1/1:  20%|██        | 1/5 [00:17<01:10, 17.59s/it, total_loss: 1.94, foundation_loss: 1.94, grad_norm: 16.79, lr: 0.00]
Epoch 1/1:  20%|██        | 1/5 [00:20<01:10, 17.59s/it, total_loss: 1.52, foundation_loss: 1.52, grad_norm: 6.80, lr: 0.00] 
Epoch 1/1:  40%|████      | 2/5 [00:20<00:27,  9.02s/it, total_loss: 1.52, foundation_loss: 1.52, grad_norm: 6.80, lr: 0.00]
Epoch 1/1:  40%|████      | 2/5 [00:23<00:27,  9.02s/it, total_loss: 1.42, foundation_loss: 1.42, grad_norm: 2.85, lr: 0.00]
Epoch 1/1:  60%|██████    | 3/5 [00:23<00:12,  6.15s/it, total_loss: 1.42, foundation_loss: 1.42, grad_norm: 2.85, lr: 0.00]
Epoch 1/1:  60%|██████    | 3/5 [00:26<00:12,  6.15s/it, total_loss: 1.36, foundation_loss: 1.36, grad_norm: 2.69, lr: 0.00]
Epoch 1/1:  80%|████████  | 4/5 [00:26<00:04,  4.90s/it, total_loss: 1.36, foundation_loss: 1.36, grad_norm: 2.69, lr: 0.00]
Epoch 1/1:  80%|████████  | 4/5 [00:29<00:04,  4.90s/it, total_loss: 1.29, foundation_loss: 1.29, grad_norm: 1.48, lr: 0.00]
Epoch 1/1: 100%|██████████| 5/5 [00:29<00:00,  4.14s/it, total_loss: 1.29, foundation_loss: 1.29, grad_norm: 1.48, lr: 0.00]
Epoch 1/1: 100%|██████████| 5/5 [00:29<00:00,  5.83s/it, total_loss: 1.29, foundation_loss: 1.29, grad_norm: 1.48, lr: 0.00]
```
### API and Usage Example

No API change.
