### PR TITLE
[optim, ckpt, ci] fix: drop empty VLM param groups for DCP resume

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -172,6 +172,7 @@ jobs:
           uv run --frozen pytest -s -x tests/optim/test_muon_unit.py
           uv run --frozen pytest -s -x tests/optim/test_muon_fsdp2_parity.py
           uv run --frozen pytest -s -x tests/optim/test_muon_fsdp2_smoke.py
+          uv run --frozen pytest -s -x tests/optim/test_optimizer_vlm_param_groups.py
       - name: Run LoRA e2e test
         # peft ships under the `gpu` extra (rolled in from the dropped `lora`
         # extra), so the earlier `uv sync --extra gpu --group dev` step is

--- a/tests/optim/test_optimizer_vlm_param_groups.py
+++ b/tests/optim/test_optimizer_vlm_param_groups.py
@@ -1,0 +1,148 @@
+"""Regression tests for VLM-style optimizer param groups + DCP resume."""
+
+import torch
+from torch.distributed.checkpoint.state_dict import (
+    StateDictOptions,
+    get_optimizer_state_dict,
+    set_optimizer_state_dict,
+)
+
+from veomni.optim.optimizer import (
+    build_optimizer,
+    filter_empty_param_groups,
+    restore_optimizer_param_group_defaults,
+)
+
+
+class _TinyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = torch.nn.Linear(4, 4, bias=False)
+
+    def forward(self, x):
+        return self.backbone(x)
+
+
+def test_filter_empty_param_groups_drops_frozen_vit_group():
+    p = torch.nn.Parameter(torch.randn(2, 2))
+    groups = [
+        {"params": [], "lr": 1e-6},
+        {"params": [p], "lr": 2e-5},
+    ]
+    filtered = filter_empty_param_groups(groups)
+    assert len(filtered) == 1
+    assert filtered[0]["params"] == [p]
+
+
+def test_filter_empty_param_groups_handles_generators():
+    """A generator params value must be materialized: an empty generator is
+    dropped (bool(generator) is always True), and a non-empty one survives
+    without being exhausted before optimizer construction."""
+    p = torch.nn.Parameter(torch.randn(2, 2))
+    groups = [
+        {"params": (x for x in []), "lr": 1e-6},  # empty generator -> dropped
+        {"params": (x for x in [p]), "lr": 2e-5},  # non-empty generator -> kept, materialized
+    ]
+    filtered = filter_empty_param_groups(groups)
+    assert len(filtered) == 1
+    assert filtered[0]["params"] == [p]  # materialized to a list, not exhausted
+
+
+def test_restore_defaults_recurses_multi_optimizer():
+    """restore_optimizer_param_group_defaults must reach sub-optimizers of a
+    MultiOptimizer-like container (optimizers_dict) that has no top-level
+    defaults/param_groups."""
+    p1 = torch.nn.Parameter(torch.randn(2, 2))
+    p2 = torch.nn.Parameter(torch.randn(2, 2))
+    sub1 = torch.optim.AdamW([p1], lr=2e-5, betas=(0.9, 0.95))
+    sub2 = torch.optim.AdamW([p2], lr=1e-6, betas=(0.9, 0.95))
+    # Simulate the betas loss on both sub-optimizers.
+    for opt in (sub1, sub2):
+        opt.param_groups[0].pop("betas")
+
+    class _FakeMultiOptimizer:
+        def __init__(self, opts):
+            self.optimizers_dict = opts
+
+    restore_optimizer_param_group_defaults(_FakeMultiOptimizer({"a": sub1, "b": sub2}))
+    assert "betas" in sub1.param_groups[0]
+    assert "betas" in sub2.param_groups[0]
+
+
+def test_build_optimizer_skips_empty_vlm_param_groups():
+    model = _TinyModel()
+    opt = build_optimizer(
+        model,
+        lr=2e-5,
+        param_groups=[
+            {"params": [], "lr": 1e-6},
+            {"params": list(model.parameters()), "lr": 2e-5},
+        ],
+    )
+    assert len(opt.param_groups) == 1
+    assert opt.param_groups[0]["lr"] == 2e-5
+
+
+def test_vlm_style_optimizer_dcp_roundtrip_step_succeeds():
+    """Reproduces production freeze_vit resume: save/load must keep betas."""
+    model = _TinyModel()
+    opt = build_optimizer(
+        model,
+        lr=2e-5,
+        param_groups=[
+            {"params": [], "lr": 1e-6},
+            {"params": list(model.parameters()), "lr": 2e-5},
+        ],
+    )
+
+    loss = model(torch.randn(2, 4)).sum()
+    loss.backward()
+    opt.step()
+
+    optim_sd = get_optimizer_state_dict(
+        model=model,
+        optimizers=opt,
+        options=StateDictOptions(flatten_optimizer_state_dict=True),
+    )
+
+    model2 = _TinyModel()
+    opt2 = build_optimizer(
+        model2,
+        lr=2e-5,
+        param_groups=[
+            {"params": [], "lr": 1e-6},
+            {"params": list(model2.parameters()), "lr": 2e-5},
+        ],
+    )
+    set_optimizer_state_dict(
+        model=model2,
+        optimizers=opt2,
+        optim_state_dict=optim_sd,
+        options=StateDictOptions(flatten_optimizer_state_dict=True),
+    )
+    restore_optimizer_param_group_defaults(opt2)
+
+    for group in opt2.param_groups:
+        assert "betas" in group
+
+    loss2 = model2(torch.randn(2, 4)).sum()
+    loss2.backward()
+    opt2.step()
+
+
+def test_restore_defaults_fixes_corrupted_empty_group():
+    p = torch.nn.Parameter(torch.randn(2, 2))
+    opt = torch.optim.AdamW(
+        [
+            {"params": [], "lr": 1e-6},
+            {"params": [p], "lr": 2e-5},
+        ],
+        lr=2e-5,
+        betas=(0.9, 0.95),
+    )
+    opt.param_groups[0] = {"params": [], "lr": 1e-6}
+    restore_optimizer_param_group_defaults(opt)
+    assert "betas" in opt.param_groups[0]
+
+    p.grad = torch.randn_like(p)
+    opt.step()

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -39,6 +39,7 @@ from torch.distributed.checkpoint.state_dict import (
 from torch.distributed.checkpoint.stateful import Stateful
 
 from ..distributed.parallel_state import get_parallel_state
+from ..optim.optimizer import restore_optimizer_param_group_defaults
 from ..utils import logging
 from ..utils.checkpoint_utils import _GLOBAL_STEP_PREFIX
 from ..utils.device import empty_cache, synchronize
@@ -274,6 +275,9 @@ class OptimizerState(Stateful):
             )
             # Delegate to MultiOptimizer (it will split/filter correctly)
             self.optimizer.load_state_dict(optim_state_without_extra_parallel_dim)
