### PR TITLE
[ckpt] feat: add dcp_save_to_lowest_rank option for DCP save planner

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -354,6 +354,7 @@ NPU validation runs at two times:
 | output_dir | `str` | `"output"` | Path to save model checkpoints. |
 | manager | `str` | `"dcp"` | Checkpoint manager. |
 | save_async | `bool` | `False` | Save checkpoints asynchronously. |
+| dcp_save_to_lowest_rank | `bool` | `False` | Write each replicated DCP shard from the lowest global rank that holds it instead of load-balancing across replicas. On a non-shared filesystem this concentrates the deduplicated copy onto the lowest-ranked replica group rather than scattering it across replicas; in the standard HSDP layout (shard within a node, replicate across nodes) that group is one node, which then holds a complete checkpoint. Only affects replicated data — unique expert/tensor/pipeline-parallel shards stay distributed. Leave `False` when `output_dir` is shared. |
 | load_path | `Optional[str]` | `None` | Path to checkpoint for resuming training. Use `"auto"` for auto-detection. |
 | save_steps | `int` | `0` | Steps between checkpoint saves. `0` to disable. |
 | save_epochs | `int` | `1` | Epochs between checkpoint saves. `0` to disable. |

--- a/tests/checkpoints/test_checkpoint_callback.py
+++ b/tests/checkpoints/test_checkpoint_callback.py
@@ -25,6 +25,7 @@ def _make_mock_trainer(save_path="/tmp/test_ckpt", save_async=False):
         save_async=save_async,
         load_path=None,
         manager="dcp",
+        dcp_save_to_lowest_rank=False,
         save_hf_weights=True,
         hf_save_steps=5,
         hf_save_epochs=1,

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -346,6 +346,7 @@ class TestGlobalStepInflation:
                     save_async=False,
                     load_path=None,
                     manager="dcp",
+                    dcp_save_to_lowest_rank=False,
                 ),
                 accelerator=SimpleNamespace(fsdp_config=SimpleNamespace(fsdp_mode="fsdp2")),
                 global_rank=0,

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -105,6 +105,44 @@ class TestAllowPartialLoad:
 
 
 # ---------------------------------------------------------------------------
+# Save planner: dcp_save_to_lowest_rank wiring
+# ---------------------------------------------------------------------------
+
+
+class TestSaveToLowestRank:
+    """execute_save() must forward ``save_to_lowest_rank`` to DCP's
+    DefaultSavePlanner, defaulting to False (stock load-balanced writes)."""
+
+    def test_config_default_is_false(self):
+        from veomni.arguments.arguments_types import CheckpointConfig
+
+        assert CheckpointConfig().dcp_save_to_lowest_rank is False
+
+    @pytest.mark.parametrize("flag", [False, True])
+    @patch("veomni.checkpoint.dcp_checkpointer.synchronize")
+    @patch("veomni.checkpoint.dcp_checkpointer.empty_cache")
+    @patch("veomni.checkpoint.dcp_checkpointer.dist")
+    @patch("veomni.checkpoint.dcp_checkpointer.dcp")
+    def test_execute_save_forwards_flag_to_planner(self, mock_dcp, mock_dist, mock_ec, mock_sync, flag):
+        from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
+
+        mock_dist.is_initialized.return_value = False
+        mock_dcp.save = MagicMock()
+
+        DistributedCheckpointer.execute_save(
+            save_state={"model": MagicMock()},
+            storage_writer=MagicMock(),
+            save_async=False,
+            save_to_lowest_rank=flag,
+        )
+
+        mock_dcp.save.assert_called_once()
+        planner = mock_dcp.save.call_args.kwargs.get("planner")
+        assert planner is not None, "save must pass a planner"
+        assert planner.dedup_save_to_lowest_rank is flag
+
+
+# ---------------------------------------------------------------------------
 # Async save lifecycle: wait_for_pending_save()
 # ---------------------------------------------------------------------------
 

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -406,6 +406,23 @@ class CheckpointConfig:
         default=False,
         metadata={"help": "Whether to save checkpoint asynchronously."},
     )
+    dcp_save_to_lowest_rank: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Route each replicated DCP shard to the lowest global rank that holds it, instead "
+                "of load-balancing writes across all replica holders. Useful on a non-shared "
+                "filesystem (each node writes to local disk): it concentrates the deduplicated copy "
+                "onto the lowest-ranked replica group instead of scattering writes across all "
+                "replicas. In the standard HSDP layout (FSDP shard within a node, replication "
+                "across nodes) that lowest replica group lives on one node, so that node holds a "
+                "complete checkpoint. Only affects replicated data (the FSDP/HSDP replicate dim); "
+                "unique expert/tensor/pipeline-parallel shards are never deduplicated and stay "
+                "distributed. Trades write parallelism for locality, so leave False when output_dir "
+                "is shared."
+            )
+        },
+    )
     load_path: Optional[str] = field(
         default=None,
         metadata={"help": "Path to checkpoint to resume from."},

--- a/veomni/checkpoint/checkpointer.py
+++ b/veomni/checkpoint/checkpointer.py
@@ -61,6 +61,7 @@ class CheckpointerBase(ABC):
         save_async: Optional[bool],
         global_steps: Optional[int],
         trainable_only: bool = False,
+        save_to_lowest_rank: bool = False,
     ):
         return
 

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -27,7 +27,7 @@ from torch.distributed.checkpoint import (
     FileSystemWriter,
     load,
 )
