### PR TITLE
[model, ci] fix: load DeepSeek V4 Flash checkpoints

### DIFF
--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -127,6 +127,11 @@ YAML Config -> VeOmniArguments -> Trainer
 6. Load weights (`load_model_weights()` or `rank0_load_and_broadcast_weights()`)
 7. Apply parallelization (`build_parallelize_model()`)
 
+Model-specific streaming checkpoint converters should reuse Transformers' registered
+`WeightRenaming` rules for namespace conversion. VeOmni converters are responsible
+only for transforms that the streaming loader must perform itself, such as block-scale
+dequantization and buffering/fusing per-expert tensors.
+
 ## Parallelization Flow
 
 VeOmni uses FSDP2 exclusively.

--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -127,11 +127,6 @@ YAML Config -> VeOmniArguments -> Trainer
 6. Load weights (`load_model_weights()` or `rank0_load_and_broadcast_weights()`)
 7. Apply parallelization (`build_parallelize_model()`)
 
-Model-specific streaming checkpoint converters should reuse Transformers' registered
-`WeightRenaming` rules for namespace conversion. VeOmni converters are responsible
-only for transforms that the streaming loader must perform itself, such as block-scale
-dequantization and buffering/fusing per-expert tensors.
-
 ## Parallelization Flow
 
 VeOmni uses FSDP2 exclusively.

--- a/tests/models/test_checkpoint_tensor_converter.py
+++ b/tests/models/test_checkpoint_tensor_converter.py
@@ -30,10 +30,10 @@ from veomni.models.checkpoint_tensor_loading import (
     get_checkpoint_tensor_converter,
     maybe_convert_checkpoint_tensor,
 )
-from veomni.models.transformers.deepseek_v4 import checkpoint_tensor_converter as deepseek_v4_converter
 from veomni.models.transformers.deepseek_v4.checkpoint_tensor_converter import (
     DeepseekV4CheckpointTensorConverter,
     _dequantize_scaled_weight,
+    _get_fp4_e2m1_table,
     convert_deepseek_v4_checkpoint_key,
     convert_deepseek_v4_fqn_to_index_mapping,
     create_deepseek_v4_checkpoint_tensor_converter,
@@ -438,6 +438,18 @@ class TestDeepseekV4ConverterCanHandle:
     def test_rejects_non_tensor_keys(self):
         assert not self.converter.can_handle("model.layers.0.mlp.experts.gate_up_proj")
 
+    @pytest.mark.parametrize("model_prefix", ("", "model."))
+    def test_ignores_mtp_checkpoint_keys(self, model_prefix: str):
+        stem = f"{model_prefix}mtp.0.attn.wkv"
+        weight = torch.ones(4, 4, dtype=torch.int8)
+
+        assert not self.converter.can_handle(f"{stem}.scale")
+        assert not self.converter.can_handle_tensor(f"{stem}.weight", weight)
+        result = maybe_convert_checkpoint_tensor(f"{stem}.weight", weight, self.converter)
+        assert result is not None
+        assert result.name == f"{stem}.weight"
+        assert result.tensor is weight
+
 
 class TestDeepseekV4ConverterConvert:
     def test_dequantizes_block_scaled_fp8_weight(self):
@@ -458,27 +470,14 @@ class TestDeepseekV4ConverterConvert:
         assert result.shape == (1, 64)
         assert torch.equal(result, expected)
 
-    def test_reuses_fp4_lookup_table(self, monkeypatch):
-        weight = torch.full((1, 32), 0x21, dtype=torch.uint8).view(torch.int8)
-        scale = torch.ones(1, 2)
-        original_tensor = torch.tensor
-        table_allocations = 0
-        deepseek_v4_converter._get_fp4_e2m1_table.cache_clear()
-
-        def counted_tensor(*args, **kwargs):
-            nonlocal table_allocations
-            if args and args[0] == deepseek_v4_converter._FP4_E2M1_VALUES:
-                table_allocations += 1
-            return original_tensor(*args, **kwargs)
-
-        monkeypatch.setattr(deepseek_v4_converter.torch, "tensor", counted_tensor)
-
+    def test_reuses_fp4_lookup_table(self):
+        _get_fp4_e2m1_table.cache_clear()
         try:
-            _dequantize_scaled_weight(weight, scale, packed_fp4=True)
-            _dequantize_scaled_weight(weight, scale, packed_fp4=True)
-            assert table_allocations == 1
+            first = _get_fp4_e2m1_table(torch.device("cpu"))
+            second = _get_fp4_e2m1_table(torch.device("cpu"))
+            assert first is second
         finally:
-            deepseek_v4_converter._get_fp4_e2m1_table.cache_clear()
+            _get_fp4_e2m1_table.cache_clear()
 
     def test_dequantizes_conventional_int8_weight_without_unpacking(self):
         weight = torch.arange(16, dtype=torch.int8).reshape(4, 4)
@@ -536,6 +535,7 @@ class TestDeepseekV4ConverterConvert:
             ("layers.2.hc_attn_base", "model.layers.2.attn_hc.base"),
             ("layers.2.hc_ffn_scale", "model.layers.2.ffn_hc.scale"),
             ("mtp.0.attn.wkv.weight", "mtp.0.attn.wkv.weight"),
+            ("model.mtp.0.attn.wkv.weight", "model.mtp.0.attn.wkv.weight"),
             ("model.custom.weight", "model.custom.weight"),
         ],
     )
@@ -803,6 +803,14 @@ class TestDeepseekV4ConverterFactoryAndMapping:
             "model.layers.0.mlp.experts.gate_up_proj": 2,
             "model.layers.0.mlp.experts.down_proj": 3,
         }
+
+    def test_fqn_mapping_preserves_mtp_keys(self):
+        mapping = {
+            "mtp.0.attn.wkv.weight": 0,
+            "model.mtp.0.attn.wkv.weight": 1,
+        }
+
+        assert convert_deepseek_v4_fqn_to_index_mapping(mapping) == mapping
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/test_checkpoint_tensor_converter.py
+++ b/tests/models/test_checkpoint_tensor_converter.py
@@ -542,6 +542,23 @@ class TestDeepseekV4ConverterConvert:
     def test_converts_deepseek_inference_checkpoint_names(self, raw_name: str, converted_name: str):
         assert convert_deepseek_v4_checkpoint_key(raw_name) == converted_name
 