+            # MultiOptimizer sub-optimizers can also lose param-group hyperparams
+            # (betas/...) for empty groups after load; restore recurses into them.
+            restore_optimizer_param_group_defaults(self.optimizer)
             return
 
         # Single torch optimizer
@@ -282,6 +286,7 @@ class OptimizerState(Stateful):
             optimizers=self.optimizer,
             optim_state_dict=optim_state_from_dcp_load,
         )
+        restore_optimizer_param_group_defaults(self.optimizer)
 
     def get_state_dict_with_extra_parallel_dim_preprocess(self, state_dict, action):
         return _apply_extra_parallel_dim(

--- a/veomni/optim/optimizer.py
+++ b/veomni/optim/optimizer.py
@@ -37,6 +37,64 @@ from .muon import DistributedMuon, split_muon_adamw_params
 logger = logging.get_logger(__name__)
 
 
+def filter_empty_param_groups(
+    param_groups: Sequence[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Drop param groups with no trainable parameters.
+
+    VLM trainers pass separate vit/backbone groups; when vit is frozen the vit
+    group is empty. PyTorch DCP only persists optimizer state for non-empty
+    groups, so keeping empty groups breaks resume (KeyError: 'betas' on
+    optimizer.step() after set_optimizer_state_dict).
+
+    ``params`` may be a generator/iterator. We materialize it into a list so
+    that (a) an empty iterator is detected correctly (``bool(generator)`` is
+    always True regardless of contents) and (b) it is not exhausted before the
+    optimizer consumes it. Non-empty groups are returned as shallow copies with
+    the materialized ``params`` list.
+    """
+    total = 0
+    non_empty: List[Dict[str, Any]] = []
+    for group in param_groups:
+        total += 1
+        params = group.get("params")
+        if params is None:
+            continue
+        params_list = list(params)
+        if not params_list:
+            continue
+        new_group = dict(group)
+        new_group["params"] = params_list
+        non_empty.append(new_group)
+    if len(non_empty) < total:
+        logger.info_rank0(
+            "Dropped %d empty optimizer param group(s) before optimizer construction.",
+            total - len(non_empty),
+        )
+    return non_empty
+
+
+def restore_optimizer_param_group_defaults(optimizer: Optimizer) -> None:
+    """Re-apply optimizer defaults to param groups after DCP load.
+
+    For ``MultiOptimizer`` (ExtraParallel+FSDP2 / Muon) the container has no
+    top-level ``defaults``/``param_groups`` — it wraps sub-optimizers in
+    ``optimizers_dict`` — so recurse into each wrapped optimizer.
+    """
+    sub_optimizers = getattr(optimizer, "optimizers_dict", None)
+    if sub_optimizers is not None:
+        for sub_optimizer in sub_optimizers.values():
+            restore_optimizer_param_group_defaults(sub_optimizer)
+        return
+
+    defaults = getattr(optimizer, "defaults", None)
+    if not defaults:
+        return
+    for group in optimizer.param_groups:
+        for key, value in defaults.items():
+            group.setdefault(key, value)
+
+
 # https://github.com/meta-llama/llama-recipes/blob/v0.0.4/src/llama_recipes/policies/anyprecision_optimizer.py
 class AnyPrecisionAdamW(Optimizer):
     def __init__(
@@ -291,6 +349,11 @@ def build_optimizer(
             muon_kwargs=muon_kwargs,
         )
 
+    if param_groups is not None:
+        param_groups = filter_empty_param_groups(param_groups)
+        if not param_groups:
+            raise ValueError("All optimizer param groups are empty; no trainable parameters to optimize.")
+
     if _should_build_extra_parallel_aware(model):
         return build_extra_parallel_fsdp2_optimizer(
             model, lr, betas, eps, weight_decay, fused, optimizer_type, param_groups, no_decay_modules, no_decay_params
@@ -312,6 +375,13 @@ def build_optimizer(
         if len(no_decay_parameters) > 0:
             logger.info_rank0(f"Parameters without weight decay: {no_decay_parameter_names}")
             param_groups.append({"params": no_decay_parameters, "weight_decay": 0.0})
+
+    # Filter again to cover the auto-built groups above: if the model has no
+    # decayed params requiring grad, the decay group is empty and would carry
+    # the same DCP-resume KeyError as an empty VLM vit group.
+    param_groups = filter_empty_param_groups(param_groups)
+    if not param_groups:
+        raise ValueError("All optimizer param groups are empty; no trainable parameters to optimize.")
 
     if optimizer_type == "adamw":
         foreach = not fused


### PR DESCRIPTION
## What & Why

VLM trainers build **separate vit / backbone optimizer param groups**. With `freeze_vit=true` the vit group has **no trainable parameters** (empty `params`).

PyTorch DCP (`get_optimizer_state_dict` / `set_optimizer_state_dict`) only persists optimizer state for **non-empty** param groups. On resume, `set_optimizer_state_dict` leaves the empty group as `{'params': [], 'lr': ...}` — its hyperparameters (`betas`, `eps`, `weight_decay`, ...) are gone. The first `AdamW.step()` then does `beta1, beta2 = group["betas"]` and raises:

```
KeyError: 'betas'
```

Cold start is unaffected (the freshly-built group still carries defaults); the crash surfaces **only on the first `optimizer.step()` after a DCP resume**.

## Fix

- `filter_empty_param_groups()` — drop empty param groups in `build_optimizer`, so the saved/loaded group layout is consistent (no empty group to lose hyperparams).
- `restore_optimizer_param_group_defaults()` — re-apply `optimizer.defaults` to every param group after `set_optimizer_state_dict`, as a safety net.
- Call the restore in `OptimizerState.load_state_dict` (`dcp_checkpointer.py`).

## Tests / CI

- New `tests/optim/test_optimizer_vlm_param_groups.py`:
  - empty-vit + backbone groups → filtered correctly,
  - VLM-style optimizer DCP save→load→`step()` succeeds (regression for the exact bug),
  - `restore_optimizer_param_group_defaults` repairs a group missing `betas`.
- Wired into `.github/workflows/gpu_unit_tests.yml`. The existing DCP save/load tests only exercise the **default** optimizer and never the VLM two-param-group path, which is why this slipped through.

## Validation

Verified end-to-end on Qwen3.5-9B + ShareGPT4V (`freeze_vit=true`, sp2, DCP), same pod A/B, only variable = this patch:

| Arm | Resume from `global_step_10` | Result |
|-----|------------------------------|--------|
| Without patch | `optimizer.step()` | `KeyError: 'betas'` on all 8 ranks |
| With patch | resume → train steps 11→20 → save `global_step_20` | completes, exit 0, no error |

Unit tests pass locally against upstream `main`.
