### PR TITLE
[trainer] feat: add channel loss logging callback

### DIFF
--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -158,5 +158,15 @@ Core files:
     - NPU kernels live in `veomni/ops/kernels/{rms_norm,rotary}/npu.py` and `veomni/ops/platform/npu/` — they must not be imported on GPU-only environments.
 
 22. **Device-agnostic code must use `veomni.utils.device` helpers**
-    - Use `get_device_type()`, `get_torch_device()`, `synchronize()`, `empty_cache()` instead of direct `torch.cuda.*` calls.
-    - Direct CUDA calls break NPU compatibility.
+   - Use `get_device_type()`, `get_torch_device()`, `synchronize()`, `empty_cache()` instead of direct `torch.cuda.*` calls.
+   - Direct CUDA calls break NPU compatibility.
+
+## Trainer Extensions
+
+23. **Trainer callback lifecycle changes must cover composed trainers**
+   - `TextDPOTrainer` and `DiTTrainer` compose a `BaseTrainer` and override `forward_backward_step()`; they do not inherit the base implementation.
+   - Lifecycle work added only inside `BaseTrainer.forward_backward_step()` is skipped by these trainers. Update every supported override or reject the unsupported trainer explicitly.
+
+24. **Module-level OpSlots are shared by every model instance**
+   - Modeling modules expose `OpSlot` objects such as `veomni_causal_lm_loss` as globals. Policy/reference models in DPO can therefore use the same slot.
+   - Temporary interception must use forward-scoped ownership and reference-counted dispatch. A closure bound to one model or callback can observe another model's forward and corrupt side-channel state.

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -64,6 +64,7 @@ Training loop, optimizer, parallelism, checkpointing, profiling, and logging.
     * `OptimizerConfig` — `train.optimizer.*`
     * `WandbConfig` — `train.wandb.*`
     * `ProfileConfig` — `train.profile.*`
+    * `ChannelLossConfig` — `train.channel_loss.*`
     * `GradientCheckpointingConfig` — `train.gradient_checkpointing.*`
     * `AcceleratorConfig` — `train.accelerator.*`
         * `FSDPConfig` — `train.accelerator.fsdp_config.*`
@@ -233,6 +234,7 @@ NPU validation runs at two times:
 | optimizer | `OptimizerConfig` | — | Optimizer and learning-rate schedule. |
 | wandb | `WandbConfig` | — | Weights & Biases logging. |
 | profile | `ProfileConfig` | — | Torch profiler settings. |
+| channel_loss | `ChannelLossConfig` | — | Detached per-channel causal-LM loss logging. |
 | gradient_checkpointing | `GradientCheckpointingConfig` | — | Gradient checkpointing settings. |
 | torch_compile | `TorchCompileConfig` | — | Per-block `torch.compile` settings. |
 | accelerator | `AcceleratorConfig` | — | Parallelism and distributed-training topology. |
@@ -293,6 +295,40 @@ NPU validation runs at two times:
 | profile_memory | `bool` | `True` | Record memory usage. |
 | with_stack | `bool` | `True` | Record stack traces. |
 | rank0_only | `bool` | `True` | Profile rank 0 only. |
+
+### ChannelLossConfig
+
+`train.channel_loss.*` — Detached per-channel causal-LM loss logging.
+
+This is an observability-only side channel. It computes detached per-token CE
+from the model loss inputs, aggregates by packed-sequence source metadata, and
+adds metrics such as `channel_loss/<source-id>__<source>` to the normal step metrics. It does
+not change the returned training loss or gradients. Fused-loss backends may
+recompute the LM-head projection on sampled steps, so the default interval is
+10 steps; set `interval=1` for per-step metrics. DiT trainers and
+`data.data_type="classification"` are not supported because they do not optimize
+a causal-LM objective. SeedOmni's `Qwen3MoeFoundationModel` is also unsupported
+because its legacy forward bypasses the observable loss dispatch. `BaseRLTrainer`
+is unsupported because it packs source alignment metadata after the common step
+lifecycle. In DPO training, only the policy-model forward is observed; the
+reference-model forward is excluded, and the chosen/rejected segments both use
+their preference pair's source metadata. If distinct source names sanitize to
+the same metric key, the stable source-ID prefix keeps their time series
+distinct from the first emission.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| enable | `bool` | `False` | Enable channel loss logging. |
+| interval | `int` | `10` | Compute and log channel loss every N optimizer steps. |
+| source_id_keys | `List[str]` | `["channel_id", "source_id", "dataset_id", "ds_idx"]` | Batch metadata keys to read as channel/source IDs. |
+| source_name_keys | `List[str]` | `["channel_name", "source_name", "dataset_name", "data_name"]` | Batch metadata keys to read as display names. |
+| extra_strip_keys | `List[str]` | `["cur_token_num"]` | Extra metadata keys removed before model forward. |
+| loss_metric_prefix | `str` | `"channel_loss"` | Prefix for average CE metrics. |
+| weighted_loss_metric_prefix | `str` | `"channel_loss_weighted"` | Prefix for loss-sum divided by all logged step tokens. |
+| token_count_metric_prefix | `str` | `"channel_tokens"` | Prefix for supervised token-count metrics. |
+| log_weighted_loss | `bool` | `True` | Log weighted loss metrics. |
+| log_token_count | `bool` | `True` | Log token-count metrics. |
+| strict | `bool` | `False` | Raise when source metadata is missing or cannot be aligned with packed segments; otherwise skip invalid batches. |
 
 ### GradientCheckpointingConfig
 

--- a/docs/usage/trainer.md
+++ b/docs/usage/trainer.md
@@ -103,6 +103,7 @@ VeOmni includes several built-in callbacks:
 - **[TqdmCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/trace_callback.py)**: Displays a progress bar.
 - **[WandbTraceCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/trace_callback.py)**: Logs metrics to wandb.
 - **[ProfileTraceCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/trace_callback.py)**: Handles profiling.
+- **[ChannelLossCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/channel_loss_callback.py)**: Logs detached per-channel causal-LM loss metrics when `train.channel_loss.enable=true`.
 - **[CheckpointerCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/checkpoint_callback.py)**: Saves training checkpoints.
 - **[HuggingfaceCkptCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/checkpoint_callback.py)**: Saves HuggingFace checkpoints.
 - **[EvaluateCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/evaluate_callback.py)**: Runs evaluation on the validation set.

