### PR TITLE
[Feat]: Add Decoupled-Trigger fsdp2 to eliminate redundant pre/post forward computations during recomputation in MoE models with EP parallelism.

### DIFF
--- a/tests/distributed/test_dt_fsdp2.py
+++ b/tests/distributed/test_dt_fsdp2.py
@@ -1,0 +1,393 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for DT-FSDP2 (disaggregated-tensor FSDP2 monkey-patch)."""
+
+import copy
+import os
+from functools import partial
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from veomni.distributed.dt_fsdp2 import (
+    DTFSDP2_SUB_MODULE_NAMES,
+    apply_dt_fsdp2_patch,
+    discover_dtfsdp2_submodules,
+    fully_shard as dt_fully_shard,
+)
+from veomni.distributed.parallel_state import init_parallel_state
+from veomni.utils.device import get_device_type, get_torch_device
+
+
+# ---------------------------------------------------------------------------
+# Toy models
+# ---------------------------------------------------------------------------
+
+class _ToyAttention(nn.Module):
+    """Minimal attention-like sub-module with a meaningful parameter count."""
+
+    def __init__(self, hidden: int = 32):
+        super().__init__()
+        self.q_proj = nn.Linear(hidden, hidden, bias=False)
+        self.k_proj = nn.Linear(hidden, hidden, bias=False)
+        self.v_proj = nn.Linear(hidden, hidden, bias=False)
+        self.o_proj = nn.Linear(hidden, hidden, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.o_proj(self.v_proj(self.k_proj(self.q_proj(x))))
+
+
+class _ToyMLP(nn.Module):
+    """Minimal MLP sub-module."""
+
+    def __init__(self, hidden: int = 32, intermediate: int = 64):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden, intermediate, bias=False)
+        self.up_proj = nn.Linear(hidden, intermediate, bias=False)
+        self.down_proj = nn.Linear(intermediate, hidden, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(
+            nn.functional.gelu(self.gate_proj(x)) * self.up_proj(x)
+        )
+
+
+class _ToyDecoderLayer(nn.Module):
+    """A tiny transformer decoder layer matching the standard sub-module pattern.
+
+    Named children: ``self_attn``, ``mlp``, ``input_layernorm``,
+    ``post_attention_layernorm``.
+    """
+
+    _no_split_modules = ["_ToyDecoderLayer"]
+
+    def __init__(self, hidden: int = 32, intermediate: int = 64):
+        super().__init__()
+        self.self_attn = _ToyAttention(hidden)
+        self.mlp = _ToyMLP(hidden, intermediate)
+        self.input_layernorm = nn.LayerNorm(hidden)
+        self.post_attention_layernorm = nn.LayerNorm(hidden)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.self_attn(self.input_layernorm(x))
+        x = x + self.mlp(self.post_attention_layernorm(x))
+        return x
+
+
+class _ToyDecoderModel(nn.Module):
+    """A small multi-layer transformer model for integration testing."""
+
+    _no_split_modules = ["_ToyDecoderLayer"]
+
+    def __init__(self, num_layers: int = 3, hidden: int = 32, intermediate: int = 64):
+        super().__init__()
+        self.embed = nn.Embedding(256, hidden)
+        self.layers = nn.ModuleList(
+            [_ToyDecoderLayer(hidden, intermediate) for _ in range(num_layers)]
+        )
+        self.final_norm = nn.LayerNorm(hidden)
+        self.lm_head = nn.Linear(hidden, 256, bias=False)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        x = self.embed(input_ids)
+        for layer in self.layers:
+            x = layer(x)
+        x = self.final_norm(x)
+        return self.lm_head(x).sum()
+
+
+# ---------------------------------------------------------------------------
+# Layer variants for discovery tests
+# ---------------------------------------------------------------------------
+
+class _LayerWithLinearAttn(nn.Module):
+    """Qwen3_5-style layer: ``linear_attn`` instead of ``self_attn``."""
+
+    def __init__(self, hidden: int = 32, intermediate: int = 64):
+        super().__init__()
+        self.linear_attn = _ToyAttention(hidden)
+        self.mlp = _ToyMLP(hidden, intermediate)
+        self.input_layernorm = nn.LayerNorm(hidden)
+        self.post_attention_layernorm = nn.LayerNorm(hidden)
+
+
+class _LayerWithHyperConnection(nn.Module):
+    """DeepSeekV4-style layer: ``attn_hc`` + ``ffn_hc`` in addition to standard modules."""
+
+    def __init__(self, hidden: int = 32, intermediate: int = 64):
+        super().__init__()
+        self.self_attn = _ToyAttention(hidden)
+        self.mlp = _ToyMLP(hidden, intermediate)
+        self.attn_hc = nn.Linear(hidden, hidden, bias=False)
+        self.ffn_hc = nn.Linear(hidden, hidden, bias=False)
+        self.input_layernorm = nn.LayerNorm(hidden)
+        self.post_attention_layernorm = nn.LayerNorm(hidden)
+
+
+class _LayerMinimal(nn.Module):
+    """A layer with only ``self_attn`` and norms — no ``mlp``."""
+
+    def __init__(self, hidden: int = 32):
+        super().__init__()
+        self.self_attn = _ToyAttention(hidden)
+        self.input_layernorm = nn.LayerNorm(hidden)
+        self.post_attention_layernorm = nn.LayerNorm(hidden)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — sub-module discovery (single-process, no GPU needed)
+# ---------------------------------------------------------------------------
+
+class TestSubmoduleDiscovery:
+    """Tests for :func:`discover_dtfsdp2_submodules`."""
+
+    def test_standard_layer(self):
+        """Standard attn + mlp + norms."""
+        layer = _ToyDecoderLayer()
+        result = discover_dtfsdp2_submodules(layer)
+        names = [n for n, _ in result]
+        assert "self_attn" in names
+        assert "mlp" in names
+        assert "input_layernorm" in names
+        assert "post_attention_layernorm" in names
+        # linear_attn, attn_hc, ffn_hc should NOT be present
+        assert "linear_attn" not in names
+        assert "attn_hc" not in names
+
+    def test_linear_attn_layer(self):
+        """Qwen3_5-style: linear_attn instead of self_attn."""
+        layer = _LayerWithLinearAttn()
+        result = discover_dtfsdp2_submodules(layer)
+        names = [n for n, _ in result]
+        assert "linear_attn" in names
+        assert "self_attn" not in names  # not present
+        assert "mlp" in names
+
+    def test_hyperconnection_layer(self):
+        """DeepSeekV4-style: attn_hc + ffn_hc."""
+        layer = _LayerWithHyperConnection()
+        result = discover_dtfsdp2_submodules(layer)
+        names = [n for n, _ in result]
+        assert "attn_hc" in names
+        assert "ffn_hc" in names
+        # Verify order: attn-like before mlp-like before hc-modules before norms
+        attn_idx = names.index("self_attn")
+        mlp_idx = names.index("mlp")
+        attn_hc_idx = names.index("attn_hc")
+        post_norm_idx = names.index("post_attention_layernorm")
+        assert attn_idx < mlp_idx < attn_hc_idx < post_norm_idx
+
+    def test_minimal_layer(self):
+        """Layer without mlp."""
+        layer = _LayerMinimal()
+        result = discover_dtfsdp2_submodules(layer)
+        names = [n for n, _ in result]
+        assert "self_attn" in names
+        assert "mlp" not in names  # missing → skipped
+        assert "input_layernorm" in names
+
+    def test_empty_layer(self):
+        """A bare nn.Module with no known sub-modules returns an empty list."""
+
+        class BareModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(8, 8)
+
+        layer = BareModule()
+        result = discover_dtfsdp2_submodules(layer)
+        # ``linear`` is not in DTFSDP2_SUB_MODULE_NAMES
+        assert len(result) == 0
+
+    def test_submodule_names_are_methods_not_modules(self):
+        """A module that has a regular method with a sub-module name is handled correctly.
+
+        getattr will return the method, but isinstance(method, nn.Module) is False.
+        """
+
+        class WeirdLayer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.real_mod = nn.Linear(8, 8)
+
+            def self_attn(self, x):
+                return x  # this is a method, not a module
+
+        layer = WeirdLayer()
+        result = discover_dtfsdp2_submodules(layer)
+        # The method ``self_attn`` should NOT be returned (it's not an nn.Module)
+        names = [n for n, _ in result]
+        assert "self_attn" not in names
+
+
+class TestDTFSDP2SubModuleNames:
+    """Validate the :data:`DTFSDP2_SUB_MODULE_NAMES` constant."""
+
+    def test_is_tuple(self):
+        assert isinstance(DTFSDP2_SUB_MODULE_NAMES, tuple)
+
+    def test_contains_essential_modules(self):
+        """The constant must include the most common sub-module names."""
+        essential = {"self_attn", "linear_attn", "mlp"}
+        assert essential <= set(DTFSDP2_SUB_MODULE_NAMES)
+
+    def test_attn_before_mlp(self):
+        """Attn modules should appear before mlp/ffn (forward execution order)."""
+        names = DTFSDP2_SUB_MODULE_NAMES
+        for attn_name in ("self_attn", "linear_attn"):
+            if attn_name in names:
+                assert names.index(attn_name) < names.index("mlp")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require FSDP2 / torch.distributed)
+# ---------------------------------------------------------------------------
+
+def _init_test_dist(rank: int, world_size: int, port: int):
+    """Initialise process group for testing on CPU (backend=gloo)."""
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    # Use gloo for CPU tests — FSDP2 supports gloo on CPU
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+
+
+def _build_and_run_dtfsdp2(rank, world_size, port, enable_dt: bool):
+    """Worker: build model with or without DT-FSDP2, run fwd/bwd, return loss."""
+    _init_test_dist(rank, world_size, port)
+
+    init_parallel_state(
+        dp_size=world_size,
+        dp_shard_size=world_size,
+        dp_mode="fsdp2",
+        device_type="cpu",
+    )
+
+    # Create model on CPU
+    model = _ToyDecoderModel(num_layers=3, hidden=32, intermediate=64)
+    # Create a copy for the native path so we start from the same initial state
+    model_copy = copy.deepcopy(model) if not enable_dt else None
+
+    if enable_dt:
+        apply_dt_fsdp2_patch()
+
+    # Import after potentially patching
+    from torch.distributed._composable.fsdp import fully_shard
+
+    # Apply FSDP2
+    if enable_dt:
+        # DT-FSDP2 path: per-sub-module
+        for layer in model.layers:
+            submods = discover_dtfsdp2_submodules(layer)
+            for _, sub_mod in submods:
+                fully_shard(sub_mod, hook_module=layer)
+        fully_shard(model)
+    else:
+        # Native FSDP2 path
+        for layer in model_copy.layers:
+            fully_shard(layer)
+        fully_shard(model_copy)
+
+    # Forward pass
+    target = model if enable_dt else model_copy
+    inp = torch.randint(0, 256, (2, 16))
+    out = target(inp)
+    if hasattr(out, "sum"):
+        out = out.sum()
+    out.backward()
+
+    # Verify gradients exist and are finite
+    grads_ok = True
+    for name, param in target.named_parameters():
+        if param.grad is not None:
+            if not torch.isfinite(param.grad).all():
+                grads_ok = False
+                break
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+    if not grads_ok:
+        raise AssertionError("Non-finite gradients detected!")
+    return out.item()
+
+
+def _build_and_run_native_fsdp2(rank, world_size, port):
+    """Worker for native FSDP2 path (separate function for clarity)."""
+    return _build_and_run_dtfsdp2(rank, world_size, port, enable_dt=False)
+
+
+def _build_and_run_dt_fsdp2(rank, world_size, port):
+    """Worker for DT-FSDP2 path."""
+    return _build_and_run_dtfsdp2(rank, world_size, port, enable_dt=True)
+
+
+class TestDTFSDP2Integration:
+    """End-to-end integration tests using torch.distributed."""
+
+    @pytest.mark.skipif(
+        not dist.is_available(),
+        reason="torch.distributed is not available",
+    )
+    def test_dt_fsdp2_forward_backward(self):
+        """DT-FSDP2 forward + backward completes without error on a toy model."""
+        import socket
+
+        import torch.multiprocessing as mp
+
+        world_size = 2
+        port = _find_free_port()
+
+        mp.spawn(
+            _build_and_run_dt_fsdp2,
+            args=(world_size, port),
+            nprocs=world_size,
+            join=True,
+        )
+
+    @pytest.mark.skipif(
+        not dist.is_available(),
+        reason="torch.distributed is not available",
+    )
+    def test_native_fsdp2_forward_backward(self):
+        """Sanity-check: native FSDP2 forward + backward works on the same model."""
+        import socket
+
+        import torch.multiprocessing as mp
+
+        world_size = 2
+        port = _find_free_port()
+
+        mp.spawn(
+            _build_and_run_native_fsdp2,
+            args=(world_size, port),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _find_free_port():
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -291,6 +291,18 @@ class FSDPConfig:
         default=True,
         metadata={"help": "Enable forward prefetch."},
     )
+    enable_dt_fsdp2: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Enable DT-FSDP2: splits each transformer layer's fully_shard "
+                "into per-sub-module (attn, mlp) fully_shard calls. Reduces peak "
+                "memory fragmentation for large MoE models by all-gathering only "
+                "the currently-needed sub-module's weights instead of the entire "
+                "layer. Requires fsdp_mode='fsdp2'."
+            )
+        },
+    )
     offload: bool = field(
         default=False,
         metadata={"help": "Enable CPU offload for FSDP2."},

--- a/veomni/distributed/dt_fsdp2.py
+++ b/veomni/distributed/dt_fsdp2.py
@@ -1,0 +1,830 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates.
+# Copyright (c) 2025-2026 Huawei Technologies Co., Ltd.
+#
+# DT-FSDP2: Disaggregated-Tensor Fully Sharded Data Parallel 2.
+#
+# A monkey-patch on PyTorch's native FSDP2 (``fully_shard``) that splits a
+# transformer layer's `fully_shard` into per-sub-module (attn, mlp, …) calls.
+# This avoids all-gathering the entire layer's weights at once, reducing peak
+# memory fragmentation for large MoE models.
+#
+# Adapted from MindSpeed-MM's reference implementation:
+#   mindspeed_mm/fsdp/ops/fully_shard/fully_shard.py
+#
+# Usage (called automatically by :func:`parallelize_model_fsdp2` when
+# ``train.accelerator.fsdp_config.enable_dt_fsdp2=True``)::
+#
+#     from veomni.distributed.dt_fsdp2 import apply_dt_fsdp2_patch
+#     apply_dt_fsdp2_patch()
+#     # Now ``fully_shard(..., hook_module=...)`` accepts the extra kwarg.
+
+import functools
+import weakref
+from typing import Any, Callable, List, NamedTuple, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from torch.distributed._composable import contract
+from torch.distributed._composable_state import _insert_module_state
+from torch.distributed.device_mesh import _get_device_handle
+from torch.distributed.tensor import DeviceMesh, Shard
+from torch.distributed.utils import _get_root_modules
+from torch.utils._pytree import tree_map
+
+# ---------------------------------------------------------------------------
+# Internal PyTorch FSDP2 imports (private API; may change across versions)
+# ---------------------------------------------------------------------------
+from torch.distributed.fsdp._fully_shard._fsdp_api import MixedPrecisionPolicy, OffloadPolicy
+from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
+    AllGatherResult,
+    foreach_all_gather_copy_out,
+    foreach_reduce,
+)
+from torch.distributed.fsdp._fully_shard._fsdp_common import (
+    FSDPMeshInfo,
+    HSDPMeshInfo,
+    TrainingState,
+    _cast_fp_tensor,
+    compiled_autograd_enabled,
+)
+from torch.distributed.fsdp._fully_shard._fsdp_init import (
+    _get_device_from_mesh,
+    _get_managed_modules,
+    _get_managed_states,
+    _get_post_forward_mesh_info,
+    _init_default_fully_shard_mesh,
+    _move_states_to_device,
+)
+from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam, alloc_storage
+from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPCommContext, FSDPParamGroup
+from torch.distributed.fsdp._fully_shard._fsdp_state import (
+    FSDPState,
+    _register_group_forward_hooks,
+    disable_if_config_true,
+    logger,
+)
+from torch.distributed.fsdp._fully_shard._fully_shard import FSDPModule, _unimplemented_deepcopy
+
+# ---------------------------------------------------------------------------
+# Global state
+# ---------------------------------------------------------------------------
+
+# Mapping from original module class to the dynamically created FSDP-wrapped class
+cls_to_fsdp_cls: dict[type, type] = {}
+
+# Tracks the number of communication contexts assigned to each hook module.
+# Key: hook_module, Value: count of contexts used (used to generate next index)
+HOOK_MODULE_COMM_CTX_COUNT: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+
+# ---------------------------------------------------------------------------
+# Extended NamedTuples (add hook_module field)
+# ---------------------------------------------------------------------------
+
+class AllGatherState(NamedTuple):
+    all_gather_result: AllGatherResult
+    event: torch.Event  # all-gather copy-out
+    hook_module: nn.Module
+
+
+class ReduceScatterState(NamedTuple):
+    reduce_scatter_input: torch.Tensor
+    event: torch.Event  # reduce-scatter event
+    hook_module: nn.Module
+
+
+class AllReduceState(NamedTuple):
+    all_reduce_input: torch.Tensor
+    event: torch.Event  # all-reduce event
+
+
+# ---------------------------------------------------------------------------
+# Core API: fully_shard (patched)
+# ---------------------------------------------------------------------------
+
+@contract(state_cls=FSDPState)
+def fully_shard(
+    module,
+    *,
+    mesh: Optional[DeviceMesh] = None,
+    reshard_after_forward: Union[bool, int] = True,
+    shard_placement_fn: Optional[Callable[[nn.Parameter], Optional[Shard]]] = None,
+    mp_policy: MixedPrecisionPolicy = MixedPrecisionPolicy(),
+    offload_policy: OffloadPolicy = OffloadPolicy(),
+    ignored_params: Optional[set[nn.Parameter]] = None,
+    hook_module: Optional[nn.Module] = None,
+):
+    """Applies FSDP2 to *module*, optionally registering hooks on *hook_module*.
+
+    When *hook_module* is provided, the forward pre/post hooks are registered
+    on *hook_module* instead of on *module* itself.  This allows multiple FSDP
+    units (e.g. ``self_attn`` and ``mlp``) to share a single hook-site
+    (typically the parent transformer block), aligning with activation
+    checkpointing boundaries.
+
+    Each unique *hook_module* receives an auto-incremented ``comm_ctx_index``
+    so that sub-modules within the same block get independent communication-
+    context slots, preventing buffer overwrites.
+
+    Args:
+        module: The module to shard.
+        mesh: DeviceMesh.  ``None`` creates a default 1D mesh.
+        reshard_after_forward: Whether to reshard after forward.
+        shard_placement_fn: Custom shard-dim placement callback.
+        mp_policy: Mixed-precision policy.
+        offload_policy: CPU offload policy.
+        ignored_params: Parameters to exclude from sharding.
+        hook_module: Module on which to register the FSDP hooks.
+            ``None`` (default) falls back to the standard behaviour
+            (hooks on *module* itself).
+    """
+    if isinstance(module, (nn.ModuleList, nn.ModuleDict)):
+        raise ValueError(
+            f"fully_shard does not support containers that do not implement forward: {module}"
+        )
+    mesh = mesh or _init_default_fully_shard_mesh()
+    if mesh.ndim not in (1, 2):
+        raise ValueError(f"fully_shard expects a 1D or 2D DeviceMesh but got {mesh}")
+    elif mesh.ndim == 1:
+        mesh_info = FSDPMeshInfo(mesh, shard_mesh_dim=0)
+    else:
+        if mesh.mesh_dim_names is None:
+            raise AssertionError(
+                "Please init the 2D mesh for HSDP with mesh_dim_names specified"
+            )
+        mesh_info = HSDPMeshInfo(mesh, shard_mesh_dim=1, replicate_mesh_dim=0)
+    device = _get_device_from_mesh(mesh)
+    post_forward_mesh_info = _get_post_forward_mesh_info(
+        reshard_after_forward, mesh_info
+    )
+
+    arg_module = module
+    modules = (
+        (module,) if isinstance(module, nn.Module) else tuple(_get_root_modules(module))
+    )
+    state = fully_shard.state(modules[0])  # type: ignore[attr-defined]
+
+    # Determine hook_module
+    if hook_module is not None:
+        _hook_module = hook_module
+    else:
+        _hook_module = modules[0] if len(modules) > 0 else modules
+
+    # Auto-increment comm_ctx_index
+    if _hook_module not in HOOK_MODULE_COMM_CTX_COUNT:
+        HOOK_MODULE_COMM_CTX_COUNT[_hook_module] = 0
+    comm_ctx_index = HOOK_MODULE_COMM_CTX_COUNT[_hook_module]
+    HOOK_MODULE_COMM_CTX_COUNT[_hook_module] = comm_ctx_index + 1
+
+    # Initialize state with custom parameters
+    state.init(
+        modules,
+        device,
+        mp_policy,
+        hook_module=hook_module,
+        comm_ctx_index=comm_ctx_index,
+    )
+
+    managed_modules = _get_managed_modules(modules, ignored_params)
+    params, buffers = _get_managed_states(managed_modules, ignored_params)
+
+    _move_states_to_device(params, buffers, device)
+    if params:
+        state._fsdp_param_group = FSDPParamGroup(
+            params,
+            modules,
+            mesh_info,
+            post_forward_mesh_info,
+            device,
+            shard_placement_fn,
+            mp_policy,
+            offload_policy,
+        )
+
+    # For Dynamo
+    for managed_module in managed_modules:
+        managed_module._is_fsdp_managed_module = True  # type: ignore[assignment]
+        managed_module._fsdp_use_orig_params = True  # type: ignore[assignment]
+
+    # Place FSDP leftmost for highest priority in the method resolution order
+    for mod in modules:
+        cls = mod.__class__
+        new_cls = cls_to_fsdp_cls.get(cls, None)
+        if not new_cls:
+            dct = {"__deepcopy__": _unimplemented_deepcopy}
+            new_cls = type(f"FSDP{cls.__name__}", (FSDPModule, cls), dct)
+            cls_to_fsdp_cls[cls] = new_cls
+        mod.__class__ = new_cls
+    return arg_module
+
+
+# ---------------------------------------------------------------------------
+# Patched FSDPState methods
+# ---------------------------------------------------------------------------
+
+def hook_module_init(
+    self,
+    modules: Tuple[nn.Module, ...],
+    device: torch.device,
+    mp_policy: MixedPrecisionPolicy,
+    hook_module: Optional[nn.Module] = None,
+    comm_ctx_index: int = 0,
+) -> None:
+    """Custom ``FSDPState.init`` that supports *hook_module* and *comm_ctx_index*.
+
+    When *hook_module* is given the forward hooks are registered on that
+    module instead of on the first managed module.
+    """
+    for mod in modules:
+        _insert_module_state(mod, self)
+    self._modules = modules
+    self._device = device
+    self._device_handle = _get_device_handle(device.type)
+    self._mp_policy = mp_policy
+    self.comm_ctx_index = comm_ctx_index
+
+    # Register hooks
+    if hook_module is not None:
+        self._pre_forward_hook_handle = hook_module.register_forward_pre_hook(
+            self._pre_forward, prepend=True, with_kwargs=True
+        )
+        self._post_forward_hook_handle = hook_module.register_forward_hook(
+            self._post_forward, prepend=False
+        )
+        self.hook_module = weakref.ref(hook_module)
+    else:
+        if len(modules) == 1:
+            self._pre_forward_hook_handle = modules[0].register_forward_pre_hook(
+                self._pre_forward, prepend=True, with_kwargs=True
+            )
+            self._post_forward_hook_handle = modules[0].register_forward_hook(
+                self._post_forward, prepend=False
+            )
+        else:
+            hook_handle = _register_group_forward_hooks(
+                modules,
+                self._pre_forward,
+                self._post_forward,
+                self._modules_to_run_forward,
+            )
+            self._pre_forward_hook_handle = hook_handle
+            self._post_forward_hook_handle = hook_handle
+        self.hook_module = weakref.ref(modules[0])
+
+
+def _copy_fsdp_comm_ctx(new_comm_ctx: FSDPCommContext, comm_ctx: FSDPCommContext) -> FSDPCommContext:
+    """Copy critical stream and state references from *comm_ctx* to *new_comm_ctx*.
+
+    Streams are **shared** (same objects), while state slots
+    (``all_gather_state``, ``reduce_scatter_state``, ``post_forward_order``)
+    are independent per context.
+    """
+    new_comm_ctx.device_handle = comm_ctx.device_handle
+
+    # Share streams
+    new_comm_ctx.all_gather_copy_in_stream = comm_ctx.all_gather_copy_in_stream
+    new_comm_ctx.all_gather_stream = comm_ctx.all_gather_stream
+    new_comm_ctx.reduce_scatter_stream = comm_ctx.reduce_scatter_stream
+    new_comm_ctx.all_reduce_stream = comm_ctx.all_reduce_stream
+
+    # Copy initial state (these will diverge after first use)
+    new_comm_ctx.all_gather_state = comm_ctx.all_gather_state
+    new_comm_ctx.reduce_scatter_state = comm_ctx.reduce_scatter_state
+    new_comm_ctx.post_forward_order = comm_ctx.post_forward_order
+
+    return new_comm_ctx
+
+
+def hook_module_init_shared_state(self) -> None:
+    """Custom ``FSDPState._init_shared_state`` that creates a ``global_comm_ctx`` list.
+
+    Every unique ``comm_ctx_index`` used by any state in the tree gets its
+    own ``FSDPCommContext`` entry.  States that share the same index reuse
+    the same context (and therefore the same state slots), while states with
+    different indices get independent slots (but share physical CUDA streams).
+    """
+    self._comm_ctx.lazy_init(self._device)
+    if not hasattr(self, "global_comm_ctx"):
+        self.global_comm_ctx = [self._comm_ctx]
+
+    # Collect all unique comm_ctx_indices
+    global_comm_ctx_list = [0]
+    for state in self._state_ctx.all_states:
+        if state.comm_ctx_index not in global_comm_ctx_list:
+            global_comm_ctx_list.append(state.comm_ctx_index)
+            new_comm_ctx = FSDPCommContext()
+            new_comm_ctx = _copy_fsdp_comm_ctx(new_comm_ctx, self._comm_ctx)
+            self.global_comm_ctx.append(new_comm_ctx)
+
+    # Assign the correct comm_ctx to each state based on its index
+    for state in self._state_ctx.all_states:
+        state._state_ctx = self._state_ctx
+        _comm_ctx = self.global_comm_ctx[global_comm_ctx_list.index(state.comm_ctx_index)]
+        setattr(state, "global_comm_ctx", self.global_comm_ctx)
+        state._comm_ctx = _comm_ctx
+        if fsdp_param_group := state._fsdp_param_group:
+            fsdp_param_group.comm_ctx = _comm_ctx
+            setattr(fsdp_param_group, "hook_module", state.hook_module)
+            setattr(fsdp_param_group, "global_comm_ctx", self.global_comm_ctx)
+
+
+def _root_post_backward_final_callback(self) -> None:
+    """Custom root post-backward callback that synchronises ALL global_comm_ctx entries."""
+    if not compiled_autograd_enabled():
+        logger.debug("FSDP::root_post_backward")
+    with torch.profiler.record_function("FSDP::root_post_backward_callback"):
+        for state in self._state_ctx.all_states:
+            fsdp_param_group = state._fsdp_param_group
+            if (
+                fsdp_param_group
+                and fsdp_param_group._training_state != TrainingState.POST_BACKWARD
+            ):
+                fsdp_param_group.post_backward()
+            state._training_state = TrainingState.IDLE
+            if fsdp_param_group:
+                fsdp_param_group._training_state = TrainingState.IDLE
+            if self._state_ctx.is_last_backward:
+                state._finalize_backward()
+        if self._state_ctx.is_last_backward:
+            self._comm_ctx.post_forward_order.clear()
+            if self._comm_ctx.reduce_scatter_state is not None:
+                self._device_handle.current_stream().wait_event(
+                    self._comm_ctx.reduce_scatter_state.event
+                )
+                self._comm_ctx.reduce_scatter_state = None
+
+            # Wait for ALL global comm contexts
+            if hasattr(self, "global_comm_ctx"):
+                for _comm_ctx in self.global_comm_ctx:
+                    _comm_ctx.post_forward_order.clear()
+                    if _comm_ctx.reduce_scatter_state is not None:
+                        self._device_handle.current_stream().wait_event(
+                            _comm_ctx.reduce_scatter_state.event
+                        )
+                    _comm_ctx.reduce_scatter_state = None
+
+        self._state_ctx.post_backward_final_callback_queued = False
+
+
+@disable_if_config_true
+def _pre_forward(
+    self, module: nn.Module, args: Tuple[Any, ...], kwargs: dict[str, Any]
+) -> Tuple[Tuple[Any, ...], dict[str, Any]]:
+    """Custom pre-forward that waits for all global_comm_ctx AG events before prefetching.
+
+    Optimization 2: Refined event dependencies — wait for ALL previous
+    all-gather events (across all global_comm_ctx slots) before triggering
+    a new prefetch, preventing excessive prefetch and bandwidth contention.
+    """
+    if self._training_state == TrainingState.PRE_BACKWARD:
+        return args, kwargs
+    self._training_state = TrainingState.FORWARD
+    args, kwargs = self._root_pre_forward(module, args, kwargs)
+    if self._mp_policy.cast_forward_inputs and self._mp_policy.param_dtype:
+        with torch.profiler.record_function("FSDP::cast_forward_inputs"):
+            cast_fn = functools.partial(
+                _cast_fp_tensor, self._mp_policy.param_dtype
+            )
+            args, kwargs = tree_map(cast_fn, args), tree_map(cast_fn, kwargs)
+    if self._fsdp_param_group:
+        args, kwargs = self._fsdp_param_group.pre_forward(module, args, kwargs)
+    for fsdp_state in self._states_to_forward_prefetch:
+        if (target_param_group := fsdp_state._fsdp_param_group) is not None:
+            prefetch_all_gather_copy_in_stream = target_param_group.comm_ctx.all_gather_copy_in_stream
+            # Wait for ALL previous global AG events before this prefetch
+            for comm_ctx in self.global_comm_ctx:
+                if comm_ctx.all_gather_state and comm_ctx.all_gather_state.event:
+                    prefetch_all_gather_copy_in_stream.wait_event(
+                        comm_ctx.all_gather_state.event
+                    )
+            FSDPParamGroup._prefetch_unshard(target_param_group, "forward")
+    return args, kwargs
+
+
+@disable_if_config_true
+def _post_forward(self, module: nn.Module, input: Any, output: Any) -> Any:
+    """Custom post-forward that frees all-gather states for ALL global_comm_ctx entries."""
+    if self._training_state == TrainingState.PRE_BACKWARD:
+        return output
+    if self._fsdp_param_group:
+        output = self._fsdp_param_group.post_forward(module, input, output)
+    output = self._register_pre_backward_hook(output)
+    self._training_state = TrainingState.IDLE
+    if self._state_ctx.iter_forward_root is self:
+        for comm_ctx in self.global_comm_ctx:
+            if comm_ctx.all_gather_state:
+                self._comm_ctx.all_gather_copy_in_stream.wait_event(
+                    comm_ctx.all_gather_state.event
+                )
+                self._comm_ctx.all_gather_stream.wait_event(comm_ctx.all_gather_state.event)
+            comm_ctx.all_gather_state = None  # free the all-gather result
+        self._state_ctx.iter_forward_root = None
+    if self._mp_policy.output_dtype is not None:
+        with torch.profiler.record_function("FSDP::cast_forward_outputs"):
+            output = tree_map(
+                functools.partial(_cast_fp_tensor, self._mp_policy.output_dtype),
+                output,
+            )
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Patched FSDPParamGroup methods — PyTorch 2.7 variant
+# ---------------------------------------------------------------------------
+
+def _pt27_wait_for_unshard(self):
+    """Wait for preceding AG operations (PyTorch 2.7 API).
+
+    Skips waiting when the previous all-gather belongs to the SAME
+    hook_module (same-layer sub-modules don't block each other).
+    """
+    if not self._all_gather_result:
+        return
+    async_op = self._all_gather_result.all_gather_work is not None
+    if self._training_state == TrainingState.FORWARD:  # implicit prefetch
+        for comm_ctx in self.global_comm_ctx:
+            if prev_all_gather_state := comm_ctx.all_gather_state:
+                if prev_all_gather_state.hook_module != self.hook_module:
+                    self._wait_all_gather_streams_on_event(prev_all_gather_state.event)
+                    comm_ctx.all_gather_state = None  # free
+
+    with torch.profiler.record_function(self._with_fqn("FSDP::all_gather_copy_out")):
+        foreach_all_gather_copy_out(
+            self._all_gather_result,
+            self.fsdp_params,
+            self._all_gather_process_group,
+        )
+    for fsdp_param in self.fsdp_params:
+        fsdp_param.init_unsharded_param()
+    self._to_unsharded()
+    all_gather_copy_out_event = self.device_handle.Event()
+    all_gather_copy_out_event.record()
+    if not async_op and self._training_state == TrainingState.FORWARD:
+        self.comm_ctx.all_gather_state = AllGatherState(
+            self._all_gather_result, all_gather_copy_out_event, self.hook_module
+        )
+    else:
+        self._wait_all_gather_streams_on_event(all_gather_copy_out_event)
+    self._all_gather_result = None  # free unless saved in `all_gather_state`
+
+
+def _pt27_post_backward(self, *unused: Any):
+    """Custom post-backward for PyTorch 2.7.
+
+    Waits for reduce-scatter events from OTHER hook modules before reducing.
+    """
+    if not compiled_autograd_enabled():
+        logger.debug("%s", self._with_fqn("FSDP::post_backward"))
+    self._training_state = TrainingState.POST_BACKWARD
+    with torch.profiler.record_function(self._with_fqn("FSDP::post_backward_accumulate")):
+        for fsdp_param in self.fsdp_params:
+            fsdp_param.accumulate_unsharded_grad_if_needed()
+
+    with torch.profiler.record_function(self._with_fqn("FSDP::post_backward_reshard")):
+        if not self.reduce_grads:
+            if self.reshard_after_backward:
+                self.reshard()
+            for fsdp_param in self.fsdp_params:
+                fsdp_param.to_accumulated_grad_if_needed()
+            return
+        fsdp_params_with_grad: list[FSDPParam] = []
+        unsharded_grads: list[torch.Tensor] = []
+        for fsdp_param in self.fsdp_params:
+            if not hasattr(fsdp_param, "_unsharded_param"):
+                continue
+            if fsdp_param.unsharded_accumulated_grad is not None:
+                fsdp_params_with_grad.append(fsdp_param)
+                unsharded_grads.append(fsdp_param.unsharded_accumulated_grad_data)
+                fsdp_param.unsharded_accumulated_grad = None
+            elif fsdp_param.unsharded_param.grad is not None:
+                fsdp_params_with_grad.append(fsdp_param)
+                unsharded_grads.append(fsdp_param.unsharded_grad_data)
+                fsdp_param.unsharded_param.grad = None
+        if self.reshard_after_backward:
+            self.reshard()
+
+    if len(fsdp_params_with_grad) == 0:
+        return
+
+    with torch.profiler.record_function(self._with_fqn("FSDP::post_backward_reduce")):
+        # Wait for local context reduce-scatter
+        if (
+            self.comm_ctx.reduce_scatter_state is not None
+            and self.comm_ctx.reduce_scatter_state.event is not None
+        ):
+            self.device_handle.current_stream().wait_event(
+                self.comm_ctx.reduce_scatter_state.event
+            )
+            self.comm_ctx.reduce_scatter_state = None
+
+        # Wait for GLOBAL context reduce-scatters from DIFFERENT hook modules
+        for comm_ctx in self.global_comm_ctx:
+            if (
+                comm_ctx.reduce_scatter_state
+                and comm_ctx.reduce_scatter_state.event is not None
+                and comm_ctx.reduce_scatter_state.hook_module != self.hook_module
+            ):
+                self.device_handle.current_stream().wait_event(
+                    comm_ctx.reduce_scatter_state.event
+                )
+                comm_ctx.reduce_scatter_state = None
+
+        all_reduce_pg = self._all_reduce_process_group if self._is_hsdp else None
+        all_reduce_stream: torch.cuda.Stream
+        if all_reduce_pg is None and self._all_reduce_hook_stream is not None:
+            if self._all_reduce_hook is None:
+                raise AssertionError(
+                    "all reduce hook stream is specified but hook itself is missing."
+                )
+            all_reduce_stream = self._all_reduce_hook_stream
+        else:
+            all_reduce_stream = self.comm_ctx.all_reduce_stream
+
+        self._wait_for_post_backward()
+        (
+            reduce_scatter_input,
+            reduce_scatter_event,
+            self._post_reduce_event,
+            all_reduce_input,
+            all_reduce_event,
+            self._partial_reduce_output,
+        ) = foreach_reduce(
+            fsdp_params_with_grad,
+            unsharded_grads,
+            self._reduce_scatter_process_group,
+            self.comm_ctx.reduce_scatter_stream,
+            self._orig_dtype,
+            self._reduce_dtype,
+            self.device,
+            self.reduce_scatter_reduce_op,
+            self._all_reduce_process_group if self._is_hsdp else None,
+            all_reduce_stream,
+            self.all_reduce_grads,
+            self._partial_reduce_output,
+            self._all_reduce_hook,
+        )
+
+        self.comm_ctx.reduce_scatter_state = ReduceScatterState(
+            reduce_scatter_input, reduce_scatter_event, self.hook_module
+        )
+        if all_reduce_input is not None:
+            if all_reduce_event is None:
+                raise AssertionError("all_reduce_event cannot be None.")
+            self._all_reduce_state = AllReduceState(
+                all_reduce_input, all_reduce_event
+            )
+
+
+# ---------------------------------------------------------------------------
+# Patched FSDPParamGroup methods — PyTorch ≥ 2.9 variant
+# ---------------------------------------------------------------------------
+
+def _pt29_wait_for_unshard(self):
+    """Wait for preceding AG operations (PyTorch ≥ 2.9 API).
+
+    Adds a world_size==1 fast-path and uses the updated ``foreach_reduce``
+    signature (``_reduce_scatter_comm``, ``gradient_divide_factor``,
+    ``force_sum_reduction_for_comms``).
+    """
+    if not self._all_gather_result:
+        return
+    async_op = self._all_gather_result.all_gather_work is not None
+    if self._training_state == TrainingState.FORWARD:  # implicit prefetch
+        for comm_ctx in self.global_comm_ctx:
+            if prev_all_gather_state := comm_ctx.all_gather_state:
+                if prev_all_gather_state.hook_module != self.hook_module:
+                    self._wait_all_gather_streams_on_event(prev_all_gather_state.event)
+                    comm_ctx.all_gather_state = None  # free
+    world_size = self._all_gather_process_group.size()
+    if world_size == 1:
+        for fsdp_param in self.fsdp_params:
+            all_gather_input = fsdp_param.all_gather_inputs[0]
+            fsdp_param.init_all_gather_outputs(
+                [all_gather_input.numel()],
+                [all_gather_input.dtype],
+                world_size,
+                self.device,
+                force_recreate=False,
+            )
+            tensor = fsdp_param.all_gather_outputs[0]
+            alloc_storage(tensor)
+            with torch.autograd._unsafe_preserve_version_counter(tensor):
+                tensor.copy_(all_gather_input)
+    else:
+        with torch.profiler.record_function(self._with_fqn("FSDP::all_gather_copy_out")):
+            foreach_all_gather_copy_out(
+                self._all_gather_result,
+                self.fsdp_params,
+                self._all_gather_process_group,
+            )
+
+    for fsdp_param in self.fsdp_params:
+        fsdp_param.init_unsharded_param()
+    self._to_unsharded()
+    all_gather_copy_out_event = self.device_handle.Event()
+    all_gather_copy_out_event.record()
+
+    if not async_op and self._training_state == TrainingState.FORWARD and world_size > 1:
+        self.comm_ctx.all_gather_state = AllGatherState(
+            self._all_gather_result, all_gather_copy_out_event, self.hook_module
+        )
+    else:
+        self._wait_all_gather_streams_on_event(all_gather_copy_out_event)
+    self._all_gather_result = None  # free unless saved in `all_gather_state`
+
+
+def _pt29_post_backward(self, *unused: Any):
+    """Custom post-backward for PyTorch ≥ 2.9.
+
+    Uses updated ``foreach_reduce`` signature with ``_reduce_scatter_comm``,
+    ``gradient_divide_factor``, and ``force_sum_reduction_for_comms``.
+    """
+    if not compiled_autograd_enabled():
+        logger.debug("%s", self._with_fqn("FSDP::post_backward"))
+    self._training_state = TrainingState.POST_BACKWARD
+    with torch.profiler.record_function(self._with_fqn("FSDP::post_backward_accumulate")):
+        for fsdp_param in self.fsdp_params:
+            fsdp_param.accumulate_unsharded_grad_if_needed()
+
+    with torch.profiler.record_function(self._with_fqn("FSDP::post_backward_reshard")):
+        if not self.reduce_grads:
+            if self.reshard_after_backward:
+                self.reshard()
+            for fsdp_param in self.fsdp_params:
+                fsdp_param.to_accumulated_grad_if_needed()
+            return
+        fsdp_params_with_grad: list[FSDPParam] = []
+        unsharded_grads: list[torch.Tensor] = []
+        for fsdp_param in self.fsdp_params:
+            if not hasattr(fsdp_param, "_unsharded_param"):
+                continue
+            if fsdp_param.unsharded_accumulated_grad is not None:
+                fsdp_params_with_grad.append(fsdp_param)
+                unsharded_grads.append(fsdp_param.unsharded_accumulated_grad_data)
+                fsdp_param.unsharded_accumulated_grad = None
+            elif fsdp_param.unsharded_param.grad is not None:
+                fsdp_params_with_grad.append(fsdp_param)
+                unsharded_grads.append(fsdp_param.unsharded_grad_data)
+                fsdp_param.unsharded_param.grad = None
+        if self.reshard_after_backward:
+            self.reshard()
+
+    if len(fsdp_params_with_grad) == 0:
+        return
+
+    with torch.profiler.record_function(self._with_fqn("FSDP::post_backward_reduce")):
+        # Wait for local context reduce-scatter
+        if (
+            self.comm_ctx.reduce_scatter_state is not None
+            and self.comm_ctx.reduce_scatter_state.event is not None
+        ):
+            self.device_handle.current_stream().wait_event(
+                self.comm_ctx.reduce_scatter_state.event
+            )
+            self.comm_ctx.reduce_scatter_state = None
+
+        # Wait for GLOBAL context reduce-scatters from DIFFERENT hook modules
+        for comm_ctx in self.global_comm_ctx:
+            if (
+                comm_ctx.reduce_scatter_state
+                and comm_ctx.reduce_scatter_state.hook_module != self.hook_module
+            ):
+                self.device_handle.current_stream().wait_event(
+                    comm_ctx.reduce_scatter_state.event
+                )
+                comm_ctx.reduce_scatter_state = None
+
+        all_reduce_pg = self._all_reduce_process_group if self._is_hsdp else None
+        all_reduce_stream: torch.cuda.Stream
+        if all_reduce_pg is None and self._all_reduce_hook_stream is not None:
+            if self._all_reduce_hook is None:
+                raise AssertionError(
+                    "all reduce hook stream is specified but hook itself is missing."
+                )
+            all_reduce_stream = self._all_reduce_hook_stream
+        else:
+            all_reduce_stream = self.comm_ctx.all_reduce_stream
+
+        self._wait_for_post_backward()
+        (
+            reduce_scatter_input,
+            reduce_scatter_event,
+            self._post_reduce_event,
+            all_reduce_input,
+            all_reduce_event,
+            self._partial_reduce_output,
+        ) = foreach_reduce(
+            fsdp_params_with_grad,
+            unsharded_grads,
+            self._reduce_scatter_process_group,
+            self.comm_ctx.reduce_scatter_stream,
+            self._reduce_scatter_comm,
+            self._orig_dtype,
+            self._reduce_dtype,
+            self.device,
+            self.gradient_divide_factor,
+            self._all_reduce_process_group if self._is_hsdp else None,
+            all_reduce_stream,
+            self.all_reduce_grads,
+            self._partial_reduce_output,
+            self._all_reduce_hook,
+            self.force_sum_reduction_for_comms,
+        )
+
+        self.comm_ctx.reduce_scatter_state = ReduceScatterState(
+            reduce_scatter_input, reduce_scatter_event, self.hook_module
+        )
+        if all_reduce_input is not None:
+            if all_reduce_event is None:
+                raise AssertionError("all_reduce_event cannot be None.")
+            self._all_reduce_state = AllReduceState(
+                all_reduce_input, all_reduce_event
+            )
+
+
+# ---------------------------------------------------------------------------
+# Patch application
+# ---------------------------------------------------------------------------
+
+def apply_dt_fsdp2_patch() -> None:
+    """Apply all DT-FSDP2 monkey-patches.  Must be called BEFORE any ``fully_shard``.
+
+    Patches:
+    - ``FSDPState.init``, ``_init_shared_state``, ``_pre_forward``,
+      ``_post_forward``, ``_root_post_backward_final_callback``
+    - ``FSDPParamGroup.wait_for_unshard``, ``post_backward``
+    - ``torch.distributed.fsdp.fully_shard``
+
+    The PyTorch version variant is auto-detected at call time so the same
+    code works on both NPU (torch 2.7.1) and GPU (torch 2.11.0).
+    """
+    # Patch FSDPState methods
+    FSDPState.init = hook_module_init
+    FSDPState._init_shared_state = hook_module_init_shared_state
+    FSDPState._root_post_backward_final_callback = _root_post_backward_final_callback
+    FSDPState._pre_forward = _pre_forward
+    FSDPState._post_forward = _post_forward
+
+    # Patch FSDPParamGroup methods — version-adaptive
+    if hasattr(FSDPParamGroup, "_reduce_scatter_comm"):
+        # PyTorch ≥ 2.9 (includes 2.11.0 on GPU)
+        FSDPParamGroup.wait_for_unshard = _pt29_wait_for_unshard
+        FSDPParamGroup.post_backward = _pt29_post_backward
+    elif hasattr(FSDPParamGroup, "reduce_scatter_reduce_op"):
+        # PyTorch 2.7 (NPU)
+        FSDPParamGroup.wait_for_unshard = _pt27_wait_for_unshard
+        FSDPParamGroup.post_backward = _pt27_post_backward
+    else:
+        raise RuntimeError(
+            f"DT-FSDP2: Unsupported PyTorch {torch.__version__}. "
+            f"FSDPParamGroup API does not match any known variant."
+        )
+
+    # Override the public fully_shard API in torch.distributed.fsdp (which
+    # is the same object as torch.distributed._composable.fsdp.fully_shard
+    # — PyTorch re-exports it).
+    import torch.distributed.fsdp as fsdp
+
+    fsdp.fully_shard = fully_shard
+
+    # Also patch the _composable.fsdp module so that existing imports in
+    # VeOmni (which use `from torch.distributed._composable.fsdp import
+    # fully_shard`) pick up the patched version when re-imported.
+    import torch.distributed._composable.fsdp as _composable_fsdp
+
+    _composable_fsdp.fully_shard = fully_shard
+
+
+# ---------------------------------------------------------------------------
+# Sub-module discovery for automatic DT-FSDP2 sharding
+# ---------------------------------------------------------------------------
+
+#: Known sub-module attribute names on transformer decoder layers, in the
+#: order they are executed during forward (attn-first, then mlp/ffn, then
+#: norms/other).  Missing attributes are silently skipped so this one list
+#: works across all model architectures.
+DTFSDP2_SUB_MODULE_NAMES: Tuple[str, ...] = (
+    "self_attn",                # Standard attention (Llama, Qwen, DeepSeek, GPT-OSS …)
+    "linear_attn",              # Qwen3_5 GatedDeltaNet (per-layer choice)
+    "mlp",                      # Dense MLP **or** SparseMoE block — all models use ``mlp``
+    "attn_hc",                  # DeepSeekV4 HyperConnection (attention path)
+    "ffn_hc",                   # DeepSeekV4 HyperConnection (FFN path)
+    "input_layernorm",          # Pre-attention LayerNorm / RMSNorm
+    "post_attention_layernorm",  # Pre-FFN LayerNorm / RMSNorm
+)
+
+
+def discover_dtfsdp2_submodules(layer_mod: nn.Module) -> List[Tuple[str, nn.Module]]:
+    """Return ``(attr_name, sub_module)`` pairs that DT-FSDP2 should shard individually.
+
+    Only children that actually exist on *layer_mod* and that are not already
+    wrapped as ``FSDPModule`` (e.g. expert-parallel expert modules) are returned.
+    The order follows :data:`DTFSDP2_SUB_MODULE_NAMES` which matches the typical
+    forward execution order (attn → mlp → norms).
+    """
+    result: List[Tuple[str, nn.Module]] = []
+    for attr_name in DTFSDP2_SUB_MODULE_NAMES:
+        sub = getattr(layer_mod, attr_name, None)
+        if sub is not None and isinstance(sub, nn.Module) and not isinstance(sub, FSDPModule):
+            result.append((attr_name, sub))
+    return result

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -73,6 +73,17 @@ def _check_extra_parallel_dim0_divisibility(model: "nn.Module", para_name: str, 
     return True
 
 
+def _collect_param_fqns_from_modules(
+    submods: List[Tuple[str, "nn.Module"]],
+) -> set:
+    """Return the set of parameter FQN strings covered by *submods* (relative to their parent)."""
+    covered: set = set()
+    for sub_name, sub_mod in submods:
+        for param_name, _ in sub_mod.named_parameters():
+            covered.add(f"{sub_name}.{param_name}")
+    return covered
+
+
 def parallelize_model_fsdp2(
     model: "nn.Module",
     weights_path: Optional[str] = None,
@@ -107,6 +118,21 @@ def parallelize_model_fsdp2(
     """
 
     parallel_state = get_parallel_state()
+
+    # ── DT-FSDP2: apply monkey-patches before any fully_shard call ──────
+    enable_dt_fsdp2 = kwargs.pop("enable_dt_fsdp2", False)
+    if enable_dt_fsdp2:
+        from veomni.distributed.dt_fsdp2 import (
+            apply_dt_fsdp2_patch,
+            discover_dtfsdp2_submodules,
+            fully_shard as _dt_fully_shard,
+        )
+
+        apply_dt_fsdp2_patch()
+        _fully_shard = _dt_fully_shard  # patched (hook_module-capable)
+        logger.info_rank0("DT-FSDP2 patch applied (per-sub-module fully_shard mode).")
+    else:
+        _fully_shard = fully_shard  # original (module-level import)
 
     model_no_split_modules = getattr(model, "_no_split_modules", None) or []
     target_classes = set(model_no_split_modules) | set(basic_modules or [])
@@ -269,7 +295,7 @@ def parallelize_model_fsdp2(
     #     | -- no more target module or extra parallel module
     #   | -- other module (e.g. attention, if provided)
     # e.g. Decoder Layer
-    # | -- layers that are sharded by fully_shard(decode_layer) (e.g., Attention)
+    # | -- layers that are sharded by _fully_shard(decode_layer) (e.g., Attention)
     # | -- experts layer (apply fully_shard separately in order to shard across EP groups on the same EP rank instead of sharding globally)
     # | -- layers (declared in model.modules_to_ignore_in_mixed_precision) that need to apply fully_shard separately due to different mp policy as the decoder layer
     #      (e.g., some models requires MoE TopK gate layer to have parameters in higher FP32 precision in forward).
@@ -298,7 +324,7 @@ def parallelize_model_fsdp2(
                 and not isinstance(extra_parallel_mod[para], FSDPModule)
             ):
                 # shard para module (e.g. expert/decoder.moe, embed_tokens/decoder.embed_tokens)
-                fully_shard(extra_parallel_mod[para], **extra_parallel_fsdp_kwargs[para])
+                _fully_shard(extra_parallel_mod[para], **extra_parallel_fsdp_kwargs[para])
                 # average para (e.g. ep) grads across para (e.g. ep) ranks
                 # NOTE: in torch 2.8 and later we should use
                 # experts_mod.set_gradient_divide_factor(parallel_state.ep_size)
@@ -317,7 +343,7 @@ def parallelize_model_fsdp2(
         if mp_ignored_classes:
             for sub_mod in layer_mod.modules():
                 if isinstance(sub_mod, mp_ignored_classes) and sub_mod is not layer_mod:
-                    fully_shard(sub_mod, **fsdp_kwargs_without_mp)
+                    _fully_shard(sub_mod, **fsdp_kwargs_without_mp)
                     layer_mod._fsdp_modules.append(sub_mod)
 
         # Shard everything else in the module:
@@ -327,8 +353,33 @@ def parallelize_model_fsdp2(
         #      is the parent of or equal to extra_parallel_mod[para] (e.g. ToyEmbed),
         #      no need to shard layer_mod again.
         if not isinstance(layer_mod, FSDPModule):
-            fully_shard(layer_mod, **fsdp_kwargs)
-            layer_mod._fsdp_modules.append(layer_mod)
+            if enable_dt_fsdp2:
+                # ── DT-FSDP2 path: split into per-sub-module fully_shard ──
+                submods = discover_dtfsdp2_submodules(layer_mod)
+                for sub_name, sub_mod in submods:
+                    if not isinstance(sub_mod, FSDPModule):
+                        _fully_shard(
+                            sub_mod,
+                            hook_module=layer_mod,
+                            **fsdp_kwargs,
+                        )
+                        layer_mod._fsdp_modules.append(sub_mod)
+
+                # Defensive: warn about any params not covered by named sub-modules
+                covered = _collect_param_fqns_from_modules(submods)
+                all_params = set(dict(layer_mod.named_parameters()).keys())
+                if uncovered := all_params - covered:
+                    logger.warning_rank0(
+                        f"DT-FSDP2: layer {layer_fqn} has parameters outside known "
+                        f"sub-modules: {sorted(uncovered)}. Wrapping the whole layer "
+                        f"as a fallback."
+                    )
+                    _fully_shard(layer_mod, **fsdp_kwargs)
+                    layer_mod._fsdp_modules.append(layer_mod)
+            else:
+                # ── Default path: single fully_shard for the whole layer ──
+                _fully_shard(layer_mod, **fsdp_kwargs)
+                layer_mod._fsdp_modules.append(layer_mod)
         logger.info_rank0(f"{layer_fqn=}, {layer_mod._fsdp_modules=}")
 
     # Shard root WITHOUT explicit `reshard_after_forward` so FSDP2's
@@ -341,11 +392,13 @@ def parallelize_model_fsdp2(
     # to a freed buffer. Decoder layers reshard normally (their calls
     # above pass `reshard_after_forward` explicitly).
     root_fsdp_kwargs = {k: v for k, v in fsdp_kwargs.items() if k != "reshard_after_forward"}
-    fully_shard(model, **root_fsdp_kwargs)
+    _fully_shard(model, **root_fsdp_kwargs)
 
     # configure manual prefetching when needed
     need_manual_prefetch = (
-        parallel_state.any_extra_parallel_enabled or mp_ignored_classes is not None
+        enable_dt_fsdp2  # DT-FSDP2 always needs manual prefetch for cross-layer control
+        or parallel_state.any_extra_parallel_enabled
+        or mp_ignored_classes is not None
     ) and kwargs.pop("enable_forward_prefetch", True)
     if need_manual_prefetch:
         blocks = [pair[1][0] for pair in layer_pairs_list]  # all target modules
@@ -353,8 +406,13 @@ def parallelize_model_fsdp2(
         for current_block, next_block in zip(blocks, next_blocks):
             if next_block is not None:
                 prefetch_modules = next_block._fsdp_modules
-                # prefetch in order of attn, gate, experts
-                current_block.set_modules_to_forward_prefetch(list(reversed(prefetch_modules)))
+                if enable_dt_fsdp2:
+                    # DT-FSDP2: _fsdp_modules is already in forward-execution order
+                    # (attn → mlp → norms), so forward prefetch keeps the natural order.
+                    current_block.set_modules_to_forward_prefetch(prefetch_modules)
+                else:
+                    # prefetch in order of attn, gate, experts (reversed order)
+                    current_block.set_modules_to_forward_prefetch(list(reversed(prefetch_modules)))
 
         # configure backward prefetch
         rev_blocks = list(reversed(blocks))
@@ -362,7 +420,11 @@ def parallelize_model_fsdp2(
         for current_block, prev_block in zip(rev_blocks, prev_blocks):
             if prev_block is not None:
                 prefetch_modules = prev_block._fsdp_modules
-                current_block.set_modules_to_backward_prefetch(list(reversed(prefetch_modules)))
+                if enable_dt_fsdp2:
+                    # DT-FSDP2: backward runs in reverse order, prefetch in reverse order
+                    current_block.set_modules_to_backward_prefetch(list(reversed(prefetch_modules)))
+                else:
+                    current_block.set_modules_to_backward_prefetch(list(reversed(prefetch_modules)))
 
     # Handle meta initialization for FSDP2 (fallback if pre-load not done)
     assert kwargs.get("init_device") == "meta", "Please use init_device: meta for FSDP2"
@@ -427,6 +489,7 @@ def build_parallelize_model(
     enable_gradient_checkpointing: bool = True,
     basic_modules: Optional[List[str]] = None,
     muon_expert_zero_comm: bool = False,
+    enable_dt_fsdp2: bool = False,
     **kwargs,
 ) -> "nn.Module":
     """Apply parallel strategies to the model.
@@ -434,6 +497,9 @@ def build_parallelize_model(
     Args:
         muon_expert_zero_comm: Shard ExtraParallel weights on dim-0 when the
             EP-local dim is divisible by ``ep_fsdp_size``.
+        enable_dt_fsdp2: If True, split each transformer layer's
+            ``fully_shard`` into per-sub-module (attn, mlp, …) calls to
+            reduce peak memory fragmentation.
     """
 
     parallel_state = get_parallel_state()
@@ -475,6 +541,7 @@ def build_parallelize_model(
                 mixed_precision=mixed_precision,
                 basic_modules=basic_modules,
                 muon_expert_zero_comm=muon_expert_zero_comm,
+                enable_dt_fsdp2=enable_dt_fsdp2,
                 **kwargs,
             )
         else:

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -513,6 +513,7 @@ class BaseTrainer(Stateful, ABC):
             enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
             enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
             enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
+            enable_dt_fsdp2=args.train.accelerator.fsdp_config.enable_dt_fsdp2,
             broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
             max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
             muon_expert_zero_comm=muon_expert_zero_comm,

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -162,6 +162,7 @@ class TextDPOTrainer:
             enable_reentrant=False,
             enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
             enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
+            enable_dt_fsdp2=args.train.accelerator.fsdp_config.enable_dt_fsdp2,
             broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
             cpu_load_param_name=cpu_load_param_name,
             max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,


### PR DESCRIPTION
…forward computations during recomputation in MoE models with EP parallelism.

### What does this PR do?

Add Decoupled-Trigger fsdp2 to eliminate redundant pre/post forward computations during recomputation in MoE models with EP parallelism.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
