### PR TITLE
[ci] chore: update NPU CI image to torch2.9.0-latest tag

### DIFF
--- a/.github/workflows/npu_e2e_test.yml
+++ b/.github/workflows/npu_e2e_test.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: [self-hosted, 910b-8]
     timeout-minutes: 90
     container:
-      image: quay.io/ascend/veomni:veomni-9.0.0-910b-ubuntu22.04-py3.11-tingyang_chore_bump_uv
+      image: quay.io/ascend/veomni:veomni-9.0.0-910b-ubuntu22.04-py3.11-torch2.9.0-latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: [self-hosted, 910b-8]
     timeout-minutes: 90
     container:
-      image: quay.io/ascend/veomni:veomni-9.0.0-910b-ubuntu22.04-py3.11-tingyang_chore_bump_uv
+      image: quay.io/ascend/veomni:veomni-9.0.0-910b-ubuntu22.04-py3.11-torch2.9.0-latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi


### PR DESCRIPTION
### What does this PR do?

Update NPU CI (e2e and unit test) workflows to use the new official image tag `veomni-9.0.0-910b-ubuntu22.04-py3.11-torch2.9.0-latest` instead of the temporary `tingyang_chore_bump_uv` tag.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A
- PR title follows `[{modules}] {type}: {description}` format

### Test

N/A — image tag reference change only.

### Design & Code Changes

- `npu_e2e_test.yml`: update container image tag
- `npu_unit_tests.yml`: update container image tag