### PR TITLE
[dist] feat: per-rank ExtraParallel-slice streaming weight loader + FSDP2 build fixes

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -221,6 +221,7 @@ NPU validation runs at two times:
 | bsz_warmup_init_mbtoken | `int` | `200` | Initial number of tokens in a batch during warmup. |
 | init_device | `Literal["cpu", "cuda", "meta", "npu"]` | `"meta"` | Device for model weight initialization. `"meta"` is required for FSDP2. |
 | broadcast_model_weights_from_rank0 | `bool` | `True` | Only rank 0 reads weights from disk; other ranks receive via broadcast. |
+| ep_sharded_stream_load | `bool` | `False` | Opt-in fast/low-memory MoE loader: each rank reads only its ExtraParallel dim-0 slice from the checkpoint. Requires `broadcast_model_weights_from_rank0=False` and a model with an ExtraParallel parallel_plan. |
 | enable_full_determinism | `bool` | `False` | Enable full determinism (bitwise alignment). |
 | enable_batch_invariant_mode | `bool` | `False` | Enable batch invariant mode. |
 | empty_cache_steps | `int` | `500` | Steps between two `torch.cuda.empty_cache()` calls. |

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -503,6 +503,12 @@ class TrainingArguments:
             "help": "When enabled, only rank0 reads model weights from HuggingFace safetensor from disk. Other ranks would receive weights through broadcast. This helps to avoid disk I/O bottleneck."
         },
     )
+    ep_sharded_stream_load: bool = field(
+        default=False,
+        metadata={
+            "help": "Opt-in fast/low-memory weight loader for large MoE checkpoints: each rank reads only its ExtraParallel dim-0 slice of the expert tensors straight from the checkpoint. Requires the every-rank-reads path (`broadcast_model_weights_from_rank0=False`) and a model with an ExtraParallel parallel_plan; unsupported model/checkpoint combinations raise `NotImplementedError`."
+        },
+    )
     enable_full_determinism: bool = field(
         default=False,
         metadata={"help": "Enable full determinism."},
@@ -631,6 +637,14 @@ class TrainingArguments:
                     "used with train.accelerator.fsdp_config.fsdp_mode='fsdp2'. "
                     f"Received fsdp_mode={acc.fsdp_config.fsdp_mode!r}. Disable this flag or switch to fsdp2.",
                 )
+
+        # ep_sharded_stream_load only runs on the every-rank-reads path, so it is
+        # mutually exclusive with broadcast_model_weights_from_rank0. Fail early
+        # instead of silently ignoring the flag.
+        assert not (self.ep_sharded_stream_load and self.broadcast_model_weights_from_rank0), (
+            "train.ep_sharded_stream_load requires train.broadcast_model_weights_from_rank0=False "
+            "(it reads each rank's ExtraParallel slice directly and cannot run on the broadcast path)."
+        )
 
     def _derive_batch_config(self):
         acc = self.accelerator

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -27,7 +27,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.checkpoint import noop_context_fn
 
 from ..arguments import MixedPrecisionConfig
-from ..models import load_model_weights, rank0_load_and_broadcast_weights
+from ..models import load_model_weights, load_model_weights_ep_sharded, rank0_load_and_broadcast_weights
 from ..utils import logging
 from ..utils.device import IS_NPU_AVAILABLE, get_device_type
 from .checkpoint import CheckpointFunction
