### PR TITLE
[ops, perf] refactor: compute MoE scatter-index in O(N) instead of two sorts

### DIFF
--- a/tests/ops/test_expert_scatter_index.py
+++ b/tests/ops/test_expert_scatter_index.py
@@ -1,0 +1,112 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Numerical parity tests for ``compute_expert_scatter_index``.
+
+The helper replaces the ``argsort(stable=True).argsort()`` pair that the
+Triton MoE (``group_gemm.py``) and Quack MoE (``quack_gemm.py``) kernels
+used to build the scatter-index tensor. The second ``argsort`` was
+inverting a permutation of ``[0..N)`` — an O(N) operation that used to be
+implemented as an O(N log N) sort. This test verifies bit-exact parity
+with the old expression and the inverse-permutation invariant.
+
+All checks run on CPU: the helper is device-agnostic (composes
+``argsort`` + ``arange`` + scatter) and the semantic parity is what
+matters for downstream kernels.
+"""
+
+import pytest
+import torch
+
+from veomni.ops.kernels.moe._scatter import compute_expert_scatter_index
+
+
+def _reference_scatter_index(expert_index: torch.Tensor) -> torch.Tensor:
+    """Old expression, kept as the numeric ground truth."""
+    return expert_index.flatten().argsort(stable=True).argsort().to(torch.int32).view(expert_index.shape)
+
+
+@pytest.mark.parametrize(
+    "num_tokens,num_experts,topk",
+    [
+        (1, 4, 1),
+        (16, 8, 2),
+        (32, 4, 2),
+        (128, 16, 4),
+        (7, 3, 1),
+        (7, 3, 3),
+    ],
+)
+def test_scatter_index_matches_argsort_argsort(num_tokens, num_experts, topk):
+    torch.manual_seed(0xC0FFEE)
+    expert_index = torch.randint(0, num_experts, (num_tokens, topk), dtype=torch.int64)
+
+    _, scatter_index = compute_expert_scatter_index(expert_index)
+    reference = _reference_scatter_index(expert_index)
+
+    assert scatter_index.shape == expert_index.shape
+    assert scatter_index.dtype == torch.int32
+    assert torch.equal(scatter_index, reference), (
+        f"scatter_index mismatch for shape ({num_tokens}, {topk}), "
+        f"num_experts={num_experts}. got={scatter_index}, ref={reference}"
+    )
+
+
+def test_scatter_index_is_a_permutation_of_range():
+    torch.manual_seed(1)
+    expert_index = torch.randint(0, 16, (64, 4), dtype=torch.int64)
+
+    _, scatter_index = compute_expert_scatter_index(expert_index)
+    flat = scatter_index.flatten().to(torch.int64)
+    assert torch.equal(flat.sort().values, torch.arange(flat.numel(), dtype=torch.int64))
+
+
+def test_sorted_order_is_stable_and_experts_are_contiguous():
+    """The MoE kernels rely on ``stable=True`` so tokens for the same expert
+    stay in original (token, top-k slot) order in the expert-sorted buffer."""
+    expert_index = torch.tensor(
+        [[0, 1], [1, 0], [0, 2], [2, 1]],
+        dtype=torch.int64,
+    )
+    sorted_order, _ = compute_expert_scatter_index(expert_index)
+
+    flat = expert_index.flatten()
+    experts_in_sorted_order = flat[sorted_order]
+    # experts_in_sorted_order should be non-decreasing (contiguous per-expert runs)
+    assert torch.all(experts_in_sorted_order[1:] >= experts_in_sorted_order[:-1])
+
+    # Within the same expert, original flat positions must be increasing (stability).
+    for e in torch.unique(flat):
+        positions = sorted_order[experts_in_sorted_order == e]
+        assert torch.all(positions[1:] > positions[:-1]), (
+            f"stability violated for expert {e.item()}: {positions.tolist()}"
+        )
+
+
+def test_scatter_index_dtype_and_device_preserved():
+    expert_index = torch.tensor([[0, 3, 2], [1, 0, 2]], dtype=torch.int64)
+    sorted_order, scatter_index = compute_expert_scatter_index(expert_index)
+
+    assert sorted_order.dtype == torch.int64  # argsort returns int64
+    assert scatter_index.dtype == torch.int32  # documented int32 for Triton kernels
+    assert scatter_index.device == expert_index.device
+
+
+def test_scatter_index_inverts_sorted_order():
+    """scatter_index and sorted_order must be inverse permutations."""
+    torch.manual_seed(42)
+    expert_index = torch.randint(0, 8, (33, 3), dtype=torch.int64)
+
+    sorted_order, scatter_index = compute_expert_scatter_index(expert_index)
+    N = sorted_order.numel()
+    flat_scatter = scatter_index.flatten().to(torch.int64)
+
+    # sorted_order[scatter_index[i]] == i  for all i in [0, N).
+    inv_check = sorted_order[flat_scatter]
+    assert torch.equal(inv_check, torch.arange(N, dtype=torch.int64))
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/veomni/ops/kernels/moe/_scatter.py
+++ b/veomni/ops/kernels/moe/_scatter.py
@@ -1,0 +1,79 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MoE dispatch bookkeeping helpers shared by the Triton / Quack backends.
+
+The scatter-index maps each ``(token, top-k slot)`` pair to its position in
+the expert-sorted flattened buffer. The reference implementation in prior
+versions of these kernels was:
+
+    perm = flat.argsort(stable=True)   # 1
+    scatter_index = perm.argsort()     # 2
+
+That's two O(N log N) sorts back-to-back, and step 2 is inverting a
+permutation of ``[0..N)`` — an inherently O(N) operation. The helper below
+inlines that observation and materializes the inverse permutation with a
+single ``arange`` + scatter, so the total cost drops to one sort + one
+linear-time index write.
+
+Kept as a plain-torch helper on purpose: it needs to work on GPU, NPU, and
+CPU (the last is needed for lightweight unit tests). The Triton path in
+``group_gemm.py`` and the Quack path in ``quack_gemm.py`` both consume this.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def compute_expert_scatter_index(
+    expert_index: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return ``(sorted_order, scatter_index)`` for MoE dispatch.
+
+    Args:
+        expert_index: ``[T, topk]`` (or any 2-D shape) of expert assignments
+            per token / top-k slot. Dtype is treated as an integer key; the
+            helper is agnostic to the actual integer width.
+
+    Returns:
+        sorted_order: 1-D int64 tensor of length ``T * topk``. Element ``i``
+            holds the flat index into ``expert_index.flatten()`` whose expert
+            assignment sorts to position ``i``. ``stable=True`` so ties keep
+            the natural (token, top-k slot) order — this stability is
+            required by the downstream group-GEMM which assumes tokens for
+            the same expert are contiguous in original order.
+        scatter_index: int32 tensor with the same shape as ``expert_index``.
+            ``scatter_index[t, k]`` is the row in the expert-sorted buffer
+            that ``(t, k)`` maps to. The int32 dtype matches the prior
+            behavior (the Triton MoE kernels take int32 indices).
+
+    Design note (why not ``argsort().argsort()``):
+        ``sorted_order.argsort()`` inverts a permutation and is unnecessarily
+        O(N log N). We instead materialize the inverse via
+        ``inv[sorted_order] = arange(N)``, which is O(N) and single-launch.
+    """
+    flat = expert_index.flatten()
+    sorted_order = flat.argsort(stable=True)
+
+    inv = torch.empty_like(sorted_order)
+    # ``sorted_order`` is a permutation of [0..N); assign each of its
+    # positions its rank, giving the inverse permutation in one pass.
+    inv[sorted_order] = torch.arange(
+        sorted_order.numel(),
+        dtype=sorted_order.dtype,
+        device=sorted_order.device,
+    )
+    scatter_index = inv.to(torch.int32).view(expert_index.shape)
+    return sorted_order, scatter_index

