### PR TITLE
[model] fix: pass swiglu limit in deepseek v4 fused moe

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Our guiding principles when building VeOmni are:
 | Model                                                    | Model size                    | Example config File                                                   |
 | -------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------|
 | [DeepSeek2.5/3/R1](https://huggingface.co/deepseek-ai)   | 236B/671B                     | [deepseek.yaml](configs/text/deepseek.yaml)                           |
+| [DeepSeek-V4](https://huggingface.co/deepseek-ai)        | Checkpoint-dependent          | [deepseek.yaml](configs/text/deepseek.yaml) template; set V4 path and eager attention (MoE stays `fused_triton` on GPU) |
 | [Llama3-3.3](https://huggingface.co/meta-llama)          | 1B/3B/8B/70B                  | [llama3.yaml](configs/text/llama3.yaml)                               |
 | [Qwen2-3](https://huggingface.co/Qwen)                   | 0.5B/1.5B/3B/7B/14B/32B/72B/  | [qwen2_5.yaml](configs/text/qwen2_5.yaml)                             |
 | [Qwen2-3 VL/QVQ](https://huggingface.co/Qwen)            | 2B/3B/7B/32B/72B              | [qwen3_vl_dense.yaml](configs/multimodal/qwen3_vl/qwen3_vl_dense.yaml)|

--- a/configs/text/deepseek.yaml
+++ b/configs/text/deepseek.yaml
@@ -1,6 +1,10 @@
 model:
+  # Set this to the target DeepSeek checkpoint, e.g. DeepSeek-V3/R1 or DeepSeek-V4.
   # model_path: deepseek-ai/DeepSeek-V3-0324
+  # model_path: <path-or-id-to-DeepSeek-V4-checkpoint>
   ops_implementation:
+    # DeepSeek-V4 attention is eager-only; set this to eager for V4 checkpoints.
+    # Keep moe_implementation as fused_triton on GPU so V4 uses clamp-aware fused MoE.
     attn_implementation: flash_attention_2
     moe_implementation: fused_triton
 

--- a/docs/design/fused_moe_kernels.md
+++ b/docs/design/fused_moe_kernels.md
@@ -1,0 +1,102 @@
+# Fused MoE Kernel Notes
+
+This note records implementation invariants for VeOmni's GPU fused MoE kernels.
+The DeepSeek-V4 hash-MoE CI failure exposed one of these invariants, but the
+invariant itself is generic and applies to the non-EP `fused_triton` MoE path.
+
+## Scatter/gather layout
+
+The non-EP fused MoE path expands tokens by their top-k routes before running
+per-expert grouped GEMMs:
+
+```text
+original hidden states: [tokens, hidden]
+scattered activations: [tokens * topk, hidden]
+```
+
+`scatter_index` maps each `(token, topk_slot)` pair into the expert-grouped
+scattered tensor. Later, `moe_gather()` sums the routed expert outputs back to
+`[tokens, hidden]`.
+
+## Backward grouped-GEMM launch bound
+
+For `group_gemm_same_nk`, `max_M` is a per-expert launch bound. It must cover
+the largest expert group in the scattered tensor. The total scattered row count
+is a conservative safe bound:
+
+```python
+grad_fc2_output = moe_scatter(grad_output, scatter_index)
+num_scattered_tokens = grad_fc2_output.shape[0]
+```
+
+Use `num_scattered_tokens` for the downstream `group_gemm_same_nk(...,
+max_M=...)` calls in non-EP backward. The matching `group_gemm_same_mn(...,
+max_K=...)` value is kept consistent with the scattered input row count, but the
+stale-row correctness issue is about `group_gemm_same_nk` under-covering its
+output rows.
+
+Do not use the original token count as the backward grouped-GEMM bound. It is
+only safe when every expert group has at most `tokens` scattered rows.
+
+## Why ordinary top-k routing may hide the bug
+
+Consider `tokens = 128` and `topk = 2`.
+
+If each token routes to two different experts in a balanced pattern:
+
+```text
+token0 -> expert0, expert1
+token1 -> expert0, expert1
+...
+token127 -> expert0, expert1
+```
+
+After grouping by expert:
+
+```text
+expert0: 128 rows
+expert1: 128 rows
+```
+
+Each expert group has at most `tokens` rows, so a stale bound like
+`max_M = tokens` may still cover every group. The implementation would still be
+relying on the wrong invariant, but this routing pattern may not expose it.
+
+## Duplicate top-k routes
+
+Some routers can assign multiple top-k slots of the same token to the same
+expert. DeepSeek-V4 hash-MoE can do this when the token-to-expert lookup maps
+both slots to the same expert.
+
+For `tokens = 128` and `topk = 2`:
+
+```text
+token0 -> expert0, expert0
+token1 -> expert0, expert0
+...
+token127 -> expert0, expert0
+```
+
+After grouping by expert:
+
+```text
+expert0: 256 rows
+```
+
+With `BLOCK_M = 128`, a stale `max_M = 128` launches enough blocks for only the
+first 128 rows of that expert group. Rows 128-255 can remain uncomputed or
+stale, and later gather/gradient operations may consume arbitrary values,
+including `inf` or `nan`. A visible symptom is a non-finite gradient norm such
+as `gnorm = nan`.
+
+## Regression test pattern
+
+A focused regression test should explicitly construct duplicate top-k routes:
+
+```text
+selected_experts = zeros([tokens, topk])
+routing_weights = full([tokens, topk], weight)
+```
+
+Then compare split-fc1 fused, merged-fc1 fused, and eager MoE backward results,
+and assert all produced gradients are finite.

--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -301,6 +301,15 @@ at ``apply_veomni_fused_moe_patch`` time — no silent hardware fallback.
 | `fused_quack` | Quack CUTLASS/CuTe | GPU, SM90+ (H100+) | No |
 | `fused_npu` | NPU group-gemm | Ascend NPU | Yes |
 
+DeepSeek-V4 attention remains eager-only, but its MoE path uses the same
+`moe_implementation` selection and therefore defaults to `fused_triton` on GPU.
+The v4-specific patched experts path passes the merged `gate_up_proj` tensor
+directly to `fused_moe_forward(...)` and forwards `swiglu_limit` so backends
+that implement the clamp preserve V4's clamped SwiGLU pre-activation semantics.
+Clamp-aware fused V4 support is GPU-only today (`fused_triton` / `fused_quack`);
+selecting `fused_npu` for a V4 model raises because the NPU fused MoE kernel
+does not yet implement `swiglu_limit`.
+
 ### Key files
 
 - Config: `veomni/arguments/arguments_types.py` — `OpsImplementationConfig`

--- a/docs/design/unified_kernel_registry.md
+++ b/docs/design/unified_kernel_registry.md
@@ -60,7 +60,7 @@ if they implement the same variant.
 | `apply_rotary_pos_emb` | `full`, `partial` | Full: rotate all dims. Partial: rotate first `rotary_dim`, passthrough rest |
 | `swiglu_mlp` | `standard` | SwiGLU MLP (gate/up/down) |
 | `attention` | `standard` | Multi-head / GQA attention (existing `ALL_ATTENTION_FUNCTIONS` — unchanged) |
-| `moe_experts` | `standard` | Expert GEMM dispatch (merged gate+up projection, HF v5 convention) |
+| `moe_experts` | `standard` | Expert GEMM dispatch (merged gate+up projection, HF v5 convention; DeepSeek-V4 additionally forwards `swiglu_limit` to clamp-aware backends) |
 | `cross_entropy_loss` | `causal`, `seq_cls` | Causal-LM CE (shifts labels) vs. sequence-classification CE (no shift) |
 | `moe_load_balancing_loss` | `standard` | Switch Transformer auxiliary loss |
 
@@ -772,7 +772,7 @@ model.forward()                                    # (5) runtime
 | `VEOMNI_USE_LIGER_KERNEL=1` env var | `rms_norm_implementation: liger` etc. | Deprecate env var; keep compat for 1 release |
 | `gpu_patch.py` monkey-patching | patchgen + `OpSlot` guards | Remove `gpu_patch.py` files |
 | `apply_veomni_loss_patch()` at import | `cross_entropy_loss_implementation` + `OpSlot` | Remove import-time patch |
-| `apply_veomni_fused_moe_patch()` | `OpSlot("moe_experts", ...)` | All MoE models (qwen3_moe, qwen3_5_moe, qwen3_vl_moe, qwen3_omni_moe, deepseek_v3) now bind through OpSlot; the function is kept only as the binding helper invoked from `_bind_veomni_ops` to set the global `_fused_moe_forward` pointer used inside the OpSlot guards. |
+| `apply_veomni_fused_moe_patch()` | `OpSlot("moe_experts", ...)` | All MoE models (qwen3_moe, qwen3_5_moe, qwen3_vl_moe, qwen3_omni_moe, deepseek_v3, deepseek_v4) now bind through OpSlot guards; the function is kept only as the binding helper invoked from `_bind_veomni_ops` to set the global `_fused_moe_forward` pointer. DeepSeek-V4 attention is still eager-only, but its MoE keeps a direct `fused_moe_forward(...)` call under that guard so it can pass its merged `gate_up_proj` layout and `swiglu_limit` clamp explicitly; clamp-aware V4 fused MoE is currently provided by the GPU backends and defaults to `fused_triton` on GPU, while `fused_npu` raises until the NPU kernel implements `swiglu_limit`. |
 | `moe_implementation: fused` (auto-picks Triton on GPU / NPU group-gemm on NPU) | `moe_implementation: fused_triton` or `fused_npu` | Breaking change — `"fused"` renamed to `"fused_triton"` and the silent NPU auto-pick replaced by explicit `"fused_npu"`. `fused_quack` is unchanged. |
 
 ---

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,6 +18,7 @@ tests/
 │   ├── test_vlm_trainer.py         # VLM freeze_vit smoke test
 │   ├── test_model_registry.py      # Model loader registry (HF vs VeOmni)
 │   ├── test_checkpoint_tensor_converter.py  # Checkpoint tensor conversion (e.g. Qwen3MoE fuse)
+│   ├── test_deepseek_v4_fused_moe.py  # DeepSeek-V4 fused MoE swiglu_limit plumbing
 │   ├── test_padded_packed_loss.py   # Padded vs packed (cu_seqlens) loss equivalence
 │   ├── utils.py                    # ModelMode, prepare_model_modes, prepare_data
 │   └── weight_sync_adapters.py     # State-dict alignment for HF↔VeOmni comparison
@@ -144,15 +145,18 @@ Additional per-directory helpers:
 |---|---|
 | Modeling backend | HuggingFace, VeOmni |
 | Attention implementation | `eager`, `flash_attention_2`, `flash_attention_3`, `veomni_flash_attention_2_with_sp`, `veomni_flash_attention_3_with_sp` |
-| MoE implementation | `eager`, `fused` (MoE models only) |
+| MoE implementation | `eager`, hardware fused backend (`fused_triton` on GPU, `fused_npu` on NPU where supported) |
 | Liger kernel | `True`, `False` (VeOmni only) |
 
 **Models covered**:
-- Text / MoE: llama3_1, qwen2, qwen3_5, qwen3_5_moe, seed_oss, deepseek_v3
+- Text / MoE: llama3_1, qwen2, qwen3_5, qwen3_5_moe, seed_oss, deepseek_v3, deepseek_v4
 - VLM: qwen2_vl, qwen2_5_vl, qwen3_vl, qwen3_vl_moe
 - Omni: qwen2_5_omni, qwen3_omni_moe
 
 **GPU**: 1 GPU, runs serially per model mode.
+
+DeepSeek-V4's fused-MoE-specific merged `gate_up_proj` and `swiglu_limit`
+forwarding are covered by `tests/models/test_deepseek_v4_fused_moe.py` (CPU).
 
 ---
 

--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -191,16 +191,15 @@ deepseek_v4_text_smoke_test_cases = [
         True,  # is_moe
         _DEFAULT_RTOL,
         _DEFAULT_ATOL,
-        # DeepSeek-V4 is eager-only (no FA / SDPA / FlexAttention) and the
-        # 4D ``[B, S, hc_mult, D]`` HyperConnection residual stack isn't
-        # SP-aware yet. Force ``max_sp_size=1`` until a v4-specific
+        # DeepSeek-V4 attention is eager-only (no FA / SDPA / FlexAttention)
+        # and the 4D ``[B, S, hc_mult, D]`` HyperConnection residual stack
+        # is not SP-aware yet. Force ``max_sp_size=1`` until a V4-specific
         # eager-SP path lands.
         1,
-        # The current generic fused MoE EP path does not preserve DeepSeek-V4's
-        # swiglu_limit clamp and is not stable for the merged gate_up layout on
-        # all backends. Keep e2e on the non-EP baseline until a V4-aware fused
-        # EP kernel lands; do not force eager MoE here because eager expert
-        # loops are incompatible with EP-sharded expert weights.
+        # The GPU fused-MoE path now preserves DeepSeek-V4's ``swiglu_limit``
+        # clamp, so keep the smoke test on the default fused_triton MoE path.
+        # EP remains disabled here because the surrounding V4 e2e coverage is
+        # a single-mode smoke test, not an EP alignment test.
         1,
     ),
     pytest.param(

--- a/tests/models/test_deepseek_v4_fused_moe.py
+++ b/tests/models/test_deepseek_v4_fused_moe.py
@@ -1,0 +1,145 @@
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+from veomni.models.transformers.deepseek_v4.generated import patched_modeling_deepseek_v4_gpu as dsv4
+
+
+def _deepseek_v4_experts_reference(
+    *,
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    gate_up_proj: torch.Tensor,
+    down_proj: torch.Tensor,
+    swiglu_limit: float,
+) -> torch.Tensor:
+    output = torch.zeros_like(hidden_states)
+    expert_mask = F.one_hot(selected_experts, num_classes=num_experts).permute(2, 1, 0)
+    expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+    for expert_idx_tensor in expert_hit:
+        expert_idx = int(expert_idx_tensor[0].item())
+        top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+        gate_up = F.linear(hidden_states[token_idx], gate_up_proj[expert_idx])
+        gate, up = gate_up.chunk(2, dim=-1)
+        gate = gate.clamp(max=swiglu_limit)
+        up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
+        current = F.linear(F.silu(gate) * up, down_proj[expert_idx])
+        current = current * routing_weights[token_idx, top_k_pos, None]
+        output.index_add_(0, token_idx, current.to(output.dtype))
+
+    return output
+
+
+def test_deepseek_v4_fused_moe_receives_merged_weights_and_swiglu_limit(monkeypatch):
+    config = SimpleNamespace(
+        num_local_experts=3,
+        hidden_size=5,
+        intermediate_size=7,
+        hidden_act="silu",
+        swiglu_limit=6.5,
+    )
+    experts = dsv4.DeepseekV4Experts(config)
+
+    gate = torch.arange(
+        config.num_local_experts * config.intermediate_size * config.hidden_size,
+        dtype=torch.float32,
+    ).reshape(config.num_local_experts, config.intermediate_size, config.hidden_size)
+    gate = gate.mul_(0.01).add_(0.1)
+    up = torch.arange(gate.numel(), dtype=torch.float32).reshape_as(gate).mul_(0.02).sub_(0.2)
+    down = torch.arange(
+        config.num_local_experts * config.hidden_size * config.intermediate_size,
+        dtype=torch.float32,
+    ).reshape(config.num_local_experts, config.hidden_size, config.intermediate_size)
+    down = down.mul_(0.015).sub_(0.05)
+
+    with torch.no_grad():
+        experts.gate_up_proj.copy_(torch.cat([gate, up], dim=1))
+        experts.down_proj.copy_(down)
+
+    hidden_states = torch.linspace(-0.7, 0.8, steps=4 * config.hidden_size).reshape(4, config.hidden_size)
+    selected_experts = torch.tensor(
+        [
+            [0, 1],
+            [2, 0],
+            [1, 2],
+            [0, 2],
+        ],
+        dtype=torch.long,
+    )
+    top_k_weights = torch.tensor(
+        [
+            [0.7, 0.3],
+            [0.6, 0.4],
+            [0.55, 0.45],
+            [0.8, 0.2],
+        ],
+        dtype=torch.float64,
+    )
+
+    class _FusedSlot:
+        use_non_eager_impl = True
+
+    captured = {}
+
+    def fake_fused_moe_forward(
+        *,
+        num_experts,
+        routing_weights,
+        selected_experts,
+        hidden_states,
+        fc1_1_weight,
+        fc1_2_weight,
+        fc2_weight,
+        fc1_1_2_weight=None,
+        swiglu_limit=None,
+    ):
+        captured.update(
+            num_experts=num_experts,
+            routing_weights=routing_weights,
+            selected_experts=selected_experts,
+            hidden_states=hidden_states,
+            fc1_1_weight=fc1_1_weight,
+            fc1_2_weight=fc1_2_weight,
+            fc2_weight=fc2_weight,
+            fc1_1_2_weight=fc1_1_2_weight,
+            swiglu_limit=swiglu_limit,
+        )
+        return _deepseek_v4_experts_reference(
+            num_experts=num_experts,
+            routing_weights=routing_weights,
+            selected_experts=selected_experts,
+            hidden_states=hidden_states,
+            gate_up_proj=fc1_1_2_weight,
+            down_proj=fc2_weight,
+            swiglu_limit=swiglu_limit,
+        )
+
+    monkeypatch.setattr(dsv4, "veomni_moe_experts_forward", _FusedSlot())
+    monkeypatch.setattr(dsv4, "fused_moe_forward", fake_fused_moe_forward)
+
+    actual = experts(hidden_states, selected_experts, top_k_weights)
+    expected = _deepseek_v4_experts_reference(
+        num_experts=config.num_local_experts,
+        routing_weights=top_k_weights.to(hidden_states.dtype),
+        selected_experts=selected_experts,
+        hidden_states=hidden_states,
+        gate_up_proj=experts.gate_up_proj,
+        down_proj=experts.down_proj,
+        swiglu_limit=config.swiglu_limit,
+    )
+
+    assert captured["num_experts"] == config.num_local_experts
+    assert captured["fc1_1_weight"] is None
+    assert captured["fc1_2_weight"] is None
+    assert captured["fc2_weight"] is experts.down_proj
+    assert captured["fc1_1_2_weight"] is experts.gate_up_proj
+    assert captured["swiglu_limit"] == config.swiglu_limit
+    assert captured["routing_weights"].dtype == hidden_states.dtype
+    torch.testing.assert_close(captured["routing_weights"], top_k_weights.to(hidden_states.dtype), rtol=0, atol=0)
+    torch.testing.assert_close(captured["fc1_1_2_weight"][:, : config.intermediate_size], gate, rtol=0, atol=0)
+    torch.testing.assert_close(captured["fc1_1_2_weight"][:, config.intermediate_size :], up, rtol=0, atol=0)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tests/models/test_deepseek_v4_fused_moe.py
+++ b/tests/models/test_deepseek_v4_fused_moe.py
@@ -34,6 +34,17 @@ def _deepseek_v4_experts_reference(
     return output
 
 
+def test_deepseek_v4_test_overrides_keep_eager_attention_and_expected_moe():
+    from tests.tools.training_utils import resolve_ops_overrides
+    from veomni.utils.import_utils import is_torch_npu_available
+
+    overrides = resolve_ops_overrides("deepseek_v4")
+
+    expected_moe = "eager" if is_torch_npu_available() else "fused_triton"
+    assert "--model.ops_implementation.attn_implementation=eager" in overrides
+    assert f"--model.ops_implementation.moe_implementation={expected_moe}" in overrides
+
+
 def test_deepseek_v4_fused_moe_receives_merged_weights_and_swiglu_limit(monkeypatch):
     config = SimpleNamespace(
         num_local_experts=3,

--- a/tests/models/test_models_patch.py
+++ b/tests/models/test_models_patch.py
@@ -457,21 +457,21 @@ def test_models_patch_fwd_bwd(
             # npu not support torch.kaiser_window init in Token2WavBigVGANModel
             return
 
-    # DeepSeek-V4 ships eager-only attention: ``_supports_flash_attn = False``
+    # DeepSeek-V4 attention is eager-only: ``_supports_flash_attn = False``
     # / ``_supports_sdpa = False`` / ``_supports_flex_attn = False`` —
     # ``head_dim=512`` exceeds FA's 256 cap, SDPA lacks the per-head learnable
     # sink, and FlexAttention can't resize BlockMask after the in-block
     # compressor concatenation. The default FA-based mode grid would fail at
     # ``TrainerTest(hf_model_modes[0])`` with
     # ``ValueError: DeepseekV4ForCausalLM does not support Flash Attention 2``.
-    # Replace with a single eager-only HF/VeOmni pair — V4's fused-MoE
-    # ``fused_triton`` path also bypasses the gpt-oss-style ``swiglu_limit``
-    # clamp that the eager loop applies via ``_apply_gate``, which can drive
-    # gate/up activations into NaN territory at the toy scale, so keep
-    # ``moe_implementation=eager`` until a v4-aware fused-MoE path lands.
+    # Keep attention eager, but exercise VeOmni's default GPU MoE path: the
+    # DeepSeek-V4 experts patch forwards ``swiglu_limit`` into the fused kernel.
+    # NPU fused MoE still raises for that clamp, so NPU keeps the eager MoE
+    # baseline until ``fused_npu`` implements ``swiglu_limit``.
     if case_id == "deepseek_v4":
         hf_model_modes = [ModelMode("hf", "eager")]
-        veomni_model_modes = [ModelMode("veomni", "eager")]
+        moe_impl = "eager" if IS_NPU_AVAILABLE else "fused_triton"
+        veomni_model_modes = [ModelMode("veomni", "eager", moe_implementation=moe_impl)]
 
     # Qwen3.5 compatibility:
     # - HF backend doesn't support the test's position_ids test cases.

--- a/tests/ops/test_fused_moe_split_vs_merged.py
+++ b/tests/ops/test_fused_moe_split_vs_merged.py
@@ -265,6 +265,104 @@ def test_fused_moe_swiglu_limit_split_vs_merged_and_eager(swiglu_limit: float, m
     torch.testing.assert_close(fc1_merged.grad, fc1_eager_grad, rtol=5e-2, atol=5e-2)
 
 
+def test_fused_moe_duplicate_topk_expert_backward_uses_scattered_token_count(monkeypatch: pytest.MonkeyPatch):
+    """Regression test for top-k routes that duplicate the same expert.
+
+    DeepSeek-V4 hash-MoE can route both top-k slots of a token to the same
+    expert. The grouped-GEMM backward must launch over ``tokens * topk``
+    scattered rows, not the original token count, otherwise the tail rows are
+    left uncomputed and may produce non-finite gradients.
+    """
+    _skip_if_unsupported()
+
+    torch.manual_seed(7)
+    device = torch.device(get_device_type())
+    dtype = torch.bfloat16
+    num_tokens, num_experts, hidden_dim, ffn_dim, topk = 256, 4, 128, 64, 2
+    swiglu_limit = 10.0
+
+    hidden_states = 0.1 * torch.randn(num_tokens, hidden_dim, device=device, dtype=dtype)
+    selected_experts = torch.zeros(num_tokens, topk, device=device, dtype=torch.long)
+    routing_weights = torch.full((num_tokens, topk), 0.75, device=device, dtype=dtype)
+    fc1_1_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
+    fc1_2_weight = 0.1 * torch.randn(num_experts, ffn_dim, hidden_dim, device=device, dtype=dtype)
+    fc1_1_2_weight = torch.cat([fc1_1_weight, fc1_2_weight], dim=1).contiguous()
+    fc2_weight = 0.1 * torch.randn(num_experts, hidden_dim, ffn_dim, device=device, dtype=dtype)
+
+    monkeypatch.setattr(fused_moe, "_fused_moe_forward", group_gemm_fused_moe_forward)
+
+    hs_split = hidden_states.clone().detach().requires_grad_(True)
+    fc1_1_split = fc1_1_weight.clone().detach().requires_grad_(True)
+    fc1_2_split = fc1_2_weight.clone().detach().requires_grad_(True)
+    fc2_split = fc2_weight.clone().detach().requires_grad_(True)
+    out_split = fused_moe_forward(
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hs_split,
+        fc1_1_weight=fc1_1_split,
+        fc1_2_weight=fc1_2_split,
+        fc2_weight=fc2_split,
+        swiglu_limit=swiglu_limit,
+    )
+    out_split.sum().backward()
+
+    hs_merged = hidden_states.clone().detach().requires_grad_(True)
+    fc1_merged = fc1_1_2_weight.clone().detach().requires_grad_(True)
+    fc2_merged = fc2_weight.clone().detach().requires_grad_(True)
+    out_merged = fused_moe_forward(
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hs_merged,
+        fc1_1_weight=None,
+        fc1_2_weight=None,
+        fc2_weight=fc2_merged,
+        fc1_1_2_weight=fc1_merged,
+        swiglu_limit=swiglu_limit,
+    )
+    out_merged.sum().backward()
+
+    hs_eager = hidden_states.clone().detach().requires_grad_(True)
+    fc1_1_eager = fc1_1_weight.clone().detach().requires_grad_(True)
+    fc1_2_eager = fc1_2_weight.clone().detach().requires_grad_(True)
+    fc2_eager = fc2_weight.clone().detach().requires_grad_(True)
+    out_eager = _eager_moe_forward(
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hs_eager,
+        fc1_1_weight=fc1_1_eager,
+        fc1_2_weight=fc1_2_eager,
+        fc2_weight=fc2_eager,
+        swiglu_limit=swiglu_limit,
+    )
+    out_eager.sum().backward()
+
+    for grad in (
+        hs_split.grad,
+        fc1_1_split.grad,
+        fc1_2_split.grad,
+        fc2_split.grad,
+        hs_merged.grad,
+        fc1_merged.grad,
+        fc2_merged.grad,
+    ):
+        assert torch.isfinite(grad).all()
+
+    torch.testing.assert_close(out_split, out_merged, rtol=0, atol=0)
+    torch.testing.assert_close(hs_split.grad, hs_merged.grad, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(fc2_split.grad, fc2_merged.grad, rtol=0, atol=0)
+    fc1_split_grad = torch.cat([fc1_1_split.grad, fc1_2_split.grad], dim=1)
+    torch.testing.assert_close(fc1_split_grad, fc1_merged.grad, rtol=0, atol=0)
+
+    torch.testing.assert_close(out_merged, out_eager, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(hs_merged.grad, hs_eager.grad, rtol=6e-2, atol=6e-2)
+    torch.testing.assert_close(fc2_merged.grad, fc2_eager.grad, rtol=2e-2, atol=2e-2)
+    fc1_eager_grad = torch.cat([fc1_1_eager.grad, fc1_2_eager.grad], dim=1)
+    torch.testing.assert_close(fc1_merged.grad, fc1_eager_grad, rtol=5e-2, atol=5e-2)
+
+
 def _make_ep_inputs(num_tokens, num_experts, hidden_dim, ffn_dim, seed):
     """Create synthetic EP test inputs: permute_tokens, cumsum, and weights."""
     torch.manual_seed(seed)

--- a/tests/ops/test_fused_moe_split_vs_merged.py
+++ b/tests/ops/test_fused_moe_split_vs_merged.py
@@ -266,12 +266,12 @@ def test_fused_moe_swiglu_limit_split_vs_merged_and_eager(swiglu_limit: float, m
 
 
 def test_fused_moe_duplicate_topk_expert_backward_uses_scattered_token_count(monkeypatch: pytest.MonkeyPatch):
-    """Regression test for top-k routes that duplicate the same expert.
+    """Regression test for duplicate top-k routes to the same expert.
 
-    DeepSeek-V4 hash-MoE can route both top-k slots of a token to the same
-    expert. The grouped-GEMM backward must launch over ``tokens * topk``
-    scattered rows, not the original token count, otherwise the tail rows are
-    left uncomputed and may produce non-finite gradients.
+    ``group_gemm_same_nk`` uses ``max_M`` as a per-expert launch bound. When
+    duplicate routes make one expert receive more than the original token
+    count, the non-EP backward must use a scattered-row bound; otherwise tail
+    rows may be left uncomputed and produce non-finite gradients.
     """
     _skip_if_unsupported()
 

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -21,8 +21,8 @@ from .launch_utils import find_free_port
 # ``OpsImplementationConfig`` defaults are GPU-optimal (Liger / Triton) and
 # raise on NPU at config validation time, so every NPU test must override
 # every per-op field. ``_NPU_OPS_DEFAULTS`` is the baseline; entries in
-# ``_NPU_PER_MODEL_OVERRIDES`` (DeepSeek-V3, Qwen-VL family) pin specific
-# fields to ``eager`` where the model has no NPU kernel.
+# ``_NPU_PER_MODEL_OVERRIDES`` (DeepSeek-V3/V4, Qwen-VL family) pin
+# specific fields to ``eager`` where the model has no NPU kernel.
 _NPU_OPS_DEFAULTS: Dict[str, str] = {
     "attn_implementation": "flash_attention_2",
     "moe_implementation": "fused_npu",
@@ -39,6 +39,14 @@ _NPU_OPS_DEFAULTS: Dict[str, str] = {
 _NPU_PER_MODEL_OVERRIDES: Dict[str, Dict[str, str]] = {
     "deepseek_v3": {
         # batch-invariant RMSNorm + deterministic RoPE are GPU-only Triton
+        "rms_norm_implementation": "eager",
+        "rotary_pos_emb_implementation": "eager",
+    },
+    "deepseek_v4": {
+        # DeepSeek-V4 attention is eager-only and its clamped SwiGLU requires
+        # swiglu_limit support that the NPU fused-MoE kernel does not yet have.
+        "attn_implementation": "eager",
+        "moe_implementation": "eager",
         "rms_norm_implementation": "eager",
         "rotary_pos_emb_implementation": "eager",
     },
@@ -103,6 +111,17 @@ _GPU_PER_MODEL_OVERRIDES: Dict[str, Dict[str, str]] = {
         "rms_norm_implementation": "eager",
         "rotary_pos_emb_implementation": "eager",
     },
+    # DeepSeek-V4 attention is eager-only, but MoE uses the GPU-default
+    # fused_triton backend now that the experts path forwards swiglu_limit.
+    # Keep RMSNorm/RoPE/SwiGLU eager because V4's custom unweighted norms,
+    # partial RoPE, and shared-expert MLP are intentionally not Liger-swapped.
+    "deepseek_v4": {
+        "attn_implementation": "eager",
+        "moe_implementation": "fused_triton",
+        "rms_norm_implementation": "eager",
+        "rotary_pos_emb_implementation": "eager",
+        "swiglu_mlp_implementation": "eager",
+    },
 }
 
 
@@ -117,9 +136,10 @@ def resolve_ops_overrides(model_name: Optional[str]) -> List[str]:
     """Return ``--model.ops_implementation.X=Y`` flags for the active hardware.
 
     On GPU returns per-model overrides for models whose patched ops disable a
-    default backend (currently Wan); empty otherwise — dataclass defaults are
-    GPU-optimal. On NPU returns the NPU-supported backend per op, with
-    per-model eager fallbacks for ops without an NPU kernel for that model.
+    default backend (for example Wan's RoPE and DeepSeek-V4's eager-only
+    attention); empty otherwise — dataclass defaults are GPU-optimal. On NPU
+    returns the NPU-supported backend per op, with per-model eager fallbacks for
+    ops without an NPU kernel for that model.
     """
     if not is_torch_npu_available():
         overrides = _GPU_PER_MODEL_OVERRIDES.get(model_name, {}) if model_name else {}

--- a/veomni/models/transformers/deepseek_v4/deepseek_v4_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/deepseek_v4/deepseek_v4_gpu_patch_gen_config.py
@@ -47,12 +47,14 @@ Intentionally NOT patched:
   untouched) plus an interleaved ``repeat_interleave(2)`` cos/sin layout
   that ``liger_rotary_pos_emb`` does not implement. SKILL.md flags this
   exact case (partial_rotary -> liger NaN).
-- ``DeepseekV4Attention.forward`` — V4 ships eager-only
+- ``DeepseekV4Attention.forward`` — V4 attention is eager-only
   (``_supports_flash_attn = False`` / ``_supports_sdpa = False`` /
   ``_supports_flex_attn = False``: ``head_dim=512`` exceeds FlashAttention's
   256 cap, SDPA lacks the per-head learnable sink, and FlexAttention can't
-  resize BlockMask after the in-block compressor concatenation). Sequence
-  parallel for V4 attention is out of scope for this patchgen pass and
+  resize BlockMask after the in-block compressor concatenation). MoE does not
+  share this limitation: the experts patch above binds VeOmni fused MoE by
+  default on GPU.
+  Sequence parallel for V4 attention is out of scope for this patchgen pass and
   needs a dedicated eager-SP path before the model can train under SP.
 - ``DeepseekV4Model.forward`` — top-level ``hidden_states`` is *4D*
   (``[B, S, hc_mult, D]`` for the manifold-constrained Hyper-Connection

--- a/veomni/models/transformers/deepseek_v4/deepseek_v4_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/deepseek_v4/deepseek_v4_gpu_patch_gen_config.py
@@ -127,7 +127,8 @@ config.add_post_import_block(
 #    MoE kernel.
 # 2. OpSlot guard for fused-MoE: when ``veomni_moe_experts_forward`` is
 #    bound to a non-eager kernel, call ``fused_moe_forward`` with stacked
-#    ``gate_up_proj``. Otherwise fall through to the eager loop.
+#    ``gate_up_proj`` and pass ``swiglu_limit`` explicitly. Otherwise fall
+#    through to the eager loop.
 # 3. Preserve V4's gpt-oss-style ``swiglu_limit`` clamp on gate / up
 #    pre-activations (paper §2.1 — required for V4's training stability).
 # Layout matches v5 upstream (direct, no transpose):
@@ -169,6 +170,7 @@ class PatchedDeepseekV4Experts(nn.Module):
                 fc1_2_weight=None,
                 fc2_weight=self.down_proj,
                 fc1_1_2_weight=self.gate_up_proj,
+                swiglu_limit=self.limit,
             )
         # --- Patch.2 ---
 

--- a/veomni/models/transformers/deepseek_v4/generated/patched_modeling_deepseek_v4_gpu.diff
+++ b/veomni/models/transformers/deepseek_v4/generated/patched_modeling_deepseek_v4_gpu.diff
@@ -91,7 +91,7 @@
 
 
  @use_kernel_forward_from_hub("RMSNorm")
-@@ -975,11 +987,29 @@
+@@ -975,11 +987,30 @@
          return down_proj
 
 
@@ -109,7 +109,8 @@
 +#    MoE kernel.
 +# 2. OpSlot guard for fused-MoE: when ``veomni_moe_experts_forward`` is
 +#    bound to a non-eager kernel, call ``fused_moe_forward`` with stacked
-+#    ``gate_up_proj``. Otherwise fall through to the eager loop.
++#    ``gate_up_proj`` and pass ``swiglu_limit`` explicitly. Otherwise fall
++#    through to the eager loop.
 +# 3. Preserve V4's gpt-oss-style ``swiglu_limit`` clamp on gate / up
 +#    pre-activations (paper §2.1 — required for V4's training stability).
 +# Layout matches v5 upstream (direct, no transpose):
@@ -123,7 +124,7 @@
          super().__init__()
          self.num_experts = config.num_local_experts
          self.hidden_dim = config.hidden_size
-@@ -990,30 +1020,56 @@
+@@ -990,30 +1021,57 @@
          self.limit = config.swiglu_limit
 
      def forward(
@@ -147,6 +148,7 @@
 +                fc1_2_weight=None,
 +                fc2_weight=self.down_proj,
 +                fc1_1_2_weight=self.gate_up_proj,
++                swiglu_limit=self.limit,
 +            )
 +        # --- Patch.2 ---
 +
@@ -193,7 +195,7 @@
 
 
  class DeepseekV4TopKRouter(nn.Module):
-@@ -1392,6 +1448,12 @@
+@@ -1392,6 +1450,12 @@
      return overall_loss * num_experts
 
 
@@ -206,7 +208,7 @@
  @auto_docstring
  class DeepseekV4ForCausalLM(DeepseekV4PreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -1410,49 +1472,36 @@
+@@ -1410,49 +1474,36 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -276,7 +278,7 @@
          outputs: MoeModelOutputWithPast = self.model(
              input_ids=input_ids,
              attention_mask=attention_mask,
-@@ -1465,26 +1514,64 @@
+@@ -1465,26 +1516,64 @@
          )
 
          hidden_states = outputs.last_hidden_state
@@ -355,7 +357,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1492,7 +1579,17 @@
+@@ -1492,7 +1581,17 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,

--- a/veomni/models/transformers/deepseek_v4/generated/patched_modeling_deepseek_v4_gpu.py
+++ b/veomni/models/transformers/deepseek_v4/generated/patched_modeling_deepseek_v4_gpu.py
@@ -1000,7 +1000,8 @@ class DeepseekV4MLP(nn.Module):
 #    MoE kernel.
 # 2. OpSlot guard for fused-MoE: when ``veomni_moe_experts_forward`` is
 #    bound to a non-eager kernel, call ``fused_moe_forward`` with stacked
-#    ``gate_up_proj``. Otherwise fall through to the eager loop.
+#    ``gate_up_proj`` and pass ``swiglu_limit`` explicitly. Otherwise fall
+#    through to the eager loop.
 # 3. Preserve V4's gpt-oss-style ``swiglu_limit`` clamp on gate / up
 #    pre-activations (paper §2.1 — required for V4's training stability).
 # Layout matches v5 upstream (direct, no transpose):
@@ -1038,6 +1039,7 @@ class DeepseekV4Experts(nn.Module):
                 fc1_2_weight=None,
                 fc2_weight=self.down_proj,
                 fc1_1_2_weight=self.gate_up_proj,
+                swiglu_limit=self.limit,
             )
         # --- Patch.2 ---
 

--- a/veomni/ops/kernels/moe/group_gemm.py
+++ b/veomni/ops/kernels/moe/group_gemm.py
@@ -181,6 +181,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
 
         # MOE Step 10
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
+        num_scattered_tokens = grad_fc2_output.shape[0]
 
         # MOE Step 9
         # grad_fc1_weighted_output = torch.empty_like(fc1_weighted_output)
@@ -190,7 +191,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             a=grad_fc2_output,
             b=fc2_weight,
             cumsum_M=cumsum_t,
-            max_M=grad_output.shape[0],
+            max_M=num_scattered_tokens,
             transpose_b=False,
         )
 
@@ -203,7 +204,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
                 b=fc1_weighted_output,
                 c=grad_fc2_weight,
                 cumsum_K=cumsum_t,
-                max_K=grad_output.shape[0],
+                max_K=num_scattered_tokens,
                 transpose_a=True,
                 transpose_b=False,
             )
@@ -238,7 +239,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             a=grad_fc1_2_output,
             b=fc1_2_weight,
             cumsum_M=cumsum_t,
-            max_M=grad_output.shape[0],
+            max_M=num_scattered_tokens,
             transpose_b=False,
         )
 
@@ -251,7 +252,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
                 b=scatter_output,
                 c=grad_fc1_2_weight,
                 cumsum_K=cumsum_t,
-                max_K=grad_output.shape[0],
+                max_K=num_scattered_tokens,
                 transpose_a=True,
                 transpose_b=False,
             )
@@ -269,7 +270,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
             a=grad_fc1_1_output,
             b=fc1_1_weight,
             cumsum_M=cumsum_t,
-            max_M=grad_output.shape[0],
+            max_M=num_scattered_tokens,
             transpose_b=False,
         )
 
@@ -282,7 +283,7 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
                 b=scatter_output,
                 c=grad_fc1_1_weight,
                 cumsum_K=cumsum_t,
-                max_K=grad_output.shape[0],
+                max_K=num_scattered_tokens,
                 transpose_a=True,
                 transpose_b=False,
             )
@@ -421,13 +422,14 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
 
         # MOE Step 10
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
+        num_scattered_tokens = grad_fc2_output.shape[0]
 
         # MOE Step 9 - dgrad
         grad_fc1_weighted_output = group_gemm_same_nk(
             a=grad_fc2_output,
             b=fc2_weight,
             cumsum_M=cumsum_t,
-            max_M=grad_output.shape[0],
+            max_M=num_scattered_tokens,
             transpose_b=False,
         )
 
@@ -440,7 +442,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
                 b=fc1_weighted_output,
                 c=grad_fc2_weight,
                 cumsum_K=cumsum_t,
-                max_K=grad_output.shape[0],
+                max_K=num_scattered_tokens,
                 transpose_a=True,
                 transpose_b=False,
             )
@@ -476,7 +478,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
             a=grad_fc1_output,
             b=fc1_1_2_weight,
             cumsum_M=cumsum_t,
-            max_M=grad_output.shape[0],
+            max_M=num_scattered_tokens,
             transpose_b=False,
         )
 
@@ -489,7 +491,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
                 b=scatter_output,
                 c=grad_fc1_1_2_weight,
                 cumsum_K=cumsum_t,
-                max_K=grad_output.shape[0],
+                max_K=num_scattered_tokens,
                 transpose_a=True,
                 transpose_b=False,
             )

--- a/veomni/ops/kernels/moe/group_gemm.py
+++ b/veomni/ops/kernels/moe/group_gemm.py
@@ -181,6 +181,9 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
 
         # MOE Step 10
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
+        # ``max_M`` for grouped GEMM is a per-expert launch bound. Duplicate
+        # top-k routes can make one expert receive more rows than the original
+        # token count, so the total scattered row count is a safe bound.
         num_scattered_tokens = grad_fc2_output.shape[0]
 
         # MOE Step 9
@@ -422,6 +425,9 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
 
         # MOE Step 10
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
+        # ``max_M`` for grouped GEMM is a per-expert launch bound. Duplicate
+        # top-k routes can make one expert receive more rows than the original
+        # token count, so the total scattered row count is a safe bound.
         num_scattered_tokens = grad_fc2_output.shape[0]
 
         # MOE Step 9 - dgrad


### PR DESCRIPTION
### What does this PR do?

> Passes DeepSeek-V4's `swiglu_limit` into the direct `fused_moe_forward(...)` path so the fused MoE kernel preserves the model's gated SwiGLU clamp semantics. Also adds a regression test that forces the DeepSeek-V4 fused branch and asserts the merged expert weights and `swiglu_limit` are forwarded correctly.

### Checklist Before Starting

- Search for relative PRs/issues and link here: follows up on fused MoE swiglu-limit support.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

> - `pytest tests/models/test_deepseek_v4_fused_moe.py -q`
> - `ruff check veomni/models/transformers/deepseek_v4/deepseek_v4_gpu_patch_gen_config.py tests/models/test_deepseek_v4_fused_moe.py`
> - `ruff format --check veomni/models/transformers/deepseek_v4/deepseek_v4_gpu_patch_gen_config.py tests/models/test_deepseek_v4_fused_moe.py`
> - `make quality`
> - `/veomni-review`: safe

### API and Usage Example

> N/A

### Design & Code Changes

> - Updates the DeepSeek-V4 patchgen config to pass `swiglu_limit=self.limit` to the direct fused MoE call.
> - Regenerates the DeepSeek-V4 generated modeling file and diff via patchgen.
> - Adds a unit test covering the direct fused path argument forwarding.

