### PR TITLE
[docker] feat: add AMD ROCm support (Dockerfile, train.sh, docs)

### DIFF
--- a/docker/rocm/Dockerfile.ROCm7.14
+++ b/docker/rocm/Dockerfile.ROCm7.14
@@ -1,0 +1,89 @@
+# VeOmni on AMD ROCm (Instinct MI300-series, gfx942).
+#
+# Base: rocm/primus:v26.4 — ships a gfx942-tuned ROCm 7.14 stack
+# (torch 2.12.0+rocm7.14, torchvision, triton, flash-attn 2.8.3). VeOmni has no
+# ROCm/HIP code and its uv.lock pins CUDA wheels, so we do NOT run `uv sync`.
+# Instead we reuse the image ROCm stack as-is and only layer the pure-Python
+# deps + the ROCm-specific fixes validated on 8xMI308X
+# (see rocm_validation/{UNIT,E2E}_TEST_REPORT.md and the wan2.1 / qwen3_omni runs).
+#
+# Build (no COPY in this Dockerfile, so use a tiny build context, NOT the repo
+# root which can be 100s of GB):
+#   docker build -f docker/rocm/Dockerfile.ROCm7.14 -t amdagi/veomni:rocm7.14_torch2.12_py3.12 docker/rocm
+#
+# Run (VeOmni itself is NOT baked in — the working tree can be 100s of GB; mount it):
+#   docker run -it --rm \
+#     --device /dev/kfd --device /dev/dri --group-add video \
+#     --ipc host --shm-size 32g --cap-add SYS_PTRACE \
+#     --security-opt seccomp=unconfined --security-opt label=disable \
+#     -v /path/to/VeOmni:/workspace/VeOmni -w /workspace/VeOmni \
+#     veomni-rocm:primus_v26.4 bash
+#   # once inside, register the editable package (instant, no deps touched):
+#   pip install -e . --no-deps
+#   # GPU detection in train.sh already handles ROCm via rocm-smi.
+FROM rocm/primus:v26.4
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_ROOT_USER_ACTION=ignore \
+    PIP_NO_CACHE_DIR=1 \
+    MAX_JOBS=16
+
+# --- ROCm runtime env baked in ------------------------------------------------
+# MIOPEN_DEBUG_FORCE_IMMED_MODE_FALLBACK: skip MIOpen conv3d exhaustive tuning
+#   (otherwise the Wan VAE conv3d autotunes for minutes on the first call).
+# FLA_TILELANG=0: force fla GatedDeltaNet onto the Triton path; the tilelang
+#   ROCm backend in this stack has a HIP codegen bug (E2E report 2.3).
+ENV MIOPEN_DEBUG_FORCE_IMMED_MODE_FALLBACK=1 \
+    FLA_TILELANG=0 \
+    TOKENIZERS_PARALLELISM=false
+
+# ffmpeg: required by torchcodec for video container decode; git: editable installs.
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends ffmpeg git \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Pin the image ROCm stack so no downstream pip resolution can swap in CUDA wheels.
+RUN printf "%s\n" \
+      "torch==2.12.0+rocm7.14.0a20260608" \
+      "torchvision==0.27.0+rocm7.14.0a20260608" \
+      "triton==3.7.0+gitb4e20bbe.rocm7.14.0a20260608" \
+      "flash_attn==2.8.3" \
+      > /opt/rocm-constraints.txt
+ENV PIP_CONSTRAINT=/opt/rocm-constraints.txt
+
+# --- Pure-Python runtime & test deps (versions validated on MI308X) -----------
+# transformers v5 (VeOmni model patches target v5); diffusers>=0.37 (DiT/Wan
+# classes); liger-kernel (default cross_entropy); the rest are runtime/test deps
+# missing from the base image.
+RUN pip install \
+      "transformers==5.12.1" \
+      "diffusers==0.37.0" \
+      "liger-kernel==0.8.0" \
+      timm expecttest megatron-energon librosa soundfile ftfy hf_transfer rich
+
+# torchcodec CPU build. The default PyPI wheel is a CUDA build linking
+# libnvrtc/libcudart/libc10_cuda/libtorch_cuda and fails to load on ROCm.
+RUN pip install --no-deps torchcodec==0.14.0 --index-url https://download.pytorch.org/whl/cpu
+
+# GatedDeltaNet stack (qwen3_5, optional). flash-linear-attention is split and
+# needs fla-core for fla.modules/fla.ops; causal-conv1d compiles a HIP extension
+# against the in-image ROCm torch (hence --no-build-isolation). Best-effort.
+RUN pip install --no-build-isolation \
+      "flash-linear-attention==0.5.1" "fla-core==0.5.1" "causal-conv1d==1.5.0.post8" \
+      || echo "WARN: GatedDeltaNet stack only partially installed (qwen3_5 is optional)"
+
+# apache-tvm-ffi must stay <0.1.10 for tilelang compat (installed last so nothing
+# bumps it back). With FLA_TILELANG=0 the tilelang path is unused anyway.
+RUN pip install "apache-tvm-ffi==0.1.9"
+
+# PEFT / torchao pin. Newer peft (>=0.19) raises a hard ImportError unless
+# torchao>0.16 (peft.import_utils.is_torchao_available), which breaks the Wan
+# LoRA path. peft 0.18.1 keeps the torchao floor at 0.4.0, so the ROCm-friendly
+# torchao 0.9.0 is accepted. transformers/diffusers otherwise pull peft 0.19+.
+RUN pip install "peft==0.18.1" "torchao==0.9.0"
+
+# torch_shm_manager ships without the executable bit in this ROCm wheel, which
+# crashes DataLoader workers (SIGSEGV) during trainer save/load. Restore +x.
+RUN find /opt -type f -name torch_shm_manager -exec chmod +x {} +
+
+WORKDIR /workspace