--- a/veomni/ops/kernels/moe/group_gemm.py
+++ b/veomni/ops/kernels/moe/group_gemm.py
@@ -18,6 +18,7 @@ from ....distributed.moe import EPGroupGemm, EPMergedFc1GroupGemm, preprocess, t
 from ....distributed.parallel_state import get_parallel_state
 from ._kernels.kernel.group_gemm import group_gemm_same_mn, group_gemm_same_nk
 from ._kernels.kernel.moe import expert_histogram, moe_gather, moe_scatter
+from ._scatter import compute_expert_scatter_index
 
 
 def _apply_swiglu_clamp(fc1_1_output, fc1_2_output, swiglu_limit):
@@ -62,8 +63,10 @@ class TritonFusedMoeExpertFunction(torch.autograd.Function):
 
         # MOE Step 3-2: compute the each token's index in result
         # scatter_index shape (batch_size * sequence_len, topk)
-        # TODO(wenyawei): opt it
-        scatter_index = expert_index.flatten().argsort(stable=True).argsort().int().view(expert_index.shape)
+        # ``argsort().argsort()`` is two O(N log N) sorts back-to-back; the second
+        # is only inverting a permutation of [0..N) and can be done in O(N).
+        # ``compute_expert_scatter_index`` inlines that.
+        _, scatter_index = compute_expert_scatter_index(expert_index)
 
         # MOE Step 3-3: compute the result, select tokens by scatter_index, and put them together
         # scatter_output shape (batch_size * sequence_len * topk, hidden_size)
