### PR TITLE
[ci] chore: bump NPU CI image to veomni-9.0.0

### DIFF
--- a/.github/workflows/npu_e2e_test.yml
+++ b/.github/workflows/npu_e2e_test.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: [self-hosted, 910b-8]
     timeout-minutes: 90
     container:
-      image: quay.io/ascend/veomni:veomni-8.3.rc2-910b-ubuntu22.04-py3.11-tingyang_chore_bump_uv
+      image: quay.io/ascend/veomni:veomni-9.0.0-910b-ubuntu22.04-py3.11-latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: [self-hosted, 910b-8]
     timeout-minutes: 90
     container:
-      image: quay.io/ascend/veomni:veomni-8.3.rc2-910b-ubuntu22.04-py3.11-tingyang_chore_bump_uv
+      image: quay.io/ascend/veomni:veomni-9.0.0-910b-ubuntu22.04-py3.11-latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi


### PR DESCRIPTION
## What does this PR do?

- Bump NPU e2e and unit test CI container image from `veomni-8.3.rc2` to `veomni-9.0.0-910b-ubuntu22.04-py3.11`.

## Checklist Before Starting

- [x] Search for relative PRs/issues: N/A
- [x] PR title follows format: `[ci] chore: bump NPU CI image to veomni-9.0.0`

## Test

- CI validation (`npu_e2e_test.yml` / `npu_unit_tests.yml`)

## API and Usage Example

N/A — CI config change only.

## Design & Code Changes

- Update container image tag in `.github/workflows/npu_e2e_test.yml` and `.github/workflows/npu_unit_tests.yml`: `veomni-8.3.rc2` → `veomni-9.0.0`

## Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] Apply pre-commit checks
- [x] PR title follows format
- [x] CI config changes only, no code impact
