### PR TITLE
[model] fix: handle DeepSeek V4 FP8 checkpoint scales

### DIFF
--- a/tests/models/test_checkpoint_tensor_converter.py
+++ b/tests/models/test_checkpoint_tensor_converter.py
@@ -32,6 +32,7 @@ from veomni.models.checkpoint_tensor_loading import (
 )
 from veomni.models.transformers.deepseek_v4.checkpoint_tensor_converter import (
     DeepseekV4CheckpointTensorConverter,
+    _dequantize_scaled_weight,
     convert_deepseek_v4_fqn_to_index_mapping,
     create_deepseek_v4_checkpoint_tensor_converter,
 )
@@ -398,6 +399,13 @@ def _make_deepseek_v4_expert_tensor(proj: str, expert_id: int) -> torch.Tensor:
     return torch.full(shape, expert_id + offset)
 
 
+def _to_fp8(tensor: torch.Tensor) -> torch.Tensor:
+    fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+    if fp8_dtype is None:
+        pytest.skip("torch.float8_e4m3fn is unavailable")
+    return tensor.to(fp8_dtype)
+
+
 class TestDeepseekV4ConverterCanHandle:
     def setup_method(self):
         self.converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
@@ -409,12 +417,113 @@ class TestDeepseekV4ConverterCanHandle:
     def test_matches_raw_and_renamed_expert_keys(self, proj: str):
         assert self.converter.can_handle(_make_deepseek_v4_expert_key(0, 1, proj))
 
-    def test_rejects_non_expert_keys(self):
-        assert not self.converter.can_handle("model.layers.0.self_attn.q_proj.weight")
+    def test_matches_scale_keys_for_fp8_scale_pairs(self):
+        assert self.converter.can_handle("model.layers.0.attn.wkv.scale")
+        assert self.converter.can_handle("model.layers.0.attn.wkv.weight_scale_inv")
+
+    def test_regular_weight_keys_are_not_name_only_handled(self):
+        assert not self.converter.can_handle("model.layers.0.attn.wkv.weight")
+
+    def test_matches_quantized_weight_tensors(self):
+        weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
+        assert self.converter.can_handle_tensor("model.layers.0.attn.wkv.weight", weight)
+
+    def test_rejects_non_tensor_keys(self):
         assert not self.converter.can_handle("model.layers.0.mlp.experts.gate_up_proj")
 
 
 class TestDeepseekV4ConverterConvert:
+    def test_dequantizes_block_scaled_fp8_weight(self):
+        weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
+        scale = torch.tensor([[1.0, 2.0], [4.0, 8.0]])
+        expected = weight.float().view(2, 2, 2, 2).mul(scale.view(2, 1, 2, 1)).reshape(4, 4)
+        assert torch.equal(_dequantize_scaled_weight(weight, scale), expected)
+
+    def test_fp8_weight_scale_pair_emits_dequantized_weight(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
+        weight_name = "model.layers.0.attn.wkv.weight"
+        scale_name = "model.layers.0.attn.wkv.scale"
+        weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
+        scale = torch.tensor([[1.0, 2.0], [4.0, 8.0]])
+
+        assert maybe_convert_checkpoint_tensor(weight_name, weight, converter) is None
+        result = maybe_convert_checkpoint_tensor(scale_name, scale, converter)
+
+        assert result is not None
+        assert result.name == weight_name
+        assert torch.equal(result.tensor, _dequantize_scaled_weight(weight, scale))
+        assert converter.finalize() == []
+
+    def test_fp8_scale_can_arrive_before_weight(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
+        weight_name = "model.layers.0.attn.wkv.weight"
+        scale_name = "model.layers.0.attn.wkv.scale"
+        weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
+        scale = torch.tensor([[1.0, 2.0], [4.0, 8.0]])
+
+        assert maybe_convert_checkpoint_tensor(scale_name, scale, converter) is None
+        result = maybe_convert_checkpoint_tensor(weight_name, weight, converter)
+
+        assert result is not None
+        assert result.name == weight_name
+        assert torch.equal(result.tensor, _dequantize_scaled_weight(weight, scale))
+        assert converter.finalize() == []
+
+    def test_fp8_weight_scale_inv_suffix_emits_dequantized_weight(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
+        weight_name = "model.layers.0.attn.wkv.weight"
+        scale_name = "model.layers.0.attn.wkv.weight_scale_inv"
+        weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
+        scale = torch.tensor([[1.0, 2.0], [4.0, 8.0]])
+
+        assert maybe_convert_checkpoint_tensor(weight_name, weight, converter) is None
+        result = maybe_convert_checkpoint_tensor(scale_name, scale, converter)
+
+        assert result is not None
+        assert result.name == weight_name
+        assert torch.equal(result.tensor, _dequantize_scaled_weight(weight, scale))
+        assert converter.finalize() == []
+
+    def test_scalar_scale_pairs_with_fp8_weight(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
+        weight_name = "model.layers.0.attn.wkv.weight"
+        scale_name = "model.layers.0.attn.wkv.scale"
+        weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
+        scale = torch.tensor(2.0)
+
+        assert maybe_convert_checkpoint_tensor(weight_name, weight, converter) is None
+        result = maybe_convert_checkpoint_tensor(scale_name, scale, converter)
+
+        assert result is not None
+        assert result.name == weight_name
+        assert torch.equal(result.tensor, weight.float() * scale)
+        assert converter.finalize() == []
+
+    def test_legitimate_scale_parameter_passes_through(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
+        tensor = torch.ones(3)
+        result = maybe_convert_checkpoint_tensor("model.layers.0.input_layernorm.scale", tensor, converter)
+        assert result is not None
+        assert result.name == "model.layers.0.input_layernorm.scale"
+        assert result.tensor is tensor
+
+    def test_2d_scale_without_quantized_weight_passes_through_on_finalize(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
+        tensor = torch.ones(2, 2)
+        assert maybe_convert_checkpoint_tensor("model.layers.0.some_module.scale", tensor, converter) is None
+        finalized = converter.finalize()
+        assert len(finalized) == 1
+        assert finalized[0].name == "model.layers.0.some_module.scale"
+        assert finalized[0].tensor is tensor
+
+    def test_quantized_weight_without_scale_errors(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
+        weight_name = "model.layers.0.attn.wkv.weight"
+        weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
+        assert maybe_convert_checkpoint_tensor(weight_name, weight, converter) is None
+        with pytest.raises(RuntimeError, match="missing scale"):
+            converter.finalize()
+
     def test_raw_w_keys_convert_to_fused_expert_layout(self):
         converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
         dispatched = {}
@@ -456,6 +565,39 @@ class TestDeepseekV4ConverterConvert:
             assert torch.equal(gate_up[expert_id, :INTERMEDIATE_DIM, :], gate_expected)
             assert torch.equal(gate_up[expert_id, INTERMEDIATE_DIM:, :], up_expected)
             assert torch.equal(down[expert_id], down_expected)
+
+    def test_fp8_expert_weights_are_dequantized_before_fusing(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
+        dispatched = {}
+        scales = {
+            "w1": torch.full((1, 1), 2.0),
+            "w2": torch.full((1, 1), 3.0),
+            "w3": torch.full((1, 1), 4.0),
+        }
+
+        for proj in ("w1", "w3", "w2"):
+            for expert_id in range(NUM_EXPERTS):
+                weight_name = _make_deepseek_v4_expert_key(0, expert_id, proj)
+                weight = _to_fp8(_make_deepseek_v4_expert_tensor(proj, expert_id))
+                assert maybe_convert_checkpoint_tensor(weight_name, weight, converter) is None
+                result = maybe_convert_checkpoint_tensor(
+                    weight_name.removesuffix(".weight") + ".scale",
+                    scales[proj],
+                    converter,
+                )
+                if result is not None:
+                    dispatched[result.name] = result.tensor
+
+        gate_up = dispatched["model.layers.0.mlp.experts.gate_up_proj"]
+        down = dispatched["model.layers.0.mlp.experts.down_proj"]
+        for expert_id in range(NUM_EXPERTS):
+            gate_expected = _to_fp8(_make_deepseek_v4_expert_tensor("w1", expert_id)).float() * scales["w1"]
+            up_expected = _to_fp8(_make_deepseek_v4_expert_tensor("w3", expert_id)).float() * scales["w3"]
+            down_expected = _to_fp8(_make_deepseek_v4_expert_tensor("w2", expert_id)).float() * scales["w2"]
+            assert torch.equal(gate_up[expert_id, :INTERMEDIATE_DIM, :], gate_expected)
+            assert torch.equal(gate_up[expert_id, INTERMEDIATE_DIM:, :], up_expected)
+            assert torch.equal(down[expert_id], down_expected)
+        assert converter.finalize() == []
 
     def test_renamed_keys_still_convert(self):
         converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)

--- a/veomni/models/checkpoint_tensor_loading.py
+++ b/veomni/models/checkpoint_tensor_loading.py
@@ -235,6 +235,11 @@ def maybe_convert_checkpoint_tensor(
         ``ConvertedCheckpointTensor`` if tensor is ready for dispatch (pass-through or converted).
         ``None`` if converter consumed the tensor but is still accumulating.
     """
-    if converter is None or not converter.can_handle(name):
+    if converter is None:
+        return ConvertedCheckpointTensor(name=name, tensor=tensor)
+    can_handle_tensor = getattr(converter, "can_handle_tensor", None)
+    if callable(can_handle_tensor) and can_handle_tensor(name, tensor):
+        return converter.convert(name, tensor)
+    if not converter.can_handle(name):
         return ConvertedCheckpointTensor(name=name, tensor=tensor)
     return converter.convert(name, tensor)

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -81,7 +81,7 @@ def _requires_byte_broadcast(dtype: "torch.dtype") -> bool:
 
 
 def _num_storage_bytes(shape: Tuple[int, ...], dtype: "torch.dtype") -> int:
-    if dtype in _FLOAT8_DTYPES:
+    if dtype in _FLOAT8_DTYPES or dtype == torch.bool:
         return math.prod(shape)
     elem_size = torch.finfo(dtype).bits // 8 if dtype.is_floating_point else torch.iinfo(dtype).bits // 8
     return math.prod(shape) * elem_size
@@ -96,6 +96,8 @@ def _view_from_bytes(tensor: "torch.Tensor", dtype: "torch.dtype", shape: Tuple[
 
 
 def _is_all_zero_tensor(tensor: "torch.Tensor") -> bool:
+    if tensor.is_meta:
+        return False
     try:
         return bool(torch.count_nonzero(tensor).item() == 0)
     except NotImplementedError:

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -63,6 +63,45 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
+_FLOAT8_DTYPES = tuple(
+    dtype
+    for dtype in (
+        getattr(torch, "float8_e4m3fn", None),
+        getattr(torch, "float8_e4m3fnuz", None),
+        getattr(torch, "float8_e5m2", None),
+        getattr(torch, "float8_e5m2fnuz", None),
+        getattr(torch, "float8_e8m0fnu", None),
+    )
+    if dtype is not None
+)
+
+
+def _requires_byte_broadcast(dtype: "torch.dtype") -> bool:
+    return dtype in _FLOAT8_DTYPES
+
+
+def _num_storage_bytes(shape: Tuple[int, ...], dtype: "torch.dtype") -> int:
+    if dtype in _FLOAT8_DTYPES:
+        return math.prod(shape)
+    elem_size = torch.finfo(dtype).bits // 8 if dtype.is_floating_point else torch.iinfo(dtype).bits // 8
+    return math.prod(shape) * elem_size
+
+
+def _view_as_bytes(tensor: "torch.Tensor") -> "torch.Tensor":
+    return tensor.contiguous().view(torch.uint8).reshape(-1)
+
+
+def _view_from_bytes(tensor: "torch.Tensor", dtype: "torch.dtype", shape: Tuple[int, ...]) -> "torch.Tensor":
+    return tensor.view(dtype).reshape(shape)
+
+
+def _is_all_zero_tensor(tensor: "torch.Tensor") -> bool:
+    try:
+        return bool(torch.count_nonzero(tensor).item() == 0)
+    except NotImplementedError:
+        return False
+
+
 @contextmanager
 def init_empty_weights():
     """
@@ -298,9 +337,7 @@ def _param_larger_than(shape: Tuple[int, ...], dtype: torch.dtype, max_load_broa
     """
     Check if a parameter is large enough to be sharded.
     """
-    num_elem = math.prod(shape)
-    elem_size = torch.finfo(dtype).bits // 8 if dtype.is_floating_point else torch.iinfo(dtype).bits // 8
-    param_size = num_elem * elem_size
+    param_size = _num_storage_bytes(tuple(shape), dtype)
     return param_size >= max_load_broadcast_size * (1024**3)
 
 
@@ -539,6 +576,12 @@ def load_model_weights_ep_sharded(
                     n_buf += 1
                     continue
                 if name not in parameter_names_to_load:
+                    if converter is not None and converter.can_handle(name):
+                        raise NotImplementedError(
+                            "ep_sharded_stream_load does not support checkpoint tensor conversion for "
+                            f"unexpected key '{name}'. Use load_model_weights or rank0_load_and_broadcast_weights "
+                            "for FP8/int8 scaled checkpoints."
+                        )
                     logger.info_rank0(f"Unexpected key in state dict: {name}.")
                     continue
 
@@ -600,15 +643,17 @@ def load_model_weights_ep_sharded(
                     _dispatch_parameter(model, name, tensor, dtensor_factory, None, dtensor_to_cpu)
                     n_ep += 1
                 else:
-                    if converter is not None and converter.can_handle(name):
-                        # A streamable (dim-0 zero-pad) converter must only touch
-                        # ExtraParallel tables; a dense key would need its conversion
-                        # applied here, which this path does not do -> bail.
-                        raise NotImplementedError(
-                            f"ep_sharded_stream_load: converter handles non-ExtraParallel key '{name}'."
-                        )
                     tensor = f.get_tensor(raw_name)
-                    _dispatch_parameter(model, name, tensor, dtensor_factory, parallel_plan, dtensor_to_cpu)
+                    converted = maybe_convert_checkpoint_tensor(name, tensor, converter)
+                    if converted is None:
+                        raise NotImplementedError(
+                            "ep_sharded_stream_load does not support checkpoint tensor conversion that buffers "
+                            f"dense key '{name}'. Use load_model_weights or rank0_load_and_broadcast_weights "
+                            "for FP8/int8 scaled checkpoints."
+                        )
+                    _dispatch_parameter(
+                        model, converted.name, converted.tensor, dtensor_factory, parallel_plan, dtensor_to_cpu
+                    )
                     n_dense += 1
                 parameter_names_to_load.discard(name)
         empty_cache()
@@ -672,16 +717,26 @@ def rank0_load_and_broadcast_weights(
     def _broadcast_and_dispatch(name, shape, dtype, tensor):
         """Broadcast a single (name, tensor) from rank0 and dispatch it."""
         logger.info_rank0(f"rank0_load_and_broadcast_weights: broadcasting {name=}")
-        if global_rank != 0:
-            tensor = torch.empty(shape, dtype=dtype, device=torch_device)
-        else:
+        broadcast_as_bytes = _requires_byte_broadcast(dtype)
+        if global_rank == 0:
             tensor = tensor.to(torch_device, non_blocking=True)
+            broadcast_tensor = _view_as_bytes(tensor) if broadcast_as_bytes else tensor
+        else:
+            if broadcast_as_bytes:
+                broadcast_tensor = torch.empty(
+                    _num_storage_bytes(shape, dtype), dtype=torch.uint8, device=torch_device
+                )
+            else:
+                tensor = torch.empty(shape, dtype=dtype, device=torch_device)
+                broadcast_tensor = tensor
 
         start_time = time.perf_counter()
-        dist.broadcast(tensor, src=0)
+        dist.broadcast(broadcast_tensor, src=0)
         logger.info_rank0(
             f"{name=}, {shape=}, {dtype=}, broadcast time (ms) spent: {1000 * (time.perf_counter() - start_time)}"
         )
+        if broadcast_as_bytes:
+            tensor = _view_from_bytes(broadcast_tensor, dtype, shape)
 
         if name in buffer_dict:
             buffer_dict[name] = tensor.detach().clone()
@@ -804,11 +859,19 @@ def rank0_load_and_broadcast_weights(
             placements = None
             shard_comm_device = _get_communication_device(init_device)
 
-        broadcast_buffer = torch.empty(
-            shard_tensor.shape,
-            dtype=shard_tensor.dtype,
-            device=shard_comm_device,
-        )
+        chunk_broadcast_as_bytes = _requires_byte_broadcast(shard_tensor.dtype)
+        if chunk_broadcast_as_bytes:
+            broadcast_buffer = torch.empty(
+                _num_storage_bytes(tuple(shard_tensor.shape), shard_tensor.dtype),
+                dtype=torch.uint8,
+                device=shard_comm_device,
+            )
+        else:
+            broadcast_buffer = torch.empty(
+                shard_tensor.shape,
+                dtype=shard_tensor.dtype,
+                device=shard_comm_device,
+            )
         shard_dst_ranks = _get_extra_parallel_shard_dst_ranks(
             parallel_state, para_group_name, para_size, shard_comm_device
         )
@@ -825,7 +888,11 @@ def rank0_load_and_broadcast_weights(
             #     when chunk_id = 3, send_seq = [3, 7], p2p tag = [6, 6]
 
             if dist.get_rank() == 0:
-                broadcast_buffer.copy_(chunk_loaded_data[chunk_id].contiguous())
+                if chunk_broadcast_as_bytes:
+                    chunk_tensor = chunk_loaded_data[chunk_id].to(device=shard_comm_device, dtype=shard_tensor.dtype)
+                    broadcast_buffer.copy_(_view_as_bytes(chunk_tensor))
+                else:
+                    broadcast_buffer.copy_(chunk_loaded_data[chunk_id].contiguous())
             dst_ranks = sorted(shard_dst_ranks[chunk_id])
             # One tag increment per chunk_id on every rank so the counter stays aligned.
             tag = _next_chunk_p2p_tag()
@@ -837,13 +904,18 @@ def rank0_load_and_broadcast_weights(
                     dist.send(broadcast_buffer, dst=dst, tag=tag)
 
                 if global_rank in dst_ranks:
+                    dispatch_buffer = (
+                        _view_from_bytes(broadcast_buffer, shard_tensor.dtype, tuple(shard_tensor.shape))
+                        if chunk_broadcast_as_bytes
+                        else broadcast_buffer
+                    )
                     if is_shard_tensor_dtensor:
-                        chunk_tensor = dtensor_factory(broadcast_buffer, device_mesh, placements).contiguous()
+                        chunk_tensor = dtensor_factory(dispatch_buffer, device_mesh, placements).contiguous()
                         if dtensor_to_cpu:
                             chunk_tensor = chunk_tensor.to("cpu")
                         shard_tensor.copy_(chunk_tensor)
                     else:
-                        shard_tensor.copy_(broadcast_buffer.to(shard_tensor.device).contiguous())
+                        shard_tensor.copy_(dispatch_buffer.to(shard_tensor.device).contiguous())
 
             elif global_rank in send_seq:
                 if is_shard_tensor_dtensor:
@@ -854,13 +926,18 @@ def rank0_load_and_broadcast_weights(
                 assert extra_para_local_rank == chunk_id, f"Rank {global_rank} is not the shard {chunk_id} rank."
                 dist.recv(broadcast_buffer, src=0, tag=tag)
 
+                dispatch_buffer = (
+                    _view_from_bytes(broadcast_buffer, shard_tensor.dtype, tuple(shard_tensor.shape))
+                    if chunk_broadcast_as_bytes
+                    else broadcast_buffer
+                )
                 if is_shard_tensor_dtensor:
-                    chunk_tensor = dtensor_factory(broadcast_buffer, device_mesh, placements).contiguous()
+                    chunk_tensor = dtensor_factory(dispatch_buffer, device_mesh, placements).contiguous()
                     if dtensor_to_cpu:
                         chunk_tensor = chunk_tensor.to("cpu")
                     shard_tensor.copy_(chunk_tensor)
                 else:
-                    shard_tensor.copy_(broadcast_buffer.to(shard_tensor.device).contiguous())
+                    shard_tensor.copy_(dispatch_buffer.to(shard_tensor.device).contiguous())
 
         logger.info_rank0(
             f"{name=}, {shape=}, {dtype=}, chunk and broadcast time (ms) spent: {1000 * (time.perf_counter() - start_time)}"
@@ -926,7 +1003,7 @@ def rank0_load_and_broadcast_weights(
                         if is_peft_model:
                             key = lora_key_overrides.get(key, "base_model.model." + key)
                         logger.info_rank0(f"loading {key=}")
-                        if torch.count_nonzero(tensor) == 0:
+                        if _is_all_zero_tensor(tensor):
                             logger.warning_rank0(
                                 f"Detected tensor with all-zero values when reading safetensor: {key=}"
                             )

--- a/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
+++ b/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
@@ -90,6 +90,7 @@ def _weight_name_from_scale_name(name: str) -> str | None:
 
 def _dequantize_scaled_weight(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
     """Apply DeepSeek block scales to an FP8/int8 checkpoint weight."""
+    scale = scale.to(device=weight.device)
     if scale.numel() == 1:
         return weight.float() * scale.float()
     if weight.ndim != 2 or scale.ndim != 2:

--- a/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
+++ b/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
@@ -61,6 +61,56 @@ _PROJ_NAME_ALIASES = {
     "w2": "down_proj",
     "w3": "up_proj",
 }
+_FLOAT8_DTYPES = tuple(
+    dtype
+    for dtype in (
+        getattr(torch, name, None)
+        for name in ("float8_e4m3fn", "float8_e5m2", "float8_e4m3fnuz", "float8_e5m2fnuz", "float8_e8m0fnu")
+    )
+    if dtype
+)
+_QUANTIZED_WEIGHT_DTYPES = _FLOAT8_DTYPES + (torch.int8,)
+
+
+def _is_quantized_weight(tensor: torch.Tensor) -> bool:
+    return tensor.dtype in _QUANTIZED_WEIGHT_DTYPES
+
+
+def _is_block_scale_tensor(tensor: torch.Tensor) -> bool:
+    return tensor.ndim == 2 or tensor.numel() == 1
+
+
+def _weight_name_from_scale_name(name: str) -> str | None:
+    if name.endswith(".scale"):
+        return f"{name.removesuffix('.scale')}.weight"
+    if name.endswith(".weight_scale_inv"):
+        return f"{name.removesuffix('.weight_scale_inv')}.weight"
+    return None
+
+
+def _dequantize_scaled_weight(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Apply DeepSeek block scales to an FP8/int8 checkpoint weight."""
+    if scale.numel() == 1:
+        return weight.float() * scale.float()
+    if weight.ndim != 2 or scale.ndim != 2:
+        raise ValueError(
+            "DeepseekV4 FP8 checkpoint weight scales must be scalar or 2D block scales; "
+            f"got weight shape {tuple(weight.shape)} and scale shape {tuple(scale.shape)}."
+        )
+    if weight.shape[0] % scale.shape[0] != 0 or weight.shape[1] % scale.shape[1] != 0:
+        raise ValueError(
+            "DeepseekV4 FP8 checkpoint weight shape must be divisible by scale shape; "
+            f"got weight shape {tuple(weight.shape)} and scale shape {tuple(scale.shape)}."
+        )
+
+    block_rows = weight.shape[0] // scale.shape[0]
+    block_cols = weight.shape[1] // scale.shape[1]
+    return (
+        weight.float()
+        .view(scale.shape[0], block_rows, scale.shape[1], block_cols)
+        .mul(scale.float().view(scale.shape[0], 1, scale.shape[1], 1))
+        .reshape(weight.shape)
+    )
 
 
 class DeepseekV4CheckpointTensorConverter:
@@ -81,14 +131,48 @@ class DeepseekV4CheckpointTensorConverter:
         self._expert_buffer: dict[tuple[str, str], dict[int, torch.Tensor]] = {}
         # {prefix: {proj_name: stacked_tensor}} for gate/up merge waiting
         self._stacked_buffer: dict[str, dict[str, torch.Tensor]] = {}
+        # {weight_name: {"weight": tensor, "scale": tensor}} for FP8/int8 checkpoint pairs.
+        self._scaled_weight_buffer: dict[str, dict[str, torch.Tensor | str]] = {}
 
     def can_handle(self, name: str) -> bool:
-        return bool(_EXPERT_PATTERN.match(name))
+        return bool(_EXPERT_PATTERN.match(name)) or _weight_name_from_scale_name(name) is not None
+
+    def can_handle_tensor(self, name: str, tensor: torch.Tensor) -> bool:
+        return self.can_handle(name) or (name.endswith(".weight") and _is_quantized_weight(tensor))
 
     def convert(self, name: str, tensor: torch.Tensor) -> ConvertedCheckpointTensor | None:
+        weight_name = _weight_name_from_scale_name(name)
+        if weight_name is not None:
+            if not _is_block_scale_tensor(tensor):
+                return ConvertedCheckpointTensor(name, tensor)
+            return self._convert_scaled_weight_part(weight_name, "scale", tensor, name)
+
+        if name.endswith(".weight") and _is_quantized_weight(tensor):
+            return self._convert_scaled_weight_part(name, "weight", tensor, None)
+
+        return self._convert_weight(name, tensor)
+
+    def _convert_scaled_weight_part(
+        self, weight_name: str, part_name: str, tensor: torch.Tensor, scale_name: str | None
+    ) -> ConvertedCheckpointTensor | None:
+        parts = self._scaled_weight_buffer.setdefault(weight_name, {})
+        parts[part_name] = tensor
+        if scale_name is not None:
+            parts["scale_name"] = scale_name
+        if "weight" not in parts or "scale" not in parts:
+            return None
+
+        weight = parts["weight"]
+        scale = parts["scale"]
+        del self._scaled_weight_buffer[weight_name]
+        assert isinstance(weight, torch.Tensor)
+        assert isinstance(scale, torch.Tensor)
+        return self._convert_weight(weight_name, _dequantize_scaled_weight(weight, scale))
+
+    def _convert_weight(self, name: str, tensor: torch.Tensor) -> ConvertedCheckpointTensor | None:
         match = _EXPERT_PATTERN.match(name)
         if not match:
-            return None
+            return ConvertedCheckpointTensor(name, tensor)
 
         prefix, expert_id_str, proj_name = match.groups()
         proj_name = _PROJ_NAME_ALIASES.get(proj_name, proj_name)
@@ -140,9 +224,19 @@ class DeepseekV4CheckpointTensorConverter:
         if self._stacked_buffer:
             unflushed = {k: list(v.keys()) for k, v in self._stacked_buffer.items()}
             errors.append(f"unflushed stacked buffer (missing gate/up pair): {unflushed}")
+        finalized: list[ConvertedCheckpointTensor] = []
+        for weight_name, parts in self._scaled_weight_buffer.items():
+            if "weight" in parts:
+                errors.append(f"unflushed scaled weight buffer (missing scale for {weight_name})")
+                continue
+            scale = parts.get("scale")
+            scale_name = parts.get("scale_name")
+            if isinstance(scale, torch.Tensor) and isinstance(scale_name, str):
+                finalized.append(ConvertedCheckpointTensor(scale_name, scale))
         if errors:
             raise RuntimeError("DeepseekV4 checkpoint converter: incomplete checkpoint detected. " + "; ".join(errors))
-        return []
+        self._scaled_weight_buffer.clear()
+        return finalized
 
 
 def create_deepseek_v4_checkpoint_tensor_converter(model):


### PR DESCRIPTION
## Summary
- dequantize DeepSeek V4 FP8/int8 checkpoint weights with .scale / .weight_scale_inv metadata before dispatch
- broadcast float8 checkpoint tensors as bytes during rank0 load
- keep converter name-only checks conservative and fail loudly for unsupported EP streaming conversion

## Tests
- ruff check tests/models/test_checkpoint_tensor_converter.py veomni/models/checkpoint_tensor_loading.py veomni/models/module_utils.py veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
- tests/models/test_checkpoint_tensor_converter.py -q passed on B200 worker before splitting
- local pytest blocked by missing libnvshmem_host.so.3 in local torch runtime