### PR TITLE
[BREAKING][dist, model, trainer] refactor: make parallel state model-owned

### DIFF
--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -131,7 +131,7 @@ YAML Config -> VeOmniArguments -> Trainer
 
 VeOmni uses FSDP2 exclusively.
 
-1. `init_parallel_state()` -> global `DeviceMesh` with named dims (`dp_shard`, `ulysses`, `cp`, etc.) + per-ExtraParallel submeshes (`[ep × ep_fsdp]`)
+1. `build_parallel_state()` / compatibility `init_parallel_state()` -> a `ParallelState` with a global `DeviceMesh` containing named dims (`dp_shard`, `ulysses`, `cp`, etc.) + per-ExtraParallel submeshes (`[ep × ep_fsdp]`)
 2. Model-specific `parallel_plan.py` -> define EP/embedding weight sharding via `ParallelPlan`
 3. `build_parallelize_model()` -> `parallelize_model_fsdp2()`:
    - `ParallelPlan.apply()` wraps EP/embedding params as DTensors on para mesh
@@ -140,6 +140,12 @@ VeOmni uses FSDP2 exclusively.
    - `fully_shard()` on root model
 4. SP is orthogonal to FSDP2 — models call Ulysses all-to-all (`gather_seq_scatter_heads` / `gather_heads_scatter_seq`) around attention; the FSDP shard mesh fuses with SP mesh (`dp_shard_sp`)
 5. EP token routing is in model MoE code + `moe_layer.py` using `ep_group` from `ParallelState`
+
+### Model-owned parallel state
+
+`ParallelState` ownership follows the model, not the trainer. `build_parallelize_model(..., parallel_state=ps)` binds a non-serialized state reference to the returned model. Optimizer, gradient clipping, checkpoint, and data-pipeline builders accept that state explicitly. This allows one RL trainer to coordinate policy, reference, reward, and drafter models with different parallel topologies.
+
+Existing patched modeling code still calls `get_parallel_state()`. During migration, `use_model_parallel_state(model)` exposes the model-owned state through a `ContextVar` for the duration of that model's execution. The context is a compatibility bridge rather than the source of truth; new model-owned APIs should accept a `ParallelState` or process group explicitly.
 
 ## Config Structure
 

--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -12,7 +12,7 @@ veomni/
 │   ├── multimodal/     Vision, audio, video preprocessing and chat templates
 │   └── diffusion/      Diffusion model data loading
 ├── distributed/        All parallelism strategies
-│   ├── parallel_state.py   init_parallel_state(), ParallelState, device mesh setup
+│   ├── parallel_state.py   build_parallel_state(), ParallelState, device mesh setup
 │   ├── torch_parallelize.py  build_parallelize_model(), parallelize_model_fsdp2()
 │   ├── parallel_plan.py    ParallelPlan for ExtraParallel (EP, embedding shard)
 │   ├── fsdp2/          FSDP2 (composable fully_shard), gradient clipping
@@ -131,7 +131,7 @@ YAML Config -> VeOmniArguments -> Trainer
 
 VeOmni uses FSDP2 exclusively.
 
-1. `build_parallel_state()` / compatibility `init_parallel_state()` -> a `ParallelState` with a global `DeviceMesh` containing named dims (`dp_shard`, `ulysses`, `cp`, etc.) + per-ExtraParallel submeshes (`[ep × ep_fsdp]`)
+1. `build_parallel_state()` -> a `ParallelState` with a `DeviceMesh` containing named dims (`dp_shard`, `ulysses`, `cp`, etc.) + per-ExtraParallel submeshes (`[ep × ep_fsdp]`)
 2. Model-specific `parallel_plan.py` -> define EP/embedding weight sharding via `ParallelPlan`
 3. `build_parallelize_model()` -> `parallelize_model_fsdp2()`:
    - `ParallelPlan.apply()` wraps EP/embedding params as DTensors on para mesh
@@ -145,7 +145,9 @@ VeOmni uses FSDP2 exclusively.
 
 `ParallelState` ownership follows the model, not the trainer. `build_parallelize_model(..., parallel_state=ps)` binds a non-serialized state reference to the returned model. Optimizer, gradient clipping, checkpoint, and data-pipeline builders accept that state explicitly. This allows one RL trainer to coordinate policy, reference, reward, and drafter models with different parallel topologies.
 
-Existing patched modeling code still calls `get_parallel_state()`. During migration, `use_model_parallel_state(model)` exposes the model-owned state through a `ContextVar` for the duration of that model's execution. The context is a compatibility bridge rather than the source of truth; new model-owned APIs should accept a `ParallelState` or process group explicitly.
+Trainer setup returns a local bootstrap state used only around model construction. The trainer does not retain a `parallel_state` attribute; once the model is bound, every downstream consumer resolves state from that model.
+
+Patched modeling code calls `get_parallel_state()` during model execution. The model's wrapped root `forward` activates its owned state through a `ContextVar` for exactly that execution. Outside model/build execution there is no default state; APIs must receive a `ParallelState` or process group explicitly.
 
 ## Config Structure
 

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -35,7 +35,7 @@ Violating any of these causes silent bugs, crashes, or incorrect training result
 VeOmni uses FSDP2 exclusively. FSDP1 has been removed.
 
 Core entry points:
-- `veomni/distributed/parallel_state.py` — `init_parallel_state()`, `ParallelState` dataclass
+- `veomni/distributed/parallel_state.py` — `build_parallel_state()`, `ParallelState` dataclass
 - `veomni/distributed/torch_parallelize.py` — `build_parallelize_model()`, `parallelize_model_fsdp2()`
 - `veomni/distributed/parallel_plan.py` — `ParallelPlan`, `SpecInfo`
 
@@ -49,10 +49,11 @@ Core entry points:
 
 5a. **Parallel state is model-owned**
    - `build_parallelize_model(..., parallel_state=ps)` binds `ps` to the model; policy, reference, reward, and drafter models may own different states in one process.
+   - Trainers may hold a local bootstrap state only while constructing the first model. They must not retain `self.parallel_state`; after binding, resolve state from the specific model.
    - Model-owned consumers (optimizer, gradient clipping, checkpointing, collators) must receive the owning state explicitly or resolve it from the model. Do not add new process-global group/state ownership.
-   - `use_model_parallel_state(model)` is a `ContextVar` compatibility bridge for existing modeling code that calls `get_parallel_state()`. Custom autograd functions must capture process groups during forward rather than consulting ambient state during backward.
+   - `use_model_parallel_state(model)` activates the owning state while modeling code calls `get_parallel_state()`. There is no process-global default state: code outside a model/build context must pass `ParallelState` explicitly. Custom autograd functions must capture process groups during forward rather than consulting ambient state during backward.
 
-6. **Device mesh initialization (`init_parallel_state()`)**
+6. **Device mesh construction (`build_parallel_state()`)**
    - Builds a global `DeviceMesh` with named dimensions: `pp`, `dp_replicate`, `dp_shard`, `ulysses`, `cp`, `tp` (each included only if size > 1).
    - Flattens subviews for common usage: `dp` (all data-parallel), `sp` (ulysses+cp), `dp_shard_sp` (FSDP shard × SP), `dp_sp` (for loss/grad sync across SP+DP).
    - For each ExtraParallel name (e.g. `ep`), builds a `[para_size × para_fsdp_size]` submesh via `init_para_mesh_matrix()`.
@@ -75,7 +76,7 @@ Core entry points:
    - Weight sharding: `ParallelPlan` in `parallel_plan.py` defines which expert parameters get `Shard(0)` on the EP mesh. `ParallelPlan.apply()` wraps matching params as DTensors and redistributes to local shards.
    - Token routing: `veomni/distributed/moe/moe_layer.py` — `preprocess()` computes dispatch counts, `token_pre_all2all()` / `tokens_post_all2all()` exchange tokens between EP ranks via `all_to_all` / `all_to_all_async` in `moe/comm.py`.
    - Expert computation: `EPGroupGemm` runs fused expert MLP on grouped tokens per rank.
-   - Device mesh: `init_parallel_state()` builds `[ep × ep_fsdp]` submesh; accessed via `ParallelState.extra_parallel_mesh("ep")`, `ep_group`, `ep_rank`.
+   - Device mesh: `build_parallel_state()` builds `[ep × ep_fsdp]` submesh; accessed via `ParallelState.extra_parallel_mesh("ep")`, `ep_group`, `ep_rank`.
    - In FSDP2: expert modules get `fully_shard()` on the `ep_fsdp` submesh with `Shard(1)` placement so hidden-dim sharding composes with EP's dim-0 sharding.
 
 ## Data Pipeline

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -47,6 +47,11 @@ Core entry points:
    - When SP is enabled, the FSDP shard mesh fuses with the SP mesh (`dp_shard_sp`) so sequence-parallel ranks co-shard via FSDP.
    - Gradient clipping: `veomni/distributed/fsdp2/clip_grad_norm.py` — handles DTensor grads and ExtraParallel param groups.
 
+5a. **Parallel state is model-owned**
+   - `build_parallelize_model(..., parallel_state=ps)` binds `ps` to the model; policy, reference, reward, and drafter models may own different states in one process.
+   - Model-owned consumers (optimizer, gradient clipping, checkpointing, collators) must receive the owning state explicitly or resolve it from the model. Do not add new process-global group/state ownership.
+   - `use_model_parallel_state(model)` is a `ContextVar` compatibility bridge for existing modeling code that calls `get_parallel_state()`. Custom autograd functions must capture process groups during forward rather than consulting ambient state during backward.
+
 6. **Device mesh initialization (`init_parallel_state()`)**
    - Builds a global `DeviceMesh` with named dimensions: `pp`, `dp_replicate`, `dp_shard`, `ulysses`, `cp`, `tp` (each included only if size > 1).
    - Flattens subviews for common usage: `dp` (all data-parallel), `sp` (ulysses+cp), `dp_shard_sp` (FSDP shard × SP), `dp_sp` (for loss/grad sync across SP+DP).

--- a/docs/key_features/model_loader.md
+++ b/docs/key_features/model_loader.md
@@ -89,9 +89,13 @@ Check existing model implementations in the `veomni/models/transformers/` and `v
 The framework will automatically handle model loading based on the configuration. You can load your model using:
 
 ```python
+from veomni.distributed.parallel_state import build_parallel_state
 from veomni.models import build_foundation_model
 