+    @pytest.mark.parametrize(
+        ("raw_name", "converted_name"),
+        [
+            ("embed.weight", "embed_tokens.weight"),
+            ("model.embed.weight", "embed_tokens.weight"),
+            ("norm.weight", "norm.weight"),
+            ("model.norm.weight", "norm.weight"),
+            ("layers.2.attn.wkv.weight", "layers.2.self_attn.kv_proj.weight"),
+            ("model.layers.2.attn.wkv.weight", "layers.2.self_attn.kv_proj.weight"),
+            ("layers.2.ffn.experts.7.w3.scale", "layers.2.mlp.experts.7.w3.scale"),
+            ("head.weight", "lm_head.weight"),
+            ("model.custom.weight", "model.custom.weight"),
+        ],
+    )
+    def test_converts_deepseek_inference_checkpoint_names_for_base_model(self, raw_name: str, converted_name: str):
+        assert convert_deepseek_v4_checkpoint_key(raw_name, target_model_prefix="") == converted_name
+
     def test_raw_inference_fp8_pair_emits_hf_name(self):
         converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
         weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
@@ -552,6 +569,18 @@ class TestDeepseekV4ConverterConvert:
 
         assert result is not None
         assert result.name == "model.layers.0.self_attn.kv_proj.weight"
+        assert torch.equal(result.tensor, weight.float())
+
+    def test_raw_inference_fp8_pair_emits_base_model_name(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS, target_model_prefix="")
+        weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
+        scale = torch.ones(2, 2)
+
+        assert maybe_convert_checkpoint_tensor("layers.0.attn.wkv.weight", weight, converter) is None
+        result = maybe_convert_checkpoint_tensor("layers.0.attn.wkv.scale", scale, converter)
+
+        assert result is not None
+        assert result.name == "layers.0.self_attn.kv_proj.weight"
         assert torch.equal(result.tensor, weight.float())
 
     def test_fp8_weight_scale_pair_emits_dequantized_weight(self):
@@ -767,10 +796,24 @@ class TestDeepseekV4ConverterConvert:
 
 class TestDeepseekV4ConverterFactoryAndMapping:
     def test_factory_creates_converter(self):
-        model = SimpleNamespace(config=SimpleNamespace(n_routed_experts=8))
+        model = SimpleNamespace(
+            config=SimpleNamespace(n_routed_experts=8),
+            named_parameters=lambda: iter([("model.embed_tokens.weight", torch.nn.Parameter(torch.empty(1)))]),
+        )
         converter = create_deepseek_v4_checkpoint_tensor_converter(model)
         assert isinstance(converter, DeepseekV4CheckpointTensorConverter)
         assert converter.num_experts == 8
+        assert converter.target_model_prefix == "model."
+
+    def test_factory_creates_base_model_converter(self):
+        model = SimpleNamespace(
+            config=SimpleNamespace(n_routed_experts=8),
+            named_parameters=lambda: iter([("embed_tokens.weight", torch.nn.Parameter(torch.empty(1)))]),
+        )
+        converter = create_deepseek_v4_checkpoint_tensor_converter(model)
+        assert isinstance(converter, DeepseekV4CheckpointTensorConverter)
+        assert converter.num_experts == 8
+        assert converter.target_model_prefix == ""
 
     def test_fqn_mapping_accepts_raw_w_keys(self):
         mapping = {
@@ -802,6 +845,24 @@ class TestDeepseekV4ConverterFactoryAndMapping:
             "model.layers.0.self_attn.kv_proj.weight": 1,
             "model.layers.0.mlp.experts.gate_up_proj": 2,
             "model.layers.0.mlp.experts.down_proj": 3,
+        }
+
+    def test_fqn_mapping_converts_inference_checkpoint_keys_for_base_model(self):
+        mapping = {
+            "embed.weight": 0,
+            "layers.0.attn.wkv.weight": 1,
+            "layers.0.ffn.experts.0.w1.weight": 2,
+            "layers.0.ffn.experts.0.w2.weight": 3,
+            "layers.0.ffn.experts.0.w3.weight": 4,
+        }
+
+        converted = convert_deepseek_v4_fqn_to_index_mapping(mapping, target_model_prefix="")
+
+        assert converted == {
+            "embed_tokens.weight": 0,
+            "layers.0.self_attn.kv_proj.weight": 1,
+            "layers.0.mlp.experts.gate_up_proj": 2,
+            "layers.0.mlp.experts.down_proj": 3,
         }
 
     def test_fqn_mapping_preserves_mtp_keys(self):