--- a/docs/hardware_support/rocm/README.md
+++ b/docs/hardware_support/rocm/README.md
@@ -1,0 +1,110 @@
+# VeOmni on AMD ROCm
+
+This document describes how to run VeOmni on **AMD Instinct GPUs (MI300 / MI355X series, gfx942/gfx950)** with ROCm.
+
+VeOmni itself contains no ROCm/HIP code. On ROCm it runs through PyTorch's HIP backend: torch exposes ROCm devices through the CUDA API and RCCL reuses the `NCCL_*` environment variables, so most of the CUDA code path applies as-is. It has been validated end-to-end on **8×MI308X** (dense text / MoE+EP / VLM / Omni / DiT all pass and align numerically).
+
+## Pre-built image
+
+We recommend using the published image directly instead of building your own:
+
+```
+amdagi/veomni:rocm7.14_torch2.12_py3.12
+```
+
+The image is based on `rocm/primus:v26.4` and ships a ROCm 7.14 stack tuned for gfx942/gfx950:
+
+| Component | Version |
+|---|---|
+| torch | `2.12.0+rocm7.14.0a20260608` |
+| torchvision | `0.27.0+rocm7.14.0a20260608` |
+| triton | `3.7.0+gitb4e20bbe.rocm7.14.0a20260608` |
+| flash-attn | `2.8.3` |
+| transformers | `5.12.1` |
+| diffusers | `0.37.0` |
+| python | `3.12` |
+
+On top of that it layers the pure-Python dependencies and ROCm-specific fixes validated on MI308X (see `docker/rocm/Dockerfile.ROCm7.14`).
+
+Pull the image:
+
+```bash
+docker pull amdagi/veomni:rocm7.14_torch2.12_py3.12
+```
+
+## Run the container
+
+The image does **not** contain VeOmni itself — clone it yourself and mount it into the container:
+
+```bash
+git clone https://github.com/ByteDance-Seed/VeOmni.git
+# Validated commit: 7be22df074b49603d17f895a22dbcf03982866e7
+```
+
+```bash
+docker run -it --rm \
+  --device /dev/kfd --device /dev/dri --group-add video \
+  --ipc host --shm-size 32g --cap-add SYS_PTRACE \
+  --security-opt seccomp=unconfined --security-opt label=disable \
+  -v /path/to/VeOmni:/workspace/VeOmni -w /workspace/VeOmni \
+  amdagi/veomni:rocm7.14_torch2.12_py3.12 bash
+```
+
+Once inside, register VeOmni as an editable package (this does not touch any installed dependency):
+
+```bash
+pip install -e . --no-deps
+```
+
+## Build the image yourself (optional)
+
+The Dockerfile lives at `docker/rocm/Dockerfile.ROCm7.14`. It has no `COPY` instruction, so use a small build context (the `docker/rocm` directory), not the repository root:
+
+```bash
+docker build \
+  -f docker/rocm/Dockerfile.ROCm7.14 \
+  -t amdagi/veomni:rocm7.14_torch2.12_py3.12 \
+  docker/rocm
+```
+
+> Note: the image's `uv.lock` pins CUDA wheels, so do **not** run `uv sync` on ROCm; reuse the in-image ROCm stack as-is.
+
+## Launch training
+
+`train.sh` auto-detects the accelerator in order: `nvidia-smi` → `rocm-smi` → NPU. On ROCm it takes the ROCm branch:
+
+- device count is detected via `rocm-smi`;
+- device visibility is controlled by `HIP_VISIBLE_DEVICES` (falling back to `CUDA_VISIBLE_DEVICES`, which ROCm torch also honors).
+
+Example (8-GPU real-model SFT, from `docs/examples/qwen3.md`):
+
+```bash
+bash train.sh tasks/train_text.py configs/text/qwen3.yaml \
+  --model.model_path /path/to/Qwen3-0.6B-Base \
+  --data.train_path  /path/to/train.parquet
+```
+
+Or specify visible devices and process count explicitly:
+
+```bash
+HIP_VISIBLE_DEVICES=0,1,2,3 NPROC_PER_NODE=4 \
+  bash train.sh tasks/train_text.py configs/text/qwen3.yaml ...
+```
+
+## ROCm environment variables
+
+The image bakes in the following ROCm-specific environment variables (you can override them on the host as needed):
+
+| Variable | Value | Purpose |
+|---|---|---|
+| `MIOPEN_DEBUG_FORCE_IMMED_MODE_FALLBACK` | `1` | Skip MIOpen conv3d exhaustive tuning (otherwise the Wan VAE conv3d autotunes for minutes on the first call) |
+| `FLA_TILELANG` | `0` | Force the fla GatedDeltaNet Triton path; the tilelang ROCm backend in this stack has a HIP codegen bug |
+| `TOKENIZERS_PARALLELISM` | `false` | Suppress tokenizer fork warnings |
+
+## Known limitations
+
+Validated on 8×MI308X / ROCm 7.14. End-to-end training (FSDP2 sharding, Ulysses SP, expert parallel EP, VLM/Omni, DiT) works and aligns numerically. Known limitations:
+
+- **CUDA-only kernels** (FA3/FA4/Quack/FlashMLA/DSA, e.g. `gpt_oss`) fall back to triton/eager on ROCm, or are skipped.
+- **GatedDeltaNet (qwen3_5 / qwen3_5_moe)**: the tilelang ROCm backend has a HIP wrapper/codegen defect; set `FLA_TILELANG=0` to use the Triton fallback (validated to train and align correctly).
+- **DCP → HF weight consolidation**: the version guard in `veomni/checkpoint/dcp_consolidation.py` only allows torch `2.9`/`2.11` and rejects the image's torch `2.12`. Relax the guard or use a 2.9/2.11 ROCm torch build; otherwise disable `save_hf_weights`.