+parallel_state = build_parallel_state(...)
+
 model = build_foundation_model(
+    parallel_state=parallel_state,
     config_path=args.model.config_path,
     weights_path=args.model.model_path,
     ...

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -68,16 +68,19 @@ class Arguments(VeOmniArguments):
 ```
 
 ## Parallel State
-VeOmni use torch device mesh to manage all the parallel state, which is useful and concise when working with multi-dimensional parallelism (i.e. 3-D parallel) where parallelism composability is required. You can create the parallel state by calling the `init_parallel_state` function. and get the parallel state by calling the `get_parallel_state` function.
+VeOmni uses torch device meshes to represent parallel state. A state is owned by the model that uses its topology, so one RL trainer can coordinate policy, reference, reward, and drafter models with different DP/SP/EP layouts. `build_parallel_state()` constructs a state without changing another model's state, and `build_parallelize_model(..., parallel_state=ps)` binds it to the model.
+
+`init_parallel_state()` and `get_parallel_state()` remain compatibility APIs for single-model tasks and existing model patches. New orchestration code should retain the returned state and pass it explicitly.
 
 More details about torch device mesh, you can refer to the [Getting Started with DeviceMesh](https://pytorch.org/tutorials/recipes/distributed_device_mesh.html).
 
 - source code [veomni/distributed/parallel_state.py](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/distributed/parallel_state.py).
 
 ```python
-from veomni.distributed.parallel_state import get_parallel_state, init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state, use_model_parallel_state
+from veomni.distributed.torch_parallelize import build_parallelize_model
 
-init_parallel_state(
+policy_state = build_parallel_state(
     dp_size=args.train.accelerator.dp_size, # data parallel size
     dp_replicate_size=args.train.accelerator.dp_replicate_size, # data parallel replicate size
     dp_shard_size=args.train.accelerator.dp_shard_size, # data parallel shard degree
@@ -88,23 +91,30 @@ init_parallel_state(
     extra_parallel_sizes=args.train.accelerator.extra_parallel_sizes, # including expert parallel size
     extra_parallel_placement_innermost=args.train.accelerator.extra_parallel_placement_innermost,
     extra_parallel_names=args.train.accelerator.extra_parallel_names,
-    mode=args.train.accelerator.fsdp_config.fsdp_mode, # data parallel mode, can be "ddp" or "fsdp2"
+    dp_mode=args.train.accelerator.fsdp_config.fsdp_mode, # data parallel mode, can be "ddp" or "fsdp2"
     async_enabled=args.train.accelerator.enable_async, # async ulysses
 )
 
-parallel_state = get_parallel_state()
+policy_model = build_parallelize_model(
+    policy_model,
+    parallel_state=policy_state,
+    # other parallelization and weight-loading options
+)
+
+with use_model_parallel_state(policy_model):
+    outputs = policy_model(**batch)
 
 # Access dp state
-dp_mesh = parallel_state.dp_mesh
-dp_group = parallel_state.dp_group
+dp_mesh = policy_state.dp_mesh
+dp_group = policy_state.dp_group
 
 # Access sp state
-sp_group = parallel_state.sp_group
-sp_rank = parallel_state.sp_rank
+sp_group = policy_state.sp_group
+sp_rank = policy_state.sp_rank
 
 # Access tp state
-tp_group = parallel_state.tp_group
-tp_mesh = parallel_state.tp_mesh
+tp_group = policy_state.tp_group
+tp_mesh = policy_state.tp_mesh
 ```
 
 ## Dataset

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -70,15 +70,18 @@ class Arguments(VeOmniArguments):
 ## Parallel State
 VeOmni uses torch device meshes to represent parallel state. A state is owned by the model that uses its topology, so one RL trainer can coordinate policy, reference, reward, and drafter models with different DP/SP/EP layouts. `build_parallel_state()` constructs a state without changing another model's state, and `build_parallelize_model(..., parallel_state=ps)` binds it to the model.
 
-`init_parallel_state()` and `get_parallel_state()` remain compatibility APIs for single-model tasks and existing model patches. New orchestration code should retain the returned state and pass it explicitly.
+`init_parallel_state()` and the process-global default state have been removed. Retain the value returned by `build_parallel_state()` long enough to construct the model and data pipeline. Model-aware utilities resolve it from the bound model. `get_parallel_state()` is only valid while a model-owned or explicit build context is active.
+
+Trainers use the constructed state only to build the model and do not keep a trainer-owned copy. After model construction, utilities such as optimizer setup and gradient clipping resolve the state from the model.
 
 More details about torch device mesh, you can refer to the [Getting Started with DeviceMesh](https://pytorch.org/tutorials/recipes/distributed_device_mesh.html).
 
 - source code [veomni/distributed/parallel_state.py](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/distributed/parallel_state.py).
 
 ```python
-from veomni.distributed.parallel_state import build_parallel_state, use_model_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
+from veomni.models import build_foundation_model
 
 policy_state = build_parallel_state(
     dp_size=args.train.accelerator.dp_size, # data parallel size
@@ -95,14 +98,16 @@ policy_state = build_parallel_state(
     async_enabled=args.train.accelerator.enable_async, # async ulysses
 )
 
+policy_model = build_foundation_model(
+    config_path=args.model.config_path,
+    weights_path=args.model.model_path,
+    parallel_state=policy_state,
+    ops_implementation=args.model.ops_implementation,
+)
 policy_model = build_parallelize_model(
     policy_model,
-    parallel_state=policy_state,
     # other parallelization and weight-loading options
 )
-
-with use_model_parallel_state(policy_model):
-    outputs = policy_model(**batch)
 
 # Access dp state
 dp_mesh = policy_state.dp_mesh
@@ -126,6 +131,7 @@ VeOmni default supports three types of datasets(source code: [veomni/data/datase
 ```python
 from veomni.data import build_dataset
 train_dataset = build_dataset(
+    parallel_state=policy_state,
     dataset_name=args.data.dataset_name,
     transform=transform,
     seed=args.train.seed,
@@ -290,6 +296,7 @@ VeOmni offered a flexible and powerful dataloader implementation, which supports
 ```python
 from veomni.data import build_dataloader
 train_dataloader = build_dataloader(
+    parallel_state=policy_state,
     dataloader_type=args.data.dataloader.type,
     dataset=train_dataset,
     micro_batch_size=args.train.micro_batch_size, # micro batch size
@@ -346,6 +353,7 @@ An example of usage in `def build_data_collate_info` in [veomni/trainer/vlm_trai
 from veomni.models import build_foundation_model
 
 model = build_foundation_model(
+    parallel_state=policy_state,
     config_path=args.model.config_path, # model config path, can be None if weights_path is not None
     weights_path=args.model.model_path, # model weights path, can be None if config_path is not None
     init_device=args.train.init_device, # model init device
@@ -438,13 +446,16 @@ lr_scheduler = build_lr_scheduler(
 After the parallel_state, model, optimizer, and dataloader are initialized, you can start the training loop.
 
 ```python
+from veomni.distributed.parallel_state import use_model_parallel_state
+
 for epoch in range(args.train.num_train_epochs):
     data_iterator = iter(train_dataloader)
     for _ in range(args.train.train_steps):
         micro_batches = next(data_iterator)
-        for micro_batch in micro_batches:
-            loss = model(**micro_batch).loss / len(micro_batches)
-            loss.backward()
+        with use_model_parallel_state(model):
+            for micro_batch in micro_batches:
+                loss = model(**micro_batch).loss / len(micro_batches)
+                loss.backward()
 
         optimizer.step()
         lr_scheduler.step()

--- a/tasks/deprecated_task/train_flux.py
+++ b/tasks/deprecated_task/train_flux.py
@@ -19,7 +19,7 @@ from veomni.data.diffusion.data_loader import build_dit_dataloader
 from veomni.data.diffusion.dataset import build_text_image_dataset
 from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
 from veomni.distributed.offloading import build_activation_offloading_context
-from veomni.distributed.parallel_state import get_parallel_state, init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state, use_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models import save_model_assets
 from veomni.models.transformers.flux.encode_flux import (
@@ -168,7 +168,7 @@ def main():
         ckpt_manager=args.train.checkpoint.manager,
     )
 
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -203,6 +203,7 @@ def main():
         )
 
         train_dataloader = build_dit_dataloader(
+            parallel_state=parallel_state,
             dataset=train_dataset,
             micro_batch_size=args.train.micro_batch_size,
             global_batch_size=args.train.global_batch_size,
@@ -220,7 +221,8 @@ def main():
     # build foundation model
     config_kwargs = {}
     config = AutoConfig.from_pretrained(args.model.config_path, trust_remote_code=True, **config_kwargs)
-    model = FluxModel(config)
+    with use_parallel_state(parallel_state):
+        model = FluxModel(config)
     model_weights = load_model(
         file_path=args.model.model_path,
         device=f"{get_device_type()}:{args.train.local_rank}",
@@ -301,6 +303,7 @@ def main():
     ops_to_save = convert_ops_to_objects(args.train.ops_to_save)
     model = build_parallelize_model(
         model,
+        parallel_state=parallel_state,
         weights_path=args.model.model_path,
         enable_reshard_after_forward=args.train.accelerator.fsdp_config.reshard_after_forward,
         mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
@@ -315,6 +318,7 @@ def main():
 
     optimizer = build_optimizer(
         model,
+        parallel_state=parallel_state,
         lr=args.train.optimizer.lr,
         weight_decay=args.train.optimizer.weight_decay,
         fused=True,
@@ -371,6 +375,7 @@ def main():
         config=model_config,
         global_batch_size=args.train.global_batch_size,
         empty_cache_steps=args.train.empty_cache_steps,
+        parallel_state=parallel_state,
     )
 
     if args.train.checkpoint.load_path:
@@ -492,7 +497,7 @@ def main():
                 total_loss += loss.item()
                 del batch
 
-            grad_norm = veomni_clip_grad_norm(model, args.train.optimizer.max_grad_norm)
+            grad_norm = veomni_clip_grad_norm(model, args.train.optimizer.max_grad_norm, parallel_state=parallel_state)
 
             optimizer.step()
             lr_scheduler.step()
@@ -500,7 +505,7 @@ def main():
             if hasattr(grad_norm, "full_tensor"):
                 grad_norm = grad_norm.full_tensor().item()
 
-            total_loss, grad_norm = all_reduce((total_loss, grad_norm), group=get_parallel_state().fsdp_group)
+            total_loss, grad_norm = all_reduce((total_loss, grad_norm), group=parallel_state.fsdp_group)
             epoch_loss += total_loss
             synchronize()
             delta_time = time.time() - start_time

--- a/tasks/deprecated_task/train_qwen_vl.py
+++ b/tasks/deprecated_task/train_qwen_vl.py
@@ -20,7 +20,7 @@ from veomni.data import (
 )
 from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
 from veomni.distributed.offloading import build_activation_offloading_context
-from veomni.distributed.parallel_state import get_parallel_state, init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models import build_foundation_model, build_processor, save_model_assets
 from veomni.optim import build_lr_scheduler, build_optimizer
@@ -117,7 +117,7 @@ def main():
         dist_backend=args.train.accelerator.fsdp_config.fsdp_mode, ckpt_manager=args.train.checkpoint.manager
     )
 
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -134,6 +134,7 @@ def main():
 
     logger.info_rank0("Prepare model")
     model = build_foundation_model(
+        parallel_state=parallel_state,
         config_path=args.model.config_path,
         weights_path=args.model.model_path,
         init_device=args.train.init_device,
@@ -161,6 +162,7 @@ def main():
     )
 
     train_dataset = build_dataset(
+        parallel_state=parallel_state,
         dataset_name=args.data.dataset_name,
         transform=transform,
         dataloader_batch_size=args.train.dataloader_batch_size,
@@ -190,6 +192,7 @@ def main():
         )
 
     train_dataloader = build_dataloader(
+        parallel_state=parallel_state,
         dataloader_type=args.data.dataloader.type,
         dataset=train_dataset,
         micro_batch_size=args.train.micro_batch_size,
@@ -224,6 +227,7 @@ def main():
 
     model = build_parallelize_model(
         model,
+        parallel_state=parallel_state,
         init_device=args.train.init_device,
         weights_path=args.model.model_path,
         enable_reshard_after_forward=args.train.accelerator.fsdp_config.reshard_after_forward,
@@ -235,6 +239,7 @@ def main():
     )
     optimizer = build_optimizer(
         model,
+        parallel_state=parallel_state,
         lr=args.train.optimizer.lr,
         weight_decay=args.train.optimizer.weight_decay,
         fused=False,
@@ -281,6 +286,7 @@ def main():
     start_epoch, start_step, global_step = 0, 0, 0
     save_checkpoint_path = None
     environ_meter = helper.EnvironMeter(
+        parallel_state=parallel_state,
         config=model_config,
         global_batch_size=args.train.global_batch_size,
         enable_multisource=args.data.enable_multisource,
@@ -367,7 +373,7 @@ def main():
                     loss: "torch.Tensor" = model(**micro_batch, use_cache=False).loss
 
                 loss_dict: Dict[str, torch.Tensor] = mean_global_loss(
-                    loss, micro_batch_token_len, micro_batches_token_len
+                    loss, micro_batch_token_len, micro_batches_token_len, parallel_state
                 )
                 loss = torch.stack(list(loss_dict.values())).sum()
                 with model_bwd_context:
@@ -376,14 +382,14 @@ def main():
                 total_loss += loss.item()
                 del micro_batch
 
-            grad_norm = veomni_clip_grad_norm(model, args.train.optimizer.max_grad_norm)
+            grad_norm = veomni_clip_grad_norm(model, args.train.optimizer.max_grad_norm, parallel_state=parallel_state)
 
             optimizer.step()
             lr_scheduler.step()
             optimizer.zero_grad()
 
             # collect mean loss across data parallel group
-            total_loss, grad_norm = all_reduce((total_loss, grad_norm), group=get_parallel_state().fsdp_group)
+            total_loss, grad_norm = all_reduce((total_loss, grad_norm), group=parallel_state.fsdp_group)
             synchronize()
             delta_time = time.time() - start_time
             lr = max(lr_scheduler.get_last_lr())

--- a/tasks/deprecated_task/train_torch.py
+++ b/tasks/deprecated_task/train_torch.py
@@ -21,7 +21,7 @@ from veomni.data import (
 )
 from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
 from veomni.distributed.offloading import build_activation_offloading_context
-from veomni.distributed.parallel_state import get_parallel_state, init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models import build_foundation_model, build_tokenizer, save_model_assets
 from veomni.optim import build_lr_scheduler, build_optimizer
@@ -69,7 +69,7 @@ def main():
         dist_backend=args.train.accelerator.fsdp_config.fsdp_mode, ckpt_manager=args.train.checkpoint.manager
     )
 
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -98,6 +98,7 @@ def main():
     )
 
     train_dataset = build_dataset(
+        parallel_state=parallel_state,
         dataset_name=args.data.dataset_name,
         transform=transform,
         dataloader_batch_size=args.train.dataloader_batch_size,
@@ -113,6 +114,7 @@ def main():
         "pad_to_length": args.train.pad_to_length,
     }
     train_dataloader = build_dataloader(
+        parallel_state=parallel_state,
         dataloader_type=args.data.dataloader.type,
         dataset=train_dataset,
         micro_batch_size=args.train.micro_batch_size,
@@ -136,6 +138,7 @@ def main():
 
     logger.info_rank0("Prepare model")
     model = build_foundation_model(
+        parallel_state=parallel_state,
         config_path=args.model.config_path,
         weights_path=args.model.model_path,
         torch_dtype="float32" if args.train.accelerator.fsdp_config.mixed_precision.enable else "bfloat16",
@@ -148,6 +151,7 @@ def main():
     get_optimizer_pre_hook = getattr(model, "get_optimizer_pre_hook", None)
     model = build_parallelize_model(
         model,
+        parallel_state=parallel_state,
         init_device=args.train.init_device,
         weights_path=args.model.model_path,
         enable_reshard_after_forward=args.train.accelerator.fsdp_config.reshard_after_forward,
@@ -160,6 +164,7 @@ def main():
 
     optimizer = build_optimizer(
         model,
+        parallel_state=parallel_state,
         lr=args.train.optimizer.lr,
         weight_decay=args.train.optimizer.weight_decay,
         fused=True,
@@ -212,6 +217,7 @@ def main():
     start_epoch, start_step, global_step = 0, 0, 0
     save_checkpoint_path = None
     environ_meter = helper.EnvironMeter(
+        parallel_state=parallel_state,
         config=model_config,
         global_batch_size=args.train.global_batch_size,
         empty_cache_steps=args.train.empty_cache_steps,
@@ -302,7 +308,7 @@ def main():
                     loss = model(**micro_batch, use_cache=False).loss
 
                 loss_dict: Dict[str, torch.Tensor] = mean_global_loss(
-                    loss, micro_batch_token_num, micro_batches_token_num
+                    loss, micro_batch_token_num, micro_batches_token_num, parallel_state
                 )
                 loss = torch.stack(list(loss_dict.values())).sum()
                 with model_bwd_context:
@@ -311,14 +317,14 @@ def main():
                 total_loss += loss.item()
                 del micro_batch
 
-            grad_norm = veomni_clip_grad_norm(model, args.train.optimizer.max_grad_norm)
+            grad_norm = veomni_clip_grad_norm(model, args.train.optimizer.max_grad_norm, parallel_state=parallel_state)
 
             optimizer.step()
             lr_scheduler.step()
             optimizer.zero_grad()
 
             # collect mean loss across data parallel group
-            total_loss, grad_norm = all_reduce((total_loss, grad_norm), group=get_parallel_state().fsdp_group)
+            total_loss, grad_norm = all_reduce((total_loss, grad_norm), group=parallel_state.fsdp_group)
             synchronize()
             delta_time = time.time() - start_time
             lr = max(lr_scheduler.get_last_lr())

--- a/tasks/deprecated_task/train_wan.py
+++ b/tasks/deprecated_task/train_wan.py
@@ -21,7 +21,7 @@ from veomni.data.diffusion.data_loader import build_dit_dataloader
 from veomni.data.diffusion.dataset import build_tensor_dataset
 from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
 from veomni.distributed.offloading import build_activation_offloading_context
-from veomni.distributed.parallel_state import get_parallel_state, init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models import (
     build_foundation_model,
@@ -105,7 +105,7 @@ def main():
         ckpt_manager=args.train.checkpoint.manager,
     )
 
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -135,6 +135,7 @@ def main():
         )
 
         train_dataloader = build_dit_dataloader(
+            parallel_state=parallel_state,
             dataset=train_dataset,
             micro_batch_size=args.train.micro_batch_size,
             global_batch_size=args.train.global_batch_size,
@@ -150,6 +151,7 @@ def main():
         raise NotImplementedError(f"Unsupported data type: {args.data.data_type}.")
 
     model = build_foundation_model(
+        parallel_state=parallel_state,
         config_path=args.model.config_path,
         weights_path=args.model.model_path,
         init_device=args.train.init_device,
@@ -194,6 +196,7 @@ def main():
     ops_to_save = convert_ops_to_objects(args.train.ops_to_save)
     model = build_parallelize_model(
         model,
+        parallel_state=parallel_state,
         weights_path=args.model.model_path,
         enable_reshard_after_forward=args.train.accelerator.fsdp_config.reshard_after_forward,
         mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
@@ -208,6 +211,7 @@ def main():
 
     optimizer = build_optimizer(
         model,
+        parallel_state=parallel_state,
         lr=args.train.optimizer.lr,
         weight_decay=args.train.optimizer.weight_decay,
         fused=True,
@@ -265,6 +269,7 @@ def main():
         config=model_config,
         global_batch_size=args.train.global_batch_size,
         empty_cache_steps=args.train.empty_cache_steps,
+        parallel_state=parallel_state,
     )
 
     if args.train.checkpoint.load_path:
@@ -387,7 +392,7 @@ def main():
                 total_loss += loss.item()
                 del micro_batch
 
-            grad_norm = veomni_clip_grad_norm(model, args.train.optimizer.max_grad_norm)
+            grad_norm = veomni_clip_grad_norm(model, args.train.optimizer.max_grad_norm, parallel_state=parallel_state)
 
             optimizer.step()
             lr_scheduler.step()
@@ -395,7 +400,7 @@ def main():
             if hasattr(grad_norm, "full_tensor"):
                 grad_norm = grad_norm.full_tensor().item()
 
-            total_loss, grad_norm = all_reduce((total_loss, grad_norm), group=get_parallel_state().fsdp_group)
+            total_loss, grad_norm = all_reduce((total_loss, grad_norm), group=parallel_state.fsdp_group)
             epoch_loss += total_loss
             synchronize()
             delta_time = time.time() - start_time

--- a/tasks/infer/infer_omni_model.py
+++ b/tasks/infer/infer_omni_model.py
@@ -10,6 +10,7 @@ from veomni.arguments import InferArguments, parse_args
 from veomni.arguments.arguments_types import OpsImplementationConfig
 from veomni.data import build_multimodal_chat_template
 from veomni.data.multimodal.multimodal_transform import mask_input_ids
+from veomni.distributed.parallel_state import ParallelState
 from veomni.models import build_foundation_model, build_processor
 from veomni.models.seed_omni import SeedOmniModel, SeedOmniProcessor
 from veomni.utils import helper
@@ -138,7 +139,12 @@ def main() -> None:
     helper.enable_third_party_logging()
     # config model and processor
     model: SeedOmniModel = (
-        build_foundation_model(args.infer.model_path, args.infer.model_path, ops_implementation=_INFERENCE_OPS)
+        build_foundation_model(
+            args.infer.model_path,
+            args.infer.model_path,
+            parallel_state=ParallelState(),
+            ops_implementation=_INFERENCE_OPS,
+        )
         .eval()
         .to(get_device_type())
     )

--- a/tasks/infer/infer_qwen2_vl.py
+++ b/tasks/infer/infer_qwen2_vl.py
@@ -6,6 +6,7 @@ from PIL import Image
 
 from veomni.arguments import InferArguments, parse_args
 from veomni.arguments.arguments_types import OpsImplementationConfig
+from veomni.distributed.parallel_state import ParallelState
 from veomni.models import build_foundation_model, build_processor
 from veomni.utils import helper
 from veomni.utils.device import get_device_type
@@ -43,7 +44,12 @@ def main() -> None:
     helper.set_seed(args.infer.seed)
     helper.enable_third_party_logging()
     model = (
-        build_foundation_model(args.infer.model_path, args.infer.model_path, ops_implementation=_INFERENCE_OPS)
+        build_foundation_model(
+            args.infer.model_path,
+            args.infer.model_path,
+            parallel_state=ParallelState(),
+            ops_implementation=_INFERENCE_OPS,
+        )
         .eval()
         .to(get_device_type())
     )

--- a/tasks/infer/infer_text.py
+++ b/tasks/infer/infer_text.py
@@ -7,6 +7,7 @@ from transformers import AutoTokenizer, TextStreamer
 
 from veomni.arguments import InferArguments, parse_args
 from veomni.arguments.arguments_types import OpsImplementationConfig
+from veomni.distributed.parallel_state import ParallelState
 from veomni.models import build_foundation_model
 from veomni.utils import helper
 from veomni.utils.import_utils import is_flash_attn_2_available
@@ -43,6 +44,7 @@ def main() -> None:
     helper.set_seed(args.infer.seed)
     helper.enable_third_party_logging()
     model = build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=args.infer.model_path,
         weights_path=args.infer.model_path,
         ops_implementation=_INFERENCE_OPS,

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -21,7 +21,7 @@ from veomni.data import (
 from veomni.data.multimodal.multimodal_transform import encode_multimodal_sample
 from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
 from veomni.distributed.offloading import build_activation_offloading_context
-from veomni.distributed.parallel_state import get_parallel_state, init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models import save_model_assets, save_model_weights
 from veomni.models.seed_omni import SeedOmniModel, build_omni_model, build_omni_processor
@@ -112,7 +112,7 @@ def main():
         dist_backend=args.train.accelerator.fsdp_config.fsdp_mode, ckpt_manager=args.train.checkpoint.manager
     )
 
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -127,6 +127,7 @@ def main():
     )
     logger.info_rank0("Prepare model")
     model: SeedOmniModel = build_omni_model(
+        parallel_state=parallel_state,
         config_path=args.model.config_path,
         weights_path=args.model.model_path,
         torch_dtype="float32" if args.train.accelerator.fsdp_config.mixed_precision.enable else "bfloat16",
@@ -165,6 +166,7 @@ def main():
     )
 
     train_dataset = build_dataset(
+        parallel_state=parallel_state,
         dataset_name=args.data.dataset_name,
         transform=transform,
         dataloader_batch_size=args.train.dataloader_batch_size,
@@ -200,6 +202,7 @@ def main():
     }
 
     train_dataloader = build_dataloader(
+        parallel_state=parallel_state,
         dataloader_type=args.data.dataloader.type,
         dataset=train_dataset,
         micro_batch_size=args.train.micro_batch_size,
@@ -250,6 +253,7 @@ def main():
 
     model = build_parallelize_model(
         model,
+        parallel_state=parallel_state,
         weights_path=args.model.model_path,
         enable_reshard_after_forward=args.train.accelerator.fsdp_config.reshard_after_forward,
         mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
@@ -265,6 +269,7 @@ def main():
     )
     optimizer = build_optimizer(
         model,
+        parallel_state=parallel_state,
         lr=args.train.optimizer.lr,
         weight_decay=args.train.optimizer.weight_decay,
         fused=False,
@@ -310,6 +315,7 @@ def main():
     start_epoch, start_step, global_step = 0, 0, 0
     save_checkpoint_path = None
     environ_meter = helper.EnvironMeter(
+        parallel_state=parallel_state,
         config=model_config,
         global_batch_size=args.train.global_batch_size,
         empty_cache_steps=args.train.empty_cache_steps,
@@ -411,7 +417,7 @@ def main():
 
                 del micro_batch
 
-            grad_norm = veomni_clip_grad_norm(model, args.train.optimizer.max_grad_norm)
+            grad_norm = veomni_clip_grad_norm(model, args.train.optimizer.max_grad_norm, parallel_state=parallel_state)
 
             optimizer.step()
             lr_scheduler.step()
@@ -420,9 +426,9 @@ def main():
                 grad_norm = grad_norm.full_tensor().item()
 
             # collect loss across data parallel group
-            total_loss, grad_norm = all_reduce((total_loss, grad_norm), group=get_parallel_state().fsdp_group)
+            total_loss, grad_norm = all_reduce((total_loss, grad_norm), group=parallel_state.fsdp_group)
             for key, v in total_losses.items():
-                total_losses[key] = all_reduce((v), group=get_parallel_state().fsdp_group)
+                total_losses[key] = all_reduce((v), group=parallel_state.fsdp_group)
             synchronize()
             delta_time = time.time() - start_time
             lr = max(lr_scheduler.get_last_lr())

--- a/tasks/train_text_rl.py
+++ b/tasks/train_text_rl.py
@@ -1,4 +1,5 @@
 from veomni.arguments import parse_args
+from veomni.distributed.parallel_state import use_parallel_state
 from veomni.trainer.base_rl_trainer import BaseRLTrainer
 from veomni.trainer.text_trainer import TextTrainer, VeOmniArguments
 
@@ -13,6 +14,10 @@ class TextRLTrainer(TextTrainer):
         self.base.args = args
 
         self.base._setup()
+        with use_parallel_state(self.base.parallel_state):
+            self._build_components()
+
+    def _build_components(self):
         self.base._build_model()
         self.base._freeze_model_module()
 

--- a/tasks/train_text_rl.py
+++ b/tasks/train_text_rl.py
@@ -13,12 +13,12 @@ class TextRLTrainer(TextTrainer):
         self.base = BaseRLTrainer.__new__(BaseRLTrainer)
         self.base.args = args
 
-        self.base._setup()
-        with use_parallel_state(self.base.parallel_state):
-            self._build_components()
+        bootstrap_state = self.base._setup()
+        with use_parallel_state(bootstrap_state):
+            self.base._build_model()
+        self._build_components()
 
     def _build_components(self):
-        self.base._build_model()
         self.base._freeze_model_module()
 
         # rewrite build_model_assets to support chat_template for conversation dataset

--- a/tasks/train_vlm_rl.py
+++ b/tasks/train_vlm_rl.py
@@ -1,4 +1,5 @@
 from veomni.arguments import parse_args
+from veomni.distributed.parallel_state import use_parallel_state
 from veomni.trainer.base_rl_trainer import BaseRLTrainer
 from veomni.trainer.vlm_trainer import VeOmniVLMArguments, VLMTrainer
 
@@ -13,7 +14,10 @@ class VLMRLTrainer(VLMTrainer):
         self.base.args = args
 
         self.base._setup()
+        with use_parallel_state(self.base.parallel_state):
+            self._build_components()
 
+    def _build_components(self):
         # rewrite build model to support data balancing
         self._build_model()
 

--- a/tasks/train_vlm_rl.py
+++ b/tasks/train_vlm_rl.py
@@ -13,14 +13,12 @@ class VLMRLTrainer(VLMTrainer):
         self.base = BaseRLTrainer.__new__(BaseRLTrainer)
         self.base.args = args
 
-        self.base._setup()
-        with use_parallel_state(self.base.parallel_state):
-            self._build_components()
+        bootstrap_state = self.base._setup()
+        with use_parallel_state(bootstrap_state):
+            self._build_model()
+        self._build_components()
 
     def _build_components(self):
-        # rewrite build model to support data balancing
-        self._build_model()
-
         # rewrite freeze_model_module to support freeze multimodal encoder, etc.
         self._freeze_model_module()
 

--- a/tests/data/multimodal/test_vlm_data_process.py
+++ b/tests/data/multimodal/test_vlm_data_process.py
@@ -24,6 +24,7 @@ from veomni.data import build_multimodal_chat_template
 from veomni.data.data_transform import (
     process_sample_qwen_vl,
 )
+from veomni.distributed.parallel_state import ParallelState
 from veomni.models import build_foundation_model, build_processor
 from veomni.utils.device import get_device_type
 
@@ -139,6 +140,7 @@ def load_veomni_model(config_path, device):
     )
     print(f"\n[Setup] Building veomni model on device: {device}")
     model = build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=config_path,
         weights_path=None,
         torch_dtype="bfloat16",

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -66,6 +66,7 @@ def test_build_dataloader_dyn_bsz_sp_filling(
     transform = partial(process_dummy_example, max_seq_len=max_seq_len)
 
     dataset = build_dataset(
+        parallel_state=ps,
         dataset_name=dataset_name,
         train_path=dummy_dataset_ci.save_path,
         transform=transform,
@@ -73,6 +74,7 @@ def test_build_dataloader_dyn_bsz_sp_filling(
     )
     dl = build_dataloader(
         "native",
+        parallel_state=ps,
         dataset=dataset,
         micro_batch_size=micro_batch_size,
         global_batch_size=global_batch_size,
@@ -114,6 +116,7 @@ def test_build_dataloader_dyn_bsz_count_mode(
     monkeypatch.setattr(m_col, "get_parallel_state", lambda: ps)
 
     dataset = build_dataset(
+        parallel_state=ps,
         dataset_name="iterable",
         train_path=dummy_dataset_ci.save_path,
         transform=partial(process_dummy_example, max_seq_len=16),
@@ -121,6 +124,7 @@ def test_build_dataloader_dyn_bsz_count_mode(
     )
     dl = build_dataloader(
         "native",
+        parallel_state=ps,
         dataset=dataset,
         micro_batch_size=2,
         global_batch_size=4,
@@ -159,6 +163,7 @@ def test_build_dataloader_dyn_bsz_physical_overflow_ratio(monkeypatch, dummy_dat
     monkeypatch.setattr(m_ds, "get_parallel_state", lambda: ps)
 
     dataset = build_dataset(
+        parallel_state=ps,
         dataset_name="iterable",
         train_path=dummy_dataset_ci.save_path,
         transform=partial(process_dummy_example, max_seq_len=16),
@@ -166,6 +171,7 @@ def test_build_dataloader_dyn_bsz_physical_overflow_ratio(monkeypatch, dummy_dat
     )
     dl = build_dataloader(
         "native",
+        parallel_state=ps,
         dataset=dataset,
         micro_batch_size=2,
         global_batch_size=4,
@@ -195,6 +201,7 @@ def test_build_dataloader_rejects_invalid_physical_overflow_ratio(monkeypatch, d
     monkeypatch.setattr(m_ds, "get_parallel_state", lambda: ps)
 
     dataset = build_dataset(
+        parallel_state=ps,
         dataset_name="iterable",
         train_path=dummy_dataset_ci.save_path,
         transform=partial(process_dummy_example, max_seq_len=16),
@@ -203,6 +210,7 @@ def test_build_dataloader_rejects_invalid_physical_overflow_ratio(monkeypatch, d
     with pytest.raises(ValueError, match="dyn_bsz_physical_overflow_ratio must be >= 1.0"):
         build_dataloader(
             "native",
+            parallel_state=ps,
             dataset=dataset,
             micro_batch_size=2,
             global_batch_size=4,

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -16,7 +16,7 @@ from transformers import PretrainedConfig
 from utils import DummyDataset, FakeModel, compare_global_batch, compare_items, compare_metrics, process_dummy_example
 
 from veomni.arguments import parse_args
-from veomni.distributed.parallel_state import get_parallel_state
+from veomni.distributed.parallel_state import bind_model_parallel_state, get_model_parallel_state, get_parallel_state
 from veomni.trainer.base import BaseTrainer, VeOmniArguments
 from veomni.trainer.callbacks import (
     Callback,
@@ -51,6 +51,7 @@ class TrainerTest(BaseTrainer):
     def _build_model(self):
         # only build fake model
         self.model = FakeModel().to(get_device_type())
+        bind_model_parallel_state(self.model, get_parallel_state())
         self.model_config = PretrainedConfig()
 
     def _build_model_assets(self):
@@ -146,22 +147,23 @@ class CheckCallback(Callback):
         micro_batches_output = [[k  for k, _ in groupby(micro_batch["input_ids"].tolist()[0])]  for micro_batch in micro_batches]
         logger.error(f"[rank{get_parallel_state().global_rank}][epoch{state.epoch}][curr_step{state.curr_step}][step {state.global_step}] micro_batches_output: {micro_batches_output}")
         """
-        if state.global_step == 1 and get_parallel_state().sp_enabled:
+        parallel_state = get_model_parallel_state(self.trainer.model)
+        if state.global_step == 1 and parallel_state.sp_enabled:
             assert (
-                micro_batches[0]["input_ids"].shape[-1] * get_parallel_state().sp_size
+                micro_batches[0]["input_ids"].shape[-1] * parallel_state.sp_size
                 == micro_batches[0]["attention_mask"].shape[-1]
             )
             assert compare_items(
                 micro_batches[0]["attention_mask"],
-                rank=get_parallel_state().sp_rank,
-                group_size=get_parallel_state().sp_size,
-                group=get_parallel_state().sp_group,
+                rank=parallel_state.sp_rank,
+                group_size=parallel_state.sp_size,
+                group=parallel_state.sp_group,
             )
             assert compare_items(
                 micro_batches[0]["cu_seq_lens_q"],
-                rank=get_parallel_state().sp_rank,
-                group_size=get_parallel_state().sp_size,
-                group=get_parallel_state().sp_group,
+                rank=parallel_state.sp_rank,
+                group_size=parallel_state.sp_size,
+                group=parallel_state.sp_group,
             )
         if self.trainer.start_save_data:
             if not self.trainer.is_resume:

--- a/tests/data/test_dynamic_batching_dataset.py
+++ b/tests/data/test_dynamic_batching_dataset.py
@@ -69,7 +69,12 @@ from veomni.data.dataset import (
     get_length_fn_by_count_mode,
 )
 from veomni.data.dynamic_batching import TextBatchingStrategy
-from veomni.distributed.parallel_state import get_parallel_state
+from veomni.distributed.parallel_state import (
+    ParallelState,
+    bind_model_parallel_state,
+    get_model_parallel_state,
+    get_parallel_state,
+)
 from veomni.trainer.base import BaseTrainer
 from veomni.trainer.callbacks import Callback, EnvironMeterCallback, TrainerState
 from veomni.utils import helper
@@ -124,7 +129,7 @@ def setup_dynamic_batching_dataset():
         dataset=iterable_dataset,
         micro_batch_seq_length=MICRO_BATCH_SEQ_LENGTH,
         ready_for_micro_batch_threshold=READY_FOR_MICRO_BATCH_THRESHOLD,
-        dynamic_batching_collate_fn=MainCollator(),
+        dynamic_batching_collate_fn=MainCollator(parallel_state=ParallelState()),
         get_length_fn=get_length_fn,
     )
 
@@ -158,7 +163,7 @@ def test_dynamic_batching_basic(shuffle, seed):
     iterable_ds = ShardedIterableDataset(size=DATASET_SIZE, shuffle=shuffle, seed=seed)
 
     # Create data collator
-    collator = MainCollator()
+    collator = MainCollator(parallel_state=ParallelState())
 
     # Create dynamic batching dataset
     dynamic_ds = DynamicBatchingSizeDataset(
@@ -298,7 +303,7 @@ def test_dynamic_batching_without_get_item():
             dataset=iterable_dataset,
             micro_batch_seq_length=MICRO_BATCH_SEQ_LENGTH,
             ready_for_micro_batch_threshold=READY_FOR_MICRO_BATCH_THRESHOLD,
-            dynamic_batching_collate_fn=MainCollator(),
+            dynamic_batching_collate_fn=MainCollator(parallel_state=ParallelState()),
             get_length_fn=get_length_fn,
             save_by_idx=True,
         )
@@ -489,7 +494,7 @@ def test_save_load_state_dict(save_by_idx):
         dataset=iterable_ds,
         micro_batch_seq_length=MICRO_BATCH_SEQ_LENGTH,
         ready_for_micro_batch_threshold=READY_FOR_MICRO_BATCH_THRESHOLD,
-        dynamic_batching_collate_fn=MainCollator(),
+        dynamic_batching_collate_fn=MainCollator(parallel_state=ParallelState()),
         get_length_fn=get_length_fn,
         save_by_idx=save_by_idx,
     )
@@ -512,7 +517,7 @@ def test_save_load_state_dict(save_by_idx):
         dataset=iterable_ds2,
         micro_batch_seq_length=MICRO_BATCH_SEQ_LENGTH,
         ready_for_micro_batch_threshold=READY_FOR_MICRO_BATCH_THRESHOLD,
-        dynamic_batching_collate_fn=MainCollator(),
+        dynamic_batching_collate_fn=MainCollator(parallel_state=ParallelState()),
         get_length_fn=get_length_fn,
         save_by_idx=save_by_idx,
     )
@@ -633,13 +638,15 @@ class TrainerTest(BaseTrainer):
         super().__init__(args)
 
     def _setup(self):
-        self.device = setup_test_distributed(self.args)
+        self.device, bootstrap_state = setup_test_distributed(self.args)
+        return bootstrap_state
 
     def _freeze_model_module(self):
         pass
 
     def _build_model(self):
         self.model = FakeModel().to(get_device_type())
+        bind_model_parallel_state(self.model, get_parallel_state())
         self.model_config = PretrainedConfig()
 
     def _build_model_assets(self):
@@ -668,6 +675,7 @@ class TrainerTest(BaseTrainer):
         dataloader_type = dataloader_kwargs.pop("type")
         dataloader_kwargs.pop("use_background_prefetcher", None)
         self.train_dataloader = build_dataloader(
+            parallel_state=get_model_parallel_state(self.model),
             dataloader_type=dataloader_type,
             dataset=self.train_dataset,
             micro_batch_size=args.train.micro_batch_size,
@@ -768,16 +776,17 @@ class CheckCallback(Callback):
         if state.global_step == 1:
             helper.print_example(example=micro_batches[0], rank=self.trainer.args.train.local_rank)
             assert 1 < len(micro_batches) <= 4, f"Unexpected micro batch count: {len(micro_batches)}"
-            if get_parallel_state().sp_enabled:
+            parallel_state = get_model_parallel_state(self.trainer.model)
+            if parallel_state.sp_enabled:
                 assert (
-                    micro_batches[0]["input_ids"].shape[-1] * get_parallel_state().sp_size
+                    micro_batches[0]["input_ids"].shape[-1] * parallel_state.sp_size
                     == micro_batches[0]["attention_mask"].shape[-1]
                 )
                 assert compare_items(
                     micro_batches[0]["attention_mask"],
-                    rank=get_parallel_state().sp_rank,
-                    group_size=get_parallel_state().sp_size,
-                    group=get_parallel_state().sp_group,
+                    rank=parallel_state.sp_rank,
+                    group_size=parallel_state.sp_size,
+                    group=parallel_state.sp_group,
                 )
 
         if state.epoch == self.trainer.save_epoch and state.curr_step > self.trainer.save_step:

--- a/tests/data/test_mm_metadata.py
+++ b/tests/data/test_mm_metadata.py
@@ -34,6 +34,8 @@ import os
 
 import torch
 
+from veomni.distributed.parallel_state import ParallelState
+
 
 # Bootstrap a single-rank "process group" env so collator import doesn't crash
 # on `get_parallel_state()`. Mirrors the pattern used by
@@ -77,7 +79,7 @@ def test_packing_collator_packs_grid_thw_and_invokes_hook():
         seen["sp_pad"] = sp_pad
         batch["multimodal_metadata"] = {"ok": True}
 
-    batch = PackingCollator(metadata_collate_func=hook)(
+    batch = PackingCollator(metadata_collate_func=hook, parallel_state=ParallelState())(
         [_mm_sample(16, [[1, 4, 4]]), _mm_sample(8, [[1, 2, 2], [2, 2, 2]])]
     )
     # image_grid_thw packed across the batch: (1+2, 3) = 3 image rows.
@@ -97,7 +99,7 @@ def test_packing_collator_no_hook_is_noop():
         "attention_mask": torch.ones(16, dtype=torch.long),
         "position_ids": torch.arange(16, dtype=torch.long),
     }
-    batch = PackingCollator()([sample, sample])
+    batch = PackingCollator(parallel_state=ParallelState())([sample, sample])
     assert "multimodal_metadata" not in batch
 
 

--- a/tests/data/test_multisource_dataset.py
+++ b/tests/data/test_multisource_dataset.py
@@ -37,7 +37,11 @@ from utils import (
 from veomni.arguments import VeOmniArguments, parse_args
 from veomni.data import build_dataloader
 from veomni.data.dataset import WeightedMultiSourceDataset
-from veomni.distributed.parallel_state import get_parallel_state
+from veomni.distributed.parallel_state import (
+    bind_model_parallel_state,
+    get_model_parallel_state,
+    get_parallel_state,
+)
 from veomni.trainer.base import BaseTrainer
 from veomni.trainer.callbacks import Callback, TrainerState
 from veomni.utils import helper
@@ -98,7 +102,7 @@ class TrainerTest(BaseTrainer):
     multisource_weights = [0.5, 0.5]
 
     def _setup(self):
-        self.device = setup_test_distributed(self.args)
+        self.device, bootstrap_state = setup_test_distributed(self.args)
 
         self.multisource_datasets = [DummyDataset(size=100, dataset_name=name) for name in self.multisource_names]
         self.multisource_paths = [dataset.save_path for dataset in self.multisource_datasets]
@@ -135,12 +139,14 @@ class TrainerTest(BaseTrainer):
         shuffle_field._field_type = dataclasses._FIELD
         self.args.data.__dataclass_fields__["shuffle"] = shuffle_field
         self.args.data.shuffle = False
+        return bootstrap_state
 
     def _freeze_model_module(self):
         pass
 
     def _build_model(self):
         self.model = FakeModel().to(get_device_type())
+        bind_model_parallel_state(self.model, get_parallel_state())
         self.model_config = PretrainedConfig()
 
     def _build_model_assets(self):
@@ -174,6 +180,7 @@ class TrainerTest(BaseTrainer):
         args = self.args
         global_batch_size = cast(int, args.train.global_batch_size)
         self.train_dataloader = build_dataloader(
+            parallel_state=get_model_parallel_state(self.model),
             dataloader_type="native",
             dataset=self.train_dataset,
             micro_batch_size=args.train.micro_batch_size,
@@ -279,6 +286,7 @@ class EnvironMeterCallbackTest(Callback):
             dataloader=trainer.train_dataloader,
             data_path=trainer.tmp_train_path,
             gc_steps=args.train.gc_steps,
+            parallel_state=get_model_parallel_state(trainer.model),
         )
 
     def on_step_begin(self, state: TrainerState, micro_batches: List[Dict[str, Any]] = None, **kwargs) -> None:
@@ -300,7 +308,7 @@ class EnvironMeterCallbackTest(Callback):
         step_train_metrics.update(loss_dict)
         step_train_metrics["grad_norm"] = grad_norm
         step_train_metrics = {
-            f"training/{k}": all_reduce(v, group=get_parallel_state().fsdp_group)
+            f"training/{k}": all_reduce(v, group=get_model_parallel_state(self.trainer.model).fsdp_group)
             for k, v in step_train_metrics.items()
         }
         step_train_metrics["training/lr"] = max(self.trainer.lr_scheduler.get_last_lr())

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 from datasets import Dataset as HuggingFaceDataset
 from torch.utils.data import IterableDataset
 
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import ParallelState, build_parallel_state
 from veomni.trainer.callbacks import CheckpointerCallback, TrainerState
 from veomni.utils import helper
 from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
@@ -25,7 +25,7 @@ def mock_empty_cache() -> None:
     pass
 
 
-def setup_test_distributed(args) -> torch.device:
+def setup_test_distributed(args) -> tuple[torch.device, ParallelState]:
     """Initialize a minimal distributed runtime for data tests."""
     device_type = get_device_type()
     if device_type != "cpu":
@@ -43,7 +43,7 @@ def setup_test_distributed(args) -> torch.device:
             rank=int(os.environ["RANK"]),
         )
 
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -57,7 +57,7 @@ def setup_test_distributed(args) -> torch.device:
         dp_mode=args.train.accelerator.fsdp_config.fsdp_mode,
     )
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)
-    return device
+    return device, parallel_state
 
 
 class StepAwareTestCheckpointerCallback(CheckpointerCallback):

--- a/tests/distributed/test_dummy_forward.py
+++ b/tests/distributed/test_dummy_forward.py
@@ -135,7 +135,7 @@ def _omni_batch(*, rank, device, dtype, patch_size, is_qwen3_omni=False):
 def _asymmetric_forward_worker(model_type, config_path, batch_fn):
     """Rank 0 gets multimodal data, other ranks get text-only. Verifies no NCCL hang."""
     from veomni import _apply_patches
-    from veomni.distributed.parallel_state import init_parallel_state
+    from veomni.distributed.parallel_state import build_parallel_state
     from veomni.distributed.torch_parallelize import build_parallelize_model
     from veomni.models.auto import build_foundation_model
     from veomni.utils.device import get_device_type
@@ -148,12 +148,13 @@ def _asymmetric_forward_worker(model_type, config_path, batch_fn):
     os.environ["NCCL_TIMEOUT"] = "120"
 
     world_size = dist.get_world_size()
-    init_parallel_state(dp_size=world_size, dp_shard_size=world_size, dp_mode="fsdp2")
+    parallel_state = build_parallel_state(dp_size=world_size, dp_shard_size=world_size, dp_mode="fsdp2")
 
     rank = dist.get_rank()
     device = torch.device(f"{get_device_type()}:{rank}")
 
     model = build_foundation_model(
+        parallel_state=parallel_state,
         config_path=config_path,
         weights_path=None,
         torch_dtype="float32",
@@ -164,6 +165,7 @@ def _asymmetric_forward_worker(model_type, config_path, batch_fn):
 
     model = build_parallelize_model(
         model,
+        parallel_state=parallel_state,
         weights_path=None,
         init_device="meta",
         mixed_precision=MixedPrecisionConfig(enable=True),

--- a/tests/distributed/test_model_owned_parallel_state.py
+++ b/tests/distributed/test_model_owned_parallel_state.py
@@ -24,15 +24,38 @@ from veomni.distributed.parallel_state import (
 )
 from veomni.distributed.sequence_parallel import comm
 from veomni.distributed.sequence_parallel import loss as sequence_parallel_loss
+from veomni.distributed.torch_compile import CompileConfig, compile_decoder_blocks
 
 
 class _Model:
     pass
 
 
+class _ForwardModel:
+    def forward(self):
+        return get_parallel_state()
+
+
+class _ToyDecoderLayer(torch.nn.Module):
+    def forward(self, value):
+        if get_parallel_state().async_enabled and comm.get_ulysses_sequence_parallel_group() is not None:
+            return value + 1
+        return value - 1
+
+
+class _CompilableModel(torch.nn.Module):
+    _no_split_modules = ["_ToyDecoderLayer"]
+
+    def __init__(self):
+        super().__init__()
+        self.layer = _ToyDecoderLayer()
+
+    def forward(self, value):
+        return self.layer(value)
+
+
 @pytest.fixture(autouse=True)
-def _reset_parallel_state(monkeypatch):
-    monkeypatch.setattr(parallel_state_module, "_PARALLEL_STATE", None)
+def _reset_parallel_state():
     token = parallel_state_module._CURRENT_PARALLEL_STATE.set(None)
     yield
     parallel_state_module._CURRENT_PARALLEL_STATE.reset(token)
@@ -54,10 +77,35 @@ def test_model_owned_state_selects_each_model_independently():
     assert get_model_parallel_state(drafter) is drafter_state
 
 
-def test_model_context_restores_after_exception():
-    default_state = ParallelState(async_enabled=False)
+def test_bound_model_forward_activates_and_restores_owned_state():
     model_state = ParallelState(async_enabled=True)
-    parallel_state_module._PARALLEL_STATE = default_state
+    model = bind_model_parallel_state(_ForwardModel(), model_state)
+
+    assert model.forward() is model_state
+    with pytest.raises(RuntimeError, match="No ParallelState is active"):
+        get_parallel_state()
+
+
+@pytest.mark.skipif(not hasattr(torch, "compile"), reason="torch.compile required")
+def test_fullgraph_compile_captures_each_models_owned_state():
+    enabled_state = SimpleNamespace(async_enabled=True, ulysses_group=object())
+    disabled_state = SimpleNamespace(async_enabled=False, ulysses_group=None)
+    enabled_model = bind_model_parallel_state(_CompilableModel(), enabled_state)
+    disabled_model = bind_model_parallel_state(_CompilableModel(), disabled_state)
+    compile_config = CompileConfig(enable=True, backend="eager", fullgraph=True)
+
+    try:
+        assert compile_decoder_blocks(enabled_model, compile_config) == 1
+        assert compile_decoder_blocks(disabled_model, compile_config) == 1
+        value = torch.tensor(2.0)
+        torch.testing.assert_close(enabled_model(value), torch.tensor(3.0))
+        torch.testing.assert_close(disabled_model(value), torch.tensor(1.0))
+    finally:
+        torch.compiler.reset()
+
+
+def test_model_context_restores_after_exception():
+    model_state = ParallelState(async_enabled=True)
     model = bind_model_parallel_state(_Model(), model_state)
 
     with pytest.raises(RuntimeError, match="boom"):
@@ -65,7 +113,8 @@ def test_model_context_restores_after_exception():
             assert get_parallel_state() is model_state
             raise RuntimeError("boom")
 
-    assert get_parallel_state() is default_state
+    with pytest.raises(RuntimeError, match="No ParallelState is active"):
+        get_parallel_state()
 
 
 def test_resolve_prefers_explicit_then_model_then_context():
@@ -86,13 +135,15 @@ def test_unbound_model_lookup_fails_loudly():
 
 
 def test_context_state_does_not_leak_to_worker_thread():
-    default_state = ParallelState(async_enabled=False)
     model_state = ParallelState(async_enabled=True)
-    parallel_state_module._PARALLEL_STATE = default_state
+
+    def _worker_lookup():
+        with pytest.raises(RuntimeError, match="No ParallelState is active"):
+            get_parallel_state()
 
     with use_parallel_state(model_state), ThreadPoolExecutor(max_workers=1) as executor:
         assert get_parallel_state() is model_state
-        assert executor.submit(get_parallel_state).result() is default_state
+        executor.submit(_worker_lookup).result()
 
 
 def test_build_parallelize_model_binds_explicit_state(monkeypatch):
@@ -112,14 +163,20 @@ def test_build_parallelize_model_binds_explicit_state(monkeypatch):
     assert get_model_parallel_state(model) is model_state
 
 
-def test_model_context_takes_precedence_over_legacy_group_override(monkeypatch):
-    legacy_group = object()
+def test_model_context_takes_precedence_over_test_group_override():
+    test_group = object()
     model_group = object()
-    monkeypatch.setattr(comm, "_ULYSSES_SEQUENCE_PARALLEL_GROUP", {"default": legacy_group})
+    comm.set_ulysses_sequence_parallel_group(test_group)
     model = bind_model_parallel_state(_Model(), SimpleNamespace(ulysses_group=model_group))
 
     with use_model_parallel_state(model):
         assert comm.get_ulysses_sequence_parallel_group() is model_group
+    comm.set_ulysses_sequence_parallel_group(None)
+
+
+def test_production_sequence_group_lookup_requires_active_state():
+    with pytest.raises(RuntimeError, match="active model-owned ParallelState"):
+        comm.get_unified_sequence_parallel_group()
 
 
 def test_worker_collator_drops_process_group_backed_state_before_pickle():

--- a/tests/distributed/test_model_owned_parallel_state.py
+++ b/tests/distributed/test_model_owned_parallel_state.py
@@ -11,6 +11,7 @@ import torch.distributed as dist
 from veomni.data.data_collator import MainCollator
 from veomni.distributed import parallel_state as parallel_state_module
 from veomni.distributed import torch_parallelize
+from veomni.distributed.checkpoint import CheckpointFunction
 from veomni.distributed.parallel_state import (
     ParallelState,
     bind_model_parallel_state,
@@ -54,6 +55,37 @@ class _CompilableModel(torch.nn.Module):
         return self.layer(value)
 
 
+class _CheckpointedModel(torch.nn.Module):
+    def __init__(self, parallel_state, observed_states):
+        super().__init__()
+        self.observed_states = observed_states
+        self.checkpoint_context_fn = torch_parallelize._model_owned_checkpoint_context_fn(
+            parallel_state, torch.utils.checkpoint.noop_context_fn
+        )
+
+    def _checkpointed_forward(self, value):
+        self.observed_states.append(get_parallel_state())
+        return torch.sin(value)
+
+    def forward(self, value):
+        return torch.utils.checkpoint.checkpoint(
+            self._checkpointed_forward,
+            value,
+            use_reentrant=False,
+            context_fn=self.checkpoint_context_fn,
+        )
+
+
+class _ReentrantCheckpointedModule(torch.nn.Module):
+    def __init__(self, observed_states):
+        super().__init__()
+        self.observed_states = observed_states
+
+    def forward(self, value):
+        self.observed_states.append(get_parallel_state())
+        return torch.sin(value)
+
+
 @pytest.fixture(autouse=True)
 def _reset_parallel_state():
     token = parallel_state_module._CURRENT_PARALLEL_STATE.set(None)
@@ -82,6 +114,38 @@ def test_bound_model_forward_activates_and_restores_owned_state():
     model = bind_model_parallel_state(_ForwardModel(), model_state)
 
     assert model.forward() is model_state
+    with pytest.raises(RuntimeError, match="No ParallelState is active"):
+        get_parallel_state()
+
+
+def test_checkpoint_recompute_activates_model_owned_state():
+    model_state = ParallelState(async_enabled=True)
+    observed_states = []
+    model = bind_model_parallel_state(_CheckpointedModel(model_state, observed_states), model_state)
+    value = torch.tensor(1.0, requires_grad=True)
+
+    model(value).backward()
+
+    assert observed_states == [model_state, model_state]
+    with pytest.raises(RuntimeError, match="No ParallelState is active"):
+        get_parallel_state()
+
+
+def test_reentrant_checkpoint_recompute_restores_captured_model_state():
+    model_state = ParallelState(async_enabled=True)
+    caller_state = ParallelState(async_enabled=False)
+    observed_states = []
+    checkpointed_module = _ReentrantCheckpointedModule(observed_states)
+    value = torch.tensor(1.0, requires_grad=True)
+
+    with use_parallel_state(model_state):
+        output = CheckpointFunction.apply(checkpointed_module, True, value)
+
+    with use_parallel_state(caller_state):
+        output.backward()
+        assert get_parallel_state() is caller_state
+
+    assert observed_states == [model_state, model_state]
     with pytest.raises(RuntimeError, match="No ParallelState is active"):
         get_parallel_state()
 

--- a/tests/distributed/test_model_owned_parallel_state.py
+++ b/tests/distributed/test_model_owned_parallel_state.py
@@ -1,0 +1,167 @@
+import pickle
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from veomni.data.data_collator import MainCollator
+from veomni.distributed import parallel_state as parallel_state_module
+from veomni.distributed import torch_parallelize
+from veomni.distributed.parallel_state import (
+    ParallelState,
+    bind_model_parallel_state,
+    build_parallel_state,
+    clear_parallel_state_cache,
+    get_model_parallel_state,
+    get_parallel_state,
+    resolve_model_parallel_state,
+    use_model_parallel_state,
+    use_parallel_state,
+)
+from veomni.distributed.sequence_parallel import comm
+from veomni.distributed.sequence_parallel import loss as sequence_parallel_loss
+
+
+class _Model:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_parallel_state(monkeypatch):
+    monkeypatch.setattr(parallel_state_module, "_PARALLEL_STATE", None)
+    token = parallel_state_module._CURRENT_PARALLEL_STATE.set(None)
+    yield
+    parallel_state_module._CURRENT_PARALLEL_STATE.reset(token)
+
+
+def test_model_owned_state_selects_each_model_independently():
+    policy_state = ParallelState(async_enabled=False)
+    drafter_state = ParallelState(async_enabled=True)
+    policy = bind_model_parallel_state(_Model(), policy_state)
+    drafter = bind_model_parallel_state(_Model(), drafter_state)
+
+    with use_model_parallel_state(policy):
+        assert get_parallel_state() is policy_state
+        with use_model_parallel_state(drafter):
+            assert get_parallel_state() is drafter_state
+        assert get_parallel_state() is policy_state
+
+    assert get_model_parallel_state(policy) is policy_state
+    assert get_model_parallel_state(drafter) is drafter_state
+
+
+def test_model_context_restores_after_exception():
+    default_state = ParallelState(async_enabled=False)
+    model_state = ParallelState(async_enabled=True)
+    parallel_state_module._PARALLEL_STATE = default_state
+    model = bind_model_parallel_state(_Model(), model_state)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with use_model_parallel_state(model):
+            assert get_parallel_state() is model_state
+            raise RuntimeError("boom")
+
+    assert get_parallel_state() is default_state
+
+
+def test_resolve_prefers_explicit_then_model_then_context():
+    context_state = ParallelState(async_enabled=False)
+    model_state = ParallelState(async_enabled=True)
+    explicit_state = ParallelState(dp_mode="ddp")
+    model = bind_model_parallel_state(_Model(), model_state)
+
+    with use_parallel_state(context_state):
+        assert resolve_model_parallel_state(model) is model_state
+        assert resolve_model_parallel_state(model, explicit_state) is explicit_state
+        assert resolve_model_parallel_state(_Model()) is context_state
+
+
+def test_unbound_model_lookup_fails_loudly():
+    with pytest.raises(ValueError, match="no bound ParallelState"):
+        get_model_parallel_state(_Model())
+
+
+def test_context_state_does_not_leak_to_worker_thread():
+    default_state = ParallelState(async_enabled=False)
+    model_state = ParallelState(async_enabled=True)
+    parallel_state_module._PARALLEL_STATE = default_state
+
+    with use_parallel_state(model_state), ThreadPoolExecutor(max_workers=1) as executor:
+        assert get_parallel_state() is model_state
+        assert executor.submit(get_parallel_state).result() is default_state
+
+
+def test_build_parallelize_model_binds_explicit_state(monkeypatch):
+    model = _Model()
+    model_state = ParallelState(async_enabled=True)
+    observed = []
+
+    def _fake_build(model, **_kwargs):
+        observed.append(get_parallel_state())
+        return model
+
+    monkeypatch.setattr(torch_parallelize, "_build_parallelize_model", _fake_build)
+    result = torch_parallelize.build_parallelize_model(model, parallel_state=model_state)
+
+    assert result is model
+    assert observed == [model_state]
+    assert get_model_parallel_state(model) is model_state
+
+
+def test_model_context_takes_precedence_over_legacy_group_override(monkeypatch):
+    legacy_group = object()
+    model_group = object()
+    monkeypatch.setattr(comm, "_ULYSSES_SEQUENCE_PARALLEL_GROUP", {"default": legacy_group})
+    model = bind_model_parallel_state(_Model(), SimpleNamespace(ulysses_group=model_group))
+
+    with use_model_parallel_state(model):
+        assert comm.get_ulysses_sequence_parallel_group() is model_group
+
+
+def test_worker_collator_drops_process_group_backed_state_before_pickle():
+    parallel_state = SimpleNamespace(sp_enabled=True, sp_size=2, sp_rank=1)
+    collator = MainCollator(parallel_state=parallel_state)
+
+    assert collator.parallel_state is None
+    assert all(getattr(stage, "parallel_state", None) is None for stage in collator.preforward_pipeline)
+    pickle.dumps(collator)
+
+
+@pytest.mark.skipif(not dist.is_available(), reason="torch.distributed required")
+def test_parallel_state_cache_is_scoped_to_default_process_group_lifetime():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        first_init = Path(tmpdir) / "first"
+        second_init = Path(tmpdir) / "second"
+        try:
+            dist.init_process_group("gloo", rank=0, world_size=1, init_method=f"file://{first_init}")
+            first_state = build_parallel_state(device_type="cpu")
+            dist.destroy_process_group()
+
+            dist.init_process_group("gloo", rank=0, world_size=1, init_method=f"file://{second_init}")
+            second_state = build_parallel_state(device_type="cpu")
+            assert second_state is not first_state
+        finally:
+            if dist.is_initialized():
+                dist.destroy_process_group()
+            clear_parallel_state_cache()
+
+
+def test_reduce_loss_backward_uses_world_size_captured_during_forward(monkeypatch):
+    group = object()
+    monkeypatch.setattr(sequence_parallel_loss, "get_unified_sequence_parallel_group", lambda: group)
+    monkeypatch.setattr(sequence_parallel_loss.dist, "all_reduce", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(sequence_parallel_loss.dist, "get_world_size", lambda observed: 2 if observed is group else 99)
+
+    value = torch.tensor(3.0, requires_grad=True)
+    reduced = sequence_parallel_loss.ReduceLoss.apply(value, torch.tensor(1.0))
+
+    # Backward must not resolve group/world-size again after the model context
+    # that owned the forward has ended.
+    monkeypatch.setattr(sequence_parallel_loss.dist, "get_world_size", lambda _group: 99)
+    reduced.backward()
+
+    torch.testing.assert_close(value.grad, torch.tensor(2.0))

--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 import torch
 
+from veomni.distributed.parallel_state import ParallelState
 from veomni.models.auto import build_foundation_model
 from veomni.utils.device import IS_NPU_AVAILABLE, get_gpu_compute_capability
 from veomni.utils.import_utils import is_diffusers_available, is_quack_gemm_available
@@ -53,6 +54,7 @@ def _materialize_weights_dir(config_path: str, output_path: str, save_original_f
     # EP=1 step-2 grad_norm diff was 0.69, blowing past the 0.1 atol+rtol envelope).
     torch.manual_seed(0)
     model = build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=config_path,
         weights_path=None,
         torch_dtype="float32",

--- a/tests/lora/test_moe_lora_trainer.py
+++ b/tests/lora/test_moe_lora_trainer.py
@@ -81,6 +81,7 @@ import yaml
 
 from veomni.arguments import VeOmniArguments, parse_args
 from veomni.data import build_dummy_dataset
+from veomni.distributed.parallel_state import get_model_parallel_state
 from veomni.trainer.base import BaseTrainer
 from veomni.trainer.callbacks.base import Callback, TrainerState
 from veomni.trainer.callbacks.checkpoint_callback import CheckpointerCallback, HFLoraCkptCallback
@@ -223,13 +224,11 @@ class _LogDictSaveCallback(Callback):
         Using the trainer's parallel state instead of a hand-rolled
         ``dp_group`` lookup so this stays correct under FSDP1/FSDP2 +
         SP combinations (``dp_group`` already excludes SP/EP/PP per
-        ``init_parallel_state``).
+        ``build_parallel_state``).
         """
         if not (dist.is_available() and dist.is_initialized()):
             return value
-        from veomni.distributed.parallel_state import get_parallel_state
-
-        ps = get_parallel_state()
+        ps = get_model_parallel_state(self.trainer.model)
         dp_group = ps.dp_group
         if dp_group is None or ps.dp_size <= 1:
             return value
@@ -374,6 +373,7 @@ def _build_and_save_toy_base(dest_dir: str) -> None:
     16 experts, 4 layers). Module-scoped means once per pytest invocation.
     """
     from veomni.arguments.arguments_types import OpsImplementationConfig
+    from veomni.distributed.parallel_state import ParallelState
     from veomni.models import build_foundation_model
     from veomni.utils import helper as _helper
 
@@ -387,6 +387,7 @@ def _build_and_save_toy_base(dest_dir: str) -> None:
         rotary_pos_emb_implementation="eager",
     )
     model = build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=_TOY_CONFIG_PATH,
         weights_path=None,
         torch_dtype="bfloat16",

--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -44,6 +44,7 @@ import transformers
 import yaml
 
 from veomni.arguments.arguments_types import OpsImplementationConfig
+from veomni.distributed.parallel_state import ParallelState
 from veomni.models import build_foundation_model
 from veomni.utils.device import get_device_type
 from veomni.utils.import_utils import is_transformers_version_greater_or_equal_to
@@ -161,6 +162,7 @@ def build_toy(toy_dir: str, *, ops: OpsImplementationConfig | None = None):
     if not os.path.isfile(os.path.join(cfg_path, "config.json")):
         pytest.skip(f"toy config not found: {cfg_path}")
     return build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=cfg_path,
         weights_path=None,
         torch_dtype="bfloat16",

--- a/tests/models/test_gpt_oss_integration.py
+++ b/tests/models/test_gpt_oss_integration.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from veomni.arguments.arguments_types import OpsImplementationConfig
+from veomni.distributed.parallel_state import ParallelState
 from veomni.models.auto import build_foundation_model
 from veomni.utils.device import IS_CUDA_AVAILABLE, get_device_type
 from veomni.utils.import_utils import is_quack_gemm_available
@@ -44,6 +45,7 @@ def test_gpt_oss_veomni_forward_loss_contract(monkeypatch):
 
     model = build_foundation_model(
         "tests/toy_config/gpt_oss_toy",
+        parallel_state=ParallelState(),
         torch_dtype="float32",
         init_device="cpu",
         ops_implementation=_ops_config(),
@@ -65,6 +67,7 @@ def test_gpt_oss_uses_dedicated_moe_opslot_variant(monkeypatch):
 
     model = build_foundation_model(
         "tests/toy_config/gpt_oss_toy",
+        parallel_state=ParallelState(),
         torch_dtype="float32",
         init_device="cpu",
         ops_implementation=_ops_config(),
@@ -81,6 +84,7 @@ def test_gpt_oss_moe_unbound_slot_does_not_fallback_to_eager(monkeypatch):
 
     model = build_foundation_model(
         "tests/toy_config/gpt_oss_toy",
+        parallel_state=ParallelState(),
         torch_dtype="float32",
         init_device="cpu",
         ops_implementation=_ops_config(moe_implementation="eager"),
@@ -107,6 +111,7 @@ def test_gpt_oss_rejects_triton_moe_backend(monkeypatch):
     with pytest.raises(KeyError, match="Unknown kernel 'triton'.*variant='gpt_oss'"):
         build_foundation_model(
             "tests/toy_config/gpt_oss_toy",
+            parallel_state=ParallelState(),
             torch_dtype="float32",
             init_device="cpu",
             ops_implementation=_ops_config(moe_implementation="fused_triton"),
@@ -124,6 +129,7 @@ def test_gpt_oss_fused_quack_without_sm90_raises(monkeypatch):
     with pytest.raises(RuntimeError, match="compute_capability>=90"):
         build_foundation_model(
             "tests/toy_config/gpt_oss_toy",
+            parallel_state=ParallelState(),
             torch_dtype="float32",
             init_device="cpu",
             ops_implementation=_ops_config(moe_implementation="fused_quack"),
@@ -141,6 +147,7 @@ def test_gpt_oss_fused_moe_matches_eager_cuda(monkeypatch):
     device = get_device_type()
     eager_model = build_foundation_model(
         "tests/toy_config/gpt_oss_toy",
+        parallel_state=ParallelState(),
         torch_dtype="bfloat16",
         init_device=device,
         ops_implementation=_ops_config(moe_implementation="eager"),
@@ -151,6 +158,7 @@ def test_gpt_oss_fused_moe_matches_eager_cuda(monkeypatch):
             layer.mlp.experts.down_proj_bias.normal_(mean=0.0, std=0.02)
     fused_model = build_foundation_model(
         "tests/toy_config/gpt_oss_toy",
+        parallel_state=ParallelState(),
         torch_dtype="bfloat16",
         init_device=device,
         ops_implementation=_ops_config(moe_implementation="fused_quack"),
@@ -178,6 +186,7 @@ def test_gpt_oss_quack_fused_moe_matches_eager_cuda(monkeypatch):
     device = get_device_type()
     eager_model = build_foundation_model(
         "tests/toy_config/gpt_oss_toy",
+        parallel_state=ParallelState(),
         torch_dtype="bfloat16",
         init_device=device,
         ops_implementation=_ops_config(moe_implementation="eager"),
@@ -194,6 +203,7 @@ def test_gpt_oss_quack_fused_moe_matches_eager_cuda(monkeypatch):
 
     fused_model = build_foundation_model(
         "tests/toy_config/gpt_oss_toy",
+        parallel_state=ParallelState(),
         torch_dtype="bfloat16",
         init_device=device,
         ops_implementation=_ops_config(moe_implementation="fused_quack"),

--- a/tests/models/test_model_forward_no_implicit_sync.py
+++ b/tests/models/test_model_forward_no_implicit_sync.py
@@ -566,6 +566,7 @@ def _single_rank_process_group():
 
 def _build_veomni_model(case, config):
     """Random-init VeOmni model — we only need forward to run, not match HF."""
+    from veomni.distributed.parallel_state import ParallelState
     from veomni.models.auto import build_foundation_model
     from veomni.ops import apply_ops_config
 
@@ -580,6 +581,7 @@ def _build_veomni_model(case, config):
     torch.manual_seed(0)
     get_torch_device().manual_seed_all(0)
     return build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=config,
         weights_path=None,
         torch_dtype=case.dtype,

--- a/tests/models/test_models_logits_equal_v5.py
+++ b/tests/models/test_models_logits_equal_v5.py
@@ -513,6 +513,7 @@ def _build_hf_model(case: Case, config, dtype: torch.dtype):
 
 def _build_veomni_model(case: Case, config, hf_state_dict):
     """VeOmni-generated model with HF state_dict loaded."""
+    from veomni.distributed.parallel_state import ParallelState
     from veomni.models.auto import build_foundation_model
     from veomni.ops import apply_ops_config
 
@@ -529,6 +530,7 @@ def _build_veomni_model(case: Case, config, hf_state_dict):
     apply_ops_config(make_eager_ops_config(attn_implementation=case.attn_implementation))
 
     model = build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=config,
         weights_path=None,
         torch_dtype=case.dtype,
@@ -768,6 +770,7 @@ def _build_veomni_model_from_disk(case: Case, config, hf_state_dict, hf_buffers,
     like ``_experts_implementation`` survive without depending on
     ``PretrainedConfig`` JSON round-trip semantics for underscored attrs.
     """
+    from veomni.distributed.parallel_state import ParallelState
     from veomni.models.auto import build_foundation_model
     from veomni.ops import apply_ops_config
 
@@ -777,6 +780,7 @@ def _build_veomni_model_from_disk(case: Case, config, hf_state_dict, hf_buffers,
     _save_hf_checkpoint(hf_state_dict, config, weights_dir)
 
     model = build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=weights_dir,
         weights_path=weights_dir,
         config_kwargs=dict(case.config_overrides),

--- a/tests/models/test_models_patch.py
+++ b/tests/models/test_models_patch.py
@@ -21,6 +21,11 @@ from veomni.arguments import (
 )
 from veomni.data.data_collator import MainCollator
 from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
+from veomni.distributed.parallel_state import (
+    bind_model_parallel_state,
+    get_model_parallel_state,
+    use_parallel_state,
+)
 from veomni.trainer.base import BaseTrainer, VeOmniArguments
 from veomni.utils.device import IS_NPU_AVAILABLE, empty_cache, get_device_type, synchronize
 from veomni.utils.env import get_env
@@ -210,7 +215,11 @@ class TrainerTest(BaseTrainer):
                 # HF expects feature_attention_mask (num_audios, seq_len) for indexing.
                 "feature_attention_mask": (0, False, None, None),
             }
-        self.collate_fn = MainCollator(seq_classification=False, data_collate_info=data_collate_info)
+        self.collate_fn = MainCollator(
+            seq_classification=False,
+            data_collate_info=data_collate_info,
+            parallel_state=get_model_parallel_state(self.model),
+        )
 
     def _build_dataloader(self):
         pass
@@ -263,7 +272,8 @@ class TrainerTest(BaseTrainer):
             self.args.model.ops_implementation.rotary_pos_emb_implementation = "eager"
             self.args.model.ops_implementation.cross_entropy_loss_implementation = "eager"
 
-        self._build_model()
+        with use_parallel_state(get_model_parallel_state(self.model)):
+            self._build_model()
         self._verify_opslot_state(model_mode)
         self._build_optimizer()
         self._build_lr_scheduler()
@@ -281,7 +291,9 @@ class TrainerTest(BaseTrainer):
 
         if self.model_config.model_type in ["qwen2_5_omni", "qwen3_omni_moe"]:
             self.model.disable_talker()
+            parallel_state = get_model_parallel_state(self.model)
             self.model = self.model.thinker
+            bind_model_parallel_state(self.model, parallel_state)
 
         print(f"{'-' * 10} {model_name}_{model_mode} {'-' * 10}")
         args: VeOmniArguments = self.args

--- a/tests/models/test_padded_packed_loss.py
+++ b/tests/models/test_padded_packed_loss.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from veomni.data.data_collator import MainCollator
+from veomni.distributed.parallel_state import ParallelState
 from veomni.models import build_foundation_model
 from veomni.ops import apply_ops_config
 from veomni.utils.device import IS_CUDA_AVAILABLE, get_device_type
@@ -33,6 +34,7 @@ def test_qwen3_loss_match_with_padded_packed_input(monkeypatch, pad_to_length):
     torch.manual_seed(0)
 
     model = build_foundation_model(
+        parallel_state=ParallelState(),
         config_path="./tests/toy_config/qwen3_toy",
         weights_path=None,
         torch_dtype="float16",

--- a/tests/models/test_return_log_probs_e2e.py
+++ b/tests/models/test_return_log_probs_e2e.py
@@ -124,6 +124,7 @@ def _build_model(toy_path: str, ce_impl: str = "chunk_loss"):
     fp16/bf16) and pins the cross-entropy backend.
     """
     from veomni.arguments.arguments_types import OpsImplementationConfig
+    from veomni.distributed.parallel_state import ParallelState
     from veomni.models.auto import build_foundation_model
 
     ops_implementation = OpsImplementationConfig(
@@ -132,6 +133,7 @@ def _build_model(toy_path: str, ce_impl: str = "chunk_loss"):
     )
 
     return build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=toy_path,
         weights_path=None,
         torch_dtype="float32",

--- a/tests/models/test_vlm_trainer.py
+++ b/tests/models/test_vlm_trainer.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from veomni.distributed.parallel_state import ParallelState
 from veomni.models import build_foundation_model
 from veomni.trainer.vlm_trainer import (
     VeOmniVLMArguments,
@@ -42,6 +43,7 @@ def test_freeze_vit_on_vlm_model(config_path, freeze_vit):
     # forwards.
     ops_implementation = make_eager_ops_config()
     model = build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=config_path,
         weights_path=None,
         torch_dtype="float32",

--- a/tests/ops/test_comp.py
+++ b/tests/ops/test_comp.py
@@ -5,6 +5,7 @@ import time
 import pytest
 import torch
 
+from veomni.distributed.parallel_state import ParallelState
 from veomni.models import build_foundation_model
 from veomni.utils.device import get_device_type, synchronize
 
@@ -180,6 +181,7 @@ def main(args):
         chunk_gated_delta_rule_implementation="eager",
     )
     dummy_model = build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=args.config_path,
         init_device=args.device,
         ops_implementation=eager_ops,

--- a/tests/optim/test_muon_fsdp2_parity.py
+++ b/tests/optim/test_muon_fsdp2_parity.py
@@ -28,7 +28,7 @@ import torch.nn as nn
 from torch.distributed.fsdp import fully_shard
 from torch.distributed.tensor import DTensor, Replicate, Shard
 
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import ParallelState, build_parallel_state
 from veomni.optim.muon import DistributedMuon
 from veomni.utils.device import (
     get_device_type,
@@ -232,11 +232,12 @@ def _eager_ops_config():
     )
 
 
-def _build_qwen3_moe(device: torch.device) -> nn.Module:
+def _build_qwen3_moe(device: torch.device, parallel_state: ParallelState) -> nn.Module:
     """Build the real Qwen3-MoE toy via ``build_foundation_model``."""
     from veomni.models import build_foundation_model
 
     return build_foundation_model(
+        parallel_state=parallel_state,
         config_path=QWEN3_MOE_TOY_CFG,
         weights_path=None,
         torch_dtype="float32",
@@ -245,9 +246,9 @@ def _build_qwen3_moe(device: torch.device) -> nn.Module:
     )
 
 
-def _qwen3_moe_golden_state(device: torch.device, full_shapes: dict) -> dict:
+def _qwen3_moe_golden_state(device: torch.device, full_shapes: dict, parallel_state: ParallelState) -> dict:
     """Single-process golden Muon step on the full Qwen3-MoE toy."""
-    model = _build_qwen3_moe(device)
+    model = _build_qwen3_moe(device, parallel_state)
     _force_reinit(model, SEED, device)
 
     from veomni.optim.muon import split_muon_adamw_params
@@ -285,7 +286,7 @@ def _run_qwen3_moe(use_zero_comm: bool) -> None:
     rank = dist.get_rank()
     assert world_size == 4, f"this test expects exactly 4 ranks, got {world_size}"
 
-    init_parallel_state(
+    ps = build_parallel_state(
         dp_size=world_size,
         dp_shard_size=world_size,
         extra_parallel_sizes=(EP_SIZE,),
@@ -293,16 +294,13 @@ def _run_qwen3_moe(use_zero_comm: bool) -> None:
         extra_parallel_names=("ep",),
         dp_mode="fsdp2",
     )
-    from veomni.distributed.parallel_state import get_parallel_state
-
-    ps = get_parallel_state()
     ep_fsdp_mesh = ps.extra_parallel_fsdp_device_mesh["ep"]["ep_fsdp"]
     ep_mesh = ps.extra_parallel_fsdp_device_mesh["ep"]["ep"]
     fsdp_mesh = ps.fsdp_mesh
 
     device = torch.device(f"{device_type}:{local_rank}")
 
-    model = _build_qwen3_moe(device)
+    model = _build_qwen3_moe(device, ps)
     _force_reinit(model, SEED, device)
 
     full_shapes = {fqn: tuple(p.shape) for fqn, p in model.named_parameters() if p.requires_grad}
@@ -381,7 +379,7 @@ def _run_qwen3_moe(use_zero_comm: bool) -> None:
         device_backend.empty_cache()
 
     if rank == 0:
-        golden = _qwen3_moe_golden_state(device, full_shapes)
+        golden = _qwen3_moe_golden_state(device, full_shapes, ps)
         common = set(fsdp_state.keys()) & set(golden.keys())
         assert common, f"no common keys between fsdp ({list(fsdp_state)[:4]}...) and golden ({list(golden)[:4]}...)"
         first_failure = None

--- a/tests/optim/test_muon_fsdp2_smoke.py
+++ b/tests/optim/test_muon_fsdp2_smoke.py
@@ -26,7 +26,7 @@ import torch.distributed as dist
 from torch.distributed.tensor import DTensor, Shard
 
 from veomni.arguments.arguments_types import MixedPrecisionConfig
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.optim import build_optimizer
 from veomni.optim.optimizer import MultiOptimizer
@@ -51,7 +51,7 @@ def _distributed_smoke(use_zero_comm: bool) -> None:
     rank = dist.get_rank()
     assert world_size == 4, f"this test expects exactly 4 ranks, got {world_size}"
 
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=world_size,
         dp_shard_size=world_size,
         extra_parallel_sizes=(EP_SIZE,),
@@ -75,6 +75,7 @@ def _distributed_smoke(use_zero_comm: bool) -> None:
     )
     # fused_triton MoE requires fp16/bf16 routing weights.
     model = build_foundation_model(
+        parallel_state=parallel_state,
         config_path=QWEN3_MOE_TOY_CFG,
         weights_path=None,
         torch_dtype="bfloat16",
@@ -83,6 +84,7 @@ def _distributed_smoke(use_zero_comm: bool) -> None:
     )
     model = build_parallelize_model(
         model,
+        parallel_state=parallel_state,
         init_device="meta",
         weights_path=None,
         mixed_precision=MixedPrecisionConfig(enable=False),
@@ -108,6 +110,7 @@ def _distributed_smoke(use_zero_comm: bool) -> None:
 
     optimizer = build_optimizer(
         model,
+        parallel_state=parallel_state,
         lr=1e-4,
         weight_decay=0.01,
         fused=True,

--- a/tests/optim/test_muon_unit.py
+++ b/tests/optim/test_muon_unit.py
@@ -25,6 +25,7 @@ muon_module = pytest.importorskip("torch.optim._muon")
 from torch.optim import Muon as UpstreamMuon  # noqa: E402
 from torch.optim._muon import _zeropower_via_newtonschulz as upstream_ns  # noqa: E402
 
+from veomni.distributed.parallel_state import ParallelState  # noqa: E402
 from veomni.optim.muon import (  # noqa: E402
     DEFAULT_NS_COEFFICIENTS,
     DEFAULT_NS_STEPS,
@@ -152,6 +153,7 @@ class TestNumerics:
         model_a = _toy_model()
         opt_a = build_optimizer(
             model_a,
+            parallel_state=ParallelState(),
             lr=1e-4,
             weight_decay=0.01,
             optimizer_type="muon",
@@ -175,6 +177,7 @@ class TestNumerics:
         model_b.load_state_dict(model_a.state_dict())
         opt_b = build_optimizer(
             model_b,
+            parallel_state=ParallelState(),
             lr=1e-4,
             weight_decay=0.01,
             optimizer_type="muon",
@@ -198,6 +201,7 @@ class TestBuildOptimizer:
         model = _toy_model()
         opt = build_optimizer(
             model,
+            parallel_state=ParallelState(),
             lr=1e-4,
             weight_decay=0.01,
             optimizer_type="muon",
@@ -213,7 +217,12 @@ class TestBuildOptimizer:
 
         model = nn.LayerNorm(4)
         with pytest.raises(ValueError, match="no eligible 2D/3D parameters"):
-            build_optimizer(model, optimizer_type="muon", muon_kwargs={"lr": 1e-3})
+            build_optimizer(
+                model,
+                parallel_state=ParallelState(),
+                optimizer_type="muon",
+                muon_kwargs={"lr": 1e-3},
+            )
 
 
 class TestBatchedNS:

--- a/tests/optim/test_optimizer_vlm_param_groups.py
+++ b/tests/optim/test_optimizer_vlm_param_groups.py
@@ -7,6 +7,7 @@ from torch.distributed.checkpoint.state_dict import (
     set_optimizer_state_dict,
 )
 
+from veomni.distributed.parallel_state import ParallelState
 from veomni.optim.optimizer import (
     build_optimizer,
     filter_empty_param_groups,
@@ -102,6 +103,7 @@ def test_build_optimizer_skips_empty_vlm_param_groups():
     model = _TinyModel()
     opt = build_optimizer(
         model,
+        parallel_state=ParallelState(),
         lr=2e-5,
         param_groups=[
             {"params": [], "lr": 1e-6},
@@ -133,7 +135,7 @@ def test_vlm_trainer_style_param_groups_skip_empty_vit():
 
     assert vit_params == []
     assert len(param_groups) == 1
-    opt = build_optimizer(model, lr=2e-5, param_groups=param_groups)
+    opt = build_optimizer(model, parallel_state=ParallelState(), lr=2e-5, param_groups=param_groups)
     assert len(opt.param_groups) == 1
     assert opt.param_groups[0]["lr"] == 2e-5
 
@@ -143,6 +145,7 @@ def test_vlm_style_optimizer_dcp_roundtrip_step_succeeds():
     model = _TinyModel()
     opt = build_optimizer(
         model,
+        parallel_state=ParallelState(),
         lr=2e-5,
         param_groups=[
             {"params": [], "lr": 1e-6},
@@ -163,6 +166,7 @@ def test_vlm_style_optimizer_dcp_roundtrip_step_succeeds():
     model2 = _TinyModel()
     opt2 = build_optimizer(
         model2,
+        parallel_state=ParallelState(),
         lr=2e-5,
         param_groups=[
             {"params": [], "lr": 1e-6},

--- a/tests/parallel/encoder_data_balance/test_balance_reverse.py
+++ b/tests/parallel/encoder_data_balance/test_balance_reverse.py
@@ -6,7 +6,7 @@ import sys
 import torch
 import torch.distributed as dist
 
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state, use_parallel_state
 from veomni.utils.data_balance.data_balance import Qwen3VLEncoderDataBalance
 from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
 
@@ -59,7 +59,7 @@ def check_recover_precision(pixel_values, image_grid_thw):
 def main():
     get_torch_device().set_device(f"{get_device_type()}:{os.getenv('RANK')}")
     dist.init_process_group(backend=get_dist_comm_backend())
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=int(os.getenv("WORLD_SIZE")),
         dp_mode="fsdp2",
     )
@@ -67,7 +67,8 @@ def main():
     # Construct fake data
     pixel_values, image_grid_thw = construct_data()
     # spatial_merge_unit = 1
-    check_recover_precision(pixel_values, image_grid_thw)
+    with use_parallel_state(parallel_state):
+        check_recover_precision(pixel_values, image_grid_thw)
 
     print("all test passed")
 

--- a/tests/parallel/ulysses/test_all_gather.py
+++ b/tests/parallel/ulysses/test_all_gather.py
@@ -1,4 +1,5 @@
 import sys
+from types import SimpleNamespace
 
 import torch
 import torch.distributed as c10d
@@ -14,6 +15,7 @@ import pytest
 import torch.distributed as dist
 from torch.testing._internal.common_utils import run_tests
 
+from veomni.distributed.parallel_state import use_parallel_state
 from veomni.distributed.sequence_parallel.data import gather_outputs, slice_input_tensor
 from veomni.distributed.sequence_parallel.loss import reduce_sequence_parallel_loss
 from veomni.utils.helper import enable_high_precision_for_bf16, set_seed
@@ -74,8 +76,9 @@ class AllToAllCommTest(SequenceParallelTest):
         local_out = AllToAllCommTest._run_forward(local_y)
         local_loss = local_out.mean()
         num_valid_tokens = torch.tensor(1.0, dtype=local_loss.dtype, device=local_loss.device)
-        reduced_loss = reduce_sequence_parallel_loss(local_loss, num_valid_tokens)
-        reduced_loss.backward()
+        with use_parallel_state(SimpleNamespace(sp_group=group)):
+            reduced_loss = reduce_sequence_parallel_loss(local_loss, num_valid_tokens)
+            reduced_loss.backward()
         return reduced_loss.item(), local_x.grad.item()
 
     @staticmethod

--- a/tests/parallel/ulysses/test_all_gather.py
+++ b/tests/parallel/ulysses/test_all_gather.py
@@ -76,7 +76,9 @@ class AllToAllCommTest(SequenceParallelTest):
         local_out = AllToAllCommTest._run_forward(local_y)
         local_loss = local_out.mean()
         num_valid_tokens = torch.tensor(1.0, dtype=local_loss.dtype, device=local_loss.device)
-        with use_parallel_state(SimpleNamespace(sp_group=group)):
+        # This standalone primitive test historically reduces through the
+        # default process group without enabling sequence parallel scaling.
+        with use_parallel_state(SimpleNamespace(sp_group=None)):
             reduced_loss = reduce_sequence_parallel_loss(local_loss, num_valid_tokens)
             reduced_loss.backward()
         return reduced_loss.item(), local_x.grad.item()

--- a/tests/parallel/ulysses/test_qwen3_5_gated_deltanet_ulysses.py
+++ b/tests/parallel/ulysses/test_qwen3_5_gated_deltanet_ulysses.py
@@ -216,11 +216,11 @@ def _run_gated_deltanet_sp_fw_bw(rank: int, world_size: int, init_file: str, bsz
     import importlib
 
     from veomni.arguments.arguments_types import OpsImplementationConfig
-    from veomni.distributed.parallel_state import init_parallel_state
+    from veomni.distributed.parallel_state import bind_model_parallel_state, build_parallel_state
     from veomni.models.auto import _bind_veomni_ops
     from veomni.models.transformers.qwen3_5.generated.patched_modeling_qwen3_5_gpu import Qwen3_5GatedDeltaNet
 
-    init_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
+    parallel_state = build_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
 
     # The module-level ``_bind_qwen3_5_op_slots`` fixture only binds OpSlots
     # in the parent test process; ``mp.spawn(start_method="spawn")`` here
@@ -233,6 +233,7 @@ def _run_gated_deltanet_sp_fw_bw(rank: int, world_size: int, init_file: str, bsz
     _set_deterministic(42)
     config = _TinyQwen3_5Config()
     layer = Qwen3_5GatedDeltaNet(config, layer_idx=0).to(device_type)
+    bind_model_parallel_state(layer, parallel_state)
     layer.train()
 
     hidden = config.hidden_size
@@ -348,11 +349,11 @@ def _run_gated_deltanet_sp_determinism(rank: int, world_size: int, init_file: st
     import importlib
 
     from veomni.arguments.arguments_types import OpsImplementationConfig
-    from veomni.distributed.parallel_state import init_parallel_state
+    from veomni.distributed.parallel_state import bind_model_parallel_state, build_parallel_state
     from veomni.models.auto import _bind_veomni_ops
     from veomni.models.transformers.qwen3_5.generated.patched_modeling_qwen3_5_gpu import Qwen3_5GatedDeltaNet
 
-    init_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
+    parallel_state = build_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
 
     # The module-level ``_bind_qwen3_5_op_slots`` fixture only binds OpSlots
     # in the parent test process; ``mp.spawn(start_method="spawn")`` here
@@ -365,6 +366,7 @@ def _run_gated_deltanet_sp_determinism(rank: int, world_size: int, init_file: st
     _set_deterministic(42)
     config = _TinyQwen3_5Config()
     layer = Qwen3_5GatedDeltaNet(config, layer_idx=0).to(device_type)
+    bind_model_parallel_state(layer, parallel_state)
     layer.train()
 
     hidden = config.hidden_size

--- a/tests/tools/training_utils.py
+++ b/tests/tools/training_utils.py
@@ -281,10 +281,12 @@ def materialize_weights(config_path: str, output_path: str, save_original_format
 
     This avoids downloading real model weights for CI tests.
     """
+    from veomni.distributed.parallel_state import ParallelState
     from veomni.models.auto import build_foundation_model
     from veomni.utils.device import empty_cache, get_device_type
 
     model = build_foundation_model(
+        parallel_state=ParallelState(),
         config_path=config_path,
         weights_path=None,
         torch_dtype="float32",

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -16,7 +16,7 @@ from torch.distributed._tensor import DTensor, Shard
 from veomni.arguments import TrainingArguments, parse_args
 from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
 from veomni.distributed.parallel_plan import ParallelPlan
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.optim import build_optimizer
 from veomni.utils import helper
@@ -126,7 +126,7 @@ def main():
     args = parse_args(Argument)
 
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -143,6 +143,7 @@ def main():
     model = ToyMoeAndEmbedModel()
     model = build_parallelize_model(
         model,
+        parallel_state=parallel_state,
         init_device=args.train.init_device,
         weights_path=None,
         mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
@@ -155,9 +156,7 @@ def main():
         max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
     )
 
-    from veomni.distributed.parallel_state import get_parallel_state
-
-    ps = get_parallel_state()
+    ps = parallel_state
     fsdp_group = ps.fsdp_group
     ep_group = ps.extra_parallel_group("ep") if ps.extra_parallel_enabled("ep") else None
     emb_group = ps.extra_parallel_group("emb") if ps.extra_parallel_enabled("emb") else None
@@ -173,6 +172,7 @@ def main():
     # build optimizer to register ep param groups when ep is enabled
     _ = build_optimizer(
         model,
+        parallel_state=parallel_state,
         lr=args.train.optimizer.lr,
         weight_decay=args.train.optimizer.weight_decay,
         fused=True,
@@ -262,7 +262,7 @@ def main():
             + 64 * 16
             + (64 * 16 * 32) * (1 / ps.extra_parallel_sizes["ep"] ** 2)
         )
-        total_grad_norm_pre_clip = veomni_clip_grad_norm(model, max_grad_norm)
+        total_grad_norm_pre_clip = veomni_clip_grad_norm(model, max_grad_norm, parallel_state=parallel_state)
 
         # check whether total grad norm meets our expectation
         torch.testing.assert_close(total_grad_norm_pre_clip, expected=expected_total_grad_norm, atol=1e-6, rtol=1e-6)

--- a/tests/utils/test_helper.py
+++ b/tests/utils/test_helper.py
@@ -8,7 +8,7 @@ import torch.distributed as dist
 from transformers import Qwen2Config
 
 from veomni.arguments import DataArguments, ModelArguments, TrainingArguments, VeOmniArguments, parse_args
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state
 from veomni.utils import helper
 from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
 
@@ -30,7 +30,7 @@ def run_environ_meter(args):
     dist.init_process_group(backend=get_dist_comm_backend(), world_size=world_size, rank=rank)
 
     config = Qwen2Config()
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -59,6 +59,7 @@ def run_environ_meter(args):
     train_meter = helper.EnvironMeter(
         config=config,
         global_batch_size=args.train.global_batch_size,
+        parallel_state=parallel_state,
     )
 
     micro_batches = [micro_batch] * 10

--- a/tests/utils/test_model_loader.py
+++ b/tests/utils/test_model_loader.py
@@ -7,7 +7,7 @@ import pytest
 import torch.distributed as dist
 
 from veomni.arguments import DataArguments, ModelArguments, TrainingArguments, VeOmniArguments, parse_args
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state
 from veomni.models import build_foundation_model
 from veomni.utils import helper
 from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
@@ -37,7 +37,7 @@ def run_environ_meter(args: Arguments):
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend(), world_size=world_size, rank=rank)
 
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -52,6 +52,7 @@ def run_environ_meter(args: Arguments):
     )
 
     model = build_foundation_model(
+        parallel_state=parallel_state,
         config_path=args.model.config_path,
         weights_path=args.model.model_path,
         init_device=args.train.init_device,

--- a/tests/utils/test_rank0_load_and_broadcast_weights.py
+++ b/tests/utils/test_rank0_load_and_broadcast_weights.py
@@ -12,7 +12,7 @@ from torch import nn
 
 from veomni.arguments import DataArguments, ModelArguments, TrainingArguments, parse_args
 from veomni.distributed.parallel_plan import ParallelPlan
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import build_parallel_state, clear_parallel_state_cache
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models.module_utils import load_model_weights, rank0_load_and_broadcast_weights
 from veomni.utils import helper
@@ -218,7 +218,7 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
     get_torch_device().set_device(args.train.local_rank)
     dist.init_process_group(backend=args.test.backend)
 
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -274,6 +274,7 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
         # 1.1 rank0_load_model init with no weights_path
         rank0_load_model = build_parallelize_model(
             rank0_load_model,
+            parallel_state=parallel_state,
             weights_path=None,
             init_device=args.train.init_device,
             mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
@@ -300,6 +301,7 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
         # 2.1 all_rank_load_model init with no weights_path
         all_rank_load_model = build_parallelize_model(
             all_rank_load_model,
+            parallel_state=parallel_state,
             weights_path=None,
             init_device=args.train.init_device,
             mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
@@ -394,9 +396,7 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
         dist.barrier()
     finally:
         dist.destroy_process_group()
-        from veomni.distributed import parallel_state as _ps
-
-        _ps._PARALLEL_STATE = None
+        clear_parallel_state_cache()
 
 
 @pytest.mark.skipif(not dist.is_available(), reason="torch.distributed required")
@@ -453,7 +453,7 @@ def run_load_weights_test(args: Arguments) -> None:
     get_torch_device().set_device(args.train.local_rank)
     dist.init_process_group(backend=args.test.backend)
 
-    init_parallel_state(
+    parallel_state = build_parallel_state(
         dp_size=args.train.accelerator.dp_size,
         dp_replicate_size=args.train.accelerator.dp_replicate_size,
         dp_shard_size=args.train.accelerator.dp_shard_size,
@@ -472,6 +472,7 @@ def run_load_weights_test(args: Arguments) -> None:
         # (the every-rank-reads-from-disk path, fixed in issue #637).
         fsdp_model = build_parallelize_model(
             ToyModel(),
+            parallel_state=parallel_state,
             weights_path=str(weights_path),
             init_device=args.train.init_device,
             mixed_precision=args.train.accelerator.fsdp_config.mixed_precision,
@@ -561,9 +562,7 @@ def run_load_weights_test(args: Arguments) -> None:
         dist.barrier()
     finally:
         dist.destroy_process_group()
-        from veomni.distributed import parallel_state as _ps
-
-        _ps._PARALLEL_STATE = None
+        clear_parallel_state_cache()
 
 
 @pytest.mark.skipif(not dist.is_available(), reason="torch.distributed required")

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -38,7 +38,7 @@ from torch.distributed.checkpoint.state_dict import (
 )
 from torch.distributed.checkpoint.stateful import Stateful
 
-from ..distributed.parallel_state import get_parallel_state
+from ..distributed.parallel_state import ParallelState, get_parallel_state, resolve_model_parallel_state
 from ..optim.optimizer import restore_optimizer_param_group_defaults
 from ..utils import logging
 from ..utils.checkpoint_utils import _GLOBAL_STEP_PREFIX
@@ -170,13 +170,15 @@ class ModelState(Stateful):
             (already populated from ``model_path``) base params are left untouched.
     """
 
-    def __init__(self, model, trainable_only: bool = False):
+    def __init__(self, model, trainable_only: bool = False, parallel_state: Optional[ParallelState] = None):
         self.model = model
         self.trainable_only = trainable_only
 
         # Determine whether this is ExtraParallel+FSDP2 case
         # If so, we need to restore Para(e.g. EP)-dim before saving to DCP
-        self.parallel_state = get_parallel_state()
+        if parallel_state is None and getattr(model, "_veomni_parallel_state", None) is None:
+            parallel_state = get_parallel_state()
+        self.parallel_state = resolve_model_parallel_state(model, parallel_state)
         self.extra_parallel_fqn2spec_info = getattr(self.model, "_fqn2spec_info", None)
         self.should_extra_parallel_aware = (
             self.extra_parallel_fqn2spec_info is not None and self.parallel_state.dp_mode == "fsdp2"
@@ -241,10 +243,12 @@ class OptimizerState(Stateful):
     ``ModelState.load_state_dict`` for non-LoRA loads.
     """
 
-    def __init__(self, model, optimizer):
+    def __init__(self, model, optimizer, parallel_state: Optional[ParallelState] = None):
         self.model = model
         self.optimizer = optimizer
-        self.parallel_state = get_parallel_state()
+        if parallel_state is None and getattr(model, "_veomni_parallel_state", None) is None:
+            parallel_state = get_parallel_state()
+        self.parallel_state = resolve_model_parallel_state(model, parallel_state)
         self.extra_parallel_fqn2spec_info = getattr(self.model, "_fqn2spec_info", None)
         self.should_extra_parallel_aware = (
             self.extra_parallel_fqn2spec_info is not None and self.parallel_state.dp_mode == "fsdp2"

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -15,7 +15,7 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -40,6 +40,9 @@ from ..utils.seqlen_pos_transform_utils import (
 # Signature: ``fn(batch: dict, sp_pad: dict[str, int]) -> None`` — mutates
 # ``batch`` in place, writing ``batch["multimodal_metadata"]``.
 MetadataCollateFunc = Callable[[Dict[str, Any], Dict[str, int]], None]
+
+if TYPE_CHECKING:
+    from ..distributed.parallel_state import ParallelState
 
 
 logger = logging.get_logger(__name__)
@@ -210,9 +213,14 @@ class PackingCollator(DataCollator):
     # Model-provided hook (see ``MetadataCollateFunc``). ``None`` for text
     # models / pipelines without multimodal metadata — then this is a no-op.
     metadata_collate_func: Optional[MetadataCollateFunc] = None
+    parallel_state: Optional["ParallelState"] = None
 
     def __post_init__(self):
-        self.sp_enabled = get_parallel_state().sp_enabled
+        parallel_state = self.parallel_state or get_parallel_state()
+        self.sp_enabled = parallel_state.sp_enabled
+        # Worker-side collators must stay pickle-safe for the documented spawn
+        # path. DeviceMesh/ProcessGroup objects remain in the parent process.
+        self.parallel_state = None
 
     def pad_feature_to_length(
         self,
@@ -307,10 +315,13 @@ class SequenceParallelCollator(DataCollator):
     # Model-provided hook (see ``MetadataCollateFunc``). ``None`` for text
     # models / pipelines without multimodal metadata — then this is a no-op.
     metadata_collate_func: Optional[MetadataCollateFunc] = None
+    parallel_state: Optional["ParallelState"] = None
 
     def __post_init__(self):
-        self.sp_size = get_parallel_state().sp_size
-        self.sp_rank = get_parallel_state().sp_rank
+        parallel_state = self.parallel_state or get_parallel_state()
+        self.sp_size = parallel_state.sp_size
+        self.sp_rank = parallel_state.sp_rank
+        self.parallel_state = None
 
     def sp_slice(self, key: str, feature: torch.Tensor, dim: int = -1) -> torch.Tensor:
         if isinstance(feature, list):
@@ -418,6 +429,7 @@ class MainCollator(DataCollator):
     pad_to_length: bool = False
     seq_classification: bool = False
     metadata_collate_func: Optional[MetadataCollateFunc] = None
+    parallel_state: Optional["ParallelState"] = None
 
     """
     Data collator pipeline with a unified collate info.
@@ -436,6 +448,8 @@ class MainCollator(DataCollator):
     """
 
     def __post_init__(self):
+        parallel_state = self.parallel_state or get_parallel_state()
+        self.parallel_state = None
         self.preforward_pipeline = []
         self.collate_infos: Dict[str, DataCollateInfo] = {}
 
@@ -465,14 +479,16 @@ class MainCollator(DataCollator):
                 pad_to_length=self.pad_to_length,
                 seq_classification=self.seq_classification,
                 metadata_collate_func=self.metadata_collate_func,
+                parallel_state=parallel_state,
             )
         )
-        if get_parallel_state().sp_enabled:
+        if parallel_state.sp_enabled:
             self.preforward_pipeline.append(
                 SequenceParallelCollator(
                     collate_infos=self.collate_infos,
                     seq_classification=self.seq_classification,
                     metadata_collate_func=self.metadata_collate_func,
+                    parallel_state=parallel_state,
                 )
             )
         logger.info_rank0(self.log_collate_infos())
@@ -508,10 +524,11 @@ class MainCollator(DataCollator):
 
 @dataclass
 class PostCollator(DataCollator):
-    def __init__(self):
+    def __init__(self, parallel_state: Optional["ParallelState"] = None):
+        self.parallel_state = parallel_state or get_parallel_state()
         self.postforward_pipeline = []
         self.compute_seqlens_func = SeqlensComputePostCollator()
-        self.postforward_pipeline.append(PackingPostCollator())
+        self.postforward_pipeline.append(PackingPostCollator(parallel_state=self.parallel_state))
 
     def __call__(self, outputs: ModelOutput, micro_batch: Dict[str, torch.Tensor]):
         seq_lens = self.compute_seqlens_func(micro_batch)
@@ -529,10 +546,15 @@ class SeqlensComputePostCollator(DataCollator):
 
 @dataclass
 class PackingPostCollator(DataCollator):
+    parallel_state: Optional["ParallelState"] = None
+
+    def __post_init__(self):
+        self.parallel_state = self.parallel_state or get_parallel_state()
+
     def __call__(self, outputs: ModelOutput, seq_lens):
         logits = outputs.logits
-        if get_parallel_state().sp_enabled:
-            logits = gather_outputs(logits, gather_dim=0, group=get_parallel_state().sp_group)
+        if self.parallel_state.sp_enabled:
+            logits = gather_outputs(logits, gather_dim=0, group=self.parallel_state.sp_group)
             logits = logits[: sum(seq_lens)]  # remove sp padding
         logits_list = logits.split(seq_lens, dim=0)
         outputs.logits = logits_list

--- a/veomni/data/data_loader.py
+++ b/veomni/data/data_loader.py
@@ -21,7 +21,7 @@ from torch.utils.data import Dataset, IterableDataset
 from torchdata.stateful_dataloader import StatefulDataLoader
 from torchdata.stateful_dataloader.sampler import StatefulDistributedSampler
 
-from ..distributed.parallel_state import get_parallel_state
+from ..distributed.parallel_state import ParallelState, get_parallel_state
 from ..utils import logging
 from ..utils.device import get_device_type
 from ..utils.registry import Registry
@@ -89,6 +89,7 @@ def build_native_dataloader(
     collate_fn_kwargs: Optional[Dict[str, Any]] = None,
     multiprocessing_context=None,
     save_steps: int = 0,
+    parallel_state: Optional[ParallelState] = None,
 ) -> "DistributedDataloader":
     """Build the native training dataloader.
 
@@ -141,11 +142,11 @@ def build_native_dataloader(
     """
     if collate_fn_kwargs is None:
         collate_fn_kwargs = {}
-    parallel_state = get_parallel_state()
+    parallel_state = parallel_state or get_parallel_state()
 
     if collate_fn is None:
         if build_collate_fn:
-            collate_fn = MainCollator(**collate_fn_kwargs)
+            collate_fn = MainCollator(parallel_state=parallel_state, **collate_fn_kwargs)
         else:
             collate_fn = NoopDataCollator()
 

--- a/veomni/data/data_loader.py
+++ b/veomni/data/data_loader.py
@@ -21,7 +21,7 @@ from torch.utils.data import Dataset, IterableDataset
 from torchdata.stateful_dataloader import StatefulDataLoader
 from torchdata.stateful_dataloader.sampler import StatefulDistributedSampler
 
-from ..distributed.parallel_state import ParallelState, get_parallel_state
+from ..distributed.parallel_state import ParallelState
 from ..utils import logging
 from ..utils.device import get_device_type
 from ..utils.registry import Registry
@@ -39,8 +39,8 @@ DATALOADER_REGISTRY = Registry("dataloader")
 logger = logging.get_logger(__name__)
 
 
-def build_dataloader(dataloader_type: str, **kwargs):
-    return DATALOADER_REGISTRY[dataloader_type](**kwargs)
+def build_dataloader(dataloader_type: str, *, parallel_state: ParallelState, **kwargs):
+    return DATALOADER_REGISTRY[dataloader_type](parallel_state=parallel_state, **kwargs)
 
 
 class DistributedDataloader(StatefulDataLoader):
@@ -69,6 +69,7 @@ def build_native_dataloader(
     dataloader_batch_size: int,
     max_seq_len: int,
     train_steps: int,
+    parallel_state: ParallelState,
     bsz_warmup_ratio: float = 0.02,
     bsz_warmup_init_mbtoken: int = 200,
     dyn_bsz: bool = True,
@@ -89,7 +90,6 @@ def build_native_dataloader(
     collate_fn_kwargs: Optional[Dict[str, Any]] = None,
     multiprocessing_context=None,
     save_steps: int = 0,
-    parallel_state: Optional[ParallelState] = None,
 ) -> "DistributedDataloader":
     """Build the native training dataloader.
 
@@ -142,8 +142,6 @@ def build_native_dataloader(
     """
     if collate_fn_kwargs is None:
         collate_fn_kwargs = {}
-    parallel_state = parallel_state or get_parallel_state()
-
     if collate_fn is None:
         if build_collate_fn:
             collate_fn = MainCollator(parallel_state=parallel_state, **collate_fn_kwargs)

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     from ..utils.hdfs_io import isdir, listdir
 
-from ..distributed.parallel_state import get_parallel_state
+from ..distributed.parallel_state import ParallelState, get_parallel_state, use_parallel_state
 from ..utils import logging
 from ..utils.constants import IGNORE_INDEX
 from ..utils.dist_utils import main_process_first
@@ -47,8 +47,9 @@ logger = logging.get_logger(__name__)
 DATASET_REGISTRY = Registry("Dataset")
 
 
-def build_dataset(dataset_name: str, **kwargs) -> "Dataset":
-    return DATASET_REGISTRY[dataset_name](**kwargs)
+def build_dataset(dataset_name: str, *, parallel_state: ParallelState, **kwargs) -> "Dataset":
+    with use_parallel_state(parallel_state):
+        return DATASET_REGISTRY[dataset_name](**kwargs)
 
 
 class MappingDataset(Dataset):

--- a/veomni/data/diffusion/data_loader.py
+++ b/veomni/data/diffusion/data_loader.py
@@ -20,7 +20,7 @@ from torchdata.stateful_dataloader.sampler import StatefulDistributedSampler
 
 from veomni.utils.device import get_device_type
 
-from ...distributed.parallel_state import get_parallel_state
+from ...distributed.parallel_state import ParallelState
 from ...utils import logging
 from ..data_collator import MainCollator, MakeMicroBatchCollator, NoopDataCollator
 from ..data_loader import DistributedDataloader
@@ -35,6 +35,7 @@ logger = logging.get_logger(__name__)
 
 def build_dit_dataloader(
     dataset: "Dataset",
+    parallel_state: ParallelState,
     micro_batch_size: int,
     global_batch_size: int,
     dataloader_batch_size: int,
@@ -50,7 +51,6 @@ def build_dit_dataloader(
     if collate_fn_kwargs is None:
         collate_fn_kwargs = {}
     # TODO: also need dyn_bsz here?
-    parallel_state = get_parallel_state()
     num_micro_batch = global_batch_size // (
         micro_batch_size * parallel_state.dp_size
     )  # num_micro_batch = num accumulation steps
@@ -63,7 +63,7 @@ def build_dit_dataloader(
     )
 
     if build_collate_fn:
-        collate_fn = MainCollator(**collate_fn_kwargs)
+        collate_fn = MainCollator(parallel_state=parallel_state, **collate_fn_kwargs)
     else:
         collate_fn = NoopDataCollator()
 

--- a/veomni/distributed/checkpoint.py
+++ b/veomni/distributed/checkpoint.py
@@ -16,6 +16,8 @@ from torch.utils.checkpoint import (
     set_device_states,
 )
 
+from .parallel_state import get_current_parallel_state, use_parallel_state
+
 
 class CheckpointFunction(torch.autograd.Function):
     @staticmethod
@@ -23,6 +25,7 @@ class CheckpointFunction(torch.autograd.Function):
         check_backward_validity(args)
         ctx.run_function = run_function
         ctx.preserve_rng_state = preserve_rng_state
+        ctx.parallel_state = get_current_parallel_state()
         # Accommodates the (remote) possibility that autocast is enabled for cpu AND gpu.
         ctx.device = _infer_device_type(*args)
         ctx.device_autocast_kwargs, ctx.cpu_autocast_kwargs = _get_autocast_kwargs(ctx.device)
@@ -112,7 +115,15 @@ class CheckpointFunction(torch.autograd.Function):
                 if torch.amp.is_autocast_available(ctx.device)
                 else contextlib.nullcontext()
             )
-            with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
+            parallel_state_ctx = (
+                use_parallel_state(ctx.parallel_state) if ctx.parallel_state is not None else contextlib.nullcontext()
+            )
+            with (
+                torch.enable_grad(),
+                device_autocast_ctx,
+                torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs),  # type: ignore[attr-defined]
+                parallel_state_ctx,
+            ):
                 outputs = ctx.run_function(*detached_inputs)
 
         if isinstance(outputs, torch.Tensor):

--- a/veomni/distributed/clip_grad_norm.py
+++ b/veomni/distributed/clip_grad_norm.py
@@ -1,16 +1,23 @@
 import torch
 
 from .fsdp2 import clip_grad_norm as fsdp2_clip_grad_norm
-from .parallel_state import get_parallel_state
+from .parallel_state import ParallelState, resolve_model_parallel_state
 
 
 def veomni_clip_grad_norm(
-    model, max_norm: float, norm_type: float = 2.0, error_if_nonfinite: bool = False, foreach: bool | None = None
+    model,
+    max_norm: float,
+    norm_type: float = 2.0,
+    error_if_nonfinite: bool = False,
+    foreach: bool | None = None,
+    parallel_state: ParallelState | None = None,
 ):
-    parallel_state = get_parallel_state()
+    parallel_state = resolve_model_parallel_state(model, parallel_state)
     dp_mode = parallel_state.dp_mode
     if dp_mode == "fsdp2":
-        grad_norm = fsdp2_clip_grad_norm(model, max_norm, norm_type, error_if_nonfinite, foreach)
+        grad_norm = fsdp2_clip_grad_norm(
+            model, max_norm, norm_type, error_if_nonfinite, foreach, parallel_state=parallel_state
+        )
     elif dp_mode == "ddp":
         grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm, foreach=foreach)
     else:

--- a/veomni/distributed/fsdp2/clip_grad_norm.py
+++ b/veomni/distributed/fsdp2/clip_grad_norm.py
@@ -9,16 +9,28 @@ from torch.utils._foreach_utils import _device_has_foreach_support, _has_foreach
 
 from ...utils.device import get_device_type
 from ...utils.logging import get_logger
-from ..parallel_state import get_parallel_state
+from ..parallel_state import ParallelState, get_parallel_state, resolve_model_parallel_state
 
 
 logger = get_logger(__name__)
 _LOCAL_NORM_CHUNK_SIZE = 128
 
 
+def _resolve_parallel_state(model, parallel_state: ParallelState | None) -> ParallelState:
+    if parallel_state is None and getattr(model, "_veomni_parallel_state", None) is None:
+        parallel_state = get_parallel_state()
+    return resolve_model_parallel_state(model, parallel_state)
+
+
 def clip_grad_norm(
-    model, max_norm: float, norm_type: float = 2.0, error_if_nonfinite: bool = False, foreach: bool | None = None
+    model,
+    max_norm: float,
+    norm_type: float = 2.0,
+    error_if_nonfinite: bool = False,
+    foreach: bool | None = None,
+    parallel_state: ParallelState | None = None,
 ) -> torch.Tensor:
+    parallel_state = _resolve_parallel_state(model, parallel_state)
     if hasattr(model, "_extra_parallel_param_groups"):
         return extra_parallel_fsdp2_clip_grad_norm(
             model,
@@ -26,6 +38,7 @@ def clip_grad_norm(
             norm_type=norm_type,
             error_if_nonfinite=error_if_nonfinite,
             foreach=foreach,
+            parallel_state=parallel_state,
         )
 
     if getattr(model, "_fsdp_cpu_offload_enabled", False):
@@ -35,6 +48,7 @@ def clip_grad_norm(
             norm_type=norm_type,
             error_if_nonfinite=error_if_nonfinite,
             foreach=foreach,
+            parallel_state=parallel_state,
         )
 
     grad_norm = torch.nn.utils.clip_grad_norm_(
@@ -67,9 +81,14 @@ def _fsdp_grad_norm_reduce_groups(ps) -> List[tuple[str, dist.ProcessGroup | Non
 
 @torch.no_grad()
 def _cpu_offload_fsdp2_clip_grad_norm(
-    model, max_norm: float, norm_type: float = 2.0, error_if_nonfinite: bool = False, foreach: bool | None = None
+    model,
+    max_norm: float,
+    norm_type: float = 2.0,
+    error_if_nonfinite: bool = False,
+    foreach: bool | None = None,
+    parallel_state: ParallelState | None = None,
 ) -> torch.Tensor:
-    ps = get_parallel_state()
+    ps = _resolve_parallel_state(model, parallel_state)
     params = [p for p in model.parameters() if p.grad is not None]
     total_norm_or_pth_sum = _fsdp2_reduce_group(
         params=params,
@@ -86,7 +105,12 @@ def _cpu_offload_fsdp2_clip_grad_norm(
 
 @torch.no_grad()
 def extra_parallel_fsdp2_clip_grad_norm(
-    model, max_norm: float, norm_type: float = 2.0, error_if_nonfinite: bool = False, foreach: bool | None = None
+    model,
+    max_norm: float,
+    norm_type: float = 2.0,
+    error_if_nonfinite: bool = False,
+    foreach: bool | None = None,
+    parallel_state: ParallelState | None = None,
 ) -> torch.Tensor:
     """
     ExtraParallel-aware gradient clipping for composable FSDP2:
@@ -98,7 +122,7 @@ def extra_parallel_fsdp2_clip_grad_norm(
     - For inf-norm: take elementwise MAX with the same reduction groups (MAX).
     - Use a single global clip coefficient for both groups.
     """
-    ps = get_parallel_state()
+    ps = _resolve_parallel_state(model, parallel_state)
     extra_parallel_group = {
         para: ps.extra_parallel_group(para) if ps.extra_parallel_enabled(para) else None
         for para in ps.extra_parallel_names

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -16,9 +16,11 @@
 # Adapted from https://github.com/pytorch/torchtitan/blob/main/torchtitan/distributed/parallel_dims.py
 
 import os
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from functools import cached_property, wraps
-from typing import TYPE_CHECKING, Callable, Dict, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, Literal, Optional, Tuple
 
 from torch import distributed as dist
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
@@ -34,7 +36,35 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 
-_PARALLEL_STATE: "ParallelState" = None
+# Backward-compatible default for code paths that have not been migrated to a
+# model-owned state yet. It is deliberately not mutated when additional models
+# build their own parallel states.
+_PARALLEL_STATE: Optional["ParallelState"] = None
+
+# The active value is execution-context-local and is only a compatibility bridge
+# for modeling code that still calls ``get_parallel_state()``. The source of
+# truth is the state bound to the model being built or executed.
+_CURRENT_PARALLEL_STATE: ContextVar[Optional["ParallelState"]] = ContextVar(
+    "veomni_current_parallel_state", default=None
+)
+
+_MODEL_PARALLEL_STATE_ATTR = "_veomni_parallel_state"
+
+# Process-group creation is collective and expensive. States with identical
+# topologies share their meshes within one default-process-group lifetime.
+_PARALLEL_STATE_CACHE: Dict[tuple, "ParallelState"] = {}
+_PARALLEL_STATE_CACHE_PROCESS_GROUP: Any = None
+_PARALLEL_STATE_CACHE_SESSION = object()
+
+
+def _parallel_state_cache_session():
+    """Return an identity token for the current default-process-group lifetime."""
+    global _PARALLEL_STATE_CACHE_PROCESS_GROUP, _PARALLEL_STATE_CACHE_SESSION
+    default_group = dist.group.WORLD if dist.is_initialized() else None
+    if default_group is not _PARALLEL_STATE_CACHE_PROCESS_GROUP:
+        _PARALLEL_STATE_CACHE_PROCESS_GROUP = default_group
+        _PARALLEL_STATE_CACHE_SESSION = object()
+    return _PARALLEL_STATE_CACHE_SESSION
 
 
 def requires_mesh(fn: Callable) -> Callable:
@@ -81,30 +111,11 @@ class ParallelState:
                 f"The product of dp_replicate_size: {self.dp_replicate_size} and dp_shard_size: {self.dp_shard_size} should be equal to dp_size: {self.dp_size}."
             )
 
-        if self.sp_enabled:
-            from ..distributed.sequence_parallel import (
-                init_sequence_parallel,
-                set_context_parallel_group,
-                set_data_parallel_group,
-                set_ulysses_sequence_parallel_group,
-                set_unified_sequence_parallel_group,
+        if self.sp_enabled and self.device_mesh is None:
+            raise ValueError(
+                "A sequence-parallel ParallelState must be built with a device mesh "
+                "through build_parallel_state() or init_parallel_state()."
             )
-
-            if self.device_mesh is not None:
-                set_data_parallel_group(self.device_mesh.get_group("dp"))
-                if self.ulysses_size > 1:
-                    set_ulysses_sequence_parallel_group(self.device_mesh.get_group("ulysses"))
-                if self.cp_size > 1:
-                    set_context_parallel_group(self.device_mesh.get_group("cp"))
-                # set unified sequence parallel group
-                set_unified_sequence_parallel_group(self.device_mesh.get_group("sp"))
-            else:
-                init_sequence_parallel(
-                    ulysses_size=self.ulysses_size,
-                    sep_dp=True,
-                    ulysses_group_key="default",
-                    cp_size=self.cp_size,
-                )
 
     @property
     def is_initialized(self) -> bool:
@@ -131,23 +142,12 @@ class ParallelState:
     def dp_group(self) -> Optional["ProcessGroup"]:
         if self.device_mesh is not None:
             return self.device_mesh.get_group("dp")
-
-        if self.sp_enabled:
-            from ..distributed.sequence_parallel import get_data_parallel_group
-
-            return get_data_parallel_group()
-
-        return self.fsdp_group
+        return None
 
     @property
     def dp_rank(self) -> int:
         if self.device_mesh is not None:
             return self.device_mesh.get_local_rank("dp")
-
-        if self.sp_enabled:
-            from ..distributed.sequence_parallel import get_data_parallel_rank
-
-            return get_data_parallel_rank()
 
         return self.fsdp_rank
 
@@ -375,26 +375,14 @@ class ParallelState:
     # ------------------------------ SP ------------------------------ #
     @property
     def sp_group(self) -> Optional["ProcessGroup"]:
-        if self.device_mesh is not None:
+        if self.device_mesh is not None and self.sp_enabled:
             return self.device_mesh.get_group("sp")
-
-        if self.sp_enabled:
-            from .sequence_parallel import get_unified_sequence_parallel_group
-
-            return get_unified_sequence_parallel_group()
-
         return None
 
     @property
     def sp_rank(self) -> int:
-        if self.device_mesh is not None:
+        if self.device_mesh is not None and self.sp_enabled:
             return self.device_mesh.get_local_rank("sp")
-
-        if self.sp_enabled:
-            from .sequence_parallel import get_unified_sequence_parallel_rank
-
-            return get_unified_sequence_parallel_rank()
-
         return -1
 
     @property
@@ -407,26 +395,14 @@ class ParallelState:
 
     @property
     def ulysses_group(self) -> Optional["ProcessGroup"]:
-        if self.device_mesh is not None:
+        if self.device_mesh is not None and self.ulysses_enabled:
             return self.device_mesh.get_group("ulysses")
-
-        if self.sp_enabled:
-            from .sequence_parallel import get_ulysses_sequence_parallel_group
-
-            return get_ulysses_sequence_parallel_group()
-
         return None
 
     @property
     def ulysses_rank(self) -> int:
-        if self.device_mesh is not None:
+        if self.device_mesh is not None and self.ulysses_enabled:
             return self.device_mesh.get_local_rank("ulysses")
-
-        if self.sp_enabled:
-            from .sequence_parallel import get_ulysses_sequence_parallel_rank
-
-            return get_ulysses_sequence_parallel_rank()
-
         return -1
 
     @property
@@ -435,26 +411,14 @@ class ParallelState:
 
     @property
     def cp_group(self) -> Optional["ProcessGroup"]:
-        if self.device_mesh is not None:
+        if self.device_mesh is not None and self.cp_enabled:
             return self.device_mesh.get_group("cp")
-
-        if self.sp_enabled:
-            from .sequence_parallel import get_context_parallel_group
-
-            return get_context_parallel_group()
-
         return None
 
     @property
     def cp_rank(self) -> int:
-        if self.device_mesh is not None:
+        if self.device_mesh is not None and self.cp_enabled:
             return self.device_mesh.get_local_rank("cp")
-
-        if self.sp_enabled:
-            from .sequence_parallel import get_context_parallel_rank
-
-            return get_context_parallel_rank()
-
         return -1
 
     @property
@@ -462,7 +426,7 @@ class ParallelState:
         return self.cp_size > 1
 
 
-def init_parallel_state(
+def build_parallel_state(
     dp_size: int = 1,
     dp_replicate_size: int = 1,
     dp_shard_size: int = 1,
@@ -477,15 +441,14 @@ def init_parallel_state(
     extra_parallel_placement_innermost: Tuple[bool] = (False,),
     extra_parallel_names: Tuple[str] = ("ep",),
     async_enabled: Optional[bool] = False,
-) -> None:
+) -> "ParallelState":
     """
-    Initializes global parallel state.
-    """
-    global _PARALLEL_STATE
-    if _PARALLEL_STATE is not None:
-        logger.warning("Parallel state has already been initialized.")
-        return
+    Build or reuse a parallel state without changing the default state.
 
+    All ranks must request topologies in the same order because creating device
+    meshes is collective. Cache entries are scoped to the current default
+    process group so distributed teardown cannot leave reusable stale groups.
+    """
     if device_type is None:
         device_type = get_device_type()
 
@@ -493,10 +456,35 @@ def init_parallel_state(
     if dp_size > 1 and dp_shard_size == 1 and dp_replicate_size == 1:
         dp_shard_size = dp_size
 
+    extra_parallel_sizes = tuple(extra_parallel_sizes)
+    extra_parallel_placement_innermost = tuple(extra_parallel_placement_innermost)
+    extra_parallel_names = tuple(extra_parallel_names)
+
     # Note that Expert Parallel is included into Extra Parallel
     assert len(extra_parallel_sizes) == len(extra_parallel_placement_innermost) == len(extra_parallel_names), (
         "each extra parallel should correspond to a size, a placement and a name"
     )
+
+    cache_key = (
+        _parallel_state_cache_session(),
+        dp_size,
+        dp_replicate_size,
+        dp_shard_size,
+        tp_size,
+        pp_size,
+        cp_size,
+        ulysses_size,
+        dp_mode,
+        device_type,
+        include_sp_in_fsdp,
+        extra_parallel_sizes,
+        extra_parallel_placement_innermost,
+        extra_parallel_names,
+        async_enabled,
+    )
+    if cached_state := _PARALLEL_STATE_CACHE.get(cache_key):
+        logger.info_rank0("Reusing parallel state for an identical topology.")
+        return cached_state
 
     logger.info_rank0(
         f"Initializing parallel state: dp_size {dp_size}, dp_replicate_size {dp_replicate_size}, "
@@ -601,7 +589,7 @@ def init_parallel_state(
     for para_name in extra_parallel_names:
         logger.info_rank0(f"{para_name} FSDP device mesh: {extra_parallel_fsdp_device_mesh[para_name]}")
 
-    _PARALLEL_STATE = ParallelState(
+    parallel_state = ParallelState(
         dp_size=dp_size,
         dp_replicate_size=dp_replicate_size,
         dp_shard_size=dp_shard_size,
@@ -619,13 +607,115 @@ def init_parallel_state(
         async_enabled=async_enabled,
     )
 
+    _PARALLEL_STATE_CACHE[cache_key] = parallel_state
+    return parallel_state
+
+
+def init_parallel_state(
+    dp_size: int = 1,
+    dp_replicate_size: int = 1,
+    dp_shard_size: int = 1,
+    tp_size: int = 1,
+    pp_size: int = 1,
+    cp_size: int = 1,
+    ulysses_size: int = 1,
+    dp_mode: Literal["ddp", "fsdp2"] = "fsdp2",
+    device_type: str = None,
+    include_sp_in_fsdp: bool = True,
+    extra_parallel_sizes: Tuple[int] = (1,),
+    extra_parallel_placement_innermost: Tuple[bool] = (False,),
+    extra_parallel_names: Tuple[str] = ("ep",),
+    async_enabled: Optional[bool] = False,
+) -> "ParallelState":
+    """Build a state and install it as the legacy default on first use."""
+    global _PARALLEL_STATE
+    parallel_state = build_parallel_state(
+        dp_size=dp_size,
+        dp_replicate_size=dp_replicate_size,
+        dp_shard_size=dp_shard_size,
+        tp_size=tp_size,
+        pp_size=pp_size,
+        cp_size=cp_size,
+        ulysses_size=ulysses_size,
+        dp_mode=dp_mode,
+        device_type=device_type,
+        include_sp_in_fsdp=include_sp_in_fsdp,
+        extra_parallel_sizes=extra_parallel_sizes,
+        extra_parallel_placement_innermost=extra_parallel_placement_innermost,
+        extra_parallel_names=extra_parallel_names,
+        async_enabled=async_enabled,
+    )
+    if _PARALLEL_STATE is None:
+        _PARALLEL_STATE = parallel_state
+    return parallel_state
+
+
+def clear_parallel_state_cache() -> None:
+    """Clear cached meshes after the default distributed process group ends."""
+    global _PARALLEL_STATE, _PARALLEL_STATE_CACHE_PROCESS_GROUP, _PARALLEL_STATE_CACHE_SESSION
+    _PARALLEL_STATE = None
+    _PARALLEL_STATE_CACHE_PROCESS_GROUP = None
+    _PARALLEL_STATE_CACHE_SESSION = object()
+    _CURRENT_PARALLEL_STATE.set(None)
+    _PARALLEL_STATE_CACHE.clear()
+
+
+@contextmanager
+def use_parallel_state(parallel_state: "ParallelState") -> Iterator["ParallelState"]:
+    """Expose a model-owned state to legacy modeling code in this context."""
+    token = _CURRENT_PARALLEL_STATE.set(parallel_state)
+    try:
+        yield parallel_state
+    finally:
+        _CURRENT_PARALLEL_STATE.reset(token)
+
+
+def bind_model_parallel_state(model: Any, parallel_state: "ParallelState") -> Any:
+    """Bind a non-serialized parallel-state reference to a model."""
+    setattr(model, _MODEL_PARALLEL_STATE_ATTR, parallel_state)
+    return model
+
+
+def get_model_parallel_state(model: Any) -> "ParallelState":
+    """Return the state owned by ``model`` or raise when it is unbound."""
+    parallel_state = getattr(model, _MODEL_PARALLEL_STATE_ATTR, None)
+    if parallel_state is None:
+        raise ValueError(
+            "The model has no bound ParallelState. Pass parallel_state to build_parallelize_model() "
+            "or call bind_model_parallel_state() first."
+        )
+    return parallel_state
+
+
+def resolve_model_parallel_state(model: Any, parallel_state: Optional["ParallelState"] = None) -> "ParallelState":
+    """Resolve an explicit state, then a model-owned state, then legacy context."""
+    if parallel_state is not None:
+        return parallel_state
+    if (model_state := getattr(model, _MODEL_PARALLEL_STATE_ATTR, None)) is not None:
+        return model_state
+    return get_parallel_state()
+
+
+@contextmanager
+def use_model_parallel_state(model: Any) -> Iterator["ParallelState"]:
+    """Run legacy modeling code under the state owned by ``model``."""
+    with use_parallel_state(get_model_parallel_state(model)) as parallel_state:
+        yield parallel_state
+
 
 def get_parallel_state() -> "ParallelState":
     """
-    Returns global parallel state.
+    Return the current model-owned state, falling back to the legacy default.
     """
+    if (parallel_state := _CURRENT_PARALLEL_STATE.get()) is not None:
+        return parallel_state
     if _PARALLEL_STATE is None:
         logger.warning_once("Parallel state has not been initialized. returning default Single-process state.")
         return ParallelState()
 
     return _PARALLEL_STATE
+
+
+def get_current_parallel_state() -> Optional["ParallelState"]:
+    """Return the state active in this execution context, without fallback."""
+    return _CURRENT_PARALLEL_STATE.get()

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from functools import cached_property, wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, Literal, Optional, Tuple
 
+import torch
 from torch import distributed as dist
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
@@ -36,14 +37,8 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 
-# Backward-compatible default for code paths that have not been migrated to a
-# model-owned state yet. It is deliberately not mutated when additional models
-# build their own parallel states.
-_PARALLEL_STATE: Optional["ParallelState"] = None
-
-# The active value is execution-context-local and is only a compatibility bridge
-# for modeling code that still calls ``get_parallel_state()``. The source of
-# truth is the state bound to the model being built or executed.
+# The active value is execution-context-local. The source of truth is the state
+# bound to the model being built or executed; there is no process-global default.
 _CURRENT_PARALLEL_STATE: ContextVar[Optional["ParallelState"]] = ContextVar(
     "veomni_current_parallel_state", default=None
 )
@@ -113,8 +108,7 @@ class ParallelState:
 
         if self.sp_enabled and self.device_mesh is None:
             raise ValueError(
-                "A sequence-parallel ParallelState must be built with a device mesh "
-                "through build_parallel_state() or init_parallel_state()."
+                "A sequence-parallel ParallelState must be built with a device mesh through build_parallel_state()."
             )
 
     @property
@@ -611,49 +605,9 @@ def build_parallel_state(
     return parallel_state
 
 
-def init_parallel_state(
-    dp_size: int = 1,
-    dp_replicate_size: int = 1,
-    dp_shard_size: int = 1,
-    tp_size: int = 1,
-    pp_size: int = 1,
-    cp_size: int = 1,
-    ulysses_size: int = 1,
-    dp_mode: Literal["ddp", "fsdp2"] = "fsdp2",
-    device_type: str = None,
-    include_sp_in_fsdp: bool = True,
-    extra_parallel_sizes: Tuple[int] = (1,),
-    extra_parallel_placement_innermost: Tuple[bool] = (False,),
-    extra_parallel_names: Tuple[str] = ("ep",),
-    async_enabled: Optional[bool] = False,
-) -> "ParallelState":
-    """Build a state and install it as the legacy default on first use."""
-    global _PARALLEL_STATE
-    parallel_state = build_parallel_state(
-        dp_size=dp_size,
-        dp_replicate_size=dp_replicate_size,
-        dp_shard_size=dp_shard_size,
-        tp_size=tp_size,
-        pp_size=pp_size,
-        cp_size=cp_size,
-        ulysses_size=ulysses_size,
-        dp_mode=dp_mode,
-        device_type=device_type,
-        include_sp_in_fsdp=include_sp_in_fsdp,
-        extra_parallel_sizes=extra_parallel_sizes,
-        extra_parallel_placement_innermost=extra_parallel_placement_innermost,
-        extra_parallel_names=extra_parallel_names,
-        async_enabled=async_enabled,
-    )
-    if _PARALLEL_STATE is None:
-        _PARALLEL_STATE = parallel_state
-    return parallel_state
-
-
 def clear_parallel_state_cache() -> None:
     """Clear cached meshes after the default distributed process group ends."""
-    global _PARALLEL_STATE, _PARALLEL_STATE_CACHE_PROCESS_GROUP, _PARALLEL_STATE_CACHE_SESSION
-    _PARALLEL_STATE = None
+    global _PARALLEL_STATE_CACHE_PROCESS_GROUP, _PARALLEL_STATE_CACHE_SESSION
     _PARALLEL_STATE_CACHE_PROCESS_GROUP = None
     _PARALLEL_STATE_CACHE_SESSION = object()
     _CURRENT_PARALLEL_STATE.set(None)
@@ -662,7 +616,7 @@ def clear_parallel_state_cache() -> None:
 
 @contextmanager
 def use_parallel_state(parallel_state: "ParallelState") -> Iterator["ParallelState"]:
-    """Expose a model-owned state to legacy modeling code in this context."""
+    """Activate a state for explicit model construction or execution."""
     token = _CURRENT_PARALLEL_STATE.set(parallel_state)
     try:
         yield parallel_state
@@ -671,8 +625,18 @@ def use_parallel_state(parallel_state: "ParallelState") -> Iterator["ParallelSta
 
 
 def bind_model_parallel_state(model: Any, parallel_state: "ParallelState") -> Any:
-    """Bind a non-serialized parallel-state reference to a model."""
+    """Bind state to a model and make every root forward activate that state."""
     setattr(model, _MODEL_PARALLEL_STATE_ATTR, parallel_state)
+    original_forward = getattr(model, "forward", None)
+    if callable(original_forward) and not getattr(model, "_veomni_parallel_forward_wrapped", False):
+
+        @wraps(original_forward)
+        def model_owned_forward(*args, **kwargs):
+            with use_parallel_state(get_model_parallel_state(model)):
+                return original_forward(*args, **kwargs)
+
+        model.forward = model_owned_forward
+        model._veomni_parallel_forward_wrapped = True
     return model
 
 
@@ -688,7 +652,7 @@ def get_model_parallel_state(model: Any) -> "ParallelState":
 
 
 def resolve_model_parallel_state(model: Any, parallel_state: Optional["ParallelState"] = None) -> "ParallelState":
-    """Resolve an explicit state, then a model-owned state, then legacy context."""
+    """Resolve an explicit state, then a model-owned or active build state."""
     if parallel_state is not None:
         return parallel_state
     if (model_state := getattr(model, _MODEL_PARALLEL_STATE_ATTR, None)) is not None:
@@ -698,24 +662,23 @@ def resolve_model_parallel_state(model: Any, parallel_state: Optional["ParallelS
 
 @contextmanager
 def use_model_parallel_state(model: Any) -> Iterator["ParallelState"]:
-    """Run legacy modeling code under the state owned by ``model``."""
+    """Run modeling code under the state owned by ``model``."""
     with use_parallel_state(get_model_parallel_state(model)) as parallel_state:
         yield parallel_state
 
 
+@torch.compiler.assume_constant_result
 def get_parallel_state() -> "ParallelState":
-    """
-    Return the current model-owned state, falling back to the legacy default.
-    """
+    """Return the state active in this explicit build/model execution context."""
     if (parallel_state := _CURRENT_PARALLEL_STATE.get()) is not None:
         return parallel_state
-    if _PARALLEL_STATE is None:
-        logger.warning_once("Parallel state has not been initialized. returning default Single-process state.")
-        return ParallelState()
+    raise RuntimeError(
+        "No ParallelState is active. Build one with build_parallel_state(), bind it to the model, "
+        "and use use_parallel_state() for pre-model build code."
+    )
 
-    return _PARALLEL_STATE
 
-
+@torch.compiler.assume_constant_result
 def get_current_parallel_state() -> Optional["ParallelState"]:
     """Return the state active in this execution context, without fallback."""
     return _CURRENT_PARALLEL_STATE.get()

--- a/veomni/distributed/sequence_parallel/__init__.py
+++ b/veomni/distributed/sequence_parallel/__init__.py
@@ -31,11 +31,7 @@ from .comm import (
     get_unified_sequence_parallel_group,
     get_unified_sequence_parallel_rank,
     get_unified_sequence_parallel_world_size,
-    init_sequence_parallel,
-    set_context_parallel_group,
-    set_data_parallel_group,
     set_ulysses_sequence_parallel_group,
-    set_unified_sequence_parallel_group,
 )
 from .data import (
     gather_outputs,
@@ -54,19 +50,15 @@ from .utils import pad_tensor, unpad_tensor, vlm_images_a2a_meta
 
 
 __all__ = [
-    "init_sequence_parallel",
-    "set_data_parallel_group",
     "get_data_parallel_group",
     "get_data_parallel_rank",
     "set_ulysses_sequence_parallel_group",
     "get_ulysses_sequence_parallel_world_size",
     "get_ulysses_sequence_parallel_rank",
     "get_ulysses_sequence_parallel_group",
-    "set_context_parallel_group",
     "get_context_parallel_group",
     "get_context_parallel_rank",
     "get_context_parallel_world_size",
-    "set_unified_sequence_parallel_group",
     "get_unified_sequence_parallel_group",
     "get_unified_sequence_parallel_rank",
     "get_unified_sequence_parallel_world_size",

--- a/veomni/distributed/sequence_parallel/comm.py
+++ b/veomni/distributed/sequence_parallel/comm.py
@@ -32,6 +32,21 @@ _UNIFIED_SEQUENCE_PARALLEL_GROUP = None
 _UNIFIED_SEQUENCE_PARALLEL_CPU_GROUP = None
 
 
+def _current_parallel_state():
+    # Lazy import avoids the parallel_state -> sequence_parallel import cycle.
+    # Production groups resolve from the model-owned state; the globals below
+    # remain only for legacy meshless initialization and unit-test injection.
+    from ..parallel_state import get_current_parallel_state
+
+    return get_current_parallel_state()
+
+
+def _fallback_parallel_state():
+    from ..parallel_state import get_parallel_state
+
+    return get_parallel_state()
+
+
 # ------------------------------ Data Parallel ------------------------------ #
 def set_data_parallel_group(group: dist.ProcessGroup):
     """
@@ -45,8 +60,12 @@ def get_data_parallel_group() -> Optional[dist.ProcessGroup]:
     """
     Get data parallel process group.
     """
-    global _DATA_PARALLEL_GROUP
-    return _DATA_PARALLEL_GROUP
+    current_state = _current_parallel_state()
+    if current_state is not None:
+        return current_state.dp_group
+    if _DATA_PARALLEL_GROUP is not None:
+        return _DATA_PARALLEL_GROUP
+    return _fallback_parallel_state().dp_group
 
 
 def get_data_parallel_rank() -> Optional[dist.ProcessGroup]:
@@ -106,7 +125,12 @@ def get_ulysses_sequence_parallel_group() -> Optional[dist.ProcessGroup]:
     group_key = get_ulysses_sequence_parallel_group_key()
     if group_key not in _ULYSSES_SEQUENCE_PARALLEL_GROUP:
         raise RuntimeError(f"Unknown key {group_key} in Ulysses sequence parallel group!")
-    return _ULYSSES_SEQUENCE_PARALLEL_GROUP[group_key]
+    current_state = _current_parallel_state()
+    if current_state is not None:
+        return current_state.ulysses_group
+    if (group := _ULYSSES_SEQUENCE_PARALLEL_GROUP[group_key]) is not None:
+        return group
+    return _fallback_parallel_state().ulysses_group
 
 
 def get_ulysses_sequence_parallel_cpu_group() -> Optional[dist.ProcessGroup]:
@@ -170,9 +194,16 @@ def set_context_parallel_group(cp_group: dist.ProcessGroup):
 def get_context_parallel_group(check_initialized=True):
     """Get the context parallel group the caller rank belongs to."""
     global _CONTEXT_PARALLEL_GROUP
+    current_state = _current_parallel_state()
+    if current_state is not None:
+        group = current_state.cp_group
+    elif _CONTEXT_PARALLEL_GROUP is not None:
+        group = _CONTEXT_PARALLEL_GROUP
+    else:
+        group = _fallback_parallel_state().cp_group
     if check_initialized:
-        assert _CONTEXT_PARALLEL_GROUP is not None, "context parallel group is not initialized"
-    return _CONTEXT_PARALLEL_GROUP
+        assert group is not None, "context parallel group is not initialized"
+    return group
 
 
 def get_context_parallel_rank():
@@ -213,8 +244,12 @@ def get_unified_sequence_parallel_group() -> Optional[dist.ProcessGroup]:
     """
     Get unified sequence parallel process group.
     """
-    global _UNIFIED_SEQUENCE_PARALLEL_GROUP
-    return _UNIFIED_SEQUENCE_PARALLEL_GROUP
+    current_state = _current_parallel_state()
+    if current_state is not None:
+        return current_state.sp_group
+    if _UNIFIED_SEQUENCE_PARALLEL_GROUP is not None:
+        return _UNIFIED_SEQUENCE_PARALLEL_GROUP
+    return _fallback_parallel_state().sp_group
 
 
 def get_unified_sequence_parallel_cpu_group() -> Optional[dist.ProcessGroup]:
@@ -336,7 +371,7 @@ def is_context_parallel_initialized() -> bool:
     """
     Check if ulysses sequence parallel is initialized.
     """
-    return get_context_parallel_group() is not None
+    return get_context_parallel_group(check_initialized=False) is not None
 
 
 def get_ulysses_group_key_context(group_key: str = "default"):

--- a/veomni/distributed/sequence_parallel/comm.py
+++ b/veomni/distributed/sequence_parallel/comm.py
@@ -12,373 +12,115 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from contextlib import nullcontext
-from typing import Any, Optional
+from contextvars import ContextVar
+from typing import Optional
 
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
 
-_DATA_PARALLEL_GROUP = None
-
-_ULYSSES_SEQUENCE_PARALLEL_GROUP = {"default": None}
-_ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP = {"default": None}
-_ULYSSES_GROUP_KEY = "default"
-
-_CONTEXT_PARALLEL_GROUP = None
-
-_UNIFIED_SEQUENCE_PARALLEL_GROUP = None
-_UNIFIED_SEQUENCE_PARALLEL_CPU_GROUP = None
+# Tests that exercise the communication primitives without constructing a
+# model may inject a Ulysses group. Production always resolves groups from the
+# ParallelState active for the model forward.
+_UNSET_TEST_GROUP = object()
+_ULYSSES_SP_GROUP_OVERRIDE: ContextVar[object] = ContextVar("veomni_ulysses_test_group", default=_UNSET_TEST_GROUP)
 
 
 def _current_parallel_state():
     # Lazy import avoids the parallel_state -> sequence_parallel import cycle.
-    # Production groups resolve from the model-owned state; the globals below
-    # remain only for legacy meshless initialization and unit-test injection.
     from ..parallel_state import get_current_parallel_state
 
     return get_current_parallel_state()
 
 
-def _fallback_parallel_state():
-    from ..parallel_state import get_parallel_state
-
-    return get_parallel_state()
-
-
-# ------------------------------ Data Parallel ------------------------------ #
-def set_data_parallel_group(group: dist.ProcessGroup):
-    """
-    Set data parallel process group.
-    """
-    global _DATA_PARALLEL_GROUP
-    _DATA_PARALLEL_GROUP = group
+def _active_group(name: str) -> Optional[ProcessGroup]:
+    state = _current_parallel_state()
+    if state is None:
+        raise RuntimeError(f"Cannot resolve {name} without an active model-owned ParallelState.")
+    return getattr(state, name, None)
 
 
-def get_data_parallel_group() -> Optional[dist.ProcessGroup]:
-    """
-    Get data parallel process group.
-    """
-    current_state = _current_parallel_state()
-    if current_state is not None:
-        return current_state.dp_group
-    if _DATA_PARALLEL_GROUP is not None:
-        return _DATA_PARALLEL_GROUP
-    return _fallback_parallel_state().dp_group
+def get_data_parallel_group() -> Optional[ProcessGroup]:
+    return _active_group("dp_group")
 
 
-def get_data_parallel_rank() -> Optional[dist.ProcessGroup]:
-    """
-    Get data parallel rank.
-    """
+def get_data_parallel_rank() -> int:
     group = get_data_parallel_group()
-    return dist.get_rank(group)
+    return dist.get_rank(group) if group is not None else 0
 
 
-def get_data_parallel_world_size() -> Optional[dist.ProcessGroup]:
-    """
-    Get data parallel world_size.
-    """
+def get_data_parallel_world_size() -> int:
     group = get_data_parallel_group()
-    return dist.get_world_size(group)
+    return dist.get_world_size(group) if group is not None else 1
 
 
-# ----------------------------- Ulysses Parallel ---------------------------- #
-def set_ulysses_sequence_parallel_group(group: dist.ProcessGroup, group_key: str = "default"):
-    """
-    Set ulysses sequence parallel process group.
-    """
-    global _ULYSSES_SEQUENCE_PARALLEL_GROUP
-    _ULYSSES_SEQUENCE_PARALLEL_GROUP[group_key] = group
+def set_ulysses_sequence_parallel_group(group: Optional[ProcessGroup]) -> None:
+    """Install the group used by standalone communication unit tests."""
+    _ULYSSES_SP_GROUP_OVERRIDE.set(group)
 
 
-def set_ulysses_sequence_parallel_cpu_group(group: dist.ProcessGroup, group_key: str = "default"):
-    """
-    Set ulysses sequence parallel process group.
-    """
-    global _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP
-    _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP[group_key] = group
+def get_ulysses_sequence_parallel_group() -> Optional[ProcessGroup]:
+    state = _current_parallel_state()
+    if state is not None:
+        return state.ulysses_group
+    test_group = _ULYSSES_SP_GROUP_OVERRIDE.get()
+    if test_group is _UNSET_TEST_GROUP:
+        raise RuntimeError("Cannot resolve ulysses_group without an active model-owned ParallelState.")
+    return test_group
 
 
-def set_ulysses_sequence_parallel_group_key(group_key: str = "default"):
-    """
-    Set ulysses sequence parallel process group key.
-    """
-    global _ULYSSES_GROUP_KEY
-    _ULYSSES_GROUP_KEY = group_key
+def get_ulysses_sequence_parallel_cpu_group() -> Optional[ProcessGroup]:
+    return _active_group("ulysses_cpu_group")
 
 
-def get_ulysses_sequence_parallel_group_key() -> str:
-    """
-    Get ulysses sequence parallel group key.
-    """
-    global _ULYSSES_GROUP_KEY
-    return _ULYSSES_GROUP_KEY
-
-
-def get_ulysses_sequence_parallel_group() -> Optional[dist.ProcessGroup]:
-    """
-    Get ulysses sequence parallel process group.
-    """
-    global _ULYSSES_SEQUENCE_PARALLEL_GROUP
-    group_key = get_ulysses_sequence_parallel_group_key()
-    if group_key not in _ULYSSES_SEQUENCE_PARALLEL_GROUP:
-        raise RuntimeError(f"Unknown key {group_key} in Ulysses sequence parallel group!")
-    current_state = _current_parallel_state()
-    if current_state is not None:
-        return current_state.ulysses_group
-    if (group := _ULYSSES_SEQUENCE_PARALLEL_GROUP[group_key]) is not None:
-        return group
-    return _fallback_parallel_state().ulysses_group
-
-
-def get_ulysses_sequence_parallel_cpu_group() -> Optional[dist.ProcessGroup]:
-    """
-    Get ulysses sequence parallel CPU process group.
-    """
-    global _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP
-    group_key = get_ulysses_sequence_parallel_group_key()
-    if group_key not in _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP:
-        raise RuntimeError(f"Unknown key {group_key} in Ulysses sequence parallel group!")
-    return _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP[group_key]
-
-
-def get_ulysses_sequence_parallel_group_by_key(group_key: str = "default") -> Optional[dist.ProcessGroup]:
-    """
-    Get ulysses sequence parallel process group.
-    """
-    global _ULYSSES_SEQUENCE_PARALLEL_GROUP
-    if group_key not in _ULYSSES_SEQUENCE_PARALLEL_GROUP:
-        raise RuntimeError(f"Unknown key {group_key} in Ulysses sequence parallel group!")
-    return _ULYSSES_SEQUENCE_PARALLEL_GROUP[group_key]
-
-
-def get_ulysses_sequence_parallel_cpu_group_by_key(group_key: str = "default") -> Optional[dist.ProcessGroup]:
-    """
-    Get ulysses sequence parallel CPU process group.
-    """
-    global _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP
-    if group_key not in _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP:
-        raise RuntimeError(f"Unknown key {group_key} in Ulysses sequence parallel group!")
-    return _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP[group_key]
-
-
-def get_ulysses_sequence_parallel_rank(group: ProcessGroup = None) -> int:
-    """
-    Get ulysses sequence parallel rank.
-    """
+def get_ulysses_sequence_parallel_rank(group: Optional[ProcessGroup] = None) -> int:
     group = get_ulysses_sequence_parallel_group() if group is None else group
-    return dist.get_rank(group) if group else 0
+    return dist.get_rank(group) if group is not None else 0
 
 
-def get_ulysses_sequence_parallel_world_size(group: ProcessGroup = None) -> int:
-    """
-    Get ulysses sequence parallel world size.
-    """
+def get_ulysses_sequence_parallel_world_size(group: Optional[ProcessGroup] = None) -> int:
     group = get_ulysses_sequence_parallel_group() if group is None else group
-    return dist.get_world_size(group) if group else 1
+    return dist.get_world_size(group) if group is not None else 1
 
 
-# ----------------------------- Context Parallel ---------------------------- #
-
-
-def set_context_parallel_group(cp_group: dist.ProcessGroup):
-    """
-    Set context parallel process group.
-    """
-    global _CONTEXT_PARALLEL_GROUP
-    _CONTEXT_PARALLEL_GROUP = cp_group
-
-
-def get_context_parallel_group(check_initialized=True):
-    """Get the context parallel group the caller rank belongs to."""
-    global _CONTEXT_PARALLEL_GROUP
-    current_state = _current_parallel_state()
-    if current_state is not None:
-        group = current_state.cp_group
-    elif _CONTEXT_PARALLEL_GROUP is not None:
-        group = _CONTEXT_PARALLEL_GROUP
-    else:
-        group = _fallback_parallel_state().cp_group
+def get_context_parallel_group(check_initialized: bool = True) -> Optional[ProcessGroup]:
+    group = _active_group("cp_group")
     if check_initialized:
         assert group is not None, "context parallel group is not initialized"
     return group
 
 
-def get_context_parallel_rank():
-    """Return my rank for the context parallel group."""
-
-    if dist.is_available() and dist.is_initialized():
-        return dist.get_rank(group=get_context_parallel_group())
-    else:
-        return 0
+def get_context_parallel_rank() -> int:
+    group = get_context_parallel_group(check_initialized=False)
+    return dist.get_rank(group) if group is not None else 0
 
 
-def get_context_parallel_world_size():
-    """Return world size for the context parallel group."""
-    if dist.is_available() and dist.is_initialized():
-        return dist.get_world_size(group=get_context_parallel_group())
-    else:
-        return 0
+def get_context_parallel_world_size() -> int:
+    group = get_context_parallel_group(check_initialized=False)
+    return dist.get_world_size(group) if group is not None else 1
 
 
-# ----------------------------- Unified Parallel ---------------------------- #
-def set_unified_sequence_parallel_group(group: dist.ProcessGroup):
-    """
-    Set unified sequence parallel process group.
-    """
-    global _UNIFIED_SEQUENCE_PARALLEL_GROUP
-    _UNIFIED_SEQUENCE_PARALLEL_GROUP = group
+def get_unified_sequence_parallel_group() -> Optional[ProcessGroup]:
+    return _active_group("sp_group")
 
 
-def set_unified_sequence_parallel_cpu_group(group: dist.ProcessGroup):
-    """
-    Set unified sequence parallel process group.
-    """
-    global _UNIFIED_SEQUENCE_PARALLEL_CPU_GROUP
-    _UNIFIED_SEQUENCE_PARALLEL_CPU_GROUP = group
-
-
-def get_unified_sequence_parallel_group() -> Optional[dist.ProcessGroup]:
-    """
-    Get unified sequence parallel process group.
-    """
-    current_state = _current_parallel_state()
-    if current_state is not None:
-        return current_state.sp_group
-    if _UNIFIED_SEQUENCE_PARALLEL_GROUP is not None:
-        return _UNIFIED_SEQUENCE_PARALLEL_GROUP
-    return _fallback_parallel_state().sp_group
-
-
-def get_unified_sequence_parallel_cpu_group() -> Optional[dist.ProcessGroup]:
-    """
-    Get unified sequence parallel CPU process group.
-    """
-    global _UNIFIED_SEQUENCE_PARALLEL_CPU_GROUP
-    return _UNIFIED_SEQUENCE_PARALLEL_CPU_GROUP
+def get_unified_sequence_parallel_cpu_group() -> Optional[ProcessGroup]:
+    return _active_group("sp_cpu_group")
 
 
 def get_unified_sequence_parallel_rank() -> int:
-    """
-    Get unified sequence parallel rank.
-    """
     group = get_unified_sequence_parallel_group()
-    return dist.get_rank(group) if group else 0
+    return dist.get_rank(group) if group is not None else 0
 
 
 def get_unified_sequence_parallel_world_size() -> int:
-    """
-    Get unified sequence parallel world size.
-    """
     group = get_unified_sequence_parallel_group()
-    return dist.get_world_size(group) if group else 1
-
-
-# ------------------------------- Initialize ------------------------------- #
-def init_sequence_parallel(
-    ulysses_size: int = 1, sep_dp: bool = False, ulysses_group_key: str = "default", cp_size: int = 1
-):
-    """
-    Initialize unified sequence parallel.
-    """
-    global _CONTEXT_PARALLEL_GROUP
-    global _ULYSSES_SEQUENCE_PARALLEL_GROUP
-    global _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP
-
-    set_ulysses_sequence_parallel_group(group=None, group_key="default")
-    set_ulysses_sequence_parallel_cpu_group(group=None, group_key="default")
-
-    if ulysses_size == 1 and cp_size == 1:
-        return
-
-    assert dist.is_initialized()
-    world_size = dist.get_world_size()
-    rank = dist.get_rank()
-    unified_sp_size = ulysses_size * cp_size
-    assert world_size % unified_sp_size == 0
-    data_parallel_size = world_size // unified_sp_size
-
-    if cp_size > 1:
-        assert _CONTEXT_PARALLEL_GROUP is None, "Context parallel group has already been initialized!"
-    if ulysses_size:
-        assert (ulysses_group_key == "default" and _ULYSSES_SEQUENCE_PARALLEL_GROUP[ulysses_group_key] is None) or (
-            ulysses_group_key != "default" and ulysses_group_key not in _ULYSSES_SEQUENCE_PARALLEL_GROUP
-        ), f"Ulysses sequence parallel group ({ulysses_group_key}) has already been initialized!"
-        assert (
-            ulysses_group_key == "default" and _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP[ulysses_group_key] is None
-        ) or (ulysses_group_key != "default" and ulysses_group_key not in _ULYSSES_SEQUENCE_PARALLEL_CPU_GROUP), (
-            f"Ulysses sequence parallel ({ulysses_group_key}) group has already been initialized!"
-        )
-
-    for i in range(data_parallel_size):
-        # build ulysses group
-        if ulysses_size > 1:
-            for j in range(cp_size):
-                start_rank = i * unified_sp_size + j * ulysses_size
-                end_rank = start_rank + ulysses_size
-                ulysses_ranks = range(start_rank, end_rank)
-                ulysses_group = dist.new_group(ulysses_ranks)
-                ulysses_cpu_group = dist.new_group(ulysses_ranks, backend="gloo")
-                if rank in ulysses_ranks:
-                    set_ulysses_sequence_parallel_group(group=ulysses_group, group_key=ulysses_group_key)
-                    set_ulysses_sequence_parallel_cpu_group(group=ulysses_cpu_group, group_key=ulysses_group_key)
-
-        # build cp group
-        if cp_size > 1:
-            for j in range(ulysses_size):
-                cp_global_ranks = range(i * unified_sp_size + j, (i + 1) * unified_sp_size, ulysses_size)
-                cp_group = dist.new_group(cp_global_ranks)
-                if rank in cp_global_ranks:
-                    set_context_parallel_group(cp_group=cp_group)
-
-        # build unified sp group
-        unified_sp_ranks = range(i * unified_sp_size, (i + 1) * unified_sp_size)
-        sp_group = dist.new_group(unified_sp_ranks)
-        sp_cpu_group = dist.new_group(unified_sp_ranks, backend="gloo")
-        if rank in unified_sp_ranks:
-            set_unified_sequence_parallel_group(group=sp_group)
-            set_unified_sequence_parallel_cpu_group(group=sp_cpu_group)
-
-    if sep_dp:
-        for j in range(unified_sp_size):
-            dp_ranks = range(j, world_size, unified_sp_size)
-            dp_group = dist.new_group(dp_ranks)
-            if rank in dp_ranks:
-                set_data_parallel_group(dp_group)
-
-
-class UlyssesGroupKeyManager:
-    def __init__(self, group_key: str):
-        self.group_key = group_key
-
-    def __enter__(self):
-        set_ulysses_sequence_parallel_group_key(group_key=self.group_key)
-
-    def __exit__(self, *args: Any):
-        set_ulysses_sequence_parallel_group_key(group_key="default")
+    return dist.get_world_size(group) if group is not None else 1
 
 
 def is_ulysses_sequence_parallel_initialized() -> bool:
-    """
-    Check if ulysses sequence parallel is initialized.
-    """
     return get_ulysses_sequence_parallel_group() is not None
 
 
 def is_context_parallel_initialized() -> bool:
-    """
-    Check if ulysses sequence parallel is initialized.
-    """
     return get_context_parallel_group(check_initialized=False) is not None
-
-
-def get_ulysses_group_key_context(group_key: str = "default"):
-    if not isinstance(group_key, str):
-        raise RuntimeError(f"A Ulysses group key must be specified, now get: {group_key}")
-
-    if group_key != "default":
-        return UlyssesGroupKeyManager(group_key)
-    else:
-        return nullcontext()

--- a/veomni/distributed/sequence_parallel/loss.py
+++ b/veomni/distributed/sequence_parallel/loss.py
@@ -18,10 +18,7 @@ from typing import Optional, Tuple
 import torch
 import torch.distributed as dist
 
-from .comm import (
-    get_unified_sequence_parallel_group,
-    get_unified_sequence_parallel_world_size,
-)
+from .comm import get_unified_sequence_parallel_group
 
 
 class ReduceLoss(torch.autograd.Function):
@@ -32,6 +29,7 @@ class ReduceLoss(torch.autograd.Function):
         local_num_tokens = num_valid_tokens.detach().clone()
         loss *= num_valid_tokens
         group = get_unified_sequence_parallel_group()
+        ctx.sp_world_size = dist.get_world_size(group)
         dist.all_reduce(loss, group=group)
         dist.all_reduce(num_valid_tokens, group=group)
         ctx.save_for_backward(local_num_tokens, num_valid_tokens)
@@ -51,12 +49,7 @@ class ReduceLoss(torch.autograd.Function):
 
         # FIX: Mirror the forward guard — zero grad when global tokens = 0,
         # preventing NaN grad_output from corrupting downstream parameters.
-        grad_output = (
-            get_unified_sequence_parallel_world_size()
-            * local_num_tokens
-            * grad_output
-            / global_num_tokens.clamp(min=1)
-        )
+        grad_output = ctx.sp_world_size * local_num_tokens * grad_output / global_num_tokens.clamp(min=1)
         return grad_output, None
 
 

--- a/veomni/distributed/sequence_parallel/loss.py
+++ b/veomni/distributed/sequence_parallel/loss.py
@@ -29,7 +29,10 @@ class ReduceLoss(torch.autograd.Function):
         local_num_tokens = num_valid_tokens.detach().clone()
         loss *= num_valid_tokens
         group = get_unified_sequence_parallel_group()
-        ctx.sp_world_size = dist.get_world_size(group)
+        # Match get_unified_sequence_parallel_world_size(): an absent SP group
+        # may still use the default process group for the reduction, but it is
+        # not sequence parallel and therefore contributes no SP grad scaling.
+        ctx.sp_world_size = dist.get_world_size(group) if group is not None else 1
         dist.all_reduce(loss, group=group)
         dist.all_reduce(num_valid_tokens, group=group)
         ctx.save_for_backward(local_num_tokens, num_valid_tokens)

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -32,7 +32,13 @@ from ..utils import logging
 from ..utils.device import IS_NPU_AVAILABLE, get_device_type
 from .checkpoint import CheckpointFunction
 from .parallel_plan import get_runtime_parallel_plan
-from .parallel_state import get_parallel_state
+from .parallel_state import (
+    ParallelState,
+    bind_model_parallel_state,
+    get_parallel_state,
+    resolve_model_parallel_state,
+    use_parallel_state,
+)
 from .torch_compile import CompileConfig, compile_decoder_blocks, validate_compile_config_for_fsdp2
 from .utils import sort_fqn_by_submodule_first
 
@@ -498,7 +504,7 @@ def parallelize_model_fsdp2(
     return model
 
 
-def build_parallelize_model(
+def _build_parallelize_model(
     model: "nn.Module",
     weights_path: Optional[str] = None,
     enable_reshard_after_forward: bool = True,
@@ -567,3 +573,33 @@ def build_parallelize_model(
         raise RuntimeError("train.torch_compile.enable requires FSDP2; compile without FSDP is not supported.")
 
     return model
+
+
+def build_parallelize_model(
+    model: "nn.Module",
+    weights_path: Optional[str] = None,
+    enable_reshard_after_forward: bool = True,
+    mixed_precision: MixedPrecisionConfig = MixedPrecisionConfig(enable=True),  # noqa
+    enable_gradient_checkpointing: bool = True,
+    basic_modules: Optional[List[str]] = None,
+    muon_expert_zero_comm: bool = False,
+    compile_config: Optional[CompileConfig] = None,
+    parallel_state: Optional[ParallelState] = None,
+    **kwargs,
+) -> "nn.Module":
+    """Parallelize ``model`` and bind the state that owns its topology."""
+    parallel_state = resolve_model_parallel_state(model, parallel_state)
+    bind_model_parallel_state(model, parallel_state)
+    with use_parallel_state(parallel_state):
+        model = _build_parallelize_model(
+            model=model,
+            weights_path=weights_path,
+            enable_reshard_after_forward=enable_reshard_after_forward,
+            mixed_precision=mixed_precision,
+            enable_gradient_checkpointing=enable_gradient_checkpointing,
+            basic_modules=basic_modules,
+            muon_expert_zero_comm=muon_expert_zero_comm,
+            compile_config=compile_config,
+            **kwargs,
+        )
+    return bind_model_parallel_state(model, parallel_state)

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -14,6 +14,7 @@
 
 
 import types
+from contextlib import contextmanager
 from functools import partial
 from typing import List, Optional, Tuple
 
@@ -44,6 +45,26 @@ from .utils import sort_fqn_by_submodule_first
 
 
 logger = logging.get_logger(__name__)
+
+
+@contextmanager
+def _checkpoint_parallel_state_context(parallel_state: ParallelState, context):
+    """Compose a checkpoint context with the state owned by its model."""
+    with use_parallel_state(parallel_state), context:
+        yield
+
+
+def _model_owned_checkpoint_context_fn(parallel_state: ParallelState, context_fn):
+    """Keep model-owned state active during non-reentrant recomputation."""
+
+    def model_owned_context_fn():
+        forward_context, recompute_context = context_fn()
+        return (
+            _checkpoint_parallel_state_context(parallel_state, forward_context),
+            _checkpoint_parallel_state_context(parallel_state, recompute_context),
+        )
+
+    return model_owned_context_fn
 
 
 def _reset_hf_initialized_flag(module: nn.Module) -> None:
@@ -535,13 +556,16 @@ def _build_parallelize_model(
     if enable_gradient_checkpointing and hasattr(model, "gradient_checkpointing_enable"):
         logger.info_rank0("Enable gradient checkpointing.")
         use_reentrant = kwargs.pop("enable_reentrant", False)
+        checkpoint_context_fn = kwargs.pop("recompute_context_fn", noop_context_fn)
         if use_reentrant:
             torch.utils.checkpoint.CheckpointFunction = CheckpointFunction
+        else:
+            checkpoint_context_fn = _model_owned_checkpoint_context_fn(parallel_state, checkpoint_context_fn)
 
         model.gradient_checkpointing_enable(
             gradient_checkpointing_kwargs={
                 "use_reentrant": use_reentrant,
-                "context_fn": kwargs.pop("recompute_context_fn", noop_context_fn),
+                "context_fn": checkpoint_context_fn,
             },
         )
 

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -25,7 +25,12 @@ from transformers import (
 )
 
 from ..arguments.arguments_types import OpsImplementationConfig
-from ..distributed.parallel_state import get_parallel_state
+from ..distributed.parallel_state import (
+    ParallelState,
+    bind_model_parallel_state,
+    get_parallel_state,
+    use_parallel_state,
+)
 from ..ops.dispatch import OpsConfigSlot, OpSlot
 from ..utils import logging
 from ..utils.device import is_torch_npu_available
@@ -107,7 +112,7 @@ def _bind_veomni_ops(modeling_module, ops_config: OpsImplementationConfig) -> bo
     return bool(bound)
 
 
-def build_foundation_model(
+def _build_foundation_model(
     config_path: Union[str, PretrainedConfig],
     weights_path: Optional[str] = None,
     torch_dtype: Literal["float16", "bfloat16", "float32"] = "bfloat16",
@@ -275,3 +280,10 @@ def build_foundation_model(
     logger.info_rank0(f"Built foundation model class: {model_class_path}")
 
     return model
+
+
+def build_foundation_model(*args, parallel_state: ParallelState, **kwargs) -> "PreTrainedModel":
+    """Build a foundation model under, and bind it to, ``parallel_state``."""
+    with use_parallel_state(parallel_state):
+        model = _build_foundation_model(*args, **kwargs)
+    return bind_model_parallel_state(model, parallel_state)

--- a/veomni/models/seed_omni/auto.py
+++ b/veomni/models/seed_omni/auto.py
@@ -19,7 +19,12 @@ import torch
 from transformers.initialization import no_init_weights
 
 from ...arguments.arguments_types import OpsImplementationConfig
-from ...distributed.parallel_state import get_parallel_state
+from ...distributed.parallel_state import (
+    ParallelState,
+    bind_model_parallel_state,
+    get_parallel_state,
+    use_parallel_state,
+)
 from ..auto import build_config, build_foundation_model, build_processor, build_tokenizer
 from ..module_utils import init_empty_weights, load_model_weights
 from .configuration_seed_omni import SeedOmniConfig
@@ -73,7 +78,7 @@ def build_omni_processor(
     return omni_processor
 
 
-def build_omni_model(
+def _build_omni_model(
     config_path: str,
     weights_path: Optional[str] = None,
     foundation: Dict[str, str] = None,
@@ -121,6 +126,7 @@ def build_omni_model(
     foundation_config: "PretrainedConfig" = build_config(config_path, **config_kwargs, **foundation)
     if isinstance(foundation_config, SeedOmniConfig):
         return build_foundation_model(
+            parallel_state=get_parallel_state(),
             config_path=config_path,
             weights_path=weights_path,
             torch_dtype=torch_dtype,
@@ -210,3 +216,10 @@ def build_omni_model(
         output_embeddings._parameters["weight"] = input_embeddings._parameters["weight"]
 
     return model
+
+
+def build_omni_model(*args, parallel_state: ParallelState, **kwargs) -> "PreTrainedModel":
+    """Build an omni model under, and bind it to, ``parallel_state``."""
+    with use_parallel_state(parallel_state):
+        model = _build_omni_model(*args, **kwargs)
+    return bind_model_parallel_state(model, parallel_state)

--- a/veomni/optim/optimizer.py
+++ b/veomni/optim/optimizer.py
@@ -29,7 +29,7 @@ from torch.distributed.checkpoint.stateful import Stateful
 from torch.optim import AdamW
 from torch.optim.optimizer import Optimizer
 
-from ..distributed.parallel_state import get_parallel_state
+from ..distributed.parallel_state import ParallelState, resolve_model_parallel_state
 from ..utils import logging
 from .muon import DistributedMuon, split_muon_adamw_params
 
@@ -349,8 +349,8 @@ class MultiOptimizer(Optimizer, Stateful):
         return len(self.optimizers_dict)
 
 
-def _should_build_extra_parallel_aware(model: "nn.Module") -> bool:
-    ps = get_parallel_state()
+def _should_build_extra_parallel_aware(model: "nn.Module", parallel_state: ParallelState) -> bool:
+    ps = parallel_state
     if ps.dp_mode == "fsdp2" and ps.any_extra_parallel_enabled:
         return True
 
@@ -409,7 +409,9 @@ def build_optimizer(
     no_decay_modules: Optional[List[str]] = None,
     no_decay_params: Optional[List[str]] = None,
     muon_kwargs: Optional[Dict[str, Any]] = None,
+    parallel_state: Optional[ParallelState] = None,
 ) -> "torch.optim.Optimizer":
+    parallel_state = resolve_model_parallel_state(model, parallel_state)
     if optimizer_type == "muon":
         if param_groups is not None:
             logger.warning_rank0(
@@ -428,6 +430,7 @@ def build_optimizer(
             no_decay_modules=no_decay_modules,
             no_decay_params=no_decay_params,
             muon_kwargs=muon_kwargs,
+            parallel_state=parallel_state,
         )
 
     if param_groups is not None:
@@ -435,9 +438,19 @@ def build_optimizer(
         if not param_groups:
             raise ValueError("All optimizer param groups are empty; no trainable parameters to optimize.")
 
-    if _should_build_extra_parallel_aware(model):
+    if _should_build_extra_parallel_aware(model, parallel_state):
         return build_extra_parallel_fsdp2_optimizer(
-            model, lr, betas, eps, weight_decay, fused, optimizer_type, param_groups, no_decay_modules, no_decay_params
+            model,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            fused,
+            optimizer_type,
+            param_groups,
+            no_decay_modules,
+            no_decay_params,
+            parallel_state,
         )
     if param_groups is None:
         decay_param_names = get_parameter_names(model, no_decay_modules, no_decay_params)
@@ -501,6 +514,7 @@ def _build_muon_with_adamw(
     no_decay_modules: Optional[List[str]],
     no_decay_params: Optional[List[str]],
     muon_kwargs: Optional[Dict[str, Any]],
+    parallel_state: ParallelState,
 ) -> "MultiOptimizer":
     """Build a Muon (2D/3D hidden weights) + AdamW (everything else) MultiOptimizer.
 
@@ -519,8 +533,7 @@ def _build_muon_with_adamw(
             "Falling back to AdamW would be silent so we raise instead."
         )
 
-    extra_parallel_aware = _should_build_extra_parallel_aware(model)
-    parallel_state = get_parallel_state() if extra_parallel_aware else None
+    extra_parallel_aware = _should_build_extra_parallel_aware(model, parallel_state)
     extra_parallel_names = list(parallel_state.extra_parallel_names) if extra_parallel_aware else []
 
     def _split_by_ep(
@@ -611,6 +624,7 @@ def build_extra_parallel_fsdp2_optimizer(
     param_groups: Optional[List[Dict[str, Any]]] = None,
     no_decay_modules: Optional[List[str]] = None,
     no_decay_params: Optional[List[str]] = None,
+    parallel_state: Optional[ParallelState] = None,
 ):
     """
     Build a MultiOptimizer instance when model is parallelized with ExtraParallel+FSDP2
@@ -622,7 +636,7 @@ def build_extra_parallel_fsdp2_optimizer(
     - Each group's params are automatically split into ExtraParallel1, ExtraParallel2, ... and non-ExtraParallel based on DTensor mesh
     - Custom learning rates and other optimizer settings are preserved per group
     """
-    parallel_state = get_parallel_state()
+    parallel_state = resolve_model_parallel_state(model, parallel_state)
 
     # Collect all ExtraParallel and non-ExtraParallel parameters across all groups
     extra_parallel_groups = {

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -58,8 +58,12 @@ from ..data.data_transform import build_data_transform
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
 from ..distributed.offloading import build_activation_offloading_context
 from ..distributed.parallel_state import (
+    ParallelState,
+    bind_model_parallel_state,
+    build_parallel_state,
     clear_parallel_state_cache,
-    init_parallel_state,
+    get_model_parallel_state,
+    get_parallel_state,
     use_model_parallel_state,
     use_parallel_state,
 )
@@ -293,14 +297,13 @@ class BaseTrainer(Stateful, ABC):
         """
 
         self.args: VeOmniArguments = args
-        self._setup()
-        with use_parallel_state(self.parallel_state):
-            self._build_components()
+        bootstrap_state = self._setup()
+        with use_parallel_state(bootstrap_state):
+            self._build_model()
+        self._build_components()
 
     def _build_components(self):
         """Build resources that belong to this trainer's model state."""
-        # build model
-        self._build_model()
         # freeze module and print trainable parameters
         self._freeze_model_module()
         # build model assets (config, tokenizer, processor, chat_template)
@@ -321,7 +324,7 @@ class BaseTrainer(Stateful, ABC):
         # Initialize callbacks
         self._init_callbacks()
 
-    def _setup(self):
+    def _setup(self) -> ParallelState:
         # log args
         logger.info_rank0(json.dumps(asdict(self.args), indent=2))
 
@@ -337,7 +340,7 @@ class BaseTrainer(Stateful, ABC):
         logger.info(f"Process rank: {self.args.train.global_rank}, world size: {self.args.train.world_size}")
 
         # Initialize parallel state
-        self.parallel_state = init_parallel_state(
+        parallel_state = build_parallel_state(
             dp_size=self.args.train.accelerator.dp_size,
             dp_replicate_size=self.args.train.accelerator.dp_replicate_size,
             dp_shard_size=self.args.train.accelerator.dp_shard_size,
@@ -368,10 +371,12 @@ class BaseTrainer(Stateful, ABC):
 
         # Gradient checkpointing debug
         set_checkpoint_debug_enabled(self.args.train.gradient_checkpointing.debug)
+        return parallel_state
 
     def _build_model(self):
         logger.info_rank0("Build model")
         self.model = build_foundation_model(
+            parallel_state=get_parallel_state(),
             config_path=self.args.model.config_path,
             weights_path=self.args.model.model_path,
             torch_dtype="float32" if self.args.train.accelerator.fsdp_config.mixed_precision.enable else "bfloat16",
@@ -411,6 +416,8 @@ class BaseTrainer(Stateful, ABC):
         if not bool(lora_config):
             return
 
+        parallel_state = get_model_parallel_state(self.model)
+
         from ..lora import VeOmniLoraConfig, VeOmniLoraModel, resolve_fused_moe_lora_targets
 
         lora_adapter_path = lora_config.get("lora_adapter", None)
@@ -428,6 +435,7 @@ class BaseTrainer(Stateful, ABC):
             cfg = VeOmniLoraConfig.from_yaml(resolved_config)
             logger.info_rank0(f"Initialising VeOmni LoRA adapter from scratch: {cfg}.")
             self.model = VeOmniLoraModel(self.model, cfg)
+        bind_model_parallel_state(self.model, parallel_state)
 
     def _freeze_model_module(self):
         self._setup_lora()
@@ -449,8 +457,10 @@ class BaseTrainer(Stateful, ABC):
 
     def _build_dataset(self):
         args: VeOmniArguments = self.args
+        parallel_state = get_model_parallel_state(self.model)
         # Build dataset
         self.train_dataset = build_dataset(
+            parallel_state=parallel_state,
             dataset_name=args.data.dataset_name,
             transform=self.data_transform,
             seed=args.train.seed,
@@ -463,20 +473,23 @@ class BaseTrainer(Stateful, ABC):
         self.train_steps = args.train_steps
 
     def _build_collate_fn(self):
+        parallel_state = get_model_parallel_state(self.model)
         seq_classification = self.args.data.data_type == "classification"
         pad_to_length = self.args.train.pad_to_length
         self.collate_fn = MainCollator(
             pad_to_length=pad_to_length,
             seq_classification=seq_classification,
-            parallel_state=self.parallel_state,
+            parallel_state=parallel_state,
         )
 
     def _build_dataloader(self):
         args: VeOmniArguments = self.args
+        parallel_state = get_model_parallel_state(self.model)
         dataloader_kwargs = asdict(args.data.dataloader)
         dataloader_type = dataloader_kwargs.pop("type")
         dataloader_kwargs.pop("use_background_prefetcher", None)
         self.train_dataloader = build_dataloader(
+            parallel_state=parallel_state,
             dataloader_type=dataloader_type,
             dataset=self.train_dataset,
             micro_batch_size=args.train.micro_batch_size,
@@ -493,7 +506,6 @@ class BaseTrainer(Stateful, ABC):
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             seed=args.train.seed,
             collate_fn=self.collate_fn,
-            parallel_state=self.parallel_state,
             save_steps=args.train.checkpoint.save_steps,
             **dataloader_kwargs,
         )
@@ -536,7 +548,6 @@ class BaseTrainer(Stateful, ABC):
             compile_config=CompileConfig(
                 **{field.name: getattr(args.train.torch_compile, field.name) for field in fields(CompileConfig)}
             ),
-            parallel_state=self.parallel_state,
             **kwargs,
         )
         self.model.train()
@@ -553,7 +564,6 @@ class BaseTrainer(Stateful, ABC):
             no_decay_modules=args.train.optimizer.no_decay_modules,
             no_decay_params=args.train.optimizer.no_decay_params,
             muon_kwargs=_collect_muon_kwargs(args.train.optimizer),
-            parallel_state=self.parallel_state,
         )
 
     def _build_lr_scheduler(self):
@@ -677,7 +687,10 @@ class BaseTrainer(Stateful, ABC):
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Postprocess model outputs after forward pass."""
         loss_dict: Dict[str, torch.Tensor] = mean_global_loss(
-            outputs.loss, self.micro_batch_token_len, self.micro_batches_token_len
+            outputs.loss,
+            self.micro_batch_token_len,
+            self.micro_batches_token_len,
+            get_model_parallel_state(self.model),
         )
         loss = torch.stack(list(loss_dict.values())).sum()
         return loss, loss_dict
@@ -763,9 +776,7 @@ class BaseTrainer(Stateful, ABC):
                 total_loss_dict[k] += v.item()
 
         # Gradient clipping
-        grad_norm = veomni_clip_grad_norm(
-            self.model, args.train.optimizer.max_grad_norm, parallel_state=self.parallel_state
-        )
+        grad_norm = veomni_clip_grad_norm(self.model, args.train.optimizer.max_grad_norm)
 
         # Optimizer and scheduler step
         self.optimizer.step()

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -57,7 +57,12 @@ from ..data.data_collator import DataCollator, MainCollator
 from ..data.data_transform import build_data_transform
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
 from ..distributed.offloading import build_activation_offloading_context
-from ..distributed.parallel_state import init_parallel_state
+from ..distributed.parallel_state import (
+    clear_parallel_state_cache,
+    init_parallel_state,
+    use_model_parallel_state,
+    use_parallel_state,
+)
 from ..distributed.torch_compile import CompileConfig, mark_compile_step_begin
 from ..distributed.torch_parallelize import build_parallelize_model
 from ..models import build_foundation_model, build_tokenizer
@@ -289,6 +294,11 @@ class BaseTrainer(Stateful, ABC):
 
         self.args: VeOmniArguments = args
         self._setup()
+        with use_parallel_state(self.parallel_state):
+            self._build_components()
+
+    def _build_components(self):
+        """Build resources that belong to this trainer's model state."""
         # build model
         self._build_model()
         # freeze module and print trainable parameters
@@ -327,7 +337,7 @@ class BaseTrainer(Stateful, ABC):
         logger.info(f"Process rank: {self.args.train.global_rank}, world size: {self.args.train.world_size}")
 
         # Initialize parallel state
-        init_parallel_state(
+        self.parallel_state = init_parallel_state(
             dp_size=self.args.train.accelerator.dp_size,
             dp_replicate_size=self.args.train.accelerator.dp_replicate_size,
             dp_shard_size=self.args.train.accelerator.dp_shard_size,
@@ -458,6 +468,7 @@ class BaseTrainer(Stateful, ABC):
         self.collate_fn = MainCollator(
             pad_to_length=pad_to_length,
             seq_classification=seq_classification,
+            parallel_state=self.parallel_state,
         )
 
     def _build_dataloader(self):
@@ -482,6 +493,7 @@ class BaseTrainer(Stateful, ABC):
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             seed=args.train.seed,
             collate_fn=self.collate_fn,
+            parallel_state=self.parallel_state,
             save_steps=args.train.checkpoint.save_steps,
             **dataloader_kwargs,
         )
@@ -524,6 +536,7 @@ class BaseTrainer(Stateful, ABC):
             compile_config=CompileConfig(
                 **{field.name: getattr(args.train.torch_compile, field.name) for field in fields(CompileConfig)}
             ),
+            parallel_state=self.parallel_state,
             **kwargs,
         )
         self.model.train()
@@ -540,6 +553,7 @@ class BaseTrainer(Stateful, ABC):
             no_decay_modules=args.train.optimizer.no_decay_modules,
             no_decay_params=args.train.optimizer.no_decay_params,
             muon_kwargs=_collect_muon_kwargs(args.train.optimizer),
+            parallel_state=self.parallel_state,
         )
 
     def _build_lr_scheduler(self):
@@ -673,16 +687,17 @@ class BaseTrainer(Stateful, ABC):
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         micro_batch = self.preforward(micro_batch)
 
-        with self.model_fwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
-            outputs: ModelOutput = self.model(**micro_batch, use_cache=False)
+        with use_model_parallel_state(self.model):
+            with self.model_fwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
+                outputs: ModelOutput = self.model(**micro_batch, use_cache=False)
 
-        loss: torch.Tensor
-        loss_dict: Dict[str, torch.Tensor]
-        loss, loss_dict = self.postforward(outputs, micro_batch)
+            loss: torch.Tensor
+            loss_dict: Dict[str, torch.Tensor]
+            loss, loss_dict = self.postforward(outputs, micro_batch)
 
-        # Backward pass
-        with self.model_bwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
-            loss.backward()
+            # Backward pass
+            with self.model_bwd_context, set_batch_invariant_mode(self.args.train.enable_batch_invariant_mode):
+                loss.backward()
 
         del micro_batch
         return loss, loss_dict
@@ -748,7 +763,9 @@ class BaseTrainer(Stateful, ABC):
                 total_loss_dict[k] += v.item()
 
         # Gradient clipping
-        grad_norm = veomni_clip_grad_norm(self.model, args.train.optimizer.max_grad_norm)
+        grad_norm = veomni_clip_grad_norm(
+            self.model, args.train.optimizer.max_grad_norm, parallel_state=self.parallel_state
+        )
 
         # Optimizer and scheduler step
         self.optimizer.step()
@@ -774,6 +791,7 @@ class BaseTrainer(Stateful, ABC):
 
         synchronize()
         dist.destroy_process_group()
+        clear_parallel_state_cache()
 
     def train(self):
         args: VeOmniArguments = self.args

--- a/veomni/trainer/base_rl_trainer.py
+++ b/veomni/trainer/base_rl_trainer.py
@@ -31,7 +31,6 @@ from transformers.modeling_outputs import ModelOutput
 
 from ..data.data_collator import MainCollator as Preforward
 from ..data.data_collator import PostCollator as Postforward
-from ..distributed.parallel_state import get_parallel_state
 from ..distributed.sequence_parallel import gather_outputs
 from .base import BaseTrainer, VeOmniArguments, build_dataloader
 
@@ -44,8 +43,8 @@ class BaseRLTrainer(BaseTrainer):
     # post init preforward and postforward hooks
     def _build_preforward_postforward(self):
         """Build preforward and postforward hooks."""
-        self.pre_forward = Preforward()
-        self.post_forward = Postforward()
+        self.pre_forward = Preforward(parallel_state=self.parallel_state)
+        self.post_forward = Postforward(parallel_state=self.parallel_state)
 
     # rewrite: do not build collate_fn in dataloader, as we pack and sp slice data in training loop in preforward
     def _build_dataloader(self):
@@ -70,6 +69,7 @@ class BaseRLTrainer(BaseTrainer):
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             seed=args.train.seed,
             build_collate_fn=False,
+            parallel_state=self.parallel_state,
             **dataloader_kwargs,
         )
 
@@ -86,8 +86,8 @@ class BaseRLTrainer(BaseTrainer):
 
         logits = torch.cat(logits, dim=0)
 
-        if get_parallel_state().sp_enabled:
-            labels = gather_outputs(labels, gather_dim=-1, group=get_parallel_state().sp_group)
+        if self.parallel_state.sp_enabled:
+            labels = gather_outputs(labels, gather_dim=-1, group=self.parallel_state.sp_group)
             labels = labels[:, : logits.shape[0]]  # unpad sp_pad
         else:
             labels = nn.functional.pad(labels, (0, 1), value=-100)

--- a/veomni/trainer/base_rl_trainer.py
+++ b/veomni/trainer/base_rl_trainer.py
@@ -31,6 +31,7 @@ from transformers.modeling_outputs import ModelOutput
 
 from ..data.data_collator import MainCollator as Preforward
 from ..data.data_collator import PostCollator as Postforward
+from ..distributed.parallel_state import get_model_parallel_state
 from ..distributed.sequence_parallel import gather_outputs
 from .base import BaseTrainer, VeOmniArguments, build_dataloader
 
@@ -43,8 +44,9 @@ class BaseRLTrainer(BaseTrainer):
     # post init preforward and postforward hooks
     def _build_preforward_postforward(self):
         """Build preforward and postforward hooks."""
-        self.pre_forward = Preforward(parallel_state=self.parallel_state)
-        self.post_forward = Postforward(parallel_state=self.parallel_state)
+        parallel_state = get_model_parallel_state(self.model)
+        self.pre_forward = Preforward(parallel_state=parallel_state)
+        self.post_forward = Postforward(parallel_state=parallel_state)
 
     # rewrite: do not build collate_fn in dataloader, as we pack and sp slice data in training loop in preforward
     def _build_dataloader(self):
@@ -53,6 +55,7 @@ class BaseRLTrainer(BaseTrainer):
         dataloader_kwargs = asdict(args.data.dataloader)
         dataloader_type = dataloader_kwargs.pop("type")
         self.train_dataloader = build_dataloader(
+            parallel_state=get_model_parallel_state(self.model),
             dataloader_type=dataloader_type,
             dataset=self.train_dataset,
             micro_batch_size=args.train.micro_batch_size,
@@ -69,7 +72,6 @@ class BaseRLTrainer(BaseTrainer):
             dyn_bsz_buffer_size=args.data.dyn_bsz_buffer_size,
             seed=args.train.seed,
             build_collate_fn=False,
-            parallel_state=self.parallel_state,
             **dataloader_kwargs,
         )
 
@@ -86,8 +88,9 @@ class BaseRLTrainer(BaseTrainer):
 
         logits = torch.cat(logits, dim=0)
 
-        if self.parallel_state.sp_enabled:
-            labels = gather_outputs(labels, gather_dim=-1, group=self.parallel_state.sp_group)
+        parallel_state = get_model_parallel_state(self.model)
+        if parallel_state.sp_enabled:
+            labels = gather_outputs(labels, gather_dim=-1, group=parallel_state.sp_group)
             labels = labels[:, : logits.shape[0]]  # unpad sp_pad
         else:
             labels = nn.functional.pad(labels, (0, 1), value=-100)

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from tqdm import trange
 
-from ...distributed.parallel_state import get_parallel_state
 from ...utils import helper
 from ...utils.dist_utils import all_reduce
 from ...utils.logging import get_logger
@@ -62,7 +61,7 @@ class MoERouterMonitorCallback(Callback):
         # mesh is guaranteed to be initialized.
         self.monitor = MoERouterMonitor(num_experts=config.num_experts)
         set_active_monitor(self.monitor)
-        ps = get_parallel_state()
+        ps = self.trainer.parallel_state
         logger.info_rank0(
             f"MoE router monitor created: num_experts={config.num_experts}, "
             f"interval={args.train.moe_load_balance_monitor_interval}, "
@@ -77,7 +76,7 @@ class MoERouterMonitorCallback(Callback):
         # fsdp_group is the dp_sp mesh dim — exactly the set of ranks that
         # hold distinct token slices. EP is intentionally not in this group;
         # see MoERouterMonitor.__init__ docstring.
-        self.monitor.dp_group = get_parallel_state().fsdp_group
+        self.monitor.dp_group = self.trainer.parallel_state.fsdp_group
 
         attached = attach_moe_router_monitor(self.trainer.model, self.monitor)
         if attached == 0:
@@ -218,7 +217,7 @@ class EnvironMeterCallback(Callback):
 
         # gather training_step_info from all ranks
         step_train_metrics = {
-            f"training/{k}": all_reduce(v, group=get_parallel_state().fsdp_group)
+            f"training/{k}": all_reduce(v, group=self.trainer.parallel_state.fsdp_group)
             for k, v in step_train_metrics.items()
         }
 

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from tqdm import trange
 
+from ...distributed.parallel_state import get_model_parallel_state
 from ...utils import helper
 from ...utils.dist_utils import all_reduce
 from ...utils.logging import get_logger
@@ -61,7 +62,7 @@ class MoERouterMonitorCallback(Callback):
         # mesh is guaranteed to be initialized.
         self.monitor = MoERouterMonitor(num_experts=config.num_experts)
         set_active_monitor(self.monitor)
-        ps = self.trainer.parallel_state
+        ps = get_model_parallel_state(self.trainer.model)
         logger.info_rank0(
             f"MoE router monitor created: num_experts={config.num_experts}, "
             f"interval={args.train.moe_load_balance_monitor_interval}, "
@@ -76,7 +77,7 @@ class MoERouterMonitorCallback(Callback):
         # fsdp_group is the dp_sp mesh dim — exactly the set of ranks that
         # hold distinct token slices. EP is intentionally not in this group;
         # see MoERouterMonitor.__init__ docstring.
-        self.monitor.dp_group = self.trainer.parallel_state.fsdp_group
+        self.monitor.dp_group = get_model_parallel_state(self.trainer.model).fsdp_group
 
         attached = attach_moe_router_monitor(self.trainer.model, self.monitor)
         if attached == 0:
@@ -196,6 +197,7 @@ class EnvironMeterCallback(Callback):
             dataloader=trainer.train_dataloader,
             data_path=args.data.train_path,
             gc_steps=args.train.gc_steps,
+            parallel_state=get_model_parallel_state(trainer.model),
         )
 
     def on_step_begin(self, state: TrainerState, micro_batches: List[Dict[str, Any]] = None, **kwargs) -> None:
@@ -217,7 +219,7 @@ class EnvironMeterCallback(Callback):
 
         # gather training_step_info from all ranks
         step_train_metrics = {
-            f"training/{k}": all_reduce(v, group=self.trainer.parallel_state.fsdp_group)
+            f"training/{k}": all_reduce(v, group=get_model_parallel_state(self.trainer.model).fsdp_group)
             for k, v in step_train_metrics.items()
         }
 

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -30,7 +30,10 @@ from ..data import build_data_transform, build_dataloader
 from ..data.data_collator import DataCollator
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
 from ..distributed.parallel_state import (
+    ParallelState,
     bind_model_parallel_state,
+    get_model_parallel_state,
+    get_parallel_state,
     use_model_parallel_state,
     use_parallel_state,
 )
@@ -50,11 +53,16 @@ logger = helper.create_logger(__name__)
 
 
 class OfflineEmbeddingSaver:
-    def __init__(self, save_path: str, dataset_length: int = 0, shard_num: int = 1, max_shard=1000):
-        from ..distributed.parallel_state import get_parallel_state
-
-        self.dp_rank = get_parallel_state().dp_rank
-        dp_size = get_parallel_state().dp_size
+    def __init__(
+        self,
+        save_path: str,
+        parallel_state: ParallelState,
+        dataset_length: int = 0,
+        shard_num: int = 1,
+        max_shard=1000,
+    ):
+        self.dp_rank = parallel_state.dp_rank
+        dp_size = parallel_state.dp_size
         if dp_size * shard_num > max_shard:
             shard_num = max_shard // dp_size
             logger.info_rank0(f"shard_num * dp_size must be smaller than max_shard, set shard_num = {shard_num}")
@@ -186,14 +194,12 @@ class DiTTrainer:
         self.base.args = args
 
         # rewrite _setup, setup arguments for dit training
-        self._setup()
-        with use_parallel_state(self.base.parallel_state):
-            self._build_components()
+        bootstrap_state = self._setup()
+        with use_parallel_state(bootstrap_state):
+            self._build_model()
+        self._build_components()
 
     def _build_components(self):
-        # rewrite _build_model, build condition model & dit model
-        self._build_model()
-
         # rewrite _freeze_model_module, freeze condition model
         self._freeze_model_module()
 
@@ -220,14 +226,14 @@ class DiTTrainer:
 
         self.base._init_callbacks()
 
-    def _setup(self):
-        self.base._setup()
+    def _setup(self) -> ParallelState:
+        bootstrap_state = self.base._setup()
         args: VeOmniDiTArguments = self.base.args
         args.train.dyn_bsz = False
         args.train.micro_batch_size = 1
         # dataloader_batch_size was computed in __post_init__ when dyn_bsz was still True
         # (default), so it was set to 1. Recompute now that dyn_bsz=False.
-        args.train.dataloader_batch_size = args.train.global_batch_size // self.base.parallel_state.dp_size
+        args.train.dataloader_batch_size = args.train.global_batch_size // bootstrap_state.dp_size
         if args.train.training_task == "offline_embedding":
             assert args.data.datasets_type == "mapping", "Datasets type must be mapping for offline embedding."
             if args.data.offline_embedding_save_dir is None:
@@ -242,7 +248,7 @@ class DiTTrainer:
             # No gradient accumulation needed; process one sample per step to
             # avoid broadcast_object_list serialising all micro-batches at once
             # which can OOM CPU memory with large video data.
-            args.train.global_batch_size = self.base.parallel_state.dp_size
+            args.train.global_batch_size = bootstrap_state.dp_size
             args.train.dataloader_batch_size = 1
             logger.info_rank0(
                 f"Task offline_embedding. Drop last: {args.data.drop_last}, shuffle: {args.data.shuffle}"
@@ -250,6 +256,7 @@ class DiTTrainer:
             args.train.num_train_epochs = 1
 
         self.training_task = args.train.training_task
+        return bootstrap_state
 
     def _build_model(self):
         logger.info_rank0("Build model")
@@ -269,6 +276,7 @@ class DiTTrainer:
         if self.training_task == "offline_training" or self.training_task == "online_training":
             logger.info_rank0(f"Task: {self.training_task}, prepare dit model.")
             self.base.model = build_foundation_model(
+                parallel_state=get_parallel_state(),
                 config_path=args.model.config_path,
                 weights_path=args.model.model_path,
                 torch_dtype="float32" if args.train.accelerator.fsdp_config.mixed_precision.enable else "bfloat16",
@@ -278,7 +286,7 @@ class DiTTrainer:
             )
             self.base.model_config = getattr(self.base.model, "config", None)
         else:
-            self.base.model = None
+            self.base.model = self.condition_model
             logger.info_rank0(f"Task: {self.training_task}, dit model is not prepared.")
 
     def _build_condition_model(
@@ -300,7 +308,7 @@ class DiTTrainer:
             self.condition_model = model_class._from_config(condition_cfg)
             self.condition_model.to(get_device_type())
             logger.info_rank0("Condition model loaded.")
-        bind_model_parallel_state(self.condition_model, self.base.parallel_state)
+        bind_model_parallel_state(self.condition_model, get_parallel_state())
 
     def _freeze_model_module(self):
         self.condition_model.requires_grad_(False)
@@ -326,7 +334,7 @@ class DiTTrainer:
 
     def _build_dataset(self):
         args: VeOmniDiTArguments = self.base.args
-        parallel_state = self.base.parallel_state
+        parallel_state = get_model_parallel_state(self.base.model)
         self.base._build_dataset()
         if parallel_state.sp_enabled and parallel_state.sp_rank != 0:
             self.base.train_dataset = None
@@ -342,6 +350,7 @@ class DiTTrainer:
                 logger.info(f"Rank {args.train.global_rank} data length to save: {valid_data_length}")
                 self.offline_embedding_saver = OfflineEmbeddingSaver(
                     save_path=self.offline_embedding_save_dir,
+                    parallel_state=parallel_state,
                     dataset_length=valid_data_length,
                 )
                 padded_len = (
@@ -371,9 +380,10 @@ class DiTTrainer:
     def _build_dataloader(self):
         """Build dataloader with dyn_bsz=False for DiT (fixed batch)."""
         args = self.base.args
-        parallel_state = self.base.parallel_state
+        parallel_state = get_model_parallel_state(self.base.model)
         if not parallel_state.sp_enabled or parallel_state.sp_rank == 0:
             self.base.train_dataloader = build_dataloader(
+                parallel_state=parallel_state,
                 dataloader_type=args.data.dataloader.type,
                 dataset=self.base.train_dataset,
                 micro_batch_size=args.train.micro_batch_size,
@@ -394,7 +404,6 @@ class DiTTrainer:
                 prefetch_factor=args.data.dataloader.prefetch_factor,
                 seed=args.train.seed,
                 collate_fn=DiTDataCollator(),
-                parallel_state=parallel_state,
                 save_steps=args.train.checkpoint.save_steps,
             )
         else:
@@ -485,7 +494,7 @@ class DiTTrainer:
 
     def train_step(self, data_iterator: Any) -> Dict[str, float]:
         args = self.base.args
-        parallel_state = self.base.parallel_state
+        parallel_state = get_model_parallel_state(self.base.model)
         self.base.state.global_step += 1
 
         # broadcast micro_batches from sp_rank_0 to all ranks
@@ -530,9 +539,7 @@ class DiTTrainer:
                     total_loss_dict[k] += v.item()
 
         if self.training_task != "offline_embedding":
-            grad_norm = veomni_clip_grad_norm(
-                self.base.model, args.train.optimizer.max_grad_norm, parallel_state=parallel_state
-            )
+            grad_norm = veomni_clip_grad_norm(self.base.model, args.train.optimizer.max_grad_norm)
             self.base.optimizer.step()
             self.base.lr_scheduler.step()
             self.base.optimizer.zero_grad()

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -29,7 +29,11 @@ from ..arguments import DataArguments, ModelArguments, TrainingArguments, VeOmni
 from ..data import build_data_transform, build_dataloader
 from ..data.data_collator import DataCollator
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
-from ..distributed.parallel_state import get_parallel_state
+from ..distributed.parallel_state import (
+    bind_model_parallel_state,
+    use_model_parallel_state,
+    use_parallel_state,
+)
 from ..models import build_foundation_model
 from ..models.auto import build_config
 from ..models.loader import MODEL_CONFIG_REGISTRY, MODELING_REGISTRY
@@ -183,7 +187,10 @@ class DiTTrainer:
 
         # rewrite _setup, setup arguments for dit training
         self._setup()
+        with use_parallel_state(self.base.parallel_state):
+            self._build_components()
 
+    def _build_components(self):
         # rewrite _build_model, build condition model & dit model
         self._build_model()
 
@@ -220,7 +227,7 @@ class DiTTrainer:
         args.train.micro_batch_size = 1
         # dataloader_batch_size was computed in __post_init__ when dyn_bsz was still True
         # (default), so it was set to 1. Recompute now that dyn_bsz=False.
-        args.train.dataloader_batch_size = args.train.global_batch_size // get_parallel_state().dp_size
+        args.train.dataloader_batch_size = args.train.global_batch_size // self.base.parallel_state.dp_size
         if args.train.training_task == "offline_embedding":
             assert args.data.datasets_type == "mapping", "Datasets type must be mapping for offline embedding."
             if args.data.offline_embedding_save_dir is None:
@@ -235,7 +242,7 @@ class DiTTrainer:
             # No gradient accumulation needed; process one sample per step to
             # avoid broadcast_object_list serialising all micro-batches at once
             # which can OOM CPU memory with large video data.
-            args.train.global_batch_size = get_parallel_state().dp_size
+            args.train.global_batch_size = self.base.parallel_state.dp_size
             args.train.dataloader_batch_size = 1
             logger.info_rank0(
                 f"Task offline_embedding. Drop last: {args.data.drop_last}, shuffle: {args.data.shuffle}"
@@ -293,6 +300,7 @@ class DiTTrainer:
             self.condition_model = model_class._from_config(condition_cfg)
             self.condition_model.to(get_device_type())
             logger.info_rank0("Condition model loaded.")
+        bind_model_parallel_state(self.condition_model, self.base.parallel_state)
 
     def _freeze_model_module(self):
         self.condition_model.requires_grad_(False)
@@ -318,14 +326,15 @@ class DiTTrainer:
 
     def _build_dataset(self):
         args: VeOmniDiTArguments = self.base.args
+        parallel_state = self.base.parallel_state
         self.base._build_dataset()
-        if get_parallel_state().sp_enabled and get_parallel_state().sp_rank != 0:
+        if parallel_state.sp_enabled and parallel_state.sp_rank != 0:
             self.base.train_dataset = None
 
         if self.training_task == "offline_embedding":
-            if not get_parallel_state().sp_enabled or get_parallel_state().sp_rank == 0:
-                dp_rank = get_parallel_state().dp_rank
-                dp_size = get_parallel_state().dp_size
+            if not parallel_state.sp_enabled or parallel_state.sp_rank == 0:
+                dp_rank = parallel_state.dp_rank
+                dp_size = parallel_state.dp_size
                 dataset_len = len(self.base.train_dataset)
                 base_count = dataset_len // dp_size
                 extra = dataset_len % dp_size
@@ -347,14 +356,14 @@ class DiTTrainer:
 
         # Sync _train_steps across the SP group AFTER padding so every rank
         # agrees on step count (required to avoid deadlocks in broadcast_object_list).
-        if get_parallel_state().sp_enabled:
+        if parallel_state.sp_enabled:
             steps_t = torch.zeros(1, dtype=torch.int64, device=torch.device(get_device_type()))
-            if get_parallel_state().sp_rank == 0:
+            if parallel_state.sp_rank == 0:
                 steps_t[0] = args._train_steps
             dist.broadcast(
                 steps_t,
-                src=dist.get_global_rank(get_parallel_state().sp_group, 0),
-                group=get_parallel_state().sp_group,
+                src=dist.get_global_rank(parallel_state.sp_group, 0),
+                group=parallel_state.sp_group,
             )
             args._train_steps = int(steps_t.item())
             self.base.train_steps = args.train_steps
@@ -362,7 +371,8 @@ class DiTTrainer:
     def _build_dataloader(self):
         """Build dataloader with dyn_bsz=False for DiT (fixed batch)."""
         args = self.base.args
-        if not get_parallel_state().sp_enabled or get_parallel_state().sp_rank == 0:
+        parallel_state = self.base.parallel_state
+        if not parallel_state.sp_enabled or parallel_state.sp_rank == 0:
             self.base.train_dataloader = build_dataloader(
                 dataloader_type=args.data.dataloader.type,
                 dataset=self.base.train_dataset,
@@ -384,6 +394,7 @@ class DiTTrainer:
                 prefetch_factor=args.data.dataloader.prefetch_factor,
                 seed=args.train.seed,
                 collate_fn=DiTDataCollator(),
+                parallel_state=parallel_state,
                 save_steps=args.train.checkpoint.save_steps,
             )
         else:
@@ -445,7 +456,7 @@ class DiTTrainer:
     def forward_backward_step(self, micro_batch: Dict[str, torch.Tensor]) -> tuple:
         micro_batch = self.preforward(micro_batch)
         if self.training_task == "online_training" or self.training_task == "offline_embedding":
-            with torch.no_grad():
+            with use_model_parallel_state(self.condition_model), torch.no_grad():
                 micro_batch = self.condition_model.get_condition(**micro_batch)
 
         if self.training_task == "offline_embedding":
@@ -455,29 +466,31 @@ class DiTTrainer:
             del micro_batch
             return 0.0, {}
 
-        with torch.no_grad():
+        with use_model_parallel_state(self.condition_model), torch.no_grad():
             micro_batch = self.condition_model.process_condition(**micro_batch)
-        with self.base.model_fwd_context:
-            outputs = self.base.model(**micro_batch)
+        with use_model_parallel_state(self.base.model):
+            with self.base.model_fwd_context:
+                outputs = self.base.model(**micro_batch)
 
-        loss: torch.Tensor
-        loss_dict: Dict[str, torch.Tensor]
-        loss, loss_dict = self.postforward(outputs, micro_batch)
+            loss: torch.Tensor
+            loss_dict: Dict[str, torch.Tensor]
+            loss, loss_dict = self.postforward(outputs, micro_batch)
 
-        # Backward pass
-        with self.base.model_bwd_context:
-            loss.backward()
+            # Backward pass
+            with self.base.model_bwd_context:
+                loss.backward()
 
         del micro_batch
         return loss, loss_dict
 
     def train_step(self, data_iterator: Any) -> Dict[str, float]:
         args = self.base.args
+        parallel_state = self.base.parallel_state
         self.base.state.global_step += 1
 
         # broadcast micro_batches from sp_rank_0 to all ranks
-        if get_parallel_state().sp_enabled:
-            if get_parallel_state().sp_rank == 0:
+        if parallel_state.sp_enabled:
+            if parallel_state.sp_rank == 0:
                 micro_batches = next(data_iterator)
             else:
                 micro_batches = None
@@ -485,8 +498,8 @@ class DiTTrainer:
             obj_list = [micro_batches]
             dist.broadcast_object_list(
                 obj_list,
-                src=dist.get_global_rank(get_parallel_state().sp_group, 0),
-                group=get_parallel_state().sp_group,
+                src=dist.get_global_rank(parallel_state.sp_group, 0),
+                group=parallel_state.sp_group,
             )
             micro_batches = obj_list[0]
         else:
@@ -517,7 +530,9 @@ class DiTTrainer:
                     total_loss_dict[k] += v.item()
 
         if self.training_task != "offline_embedding":
-            grad_norm = veomni_clip_grad_norm(self.base.model, args.train.optimizer.max_grad_norm)
+            grad_norm = veomni_clip_grad_norm(
+                self.base.model, args.train.optimizer.max_grad_norm, parallel_state=parallel_state
+            )
             self.base.optimizer.step()
             self.base.lr_scheduler.step()
             self.base.optimizer.zero_grad()

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -25,7 +25,12 @@ from ..arguments import MixedPrecisionConfig, VeOmniArguments
 from ..data import build_chat_template, build_data_transform
 from ..data.data_collator import PostCollator
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
-from ..distributed.parallel_state import get_parallel_state, use_model_parallel_state, use_parallel_state
+from ..distributed.parallel_state import (
+    get_model_parallel_state,
+    get_parallel_state,
+    use_model_parallel_state,
+    use_parallel_state,
+)
 from ..distributed.sequence_parallel import gather_outputs
 from ..distributed.torch_compile import mark_compile_step_begin
 from ..distributed.torch_parallelize import build_parallelize_model
@@ -140,12 +145,12 @@ class TextDPOTrainer:
         self.base = BaseTrainer.__new__(BaseTrainer)
         self.base.args = args
 
-        self.base._setup()
-        with use_parallel_state(self.base.parallel_state):
-            self._build_components()
+        bootstrap_state = self.base._setup()
+        with use_parallel_state(bootstrap_state):
+            self.base._build_model()
+        self._build_components()
 
     def _build_components(self):
-        self.base._build_model()
         self.base._freeze_model_module()
 
         self._build_model_assets()
@@ -180,8 +185,9 @@ class TextDPOTrainer:
         )
 
     def _build_postforward(self):
-        self.post_forward = PostCollator(parallel_state=self.base.parallel_state)
-        self.sp_enabled = self.base.parallel_state.sp_enabled
+        policy_state = get_model_parallel_state(self.base.model)
+        self.post_forward = PostCollator(parallel_state=policy_state)
+        self.sp_enabled = policy_state.sp_enabled
 
     def _build_reference_model(self):
         """Build and freeze a reference model with the same architecture and FSDP sharding."""
@@ -189,6 +195,7 @@ class TextDPOTrainer:
         logger.info_rank0("Building frozen reference model for DPO")
 
         self.reference_model = build_foundation_model(
+            parallel_state=get_model_parallel_state(self.base.model),
             config_path=args.model.config_path,
             weights_path=args.model.model_path,
             torch_dtype=args.dpo_config.refer_model_precision,
@@ -218,7 +225,6 @@ class TextDPOTrainer:
             broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
             cpu_load_param_name=cpu_load_param_name,
             max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
-            parallel_state=self.base.parallel_state,
         )
         self.reference_model.eval()
         helper.print_device_mem_info("VRAM usage after building reference model")
@@ -408,9 +414,7 @@ class TextDPOTrainer:
             for k, v in loss_dict.items():
                 total_loss_dict[k] += v.item()
 
-        grad_norm = veomni_clip_grad_norm(
-            self.base.model, args.train.optimizer.max_grad_norm, parallel_state=self.base.parallel_state
-        )
+        grad_norm = veomni_clip_grad_norm(self.base.model, args.train.optimizer.max_grad_norm)
 
         self.base.optimizer.step()
         self.base.lr_scheduler.step()

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -25,7 +25,7 @@ from ..arguments import MixedPrecisionConfig, VeOmniArguments
 from ..data import build_chat_template, build_data_transform
 from ..data.data_collator import PostCollator
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
-from ..distributed.parallel_state import get_parallel_state
+from ..distributed.parallel_state import get_parallel_state, use_model_parallel_state, use_parallel_state
 from ..distributed.sequence_parallel import gather_outputs
 from ..distributed.torch_compile import mark_compile_step_begin
 from ..distributed.torch_parallelize import build_parallelize_model
@@ -141,6 +141,10 @@ class TextDPOTrainer:
         self.base.args = args
 
         self.base._setup()
+        with use_parallel_state(self.base.parallel_state):
+            self._build_components()
+
+    def _build_components(self):
         self.base._build_model()
         self.base._freeze_model_module()
 
@@ -176,8 +180,8 @@ class TextDPOTrainer:
         )
 
     def _build_postforward(self):
-        self.post_forward = PostCollator()
-        self.sp_enabled = get_parallel_state().sp_enabled
+        self.post_forward = PostCollator(parallel_state=self.base.parallel_state)
+        self.sp_enabled = self.base.parallel_state.sp_enabled
 
     def _build_reference_model(self):
         """Build and freeze a reference model with the same architecture and FSDP sharding."""
@@ -214,6 +218,7 @@ class TextDPOTrainer:
             broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,
             cpu_load_param_name=cpu_load_param_name,
             max_load_broadcast_size=args.train.accelerator.fsdp_config.max_load_broadcast_size,
+            parallel_state=self.base.parallel_state,
         )
         self.reference_model.eval()
         helper.print_device_mem_info("VRAM usage after building reference model")
@@ -254,7 +259,9 @@ class TextDPOTrainer:
 
         return losses, chosen_rewards, rejected_rewards
 
-    def concatenated_forward(self, model: nn.Module, micro_batch: Dict[str, Any]) -> Tuple[torch.Tensor, torch.Tensor]:
+    def _concatenated_forward(
+        self, model: nn.Module, micro_batch: Dict[str, Any]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Run a single forward pass on the packed batch containing chosen+rejected pairs.
 
         Each DPO sample contributes two consecutive sequences (chosen
@@ -312,6 +319,11 @@ class TextDPOTrainer:
         all_logps_t = torch.stack(all_logps)
         return all_logps_t[0::2], all_logps_t[1::2]
 
+    def concatenated_forward(self, model: nn.Module, micro_batch: Dict[str, Any]) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run DPO forward under the state owned by ``model``."""
+        with use_model_parallel_state(model):
+            return self._concatenated_forward(model, micro_batch)
+
     def forward_backward_step(
         self, micro_batch: Dict[str, torch.Tensor]
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
@@ -348,8 +360,9 @@ class TextDPOTrainer:
             "reward_margin": (chosen_rewards - rejected_rewards).mean().detach(),
         }
 
-        with self.base.model_bwd_context, set_batch_invariant_mode(args.train.enable_batch_invariant_mode):
-            loss.backward()
+        with use_model_parallel_state(self.base.model):
+            with self.base.model_bwd_context, set_batch_invariant_mode(args.train.enable_batch_invariant_mode):
+                loss.backward()
 
         del micro_batch
         return loss, loss_dict
@@ -395,7 +408,9 @@ class TextDPOTrainer:
             for k, v in loss_dict.items():
                 total_loss_dict[k] += v.item()
 
-        grad_norm = veomni_clip_grad_norm(self.base.model, args.train.optimizer.max_grad_norm)
+        grad_norm = veomni_clip_grad_norm(
+            self.base.model, args.train.optimizer.max_grad_norm, parallel_state=self.base.parallel_state
+        )
 
         self.base.optimizer.step()
         self.base.lr_scheduler.step()

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -44,12 +44,12 @@ class TextTrainer:
         self.base = BaseTrainer.__new__(BaseTrainer)
         self.base.args = args
 
-        self.base._setup()
-        with use_parallel_state(self.base.parallel_state):
-            self._build_components()
+        bootstrap_state = self.base._setup()
+        with use_parallel_state(bootstrap_state):
+            self.base._build_model()
+        self._build_components()
 
     def _build_components(self):
-        self.base._build_model()
         self.base._freeze_model_module()
 
         # rewrite build_model_assets to support chat_template for conversation dataset
@@ -141,9 +141,7 @@ class TextTrainer:
                 total_loss_dict[k] += v.item()
 
         # Gradient clipping
-        grad_norm = veomni_clip_grad_norm(
-            self.base.model, args.train.optimizer.max_grad_norm, parallel_state=self.base.parallel_state
-        )
+        grad_norm = veomni_clip_grad_norm(self.base.model, args.train.optimizer.max_grad_norm)
 
         # Optimizer and scheduler step
         self.base.optimizer.step()

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -23,6 +23,7 @@ from ..data import (
     build_data_transform,
 )
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
+from ..distributed.parallel_state import use_parallel_state
 from ..distributed.torch_compile import mark_compile_step_begin
 from ..models import build_tokenizer
 from ..utils import helper
@@ -44,6 +45,10 @@ class TextTrainer:
         self.base.args = args
 
         self.base._setup()
+        with use_parallel_state(self.base.parallel_state):
+            self._build_components()
+
+    def _build_components(self):
         self.base._build_model()
         self.base._freeze_model_module()
 
@@ -136,7 +141,9 @@ class TextTrainer:
                 total_loss_dict[k] += v.item()
 
         # Gradient clipping
-        grad_norm = veomni_clip_grad_norm(self.base.model, args.train.optimizer.max_grad_norm)
+        grad_norm = veomni_clip_grad_norm(
+            self.base.model, args.train.optimizer.max_grad_norm, parallel_state=self.base.parallel_state
+        )
 
         # Optimizer and scheduler step
         self.base.optimizer.step()

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -21,6 +21,7 @@ import torch
 from ..arguments import DataArguments, ModelArguments, TrainingArguments, VeOmniArguments
 from ..data import MainCollator, build_data_transform, build_multimodal_chat_template
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
+from ..distributed.parallel_state import use_parallel_state
 from ..models import build_foundation_model, build_processor
 from ..optim import build_optimizer
 from ..utils import helper
@@ -103,7 +104,10 @@ class VLMTrainer:
         self.base.args = args
 
         self.base._setup()
+        with use_parallel_state(self.base.parallel_state):
+            self._build_components()
 
+    def _build_components(self):
         # rewrite build model to support data balancing
         self._build_model()
 
@@ -222,6 +226,7 @@ class VLMTrainer:
             seq_classification=seq_classification,
             data_collate_info=data_collate_info,
             metadata_collate_func=metadata_collate_func,
+            parallel_state=self.base.parallel_state,
         )
 
     def _build_optimizer(self):
@@ -256,6 +261,7 @@ class VLMTrainer:
             no_decay_modules=args.train.optimizer.no_decay_modules,
             no_decay_params=args.train.optimizer.no_decay_params,
             muon_kwargs=_collect_muon_kwargs(args.train.optimizer),
+            parallel_state=self.base.parallel_state,
         )
 
     def on_train_begin(self):
@@ -310,7 +316,9 @@ class VLMTrainer:
                 total_loss_dict[k] += v.item()
 
         # Gradient clipping
-        grad_norm = veomni_clip_grad_norm(self.base.model, args.train.optimizer.max_grad_norm)
+        grad_norm = veomni_clip_grad_norm(
+            self.base.model, args.train.optimizer.max_grad_norm, parallel_state=self.base.parallel_state
+        )
 
         # Optimizer and scheduler step
         self.base.optimizer.step()

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -21,7 +21,7 @@ import torch
 from ..arguments import DataArguments, ModelArguments, TrainingArguments, VeOmniArguments
 from ..data import MainCollator, build_data_transform, build_multimodal_chat_template
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
-from ..distributed.parallel_state import use_parallel_state
+from ..distributed.parallel_state import get_model_parallel_state, get_parallel_state, use_parallel_state
 from ..models import build_foundation_model, build_processor
 from ..optim import build_optimizer
 from ..utils import helper
@@ -103,14 +103,12 @@ class VLMTrainer:
         self.base = BaseTrainer.__new__(BaseTrainer)
         self.base.args = args
 
-        self.base._setup()
-        with use_parallel_state(self.base.parallel_state):
-            self._build_components()
+        bootstrap_state = self.base._setup()
+        with use_parallel_state(bootstrap_state):
+            self._build_model()
+        self._build_components()
 
     def _build_components(self):
-        # rewrite build model to support data balancing
-        self._build_model()
-
         # rewrite freeze_model_module to support freeze multimodal encoder, etc.
         self._freeze_model_module()
 
@@ -139,6 +137,7 @@ class VLMTrainer:
         args: VeOmniVLMArguments = self.base.args
         logger.info_rank0("Build model")
         self.base.model = build_foundation_model(
+            parallel_state=get_parallel_state(),
             config_path=args.model.config_path,
             weights_path=args.model.model_path,
             torch_dtype="float32" if args.train.accelerator.fsdp_config.mixed_precision.enable else "bfloat16",
@@ -226,7 +225,7 @@ class VLMTrainer:
             seq_classification=seq_classification,
             data_collate_info=data_collate_info,
             metadata_collate_func=metadata_collate_func,
-            parallel_state=self.base.parallel_state,
+            parallel_state=get_model_parallel_state(self.base.model),
         )
 
     def _build_optimizer(self):
@@ -261,7 +260,6 @@ class VLMTrainer:
             no_decay_modules=args.train.optimizer.no_decay_modules,
             no_decay_params=args.train.optimizer.no_decay_params,
             muon_kwargs=_collect_muon_kwargs(args.train.optimizer),
-            parallel_state=self.base.parallel_state,
         )
 
     def on_train_begin(self):
@@ -316,9 +314,7 @@ class VLMTrainer:
                 total_loss_dict[k] += v.item()
 
         # Gradient clipping
-        grad_norm = veomni_clip_grad_norm(
-            self.base.model, args.train.optimizer.max_grad_norm, parallel_state=self.base.parallel_state
-        )
+        grad_norm = veomni_clip_grad_norm(self.base.model, args.train.optimizer.max_grad_norm)
 
         # Optimizer and scheduler step
         self.base.optimizer.step()

--- a/veomni/utils/dit_utils.py
+++ b/veomni/utils/dit_utils.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 
+from ..distributed.parallel_state import ParallelState
 from .device import synchronize
 from .helper import EnvironMeter as OriginalEnvironMeter
 
@@ -95,8 +96,15 @@ class EnvironMeter(OriginalEnvironMeter):
         config: "PretrainedConfig",
         global_batch_size: int,
         empty_cache_steps: int = 500,
+        *,
+        parallel_state: ParallelState,
     ) -> None:
-        super().__init__(config, global_batch_size, empty_cache_steps=empty_cache_steps)
+        super().__init__(
+            config,
+            global_batch_size,
+            empty_cache_steps=empty_cache_steps,
+            parallel_state=parallel_state,
+        )
 
     def add(self, micro_batch: Dict[str, "torch.Tensor"], model_type: Optional[str] = None) -> None:
         if model_type == "wan":

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -36,7 +36,7 @@ import torch.nn as nn
 import transformers
 from transformers import set_seed as set_seed_func
 
-from ..distributed.parallel_state import get_parallel_state
+from ..distributed.parallel_state import ParallelState
 from . import logging
 from .count_flops import VeomniFlopsCounter
 from .device import (
@@ -170,12 +170,15 @@ class EnvironMeter:
         data_path: str = "",
         empty_cache_steps: int = 500,
         gc_steps: int = 0,
+        *,
+        parallel_state: ParallelState,
     ) -> None:
         self.config = config
         self.global_batch_size = global_batch_size
         self.enable_multisource = enable_multisource
         self.empty_cache_steps = empty_cache_steps
         self.gc_steps = gc_steps
+        self.parallel_state = parallel_state
         self.world_size = dist.get_world_size()
         self.consume_tokens = 0
         self.consume_chunks = 0
@@ -189,7 +192,9 @@ class EnvironMeter:
                     "`dataloader` and `data_path` is required for `EnvironMeter` with multi-source dataloader."
                 )
 
-            self.multisource_tracker = MultiSourceInfoTracker(dataloader=dataloader, data_path=data_path)
+            self.multisource_tracker = MultiSourceInfoTracker(
+                dataloader=dataloader, data_path=data_path, parallel_state=parallel_state
+            )
 
         # for internal use
         if VALID_CONFIG_TYPE is not None and isinstance(config, VALID_CONFIG_TYPE):
@@ -239,7 +244,7 @@ class EnvironMeter:
         flops_achieved, batch_tokens, real_global_batch_size = all_reduce(
             (flops_achieved, sum(self.batch_seqlens), len(self.batch_seqlens)),
             op="sum",
-            group=get_parallel_state().dp_group,
+            group=self.parallel_state.dp_group,
         )
         flops_promised = flops_promised * self.world_size
         mfu = flops_achieved / flops_promised if flops_promised else 0
@@ -315,13 +320,14 @@ class MultiSourceInfoTracker:
     Tracks the statistics about the weighted multi-source dataset.
     """
 
-    def __init__(self, dataloader: Optional["DataLoader"], data_path: str) -> None:
+    def __init__(self, dataloader: Optional["DataLoader"], data_path: str, parallel_state: ParallelState) -> None:
         self.dataloader = dataloader
         self.accumulate_counter = dict()
         self.batch_idx = 0
         self.multisource_config = parse_multisource_config(data_path)
         self.names = self.multisource_config["names"]
         self.boundary_type = self.multisource_config.get("boundary_type", "token")
+        self.parallel_state = parallel_state
 
     def state_dict(self) -> Dict[str, Any]:
         return {"accumulate_counter": self.accumulate_counter, "batch_idx": self.batch_idx}
@@ -338,8 +344,8 @@ class MultiSourceInfoTracker:
         for ds_idx, seq_len in zip(batch_ds_idx, batch_seqlens):
             counter[ds_idx].increment(seq_len, 1)
 
-        counter_list: List[Dict[int, MultiSourceCounterItem]] = [None for _ in range(get_parallel_state().dp_size)]
-        dist.all_gather_object(counter_list, counter, group=get_parallel_state().dp_group)
+        counter_list: List[Dict[int, MultiSourceCounterItem]] = [None for _ in range(self.parallel_state.dp_size)]
+        dist.all_gather_object(counter_list, counter, group=self.parallel_state.dp_group)
 
         global_counter = defaultdict(MultiSourceCounterItem)
         for counter in counter_list:
@@ -355,7 +361,7 @@ class MultiSourceInfoTracker:
         global_comsumed_samples = sum([item.num_samples for item in self.accumulate_counter.values()])
 
         if hasattr(self.dataloader, "update_consumed_tokens") and (
-            not get_parallel_state().tp_enabled or get_parallel_state().tp_rank == 0
+            not self.parallel_state.tp_enabled or self.parallel_state.tp_rank == 0
         ):  # update at every dp rank
             if self.boundary_type == "token":
                 self.dataloader.update_consumed_tokens((self.batch_idx, global_consumed_tokens))

--- a/veomni/utils/loss_utils.py
+++ b/veomni/utils/loss_utils.py
@@ -16,7 +16,7 @@ from typing import Union
 
 import torch
 
-from ..distributed.parallel_state import get_parallel_state
+from ..distributed.parallel_state import ParallelState
 from .constants import IGNORE_INDEX
 from .dist_utils import all_reduce
 
@@ -55,9 +55,10 @@ def mean_global_loss(
     losses: Union[dict[str, torch.Tensor], torch.Tensor],
     micro_batch_token_len: dict[str, torch.Tensor],
     micro_batches_token_len: dict[str, torch.Tensor],
+    parallel_state: ParallelState,
 ):
     """Calcuate the global mean loss. Avg on all_reduced_token_num instead of on dp_size.
-    - cur_losses[key] = cur_loss * cur_token_num / global_batches_token_num * get_parallel_state().fsdp_size
+    - cur_losses[key] = cur_loss * cur_token_num / global_batches_token_num * parallel_state.fsdp_size
     # fsdp by default divides gradients by its size, so we need to multiply by fsdp_size
     """
     loss_dict = {}
@@ -69,21 +70,21 @@ def mean_global_loss(
         loss_name = key.split("_loss")[0]  # foundation/image_decoder/**
 
         cur_token_len = micro_batch_token_len[f"{loss_name}_tokens"]
-        if get_parallel_state().sp_enabled:
-            cur_token_len = all_reduce(cur_token_len.item(), op="sum", group=get_parallel_state().sp_group)
+        if parallel_state.sp_enabled:
+            cur_token_len = all_reduce(cur_token_len.item(), op="sum", group=parallel_state.sp_group)
 
         all_reduced_len = all_reduce((micro_batches_token_len[f"{loss_name}_tokens"].item()), op="sum")
 
         if all_reduced_len != 0:
-            cur_loss = cur_loss * cur_token_len / all_reduced_len * get_parallel_state().fsdp_size
+            cur_loss = cur_loss * cur_token_len / all_reduced_len * parallel_state.fsdp_size
         else:
             if not torch.allclose(cur_loss, torch.zeros_like(cur_loss)):
                 raise ValueError(
                     f"The all_reduced_len for {loss_name}_tokens is 0, but the cur_loss is not 0: {cur_loss}"
                 )
 
-        if get_parallel_state().sp_enabled:
-            cur_loss = cur_loss / get_parallel_state().sp_size
+        if parallel_state.sp_enabled:
+            cur_loss = cur_loss / parallel_state.sp_size
 
         loss_dict[key] = cur_loss
 


### PR DESCRIPTION
[BREAKING][dist, model, trainer] refactor: make parallel state model-owned

### What does this PR do?

Makes `ParallelState` model-owned so one RL trainer can coordinate policy, reference, reward, and drafter models with different parallel topologies.

This refines the design discussed in #893: model binding is the source of truth, while a `ContextVar` scopes existing patched modeling code that calls `get_parallel_state()` to the active model execution.

### Checklist Before Starting

- Related PR: #893
- PR title follows `[{modules}] {type}: {description}` format.

### Test

- `source .venv/bin/activate && make quality`
- `python3 -m compileall -q veomni tasks tests`
- Added model-ownership, nested-context, worker-pickle, process-group-lifetime, fullgraph compile, strict group-resolution, test-group-precedence, and autograd backward regression tests.
- Full pytest cannot run in the local macOS environment because the project GPU/NPU PyTorch stack is unavailable there. GPU, NPU, distributed, and torch.compile validation is delegated to the GitHub CI pipeline.

### API and Usage Example

```python
policy_state = build_parallel_state(dp_size=8, ulysses_size=1)
drafter_state = build_parallel_state(dp_size=4, ulysses_size=2)

policy = build_foundation_model(..., parallel_state=policy_state)
drafter = build_foundation_model(..., parallel_state=drafter_state)

policy = build_parallelize_model(policy, ...)
drafter = build_parallelize_model(drafter, ...)

draft = drafter(**draft_inputs)
with use_model_parallel_state(policy):
    outputs = policy(**policy_inputs)
    outputs.loss.backward()
```

This is a breaking API change: `init_parallel_state()` and the process-global default state are removed. Callers must retain `build_parallel_state()`'s result and pass it explicitly.

### Design & Code Changes

- Add side-effect-free `build_parallel_state()` with process-group-lifetime-aware topology caching.
- Bind a non-serialized state reference in `build_parallelize_model(..., parallel_state=...)`.
- Keep bootstrap state local to model construction; trainers do not retain a `parallel_state` attribute.
- Add nested and exception-safe model execution contexts backed by `ContextVar`.
- Mark context lookups as per-graph constants so `torch.compile(fullgraph=True)` captures each model's topology without tracing `ContextVar.get()`.
- Resolve optimizer, gradient clipping, checkpoint, collator, and dataloader behavior from explicit/model-owned state.
- Make DPO policy/reference and DiT condition/foundation execution select state by model.
- Resolve SP communication groups only from the active model context, with a narrow Ulysses group override for standalone communication tests.
- Keep worker collators pickle-safe by storing only scalar SP metadata.
- Capture SP world size during `ReduceLoss.forward()` so backward never reads another model's ambient state.
- Update developer constraints, architecture notes, and user documentation.

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] Applied pre-commit quality checks
- [x] Added/updated documentation
- [x] Added tests for the new ownership and lifecycle behavior