-from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
+from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner, DefaultSavePlanner
 from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE, Metadata
 from torch.distributed.checkpoint.state_dict import (
     StateDictOptions,
@@ -404,6 +404,7 @@ class DistributedCheckpointer(CheckpointerBase):
         global_steps: int = None,
         storage_writer: Optional[FileSystemWriter] = None,
         trainable_only: bool = False,
+        save_to_lowest_rank: bool = False,
     ) -> None:
         """
         save training state to distributed checkpoint
@@ -420,6 +421,15 @@ class DistributedCheckpointer(CheckpointerBase):
                 state is already trainable-only by construction (the optimizer is built
                 from ``filter(lambda p: p.requires_grad, ...)``), so this flag only
                 affects the model state dump.
+            save_to_lowest_rank: forwarded to the DCP ``DefaultSavePlanner``. When True, each
+                replicated shard is written by the lowest global rank that holds it, instead of
+                being load-balanced across all replica holders. On a non-shared filesystem this
+                concentrates the (already deduplicated) copy onto the lowest-ranked replica group
+                instead of scattering it across replicas; in the standard HSDP layout (shard within
+                a node, replicate across nodes) that group is one node, which then holds a complete
+                checkpoint. Note this only consolidates *replicated* data: unique shards from
+                expert/tensor/pipeline parallelism are never deduplicated and remain distributed.
+                See ``CheckpointConfig.dcp_save_to_lowest_rank``.
         return:
             None
         """
@@ -439,7 +449,12 @@ class DistributedCheckpointer(CheckpointerBase):
         if storage_writer is None:
             storage_writer = cls._create_storage_writer(checkpoint_dir)
 
-        cls.execute_save(save_state=save_state, storage_writer=storage_writer, save_async=save_async)
+        cls.execute_save(
+            save_state=save_state,
+            storage_writer=storage_writer,
+            save_async=save_async,
+            save_to_lowest_rank=save_to_lowest_rank,
+        )
 
         logger.info_rank0(f"Saved checkpoint to {checkpoint_dir}")
 
@@ -528,8 +543,14 @@ class DistributedCheckpointer(CheckpointerBase):
         save_state: Dict[str, Any],
         storage_writer: FileSystemWriter,
         save_async: bool,
+        save_to_lowest_rank: bool = False,
     ) -> None:
-        """Execute DCP save with optional async support."""
+        """Execute DCP save with optional async support.
+
+        ``save_to_lowest_rank`` is forwarded to ``DefaultSavePlanner``; the default
+        (False) preserves DCP's load-balanced write assignment across replica holders.
+        """
+        planner = DefaultSavePlanner(dedup_save_to_lowest_rank=save_to_lowest_rank)
         if save_async:
             # Lazily create a dedicated Gloo process group for async DCP saves
             if cls._async_process_group is None:
@@ -541,11 +562,13 @@ class DistributedCheckpointer(CheckpointerBase):
                 state_dict=save_state,
                 storage_writer=storage_writer,
                 process_group=cls._async_process_group,
+                planner=planner,
             )
         else:
             dcp.save(
                 state_dict=save_state,
                 storage_writer=storage_writer,
+                planner=planner,
             )
             if dist.is_initialized():
                 dist.barrier()

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -141,6 +141,7 @@ class CheckpointerCallback(Callback):
             ckpt_state,
             save_async=args.train.checkpoint.save_async,
             trainable_only=bool(getattr(args.model, "lora_config", None)),
+            save_to_lowest_rank=args.train.checkpoint.dcp_save_to_lowest_rank,
         )
 
         # Empty cache and barrier


### PR DESCRIPTION
## What

Add an opt-in `train.checkpoint.dcp_save_to_lowest_rank` flag (default `False`) that forwards `dedup_save_to_lowest_rank` to DCP's `DefaultSavePlanner`.

## Why

VeOmni's `execute_save` passes no planner to `dcp.save`/`dcp.async_save`, so it uses torch's default (`dedup_save_to_lowest_rank=False`), which load-balances each replicated shard's write across all replica holders. On a **non-shared filesystem** (each node writes to local disk), this scatters the single deduplicated checkpoint copy across nodes — the global `.metadata` on rank 0 then references shard files that physically live on other nodes, so no single node holds a loadable checkpoint.

## Behavior

When enabled, each replicated shard is written by the lowest-ranked replica holder, concentrating the deduplicated copy onto the lowest replica group. In the standard HSDP layout (FSDP shard within a node, replication across nodes) that group is one node, which then holds a complete, self-contained checkpoint. Only affects **replicated** data; unique expert/tensor/pipeline-parallel shards are never deduplicated and stay distributed. Trades write parallelism for locality — leave `False` when `output_dir` is shared.

Default (`False`) preserves the existing load-balanced write behavior.

## Tests

- `tests/checkpoints/test_dcp_checkpointer.py::TestSaveToLowestRank` — asserts the config default is `False` and that `execute_save` forwards the flag to the planner for both values.
- Also updates `docs/usage/arguments.md`.