--- a/train.sh
+++ b/train.sh
@@ -15,6 +15,18 @@ if command -v nvidia-smi &> /dev/null && nvidia-smi --list-gpus &> /dev/null; th
     NPROC_PER_NODE=${NPROC_PER_NODE:=$(nvidia-smi --list-gpus | wc -l)}
   fi
   export NCCL_DEBUG=WARN
+elif command -v rocm-smi &> /dev/null && rocm-smi --showid &> /dev/null; then
+  # AMD GPU (ROCm/HIP). Torch exposes ROCm devices through the CUDA API, and
+  # RCCL reuses the NCCL_* environment variables, so most of the CUDA path
+  # applies. Visibility is controlled by HIP_VISIBLE_DEVICES (falling back to
+  # CUDA_VISIBLE_DEVICES, which ROCm torch also honors).
+  visible_devices="${HIP_VISIBLE_DEVICES:-${CUDA_VISIBLE_DEVICES}}"
+  if [[ -n "${visible_devices}" ]]; then
+    NPROC_PER_NODE=${NPROC_PER_NODE:=$(echo "${visible_devices}" | tr ',' '\n' | wc -l)}
+  else
+    NPROC_PER_NODE=${NPROC_PER_NODE:=$(rocm-smi --showid --csv | grep -c '^card')}
+  fi
+  export NCCL_DEBUG=WARN
 else
   # NPU
   if [[ -n "${ASCEND_RT_VISIBLE_DEVICES}" ]]; then


### PR DESCRIPTION
Add ROCm 7.14 Dockerfile for AMD Instinct GPUs (MI300/MI355X), a ROCm detection branch in train.sh, and hardware_support docs referencing the prebuilt image amdagi/veomni:rocm7.14_torch2.12_py3.12.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