--- a/tests/checkpoints/test_checkpoint_callback.py
+++ b/tests/checkpoints/test_checkpoint_callback.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
 from veomni.trainer.callbacks.base import TrainerState
 from veomni.trainer.callbacks.checkpoint_callback import (
@@ -49,6 +50,8 @@ def _make_mock_trainer(save_path="/tmp/test_ckpt", save_async=False):
     trainer.lr_scheduler = MagicMock()
     trainer.train_dataloader = MagicMock()
     trainer.environ_meter = MagicMock()
+    trainer.channel_loss_callback = MagicMock()
+    trainer.channel_loss_callback.state_dict.return_value = {}
     trainer.checkpointer = MagicMock()
     trainer.checkpointer.save_future = None
     trainer.model_assets = []
@@ -82,6 +85,44 @@ class TestCheckpointerCallbackLastSavedStep:
         with pytest.raises(RuntimeError, match="disk full"):
             cb._save_checkpoint(state)
         assert cb._last_saved_step == -1
+
+    def test_save_includes_channel_loss_callback_state(self, mock_helper, mock_dist, mock_build_ckpt):
+        trainer = _make_mock_trainer()
+        trainer.channel_loss_callback.state_dict.return_value = {
+            "source_registry": [(1, "train/a")],
+        }
+        mock_build_ckpt.return_value = trainer.checkpointer
+        cb = CheckpointerCallback(trainer)
+
+        cb._save_checkpoint(TrainerState(global_step=10))
+
+        checkpoint_state = trainer.checkpointer.save.call_args.args[1]
+        assert checkpoint_state["extra_state"]["channel_loss_callback"] == {"source_registry": [(1, "train/a")]}
+
+    def test_load_restores_channel_loss_callback_state(self, mock_helper, mock_dist, mock_build_ckpt):
+        trainer = _make_mock_trainer()
+        trainer.args.train.checkpoint.load_path = "/tmp/test_ckpt/global_step_7"
+        trainer.args.train_steps = 100
+        trainer.state = TrainerState()
+        mock_build_ckpt.return_value = trainer.checkpointer
+        callback_state = {"source_registry": [(1, "train/a")]}
+
+        def load_checkpoint(path, state, **kwargs):
+            state["extra_state"] = {
+                "global_step": 7,
+                "lr_scheduler": {},
+                "train_dataloader": None,
+                "environ_meter": {},
+                "channel_loss_callback": callback_state,
+                "torch_rng_state": torch.get_rng_state(),
+            }
+
+        trainer.checkpointer.load.side_effect = load_checkpoint
+        cb = CheckpointerCallback(trainer)
+
+        cb._load_checkpoint()
+
+        trainer.channel_loss_callback.load_state_dict.assert_called_once_with(callback_state)
 
     def test_epoch_end_retries_after_failed_save(self, mock_helper, mock_dist, mock_build_ckpt):
         """If save fails at step_end, epoch_end should still attempt to save (not skip)."""

--- a/tests/data/test_dpo_data_processor.py
+++ b/tests/data/test_dpo_data_processor.py
@@ -80,11 +80,16 @@ def test_dpo_main_collator_sp_disabled(monkeypatch):
 
     s1 = _make_flat_dpo_sample([1, 2, 3], [4, 5, 6])
     s2 = _make_flat_dpo_sample([7, 8], [9, 10])
+    s1.update(ds_idx=3, source_name="train/a")
+    s2.update(ds_idx=4, source_name="train/b")
     batch = m.MainCollator()([s1, s2])
 
     assert batch["input_ids"].view(-1).tolist() == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     assert batch["position_ids"].view(-1).tolist() == [0, 1, 2, 0, 1, 2, 0, 1, 0, 1]
     assert batch["cu_seq_lens_q"].tolist() == [0, 3, 6, 8, 10]
+    assert batch["ds_idx"].tolist() == [3, 4]
+    assert batch["source_name"] == ["train/a", "train/b"]
+    assert batch["position_ids"].eq(0).sum().item() == 2 * batch["ds_idx"].numel()
 
 
 def test_dpo_main_collator_sp_enabled(monkeypatch):

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -1,0 +1,1339 @@
+import importlib.util
+import math
+import os
+import sys
+from contextlib import nullcontext
+from functools import partial
+from importlib.machinery import ModuleSpec
+from types import SimpleNamespace
+
+
+os.environ.setdefault("TORCH_DEVICE_BACKEND_AUTOLOAD", "0")
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+_real_find_spec = importlib.util.find_spec
+
+
+def _find_spec_without_torch_npu(name: str, package: str | None = None) -> ModuleSpec | None:
+    if name == "torch_npu":
+        return None
+    return _real_find_spec(name, package)
+
+
+importlib.util.find_spec = _find_spec_without_torch_npu  # type: ignore[assignment]
+try:
+    import veomni.trainer.callbacks.channel_loss_callback as channel_loss_module
+    from veomni.arguments.arguments_types import ChannelLossConfig
+    from veomni.models.seed_omni.foundation.qwen3_moe_foundation.modeling_qwen3_moe_foundation import (
+        Qwen3MoeFoundationModel,
+    )
+    from veomni.models.seed_omni.modeling_seed_omni import SeedOmniModel
+    from veomni.models.transformers.qwen2_5_omni.generated.patched_modeling_qwen2_5_omni_gpu import (
+        Qwen2_5OmniForConditionalGeneration,
+    )
+    from veomni.models.transformers.qwen3_omni_moe.generated.patched_modeling_qwen3_omni_moe_gpu import (
+        Qwen3OmniMoeForConditionalGeneration,
+    )
+    from veomni.trainer.base import BaseTrainer
+    from veomni.trainer.base_rl_trainer import BaseRLTrainer
+    from veomni.trainer.callbacks.base import TrainerState
+    from veomni.trainer.callbacks.channel_loss_callback import (
+        ChannelLossCallback,
+        ChannelLossComputer,
+        ChannelLossMetadataError,
+    )
+    from veomni.trainer.dit_trainer import DiTTrainer
+    from veomni.trainer.text_dpo_trainer import TextDPOTrainer
+    from veomni.utils.constants import IGNORE_INDEX
+finally:
+    importlib.util.find_spec = _real_find_spec  # type: ignore[assignment]
+
+
+class _DummyOpSlot:
+    def __init__(self, kernel):
+        self._kernel = kernel
+        self.use_non_eager_impl = True
+
+    def __call__(self, *args, **kwargs):
+        return self._kernel(*args, **kwargs)
+
+
+class _TinyLossModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor(1.0))
+
+    def forward(self, x, use_cache=False):
+        return SimpleNamespace(loss=(self.weight * x).sum())
+
+
+def _expected_segment(logits, labels, start, end):
+    shifted = F.pad(labels, (0, 1), value=IGNORE_INDEX)[..., 1:].contiguous().view(-1)
+    losses = F.cross_entropy(
+        logits.float().view(-1, logits.size(-1)), shifted, ignore_index=IGNORE_INDEX, reduction="none"
+    )
+    valid = shifted[start : end + 1] != IGNORE_INDEX
+    return losses[start : end + 1][valid].sum().item(), valid.sum().item()
+
+
+def test_channel_loss_computer_aggregates_packed_logits_by_source():
+    torch.manual_seed(0)
+    vocab_size = 32
+    labels = torch.tensor([[10, 11, 12, IGNORE_INDEX, 21]], dtype=torch.long)
+    position_ids = torch.tensor([[0, 1, 2, 0, 1]], dtype=torch.long)
+    logits = torch.randn(1, 5, vocab_size)
+
+    computer = ChannelLossComputer()
+    computer._source_ids = [0, 1]
+    computer._position_ids = position_ids
+
+    result = computer._compute_channel_loss(
+        logits=logits,
+        labels=labels,
+        vocab_size=vocab_size,
+        hidden_states=None,
+        weights=None,
+        attention_mask=None,
+        shift_labels=None,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    loss_0, tokens_0 = _expected_segment(logits, labels, 0, 2)
+    loss_1, tokens_1 = _expected_segment(logits, labels, 3, 4)
+    assert result == [
+        {"source_id": 0, "loss_sum": pytest.approx(loss_0), "token_count": tokens_0},
+        {"source_id": 1, "loss_sum": pytest.approx(loss_1), "token_count": tokens_1},
+    ]
+
+
+def test_channel_loss_computer_hidden_states_path_matches_logits_path():
+    torch.manual_seed(1)
+    vocab_size = 16
+    hidden_size = 8
+    labels = torch.tensor([[3, 4, IGNORE_INDEX, 7]], dtype=torch.long)
+    position_ids = torch.tensor([[0, 1, 0, 1]], dtype=torch.long)
+    hidden_states = torch.randn(1, 4, hidden_size)
+    weights = torch.randn(vocab_size, hidden_size)
+    logits = F.linear(hidden_states, weights)
+
+    logits_computer = ChannelLossComputer()
+    logits_computer._source_ids = ["a", "b"]
+    logits_computer._position_ids = position_ids
+    logits_result = logits_computer._compute_channel_loss(
+        logits=logits,
+        labels=labels,
+        vocab_size=vocab_size,
+        hidden_states=None,
+        weights=None,
+        attention_mask=None,
+        shift_labels=None,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    hs_computer = ChannelLossComputer()
+    hs_computer._source_ids = ["a", "b"]
+    hs_computer._position_ids = position_ids
+    hs_result = hs_computer._compute_channel_loss(
+        logits=None,
+        labels=labels,
+        vocab_size=vocab_size,
+        hidden_states=hidden_states,
+        weights=weights,
+        attention_mask=None,
+        shift_labels=None,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    assert hs_result == logits_result
+
+
+def test_channel_loss_wrapper_forwards_original_call_unchanged():
+    class DummyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+
+        def loss_function(
+            self,
+            logits,
+            labels,
+            vocab_size,
+            num_items_in_batch=None,
+            ignore_index=IGNORE_INDEX,
+            **kwargs,
+        ):
+            self.calls.append((logits, labels, vocab_size, num_items_in_batch, ignore_index, kwargs))
+            return "main-loss"
+
+    model = DummyModel()
+    computer = ChannelLossComputer()
+    computer._source_ids = [0]
+    computer._position_ids = torch.tensor([[0, 1, 2]])
+    logits = torch.randn(1, 3, 8)
+    labels = torch.tensor([[1, 2, 3]])
+    num_items = object()
+
+    try:
+        computer.install(model)
+        with computer.capture():
+            result = model.loss_function(logits, labels, 8, num_items, -1, passthrough=True)
+        assert result == "main-loss"
+        assert model.calls == [(logits, labels, 8, num_items, -1, {"passthrough": True})]
+        assert computer._result
+        assert computer._result[0]["source_id"] == 0
+    finally:
+        computer.uninstall()
+
+
+def test_channel_loss_opslot_wrapper_handles_positional_loss_args():
+    def original_kernel(logits, labels, vocab_size, num_items_in_batch=None, ignore_index=IGNORE_INDEX, **kwargs):
+        return "main-loss", logits, None
+
+    module = sys.modules[__name__]
+    old_slot = getattr(module, "veomni_causal_lm_loss", None)
+    module.veomni_causal_lm_loss = _DummyOpSlot(original_kernel)
+
+    class DummyModel(torch.nn.Module):
+        pass
+
+    computer = ChannelLossComputer()
+    computer._source_ids = [0]
+    computer._position_ids = torch.tensor([[0, 1, 2]])
+    logits = torch.randn(1, 3, 8)
+    labels = torch.tensor([[1, 2, 3]])
+
+    try:
+        computer.install(DummyModel())
+        assert computer._wrapped_opslots
+        with computer.capture():
+            result = module.veomni_causal_lm_loss(logits, labels, 8)
+        assert result[0] == "main-loss"
+        assert result[1] is logits
+        assert result[2] is None
+        assert computer._result
+        assert computer._result[0]["source_id"] == 0
+    finally:
+        computer.uninstall()
+        if old_slot is None:
+            delattr(module, "veomni_causal_lm_loss")
+        else:
+            module.veomni_causal_lm_loss = old_slot
+
+
+@pytest.mark.parametrize("signature_kind", ["liger_partial", "chunk_dispatch"])
+def test_channel_loss_extracts_fused_inputs_from_variadic_loss_signatures(signature_kind):
+    from veomni.ops.kernels.cross_entropy import ForCausalLMLoss, _chunk_loss_dispatch
+
+    if signature_kind == "liger_partial":
+
+        def fake_fused_cross_entropy(*args, **kwargs):
+            return torch.tensor(0.0), None
+
+        loss_fn = partial(ForCausalLMLoss, cross_entropy_fn=fake_fused_cross_entropy)
+    else:
+        loss_fn = _chunk_loss_dispatch
+
+    computer = ChannelLossComputer()
+    computer._source_ids = [0]
+    computer._position_ids = torch.tensor([[0, 1, 2]])
+    labels = torch.tensor([[1, 2, 3]])
+    hidden_states = torch.randn(1, 3, 4)
+    weights = torch.randn(8, 4)
+
+    with computer.capture():
+        computer._observe_opslot_call(
+            loss_fn,
+            (),
+            {
+                "logits": None,
+                "labels": labels,
+                "vocab_size": 8,
+                "hidden_states": hidden_states,
+                "weights": weights,
+            },
+        )
+
+    assert computer._result
+    assert computer._result[0]["source_id"] == 0
+    assert computer._result[0]["token_count"].item() == 2
+
+
+def test_channel_loss_unwraps_native_lora_model_for_eager_loss():
+    from veomni.lora.config import VeOmniLoraConfig
+    from veomni.lora.model import VeOmniLoraModel
+
+    class EagerLossModel(torch.nn.Module):
+        def loss_function(self, logits, labels, vocab_size, **kwargs):
+            return "main-loss"
+
+        def forward(self, logits, labels, vocab_size):
+            return self.loss_function(logits, labels, vocab_size)
+
+    inner_model = EagerLossModel()
+    lora_model = VeOmniLoraModel(
+        inner_model,
+        VeOmniLoraConfig(target_modules=["unused"]),
+        inject=False,
+    )
+    computer = ChannelLossComputer()
+    computer._source_ids = [0]
+    computer._position_ids = torch.tensor([[0, 1, 2]])
+    logits = torch.randn(1, 3, 8)
+    labels = torch.tensor([[1, 2, 3]])
+
+    try:
+        computer.install(lora_model)
+        assert computer._model_ref is inner_model
+        with computer.capture():
+            result = lora_model(logits, labels, 8)
+        assert result == "main-loss"
+        assert computer._result
+        assert computer._result[0]["source_id"] == 0
+    finally:
+        computer.uninstall()
+
+
+def test_channel_loss_unwraps_seed_omni_foundation_loss():
+    class EagerFoundationModel(torch.nn.Module):
+        def loss_function(self, logits, labels, vocab_size, **kwargs):
+            return "foundation-loss"
+
+        def forward(self, logits, labels, vocab_size):
+            return self.loss_function(logits, labels, vocab_size)
+
+    class LightweightSeedOmniModel(SeedOmniModel):
+        def __init__(self, foundation):
+            torch.nn.Module.__init__(self)
+            self.foundation = foundation
+
+        def forward(self, *args, **kwargs):
+            return self.foundation(*args, **kwargs)
+
+    foundation = EagerFoundationModel()
+    model = LightweightSeedOmniModel(foundation)
+    computer = ChannelLossComputer()
+    computer._source_ids = [0]
+    computer._position_ids = torch.tensor([[0, 1, 2]])
+    logits = torch.randn(1, 3, 8)
+    labels = torch.tensor([[1, 2, 3]])
+
+    try:
+        computer.install(model)
+        assert computer._model_ref is foundation
+        with computer.capture():
+            result = model(logits, labels, 8)
+        assert result == "foundation-loss"
+        assert computer._result
+        assert computer._result[0]["source_id"] == 0
+    finally:
+        computer.uninstall()
+
+
+def test_channel_loss_rejects_seed_omni_qwen3_moe_direct_loss():
+    class LightweightSeedOmniModel(SeedOmniModel):
+        def __init__(self, foundation):
+            torch.nn.Module.__init__(self)
+            self.foundation = foundation
+
+    foundation = object.__new__(Qwen3MoeFoundationModel)
+    torch.nn.Module.__init__(foundation)
+    model = LightweightSeedOmniModel(foundation)
+    computer = ChannelLossComputer()
+
+    try:
+        with pytest.raises(ValueError, match="Qwen3MoeFoundationModel.*computes causal-LM loss directly"):
+            computer.install(model)
+    finally:
+        computer.uninstall()
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    [Qwen2_5OmniForConditionalGeneration, Qwen3OmniMoeForConditionalGeneration],
+)
+def test_channel_loss_unwraps_omni_thinker_loss(model_cls):
+    class EagerThinkerModel(torch.nn.Module):
+        def loss_function(self, logits, labels, vocab_size, **kwargs):
+            return "thinker-loss"
+
+        def forward(self, logits, labels, vocab_size):
+            return self.loss_function(logits, labels, vocab_size)
+
+    thinker = EagerThinkerModel()
+    model = object.__new__(model_cls)
+    torch.nn.Module.__init__(model)
+    model.thinker = thinker
+    computer = ChannelLossComputer()
+    computer._source_ids = [0]
+    computer._position_ids = torch.tensor([[0, 1, 2]])
+    logits = torch.randn(1, 3, 8)
+    labels = torch.tensor([[1, 2, 3]])
+
+    try:
+        computer.install(model)
+        assert computer._model_ref is thinker
+        with computer.capture():
+            result = model(logits=logits, labels=labels, vocab_size=8)
+        assert result == "thinker-loss"
+        assert computer._result
+        assert computer._result[0]["source_id"] == 0
+    finally:
+        computer.uninstall()
+
+
+def test_channel_loss_opslot_dispatch_is_scoped_and_reference_counted():
+    def original_kernel(logits, labels, vocab_size, **kwargs):
+        return "main-loss", logits, None
+
+    module = sys.modules[__name__]
+    old_slot = getattr(module, "veomni_causal_lm_loss", None)
+    slot = _DummyOpSlot(original_kernel)
+    module.veomni_causal_lm_loss = slot
+
+    class DummyModel(torch.nn.Module):
+        pass
+
+    first = ChannelLossComputer()
+    second = ChannelLossComputer()
+    for index, computer in enumerate((first, second)):
+        computer._source_ids = [index]
+        computer._position_ids = torch.tensor([[0, 1, 2]])
+
+    logits = torch.randn(1, 3, 8)
+    labels = torch.tensor([[1, 2, 3]])
+
+    try:
+        first.install(DummyModel())
+        dispatcher = slot._kernel
+        second.install(DummyModel())
+        assert slot._kernel is dispatcher
+
+        slot(logits, labels, 8)
+        assert first._result is None
+        assert second._result is None
+
+        with first.capture():
+            slot(logits, labels, 8)
+        assert first._result and first._result[0]["source_id"] == 0
+        assert second._result is None
+
+        with second.capture():
+            slot(logits, labels, 8)
+        assert second._result and second._result[0]["source_id"] == 1
+
+        first.uninstall()
+        assert slot._kernel is dispatcher
+        second.uninstall()
+        assert slot._kernel is original_kernel
+    finally:
+        first.uninstall()
+        second.uninstall()
+        if old_slot is None:
+            delattr(module, "veomni_causal_lm_loss")
+        else:
+            module.veomni_causal_lm_loss = old_slot
+
+
+def test_channel_loss_sp_reduce_preserves_batch_order_for_multiple_sources(monkeypatch):
+    rank1_metadata = [
+        {"batch_idx": 0, "sp_rank": 1, "local_order": 0, "is_start": False},
+        {"batch_idx": 1, "sp_rank": 1, "local_order": 0, "is_start": False},
+    ]
+    gather_inputs = []
+
+    def fake_all_gather_object(gathered, local_metadata, group=None):
+        gathered[0] = local_metadata
+        gathered[1] = rank1_metadata
+
+    def fake_all_gather(gathered, local_values, group=None):
+        gathered[0].copy_(local_values)
+        if local_values.dtype == torch.float32:
+            gathered[1].copy_(torch.tensor([5.0, 7.0]))
+        else:
+            gathered[1].copy_(torch.tensor([[1, 0, 0], [1, 0, 0]], dtype=torch.int64))
+        gather_inputs.append((local_values.dtype, tuple(local_values.shape)))
+
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: object())
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
+
+    result = ChannelLossComputer._aggregate_sp(
+        per_token_loss=torch.tensor([1.0, 2.0, 10.0, 20.0]),
+        labels_flat=torch.tensor([1, 1, 1, 1]),
+        attention_mask_flat=None,
+        source_ids=["batch0", "batch1"],
+        positions=torch.tensor([[0, 1], [0, 1]]),
+        seq_len=4,
+        ignore_index=IGNORE_INDEX,
+        strict=True,
+    )
+
+    assert result == [
+        {"source_id": "batch0", "loss_sum": 8.0, "token_count": 3},
+        {"source_id": "batch1", "loss_sum": 37.0, "token_count": 3},
+    ]
+    assert gather_inputs == [(torch.float32, (2,)), (torch.int64, (2, 3))]
+
+
+def test_channel_loss_sp_reduce_handles_empty_local_rank(monkeypatch):
+    rank1_metadata = [{"batch_idx": 0, "sp_rank": 1, "local_order": 0, "is_start": True}]
+
+    def fake_all_gather_object(gathered, local_metadata, group=None):
+        assert local_metadata == []
+        gathered[0] = []
+        gathered[1] = rank1_metadata
+
+    def fake_all_gather(gathered, local_values, group=None):
+        gathered[0].copy_(local_values)
+        if local_values.dtype == torch.float32:
+            gathered[1].copy_(torch.tensor([4.0]))
+        else:
+            gathered[1].copy_(torch.tensor([[2, 0, 0]], dtype=torch.int64))
+
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: object())
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
+
+    result = ChannelLossComputer._reduce_sp(
+        local_segments=[],
+        source_ids=["remote"],
+        device=torch.device("cpu"),
+        strict=True,
+    )
+
+    assert result == [{"source_id": "remote", "loss_sum": 4.0, "token_count": 2}]
+
+
+def test_channel_loss_sp_reduce_filters_uneven_remote_padding_segments(monkeypatch):
+    rank1_metadata = [
+        {"batch_idx": 0, "sp_rank": 1, "local_order": 0, "is_start": True},
+        {"batch_idx": 0, "sp_rank": 1, "local_order": 1, "is_start": True},
+    ]
+
+    def fake_all_gather_object(gathered, local_metadata, group=None):
+        assert len(local_metadata) == 1
+        gathered[0] = local_metadata
+        gathered[1] = rank1_metadata
+
+    def fake_all_gather(gathered, local_values, group=None):
+        gathered[0].copy_(local_values)
+        if local_values.dtype == torch.float32:
+            gathered[1].zero_()
+        else:
+            gathered[1].copy_(torch.tensor([[0, 1, 1], [0, 1, 1]], dtype=torch.int64))
+
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: object())
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
+
+    result = ChannelLossComputer._aggregate_sp(
+        per_token_loss=torch.tensor([1.0, 2.0]),
+        labels_flat=torch.tensor([1, 1]),
+        attention_mask_flat=torch.ones(2, dtype=torch.long),
+        source_ids=["doc"],
+        positions=torch.tensor([[0, 1]]),
+        seq_len=2,
+        ignore_index=IGNORE_INDEX,
+        strict=True,
+    )
+
+    assert result == [{"source_id": "doc", "loss_sum": 3.0, "token_count": 2}]
+
+
+def test_channel_loss_sp_aggregation_does_not_extract_segment_scalars(monkeypatch):
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+
+    def fail_item(tensor):
+        raise AssertionError(f"SP segment aggregation extracted a scalar with shape={tuple(tensor.shape)}")
+
+    with monkeypatch.context() as context:
+        context.setattr(torch.Tensor, "item", fail_item)
+        result = ChannelLossComputer._aggregate_sp(
+            per_token_loss=torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            labels_flat=torch.ones(6, dtype=torch.long),
+            attention_mask_flat=torch.ones(6, dtype=torch.long),
+            source_ids=["a", "b", "c"],
+            positions=torch.tensor([[0, 1, 0, 1, 0, 1]]),
+            seq_len=6,
+            ignore_index=IGNORE_INDEX,
+            strict=True,
+        )
+
+    assert result == [
+        {"source_id": "a", "loss_sum": 3.0, "token_count": 2},
+        {"source_id": "b", "loss_sum": 7.0, "token_count": 2},
+        {"source_id": "c", "loss_sum": 11.0, "token_count": 2},
+    ]
+
+
+def test_channel_loss_segment_count_mismatch_skips_or_raises():
+    kwargs = dict(
+        per_token_loss=torch.tensor([1.0, 2.0, 3.0, 4.0]),
+        labels_flat=torch.tensor([1, 1, 1, 1]),
+        attention_mask_flat=None,
+        source_ids=["only_one_source"],
+        position_ids=torch.tensor([[0, 1, 0, 1]]),
+        ignore_index=IGNORE_INDEX,
+    )
+
+    assert ChannelLossComputer._aggregate_by_source(**kwargs, strict=False) == []
+    with pytest.raises(ChannelLossMetadataError, match="source metadata count"):
+        ChannelLossComputer._aggregate_by_source(**kwargs, strict=True)
+
+
+def test_channel_loss_ignores_pad_to_length_position_zero_segments():
+    result = ChannelLossComputer._aggregate_by_source(
+        per_token_loss=torch.tensor([1.0, 2.0, 3.0, 100.0, 100.0]),
+        labels_flat=torch.tensor([1, 1, 1, IGNORE_INDEX, IGNORE_INDEX]),
+        attention_mask_flat=torch.ones(5, dtype=torch.long),
+        source_ids=["doc"],
+        position_ids=torch.tensor([[0, 1, 2, 0, 0]]),
+        ignore_index=IGNORE_INDEX,
+        strict=True,
+    )
+
+    assert result == [{"source_id": "doc", "loss_sum": 6.0, "token_count": 3}]
+
+
+def test_channel_loss_filters_padding_tail_per_batch_row():
+    result = ChannelLossComputer._aggregate_by_source(
+        per_token_loss=torch.tensor([1.0, 2.0, 100.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
+        labels_flat=torch.tensor([1, 1, IGNORE_INDEX, IGNORE_INDEX, 1, 1, IGNORE_INDEX, IGNORE_INDEX]),
+        attention_mask_flat=torch.tensor([1, 1, 0, 0, 1, 1, 0, 0]),
+        source_ids=["row0", "row1"],
+        position_ids=torch.tensor([[0, 1, 0, 0], [0, 1, 0, 0]]),
+        ignore_index=IGNORE_INDEX,
+        strict=True,
+    )
+
+    assert result == [
+        {"source_id": "row0", "loss_sum": 3.0, "token_count": 2},
+        {"source_id": "row1", "loss_sum": 7.0, "token_count": 2},
+    ]
+
+
+def test_channel_loss_preserves_zero_supervision_tail_when_later_row_has_padding():
+    result = ChannelLossComputer._aggregate_by_source(
+        per_token_loss=torch.tensor([1.0, 2.0, 3.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
+        labels_flat=torch.tensor([1, 1, 1, IGNORE_INDEX, 1, 1, IGNORE_INDEX, IGNORE_INDEX]),
+        attention_mask_flat=torch.tensor([1, 1, 1, 1, 1, 1, 0, 0]),
+        source_ids=["row0_normal", "row0_zero", "row1_normal"],
+        position_ids=torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]]),
+        ignore_index=IGNORE_INDEX,
+        strict=True,
+    )
+
+    assert result == [
+        {"source_id": "row0_normal", "loss_sum": 6.0, "token_count": 3},
+        {"source_id": "row0_zero", "loss_sum": 0.0, "token_count": 0},
+        {"source_id": "row1_normal", "loss_sum": 7.0, "token_count": 2},
+    ]
+
+
+def test_channel_loss_compute_uses_position_aligned_mask_for_padding_evidence(monkeypatch):
+    monkeypatch.setattr(channel_loss_module, "_is_sp_enabled", lambda: False)
+    computer = ChannelLossComputer()
+    computer.strict = True
+    computer._source_ids = ["row0_normal", "row0_zero", "row1_normal"]
+    computer._position_ids = torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]])
+    labels = torch.tensor([[1, 2, 3, 4], [1, 2, IGNORE_INDEX, IGNORE_INDEX]])
+    logits = torch.randn(2, 4, 8)
+
+    result = computer._compute_channel_loss(
+        logits=logits,
+        labels=labels,
+        vocab_size=8,
+        hidden_states=None,
+        weights=None,
+        attention_mask=torch.tensor([[1, 1, 1, 1], [1, 1, 0, 0]]),
+        shift_labels=None,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    assert [item["source_id"] for item in result] == ["row0_normal", "row0_zero", "row1_normal"]
+    assert [item["token_count"].item() for item in result] == [3, 0, 1]
+
+
+def test_channel_loss_rejects_ambiguous_per_row_padding_without_mask_evidence():
+    kwargs = dict(
+        per_token_loss=torch.tensor([1.0, 2.0, 3.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
+        labels_flat=torch.tensor([1, 1, 1, IGNORE_INDEX, 1, 1, IGNORE_INDEX, IGNORE_INDEX]),
+        attention_mask_flat=torch.ones(8, dtype=torch.long),
+        source_ids=["row0_normal", "row0_zero", "row1_normal"],
+        position_ids=torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]]),
+        ignore_index=IGNORE_INDEX,
+    )
+
+    assert ChannelLossComputer._aggregate_by_source(**kwargs, strict=False) == []
+    with pytest.raises(ChannelLossMetadataError, match="source metadata count"):
+        ChannelLossComputer._aggregate_by_source(**kwargs, strict=True)
+
+
+def test_channel_loss_keeps_zero_supervision_segment_before_tail_padding():
+    result = ChannelLossComputer._aggregate_by_source(
+        per_token_loss=torch.tensor([100.0, 2.0, 100.0]),
+        labels_flat=torch.tensor([IGNORE_INDEX, 1, IGNORE_INDEX]),
+        attention_mask_flat=torch.ones(3, dtype=torch.long),
+        source_ids=["one_token", "normal"],
+        position_ids=torch.tensor([[0, 0, 0]]),
+        ignore_index=IGNORE_INDEX,
+        strict=True,
+    )
+
+    assert result == [
+        {"source_id": "one_token", "loss_sum": 0.0, "token_count": 0},
+        {"source_id": "normal", "loss_sum": 2.0, "token_count": 1},
+    ]
+
+
+def test_channel_loss_sp_ignores_padding_only_position_zero_segments(monkeypatch):
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+
+    result = ChannelLossComputer._aggregate_sp(
+        per_token_loss=torch.tensor([1.0, 2.0, 100.0, 100.0]),
+        labels_flat=torch.tensor([1, 1, IGNORE_INDEX, IGNORE_INDEX]),
+        attention_mask_flat=None,
+        source_ids=["doc"],
+        positions=torch.tensor([[0, 1, 0, 0]]),
+        seq_len=4,
+        ignore_index=IGNORE_INDEX,
+        strict=True,
+    )
+
+    assert result == [{"source_id": "doc", "loss_sum": 3.0, "token_count": 2}]
+
+
+def test_channel_loss_sp_filters_padding_tail_per_batch_row(monkeypatch):
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+
+    result = ChannelLossComputer._aggregate_sp(
+        per_token_loss=torch.tensor([1.0, 2.0, 100.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
+        labels_flat=torch.tensor([1, 1, IGNORE_INDEX, IGNORE_INDEX, 1, 1, IGNORE_INDEX, IGNORE_INDEX]),
+        attention_mask_flat=torch.tensor([1, 1, 0, 0, 1, 1, 0, 0]),
+        source_ids=["row0", "row1"],
+        positions=torch.tensor([[0, 1, 0, 0], [0, 1, 0, 0]]),
+        seq_len=8,
+        ignore_index=IGNORE_INDEX,
+        strict=True,
+    )
+
+    assert result == [
+        {"source_id": "row0", "loss_sum": 3.0, "token_count": 2},
+        {"source_id": "row1", "loss_sum": 7.0, "token_count": 2},
+    ]
+
+
+def test_channel_loss_sp_preserves_zero_supervision_tail_when_later_row_has_padding(monkeypatch):
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+
+    result = ChannelLossComputer._aggregate_sp(
+        per_token_loss=torch.tensor([1.0, 2.0, 3.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
+        labels_flat=torch.tensor([1, 1, 1, IGNORE_INDEX, 1, 1, IGNORE_INDEX, IGNORE_INDEX]),
+        attention_mask_flat=torch.tensor([1, 1, 1, 1, 1, 1, 0, 0]),
+        source_ids=["row0_normal", "row0_zero", "row1_normal"],
+        positions=torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]]),
+        seq_len=8,
+        ignore_index=IGNORE_INDEX,
+        strict=True,
+    )
+
+    assert result == [
+        {"source_id": "row0_normal", "loss_sum": 6.0, "token_count": 3},
+        {"source_id": "row0_zero", "loss_sum": 0.0, "token_count": 0},
+        {"source_id": "row1_normal", "loss_sum": 7.0, "token_count": 2},
+    ]
+
+
+def test_channel_loss_sp_rejects_ambiguous_per_row_padding_without_mask_evidence(monkeypatch):
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    kwargs = dict(
+        per_token_loss=torch.tensor([1.0, 2.0, 3.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
+        labels_flat=torch.tensor([1, 1, 1, IGNORE_INDEX, 1, 1, IGNORE_INDEX, IGNORE_INDEX]),
+        attention_mask_flat=torch.ones(8, dtype=torch.long),
+        source_ids=["row0_normal", "row0_zero", "row1_normal"],
+        positions=torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]]),
+        seq_len=8,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    assert ChannelLossComputer._aggregate_sp(**kwargs, strict=False) == []
+    with pytest.raises(ChannelLossMetadataError, match="source metadata count"):
+        ChannelLossComputer._aggregate_sp(**kwargs, strict=True)
+
+
+def test_channel_loss_sp_keeps_zero_supervision_segment_before_tail_padding(monkeypatch):
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
+    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+
+    result = ChannelLossComputer._aggregate_sp(
+        per_token_loss=torch.tensor([100.0, 2.0, 100.0]),
+        labels_flat=torch.tensor([IGNORE_INDEX, 1, IGNORE_INDEX]),
+        attention_mask_flat=torch.ones(3, dtype=torch.long),
+        source_ids=["one_token", "normal"],
+        positions=torch.tensor([[0, 0, 0]]),
+        seq_len=3,
+        ignore_index=IGNORE_INDEX,
+        strict=True,
+    )
+
+    assert result == [
+        {"source_id": "one_token", "loss_sum": 0.0, "token_count": 0},
+        {"source_id": "normal", "loss_sum": 2.0, "token_count": 1},
+    ]
+
+
+def test_channel_loss_logits_path_computes_ce_in_chunks(monkeypatch):
+    calls = []
+    original_cross_entropy = F.cross_entropy
+
+    def spy_cross_entropy(input, target, **kwargs):
+        calls.append(input.shape[0])
+        return original_cross_entropy(input, target, **kwargs)
+
+    monkeypatch.setattr(channel_loss_module.F, "cross_entropy", spy_cross_entropy)
+    monkeypatch.setattr(ChannelLossComputer, "EAGER_CHUNK_SIZE", 2)
+
+    logits = torch.randn(1, 5, 8)
+    labels_flat = torch.tensor([1, 2, 3, 4, 5])
+
+    result = ChannelLossComputer()._per_token_ce(
+        logits=logits,
+        labels_flat=labels_flat,
+        vocab_size=8,
+        hidden_states=None,
+        weights=None,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    assert result.shape == (5,)
+    assert calls == [2, 2, 1]
+
+
+def test_channel_loss_config_validates_sampling_interval():
+    assert ChannelLossConfig().interval == 10
+    with pytest.raises(ValueError, match="interval must be at least 1"):
+        ChannelLossConfig(interval=0)
+
+
+def test_channel_loss_computer_aggregates_step_results_locally():
+    computer = ChannelLossComputer()
+    computer.begin_step([], [], [])
+    computer._result = [
+        {"source_id": "a", "loss_sum": torch.tensor(2.0), "token_count": torch.tensor(1)},
+        {"source_id": "a", "loss_sum": torch.tensor(4.0), "token_count": torch.tensor(2)},
+        {"source_id": "b", "loss_sum": torch.tensor(3.0), "token_count": torch.tensor(1)},
+    ]
+
+    computer.after_micro_step()
+
+    assert set(computer.step_totals) == {"a", "b"}
+    assert computer.step_totals["a"][0].item() == 6.0
+    assert computer.step_totals["a"][1].item() == 3
+
+
+def test_base_forward_backward_allows_missing_channel_loss_callback():
+    trainer = object.__new__(BaseTrainer)
+    trainer.state = TrainerState(global_step=1)
+    trainer.device = torch.device("cpu")
+    trainer.args = SimpleNamespace(
+        train=SimpleNamespace(
+            enable_batch_invariant_mode=False,
+            local_rank=0,
+        )
+    )
+    trainer.model = _TinyLossModel()
+    trainer.model_fwd_context = nullcontext()
+    trainer.model_bwd_context = nullcontext()
+    trainer.micro_batch_token_len = 1
+    trainer.micro_batches_token_len = 1
+    trainer.LOG_SAMPLE = False
+    trainer.postforward = lambda outputs, micro_batch: (outputs.loss, {"loss": outputs.loss.detach()})
+
+    loss, loss_dict = BaseTrainer.forward_backward_step(trainer, {"x": torch.tensor(2.0)})
+
+    assert loss.item() == 2.0
+    assert loss_dict["loss"].item() == 2.0
+    assert trainer.model.weight.grad.item() == 2.0
+
+
+def test_base_forward_backward_strips_channel_metadata_after_preforward():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = object.__new__(BaseTrainer)
+    trainer.state = TrainerState(global_step=1)
+    trainer.device = torch.device("cpu")
+    trainer.args = SimpleNamespace(
+        train=SimpleNamespace(
+            channel_loss=cfg,
+            enable_batch_invariant_mode=False,
+            local_rank=0,
+        )
+    )
+    trainer.model = _TinyLossModel()
+    trainer.model_fwd_context = nullcontext()
+    trainer.model_bwd_context = nullcontext()
+    trainer.micro_batch_token_len = 1
+    trainer.micro_batches_token_len = 1
+    trainer.LOG_SAMPLE = False
+    trainer.postforward = lambda outputs, micro_batch: (outputs.loss, {"loss": outputs.loss.detach()})
+    trainer.channel_loss_callback = ChannelLossCallback(trainer)
+    preforward_seen = {}
+
+    def preforward(micro_batch):
+        preforward_seen["has_source_metadata"] = "ds_idx" in micro_batch and "cur_token_num" in micro_batch
+        return BaseTrainer.preforward(trainer, micro_batch)
+
+    trainer.preforward = preforward
+    micro_batch = {
+        "x": torch.tensor(2.0),
+        "ds_idx": torch.tensor([3]),
+        "source_name": ["train/a"],
+        "cur_token_num": torch.tensor([1]),
+    }
+
+    trainer.channel_loss_callback.on_step_begin(trainer.state, micro_batches=[micro_batch])
+    loss, loss_dict = BaseTrainer.forward_backward_step(trainer, micro_batch)
+
+    assert preforward_seen["has_source_metadata"]
+    assert loss.item() == 2.0
+    assert loss_dict["loss"].item() == 2.0
+    assert trainer.model.weight.grad.item() == 2.0
+
+
+def test_dpo_forward_backward_scopes_channel_loss_to_policy_model():
+    cfg = ChannelLossConfig(enable=True, interval=1)
+    state = TrainerState(global_step=1)
+    policy_model = object()
+    reference_model = object()
+    base = SimpleNamespace(
+        args=SimpleNamespace(
+            train=SimpleNamespace(channel_loss=cfg, enable_batch_invariant_mode=False),
+            dpo_config=SimpleNamespace(
+                beta=0.1,
+                label_smoothing=0.0,
+                loss_type="sigmoid",
+                reference_free=False,
+            ),
+        ),
+        state=state,
+        model=policy_model,
+        model_fwd_context=nullcontext(),
+        model_bwd_context=nullcontext(),
+    )
+    base.channel_loss_callback = ChannelLossCallback(base)
+    preforward_seen = {}
+
+    def preforward(micro_batch):
+        preforward_seen["metadata"] = "ds_idx" in micro_batch and "source_name" in micro_batch
+        return micro_batch
+
+    base.preforward = preforward
+    trainer = object.__new__(TextDPOTrainer)
+    trainer.base = base
+    trainer.reference_model = reference_model
+    forward_calls = []
+
+    def concatenated_forward(model, micro_batch):
+        forward_calls.append(
+            {
+                "model": model,
+                "capture_active": base.channel_loss_callback.computer.capture_active,
+                "has_metadata": "ds_idx" in micro_batch or "source_name" in micro_batch,
+            }
+        )
+        if model is reference_model:
+            return torch.tensor([0.2]), torch.tensor([0.1])
+        return torch.tensor([0.3], requires_grad=True), torch.tensor([0.1], requires_grad=True)
+
+    trainer.concatenated_forward = concatenated_forward
+    micro_batch = {
+        "labels": torch.tensor([[1, 2, 3]]),
+        "position_ids": torch.tensor([[0, 1, 2]]),
+        "ds_idx": torch.tensor([3]),
+        "source_name": ["train/a"],
+    }
+    base.channel_loss_callback.on_step_begin(state, micro_batches=[micro_batch])
+
+    loss, _ = TextDPOTrainer.forward_backward_step(trainer, micro_batch)
+
+    assert loss.item() > 0
+    assert preforward_seen["metadata"]
+    assert forward_calls == [
+        {"model": reference_model, "capture_active": False, "has_metadata": False},
+        {"model": policy_model, "capture_active": True, "has_metadata": False},
+    ]
+    assert base.channel_loss_callback.computer._micro_step == 1
+    assert base.channel_loss_callback.computer._source_ids == []
+
+
+def test_dpo_channel_loss_emits_policy_totals():
+    class DpoLossModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.scale = torch.nn.Parameter(torch.tensor(1.0))
+            self.loss_calls = 0
+
+        def loss_function(self, logits, labels, vocab_size, **kwargs):
+            self.loss_calls += 1
+            return logits.sum() * 0
+
+        def forward(self, labels=None, **kwargs):
+            seq_len = labels.size(-1) if labels is not None else 8
+            logits = torch.randn(1, seq_len, 8)
+            if labels is not None:
+                self.loss_function(logits=logits, labels=labels, vocab_size=8)
+            log_probs = self.scale * (-torch.arange(1, seq_len + 1, dtype=torch.float32).unsqueeze(0) / 10)
+            return SimpleNamespace(fused_linear_aux=SimpleNamespace(log_probs=log_probs))
+
+    cfg = ChannelLossConfig(enable=True, interval=1)
+    state = TrainerState(global_step=1)
+    policy_model = DpoLossModel()
+    reference_model = DpoLossModel()
+    base = SimpleNamespace(
+        args=SimpleNamespace(
+            train=SimpleNamespace(channel_loss=cfg, enable_batch_invariant_mode=False),
+            dpo_config=SimpleNamespace(
+                beta=0.1,
+                label_smoothing=0.0,
+                loss_type="sigmoid",
+                reference_free=False,
+                average_log_prob=False,
+            ),
+        ),
+        state=state,
+        model=policy_model,
+        model_fwd_context=nullcontext(),
+        model_bwd_context=nullcontext(),
+        preforward=lambda micro_batch: micro_batch,
+    )
+    base.channel_loss_callback = ChannelLossCallback(base)
+    step_begin_args = {}
+
+    def on_step_begin(micro_batches=None, channel_loss_source_repeat=1):
+        step_begin_args["source_repeat"] = channel_loss_source_repeat
+        base.channel_loss_callback.on_step_begin(
+            state,
+            micro_batches=micro_batches,
+            source_repeat=channel_loss_source_repeat,
+        )
+
+    base.on_step_begin = on_step_begin
+    trainer = object.__new__(TextDPOTrainer)
+    trainer.base = base
+    trainer.reference_model = reference_model
+    trainer.post_forward = SimpleNamespace(compute_seqlens_func=lambda micro_batch: [2, 2, 2, 2])
+    trainer.sp_enabled = False
+    micro_batch = {
+        "input_ids": torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]]),
+        "labels": torch.tensor([[1, 2, IGNORE_INDEX, 4, IGNORE_INDEX, 6, IGNORE_INDEX, 7]]),
+        "position_ids": torch.tensor([[0, 1, 0, 1, 0, 1, 0, 1]]),
+        "ds_idx": torch.tensor([3, 4]),
+        "source_name": ["train/a", "train/b"],
+    }
+
+    try:
+        base.channel_loss_callback.computer.install(policy_model)
+        TextDPOTrainer.on_step_begin(trainer, micro_batches=[micro_batch])
+        assert step_begin_args == {"source_repeat": 2}
+        assert base.channel_loss_callback.computer._per_mb_source_ids == [[3, 3, 4, 4]]
+        TextDPOTrainer.forward_backward_step(trainer, micro_batch)
+
+        assert policy_model.loss_calls == 1
+        assert reference_model.loss_calls == 1
+        assert set(base.channel_loss_callback.computer.step_totals) == {3, 4}
+        assert base.channel_loss_callback.computer.step_totals[3][1].item() == 2
+        assert base.channel_loss_callback.computer.step_totals[4][1].item() == 2
+        assert base.channel_loss_callback.computer.source_names == {3: "train/a", 4: "train/b"}
+        assert policy_model.scale.grad is not None
+        assert reference_model.scale.grad is None
+    finally:
+        base.channel_loss_callback.computer.uninstall()
+
+
+def test_dit_rejects_channel_loss_before_initialization():
+    args = SimpleNamespace(train=SimpleNamespace(channel_loss=ChannelLossConfig(enable=True)))
+    with pytest.raises(ValueError, match="causal-LM trainers"):
+        DiTTrainer(args)
+
+
+def test_channel_loss_rejects_classification_objective():
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(
+            train=SimpleNamespace(channel_loss=ChannelLossConfig(enable=True)),
+            data=SimpleNamespace(data_type="classification"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="causal-LM objectives.*classification"):
+        ChannelLossCallback(trainer)
+
+
+def test_channel_loss_rejects_base_rl_trainer():
+    trainer = object.__new__(BaseRLTrainer)
+    trainer.args = SimpleNamespace(
+        train=SimpleNamespace(channel_loss=ChannelLossConfig(enable=True)),
+        data=SimpleNamespace(data_type="conversation"),
+    )
+
+    with pytest.raises(ValueError, match="BaseRLTrainer.*packs metadata during preforward"):
+        ChannelLossCallback(trainer)
+
+
+def test_channel_loss_resolve_source_name_handles_missing_environ_meter():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+
+    assert callback._resolve_source_name(7) == "source_7"
+
+
+def test_channel_loss_metric_name_collisions_remain_distinct():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+    totals = {1: (6.0, 2), 2: (9.0, 3)}
+    source_names = {1: "train/a", 2: "train_a"}
+
+    metrics = callback._build_metrics(totals, source_names)
+
+    assert metrics["channel_loss/source-i-1__train_a"] == 3.0
+    assert metrics["channel_loss/source-i-2__train_a"] == 3.0
+    assert metrics["channel_tokens/source-i-1__train_a"] == 2.0
+    assert metrics["channel_tokens/source-i-2__train_a"] == 3.0
+    assert len(metrics) == 6
+
+    callback.config.strict = True
+    assert callback._build_metrics(totals, source_names) == metrics
+
+
+def test_channel_loss_metric_name_is_source_qualified_from_first_emission():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+
+    metrics = callback._build_metrics({1: (6.0, 2)}, {1: "train/a"})
+
+    assert "channel_loss/source-i-1__train_a" in metrics
+    assert "channel_loss/train_a" not in metrics
+
+
+def test_channel_loss_metric_name_collision_registry_persists_across_steps():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+
+    first = callback._build_metrics({1: (6.0, 2)}, {1: "train/a"})
+    second = callback._build_metrics({2: (9.0, 3)}, {2: "train_a"})
+    third = callback._build_metrics({1: (3.0, 1)}, {1: "train/a"})
+
+    assert "channel_loss/source-i-1__train_a" in first
+    assert "channel_loss/source-i-2__train_a" in second
+    assert "channel_loss/source-i-1__train_a" in third
+
+    strict_cfg = ChannelLossConfig(enable=True, strict=True)
+    strict_trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=strict_cfg)), environ_meter=None
+    )
+    strict_callback = ChannelLossCallback(strict_trainer)
+    strict_first = strict_callback._build_metrics({1: (6.0, 2)}, {1: "train/a"})
+    strict_second = strict_callback._build_metrics({2: (9.0, 3)}, {2: "train_a"})
+    assert "channel_loss/source-i-1__train_a" in strict_first
+    assert "channel_loss/source-i-2__train_a" in strict_second
+
+
+def test_channel_loss_source_registry_round_trips_across_resume():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+    callback._build_metrics({1: (6.0, 2)}, {1: "train/a"})
+
+    resumed = ChannelLossCallback(trainer)
+    resumed.load_state_dict(callback.state_dict())
+    metrics = resumed._build_metrics({2: (9.0, 3)}, {2: "train_a"})
+
+    assert "channel_loss/train_a" not in metrics
+    assert "channel_loss/source-i-2__train_a" in metrics
+
+
+def test_channel_loss_callback_strips_metadata_after_preforward():
+    cfg = ChannelLossConfig(enable=True, interval=1)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    state = TrainerState(global_step=1)
+    micro_batch = {
+        "input_ids": torch.tensor([[1, 2, 3]]),
+        "labels": torch.tensor([[1, 2, 3]]),
+        "position_ids": torch.tensor([[0, 1, 2]]),
+        "ds_idx": torch.tensor([3]),
+        "source_name": ["train/a"],
+        "cur_token_num": torch.tensor([3]),
+    }
+
+    callback.on_step_begin(state, micro_batches=[micro_batch])
+    callback.on_micro_step_begin(state, micro_batch=micro_batch)
+
+    assert "ds_idx" in micro_batch
+    assert "source_name" in micro_batch
+    assert "cur_token_num" in micro_batch
+    callback.strip_model_inputs(micro_batch)
+
+    assert "ds_idx" not in micro_batch
+    assert "source_name" not in micro_batch
+    assert "cur_token_num" not in micro_batch
+    assert "position_ids" in micro_batch
+    assert callback.computer._source_ids == [3]
+    assert callback.computer.source_names == {3: "train/a"}
+
+
+def test_channel_loss_callback_samples_steps_but_always_strips_metadata():
+    cfg = ChannelLossConfig(enable=True, interval=2)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "position_ids": torch.tensor([[0, 1]]),
+        "ds_idx": torch.tensor([3]),
+        "source_name": ["train/a"],
+    }
+
+    callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
+    callback.on_micro_step_begin(TrainerState(global_step=1), micro_batch=micro_batch)
+    with callback.model_forward_context():
+        assert not callback.computer.capture_active
+    assert callback.computer._source_ids == []
+    callback.strip_model_inputs(micro_batch)
+    assert "ds_idx" not in micro_batch
+    assert "source_name" not in micro_batch
+
+    sampled_batch = {
+        "position_ids": torch.tensor([[0, 1]]),
+        "ds_idx": torch.tensor([4]),
+        "source_name": ["train/b"],
+    }
+    callback.on_step_begin(TrainerState(global_step=2), micro_batches=[sampled_batch])
+    callback.on_micro_step_begin(TrainerState(global_step=2), micro_batch=sampled_batch)
+    with callback.model_forward_context():
+        assert callback.computer.capture_active
+    assert callback.computer._source_ids == [4]
+    callback.on_micro_step_end(TrainerState(global_step=2))
+
+
+def test_channel_loss_callback_updates_trainer_metrics():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        step_train_metrics={},
+        step_env_metrics={},
+    )
+    callback = ChannelLossCallback(trainer)
+    callback.computer.source_names = {0: "source/a", 1: "source-b"}
+    callback.computer.step_totals = {
+        0: (torch.tensor(6.0), torch.tensor(3)),
+        1: (torch.tensor(3.0), torch.tensor(1)),
+    }
+    callback._collect_step = True
+
+    callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert math.isclose(trainer.step_env_metrics["channel_loss/source-i-0__source_a"], 2.0)
+    assert math.isclose(trainer.step_env_metrics["channel_loss/source-i-1__source-b"], 3.0)
+    assert math.isclose(trainer.step_env_metrics["channel_loss_weighted/source-i-0__source_a"], 1.5)
+    assert math.isclose(trainer.step_env_metrics["channel_tokens/source-i-1__source-b"], 1.0)
+    assert trainer.step_train_metrics == trainer.step_env_metrics
+
+
+def test_channel_loss_callback_reduces_compact_totals_and_syncs_names(monkeypatch):
+    cfg = ChannelLossConfig(enable=True, interval=1)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        device=torch.device("cpu"),
+        step_train_metrics={},
+        step_env_metrics={},
+    )
+    callback = ChannelLossCallback(trainer)
+    callback._collect_step = True
+    callback.computer.source_names = {0: "source/a"}
+    callback.computer.step_totals = {0: (torch.tensor(6.0), torch.tensor(3))}
+    group = object()
+    observed = {}
+
+    monkeypatch.setattr(channel_loss_module, "get_parallel_state", lambda: SimpleNamespace(dp_size=2, dp_group=group))
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_all_gather_object(gathered, local_metadata, group=None):
+        observed["metadata"] = local_metadata
+        gathered[0] = local_metadata
+        gathered[1] = [(1, "source-b")]
+
+    def fake_all_reduce(value, group=None):
+        assert group is not None
+        if value.dtype.is_floating_point:
+            value.add_(torch.tensor([0.0, 3.0]))
+        else:
+            value.add_(torch.tensor([0, 1]))
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(channel_loss_module.dist, "all_reduce", fake_all_reduce)
+
+    callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert observed["metadata"] == [(0, "source/a")]
+    assert trainer.step_env_metrics["channel_loss/source-i-0__source_a"] == 2.0
+    assert trainer.step_env_metrics["channel_loss/source-i-1__source-b"] == 3.0
+    assert trainer.step_env_metrics["channel_tokens/source-i-1__source-b"] == 1.0
+
+
+def test_channel_loss_callback_strict_rejects_cross_rank_name_mismatch(monkeypatch):
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=True)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        device=torch.device("cpu"),
+        step_train_metrics={},
+        step_env_metrics={},
+    )
+    callback = ChannelLossCallback(trainer)
+    callback._collect_step = True
+    callback.computer.source_names = {0: "source-a"}
+    callback.computer.step_totals = {0: (torch.tensor(1.0), torch.tensor(1))}
+
+    monkeypatch.setattr(
+        channel_loss_module, "get_parallel_state", lambda: SimpleNamespace(dp_size=2, dp_group=object())
+    )
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_all_gather_object(gathered, local_metadata, group=None):
+        gathered[0] = local_metadata
+        gathered[1] = [(0, "source-b")]
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
+
+    with pytest.raises(ChannelLossMetadataError, match="inconsistent names"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+
+def test_channel_loss_callback_strict_requires_source_id():
+    cfg = ChannelLossConfig(enable=True, strict=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    with pytest.raises(ValueError, match="no configured source ID"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[{"input_ids": torch.tensor([[1]])}])

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -32,6 +32,7 @@ logger = logging.get_logger(__name__)
 #   ├── optimizer.*          → OptimizerConfig
 #   ├── wandb.*              → WandbConfig
 #   ├── profile.*            → ProfileConfig
+#   ├── channel_loss.*       → ChannelLossConfig
 #   ├── gradient_checkpointing.*  → GradientCheckpointingConfig
 #   ├── accelerator.*        → AcceleratorConfig
 #   │   ├── fsdp_config.*    → FSDPConfig
@@ -214,6 +215,91 @@ class ProfileConfig:
             "help": "whether to profile rank0 only. When false, every rank will be profiled; Please expect many files to save, which can be slow and take a lot of disk space."
         },
     )
