### PR TITLE
[agent] chore: add reusable workflow skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -41,4 +41,5 @@ See the [Agent Skills specification](https://agentskills.io/specification) for t
 | `veomni-uv-update` | Dependency management with uv (version bumps, torch, lockfile) |
 | `create-pr` | Create a pull request — handles uncommitted changes, generates CI-compliant title and description |
 | `pr-draft-maintainer` | Maintain PR/MR descriptions and local draft markdown from reports, logs, reviewer feedback, or issue context |
+| `veomni-patch-to-pr` | Apply external diffs/reports and package them into clean VeOmni PRs without scratch artifacts or author/claim leaks |
 | `veomni-profile` | Performance profiling — analyze traces/snapshots or generate profiles and optimize |

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -40,4 +40,5 @@ See the [Agent Skills specification](https://agentskills.io/specification) for t
 | `veomni-new-op` | Adding a new optimized kernel/operator to veomni/ops/ |
 | `veomni-uv-update` | Dependency management with uv (version bumps, torch, lockfile) |
 | `create-pr` | Create a pull request — handles uncommitted changes, generates CI-compliant title and description |
+| `pr-draft-maintainer` | Maintain PR/MR descriptions and local draft markdown from reports, logs, reviewer feedback, or issue context |
 | `veomni-profile` | Performance profiling — analyze traces/snapshots or generate profiles and optimize |

--- a/.agents/skills/pr-draft-maintainer/SKILL.md
+++ b/.agents/skills/pr-draft-maintainer/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: pr-draft-maintainer
+description: Maintain pull request or merge request descriptions and local PR draft markdown across repositories. Use when updating PR text from reports, benchmark results, CI or test logs, reviewer feedback, issue context, changelogs, release notes, or when syncing a local draft with a hosted PR via GitHub CLI or similar tools; for PR body and title refinement without changing source code.
+---
+
+# PR Draft Maintainer
+
+## Scope
+
+Maintain pull request prose. Do not modify implementation files, tests, configs, branch history, or commits unless the user explicitly asks. Work with any repository convention: hosted PR only, local markdown draft, title/body split, template-based body, issue-tracker text, GitHub PR, or GitLab merge request.
+
+## Core rules
+
+- Discover the repo's convention before editing: PR template, contribution guide, existing draft files, prior PRs, and hosted PR metadata.
+- Preserve the existing title/body format unless the user asks to restructure it.
+- Use only defensible facts from supplied artifacts or inspected state. Do not invent tests, benchmark numbers, approvals, or CI status.
+- Separate evidence types clearly: functional tests, CI, performance, correctness parity, risk, rollout, known limits.
+- Keep public PR text concise, reviewer-oriented, and in the same language as the existing PR/template unless the user requests another language.
+
+## Workflow
+
+1. **Resolve the target**
+   - Identify the PR/MR URL, number, repository, branch, and hosting tool.
+   - Identify local draft files if any. Search common paths only when needed: `.pr-drafts/`, `.github/`, `docs/`, `changelog`, or paths supplied by the user.
+   - Identify source artifacts: reports, logs, benchmark output, screenshots, release notes, reviewer comments, issue links, or prior draft text.
+
+2. **Load current context**
+   - Read the existing local draft and source artifacts.
+   - Read the repo PR template if present, for example `.github/PULL_REQUEST_TEMPLATE.md`.
+   - If syncing or updating a hosted PR, inspect the current remote title/body first. GitHub example:
+     ```bash
+     gh pr view PR_NUMBER --json title,body,url,headRefName,baseRefName,isDraft
+     ```
+   - Check whether draft files are gitignored. If ignored, validate with `sed`, `grep`, `wc`, or `stat`; do not rely on `git diff`.
+
+3. **Determine the draft format**
+   - Body-only markdown.
+   - First line is title, then blank line, then body.
+   - Separate title and body files.
+   - Hosted PR body with no local draft.
+   - Repository-specific template sections.
+
+   Preserve the detected format. If ambiguous, avoid putting a title line into the body unless the existing draft already does that.
+
+4. **Integrate new material**
+   - Add new facts to the most relevant existing section instead of appending a disconnected block.
+   - For test logs: include command, outcome, and meaningful scope; omit noisy raw logs.
+   - For reviewer feedback: summarize the addressed concern and the resulting change or clarification.
+   - For issue context: link or mention issue IDs and explain the resolved user-visible problem.
+   - For release notes or changelogs: keep user impact separate from implementation details.
+   - For screenshots or demos: include only stable links/paths and a one-line explanation of what they verify.
+
+5. **Handle performance data carefully**
+   - Include workload, hardware/runtime, timing method, sample size, and warmup/exclusion policy when relevant.
+   - Separate steady-state throughput claims from profiler counters or narrow trace-window observations.
+   - State one-time costs separately from steady-state results.
+   - Use compact tables for core metrics: latency, throughput, memory, CPU/GPU utilization, launch counts, error rate, or other domain-specific metrics.
+   - Avoid broad production claims from a narrow benchmark. Say “in this tested scenario” and preserve caveats.
+
+6. **Sync hosted PR only when requested or clearly implied**
+   - Prefer file-based updates to avoid shell escaping issues.
+   - GitHub body-only example:
+     ```bash
+     gh pr edit PR_NUMBER --body-file draft.md
+     ```
+   - GitHub title-plus-body draft example:
+     ```bash
+     title=$(sed -n '1p' draft.md)
+     tail -n +3 draft.md > /tmp/pr-body.md
+     gh pr edit PR_NUMBER --title "$title" --body-file /tmp/pr-body.md
+     ```
+   - If using GitLab or another host, use the equivalent CLI/API pattern and still read back the final remote text.
+   - If the user only asks to draft locally, do not sync remotely.
+
+7. **Validate the result**
+   - Re-read the edited draft or hosted PR body.
+   - Grep or print key updated lines and any changed tables.
+   - Recompute simple deltas when source values allow it.
+   - Confirm no unrelated files were modified.
+
+## Quality bar
+
+A good PR update answers, in order:
+
+1. What changed?
+2. Why was it needed?
+3. How was it validated?
+4. What changed in behavior, API, performance, or risk?
+5. What should reviewers focus on?
+
+Do not force all five headings into every PR. Match the repository template and keep the text as short as the evidence allows.
+
+## Safety checks
+
+- Do not fabricate validation, benchmark results, compatibility, approvals, or deployment status.
+- Do not expose secrets, internal-only hostnames, credentials, or irrelevant local filesystem paths in public PR text.
+- Do not run expensive tests or benchmarks for a text-only update unless explicitly asked.
+- If important source artifacts conflict and three reconciliation attempts fail, stop and ask which source is authoritative.

--- a/.agents/skills/pr-draft-maintainer/agents/openai.yaml
+++ b/.agents/skills/pr-draft-maintainer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Draft Maintainer"
+  short_description: "Maintain PR descriptions and local drafts"
+  default_prompt: "Use $pr-draft-maintainer to update a pull request description from test results, reviewer feedback, or a report."

--- a/.agents/skills/veomni-patch-to-pr/SKILL.md
+++ b/.agents/skills/veomni-patch-to-pr/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: veomni-patch-to-pr
+description: "Apply an external diff/patch or report bundle to VeOmni and turn it into a clean pull request. Use when the user says apply a .diff/.patch, create a branch, write/update a PR from a report, push/submit, or package experimental changes for review. Reuses /veomni-develop, /veomni-debug, /veomni-review, /pr-draft-maintainer, and /create-pr instead of replacing them."
+---
+
+# VeOmni Patch to PR
+
+## Purpose
+
+Turn a supplied patch plus optional reports/logs/reviewer context into a reviewable VeOmni branch and PR without leaking scratch artifacts, local paths, wrong authors, or unsupported claims.
+
+## Workflow
+
+1. **Resolve intent and inputs**
+   - Identify the target repo, base branch, patch files, report/log files, PR URL/number if any, and whether the user wants local draft only or remote PR update.
+   - If the user only asks for PR prose, use `/pr-draft-maintainer` and do not touch code.
+   - If the task is a bug/CI failure rather than patch packaging, use `/veomni-debug` or `gh-fix-ci` first, then return here for PR packaging.
+
+2. **Prepare a safe workspace**
+   - Check `git status --short`, current branch, upstream, and recent commits.
+   - Never apply a patch on `main`. Create a feature branch or worktree with a descriptive name.
+   - Record original `user.name` and `user.email`; before committing, ensure the author is the intended contributor and avoid accidental `bytedance`/local-machine authorship.
+   - Read `.agents/knowledge/constraints.md`; for feature or refactor work also use `/veomni-develop`, for new ops use `/veomni-new-op`, and for patchgen/model work use `/veomni-migrate-transformers-v5`.
+
+3. **Apply and inspect the patch**
+   - Prefer `git apply --check <patch>` before applying. If it fails, inspect reject context and decide whether to use `git apply --3way` or manual conflict resolution.
+   - After applying, run `git status --short` and `git diff --stat`.
+   - Inspect for scratch artifacts before they enter the PR: one-off scripts, raw reports, benchmark dumps, logs, generated temp files, local absolute paths, and files explicitly excluded by the user.
+   - Generated files under `veomni/models/transformers/*/generated/` must only change as part of a regenerated patchgen flow; otherwise stop and fix the source config instead.
+
+4. **Integrate evidence into code, docs, and PR text**
+   - Convert supplied reports into concise PR validation statements; do not commit large raw reports unless the user asks and the repo convention supports it.
+   - Use `/pr-draft-maintainer` for PR body updates from benchmarks, CI logs, reviewer feedback, or test reports.
+   - Keep performance claims scoped to the supplied workload, hardware/runtime, sample size, and caveats.
+   - Remove irrelevant local filesystem paths from public PR text.
+
+5. **Validate the branch**
+   - Run the smallest meaningful test set first, then required quality gates such as `make quality`.
+   - If tests are unavailable locally, state the exact command that could not be run and why.
+   - Run `/veomni-review` before committing. For a risky verdict, do not commit until the issue is fixed or the user approves the risk.
+
+6. **Commit, push, and open/update the PR**
+   - Commit only related changes. Do not batch cleanup, unrelated refactors, and feature changes together.
+   - Use a VeOmni-compliant PR title: `[{modules}] {type}: {description}`.
+   - Use `/create-pr` for the final GitHub PR creation flow, or `gh pr edit --body-file` when updating an existing PR.
+   - After push, read back the remote PR title/body and run `gh pr checks` or explain when checks are pending/unavailable.
+
+## Final response checklist
+
+Report:
+- Branch name and PR URL or draft path.
+- What patch/report inputs were used.
+- What was intentionally excluded from the PR.
+- Tests/quality/review commands run and their results.
+- Any remaining CI, reviewer, or environment follow-up.

--- a/.agents/skills/veomni-patch-to-pr/agents/openai.yaml
+++ b/.agents/skills/veomni-patch-to-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "VeOmni Patch to PR"
+  short_description: "Apply an external patch and turn it into a clean PR"
+  default_prompt: "Use $veomni-patch-to-pr to apply a diff/report bundle, clean it up, create a branch, and open or update a VeOmni PR."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ Skills follow the [Agent Skills](https://agentskills.io) open standard. Each ski
 | Add new op/kernel | `/veomni-new-op` |
 | Update dependencies (uv) | `/veomni-uv-update` |
 | Performance profiling | `/veomni-profile` |
+| PR/MR draft maintenance | `/pr-draft-maintainer` |
 
 ### Quick Decision Guide
 
@@ -105,3 +106,4 @@ Skills follow the [Agent Skills](https://agentskills.io) open standard. Each ski
 - **"Add a new capability" / "refactor" / "clean up"** → `/veomni-develop`
 - **"Update package X" / "bump uv" / "upgrade torch"** → `/veomni-uv-update`
 - **"Analyze this trace" / "why is training slow" / "profile" / "MFU"** → `/veomni-profile`
+- **"Update PR description" / "sync PR draft" / "add benchmark results to PR"** → `/pr-draft-maintainer`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Skills follow the [Agent Skills](https://agentskills.io) open standard. Each ski
 | Update dependencies (uv) | `/veomni-uv-update` |
 | Performance profiling | `/veomni-profile` |
 | PR/MR draft maintenance | `/pr-draft-maintainer` |
+| Patch/apply-to-PR packaging | `/veomni-patch-to-pr` |
 
 ### Quick Decision Guide
 
@@ -107,3 +108,4 @@ Skills follow the [Agent Skills](https://agentskills.io) open standard. Each ski
 - **"Update package X" / "bump uv" / "upgrade torch"** → `/veomni-uv-update`
 - **"Analyze this trace" / "why is training slow" / "profile" / "MFU"** → `/veomni-profile`
 - **"Update PR description" / "sync PR draft" / "add benchmark results to PR"** → `/pr-draft-maintainer`
+- **"Apply this diff" / "write a PR from this report" / "push this patch"** → `/veomni-patch-to-pr`


### PR DESCRIPTION
## Summary
- add `pr-draft-maintainer` for maintaining PR/MR descriptions and local draft markdown from reports, logs, benchmarks, and reviewer context
- add `veomni-patch-to-pr` for packaging external diff/report bundles into clean VeOmni PRs
- update `AGENTS.md` and `.agents/skills/README.md` so the new skills are discoverable in the repo workflow guide

## Validation
- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/pr-draft-maintainer`
- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/veomni-patch-to-pr`
- `git diff --check upstream/main..HEAD`