--- a/tests/models/test_checkpoint_tensor_converter.py
+++ b/tests/models/test_checkpoint_tensor_converter.py
@@ -33,6 +33,7 @@ from veomni.models.checkpoint_tensor_loading import (
 from veomni.models.transformers.deepseek_v4.checkpoint_tensor_converter import (
     DeepseekV4CheckpointTensorConverter,
     _dequantize_scaled_weight,
+    convert_deepseek_v4_checkpoint_key,
     convert_deepseek_v4_fqn_to_index_mapping,
     create_deepseek_v4_checkpoint_tensor_converter,
 )
@@ -428,6 +429,11 @@ class TestDeepseekV4ConverterCanHandle:
         weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
         assert self.converter.can_handle_tensor("model.layers.0.attn.wkv.weight", weight)
 
+    def test_matches_raw_inference_checkpoint_names(self):
+        assert self.converter.can_handle("embed.weight")
+        assert self.converter.can_handle("layers.0.attn.wkv.scale")
+        assert self.converter.can_handle_tensor("layers.0.attn.wkv.weight", torch.ones(4, 4))
+
     def test_rejects_non_tensor_keys(self):
         assert not self.converter.can_handle("model.layers.0.mlp.experts.gate_up_proj")
 
@@ -438,6 +444,82 @@ class TestDeepseekV4ConverterConvert:
         scale = torch.tensor([[1.0, 2.0], [4.0, 8.0]])
         expected = weight.float().view(2, 2, 2, 2).mul(scale.view(2, 1, 2, 1)).reshape(4, 4)
         assert torch.equal(_dequantize_scaled_weight(weight, scale), expected)
+
+    def test_dequantizes_packed_fp4_expert_weight(self):
+        # Each int8 byte stores two E2M1 values, low nibble first. 0x21 maps
+        # to [0.5, 1.0]. DeepSeek applies one E8M0 scale per 32 FP4 values.
+        weight = torch.full((1, 32), 0x21, dtype=torch.uint8).view(torch.int8)
+        scale = torch.tensor([[2.0, 4.0]])
+        expected = torch.tensor([[1.0, 2.0] * 16 + [2.0, 4.0] * 16])
+
+        result = _dequantize_scaled_weight(weight, scale, packed_fp4=True)
+
+        assert result.shape == (1, 64)
+        assert torch.equal(result, expected)
+
+    def test_dequantizes_conventional_int8_weight_without_unpacking(self):
+        weight = torch.arange(16, dtype=torch.int8).reshape(4, 4)
+        scale = torch.tensor([[1.0, 2.0], [4.0, 8.0]])
+        expected = weight.float().view(2, 2, 2, 2).mul(scale.view(2, 1, 2, 1)).reshape(4, 4)
+
+        result = _dequantize_scaled_weight(weight, scale)
+
+        assert result.shape == weight.shape
+        assert torch.equal(result, expected)
+
+    @pytest.mark.parametrize(
+        ("raw_name", "converted_name"),
+        [
+            ("embed.weight", "model.embed_tokens.weight"),
+            ("head.weight", "lm_head.weight"),
+            ("norm.weight", "model.norm.weight"),
+            ("hc_head_fn", "model.hc_head.hc_fn"),
+            ("layers.2.attn_norm.weight", "model.layers.2.input_layernorm.weight"),
+            ("layers.2.ffn_norm.weight", "model.layers.2.post_attention_layernorm.weight"),
+            ("layers.2.attn.wkv.weight", "model.layers.2.self_attn.kv_proj.weight"),
+            ("layers.2.attn.wq_a.scale", "model.layers.2.self_attn.q_a_proj.scale"),
+            ("layers.2.attn.attn_sink", "model.layers.2.self_attn.sinks"),
+            (
+                "layers.2.attn.compressor.wgate.weight",
+                "model.layers.2.self_attn.compressor.gate_proj.weight",
+            ),
+            (
+                "layers.2.attn.indexer.compressor.wkv.weight",
+                "model.layers.2.self_attn.compressor.indexer.kv_proj.weight",
+            ),
+            (
+                "layers.2.attn.indexer.weights_proj.weight",
+                "model.layers.2.self_attn.compressor.indexer.weights_proj.weight",
+            ),
+            ("layers.2.ffn.gate.bias", "model.layers.2.mlp.gate.e_score_correction_bias"),
+            ("layers.2.ffn.gate.tid2eid", "model.layers.2.mlp.gate.tid2eid"),
+            (
+                "layers.2.ffn.shared_experts.w1.weight",
+                "model.layers.2.mlp.shared_experts.gate_proj.weight",
+            ),
+            (
+                "layers.2.ffn.experts.7.w3.scale",
+                "model.layers.2.mlp.experts.7.w3.scale",
+            ),
+            ("layers.2.hc_attn_base", "model.layers.2.attn_hc.base"),
+            ("layers.2.hc_ffn_scale", "model.layers.2.ffn_hc.scale"),
+            ("mtp.0.attn.wkv.weight", "mtp.0.attn.wkv.weight"),
+        ],
+    )
+    def test_converts_deepseek_inference_checkpoint_names(self, raw_name: str, converted_name: str):
+        assert convert_deepseek_v4_checkpoint_key(raw_name) == converted_name
+
+    def test_raw_inference_fp8_pair_emits_hf_name(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
+        weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
+        scale = torch.ones(2, 2)
+
+        assert maybe_convert_checkpoint_tensor("layers.0.attn.wkv.weight", weight, converter) is None
+        result = maybe_convert_checkpoint_tensor("layers.0.attn.wkv.scale", scale, converter)
+
+        assert result is not None
+        assert result.name == "model.layers.0.self_attn.kv_proj.weight"
+        assert torch.equal(result.tensor, weight.float())
 
     def test_fp8_weight_scale_pair_emits_dequantized_weight(self):
         converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
@@ -599,6 +681,35 @@ class TestDeepseekV4ConverterConvert:
             assert torch.equal(down[expert_id], down_expected)
         assert converter.finalize() == []
 
+    def test_raw_inference_fp4_experts_are_unpacked_before_fusing(self):
+        converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
+        dispatched = {}
+
+        for proj in ("w1", "w3", "w2"):
+            logical_shape = (HIDDEN_DIM, INTERMEDIATE_DIM) if proj == "w2" else (INTERMEDIATE_DIM, HIDDEN_DIM)
+            packed_shape = (logical_shape[0], logical_shape[1] // 2)
+            for expert_id in range(NUM_EXPERTS):
+                stem = f"layers.0.ffn.experts.{expert_id}.{proj}"
+                packed = torch.full(packed_shape, 0x21, dtype=torch.uint8).view(torch.int8)
+                assert maybe_convert_checkpoint_tensor(f"{stem}.weight", packed, converter) is None
+                result = maybe_convert_checkpoint_tensor(f"{stem}.scale", torch.tensor(1.0), converter)
+                if result is not None:
+                    dispatched[result.name] = result.tensor
+
+        assert converter.finalize() == []
+        assert dispatched["model.layers.0.mlp.experts.gate_up_proj"].shape == (
+            NUM_EXPERTS,
+            2 * INTERMEDIATE_DIM,
+            HIDDEN_DIM,
+        )
+        assert dispatched["model.layers.0.mlp.experts.down_proj"].shape == (
+            NUM_EXPERTS,
+            HIDDEN_DIM,
+            INTERMEDIATE_DIM,
+        )
+        expected_values = torch.tensor([0.5, 1.0] * (HIDDEN_DIM // 2))
+        assert torch.equal(dispatched["model.layers.0.mlp.experts.gate_up_proj"][0, 0], expected_values)
+
     def test_renamed_keys_still_convert(self):
         converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
         emitted = []
@@ -635,6 +746,24 @@ class TestDeepseekV4ConverterFactoryAndMapping:
             "model.layers.0.mlp.experts.gate_up_proj": 3,
             "model.layers.0.mlp.experts.down_proj": 4,
             "model.layers.0.self_attn.q_proj.weight": 7,
+        }
+
+    def test_fqn_mapping_converts_inference_checkpoint_keys(self):
+        mapping = {
+            "embed.weight": 0,
+            "layers.0.attn.wkv.weight": 1,
+            "layers.0.ffn.experts.0.w1.weight": 2,
+            "layers.0.ffn.experts.0.w2.weight": 3,
+            "layers.0.ffn.experts.0.w3.weight": 4,
+        }
+
+        converted = convert_deepseek_v4_fqn_to_index_mapping(mapping)
+
+        assert converted == {
+            "model.embed_tokens.weight": 0,
+            "model.layers.0.self_attn.kv_proj.weight": 1,
+            "model.layers.0.mlp.experts.gate_up_proj": 2,
+            "model.layers.0.mlp.experts.down_proj": 3,
         }
 
 

--- a/tests/models/test_checkpoint_tensor_converter.py
+++ b/tests/models/test_checkpoint_tensor_converter.py
@@ -30,6 +30,7 @@ from veomni.models.checkpoint_tensor_loading import (
     get_checkpoint_tensor_converter,
     maybe_convert_checkpoint_tensor,
 )
+from veomni.models.transformers.deepseek_v4 import checkpoint_tensor_converter as deepseek_v4_converter
 from veomni.models.transformers.deepseek_v4.checkpoint_tensor_converter import (
     DeepseekV4CheckpointTensorConverter,
     _dequantize_scaled_weight,
@@ -422,8 +423,8 @@ class TestDeepseekV4ConverterCanHandle:
         assert self.converter.can_handle("model.layers.0.attn.wkv.scale")
         assert self.converter.can_handle("model.layers.0.attn.wkv.weight_scale_inv")
 
-    def test_regular_weight_keys_are_not_name_only_handled(self):
-        assert not self.converter.can_handle("model.layers.0.attn.wkv.weight")
+    def test_prefixed_raw_weight_keys_are_name_handled(self):
+        assert self.converter.can_handle("model.layers.0.attn.wkv.weight")
 
     def test_matches_quantized_weight_tensors(self):
         weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
@@ -457,6 +458,28 @@ class TestDeepseekV4ConverterConvert:
         assert result.shape == (1, 64)
         assert torch.equal(result, expected)
 
+    def test_reuses_fp4_lookup_table(self, monkeypatch):
+        weight = torch.full((1, 32), 0x21, dtype=torch.uint8).view(torch.int8)
+        scale = torch.ones(1, 2)
+        original_tensor = torch.tensor
+        table_allocations = 0
+        deepseek_v4_converter._get_fp4_e2m1_table.cache_clear()
+
+        def counted_tensor(*args, **kwargs):
+            nonlocal table_allocations
+            if args and args[0] == deepseek_v4_converter._FP4_E2M1_VALUES:
+                table_allocations += 1
+            return original_tensor(*args, **kwargs)
+
+        monkeypatch.setattr(deepseek_v4_converter.torch, "tensor", counted_tensor)
+
+        try:
+            _dequantize_scaled_weight(weight, scale, packed_fp4=True)
+            _dequantize_scaled_weight(weight, scale, packed_fp4=True)
+            assert table_allocations == 1
+        finally:
+            deepseek_v4_converter._get_fp4_e2m1_table.cache_clear()
+
     def test_dequantizes_conventional_int8_weight_without_unpacking(self):
         weight = torch.arange(16, dtype=torch.int8).reshape(4, 4)
         scale = torch.tensor([[1.0, 2.0], [4.0, 8.0]])
@@ -471,12 +494,17 @@ class TestDeepseekV4ConverterConvert:
         ("raw_name", "converted_name"),
         [
             ("embed.weight", "model.embed_tokens.weight"),
+            ("model.embed.weight", "model.embed_tokens.weight"),
             ("head.weight", "lm_head.weight"),
+            ("model.head.weight", "lm_head.weight"),
             ("norm.weight", "model.norm.weight"),
+            ("model.norm.weight", "model.norm.weight"),
             ("hc_head_fn", "model.hc_head.hc_fn"),
+            ("model.hc_head_fn", "model.hc_head.hc_fn"),
             ("layers.2.attn_norm.weight", "model.layers.2.input_layernorm.weight"),
             ("layers.2.ffn_norm.weight", "model.layers.2.post_attention_layernorm.weight"),
             ("layers.2.attn.wkv.weight", "model.layers.2.self_attn.kv_proj.weight"),
+            ("model.layers.2.attn.wkv.weight", "model.layers.2.self_attn.kv_proj.weight"),
             ("layers.2.attn.wq_a.scale", "model.layers.2.self_attn.q_a_proj.scale"),
             ("layers.2.attn.attn_sink", "model.layers.2.self_attn.sinks"),
             (
@@ -498,12 +526,17 @@ class TestDeepseekV4ConverterConvert:
                 "model.layers.2.mlp.shared_experts.gate_proj.weight",
             ),
             (
+                "model.layers.2.ffn.shared_experts.w1.weight",
+                "model.layers.2.mlp.shared_experts.gate_proj.weight",
+            ),
+            (
                 "layers.2.ffn.experts.7.w3.scale",
                 "model.layers.2.mlp.experts.7.w3.scale",
             ),
             ("layers.2.hc_attn_base", "model.layers.2.attn_hc.base"),
             ("layers.2.hc_ffn_scale", "model.layers.2.ffn_hc.scale"),
             ("mtp.0.attn.wkv.weight", "mtp.0.attn.wkv.weight"),
+            ("model.custom.weight", "model.custom.weight"),
         ],
     )
     def test_converts_deepseek_inference_checkpoint_names(self, raw_name: str, converted_name: str):
@@ -525,6 +558,7 @@ class TestDeepseekV4ConverterConvert:
         converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
         weight_name = "model.layers.0.attn.wkv.weight"
         scale_name = "model.layers.0.attn.wkv.scale"
+        converted_weight_name = "model.layers.0.self_attn.kv_proj.weight"
         weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
         scale = torch.tensor([[1.0, 2.0], [4.0, 8.0]])
 
@@ -532,7 +566,7 @@ class TestDeepseekV4ConverterConvert:
         result = maybe_convert_checkpoint_tensor(scale_name, scale, converter)
 
         assert result is not None
-        assert result.name == weight_name
+        assert result.name == converted_weight_name
         assert torch.equal(result.tensor, _dequantize_scaled_weight(weight, scale))
         assert converter.finalize() == []
 
@@ -540,6 +574,7 @@ class TestDeepseekV4ConverterConvert:
         converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
         weight_name = "model.layers.0.attn.wkv.weight"
         scale_name = "model.layers.0.attn.wkv.scale"
+        converted_weight_name = "model.layers.0.self_attn.kv_proj.weight"
         weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
         scale = torch.tensor([[1.0, 2.0], [4.0, 8.0]])
 
@@ -547,7 +582,7 @@ class TestDeepseekV4ConverterConvert:
         result = maybe_convert_checkpoint_tensor(weight_name, weight, converter)
 
         assert result is not None
-        assert result.name == weight_name
+        assert result.name == converted_weight_name
         assert torch.equal(result.tensor, _dequantize_scaled_weight(weight, scale))
         assert converter.finalize() == []
 
@@ -555,6 +590,7 @@ class TestDeepseekV4ConverterConvert:
         converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
         weight_name = "model.layers.0.attn.wkv.weight"
         scale_name = "model.layers.0.attn.wkv.weight_scale_inv"
+        converted_weight_name = "model.layers.0.self_attn.kv_proj.weight"
         weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
         scale = torch.tensor([[1.0, 2.0], [4.0, 8.0]])
 
@@ -562,7 +598,7 @@ class TestDeepseekV4ConverterConvert:
         result = maybe_convert_checkpoint_tensor(scale_name, scale, converter)
 
         assert result is not None
-        assert result.name == weight_name
+        assert result.name == converted_weight_name
         assert torch.equal(result.tensor, _dequantize_scaled_weight(weight, scale))
         assert converter.finalize() == []
 
@@ -570,6 +606,7 @@ class TestDeepseekV4ConverterConvert:
         converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
         weight_name = "model.layers.0.attn.wkv.weight"
         scale_name = "model.layers.0.attn.wkv.scale"
+        converted_weight_name = "model.layers.0.self_attn.kv_proj.weight"
         weight = _to_fp8(torch.arange(16, dtype=torch.float32).reshape(4, 4))
         scale = torch.tensor(2.0)
 
@@ -577,7 +614,7 @@ class TestDeepseekV4ConverterConvert:
         result = maybe_convert_checkpoint_tensor(scale_name, scale, converter)
 
         assert result is not None
-        assert result.name == weight_name
+        assert result.name == converted_weight_name
         assert torch.equal(result.tensor, weight.float() * scale)
         assert converter.finalize() == []
 
@@ -681,7 +718,8 @@ class TestDeepseekV4ConverterConvert:
             assert torch.equal(down[expert_id], down_expected)
         assert converter.finalize() == []
 
-    def test_raw_inference_fp4_experts_are_unpacked_before_fusing(self):
+    @pytest.mark.parametrize("model_prefix", ("", "model."))
+    def test_raw_inference_fp4_experts_are_unpacked_before_fusing(self, model_prefix: str):
         converter = DeepseekV4CheckpointTensorConverter(num_experts=NUM_EXPERTS)
         dispatched = {}
 
@@ -689,7 +727,7 @@ class TestDeepseekV4ConverterConvert:
             logical_shape = (HIDDEN_DIM, INTERMEDIATE_DIM) if proj == "w2" else (INTERMEDIATE_DIM, HIDDEN_DIM)
             packed_shape = (logical_shape[0], logical_shape[1] // 2)
             for expert_id in range(NUM_EXPERTS):
-                stem = f"layers.0.ffn.experts.{expert_id}.{proj}"
+                stem = f"{model_prefix}layers.0.ffn.experts.{expert_id}.{proj}"
                 packed = torch.full(packed_shape, 0x21, dtype=torch.uint8).view(torch.int8)
                 assert maybe_convert_checkpoint_tensor(f"{stem}.weight", packed, converter) is None
                 result = maybe_convert_checkpoint_tensor(f"{stem}.scale", torch.tensor(1.0), converter)

--- a/veomni/models/transformers/deepseek_v4/__init__.py
+++ b/veomni/models/transformers/deepseek_v4/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import partial
+
 from ...loader import MODELING_REGISTRY
 
 
@@ -26,9 +28,17 @@ def register_deepseek_v4_modeling(architecture: str):
     DeepseekV4ForCausalLM = gen.DeepseekV4ForCausalLM
     DeepseekV4Model = gen.DeepseekV4Model
 
-    for model_cls in (DeepseekV4ForCausalLM, DeepseekV4Model):
-        model_cls._create_checkpoint_tensor_converter = staticmethod(create_deepseek_v4_checkpoint_tensor_converter)
-        model_cls._convert_fqn_to_index_mapping = staticmethod(convert_deepseek_v4_fqn_to_index_mapping)
+    DeepseekV4ForCausalLM._create_checkpoint_tensor_converter = staticmethod(
+        create_deepseek_v4_checkpoint_tensor_converter
+    )
+    DeepseekV4ForCausalLM._convert_fqn_to_index_mapping = staticmethod(
+        partial(convert_deepseek_v4_fqn_to_index_mapping, target_model_prefix="model.")
+    )
+
+    DeepseekV4Model._create_checkpoint_tensor_converter = staticmethod(create_deepseek_v4_checkpoint_tensor_converter)
+    DeepseekV4Model._convert_fqn_to_index_mapping = staticmethod(
+        partial(convert_deepseek_v4_fqn_to_index_mapping, target_model_prefix="")
+    )
 
     if "ForCausalLM" in architecture:
         return DeepseekV4ForCausalLM

--- a/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
+++ b/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
@@ -108,7 +108,7 @@ def _is_mtp_checkpoint_key(name: str) -> bool:
     return name.removeprefix("model.").startswith("mtp.")
 
 
-def convert_deepseek_v4_checkpoint_key(name: str) -> str:
+def convert_deepseek_v4_checkpoint_key(name: str, *, target_model_prefix: str = "model.") -> str:
     """Convert DeepSeek's inference checkpoint names to Transformers v5 names."""
     if _is_mtp_checkpoint_key(name):
         return name
@@ -116,7 +116,7 @@ def convert_deepseek_v4_checkpoint_key(name: str) -> str:
     source_name = name.removeprefix("model.") if has_model_prefix else name
     converted_name, _ = rename_source_key(source_name, _DEEPSEEK_V4_WEIGHT_RENAMINGS, [])
     if converted_name.startswith(_BASE_MODEL_KEY_PREFIXES):
-        return f"model.{converted_name}"
+        return f"{target_model_prefix}{converted_name}"
     if has_model_prefix and converted_name == source_name:
         return name
     return converted_name
@@ -189,8 +189,9 @@ class DeepseekV4CheckpointTensorConverter:
             via ``DeepseekV4Config.attribute_map``).
     """
 
-    def __init__(self, num_experts: int):
+    def __init__(self, num_experts: int, *, target_model_prefix: str = "model."):
         self.num_experts = num_experts
+        self.target_model_prefix = target_model_prefix
         # {(prefix, proj_name): {expert_id: tensor}}
         self._expert_buffer: dict[tuple[str, str], dict[int, torch.Tensor]] = {}
         # {prefix: {proj_name: stacked_tensor}} for gate/up merge waiting
@@ -201,7 +202,7 @@ class DeepseekV4CheckpointTensorConverter:
     def can_handle(self, name: str) -> bool:
         if _is_mtp_checkpoint_key(name):
             return False
-        converted_name = convert_deepseek_v4_checkpoint_key(name)
+        converted_name = convert_deepseek_v4_checkpoint_key(name, target_model_prefix=self.target_model_prefix)
         return (
             converted_name != name
             or bool(_EXPERT_PATTERN.match(converted_name))
@@ -211,14 +212,14 @@ class DeepseekV4CheckpointTensorConverter:
     def can_handle_tensor(self, name: str, tensor: torch.Tensor) -> bool:
         if _is_mtp_checkpoint_key(name):
             return False
-        converted_name = convert_deepseek_v4_checkpoint_key(name)
+        converted_name = convert_deepseek_v4_checkpoint_key(name, target_model_prefix=self.target_model_prefix)
         return self.can_handle(name) or (converted_name.endswith(".weight") and _is_quantized_weight(tensor))
 
     def convert(self, name: str, tensor: torch.Tensor) -> ConvertedCheckpointTensor | None:
         if _is_mtp_checkpoint_key(name):
             return ConvertedCheckpointTensor(name, tensor)
         packed_fp4 = tensor.dtype == torch.int8 and bool(_RAW_FP4_EXPERT_WEIGHT_PATTERN.fullmatch(name))
-        name = convert_deepseek_v4_checkpoint_key(name)
+        name = convert_deepseek_v4_checkpoint_key(name, target_model_prefix=self.target_model_prefix)
         weight_name = _weight_name_from_scale_name(name)
         if weight_name is not None:
             if not _is_block_scale_tensor(tensor):
@@ -332,17 +333,34 @@ def create_deepseek_v4_checkpoint_tensor_converter(model):
     """Factory function registered on model classes via _create_checkpoint_tensor_converter."""
     return DeepseekV4CheckpointTensorConverter(
         num_experts=model.config.n_routed_experts,
+        target_model_prefix=_get_deepseek_v4_target_model_prefix(model),
     )
 
 
-def convert_deepseek_v4_fqn_to_index_mapping(fqn_to_index_mapping: dict[str, int]) -> dict[str, int]:
+def _get_deepseek_v4_target_model_prefix(model) -> str:
+    named_parameters = getattr(model, "named_parameters", None)
+    if callable(named_parameters):
+        for name, _ in named_parameters():
+            if name.startswith("model."):
+                return "model."
+            if name.startswith(_BASE_MODEL_KEY_PREFIXES):
+                return ""
+
+    if type(model).__name__.endswith("ForCausalLM"):
+        return "model."
+    return ""
+
+
+def convert_deepseek_v4_fqn_to_index_mapping(
+    fqn_to_index_mapping: dict[str, int], *, target_model_prefix: str = "model."
+) -> dict[str, int]:
     """Align HF safetensors index keys with fused expert parameter names."""
     gate_up_shard_indices: dict[str, list[int]] = defaultdict(list)
     down_shard_indices: dict[str, list[int]] = defaultdict(list)
     converted: dict[str, int] = {}
 
     for fqn, shard_idx in fqn_to_index_mapping.items():
-        fqn = convert_deepseek_v4_checkpoint_key(fqn)
+        fqn = convert_deepseek_v4_checkpoint_key(fqn, target_model_prefix=target_model_prefix)
         match = _EXPERT_PATTERN.match(fqn)
         if not match:
             converted[fqn] = shard_idx

--- a/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
+++ b/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
@@ -104,8 +104,14 @@ def _is_quantized_weight(tensor: torch.Tensor) -> bool:
     return tensor.dtype in _QUANTIZED_WEIGHT_DTYPES
 
 
+def _is_mtp_checkpoint_key(name: str) -> bool:
+    return name.removeprefix("model.").startswith("mtp.")
+
+
 def convert_deepseek_v4_checkpoint_key(name: str) -> str:
     """Convert DeepSeek's inference checkpoint names to Transformers v5 names."""
+    if _is_mtp_checkpoint_key(name):
+        return name
     has_model_prefix = name.startswith("model.")
     source_name = name.removeprefix("model.") if has_model_prefix else name
     converted_name, _ = rename_source_key(source_name, _DEEPSEEK_V4_WEIGHT_RENAMINGS, [])
@@ -153,12 +159,12 @@ def _dequantize_scaled_weight(weight: torch.Tensor, scale: torch.Tensor, *, pack
         return weight * scale.float()
     if weight.ndim != 2 or scale.ndim != 2:
         raise ValueError(
-            "DeepseekV4 FP8 checkpoint weight scales must be scalar or 2D block scales; "
+            "DeepseekV4 quantized checkpoint weight scales must be scalar or 2D block scales; "
             f"got weight shape {tuple(weight.shape)} and scale shape {tuple(scale.shape)}."
         )
     if weight.shape[0] % scale.shape[0] != 0 or weight.shape[1] % scale.shape[1] != 0:
         raise ValueError(
-            "DeepseekV4 FP8 checkpoint weight shape must be divisible by scale shape; "
+            "DeepseekV4 quantized checkpoint weight shape must be divisible by scale shape; "
             f"got weight shape {tuple(weight.shape)} and scale shape {tuple(scale.shape)}."
         )
 
@@ -190,10 +196,10 @@ class DeepseekV4CheckpointTensorConverter:
         # {prefix: {proj_name: stacked_tensor}} for gate/up merge waiting
         self._stacked_buffer: dict[str, dict[str, torch.Tensor]] = {}
         # {weight_name: {"weight": tensor, "scale": tensor}} for FP8/int8 checkpoint pairs.
-        self._scaled_weight_buffer: dict[str, dict[str, torch.Tensor | str]] = {}
+        self._scaled_weight_buffer: dict[str, dict[str, torch.Tensor | str | bool]] = {}
 
     def can_handle(self, name: str) -> bool:
-        if name.startswith("mtp."):
+        if _is_mtp_checkpoint_key(name):
             return False
         converted_name = convert_deepseek_v4_checkpoint_key(name)
         return (
@@ -203,12 +209,14 @@ class DeepseekV4CheckpointTensorConverter:
         )
 
     def can_handle_tensor(self, name: str, tensor: torch.Tensor) -> bool:
-        if name.startswith("mtp."):
+        if _is_mtp_checkpoint_key(name):
             return False
         converted_name = convert_deepseek_v4_checkpoint_key(name)
         return self.can_handle(name) or (converted_name.endswith(".weight") and _is_quantized_weight(tensor))
 
     def convert(self, name: str, tensor: torch.Tensor) -> ConvertedCheckpointTensor | None:
+        if _is_mtp_checkpoint_key(name):
+            return ConvertedCheckpointTensor(name, tensor)
         packed_fp4 = tensor.dtype == torch.int8 and bool(_RAW_FP4_EXPERT_WEIGHT_PATTERN.fullmatch(name))
         name = convert_deepseek_v4_checkpoint_key(name)
         weight_name = _weight_name_from_scale_name(name)

--- a/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
+++ b/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
+from functools import lru_cache
 
 import torch
 from transformers.conversion_mapping import get_checkpoint_conversion_mapping
@@ -58,7 +59,7 @@ logger = logging.get_logger(__name__)
 #   model.layers.0.mlp.experts.3.w1.weight
 #   model.layers.0.mlp.experts.3.gate_proj.weight
 _EXPERT_PATTERN = re.compile(r"^(.+\.mlp)\.experts\.(\d+)\.(w1|w2|w3|gate_proj|up_proj|down_proj)\.weight$")
-_RAW_FP4_EXPERT_WEIGHT_PATTERN = re.compile(r"^layers\.\d+\.ffn\.experts\.\d+\.w[123]\.weight$")
+_RAW_FP4_EXPERT_WEIGHT_PATTERN = re.compile(r"^(?:model\.)?layers\.\d+\.ffn\.experts\.\d+\.w[123]\.weight$")
 _PROJ_NAME_ALIASES = {
     "w1": "gate_proj",
     "w2": "down_proj",
@@ -69,7 +70,25 @@ _DEEPSEEK_V4_WEIGHT_RENAMINGS = [
     for transform in (get_checkpoint_conversion_mapping("deepseek_v4") or [])
     if isinstance(transform, WeightRenaming)
 ]
-_FP4_E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0)
+_FP4_E2M1_VALUES = (
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+)
+_BASE_MODEL_KEY_PREFIXES = ("embed_tokens.", "hc_head.", "layers.", "norm.")
 _FLOAT8_DTYPES = tuple(
     dtype
     for dtype in (
@@ -87,10 +106,19 @@ def _is_quantized_weight(tensor: torch.Tensor) -> bool:
 
 def convert_deepseek_v4_checkpoint_key(name: str) -> str:
     """Convert DeepSeek's inference checkpoint names to Transformers v5 names."""
-    converted_name, _ = rename_source_key(name, _DEEPSEEK_V4_WEIGHT_RENAMINGS, [])
-    if converted_name.startswith(("embed_tokens.", "hc_head.", "layers.", "norm.")):
-        converted_name = f"model.{converted_name}"
+    has_model_prefix = name.startswith("model.")
+    source_name = name.removeprefix("model.") if has_model_prefix else name
+    converted_name, _ = rename_source_key(source_name, _DEEPSEEK_V4_WEIGHT_RENAMINGS, [])
+    if converted_name.startswith(_BASE_MODEL_KEY_PREFIXES):
+        return f"model.{converted_name}"
+    if has_model_prefix and converted_name == source_name:
+        return name
     return converted_name
+
+
+@lru_cache(maxsize=None)
+def _get_fp4_e2m1_table(device: torch.device) -> torch.Tensor:
+    return torch.tensor(_FP4_E2M1_VALUES, dtype=torch.float32, device=device)
 
 
 def _is_block_scale_tensor(tensor: torch.Tensor) -> bool:
@@ -114,7 +142,7 @@ def _dequantize_scaled_weight(weight: torch.Tensor, scale: torch.Tensor, *, pack
         # DeepSeek-V4 stores two E2M1 FP4 expert values in every int8 byte.
         # Preserve the bit pattern when splitting the low and high nibbles.
         packed = weight.contiguous().view(torch.uint8)
-        table = torch.tensor(_FP4_E2M1_VALUES, dtype=torch.float32, device=weight.device)
+        table = _get_fp4_e2m1_table(weight.device)
         low = table[(packed & 0x0F).long()]
         high = table[((packed >> 4) & 0x0F).long()]
         weight = torch.stack((low, high), dim=-1).flatten(-2)

--- a/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
+++ b/veomni/models/transformers/deepseek_v4/checkpoint_tensor_converter.py
@@ -44,6 +44,8 @@ import re
 from collections import defaultdict
 
 import torch
+from transformers.conversion_mapping import get_checkpoint_conversion_mapping
+from transformers.core_model_loading import WeightRenaming, rename_source_key
 
 from ....utils import logging
 from ...checkpoint_tensor_loading import ConvertedCheckpointTensor
@@ -56,11 +58,18 @@ logger = logging.get_logger(__name__)
 #   model.layers.0.mlp.experts.3.w1.weight
 #   model.layers.0.mlp.experts.3.gate_proj.weight
 _EXPERT_PATTERN = re.compile(r"^(.+\.mlp)\.experts\.(\d+)\.(w1|w2|w3|gate_proj|up_proj|down_proj)\.weight$")
+_RAW_FP4_EXPERT_WEIGHT_PATTERN = re.compile(r"^layers\.\d+\.ffn\.experts\.\d+\.w[123]\.weight$")
 _PROJ_NAME_ALIASES = {
     "w1": "gate_proj",
     "w2": "down_proj",
     "w3": "up_proj",
 }
+_DEEPSEEK_V4_WEIGHT_RENAMINGS = [
+    transform
+    for transform in (get_checkpoint_conversion_mapping("deepseek_v4") or [])
+    if isinstance(transform, WeightRenaming)
+]
+_FP4_E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0)
 _FLOAT8_DTYPES = tuple(
     dtype
     for dtype in (
@@ -76,6 +85,14 @@ def _is_quantized_weight(tensor: torch.Tensor) -> bool:
     return tensor.dtype in _QUANTIZED_WEIGHT_DTYPES
 
 
+def convert_deepseek_v4_checkpoint_key(name: str) -> str:
+    """Convert DeepSeek's inference checkpoint names to Transformers v5 names."""
+    converted_name, _ = rename_source_key(name, _DEEPSEEK_V4_WEIGHT_RENAMINGS, [])
+    if converted_name.startswith(("embed_tokens.", "hc_head.", "layers.", "norm.")):
+        converted_name = f"model.{converted_name}"
+    return converted_name
+
+
 def _is_block_scale_tensor(tensor: torch.Tensor) -> bool:
     return tensor.ndim == 2 or tensor.numel() == 1
 
@@ -88,11 +105,24 @@ def _weight_name_from_scale_name(name: str) -> str | None:
     return None
 
 
-def _dequantize_scaled_weight(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-    """Apply DeepSeek block scales to an FP8/int8 checkpoint weight."""
+def _dequantize_scaled_weight(weight: torch.Tensor, scale: torch.Tensor, *, packed_fp4: bool = False) -> torch.Tensor:
+    """Apply DeepSeek block scales to an FP8 or packed E2M1 FP4 weight."""
     scale = scale.to(device=weight.device)
+    if packed_fp4:
+        if weight.dtype != torch.int8:
+            raise TypeError(f"Packed E2M1 FP4 weights must use int8 storage, got {weight.dtype}.")
+        # DeepSeek-V4 stores two E2M1 FP4 expert values in every int8 byte.
+        # Preserve the bit pattern when splitting the low and high nibbles.
+        packed = weight.contiguous().view(torch.uint8)
+        table = torch.tensor(_FP4_E2M1_VALUES, dtype=torch.float32, device=weight.device)
+        low = table[(packed & 0x0F).long()]
+        high = table[((packed >> 4) & 0x0F).long()]
+        weight = torch.stack((low, high), dim=-1).flatten(-2)
+    else:
+        weight = weight.float()
+
     if scale.numel() == 1:
-        return weight.float() * scale.float()
+        return weight * scale.float()
     if weight.ndim != 2 or scale.ndim != 2:
         raise ValueError(
             "DeepseekV4 FP8 checkpoint weight scales must be scalar or 2D block scales; "
@@ -107,8 +137,7 @@ def _dequantize_scaled_weight(weight: torch.Tensor, scale: torch.Tensor) -> torc
     block_rows = weight.shape[0] // scale.shape[0]
     block_cols = weight.shape[1] // scale.shape[1]
     return (
-        weight.float()
-        .view(scale.shape[0], block_rows, scale.shape[1], block_cols)
+        weight.view(scale.shape[0], block_rows, scale.shape[1], block_cols)
         .mul(scale.float().view(scale.shape[0], 1, scale.shape[1], 1))
         .reshape(weight.shape)
     )
@@ -136,12 +165,24 @@ class DeepseekV4CheckpointTensorConverter:
         self._scaled_weight_buffer: dict[str, dict[str, torch.Tensor | str]] = {}
 
     def can_handle(self, name: str) -> bool:
-        return bool(_EXPERT_PATTERN.match(name)) or _weight_name_from_scale_name(name) is not None
+        if name.startswith("mtp."):
+            return False
+        converted_name = convert_deepseek_v4_checkpoint_key(name)
+        return (
+            converted_name != name
+            or bool(_EXPERT_PATTERN.match(converted_name))
+            or _weight_name_from_scale_name(converted_name) is not None
+        )
 
     def can_handle_tensor(self, name: str, tensor: torch.Tensor) -> bool:
-        return self.can_handle(name) or (name.endswith(".weight") and _is_quantized_weight(tensor))
+        if name.startswith("mtp."):
+            return False
+        converted_name = convert_deepseek_v4_checkpoint_key(name)
+        return self.can_handle(name) or (converted_name.endswith(".weight") and _is_quantized_weight(tensor))
 
     def convert(self, name: str, tensor: torch.Tensor) -> ConvertedCheckpointTensor | None:
+        packed_fp4 = tensor.dtype == torch.int8 and bool(_RAW_FP4_EXPERT_WEIGHT_PATTERN.fullmatch(name))
+        name = convert_deepseek_v4_checkpoint_key(name)
         weight_name = _weight_name_from_scale_name(name)
         if weight_name is not None:
             if not _is_block_scale_tensor(tensor):
@@ -149,15 +190,23 @@ class DeepseekV4CheckpointTensorConverter:
             return self._convert_scaled_weight_part(weight_name, "scale", tensor, name)
 
         if name.endswith(".weight") and _is_quantized_weight(tensor):
-            return self._convert_scaled_weight_part(name, "weight", tensor, None)
+            return self._convert_scaled_weight_part(name, "weight", tensor, None, packed_fp4=packed_fp4)
 
         return self._convert_weight(name, tensor)
 
     def _convert_scaled_weight_part(
-        self, weight_name: str, part_name: str, tensor: torch.Tensor, scale_name: str | None
+        self,
+        weight_name: str,
+        part_name: str,
+        tensor: torch.Tensor,
+        scale_name: str | None,
+        *,
+        packed_fp4: bool = False,
     ) -> ConvertedCheckpointTensor | None:
         parts = self._scaled_weight_buffer.setdefault(weight_name, {})
         parts[part_name] = tensor
+        if part_name == "weight":
+            parts["packed_fp4"] = packed_fp4
         if scale_name is not None:
             parts["scale_name"] = scale_name
         if "weight" not in parts or "scale" not in parts:
@@ -168,7 +217,10 @@ class DeepseekV4CheckpointTensorConverter:
         del self._scaled_weight_buffer[weight_name]
         assert isinstance(weight, torch.Tensor)
         assert isinstance(scale, torch.Tensor)
-        return self._convert_weight(weight_name, _dequantize_scaled_weight(weight, scale))
+        return self._convert_weight(
+            weight_name,
+            _dequantize_scaled_weight(weight, scale, packed_fp4=bool(parts.get("packed_fp4", False))),
+        )
 
     def _convert_weight(self, name: str, tensor: torch.Tensor) -> ConvertedCheckpointTensor | None:
         match = _EXPERT_PATTERN.match(name)
@@ -254,6 +306,7 @@ def convert_deepseek_v4_fqn_to_index_mapping(fqn_to_index_mapping: dict[str, int
     converted: dict[str, int] = {}
 
     for fqn, shard_idx in fqn_to_index_mapping.items():
+        fqn = convert_deepseek_v4_checkpoint_key(fqn)
         match = _EXPERT_PATTERN.match(fqn)
         if not match:
             converted[fqn] = shard_idx


### PR DESCRIPTION
### What does this PR do?

> Follow-up to #899. Load the released DeepSeek-V4-Flash inference checkpoint through VeOmni's streaming FSDP2 loader, including its raw inference namespace and packed FP4 expert weights.

### Checklist Before Starting

- Related work: #899
- PR title follows `[{modules}] {type}: {description}` format.

### Test

> - `make quality`
> - `pytest -q tests/models/test_checkpoint_tensor_converter.py`: 112 passed
> - `pytest -q -x tests/models/test_models_patch.py -k deepseek_v4`: 1 passed
> - Verified all 69,187 entries in `deepseek-ai/DeepSeek-V4-Flash`: 1,199 direct model tensors, 365 block-scale tensors, 66,048 expert parts, and 1,575 intentionally ignored MTP tensors; no unmatched base-model keys or shape mismatches
> - Built the full 284,332,230,231-parameter checkpoint with FSDP2 and EP=4 on four NVIDIA GB200 GPUs: all 46 shards loaded, 64 experts per rank, no remaining meta tensors, and 142.2 GB allocated per rank

### Forward Output Comparison

Compared the checkpoint's bundled official inference implementation against VeOmni on four NVIDIA GB200 GPUs using the same 10-token chat prefill for `Hello, who are you?`:

- Official path: bundled converter and inference code, MP=4, native FP4/FP8 kernels.
- VeOmni path: EP=4 + FSDP2, dequantized BF16 weights, eager attention, and fused Triton MoE.
- Both paths produced finite logits for the complete 129,280-token vocabulary.
- Both selected token `19923` (`Hello`) as the greedy next token.
- After addressing review feedback, the full EP=4 forward remained bit-for-bit identical to the pre-change VeOmni baseline (maximum absolute logit difference `0.0`); all official-comparison metrics below were unchanged.

| Metric | Result |
| --- | ---: |
| Top-5 overlap | 4/5 |
| Top-10 overlap | 9/10 |
| Mean absolute logit difference | 0.9147 |
| RMSE | 1.1315 |
| Maximum absolute logit difference | 6.5364 |
| Relative L2 error | 21.15% |
| Cosine similarity | 0.97738 |
| Pearson correlation | 0.98424 |
| KL divergence, official to VeOmni | 0.01190 |
| Jensen-Shannon divergence | 0.00254 |
| Total-variation distance | 3.40% |
| Official / VeOmni top-1 probability | 87.57% / 84.96% |

The ranking and probability-distribution agreement are strong for this prefill, while the raw logits are not bitwise equivalent because the official path executes quantized FP4/FP8 kernels and VeOmni executes dequantized BF16 weights. This short-prompt comparison does not exercise long-context compression or every routed expert.

### API and Usage Example

> N/A. Existing DeepSeek V4 model-loading APIs now accept the released Flash checkpoint format.

### Design & Code Changes

> - Reuse Transformers 5.9's registered DeepSeek V4 `WeightRenaming` rules for raw inference-to-model key conversion.
> - Unpack raw expert `I8` storage as two E2M1 FP4 values per byte before applying E8M0 block scales.
> - Restrict FP4 unpacking to raw DeepSeek expert keys, preserving conventional int8 block-scale behavior.
> - Preserve both `mtp.*` and optionally prefixed `model.mtp.*` keys for the separate MTP loading path.
> - Convert safetensor index mappings through the same namespace path and add FP8, FP4, int8, expert-fusion, and key-mapping regression coverage.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added regression tests collected by the existing model unit-test workflow