+
+
+@dataclass
+class ChannelLossConfig:
+    """train.channel_loss.* — Per-channel causal-LM loss logging."""
+
+    enable: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Enable detached per-channel cross-entropy logging. This is an observability-only "
+                "side channel and does not change the training objective."
+            )
+        },
+    )
+    interval: int = field(
+        default=10,
+        metadata={
+            "help": (
+                "Compute and log channel loss every N optimizer steps. The detached fused-loss "
+                "fallback recomputes the LM-head projection on sampled steps; use 1 to sample every step."
+            )
+        },
+    )
+    source_id_keys: List[str] = field(
+        default_factory=lambda: ["channel_id", "source_id", "dataset_id", "ds_idx"],
+        metadata={
+            "help": (
+                "Batch metadata keys to read as channel/source IDs. The first key found in each "
+                "micro-batch is used. Values should be one per packed sequence."
+            )
+        },
+    )
+    source_name_keys: List[str] = field(
+        default_factory=lambda: ["channel_name", "source_name", "dataset_name", "data_name"],
+        metadata={
+            "help": (
+                "Batch metadata keys to read as display names for channel/source IDs. Values should "
+                "align with source_id_keys when provided."
+            )
+        },
+    )
+    extra_strip_keys: List[str] = field(
+        default_factory=lambda: ["cur_token_num"],
+        metadata={
+            "help": (
+                "Extra metadata keys to remove from each micro-batch before model forward when "
+                "channel loss is enabled."
+            )
+        },
+    )
+    loss_metric_prefix: str = field(
+        default="channel_loss",
+        metadata={"help": "Metric prefix for per-channel average CE."},
+    )
+    weighted_loss_metric_prefix: str = field(
+        default="channel_loss_weighted",
+        metadata={"help": "Metric prefix for per-channel CE weighted by all logged tokens in the step."},
+    )
+    token_count_metric_prefix: str = field(
+        default="channel_tokens",
+        metadata={"help": "Metric prefix for per-channel supervised token counts."},
+    )
+    log_weighted_loss: bool = field(
+        default=True,
+        metadata={"help": "Log loss_sum / total_step_tokens for each channel."},
+    )
+    log_token_count: bool = field(
+        default=True,
+        metadata={"help": "Log supervised token count for each channel."},
+    )
+    strict: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Raise when enabled but a micro-batch has no configured source ID, or when "
+                "source metadata cannot be aligned with packed segments. Default False skips "
+                "micro-batches with missing or mismatched metadata."
+            )
+        },
+    )
+
+    def __post_init__(self) -> None:
+        if self.interval < 1:
+            raise ValueError("train.channel_loss.interval must be at least 1.")
 
 
 @dataclass