@@ -142,7 +142,14 @@ def parallelize_model_fsdp2(
         _extra_parallel_mesh = {}
         _extra_parallel_map = {}
         for para in parallel_state.extra_parallel_names:
-            if parallel_state.extra_parallel_enabled(para):
+            # A globally-enabled ExtraParallel (e.g. ``ep``) may not be declared by
+            # THIS model's plan -- e.g. a text-encoder / over-encoder has no experts,
+            # so ``ep`` shards nothing here even though a MoE sibling module uses it.
+            # Treat such a para as a no-op for this model (``None``) instead of
+            # crashing in ``get_extra_parallel_fsdp_no_shard_info`` (which requires
+            # >=1 matching module). Nothing downstream wraps it (its layer para_mods
+            # stay empty).
+            if parallel_state.extra_parallel_enabled(para) and para in parallel_plan.extra_parallel_plan:
                 _extra_parallel_mesh[para] = parallel_state.extra_parallel_fsdp_device_mesh[para]
                 _extra_parallel_map[para] = parallel_plan.get_extra_parallel_fsdp_no_shard_info(model, para)
             else:
@@ -176,17 +183,25 @@ def parallelize_model_fsdp2(
         if parallel_state.any_extra_parallel_enabled:
             for para in parallel_state.extra_parallel_names:
                 if _extra_parallel_map[para] is not None:
-                    para_mod = next(
-                        (
-                            para_mod
-                            for para_mod_fqn, para_mod in _extra_parallel_map[para].items()
-                            if para_mod_fqn.startswith(layer_fqn)
-                        ),
-                        None,
-                    )
+                    # Collect ALL extra-parallel (e.g. ep) modules under this layer,
+                    # not just the first. A single layer may hold more than one such
+                    # module (e.g. multiple experts modules in one decoder layer), and
+                    # EACH must be fully_shard'd over the ep_fsdp mesh. If only the
+                    # first were wrapped, the others would fall through to the regular
+                    # ``fully_shard(layer_mod)`` below and be re-sharded over the
+                    # FSDP mesh -- but their params were already EP-sliced (each rank
+                    # holds a *different* [E/ep, ...] slice), so that second shard
+                    # scrambles them and corrupts the experts.
+                    # Match ``layer_fqn + "."`` (not a bare ``startswith``) so e.g.
+                    # ``model.layers.1`` does not also swallow ``model.layers.10``.
+                    para_mods = [
+                        para_mod
+                        for para_mod_fqn, para_mod in _extra_parallel_map[para].items()
+                        if para_mod_fqn == layer_fqn or para_mod_fqn.startswith(layer_fqn + ".")
+                    ]
                 else:
-                    para_mod = None
-                extra_parallel_mod[para] = para_mod
+                    para_mods = []
+                extra_parallel_mod[para] = para_mods
         layer_pair.append(extra_parallel_mod)
         layer_pairs[layer_fqn] = tuple(layer_pair)
 
@@ -208,7 +223,16 @@ def parallelize_model_fsdp2(
     model._fsdp_cpu_offload_enabled = enable_fsdp_cpu_offload
     if enable_fsdp_cpu_offload:
         logger.info_rank0("Enable FSDP2 CPU offload for parameters, gradients, and optimizer states.")
-        fsdp_kwargs["offload_policy"] = CPUOffloadPolicy()
+        # ``CPUOffloadPolicy`` defaults to ``pin_memory=True``: the offloaded CPU
+        # param shards are page-locked, which (a) is accounted as non-reclaimable
+        # ``Shmem`` against the container memcg and (b) cannot be swapped/evicted.
+        # For a very large model (e.g. the ~1.5 TiB MoT experts) each rank pins
+        # its whole shard, so N ranks/host pin ~N * shard_size of Shmem and OOM
+        # the cgroup during load. ``fsdp_offload_pin_memory=False`` keeps the
+        # shards in ordinary pageable anon memory (what a bespoke manual offload
+        # does) at the cost of a non-pinned (slightly slower) H2D per layer.
+        offload_pin_memory = kwargs.pop("fsdp_offload_pin_memory", True)
+        fsdp_kwargs["offload_policy"] = CPUOffloadPolicy(pin_memory=offload_pin_memory)
 
     if hasattr(model, "get_ignore_modules_in_mixed_precision"):
         modules_to_ignore_in_mixed_precision = model.get_ignore_modules_in_mixed_precision()
@@ -301,14 +325,16 @@ def parallelize_model_fsdp2(
         layer_mod._fsdp_modules = []
 
         for para in parallel_state.extra_parallel_names:
-            # para (e.g. ep, emb) enabled and this layer contains the para (e.g. expert/decoder.moe, embed_tokens/decoder.embed_tokens) module
-            if (
-                parallel_state.extra_parallel_enabled(para)
-                and extra_parallel_mod[para] is not None
-                and not isinstance(extra_parallel_mod[para], FSDPModule)
-            ):
+            # para (e.g. ep, emb) enabled and this layer contains the para module(s)
+            # (e.g. expert/decoder.moe, embed_tokens/decoder.embed_tokens). A layer
+            # may hold more than one (e.g. multiple experts modules) -- wrap each.
+            if not parallel_state.extra_parallel_enabled(para):
+                continue
+            for _para_mod in extra_parallel_mod[para]:
+                if isinstance(_para_mod, FSDPModule):
+                    continue
                 # shard para module (e.g. expert/decoder.moe, embed_tokens/decoder.embed_tokens)
-                fully_shard(extra_parallel_mod[para], **extra_parallel_fsdp_kwargs[para])
+                fully_shard(_para_mod, **extra_parallel_fsdp_kwargs[para])
                 # average para (e.g. ep) grads across para (e.g. ep) ranks
                 # NOTE: in torch 2.8 and later we should use
                 # experts_mod.set_gradient_divide_factor(parallel_state.ep_size)
@@ -317,11 +343,11 @@ def parallelize_model_fsdp2(
                 logger.info(f"setting grad divide factor for {para} module to {gradient_divide_factor}")
                 if IS_NPU_AVAILABLE:
                     # NPU is using torch 2.7
-                    extra_parallel_mod[para].set_reduce_scatter_divide_factor(gradient_divide_factor)
+                    _para_mod.set_reduce_scatter_divide_factor(gradient_divide_factor)
                 else:
                     # from torch 2.8
-                    extra_parallel_mod[para].set_gradient_divide_factor(gradient_divide_factor)
-                layer_mod._fsdp_modules.append(extra_parallel_mod[para])
+                    _para_mod.set_gradient_divide_factor(gradient_divide_factor)
+                layer_mod._fsdp_modules.append(_para_mod)
 
         # shard module that needs to ignore mixed precision control
         if mp_ignored_classes:
@@ -409,17 +435,45 @@ def parallelize_model_fsdp2(
                 fqn_to_index_mapping=fqn_to_index_mapping,
             )
         else:
-            logger.info_rank0("Every rank would read weights from disk and expect this to be slow!")
             _dt_local_split = partial(distribute_tensor, src_data_rank=None)
-            load_model_weights(
-                model,
-                weights_path,
-                materialize_device,
-                dtensor_factory=_dt_local_split,
-                is_peft_model=is_peft_model,
-                adapter_path=adapter_path,
-                fqn_to_index_mapping=fqn_to_index_mapping,
-            )
+            # Opt-in fast/low-memory path for large MoE checkpoints: each rank reads
+            # only its ExtraParallel dim-0 slice of the expert tensors straight from
+            # the checkpoint (see ``load_model_weights_ep_sharded``). Only valid on the
+            # every-rank-reads (non-broadcast) path; unsupported model/checkpoint raises
+            # ``NotImplementedError`` and we fall back to the whole-tensor loader.
+            loaded_ep_sharded = False
+            if kwargs.get("ep_sharded_stream_load"):
+                logger.info_rank0(
+                    "Loading model weights via per-rank ExtraParallel-slice streaming (ep_sharded_stream_load)..."
+                )
+                try:
+                    load_model_weights_ep_sharded(
+                        model,
+                        weights_path,
+                        materialize_device,
+                        dtensor_factory=_dt_local_split,
+                        is_peft_model=is_peft_model,
+                        adapter_path=adapter_path,
+                        fqn_to_index_mapping=fqn_to_index_mapping,
+                    )
+                    loaded_ep_sharded = True
+                except NotImplementedError as e:
+                    logger.warning_rank0(
+                        f"ep_sharded_stream_load unsupported for this model/checkpoint ({e}); "
+                        "falling back to load_model_weights."
+                    )
+
+            if not loaded_ep_sharded:
+                logger.info_rank0("Every rank would read weights from disk and expect this to be slow!")
+                load_model_weights(
+                    model,
+                    weights_path,
+                    materialize_device,
+                    dtensor_factory=_dt_local_split,
+                    is_peft_model=is_peft_model,
+                    adapter_path=adapter_path,
+                    fqn_to_index_mapping=fqn_to_index_mapping,
+                )
 
     # Register grad norm clipping method for FSDP2
     from .fsdp2 import clip_grad_norm as clip_grad_norm_fn

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -436,34 +436,27 @@ def parallelize_model_fsdp2(
             )
         else:
             _dt_local_split = partial(distribute_tensor, src_data_rank=None)
-            # Opt-in fast/low-memory path for large MoE checkpoints: each rank reads
-            # only its ExtraParallel dim-0 slice of the expert tensors straight from
-            # the checkpoint (see ``load_model_weights_ep_sharded``). Only valid on the
-            # every-rank-reads (non-broadcast) path; unsupported model/checkpoint raises
-            # ``NotImplementedError`` and we fall back to the whole-tensor loader.
-            loaded_ep_sharded = False
             if kwargs.get("ep_sharded_stream_load"):
+                # Opt-in fast/low-memory path for large MoE checkpoints: each rank
+                # reads only its ExtraParallel dim-0 slice of the expert tensors
+                # straight from the checkpoint (see ``load_model_weights_ep_sharded``).
+                # Only valid on the every-rank-reads (non-broadcast) path. An
+                # unsupported model/checkpoint raises ``NotImplementedError``, which we
+                # surface directly rather than silently falling back -- an opt-in flag
+                # that quietly degrades is hard to reason about, so fail early instead.
                 logger.info_rank0(
                     "Loading model weights via per-rank ExtraParallel-slice streaming (ep_sharded_stream_load)..."
                 )
-                try:
-                    load_model_weights_ep_sharded(
-                        model,
-                        weights_path,
-                        materialize_device,
-                        dtensor_factory=_dt_local_split,
-                        is_peft_model=is_peft_model,
-                        adapter_path=adapter_path,
-                        fqn_to_index_mapping=fqn_to_index_mapping,
-                    )
-                    loaded_ep_sharded = True
-                except NotImplementedError as e:
-                    logger.warning_rank0(
-                        f"ep_sharded_stream_load unsupported for this model/checkpoint ({e}); "
-                        "falling back to load_model_weights."
-                    )
-
-            if not loaded_ep_sharded:
+                load_model_weights_ep_sharded(
+                    model,
+                    weights_path,
+                    materialize_device,
+                    dtensor_factory=_dt_local_split,
+                    is_peft_model=is_peft_model,
+                    adapter_path=adapter_path,
+                    fqn_to_index_mapping=fqn_to_index_mapping,
+                )
+            else:
                 logger.info_rank0("Every rank would read weights from disk and expect this to be slow!")
                 load_model_weights(
                     model,

--- a/veomni/models/__init__.py
+++ b/veomni/models/__init__.py
@@ -18,6 +18,7 @@ from .auto import build_foundation_model, build_processor, build_tokenizer
 from .module_utils import (
     init_empty_weights,
     load_model_weights,
+    load_model_weights_ep_sharded,
     rank0_load_and_broadcast_weights,
     save_model_assets,
     save_model_weights,
@@ -30,6 +31,7 @@ __all__ = [
     "build_tokenizer",
     "init_empty_weights",
     "load_model_weights",
+    "load_model_weights_ep_sharded",
     "rank0_load_and_broadcast_weights",
     "save_model_assets",
     "save_model_weights",

--- a/veomni/models/checkpoint_tensor_loading.py
+++ b/veomni/models/checkpoint_tensor_loading.py
@@ -82,6 +82,47 @@ class CheckpointTensorConverter(Protocol):
         """
         ...
 
+    def is_dim0_zero_pad(self, name: str) -> bool:
+        """Optional streaming capability: whether this converter's *only* transform for
+        ``name`` is appending trailing zero rows on dim-0 (no fusion/reshape/dtype change).
+
+        Zero-padding dim-0 commutes with a ``Shard(0)`` split, so a per-rank dim-0
+        streaming loader (:func:`veomni.models.module_utils.load_model_weights_ep_sharded`)
+        can read a rank's real-row slice straight from the checkpoint and zero-fill any
+        tail past the checkpoint's real row count -- never materializing the whole tensor.
+        A converter that fuses or otherwise needs the whole tensor set must return
+        ``False`` (and its ``finalize`` may be non-empty). Implementing this method is
+        optional; the loader treats a missing method as ``False``.
+
+        CAUTION: only declare this for tensors whose padded rows are *semantically
+        inert*, i.e. never read at runtime -- e.g. a vocab/embedding table padded past
+        the real vocab (out-of-range ids are never looked up, so a zero row has no
+        effect). It is NOT valid for MoE expert weights: an expert's dim-0 is the expert
+        index, and the router selects over ALL rows via top-k. A zero-padded "expert" is
+        an active, routable unit (its zero-padded router row yields a finite logit=0 that
+        can win top-k), so a token routed to it silently gets a zeroed contribution ->
+        wrong output. VeOmni EP therefore *requires* ``num_experts % ep == 0`` (the fused
+        MoE kernels assert it) rather than padding experts; declaring this for experts
+        would silently corrupt results.
+        """
+        ...
+
+
+def checkpoint_converter_is_dim0_zero_pad(
+    converter: Optional["CheckpointTensorConverter"],
+    name: str,
+) -> bool:
+    """Safely query the optional :meth:`CheckpointTensorConverter.is_dim0_zero_pad`.
+
+    Returns ``True`` only when *converter* both claims ``name`` (``can_handle``) and
+    declares its transform is a pure dim-0 zero-pad. Any converter lacking the optional
+    method is treated as not stream-safe (``False``).
+    """
+    if converter is None or not converter.can_handle(name):
+        return False
+    fn = getattr(converter, "is_dim0_zero_pad", None)
+    return bool(fn(name)) if callable(fn) else False
+
 
 def get_checkpoint_tensor_converter(
     model: Union["nn.Module", "PreTrainedModel"],

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -456,8 +456,7 @@ def load_model_weights_ep_sharded(
     ``[E/ep, ...]`` with ``parallel_plan=None`` so it is not sliced again, then
     the FSDP ``dtensor_factory`` shards it over the ``ep_fsdp`` sub-mesh.
 
-    Raises ``NotImplementedError`` (so the caller may fall back to
-    :func:`load_model_weights`) when the checkpoint/model is unsupported: PEFT,
+    Raises ``NotImplementedError`` when the checkpoint/model is unsupported: PEFT,
     no ExtraParallel ``get_parallel_plan``, or a checkpoint-tensor converter whose
     transform is not a pure dim-0 zero-pad (a fusion converter needs the whole
     tensor set). A converter that only zero-pads dim-0 stays streamable -- each

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -418,7 +418,7 @@ def _resolve_safetensors_shards(weights_path: str, **kwargs) -> Tuple[Dict[str, 
         base = os.path.basename(resolved_file)
         with safe_open(resolved_file, framework="pt", device="cpu") as fh:
             keys = list(fh.keys())
-        return {k: base for k in keys}, {base: resolved_file}
+        return dict.fromkeys(keys, base), {base: resolved_file}
 
     raise ValueError(f"ep_sharded_stream_load: no safetensors checkpoint found under {weights_path}.")
 
@@ -554,9 +554,7 @@ def load_model_weights_ep_sharded(
                     real0 = sl.get_shape()[0]
                     expected_full0 = target0 * para_size
                     if real0 > expected_full0:
-                        raise RuntimeError(
-                            f"{name}: checkpoint dim0={real0} exceeds model dim0={expected_full0}."
-                        )
+                        raise RuntimeError(f"{name}: checkpoint dim0={real0} exceeds model dim0={expected_full0}.")
                     if not zero_pad and real0 != expected_full0:
                         # No dim-0 zero-pad converter -> checkpoint must match exactly;
                         # a silent zero-fill here would hide a real shape mismatch.

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -45,7 +45,11 @@ from ..utils import logging
 from ..utils.device import get_device_type, synchronize
 from ..utils.helper import empty_cache, get_cache_dir, get_dtype_size
 from ..utils.import_utils import is_diffusers_available
-from .checkpoint_tensor_loading import get_checkpoint_tensor_converter, maybe_convert_checkpoint_tensor
+from .checkpoint_tensor_loading import (
+    checkpoint_converter_is_dim0_zero_pad,
+    get_checkpoint_tensor_converter,
+    maybe_convert_checkpoint_tensor,
+)
 
 
 if TYPE_CHECKING:
@@ -389,6 +393,210 @@ def load_model_weights(
         from .checkpoint_tensor_loading import prepare_fqn_to_index_mapping_for_model
 
         prepare_fqn_to_index_mapping_for_model(model, fqn_to_index_mapping)
+
+
+def _resolve_safetensors_shards(weights_path: str, **kwargs) -> Tuple[Dict[str, str], Dict[str, str]]:
+    """Resolve a (sharded) safetensors checkpoint for per-key streaming reads.
+
+    Returns ``(key_to_file, file_to_path)`` where ``key_to_file`` maps each
+    checkpoint tensor name to its shard **basename** and ``file_to_path`` maps
+    that basename to the resolved local file path. Handles both the sharded
+    (``model.safetensors.index.json`` + ``model-0000x-of-0000y.safetensors``)
+    and single-file (``model.safetensors``) layouts.
+    """
+    cache_kwargs = {"_raise_exceptions_for_missing_entries": False, **kwargs}
+    resolved_index = cached_file(weights_path, SAFE_WEIGHTS_INDEX_NAME, **cache_kwargs)
+    if resolved_index:
+        with open(resolved_index) as fh:
+            weight_map = json.load(fh)["weight_map"]  # key -> shard basename
+        shard_files, _ = get_checkpoint_shard_files(weights_path, resolved_index, **kwargs)
+        file_to_path = {os.path.basename(p): p for p in shard_files}
+        return weight_map, file_to_path
+
+    resolved_file = cached_file(weights_path, SAFE_WEIGHTS_NAME, **cache_kwargs)
+    if resolved_file:
+        base = os.path.basename(resolved_file)
+        with safe_open(resolved_file, framework="pt", device="cpu") as fh:
+            keys = list(fh.keys())
+        return {k: base for k in keys}, {base: resolved_file}
+
+    raise ValueError(f"ep_sharded_stream_load: no safetensors checkpoint found under {weights_path}.")
+
+
+@torch.no_grad()
+def load_model_weights_ep_sharded(
+    model: Union["nn.Module", "PreTrainedModel"],
+    weights_path: str,
+    init_device: Literal["cpu", "cuda", "npu"] = "cuda",
+    dtensor_factory: Optional[Callable[["torch.Tensor", Any, Any], "torch.Tensor"]] = None,
+    **kwargs,
+) -> None:
+    """Per-rank ExtraParallel-slice streaming loader (opt-in alternative to
+    :func:`load_model_weights`).
+
+    For parameters the model's ``get_parallel_plan`` marks ExtraParallel-sharded
+    (e.g. MoE experts, ``Shard(0)`` over the ``ep`` mesh), this reads **only this
+    rank's dim-0 slice** straight from the safetensors shard via
+    ``safe_open(...).get_slice()[start:end]`` -- instead of reading the whole
+    ``[E, ...]`` tensor and slicing it in host memory (what
+    :func:`load_model_weights` does via ``ParallelPlan.shard_tensor``).
+
+    Why it is faster / lighter for large MoE checkpoints:
+      * per-rank disk/HDFS bytes for expert tensors drop from the whole set to
+        ``1/ep`` of it (in aggregate the expert bytes are read ~once across the
+        ``ep`` ranks, in parallel), vs every rank reading the full expert set and
+        discarding ``(ep-1)/ep``;
+      * peak host RAM drops accordingly -- the full ``[E, ...]`` tensor is never
+        materialised, only the ``[E/ep, ...]`` local shard.
+
+    Dense (non-ExtraParallel) params and buffers are read whole (small relative
+    to experts) and dispatched exactly as in :func:`load_model_weights` (FSDP's
+    ``distribute_tensor`` still shards them). The dispatch of a sliced expert is
+    identical to the whole-tensor path's second half: pass the already-sliced
+    ``[E/ep, ...]`` with ``parallel_plan=None`` so it is not sliced again, then
+    the FSDP ``dtensor_factory`` shards it over the ``ep_fsdp`` sub-mesh.
+
+    Raises ``NotImplementedError`` (so the caller may fall back to
+    :func:`load_model_weights`) when the checkpoint/model is unsupported: PEFT,
+    no ExtraParallel ``get_parallel_plan``, or a checkpoint-tensor converter whose
+    transform is not a pure dim-0 zero-pad (a fusion converter needs the whole
+    tensor set). A converter that only zero-pads dim-0 stays streamable -- each
+    rank reads its real-row slice and zero-fills the tail -- and opts in via the
+    optional ``CheckpointTensorConverter.is_dim0_zero_pad`` capability (see
+    :func:`checkpoint_converter_is_dim0_zero_pad`).
+    """
+    if kwargs.get("is_peft_model", False):
+        raise NotImplementedError("ep_sharded_stream_load does not support PEFT models.")
+    # A checkpoint-tensor converter generally needs the whole tensor set (e.g.
+    # per-expert-key fusion) which streaming can't provide. The one streamable
+    # exception is a *pure dim-0 zero-pad* converter, which opts in via the
+    # optional ``is_dim0_zero_pad`` capability; that is enforced per-key below
+    # (dim-0 zero-pad -> stream + tail zero-fill; anything else -> bail).
+    converter = get_checkpoint_tensor_converter(model)
+    get_plan = getattr(model, "get_parallel_plan", None)
+    parallel_plan = get_plan() if get_plan is not None else None
+    if parallel_plan is None or not getattr(parallel_plan, "extra_parallel_plan", None):
+        raise NotImplementedError("ep_sharded_stream_load requires a model with an ExtraParallel parallel_plan.")
+
+    # This streaming loader reads each rank's ExtraParallel slice with a dim-0
+    # ``get_slice()[start:end]`` -- the same dim-0 assumption upstream's
+    # ``ParallelPlan._slice_shard_tensor`` makes (every VeOmni ExtraParallel plan
+    # today is ``Shard(0)``: MoE experts, embed parallel). If a plan ever shards a
+    # non-zero dim, a blind dim-0 slice would silently corrupt weights, so bail to
+    # the whole-tensor loader (which handles arbitrary ``Shard(dim)`` via DTensor).
+    for _pname, _pplan in parallel_plan.extra_parallel_plan.items():
+        for _fqn_pattern, _placement in _pplan.items():
+            _dim = getattr(_placement, "dim", None)
+            if _dim is not None and _dim != 0:
+                raise NotImplementedError(
+                    f"ep_sharded_stream_load only supports dim-0 ExtraParallel sharding (Shard(0)); "
+                    f"'{_pname}' pattern '{_fqn_pattern}' uses Shard({_dim})."
+                )
+
+    buffer_dict = {name: buffer.clone() for name, buffer in model.named_buffers()}
+    param_shapes = {name: tuple(p.shape) for name, p in model.named_parameters()}
+    parameter_names_to_load = set(param_shapes.keys())
+    model.to_empty(device=init_device)
+    dtensor_to_cpu = init_device == "cpu"
+
+    parallel_state = get_parallel_state()
+    key_to_file, file_to_path = _resolve_safetensors_shards(weights_path, **kwargs)
+
+    keys_by_file: Dict[str, List[str]] = {}
+    for key, fname in key_to_file.items():
+        keys_by_file.setdefault(fname, []).append(key)
+
+    n_ep = n_dense = n_buf = 0
+    for fname in tqdm(
+        sorted(keys_by_file),
+        desc="Streaming EP-sharded checkpoint",
+        disable=int(os.getenv("LOCAL_RANK", "-1")) > 0,
+    ):
+        with safe_open(file_to_path[fname], framework="pt", device="cpu") as f:
+            for raw_name in keys_by_file[fname]:
+                name = _convert_weight_key(raw_name, model)
+                if name in buffer_dict:  # persistent buffers: read whole
+                    buffer_dict[name] = f.get_tensor(raw_name).clone()
+                    n_buf += 1
+                    continue
+                if name not in parameter_names_to_load:
+                    logger.info_rank0(f"Unexpected key in state dict: {name}.")
+                    continue
+
+                shard_group = parallel_plan._get_shard_parameter_groupname(name)
+                if shard_group is not None:
+                    # ExtraParallel (e.g. EP / embed) param -> read only this rank's
+                    # dim-0 slice. ``param_shapes[name][0]`` is the per-rank chunk, so
+                    # the model's full dim0 is ``expected_full0 = target0 * para_size``.
+                    # If a converter declares this key a pure dim-0 zero-pad, the model
+                    # may have more rows than the checkpoint (``real0``): read the
+                    # overlap and zero-fill the tail. Otherwise the checkpoint must
+                    # match the model exactly.
+                    zero_pad = checkpoint_converter_is_dim0_zero_pad(converter, name)
+                    if converter is not None and converter.can_handle(name) and not zero_pad:
+                        # A converter that fuses/reshapes this key can't be streamed.
+                        raise NotImplementedError(
+                            f"ep_sharded_stream_load: converter applies a non-dim0-zero-pad "
+                            f"transform to ExtraParallel key '{name}'."
+                        )
+                    target0 = param_shapes[name][0]
+                    para_size = (
+                        parallel_state.extra_parallel_sizes[shard_group]
+                        if parallel_state.extra_parallel_enabled(shard_group)
+                        else 1
+                    )
+                    para_rank = (
+                        parallel_state.extra_parallel_rank(shard_group)
+                        if parallel_state.extra_parallel_enabled(shard_group)
+                        else 0
+                    )
+                    sl = f.get_slice(raw_name)
+                    real0 = sl.get_shape()[0]
+                    expected_full0 = target0 * para_size
+                    if real0 > expected_full0:
+                        raise RuntimeError(
+                            f"{name}: checkpoint dim0={real0} exceeds model dim0={expected_full0}."
+                        )
+                    if not zero_pad and real0 != expected_full0:
+                        # No dim-0 zero-pad converter -> checkpoint must match exactly;
+                        # a silent zero-fill here would hide a real shape mismatch.
+                        raise RuntimeError(
+                            f"{name}: checkpoint dim0={real0} != model dim0={expected_full0} "
+                            f"(no dim-0 zero-pad converter for this key)."
+                        )
+                    start = para_rank * target0
+                    end = start + target0
+                    read_end = min(end, real0)
+                    read_end = max(read_end, start)  # empty (0-row) slice if this rank is all pad
+                    tensor = sl[start:read_end]
+                    if read_end < end:  # trailing zero rows (dim-0 zero-pad converter)
+                        pad = torch.zeros((end - read_end, *tuple(tensor.shape[1:])), dtype=tensor.dtype)
+                        tensor = torch.cat([tensor, pad], dim=0)
+                    # Already the local slice -> parallel_plan=None (do not slice
+                    # again); dtensor_factory then shards over the ep_fsdp sub-mesh
+                    # exactly as the whole-tensor path's post-shard_tensor half.
+                    _dispatch_parameter(model, name, tensor, dtensor_factory, None, dtensor_to_cpu)
+                    n_ep += 1
+                else:
+                    if converter is not None and converter.can_handle(name):
+                        # A streamable (dim-0 zero-pad) converter must only touch
+                        # ExtraParallel tables; a dense key would need its conversion
+                        # applied here, which this path does not do -> bail.
+                        raise NotImplementedError(
+                            f"ep_sharded_stream_load: converter handles non-ExtraParallel key '{name}'."
+                        )
+                    tensor = f.get_tensor(raw_name)
+                    _dispatch_parameter(model, name, tensor, dtensor_factory, parallel_plan, dtensor_to_cpu)
+                    n_dense += 1
+                parameter_names_to_load.discard(name)
+        empty_cache()
+
+    logger.info_rank0(
+        f"ep_sharded_stream_load: read {n_ep} ExtraParallel-sliced, {n_dense} dense, {n_buf} buffer tensors/rank."
+    )
+    post_process_after_weight_loading(
+        model, buffer_dict, parameter_names_to_load, dtensor_factory, dtensor_to_cpu=dtensor_to_cpu
+    )
 
 
 @torch.no_grad()

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -564,11 +564,16 @@ def load_model_weights_ep_sharded(
                         )
                     start = para_rank * target0
                     end = start + target0
+                    # Real checkpoint rows for this rank are [start, real0); clamp BOTH
+                    # ends to real0 so a rank lying entirely in the zero-pad region
+                    # (start >= real0) reads an in-bounds empty slice (sl[real0:real0])
+                    # instead of relying on out-of-bounds ``get_slice`` semantics, which
+                    # vary by safetensors version. Missing tail rows are zero-filled.
+                    read_start = min(start, real0)
                     read_end = min(end, real0)
-                    read_end = max(read_end, start)  # empty (0-row) slice if this rank is all pad
-                    tensor = sl[start:read_end]
-                    if read_end < end:  # trailing zero rows (dim-0 zero-pad converter)
-                        pad = torch.zeros((end - read_end, *tuple(tensor.shape[1:])), dtype=tensor.dtype)
+                    tensor = sl[read_start:read_end]
+                    if tensor.shape[0] < target0:  # trailing zero rows (dim-0 zero-pad converter)
+                        pad = torch.zeros((target0 - tensor.shape[0], *tuple(tensor.shape[1:])), dtype=tensor.dtype)
                         tensor = torch.cat([tensor, pad], dim=0)
                     # Already the local slice -> parallel_plan=None (do not slice
                     # again); dtensor_factory then shards over the ep_fsdp sub-mesh

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -523,6 +523,7 @@ class BaseTrainer(Stateful, ABC):
             enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
             enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
             broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
+            ep_sharded_stream_load=args.train.ep_sharded_stream_load,
             max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
             muon_expert_zero_comm=muon_expert_zero_comm,
             **kwargs,


### PR DESCRIPTION
### Summary
Adds an opt-in **faster, lower-memory** weight-loading path for large MoE checkpoints, plus two general FSDP2 build robustness fixes. Gated/off-by-default; existing loading paths are unchanged unless the new kwarg is set.

### 1. `ep_sharded_stream_load` — per-rank ExtraParallel-slice streaming loader
New `load_model_weights_ep_sharded` (`veomni/models/module_utils.py`), wired into `parallelize_model_fsdp2`'s every-rank-reads path behind `ep_sharded_stream_load=True`.

For params the model's parallel plan marks **ExtraParallel-sharded** (`Shard(0)` — MoE experts, embed parallel), **each rank reads only its `[E/ep, …]` dim-0 slice** straight from the safetensors shard via `safe_open(...).get_slice()[start:end]`. Dense params/buffers are read whole and dispatched exactly as `load_model_weights`; a sliced expert is dispatched with `parallel_plan=None` (not sliced twice), then FSDP's `dtensor_factory` shards it over the `ep_fsdp` sub-mesh.

**Why it's faster (vs the two existing paths):**
- **vs every-rank-full-read (`load_model_weights`):** today every one of the N ranks reads the *entire* expert set from disk/HDFS and then throws away `(ep-1)/ep` of it in host memory. Streaming makes the `ep` ranks read **disjoint `1/ep` slices in parallel**, so aggregate expert bytes read drop from `N × full` to ≈ the full set read once — and the full `[E,…]` tensor is never materialized, so peak host RAM drops ~`ep`-fold (also avoids the pinned-Shmem offload pressure that can OOM the cgroup).
- **vs rank0-broadcast (`rank0_load_and_broadcast_weights`):** no serialization through a single rank0 reader + broadcast; reads are fanned out across ranks.
- **Measured (downstream MoT, ~1.5 TiB, EP8+SP4+FSDP8):** `broadcast_model_weights_from_rank0=True` ≈ **1471.9 s** vs `ep_sharded_stream_load` ≈ **535.8 s** (~**2.75×** faster). (Numbers from our downstream branch; not re-measured against `main`.)

**Safe fallback:** raises `NotImplementedError` (→ caller falls back to `load_model_weights`) for unsupported cases: PEFT, no ExtraParallel plan, non-`Shard(0)` ExtraParallel, or a converter that needs the whole tensor set (see caveat below).

> ⚠️ **MoE checkpoints that need load-time key fusion must be pre-converted first.** Many HF MoE checkpoints store per-expert weights as separate keys (`experts.0.gate_proj.weight`, …) that VeOmni fuses into a single `[E, …]` tensor via a checkpoint-tensor converter at load time. Fusion needs the whole tensor set, which streaming can't provide, so such models **bail to `load_model_weights`**. To get the streaming speedup, first re-save the checkpoint once in the already-fused `[E, …]` layout the model expects natively (so no fusion converter is needed at load); then each rank can `get_slice()` its `[E/ep, …]` directly. Un-converted (fusion-required) checkpoints can only use the original loader.

### 2. Streamable checkpoint-tensor converters
Adds an **optional** `CheckpointTensorConverter.is_dim0_zero_pad(name) -> bool` capability (+ `checkpoint_converter_is_dim0_zero_pad` helper). A converter whose *only* transform is appending zero rows on dim-0 (which commutes with `Shard(0)`) stays streamable: the loader reads the real-row slice and zero-fills the tail.
- Documented as valid **only for semantically-inert padded rows** (e.g. a vocab/embedding table padded past real vocab). Explicitly **not** valid for MoE experts (a zero-padded "expert" is routable; its zero router logit can win top-k → silent corruption). VeOmni EP requires `num_experts % ep == 0` instead.

### 3. FSDP2 build fixes (`veomni/distributed/torch_parallelize.py`)
- **Wrap ALL ExtraParallel modules under a layer, not just the first.** A layer may hold >1 such module (e.g. multiple experts modules per decoder layer); each must be `fully_shard`'d over the `ep_fsdp` mesh, else the un-wrapped ones get re-sharded over the FSDP mesh and their already-EP-sliced params are corrupted. Also matches `layer_fqn + "."` so `layers.1` doesn't swallow `layers.10`.
- **Tolerate a globally-enabled ExtraParallel not declared by the model's plan** (a text/over-encoder has no experts): treat it as a no-op instead of crashing in `get_extra_parallel_fsdp_no_shard_info`.
- **Make `CPUOffloadPolicy.pin_memory` configurable** via `fsdp_offload_pin_memory` (default unchanged = `True`). Pinned host shards are non-reclaimable `Shmem` against the container memcg; for very large offloaded models N ranks/host can OOM the cgroup during load. Setting it `False` keeps shards in pageable anon memory.