### PR TITLE
[data] fix: loss_mask checking in chatml template

### DIFF
--- a/veomni/data/chat_template.py
+++ b/veomni/data/chat_template.py
@@ -240,7 +240,7 @@ class ChatmlTemplate(ChatTemplate):
             input_ids += content_ids
             attention_mask += [1] * len(content_ids)
 
-            if hasattr(message, "loss_mask"):
+            if "loss_mask" in message:
                 loss_mask = message["loss_mask"]
             else:
                 loss_mask = 1 if message["role"] == "assistant" else 0


### PR DESCRIPTION
As `message` is a dict, the origin `hasattr(message, "loss_mask")` will always return `False`. Obviously it's a bug.

### What does this PR do?

> Fix a bug about loss mask condition

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