@@ -605,6 +691,7 @@ class TrainingArguments:
     optimizer: OptimizerConfig = field(default_factory=OptimizerConfig)
     wandb: WandbConfig = field(default_factory=WandbConfig)
     profile: ProfileConfig = field(default_factory=ProfileConfig)
+    channel_loss: ChannelLossConfig = field(default_factory=ChannelLossConfig)
     gradient_checkpointing: GradientCheckpointingConfig = field(default_factory=GradientCheckpointingConfig)
     torch_compile: TorchCompileConfig = field(default_factory=TorchCompileConfig)
     accelerator: AcceleratorConfig = field(default_factory=AcceleratorConfig)

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -32,6 +32,7 @@ import queue
 import threading
 from abc import ABC
 from collections import defaultdict
+from contextlib import nullcontext
 from dataclasses import asdict, fields
 from typing import Any, Callable, Dict, List
 
@@ -74,6 +75,7 @@ from ..utils.device import (
 from ..utils.loss_utils import count_loss_token, mean_global_loss
 from ..utils.model_utils import pretty_print_trainable_parameters
 from .callbacks import (
+    ChannelLossCallback,
     CheckpointerCallback,
     EnvironMeterCallback,
     EvaluateCallback,
@@ -577,9 +579,11 @@ class BaseTrainer(Stateful, ABC):
             self.hf_ckpt_callback = HuggingfaceCkptCallback(self)
         self.evaluate_callback = EvaluateCallback(self)
         self.moe_monitor_callback = MoERouterMonitorCallback(self)
+        self.channel_loss_callback = ChannelLossCallback(self)
         self.state = TrainerState()
 
     def on_train_begin(self):
+        self.channel_loss_callback.on_train_begin(self.state)
         self.environ_meter_callback.on_train_begin(self.state)
         self.tqdm_callback.on_train_begin(self.state)
         self.wandb_callback.on_train_begin(self.state)
@@ -598,6 +602,7 @@ class BaseTrainer(Stateful, ABC):
         self.hf_ckpt_callback.on_train_end(self.state)
         self.evaluate_callback.on_train_end(self.state)
         self.moe_monitor_callback.on_train_end(self.state)
+        self.channel_loss_callback.on_train_end(self.state)
 
     def on_epoch_begin(self):
         self.environ_meter_callback.on_epoch_begin(self.state)
@@ -617,7 +622,12 @@ class BaseTrainer(Stateful, ABC):
         self.hf_ckpt_callback.on_epoch_end(self.state)
         self.evaluate_callback.on_epoch_end(self.state)
 
-    def on_step_begin(self, micro_batches=None):
+    def on_step_begin(self, micro_batches=None, channel_loss_source_repeat: int = 1):
+        self.channel_loss_callback.on_step_begin(
+            self.state,
+            micro_batches=micro_batches,
+            source_repeat=channel_loss_source_repeat,
+        )
         self.environ_meter_callback.on_step_begin(self.state, micro_batches=micro_batches)
         self.tqdm_callback.on_step_begin(self.state, micro_batches=micro_batches)
         self.wandb_callback.on_step_begin(self.state, micro_batches=micro_batches)
@@ -629,6 +639,7 @@ class BaseTrainer(Stateful, ABC):
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
         self.environ_meter_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
         self.tqdm_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
+        self.channel_loss_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
         self.wandb_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
         self.profile_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
         self.checkpointer_callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
@@ -671,21 +682,37 @@ class BaseTrainer(Stateful, ABC):
     def forward_backward_step(
         self, micro_batch: dict[str, torch.Tensor]
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
-        micro_batch = self.preforward(micro_batch)
+        channel_loss_callback = getattr(self, "channel_loss_callback", None)
+        micro_step_context = (
+            channel_loss_callback.micro_step_context(self.state, micro_batch)
+            if channel_loss_callback is not None
+            else nullcontext()
+        )
+        with micro_step_context:
+            micro_batch = self.preforward(micro_batch)
+            if channel_loss_callback is not None:
+                channel_loss_callback.strip_model_inputs(micro_batch)
 
-        with self.model_fwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
-            outputs: ModelOutput = self.model(**micro_batch, use_cache=False)
+            channel_forward_context = (
+                channel_loss_callback.model_forward_context() if channel_loss_callback is not None else nullcontext()
+            )
+            with (
+                self.model_fwd_context,
+                set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode),
+                channel_forward_context,
+            ):
+                outputs: ModelOutput = self.model(**micro_batch, use_cache=False)
 
-        loss: torch.Tensor
-        loss_dict: Dict[str, torch.Tensor]
-        loss, loss_dict = self.postforward(outputs, micro_batch)
+            loss: torch.Tensor
+            loss_dict: Dict[str, torch.Tensor]
+            loss, loss_dict = self.postforward(outputs, micro_batch)
 
-        # Backward pass
-        with self.model_bwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
-            loss.backward()
+            # Backward pass
+            with self.model_bwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
+                loss.backward()
 
-        del micro_batch
-        return loss, loss_dict
+            del micro_batch
+            return loss, loss_dict
 
     def model_reshard(self, micro_step: int, num_micro_steps: int):
         """Reshard model after backward pass."""

--- a/veomni/trainer/callbacks/__init__.py
+++ b/veomni/trainer/callbacks/__init__.py
@@ -19,6 +19,7 @@ Provides callback system for customizing trainer behavior at various stages of t
 """
 
 from .base import Callback, TrainerState
+from .channel_loss_callback import ChannelLossCallback, ChannelLossComputer
 from .checkpoint_callback import CheckpointerCallback, HFLoraCkptCallback, HuggingfaceCkptCallback
 from .evaluate_callback import EvaluateCallback
 from .trace_callback import (
@@ -33,6 +34,8 @@ from .trace_callback import (
 __all__ = [
     "Callback",
     "TrainerState",
+    "ChannelLossCallback",
+    "ChannelLossComputer",
     "CheckpointerCallback",
     "HuggingfaceCkptCallback",
     "HFLoraCkptCallback",

--- a/veomni/trainer/callbacks/base.py
+++ b/veomni/trainer/callbacks/base.py
@@ -38,6 +38,12 @@ class Callback:
     ) -> None:
         pass
 
+    def on_micro_step_begin(self, state: TrainerState, micro_batch: Dict[str, Any], **kwargs) -> None:
+        pass
+
+    def on_micro_step_end(self, state: TrainerState, **kwargs) -> None:
+        pass
+
     def on_epoch_begin(self, state: TrainerState, **kwargs) -> None:
         pass
 

--- a/veomni/trainer/callbacks/channel_loss_callback.py
+++ b/veomni/trainer/callbacks/channel_loss_callback.py
@@ -1,0 +1,1526 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Detached per-channel loss logging for causal language-model training.
+
+The callback computes per-token cross entropy as an observability side channel.
+It never contributes to the returned model loss and all tensors are detached
+under ``torch.no_grad()`` before the extra CE work runs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import re
+from collections import defaultdict
+from collections.abc import Hashable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from numbers import Integral
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from weakref import WeakSet
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+from ...distributed.parallel_state import get_parallel_state
+from ...utils.constants import IGNORE_INDEX
+from ...utils.logging import get_logger
+from .base import Callback, TrainerState
+
+
+logger = get_logger(__name__)
+
+
+if TYPE_CHECKING:
+    from ..base import BaseTrainer
+
+
+try:
+    from ...distributed.sequence_parallel import (
+        get_unified_sequence_parallel_group,
+        get_unified_sequence_parallel_rank,
+        get_unified_sequence_parallel_world_size,
+    )
+except ImportError:
+    get_unified_sequence_parallel_group = None  # type: ignore[assignment]
+    get_unified_sequence_parallel_rank = None  # type: ignore[assignment]
+    get_unified_sequence_parallel_world_size = None  # type: ignore[assignment]
+
+
+ChannelKey = Hashable
+_LOSS_CALL_POSITIONAL_KEYS = ("logits", "labels", "vocab_size", "num_items_in_batch", "ignore_index")
+_ACTIVE_CHANNEL_LOSS_COMPUTER: ContextVar[Optional["ChannelLossComputer"]] = ContextVar(
+    "veomni_active_channel_loss_computer", default=None
+)
+
+
+class _OpSlotDispatcher:
+    """Shared dispatcher for a module-global causal-loss OpSlot."""
+
+    def __init__(self, slot: Any, original_kernel: Callable[..., Any]) -> None:
+        self.slot = slot
+        self.original_kernel = original_kernel
+        self.owners: WeakSet[Any] = WeakSet()
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        result = self.original_kernel(*args, **kwargs)
+        owner = _ACTIVE_CHANNEL_LOSS_COMPUTER.get()
+        if owner is not None and owner in self.owners:
+            owner._observe_opslot_call(self.original_kernel, args, kwargs)
+        return result
+
+
+_OP_SLOT_DISPATCHERS: Dict[Any, _OpSlotDispatcher] = {}
+
+
+class ChannelLossMetadataError(ValueError):
+    """Raised when channel metadata cannot be aligned with packed segments."""
+
+
+def _is_sp_enabled() -> bool:
+    try:
+        return get_parallel_state().sp_enabled
+    except Exception:
+        return False
+
+
+class ChannelLossComputer:
+    """Computes detached per-source CE from model loss-function inputs."""
+
+    EAGER_CHUNK_SIZE = 512
+
+    def __init__(self) -> None:
+        self._original_loss_fn: Optional[Callable[..., Any]] = None
+        self._model_ref: Optional[torch.nn.Module] = None
+        self._installed = False
+        self._wrapped_opslots: List[Any] = []
+
+        self._source_ids: List[ChannelKey] = []
+        self._position_ids: Optional[torch.Tensor] = None
+        self._attention_mask: Optional[torch.Tensor] = None
+        self._result: Optional[List[Dict[str, Any]]] = None
+        self._per_mb_source_ids: List[List[ChannelKey]] = []
+        self._per_mb_position_ids: List[Optional[torch.Tensor]] = []
+        self._per_mb_attention_masks: List[Optional[torch.Tensor]] = []
+        self._micro_step = 0
+        self.step_totals: Dict[ChannelKey, tuple[torch.Tensor, torch.Tensor]] = {}
+        self.source_names: Dict[ChannelKey, str] = {}
+        self.strict = False
+
+    @staticmethod
+    def _resolve_loss_fn_host(model: torch.nn.Module) -> Optional[torch.nn.Module]:
+        """Walk common wrappers to find the module whose forward calls ``loss_function``."""
+
+        visited = set()
+        cur: Optional[torch.nn.Module] = model
+        while cur is not None and id(cur) not in visited:
+            visited.add(id(cur))
+            cls_name = type(cur).__name__
+            is_native_lora = any(cls.__name__ == "VeOmniLoraModel" for cls in type(cur).__mro__)
+            if is_native_lora:
+                get_base_model = getattr(cur, "get_base_model", None)
+                nxt = get_base_model() if callable(get_base_model) else None
+                if isinstance(nxt, torch.nn.Module) and nxt is not cur:
+                    cur = nxt
+                    continue
+            is_omni_thinker_wrapper = any(
+                cls.__name__
+                in {
+                    "Qwen2_5OmniForConditionalGeneration",
+                    "Qwen3OmniMoeForConditionalGeneration",
+                }
+                for cls in type(cur).__mro__
+            )
+            if is_omni_thinker_wrapper:
+                nxt = getattr(cur, "thinker", None)
+                if isinstance(nxt, torch.nn.Module) and nxt is not cur:
+                    cur = nxt
+                    continue
+            is_seed_omni = any(cls.__name__ == "SeedOmniModel" for cls in type(cur).__mro__)
+            if is_seed_omni:
+                nxt = getattr(cur, "foundation", None)
+                if isinstance(nxt, torch.nn.Module) and nxt is not cur:
+                    cur = nxt
+                    continue
+            if cls_name.startswith("Peft"):
+                nxt = getattr(cur, "base_model", None)
+                if isinstance(nxt, torch.nn.Module):
+                    cur = nxt
+                    continue
+            if cls_name in ("LoraModel", "AdaLoraModel"):
+                nxt = getattr(cur, "model", None)
+                if isinstance(nxt, torch.nn.Module):
+                    cur = nxt
+                    continue
+            nxt = getattr(cur, "module", None)
+            if isinstance(nxt, torch.nn.Module):
+                cur = nxt
+                continue
+            break
+        return cur
+
+    def install(self, model: torch.nn.Module) -> None:
+        if self._installed:
+            return
+
+        host = self._resolve_loss_fn_host(model)
+        if host is not None and any(
+            cls.__name__ == "Qwen3MoeFoundationModel"
+            and ".seed_omni.foundation.qwen3_moe_foundation." in cls.__module__
+            for cls in type(host).__mro__
+        ):
+            raise ValueError(
+                "train.channel_loss does not support SeedOmni Qwen3MoeFoundationModel because it "
+                "computes causal-LM loss directly instead of using loss_function or a loss OpSlot."
+            )
+        if host is None or not hasattr(host, "loss_function"):
+            logger.warning_rank0(
+                "Channel loss: could not locate model.loss_function "
+                f"(outer_type={type(model).__name__}, inner_type={type(host).__name__ if host else None}). "
+                "Only OpSlot-based fused CE paths, if any, can be observed."
+            )
+        else:
+            self._original_loss_fn = host.loss_function
+            host.loss_function = self._wrapped_loss_fn
+            self._model_ref = host
+            logger.info_rank0(
+                f"Channel loss: wrapped {type(host).__name__}.loss_function (outer={type(model).__name__})."
+            )
+
+        self._wrap_causal_loss_opslots(model, host)
+        self._installed = self._original_loss_fn is not None or bool(self._wrapped_opslots)
+        if not self._installed:
+            logger.warning_rank0("Channel loss: no causal loss hook was installed.")
+
+    def uninstall(self) -> None:
+        if self._model_ref is not None and self._original_loss_fn is not None:
+            self._model_ref.loss_function = self._original_loss_fn
+
+        for slot in reversed(self._wrapped_opslots):
+            dispatcher = _OP_SLOT_DISPATCHERS.get(slot)
+            if dispatcher is None:
+                continue
+            dispatcher.owners.discard(self)
+            if dispatcher.owners:
+                continue
+            if getattr(slot, "_kernel", None) is dispatcher:
+                slot._kernel = dispatcher.original_kernel
+            _OP_SLOT_DISPATCHERS.pop(slot, None)
+
+        self._original_loss_fn = None
+        self._model_ref = None
+        self._wrapped_opslots = []
+        self._installed = False
+
+    def _wrap_causal_loss_opslots(
+        self,
+        model: torch.nn.Module,
+        host: Optional[torch.nn.Module],
+    ) -> None:
+        modules = []
+        seen = set()
+        for root in (model, host):
+            if root is None:
+                continue
+            for cls in type(root).__mro__:
+                module_name = getattr(cls, "__module__", None)
+                if not module_name or module_name in seen:
+                    continue
+                seen.add(module_name)
+                try:
+                    modules.append(importlib.import_module(module_name))
+                except Exception:
+                    continue
+
+        for module in modules:
+            slot = getattr(module, "veomni_causal_lm_loss", None)
+            if slot is None or not getattr(slot, "use_non_eager_impl", False):
+                continue
+            original_kernel = getattr(slot, "_kernel", None)
+            if original_kernel is None:
+                continue
+            dispatcher = _OP_SLOT_DISPATCHERS.get(slot)
+            if dispatcher is None:
+                dispatcher = _OpSlotDispatcher(slot, original_kernel)
+                _OP_SLOT_DISPATCHERS[slot] = dispatcher
+                slot._kernel = dispatcher
+                logger.info_rank0(f"Channel loss: installed dispatcher for {module.__name__}.veomni_causal_lm_loss.")
+            elif getattr(slot, "_kernel", None) is not dispatcher:
+                logger.warning_rank0(
+                    f"Channel loss: {module.__name__}.veomni_causal_lm_loss was rebound after interception; "
+                    "skipping this slot."
+                )
+                continue
+
+            dispatcher.owners.add(self)
+            self._wrapped_opslots.append(slot)
+
+    @property
+    def capture_active(self) -> bool:
+        return _ACTIVE_CHANNEL_LOSS_COMPUTER.get() is self
+
+    @contextmanager
+    def capture(self) -> Iterator[None]:
+        token = _ACTIVE_CHANNEL_LOSS_COMPUTER.set(self)
+        try:
+            yield
+        finally:
+            _ACTIVE_CHANNEL_LOSS_COMPUTER.reset(token)
+
+    def _observe_opslot_call(
+        self,
+        original_kernel: Callable[..., Any],
+        args: tuple[Any, ...],
+        kwargs: Dict[str, Any],
+    ) -> None:
+        call_args = _bind_loss_call_args(original_kernel, args, kwargs)
+        labels = call_args.get("labels")
+        ignore_index = call_args.get("ignore_index", IGNORE_INDEX)
+        if ignore_index is None:
+            ignore_index = IGNORE_INDEX
+        if self.capture_active and self._source_ids and labels is not None:
+            self.compute_side_channel(
+                logits=call_args.get("logits"),
+                labels=labels,
+                vocab_size=call_args.get("vocab_size"),
+                hidden_states=call_args.get("hidden_states"),
+                weights=call_args.get("weights"),
+                shift_labels=call_args.get("shift_labels"),
+                ignore_index=ignore_index,
+            )
+
+    def begin_step(
+        self,
+        per_mb_source_ids: List[List[ChannelKey]],
+        per_mb_position_ids: List[Optional[torch.Tensor]],
+        per_mb_attention_masks: List[Optional[torch.Tensor]],
+    ) -> None:
+        self._per_mb_source_ids = per_mb_source_ids
+        self._per_mb_position_ids = per_mb_position_ids
+        self._per_mb_attention_masks = per_mb_attention_masks
+        self._micro_step = 0
+        self.step_totals = {}
+
+    def before_micro_step(self) -> None:
+        step = self._micro_step
+        if step < len(self._per_mb_source_ids):
+            self._source_ids = self._per_mb_source_ids[step]
+            self._position_ids = self._per_mb_position_ids[step]
+            self._attention_mask = self._per_mb_attention_masks[step]
+        else:
+            self._source_ids = []
+            self._position_ids = None
+            self._attention_mask = None
+        self._result = None
+
+    def after_micro_step(self) -> None:
+        if self._result:
+            for item in self._result:
+                source_id = item["source_id"]
+                loss_sum = item["loss_sum"].detach()
+                token_count = item["token_count"].detach()
+                previous = self.step_totals.get(source_id)
+                if previous is None:
+                    self.step_totals[source_id] = (loss_sum, token_count)
+                else:
+                    self.step_totals[source_id] = (previous[0] + loss_sum, previous[1] + token_count)
+        self._source_ids = []
+        self._position_ids = None
+        self._attention_mask = None
+        self._result = None
+        self._micro_step += 1
+
+    def record_source_names(self, source_ids: List[ChannelKey], source_names: List[str]) -> None:
+        if not source_ids or not source_names:
+            return
+        if len(source_names) == 1:
+            for source_id in source_ids:
+                self.source_names[source_id] = source_names[0]
+            return
+        for source_id, name in zip(source_ids, source_names):
+            self.source_names[source_id] = name
+
+    def _wrapped_loss_fn(self, *args: Any, **kwargs: Any) -> Any:
+        assert self._original_loss_fn is not None
+        main_loss = self._original_loss_fn(*args, **kwargs)
+
+        call_args = _bind_loss_call_args(self._original_loss_fn, args, kwargs)
+        logits = call_args.get("logits")
+        labels = call_args.get("labels")
+        vocab_size = call_args.get("vocab_size")
+        ignore_index = call_args.get("ignore_index", IGNORE_INDEX)
+        if ignore_index is None:
+            ignore_index = IGNORE_INDEX
+        if self.capture_active and self._source_ids and labels is not None:
+            self.compute_side_channel(
+                logits=logits,
+                labels=labels,
+                vocab_size=vocab_size,
+                hidden_states=call_args.get("hidden_states"),
+                weights=call_args.get("weights"),
+                shift_labels=call_args.get("shift_labels"),
+                ignore_index=ignore_index,
+            )
+
+        return main_loss
+
+    def compute_side_channel(
+        self,
+        logits: Optional[torch.Tensor],
+        labels: torch.Tensor,
+        vocab_size: Optional[int],
+        hidden_states: Optional[torch.Tensor],
+        weights: Optional[torch.Tensor],
+        shift_labels: Optional[torch.Tensor] = None,
+        ignore_index: int = IGNORE_INDEX,
+    ) -> None:
+        try:
+            self._result = self._compute_channel_loss(
+                logits=logits,
+                labels=labels,
+                vocab_size=vocab_size,
+                hidden_states=hidden_states,
+                weights=weights,
+                attention_mask=self._attention_mask,
+                shift_labels=shift_labels,
+                ignore_index=ignore_index,
+            )
+        except ChannelLossMetadataError:
+            if self.strict:
+                raise
+            logger.warning_rank0("Channel loss: metadata mismatch; skipping this micro-batch.", exc_info=True)
+            self._result = None
+        except Exception:
+            logger.warning_rank0("Channel loss: per-token CE failed; skipping this micro-batch.", exc_info=True)
+            self._result = None
+
+    @torch.no_grad()
+    def _compute_channel_loss(
+        self,
+        logits: Optional[torch.Tensor],
+        labels: torch.Tensor,
+        vocab_size: Optional[int],
+        hidden_states: Optional[torch.Tensor],
+        weights: Optional[torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        shift_labels: Optional[torch.Tensor],
+        ignore_index: int,
+    ) -> List[Dict[str, Any]]:
+        sp_enabled = _is_sp_enabled()
+        if sp_enabled:
+            effective_labels = labels
+        elif shift_labels is not None:
+            effective_labels = shift_labels
+        else:
+            effective_labels = F.pad(labels, (0, 1), value=ignore_index)[..., 1:].contiguous()
+
+        labels_flat = effective_labels.reshape(-1)
+        attention_mask_flat = _position_aligned_attention_mask_flat(
+            attention_mask=attention_mask,
+            labels=labels,
+            effective_labels=effective_labels,
+        )
+        per_token_loss = self._per_token_ce(logits, labels_flat, vocab_size, hidden_states, weights, ignore_index)
+        if per_token_loss is None:
+            return []
+        labels_flat = labels_flat.to(per_token_loss.device)
+        if attention_mask_flat is not None:
+            attention_mask_flat = attention_mask_flat.to(per_token_loss.device)
+
+        return self._aggregate_by_source(
+            per_token_loss=per_token_loss,
+            labels_flat=labels_flat,
+            attention_mask_flat=attention_mask_flat,
+            source_ids=self._source_ids,
+            position_ids=self._position_ids,
+            ignore_index=ignore_index,
+            sp_enabled=sp_enabled,
+            strict=self.strict,
+        )
+
+    def _per_token_ce(
+        self,
+        logits: Optional[torch.Tensor],
+        labels_flat: torch.Tensor,
+        vocab_size: Optional[int],
+        hidden_states: Optional[torch.Tensor],
+        weights: Optional[torch.Tensor],
+        ignore_index: int,
+    ) -> Optional[torch.Tensor]:
+        if hidden_states is not None and weights is not None:
+            hs = hidden_states.detach().reshape(-1, hidden_states.size(-1))
+            w = weights.detach()
+            return self._eager_chunked(hs, w, labels_flat.to(hs.device), ignore_index)
+
+        if logits is not None:
+            vocab = vocab_size if vocab_size is not None else logits.size(-1)
+            flat_logits = logits.detach().reshape(-1, vocab)
+            return self._logits_chunked(flat_logits, labels_flat.to(flat_logits.device), ignore_index)
+
+        return None
+
+    @classmethod
+    def _logits_chunked(
+        cls,
+        logits: torch.Tensor,
+        labels_flat: torch.Tensor,
+        ignore_index: int,
+    ) -> torch.Tensor:
+        seq_len = logits.size(0)
+        result = torch.empty(seq_len, device=logits.device, dtype=torch.float32)
+        for start in range(0, seq_len, cls.EAGER_CHUNK_SIZE):
+            end = min(start + cls.EAGER_CHUNK_SIZE, seq_len)
+            result[start:end] = F.cross_entropy(
+                logits[start:end].float(),
+                labels_flat[start:end],
+                ignore_index=ignore_index,
+                reduction="none",
+            )
+        return result
+
+    @classmethod
+    def _eager_chunked(
+        cls,
+        hidden_states: torch.Tensor,
+        weights: torch.Tensor,
+        labels_flat: torch.Tensor,
+        ignore_index: int,
+    ) -> torch.Tensor:
+        seq_len = hidden_states.size(0)
+        result = torch.empty(seq_len, device=hidden_states.device, dtype=torch.float32)
+        for start in range(0, seq_len, cls.EAGER_CHUNK_SIZE):
+            end = min(start + cls.EAGER_CHUNK_SIZE, seq_len)
+            chunk_logits = F.linear(hidden_states[start:end], weights).float()
+            result[start:end] = F.cross_entropy(
+                chunk_logits,
+                labels_flat[start:end],
+                ignore_index=ignore_index,
+                reduction="none",
+            )
+            del chunk_logits
+        return result
+
+    @staticmethod
+    def _aggregate_by_source(
+        per_token_loss: torch.Tensor,
+        labels_flat: torch.Tensor,
+        attention_mask_flat: Optional[torch.Tensor],
+        source_ids: List[ChannelKey],
+        position_ids: Optional[torch.Tensor],
+        ignore_index: int,
+        sp_enabled: bool = False,
+        strict: bool = False,
+    ) -> List[Dict[str, Any]]:
+        if not source_ids:
+            return []
+
+        seq_len = min(per_token_loss.numel(), labels_flat.numel())
+        per_token_loss = per_token_loss[:seq_len]
+        labels_flat = labels_flat[:seq_len]
+
+        segments: List[tuple[int, int, int]] = []
+        pos_flat: Optional[torch.Tensor] = None
+        if position_ids is not None:
+            pos = position_ids
+            if pos.dim() == 3:
+                pos = pos[:, 0, :]
+            if pos.dim() == 1:
+                pos_2d = pos.reshape(1, -1)
+            else:
+                pos_2d = pos.reshape(pos.size(0), -1)
+            pos_flat = pos_2d.reshape(-1)[:seq_len]
+
+            if sp_enabled and get_unified_sequence_parallel_rank is not None:
+                return ChannelLossComputer._aggregate_sp(
+                    per_token_loss=per_token_loss,
+                    labels_flat=labels_flat,
+                    attention_mask_flat=attention_mask_flat,
+                    source_ids=source_ids,
+                    positions=pos_2d,
+                    seq_len=seq_len,
+                    ignore_index=ignore_index,
+                    strict=strict,
+                )
+
+            row_width = pos_2d.size(1)
+            for batch_idx, row_pos in enumerate(pos_2d):
+                row_len = min(row_width, max(seq_len - batch_idx * row_width, 0))
+                if row_len <= 0:
+                    continue
+                row_starts = row_pos[:row_len].eq(0).nonzero(as_tuple=True)[0].cpu()
+                if row_starts.numel() == 0:
+                    continue
+                row_ends = torch.cat([row_starts[1:], torch.tensor([row_len])])
+                row_offset = batch_idx * row_width
+                segments.extend(
+                    (batch_idx, row_offset + int(start), row_offset + int(end) - 1)
+                    for start, end in zip(row_starts.tolist(), row_ends.tolist())
+                )
+        else:
+            segments = [(0, 0, seq_len - 1)]
+
+        if len(segments) > len(source_ids):
+            segments = _filter_surplus_tail_padding_segments(
+                segments=segments,
+                source_count=len(source_ids),
+                labels_flat=labels_flat,
+                positions_flat=pos_flat,
+                attention_mask_flat=attention_mask_flat,
+                ignore_index=ignore_index,
+            )
+
+        n_segments = len(segments)
+        if not _validate_segment_count(n_segments, len(source_ids), strict, "packed segment count"):
+            return []
+
+        channel_loss: List[Dict[str, Any]] = []
+        for i, (_, start, end) in enumerate(segments):
+            labels_slice = labels_flat[start : end + 1]
+            loss_slice = per_token_loss[start : end + 1]
+            valid = labels_slice != ignore_index
+            token_count = valid.sum()
+            loss_sum = loss_slice[valid].sum()
+            channel_loss.append(
+                {
+                    "source_id": source_ids[i],
+                    "loss_sum": loss_sum,
+                    "token_count": token_count,
+                }
+            )
+        return channel_loss
+
+    @staticmethod
+    def _aggregate_sp(
+        per_token_loss: torch.Tensor,
+        labels_flat: torch.Tensor,
+        attention_mask_flat: Optional[torch.Tensor],
+        source_ids: List[ChannelKey],
+        positions: torch.Tensor,
+        seq_len: int,
+        ignore_index: int,
+        strict: bool = False,
+    ) -> List[Dict[str, Any]]:
+        assert get_unified_sequence_parallel_rank is not None
+        sp_rank = get_unified_sequence_parallel_rank()
+        segments: List[Dict[str, Any]] = []
+
+        if positions.dim() == 1:
+            positions_2d = positions.reshape(1, -1)
+        else:
+            positions_2d = positions.reshape(positions.size(0), -1)
+
+        local_width = positions_2d.size(1)
+        # Segment ordering is host-side; copy positions once instead of synchronizing per segment.
+        positions_cpu = positions_2d.detach().cpu()
+
+        def _partial(
+            batch_idx: int,
+            start: int,
+            end: int,
+            is_start: bool,
+            local_order: int,
+        ) -> None:
+            if end <= start:
+                return
+            flat_start = batch_idx * local_width + start
+            flat_end = min(batch_idx * local_width + end, seq_len)
+            labels_slice = labels_flat[flat_start:flat_end]
+            loss_slice = per_token_loss[flat_start:flat_end]
+            pos_slice = positions_cpu[batch_idx, start:end].reshape(-1)[: labels_slice.numel()]
+            mask_slice = None
+            if attention_mask_flat is not None:
+                mask_slice = attention_mask_flat[flat_start:flat_end]
+            valid = labels_slice != ignore_index
+            token_count = valid.sum(dtype=torch.int64)
+            loss_sum = loss_slice[valid].sum()
+            false_flag = torch.zeros((), dtype=torch.bool, device=labels_slice.device)
+            has_explicit_padding_mask = (
+                ~mask_slice.to(torch.bool).any()
+                if labels_slice.numel() > 0 and mask_slice is not None and mask_slice.numel() > 0
+                else false_flag
+            )
+            has_only_zero_positions = bool(pos_slice.eq(0).all().tolist()) if pos_slice.numel() > 0 else False
+            segments.append(
+                {
+                    "batch_idx": batch_idx,
+                    "sp_rank": sp_rank,
+                    "local_order": local_order,
+                    "is_start": is_start,
+                    "has_explicit_padding_mask": has_explicit_padding_mask,
+                    "has_only_zero_positions": has_only_zero_positions,
+                    "loss_sum": loss_sum,
+                    "token_count": token_count,
+                }
+            )
+
+        for batch_idx, row_pos in enumerate(positions_cpu):
+            row_len = min(local_width, max(seq_len - batch_idx * local_width, 0))
+            if row_len <= 0:
+                continue
+            local_starts = row_pos[:row_len].eq(0).nonzero(as_tuple=True)[0].tolist()
+            local_order = 0
+            if not local_starts:
+                _partial(batch_idx, 0, row_len, is_start=False, local_order=local_order)
+                continue
+
+            first = local_starts[0]
+            if first > 0:
+                _partial(batch_idx, 0, first, is_start=False, local_order=local_order)
+                local_order += 1
+            ends = local_starts[1:] + [row_len]
+            for start, end in zip(local_starts, ends):
+                _partial(batch_idx, start, end, is_start=True, local_order=local_order)
+                local_order += 1
+
+        reduced = ChannelLossComputer._reduce_sp(
+            segments,
+            source_ids,
+            device=per_token_loss.device,
+            strict=strict,
+        )
+        return [
+            {
+                "source_id": item["source_id"],
+                "loss_sum": torch.as_tensor(item["loss_sum"], device=per_token_loss.device, dtype=torch.float32),
+                "token_count": torch.as_tensor(item["token_count"], device=per_token_loss.device, dtype=torch.int64),
+            }
+            for item in reduced
+        ]
+
+    @staticmethod
+    def _reduce_sp(
+        local_segments: List[Dict[str, Any]],
+        source_ids: List[ChannelKey],
+        device: torch.device,
+        strict: bool = False,
+    ) -> List[Dict[str, Any]]:
+        if local_segments:
+            local_zero_position_flags = torch.tensor(
+                [segment["has_only_zero_positions"] for segment in local_segments],
+                dtype=torch.bool,
+                device=device,
+            )
+            for segment, zero_position_flag in zip(local_segments, local_zero_position_flags.unbind()):
+                segment["has_only_zero_positions"] = zero_position_flag
+
+        group = get_unified_sequence_parallel_group()
+        world = get_unified_sequence_parallel_world_size()
+        if group is None or world <= 1:
+            all_segments = local_segments
+        else:
+            local_metadata = [
+                {
+                    "batch_idx": segment["batch_idx"],
+                    "sp_rank": segment["sp_rank"],
+                    "local_order": segment["local_order"],
+                    "is_start": segment["is_start"],
+                }
+                for segment in local_segments
+            ]
+            gathered_metadata: List[Optional[List[Dict[str, Any]]]] = [None] * world
+            dist.all_gather_object(gathered_metadata, local_metadata, group=group)
+            rank_segment_counts = [len(rank_metadata or []) for rank_metadata in gathered_metadata]
+            max_segment_count = max(rank_segment_counts, default=0)
+
+            all_segments = []
+            if max_segment_count > 0:
+                # Keep losses and exact integer counts in dtype-specific compact collectives.
+                if local_segments:
+                    local_loss_sums = torch.stack(
+                        [segment["loss_sum"].to(device=device, dtype=torch.float32) for segment in local_segments]
+                    )
+                    local_token_counts = torch.stack([segment["token_count"] for segment in local_segments]).to(
+                        device=device, dtype=torch.int64
+                    )
+                    local_explicit_padding_flags = torch.stack(
+                        [segment["has_explicit_padding_mask"] for segment in local_segments]
+                    ).to(device=device, dtype=torch.int64)
+                    local_zero_position_flags = torch.stack(
+                        [segment["has_only_zero_positions"] for segment in local_segments]
+                    ).to(device=device, dtype=torch.int64)
+                    local_integer_stats = torch.stack(
+                        [local_token_counts, local_explicit_padding_flags, local_zero_position_flags], dim=1
+                    )
+                else:
+                    local_loss_sums = torch.empty(0, dtype=torch.float32, device=device)
+                    local_integer_stats = torch.empty((0, 3), dtype=torch.int64, device=device)
+
+                loss_padding = local_loss_sums.new_zeros(max_segment_count - local_loss_sums.size(0))
+                integer_padding = local_integer_stats.new_zeros(
+                    (max_segment_count - local_integer_stats.size(0), local_integer_stats.size(1))
+                )
+                padded_loss_sums = torch.cat([local_loss_sums, loss_padding])
+                padded_integer_stats = torch.cat([local_integer_stats, integer_padding])
+                gathered_loss_sums = [torch.empty_like(padded_loss_sums) for _ in range(world)]
+                gathered_integer_stats = [torch.empty_like(padded_integer_stats) for _ in range(world)]
+                dist.all_gather(gathered_loss_sums, padded_loss_sums, group=group)
+                dist.all_gather(gathered_integer_stats, padded_integer_stats, group=group)
+
+                for rank_idx, rank_metadata in enumerate(gathered_metadata):
+                    for segment_idx, metadata in enumerate(rank_metadata or []):
+                        integer_stats = gathered_integer_stats[rank_idx][segment_idx]
+                        all_segments.append(
+                            {
+                                **metadata,
+                                "loss_sum": gathered_loss_sums[rank_idx][segment_idx],
+                                "token_count": integer_stats[0],
+                                "has_explicit_padding_mask": integer_stats[1].to(torch.bool),
+                                "has_only_zero_positions": integer_stats[2].to(torch.bool),
+                            }
+                        )
+
+        all_segments.sort(
+            key=lambda segment: (
+                int(segment.get("batch_idx", 0)),
+                int(segment.get("sp_rank", 0)),
+                int(segment.get("local_order", 0)),
+            )
+        )
+        start_count = sum(1 for segment in all_segments if segment["is_start"])
+        if start_count > len(source_ids):
+            token_counts = torch.stack([segment["token_count"] for segment in all_segments])
+            explicit_padding_flags = torch.stack([segment["has_explicit_padding_mask"] for segment in all_segments])
+            zero_position_flags = torch.stack([segment["has_only_zero_positions"] for segment in all_segments])
+            is_padding_only = token_counts.eq(0) & (explicit_padding_flags | zero_position_flags)
+            padding_flags = torch.stack([is_padding_only, explicit_padding_flags], dim=1).to(
+                device="cpu", dtype=torch.bool
+            )
+            for segment, (is_padding_only, has_explicit_padding_mask) in zip(all_segments, padding_flags.tolist()):
+                segment["is_padding_only"] = is_padding_only
+                segment["has_explicit_padding_mask"] = has_explicit_padding_mask
+            all_segments = _filter_surplus_tail_padding_sp_segments(all_segments, len(source_ids))
+            start_count = sum(1 for segment in all_segments if segment["is_start"])
+        if not _validate_segment_count(start_count, len(source_ids), strict, "SP packed segment count"):
+            return []
+
+        doc_idx = 0
+        result: List[Dict[str, Any]] = []
+        last_result_idx_by_batch: Dict[int, int] = {}
+        for segment in all_segments:
+            batch_idx = int(segment.get("batch_idx", 0))
+            if segment["is_start"]:
+                result.append(
+                    {
+                        "source_id": source_ids[doc_idx],
+                        "loss_sum": segment["loss_sum"],
+                        "token_count": segment["token_count"],
+                    }
+                )
+                last_result_idx_by_batch[batch_idx] = len(result) - 1
+                doc_idx += 1
+                continue
+
+            result_idx = last_result_idx_by_batch.get(batch_idx)
+            if result_idx is None:
+                msg = (
+                    "Channel loss: SP continuation segment appeared before any source segment "
+                    f"for batch_idx={batch_idx}; skipping this partial segment."
+                )
+                if strict:
+                    raise ChannelLossMetadataError(msg)
+                logger.warning_rank0(msg)
+                continue
+            result[result_idx]["loss_sum"] += segment["loss_sum"]
+            result[result_idx]["token_count"] += segment["token_count"]
+        return result
+
+
+class ChannelLossCallback(Callback):
+    """Trainer callback for detached per-source causal-LM loss metrics."""
+
+    def __init__(self, trainer: "BaseTrainer") -> None:
+        super().__init__(trainer)
+        self.config = trainer.args.train.channel_loss
+        data_type = getattr(getattr(trainer.args, "data", None), "data_type", None)
+        if self.config.enable and data_type == "classification":
+            raise ValueError(
+                "train.channel_loss is only supported by causal-LM objectives; "
+                "data.data_type='classification' uses sequence-classification loss."
+            )
+        is_base_rl_trainer = any(
+            cls.__name__ == "BaseRLTrainer" and cls.__module__ == "veomni.trainer.base_rl_trainer"
+            for cls in type(trainer).__mro__
+        )
+        if self.config.enable and is_base_rl_trainer:
+            raise ValueError(
+                "train.channel_loss does not support BaseRLTrainer because it packs metadata during preforward, "
+                "after the common channel-loss step lifecycle captures alignment metadata."
+            )
+        self.computer = ChannelLossComputer()
+        self._strip_keys = set(self.config.source_id_keys)
+        self._strip_keys.update(self.config.source_name_keys)
+        self._strip_keys.update(self.config.extra_strip_keys)
+        self.computer.strict = bool(self.config.strict)
+        self._collect_step = False
+        self._source_registry: Dict[ChannelKey, Optional[str]] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.config.enable)
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {
+            "source_registry": sorted(
+                self._source_registry.items(),
+                key=lambda item: _channel_sort_key(item[0]),
+            )
+        }
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        entries = state_dict.get("source_registry", [])
+        if not isinstance(entries, (list, tuple)):
+            raise ValueError("Channel loss checkpoint source_registry must be a list of pairs.")
+
+        restored: Dict[ChannelKey, Optional[str]] = {}
+        for entry in entries:
+            if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+                raise ValueError("Channel loss checkpoint source_registry entries must be (source_id, source_name).")
+            raw_source_id, raw_source_name = entry
+            source_ids = _as_channel_key_list(raw_source_id)
+            if len(source_ids) != 1:
+                raise ValueError(f"Invalid channel loss checkpoint source ID: {raw_source_id!r}.")
+            source_id = source_ids[0]
+            source_name = None if raw_source_name is None else str(raw_source_name)
+            if source_id in restored and restored[source_id] != source_name:
+                raise ValueError(f"Duplicate channel loss checkpoint source ID with conflicting names: {source_id!r}.")
+            restored[source_id] = source_name
+
+        self._source_registry = restored
+        self.computer.source_names.update(
+            {source_id: source_name for source_id, source_name in restored.items() if source_name is not None}
+        )
+
+    def on_train_begin(self, state: TrainerState, **kwargs: Any) -> None:
+        if not self.enabled:
+            return
+        self.computer.install(self.trainer.model)
+        logger.info_rank0(
+            "Channel loss enabled "
+            f"(interval={self.config.interval}, source_id_keys={self.config.source_id_keys}, "
+            f"source_name_keys={self.config.source_name_keys})."
+        )
+
+    def on_train_end(self, state: TrainerState, **kwargs: Any) -> None:
+        if self.enabled:
+            self.computer.uninstall()
+
+    def on_step_begin(
+        self,
+        state: TrainerState,
+        micro_batches: List[Dict[str, Any]] = None,
+        source_repeat: int = 1,
+        **kwargs: Any,
+    ) -> None:
+        if not self.enabled:
+            self._collect_step = False
+            return
+        if source_repeat < 1:
+            raise ValueError(f"Channel loss source_repeat must be >= 1, got {source_repeat}.")
+
+        self._collect_step = state.global_step % self.config.interval == 0
+        if not self._collect_step:
+            self.computer.begin_step([], [], [])
+            if self.config.strict:
+                for micro_batch in micro_batches or []:
+                    source_ids, _, _, _ = self._extract_metadata(micro_batch)
+                    self._require_source_ids(source_ids)
+            return
+
+        per_mb_source_ids: List[List[ChannelKey]] = []
+        per_mb_position_ids: List[Optional[torch.Tensor]] = []
+        per_mb_attention_masks: List[Optional[torch.Tensor]] = []
+        for micro_batch in micro_batches or []:
+            source_ids, source_names, position_ids, attention_mask = self._extract_metadata(micro_batch)
+            if self.config.strict:
+                self._require_source_ids(source_ids)
+            source_ids, source_names = self._repeat_source_metadata(source_ids, source_names, source_repeat)
+            self.computer.record_source_names(source_ids, source_names)
+            per_mb_source_ids.append(source_ids)
+            per_mb_position_ids.append(position_ids)
+            per_mb_attention_masks.append(attention_mask)
+
+        self.computer.begin_step(per_mb_source_ids, per_mb_position_ids, per_mb_attention_masks)
+
+    @staticmethod
+    def _repeat_source_metadata(
+        source_ids: List[ChannelKey],
+        source_names: List[str],
+        repeat: int,
+    ) -> tuple[List[ChannelKey], List[str]]:
+        if repeat == 1:
+            return source_ids, source_names
+
+        repeated_ids = [source_id for source_id in source_ids for _ in range(repeat)]
+        if len(source_names) == len(source_ids):
+            source_names = [source_name for source_name in source_names for _ in range(repeat)]
+        return repeated_ids, source_names
+
+    def _require_source_ids(self, source_ids: List[ChannelKey]) -> None:
+        if source_ids:
+            return
+        raise ValueError(
+            "train.channel_loss.enable=True but no configured source ID was found in a micro-batch. "
+            f"Checked keys: {self.config.source_id_keys}."
+        )
+
+    def on_micro_step_begin(
+        self,
+        state: TrainerState,
+        micro_batch: Dict[str, Any],
+        **kwargs: Any,
+    ) -> None:
+        if not self._collect_step:
+            return
+        self.computer.before_micro_step()
+
+    def strip_model_inputs(self, micro_batch: Dict[str, Any]) -> None:
+        if not self.enabled or not isinstance(micro_batch, dict):
+            return
+        for key in self._strip_keys:
+            micro_batch.pop(key, None)
+
+    def on_micro_step_end(self, state: TrainerState, **kwargs: Any) -> None:
+        if self._collect_step:
+            self.computer.after_micro_step()
+
+    @contextmanager
+    def micro_step_context(self, state: TrainerState, micro_batch: Dict[str, Any]) -> Iterator[None]:
+        if not self._collect_step:
+            yield
+            return
+        self.on_micro_step_begin(state, micro_batch=micro_batch)
+        try:
+            yield
+        finally:
+            self.on_micro_step_end(state)
+
+    @contextmanager
+    def model_forward_context(self) -> Iterator[None]:
+        if not self._collect_step:
+            yield
+            return
+        with self.computer.capture():
+            yield
+
+    def on_step_end(
+        self,
+        state: TrainerState,
+        loss: float,
+        loss_dict: Dict[str, float],
+        grad_norm: float,
+        **kwargs: Any,
+    ) -> None:
+        if not self._collect_step:
+            return
+
+        totals, source_names = self._reduce_step_totals(self.computer.step_totals)
+        if not totals:
+            return
+
+        metrics = self._build_metrics(totals, source_names)
+        if not metrics:
+            return
+
+        if getattr(self.trainer, "step_train_metrics", None) is None:
+            self.trainer.step_train_metrics = {}
+        if getattr(self.trainer, "step_env_metrics", None) is None:
+            self.trainer.step_env_metrics = {}
+
+        self.trainer.step_train_metrics.update(metrics)
+        self.trainer.step_env_metrics.update(metrics)
+
+    def _reduce_step_totals(
+        self,
+        local_totals: Dict[ChannelKey, tuple[torch.Tensor, torch.Tensor]],
+    ) -> tuple[Dict[ChannelKey, tuple[float, int]], Dict[ChannelKey, str]]:
+        try:
+            ps = get_parallel_state()
+            dp_size = ps.dp_size
+            dp_group = ps.dp_group
+        except Exception:
+            dp_size = 1
+            dp_group = None
+
+        distributed = dp_size > 1 and dist.is_available() and dist.is_initialized()
+        local_metadata = [
+            (source_id, self._lookup_source_name(source_id))
+            for source_id in sorted(local_totals, key=_channel_sort_key)
+        ]
+        if distributed:
+            gathered_metadata: List[Optional[List[tuple[ChannelKey, Optional[str]]]]] = [None] * dp_size
+            dist.all_gather_object(gathered_metadata, local_metadata, group=dp_group)
+        else:
+            gathered_metadata = [local_metadata]
+
+        source_ids = sorted(
+            {source_id for rank_metadata in gathered_metadata if rank_metadata for source_id, _ in rank_metadata},
+            key=_channel_sort_key,
+        )
+        if not source_ids:
+            return {}, {}
+
+        name_candidates: Dict[ChannelKey, set[str]] = defaultdict(set)
+        for rank_metadata in gathered_metadata:
+            for source_id, source_name in rank_metadata or []:
+                if source_name:
+                    name_candidates[source_id].add(source_name)
+
+        synchronized_names: Dict[ChannelKey, str] = {}
+        for source_id in source_ids:
+            candidates = sorted(name_candidates[source_id])
+            if len(candidates) > 1:
+                msg = f"Channel loss: source_id={source_id!r} has inconsistent names across DP ranks: {candidates}."
+                if self.config.strict:
+                    raise ChannelLossMetadataError(msg)
+                logger.warning_rank0(msg + " Using the lexicographically first name.")
+            if candidates:
+                synchronized_names[source_id] = candidates[0]
+
+        device = self._totals_device(local_totals)
+        loss_sums = torch.zeros(len(source_ids), dtype=torch.float32, device=device)
+        token_counts = torch.zeros(len(source_ids), dtype=torch.int64, device=device)
+        source_indices = {source_id: index for index, source_id in enumerate(source_ids)}
+        for source_id, (loss_sum, token_count) in local_totals.items():
+            index = source_indices[source_id]
+            loss_sums[index] = torch.as_tensor(loss_sum, dtype=torch.float32, device=device)
+            token_counts[index] = torch.as_tensor(token_count, dtype=torch.int64, device=device)
+
+        if distributed:
+            dist.all_reduce(loss_sums, group=dp_group)
+            dist.all_reduce(token_counts, group=dp_group)
+
+        loss_values = loss_sums.cpu().tolist()
+        token_values = token_counts.cpu().tolist()
+        totals = {
+            source_id: (float(loss_values[index]), int(token_values[index]))
+            for index, source_id in enumerate(source_ids)
+        }
+        registered_names = self._register_sources(source_ids, synchronized_names)
+        return totals, registered_names
+
+    def _register_sources(
+        self,
+        source_ids: List[ChannelKey],
+        source_names: Optional[Dict[ChannelKey, str]] = None,
+    ) -> Dict[ChannelKey, str]:
+        source_names = source_names or {}
+        for source_id in source_ids:
+            incoming_name = source_names.get(source_id)
+            if source_id not in self._source_registry:
+                self._source_registry[source_id] = incoming_name
+                continue
+
+            registered_name = self._source_registry[source_id]
+            if incoming_name is None or incoming_name == registered_name:
+                continue
+            if registered_name is None:
+                self._source_registry[source_id] = incoming_name
+                continue
+
+            candidates = sorted({registered_name, incoming_name})
+            msg = f"Channel loss: source_id={source_id!r} has inconsistent names across sampled steps: {candidates}."
+            if self.config.strict:
+                raise ChannelLossMetadataError(msg)
+            logger.warning_once(msg + " Using the lexicographically first name.")
+            self._source_registry[source_id] = candidates[0]
+
+        registered_names = {
+            source_id: source_name
+            for source_id, source_name in self._source_registry.items()
+            if source_name is not None
+        }
+        self.computer.source_names.update(registered_names)
+        return {source_id: registered_names[source_id] for source_id in source_ids if source_id in registered_names}
+
+    def _totals_device(
+        self,
+        local_totals: Dict[ChannelKey, tuple[torch.Tensor, torch.Tensor]],
+    ) -> torch.device:
+        for loss_sum, _ in local_totals.values():
+            if isinstance(loss_sum, torch.Tensor):
+                return loss_sum.device
+
+        trainer_device = getattr(self.trainer, "device", None)
+        if trainer_device is not None:
+            return torch.device(trainer_device)
+
+        model = getattr(self.trainer, "model", None)
+        if model is not None:
+            try:
+                return next(model.parameters()).device
+            except (AttributeError, StopIteration):
+                pass
+        return torch.device("cpu")
+
+    def _build_metrics(
+        self,
+        totals: Dict[ChannelKey, tuple[float, int]],
+        source_names: Optional[Dict[ChannelKey, str]] = None,
+    ) -> Dict[str, float]:
+        total_tokens = sum(token_count for _, token_count in totals.values())
+        metric_names = self._render_metric_names(totals, source_names)
+        metrics: Dict[str, float] = {}
+        for source_id, (loss_sum, token_count) in sorted(totals.items(), key=lambda item: _channel_sort_key(item[0])):
+            if token_count <= 0:
+                continue
+            name = metric_names[source_id]
+            metrics[f"{self.config.loss_metric_prefix}/{name}"] = loss_sum / token_count
+            if self.config.log_weighted_loss and total_tokens > 0:
+                metrics[f"{self.config.weighted_loss_metric_prefix}/{name}"] = loss_sum / total_tokens
+            if self.config.log_token_count:
+                metrics[f"{self.config.token_count_metric_prefix}/{name}"] = float(token_count)
+        return metrics
+
+    def _render_metric_names(
+        self,
+        totals: Dict[ChannelKey, tuple[float, int]],
+        source_names: Optional[Dict[ChannelKey, str]],
+    ) -> Dict[ChannelKey, str]:
+        self._register_sources(list(totals), source_names)
+        rendered: Dict[ChannelKey, str] = {}
+        for source_id in totals:
+            source_name = self._source_registry[source_id]
+            display_name = (
+                _sanitize_metric_fragment(source_name)
+                if source_name is not None
+                else self._resolve_source_name(source_id)
+            )
+            rendered[source_id] = f"{_stable_source_metric_fragment(source_id)}__{display_name}"
+        return rendered
+
+    def _resolve_source_name(self, source_id: ChannelKey) -> str:
+        source_name = self._lookup_source_name(source_id)
+        if source_name is not None:
+            return _sanitize_metric_fragment(source_name)
+
+        return _sanitize_metric_fragment(f"source_{source_id}")
+
+    def _lookup_source_name(self, source_id: ChannelKey) -> Optional[str]:
+        if source_id in self.computer.source_names:
+            return str(self.computer.source_names[source_id])
+
+        meter = getattr(self.trainer, "environ_meter", None)
+        tracker = getattr(meter, "multisource_tracker", None) if meter is not None else None
+        names = getattr(tracker, "names", None) if tracker is not None else None
+        if isinstance(names, dict) and source_id in names:
+            return str(names[source_id])
+        if isinstance(source_id, int) and isinstance(names, (list, tuple)) and 0 <= source_id < len(names):
+            return str(names[source_id])
+
+        return None
+
+    def _extract_metadata(
+        self,
+        micro_batch: Any,
+    ) -> tuple[List[ChannelKey], List[str], Optional[torch.Tensor], Optional[torch.Tensor]]:
+        if isinstance(micro_batch, dict):
+            source_ids = self._first_present_list(micro_batch, self.config.source_id_keys, _as_channel_key_list)
+            source_names = self._first_present_list(micro_batch, self.config.source_name_keys, _as_str_list)
+            position_ids = micro_batch.get("position_ids")
+            attention_mask = micro_batch.get("attention_mask")
+            return (
+                source_ids,
+                source_names,
+                position_ids if isinstance(position_ids, torch.Tensor) else None,
+                attention_mask if isinstance(attention_mask, torch.Tensor) else None,
+            )
+
+        if isinstance(micro_batch, (list, tuple)):
+            source_ids: List[ChannelKey] = []
+            source_names: List[str] = []
+            for sample in micro_batch:
+                if not isinstance(sample, dict):
+                    continue
+                source_ids.extend(self._first_present_list(sample, self.config.source_id_keys, _as_channel_key_list))
+                source_names.extend(self._first_present_list(sample, self.config.source_name_keys, _as_str_list))
+            return source_ids, source_names, None, None
+
+        return [], [], None, None
+
+    @staticmethod
+    def _first_present_list(
+        batch: Dict[str, Any],
+        keys: List[str],
+        converter: Callable[[Any], List[Any]],
+    ) -> List[Any]:
+        for key in keys:
+            if key in batch:
+                return converter(batch[key])
+        return []
+
+
+def _as_flat_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu().tolist()
+    elif hasattr(value, "tolist") and not isinstance(value, (str, bytes)):
+        try:
+            value = value.tolist()
+        except Exception:
+            pass
+    if isinstance(value, (list, tuple)):
+        result: List[Any] = []
+        for item in value:
+            result.extend(_as_flat_list(item))
+        return result
+    return [value]
+
+
+def _bind_loss_call_args(
+    loss_fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: Dict[str, Any],
+) -> Dict[str, Any]:
+    try:
+        signature = inspect.signature(loss_fn)
+        bound = signature.bind_partial(*args, **kwargs)
+        bound.apply_defaults()
+        bound_args = dict(bound.arguments)
+        for name, parameter in signature.parameters.items():
+            if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+                extra_kwargs = bound_args.pop(name, {})
+                if isinstance(extra_kwargs, dict):
+                    bound_args.update(extra_kwargs)
+            elif parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+                bound_args.pop(name, None)
+
+        for key, value in zip(_LOSS_CALL_POSITIONAL_KEYS, args):
+            bound_args.setdefault(key, value)
+        return bound_args
+    except (TypeError, ValueError):
+        bound_args = dict(zip(_LOSS_CALL_POSITIONAL_KEYS, args))
+        bound_args.update(kwargs)
+        return bound_args
+
+
+def _position_aligned_attention_mask_flat(
+    attention_mask: Optional[torch.Tensor],
+    labels: torch.Tensor,
+    effective_labels: torch.Tensor,
+) -> Optional[torch.Tensor]:
+    if attention_mask is None:
+        return None
+
+    if attention_mask.numel() == labels.numel() or attention_mask.numel() == effective_labels.numel():
+        return attention_mask.reshape(-1)
+    return None
+
+
+def _filter_surplus_tail_padding_segments(
+    segments: List[tuple[int, int, int]],
+    source_count: int,
+    labels_flat: torch.Tensor,
+    positions_flat: Optional[torch.Tensor],
+    attention_mask_flat: Optional[torch.Tensor],
+    ignore_index: int,
+) -> List[tuple[int, int, int]]:
+    surplus = len(segments) - source_count
+    if surplus <= 0:
+        return segments
+
+    indexed_by_batch: Dict[int, List[tuple[int, int, int]]] = defaultdict(list)
+    for segment_idx, (batch_idx, start, end) in enumerate(segments):
+        indexed_by_batch[batch_idx].append((segment_idx, start, end))
+
+    candidates_by_batch: Dict[int, List[tuple[bool, int]]] = defaultdict(list)
+    for batch_idx, row_segments in indexed_by_batch.items():
+        for segment_idx, start, end in reversed(row_segments):
+            mask_slice = attention_mask_flat[start : end + 1] if attention_mask_flat is not None else None
+            if not _is_padding_only_segment(
+                labels_slice=labels_flat[start : end + 1],
+                positions_slice=positions_flat[start : end + 1] if positions_flat is not None else None,
+                attention_mask_slice=mask_slice,
+                ignore_index=ignore_index,
+            ):
+                break
+            candidates_by_batch[batch_idx].append((_has_explicit_padding_mask(mask_slice), segment_idx))
+
+    selected = _select_unambiguous_tail_candidates(candidates_by_batch, surplus)
+    if selected is None:
+        return segments
+    removed = set(selected)
+    return [segment for segment_idx, segment in enumerate(segments) if segment_idx not in removed]
+
+
+def _filter_surplus_tail_padding_sp_segments(
+    segments: List[Dict[str, Any]],
+    source_count: int,
+) -> List[Dict[str, Any]]:
+    surplus = sum(1 for segment in segments if segment["is_start"]) - source_count
+    if surplus <= 0:
+        return segments
+
+    indexed_by_batch: Dict[int, List[tuple[int, Dict[str, Any]]]] = defaultdict(list)
+    for segment_idx, segment in enumerate(segments):
+        indexed_by_batch[int(segment.get("batch_idx", 0))].append((segment_idx, segment))
+
+    candidates_by_batch: Dict[int, List[tuple[bool, List[int]]]] = defaultdict(list)
+    for batch_idx, row_partials in indexed_by_batch.items():
+        logical_segments: List[List[tuple[int, Dict[str, Any]]]] = []
+        for segment_idx, segment in row_partials:
+            if segment["is_start"]:
+                logical_segments.append([])
+            if logical_segments:
+                logical_segments[-1].append((segment_idx, segment))
+
+        for logical_segment in reversed(logical_segments):
+            if not logical_segment or not all(partial.get("is_padding_only", False) for _, partial in logical_segment):
+                break
+            candidates_by_batch[batch_idx].append(
+                (
+                    all(partial.get("has_explicit_padding_mask", False) for _, partial in logical_segment),
+                    [segment_idx for segment_idx, _ in logical_segment],
+                )
+            )
+
+    selected = _select_unambiguous_tail_candidates(candidates_by_batch, surplus)
+    if selected is None:
+        return segments
+    removed: set[int] = set()
+    for segment_indices in selected:
+        removed.update(segment_indices)
+    return [segment for segment_idx, segment in enumerate(segments) if segment_idx not in removed]
+
+
+def _is_padding_only_segment(
+    labels_slice: torch.Tensor,
+    positions_slice: Optional[torch.Tensor],
+    attention_mask_slice: Optional[torch.Tensor],
+    ignore_index: int,
+) -> bool:
+    if labels_slice.numel() == 0 or labels_slice.ne(ignore_index).any().item():
+        return False
+
+    if attention_mask_slice is not None and attention_mask_slice.numel() > 0:
+        if not attention_mask_slice.to(torch.bool).any().item():
+            return True
+
+    if positions_slice is not None and positions_slice.numel() > 0:
+        return bool(positions_slice.eq(0).all().item())
+
+    return False
+
+
+def _has_explicit_padding_mask(attention_mask_slice: Optional[torch.Tensor]) -> bool:
+    return bool(
+        attention_mask_slice is not None
+        and attention_mask_slice.numel() > 0
+        and not attention_mask_slice.to(torch.bool).any().item()
+    )
+
+
+def _select_unambiguous_tail_candidates(
+    candidates_by_batch: Dict[int, List[tuple[bool, Any]]],
+    surplus: int,
+) -> Optional[List[Any]]:
+    # Each layer stores compact backpointers instead of copying payload prefixes.
+    batch_ids = sorted(candidates_by_batch)
+    states: Dict[int, tuple[int, bool]] = {0: (0, True)}
+    layers: List[Dict[int, tuple[int, bool, int, int]]] = []
+    for batch_idx in batch_ids:
+        row_candidates = candidates_by_batch[batch_idx]
+        explicit_prefix = [0]
+        for has_explicit_mask, _ in row_candidates:
+            explicit_prefix.append(explicit_prefix[-1] + int(has_explicit_mask))
+
+        next_layer: Dict[int, tuple[int, bool, int, int]] = {}
+        for removed_count, (score, is_unique) in states.items():
+            for row_removed in range(len(row_candidates) + 1):
+                new_count = removed_count + row_removed
+                if new_count > surplus:
+                    break
+                candidate_score = score + explicit_prefix[row_removed]
+                existing = next_layer.get(new_count)
+                if existing is None or candidate_score > existing[0]:
+                    next_layer[new_count] = (candidate_score, is_unique, removed_count, row_removed)
+                elif candidate_score == existing[0]:
+                    next_layer[new_count] = (existing[0], False, existing[2], existing[3])
+        layers.append(next_layer)
+        states = {removed_count: (entry[0], entry[1]) for removed_count, entry in next_layer.items()}
+
+    best = states.get(surplus)
+    if best is None or not best[1]:
+        return None
+
+    selected: List[Any] = []
+    removed_count = surplus
+    for batch_idx, layer in zip(reversed(batch_ids), reversed(layers)):
+        _, _, previous_count, row_removed = layer[removed_count]
+        selected.extend(payload for _, payload in candidates_by_batch[batch_idx][:row_removed])
+        removed_count = previous_count
+    return selected
+
+
+def _validate_segment_count(segment_count: int, source_count: int, strict: bool, context: str) -> bool:
+    if segment_count == source_count:
+        return True
+
+    msg = (
+        f"Channel loss: source metadata count ({source_count}) does not match {context} "
+        f"({segment_count}); skipping this micro-batch."
+    )
+    if strict:
+        raise ChannelLossMetadataError(msg)
+    logger.warning_rank0(msg)
+    return False
+
+
+def _as_channel_key_list(value: Any) -> List[ChannelKey]:
+    result: List[ChannelKey] = []
+    for item in _as_flat_list(value):
+        if item is None:
+            continue
+        if isinstance(item, bytes):
+            item = item.decode("utf-8", errors="replace")
+        if isinstance(item, Integral):
+            result.append(int(item))
+            continue
+        text = str(item)
+        if text:
+            result.append(text)
+    return result
+
+
+def _as_str_list(value: Any) -> List[str]:
+    result: List[str] = []
+    for item in _as_flat_list(value):
+        if item is None:
+            continue
+        if isinstance(item, bytes):
+            item = item.decode("utf-8", errors="replace")
+        text = str(item)
+        if text:
+            result.append(text)
+    return result
+
+
+def _sanitize_metric_fragment(value: Any) -> str:
+    text = str(value)
+    text = re.sub(r"[^A-Za-z0-9_.-]+", "_", text).strip("_")
+    return text or "unknown"
+
+
+def _stable_source_metric_fragment(value: ChannelKey) -> str:
+    if isinstance(value, int):
+        return f"source-i-{value}"
+    encoded = str(value).encode("utf-8").hex()
+    return f"source-s-{encoded or 'empty'}"
+
+
+def _channel_sort_key(value: ChannelKey) -> tuple[int, str]:
+    return (0 if isinstance(value, int) else 1, str(value))

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -86,6 +86,11 @@ class CheckpointerCallback(Callback):
 
         self.trainer.lr_scheduler.load_state_dict(state["extra_state"]["lr_scheduler"])
 
+        channel_loss_state = state["extra_state"].get("channel_loss_callback")
+        channel_loss_callback = getattr(self.trainer, "channel_loss_callback", None)
+        if channel_loss_state is not None and channel_loss_callback is not None:
+            channel_loss_callback.load_state_dict(channel_loss_state)
+
         # dataloader may only init on sp_rank_0 to save memory
         if (
             self.trainer.train_dataloader is not None
@@ -115,6 +120,9 @@ class CheckpointerCallback(Callback):
         else:
             train_dataloader_state = {}
 
+        channel_loss_callback = getattr(self.trainer, "channel_loss_callback", None)
+        channel_loss_state = channel_loss_callback.state_dict() if channel_loss_callback is not None else {}
+
         ckpt_state = {
             "model": self.trainer.model,
             "optimizer": self.trainer.optimizer,
@@ -123,6 +131,7 @@ class CheckpointerCallback(Callback):
                 "lr_scheduler": self.trainer.lr_scheduler.state_dict(),
                 "train_dataloader": train_dataloader_state,
                 "environ_meter": self.trainer.environ_meter.state_dict(),
+                "channel_loss_callback": channel_loss_state,
                 "torch_rng_state": torch.get_rng_state(),
             },
         }

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -178,6 +178,10 @@ class DiTTrainer:
     offline_embedding_saver: OfflineEmbeddingSaver = None
 
     def __init__(self, args: VeOmniDiTArguments):
+        if args.train.channel_loss.enable:
+            raise ValueError(
+                "train.channel_loss is only supported by causal-LM trainers; DiTTrainer uses diffusion objectives."
+            )
         self.base = BaseTrainer.__new__(BaseTrainer)
         self.base.args = args
 

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import defaultdict
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Tuple
 
@@ -315,44 +316,60 @@ class TextDPOTrainer:
     def forward_backward_step(
         self, micro_batch: Dict[str, torch.Tensor]
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
-        args: VeOmniDPOArguments = self.base.args
-        dpo_config = args.dpo_config
-
-        micro_batch = self.base.preforward(micro_batch)
-
-        with torch.no_grad():
-            ref_chosen_logps, ref_rejected_logps = self.concatenated_forward(self.reference_model, micro_batch)
-
-        with self.base.model_fwd_context, set_batch_invariant_mode(args.train.enable_batch_invariant_mode):
-            policy_chosen_logps, policy_rejected_logps = self.concatenated_forward(self.base.model, micro_batch)
-
-        losses, chosen_rewards, rejected_rewards = self.dpo_loss(
-            policy_chosen_logps,
-            policy_rejected_logps,
-            ref_chosen_logps,
-            ref_rejected_logps,
-            beta=dpo_config.beta,
-            label_smoothing=dpo_config.label_smoothing,
-            loss_type=dpo_config.loss_type,
-            reference_free=dpo_config.reference_free,
+        channel_loss_callback = getattr(self.base, "channel_loss_callback", None)
+        micro_step_context = (
+            channel_loss_callback.micro_step_context(self.base.state, micro_batch)
+            if channel_loss_callback is not None
+            else nullcontext()
         )
+        with micro_step_context:
+            args: VeOmniDPOArguments = self.base.args
+            dpo_config = args.dpo_config
 
-        loss = losses.mean()
+            micro_batch = self.base.preforward(micro_batch)
+            if channel_loss_callback is not None:
+                channel_loss_callback.strip_model_inputs(micro_batch)
 
-        reward_accuracies = (chosen_rewards > rejected_rewards).float().mean()
-        loss_dict: Dict[str, torch.Tensor] = {
-            "dpo_loss": loss.detach(),
-            "chosen_rewards": chosen_rewards.mean().detach(),
-            "rejected_rewards": rejected_rewards.mean().detach(),
-            "reward_accuracy": reward_accuracies.detach(),
-            "reward_margin": (chosen_rewards - rejected_rewards).mean().detach(),
-        }
+            with torch.no_grad():
+                ref_chosen_logps, ref_rejected_logps = self.concatenated_forward(self.reference_model, micro_batch)
 
-        with self.base.model_bwd_context, set_batch_invariant_mode(args.train.enable_batch_invariant_mode):
-            loss.backward()
+            channel_forward_context = (
+                channel_loss_callback.model_forward_context() if channel_loss_callback is not None else nullcontext()
+            )
+            with (
+                self.base.model_fwd_context,
+                set_batch_invariant_mode(args.train.enable_batch_invariant_mode),
+                channel_forward_context,
+            ):
+                policy_chosen_logps, policy_rejected_logps = self.concatenated_forward(self.base.model, micro_batch)
 
-        del micro_batch
-        return loss, loss_dict
+            losses, chosen_rewards, rejected_rewards = self.dpo_loss(
+                policy_chosen_logps,
+                policy_rejected_logps,
+                ref_chosen_logps,
+                ref_rejected_logps,
+                beta=dpo_config.beta,
+                label_smoothing=dpo_config.label_smoothing,
+                loss_type=dpo_config.loss_type,
+                reference_free=dpo_config.reference_free,
+            )
+
+            loss = losses.mean()
+
+            reward_accuracies = (chosen_rewards > rejected_rewards).float().mean()
+            loss_dict: Dict[str, torch.Tensor] = {
+                "dpo_loss": loss.detach(),
+                "chosen_rewards": chosen_rewards.mean().detach(),
+                "rejected_rewards": rejected_rewards.mean().detach(),
+                "reward_accuracy": reward_accuracies.detach(),
+                "reward_margin": (chosen_rewards - rejected_rewards).mean().detach(),
+            }
+
+            with self.base.model_bwd_context, set_batch_invariant_mode(args.train.enable_batch_invariant_mode):
+                loss.backward()
+
+            del micro_batch
+            return loss, loss_dict
 
     def on_train_begin(self):
         self.base.on_train_begin()
@@ -367,7 +384,9 @@ class TextDPOTrainer:
         self.base.on_epoch_end()
 
     def on_step_begin(self, micro_batches=None):
-        self.base.on_step_begin(micro_batches=micro_batches)
+        # Each DPO preference pair is packed as two consecutive causal-LM
+        # segments (chosen, rejected) but carries one source metadata entry.
+        self.base.on_step_begin(micro_batches=micro_batches, channel_loss_source_repeat=2)
 
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
         self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)


### PR DESCRIPTION
## Summary
- Add `train.channel_loss.*` config for detached per-channel causal-LM loss logging.
- Add a generic `ChannelLossCallback` that captures batch source metadata, strips non-model metadata before forward, and logs per-channel loss/token metrics through existing trainer metrics.
- Cover eager `loss_function` and fused `veomni_causal_lm_loss` OpSlot paths without changing the main training loss.

## Tests
- `PATH=.venv/bin:$PATH make quality`
- `TORCH_DEVICE_BACKEND_AUTOLOAD=0 PYTHONPATH=/home/tiger/Open-VeOmni-github uv run --project /home/tiger/modelchef/submodules/Open-VeOmni --frozen --group test python -m pytest /home/tiger/Open-VeOmni-github/tests/trainer/test_channel_loss_callback.py -q`