@@ -329,7 +332,7 @@ class MergedFc1TritonFusedMoeExpertFunction(torch.autograd.Function):
         swiglu_limit=None,
     ):
         splits = expert_histogram(expert_index, num_experts)
-        scatter_index = expert_index.flatten().argsort(stable=True).argsort().int().view(expert_index.shape)
+        _, scatter_index = compute_expert_scatter_index(expert_index)
         scatter_output = moe_scatter(hidden_states, scatter_index)
 
         cumsum_t = torch.cumsum(splits, dim=0)

--- a/veomni/ops/kernels/moe/quack_gemm.py
+++ b/veomni/ops/kernels/moe/quack_gemm.py
@@ -30,6 +30,7 @@ from quack.gemm_interface import gemm
 from ....distributed.moe import preprocess, token_pre_all2all, tokens_post_all2all
 from ....distributed.parallel_state import get_parallel_state
 from ._kernels.kernel.moe import expert_histogram, moe_gather, moe_scatter
+from ._scatter import compute_expert_scatter_index
 from .group_gemm import _apply_swiglu_clamp
 
 
@@ -46,9 +47,10 @@ def _build_moe_indices(expert_index: torch.Tensor, num_experts: int):
         scatter_index: [T, topk] indices for moe_gather/moe_scatter (int32).
     """
     topk = expert_index.shape[1]
-    flat = expert_index.flatten()
-    sorted_order = flat.argsort(stable=True)
-    scatter_index = sorted_order.argsort().int().view(expert_index.shape)
+    # ``argsort().argsort()`` on the flat expert_index was two O(N log N) sorts.
+    # ``compute_expert_scatter_index`` returns the same ``sorted_order`` alongside
+    # an O(N) inverse-permutation ``scatter_index``.
+    sorted_order, scatter_index = compute_expert_scatter_index(expert_index)
     # A_idx maps expert-sorted positions to original token indices (0..T-1).
     # sorted_order values are flat indices (t*topk + k), so integer-divide by topk.
     A_idx = (sorted_order // topk).int()


### PR DESCRIPTION
### What does this PR do?

The Triton and Quack fused-MoE backends built the dispatch scatter-index with a
back-to-back `argsort(stable=True).argsort()`. The second `argsort` only inverts
a permutation of `[0..N)` — an inherently O(N) operation that was implemented as
a full O(N log N) sort, i.e. one extra sort-kernel launch per MoE forward and per
MoE backward, per layer. The source already carried a `TODO(wenyawei): opt it`
next to this line.

This PR introduces a shared helper, `compute_expert_scatter_index`, that keeps the
single stable sort and builds the inverse permutation directly with one
`arange` + scatter, then rewires all three call sites to use it. Behavior is
preserved bit-exact.

### Checklist Before Starting

- Search for relative PRs/issues and link here: addresses the in-code
  `TODO(wenyawei): opt it` at the MoE scatter-index construction.
- PR title follows `[{modules}] {type}: {description}` format — `[ops, perf] refactor: ...`.

### Test

`tests/ops/test_expert_scatter_index.py` (new, 10 cases, all passing on CPU):

```
$ pytest tests/ops/test_expert_scatter_index.py -v
...
============================= 10 passed in 32.79s ==============================
```

Coverage:
- Bit-exact parity with the previous `argsort(stable=True).argsort().int()`
  expression across 6 `(num_tokens, num_experts, topk)` shapes.
- `scatter_index` is a permutation of `[0, N)`.
- Stability: same-expert tokens keep their original `(token, top-k slot)` order
  (the property group-GEMM relies on).
- Dtype/device preserved: `sorted_order` int64, `scatter_index` int32, same device
  as input.
- `sorted_order` and `scatter_index` are mutual inverses.

`make quality` passes (ruff check + format).

#### GPU benchmark (H100)

Measured with a standalone microbenchmark (not part of this PR) comparing the old
`argsort(stable=True).argsort()` expression against `compute_expert_scatter_index`
across realistic MoE shapes.

- Device: `NVIDIA H100 80GB HBM3` (SM 9.0); PyTorch 2.7.1 / CUDA 12.8; dtype `int64`
- Timing: `torch.cuda.Event`, 20 warmup + 200 timed iters per measurement,
  3 interleaved rounds, reported as median of medians
- Numerical parity (`torch.equal(old, new)`) verified per shape before timing;
  all 10 shapes passed

|     T | topk | experts | old (ms) | new (ms) | speedup |
| ----: | ---: | ------: | -------: | -------: | ------: |
|  4096 |    8 |     128 |   0.2010 |   0.1117 |   1.80x |
|  8192 |    8 |     128 |   0.2103 |   0.1160 |   1.81x |
| 16384 |    8 |     128 |   0.2238 |   0.1227 |   1.82x |
| 32768 |    8 |     128 |   0.2487 |   0.1375 |   1.81x |
| 65536 |    8 |     128 |   0.2864 |   0.1618 |   1.77x |
|  4096 |    4 |      64 |   0.1921 |   0.1061 |   1.81x |
| 16384 |    4 |      64 |   0.2100 |   0.1159 |   1.81x |
| 65536 |    4 |      64 |   0.2487 |   0.1375 |   1.81x |
|  4096 |    2 |       8 |   0.1957 |   0.1069 |   1.83x |
| 16384 |    2 |       8 |   0.2000 |   0.1109 |   1.80x |

Consistent 1.77x–1.83x speedup across every tested shape. The win comes from
eliminating one full `argsort` kernel launch (the second sort); what remains is
one sort + one O(N) scatter. Absolute per-call time is small (~0.1–0.3 ms), but
MoE forward+backward hits this dispatch on every layer, so the removed launch
compounds across a step.

### API and Usage Example

No public API change. Internal helper only:

```python
# veomni/ops/kernels/moe/_scatter.py
def compute_expert_scatter_index(expert_index: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
    """Return (sorted_order, scatter_index) for MoE dispatch."""
```

### Design & Code Changes

Root cause — `sorted_order = flat.argsort(stable=True)` returns a permutation of
`[0..N)`; its inverse is computable in O(N) via a single scatter, but the code
re-used `argsort` for it, incurring a full O(N log N) sort of that permutation.

Fix — add `veomni/ops/kernels/moe/_scatter.py`:

```python
flat = expert_index.flatten()
sorted_order = flat.argsort(stable=True)
inv = torch.empty_like(sorted_order)
inv[sorted_order] = torch.arange(sorted_order.numel(), dtype=sorted_order.dtype, device=sorted_order.device)
scatter_index = inv.to(torch.int32).view(expert_index.shape)
return sorted_order, scatter_index
```

Properties preserved so downstream kernels don't notice the change:
- **Stability** — `stable=True` on the remaining sort keeps same-expert tokens in
  original flat-index order.
- **Dtype** — returns int32 (the Triton `moe_scatter`/`moe_gather` kernels take
  int32 indices).
- **`sorted_order` pass-through** — the Quack path needs it for
  `A_idx = sorted_order // topk`, so the helper returns it (no recomputation).
- **Device-agnostic** — derives device from the input tensor; no `torch.cuda.*`.

Call sites rewired (3):
- `veomni/ops/kernels/moe/group_gemm.py` — `TritonFusedMoeExpertFunction.forward`
- `veomni/ops/kernels/moe/group_gemm.py` — `MergedFc1TritonFusedMoeExpertFunction.forward`
- `veomni/ops/kernels/moe/quack_gemm.py` — `_build_moe_indices`

Files changed:

| Path | Kind | Delta |
| --- | --- | --- |
| `veomni/ops/kernels/moe/_scatter.py` | new | +79 |
| `veomni/ops/kernels/moe/group_gemm.py` | modified | +6 -3 |
| `veomni/ops/kernels/moe/quack_gemm.py` | modified | +5 -3 |
| `tests/ops/test_expert_scatter_index.py` | new | +112 |

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks (`make quality` passes)
- Added/updated documentation — N/A (no public API, config, or workflow change)
- If `tasks/` training scripts were moved or renamed — N/A
- Added tests to CI workflow — `tests/ops/test_expert_scatter_index.py` (CPU-only,
  runs in the standard `pytest tests/` collection)
