### PR TITLE
[model] fix: gather input_ids along sequence dim for SP placeholder mask

### DIFF
--- a/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.diff
+++ b/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.diff
@@ -905,7 +905,7 @@
 +        if video_mask is None and image_mask is None:
 +            input_ids_list = [torch.zeros_like(input_ids) for _ in range(get_parallel_state().sp_size)]
 +            dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-+            image_mask, video_mask = self.get_placeholder_mask(torch.cat(input_ids_list, dim=0))
++            image_mask, video_mask = self.get_placeholder_mask(torch.cat(input_ids_list, dim=1))
 +        # --- Patch.2 ---
 +
 +        # --- Patch.3 ---

--- a/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.py
+++ b/veomni/models/transformers/qwen2_5vl/generated/patched_modeling_qwen2_5_vl_gpu.py
@@ -1730,7 +1730,7 @@ class Qwen2_5_VLModel(Qwen2_5_VLPreTrainedModel):
         if video_mask is None and image_mask is None:
             input_ids_list = [torch.zeros_like(input_ids) for _ in range(get_parallel_state().sp_size)]
             dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-            image_mask, video_mask = self.get_placeholder_mask(torch.cat(input_ids_list, dim=0))
+            image_mask, video_mask = self.get_placeholder_mask(torch.cat(input_ids_list, dim=1))
         # --- Patch.2 ---
 
         # --- Patch.3 ---

--- a/veomni/models/transformers/qwen2_5vl/qwen2_5_vl_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen2_5vl/qwen2_5_vl_gpu_patch_gen_config.py
@@ -620,7 +620,7 @@ def qwen2_5_vl_model_forward_patched(
     if video_mask is None and image_mask is None:
         input_ids_list = [torch.zeros_like(input_ids) for _ in range(get_parallel_state().sp_size)]
         dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-        image_mask, video_mask = self.get_placeholder_mask(torch.cat(input_ids_list, dim=0))
+        image_mask, video_mask = self.get_placeholder_mask(torch.cat(input_ids_list, dim=1))
     # --- Patch.2 ---
 
     # --- Patch.3 ---

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
@@ -1320,7 +1320,7 @@
 +            if get_parallel_state().sp_enabled:
 +                input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
 +                dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-+                input_ids = torch.cat(input_ids_list, dim=0)
++                input_ids = torch.cat(input_ids_list, dim=1)
 +            image_mask, video_mask = self.get_placeholder_mask(input_ids)
 +        # --- Patch.1 ---
 +

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
@@ -2195,7 +2195,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
             if get_parallel_state().sp_enabled:
                 input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
                 dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-                input_ids = torch.cat(input_ids_list, dim=0)
+                input_ids = torch.cat(input_ids_list, dim=1)
             image_mask, video_mask = self.get_placeholder_mask(input_ids)
         # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
@@ -1305,7 +1305,7 @@
 +            if get_parallel_state().sp_enabled:
 +                input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
 +                dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-+                input_ids = torch.cat(input_ids_list, dim=0)
++                input_ids = torch.cat(input_ids_list, dim=1)
 +            image_mask, video_mask = self.get_placeholder_mask(input_ids)
 +        # --- Patch.1 ---
 +

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
@@ -2153,7 +2153,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
             if get_parallel_state().sp_enabled:
                 input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
                 dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-                input_ids = torch.cat(input_ids_list, dim=0)
+                input_ids = torch.cat(input_ids_list, dim=1)
             image_mask, video_mask = self.get_placeholder_mask(input_ids)
         # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
@@ -1138,7 +1138,7 @@ def qwen3_5_model_forward(
         if get_parallel_state().sp_enabled:
             input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
             dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-            input_ids = torch.cat(input_ids_list, dim=0)
+            input_ids = torch.cat(input_ids_list, dim=1)
         image_mask, video_mask = self.get_placeholder_mask(input_ids)
     # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
@@ -1461,7 +1461,7 @@
 +            if get_parallel_state().sp_enabled:
 +                input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
 +                dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-+                input_ids = torch.cat(input_ids_list, dim=0)
++                input_ids = torch.cat(input_ids_list, dim=1)
 +            image_mask, video_mask = self.get_placeholder_mask(input_ids)
 +        # --- Patch.1 ---
 +

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -2399,7 +2399,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
             if get_parallel_state().sp_enabled:
                 input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
                 dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-                input_ids = torch.cat(input_ids_list, dim=0)
+                input_ids = torch.cat(input_ids_list, dim=1)
             image_mask, video_mask = self.get_placeholder_mask(input_ids)
         # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
@@ -1454,7 +1454,7 @@
 +            if get_parallel_state().sp_enabled:
 +                input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
 +                dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-+                input_ids = torch.cat(input_ids_list, dim=0)
++                input_ids = torch.cat(input_ids_list, dim=1)
 +            image_mask, video_mask = self.get_placeholder_mask(input_ids)
 +        # --- Patch.1 ---
 +

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -2366,7 +2366,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
             if get_parallel_state().sp_enabled:
                 input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
                 dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-                input_ids = torch.cat(input_ids_list, dim=0)
+                input_ids = torch.cat(input_ids_list, dim=1)
             image_mask, video_mask = self.get_placeholder_mask(input_ids)
         # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_5_moe/qwen3_5_moe_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5_moe/qwen3_5_moe_gpu_patch_gen_config.py
@@ -353,7 +353,7 @@ def qwen3_5_moe_model_forward_patched(
         if get_parallel_state().sp_enabled:
             input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
             dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-            input_ids = torch.cat(input_ids_list, dim=0)
+            input_ids = torch.cat(input_ids_list, dim=1)
         image_mask, video_mask = self.get_placeholder_mask(input_ids)
     # --- Patch.1 ---
 


### PR DESCRIPTION
### What does this PR do?

Under Ulysses sequence parallel (SP), `input_ids` is sharded along the **sequence** dimension (`dim=1`). When placeholder masks are not precomputed, the patched model reconstructs the full sequence via `dist.all_gather` before calling `get_placeholder_mask`. The gathered shards were concatenated with `dim=0`, which stacks them onto the **batch** axis instead of the sequence axis.

This PR fixes `dim=0` → `dim=1` for the three model families that got it wrong: `qwen2_5vl`, `qwen3_5`, `qwen3_5_moe`. `qwen3_vl` and `qwen3_vl_moe` already use `dim=1`.

### Checklist Before Starting

- Searched existing PRs/issues — no prior report found for this SP gather-dim bug.
- PR title follows `[{modules}] {type}: {description}`.

### The bug

Each SP rank holds `input_ids` of shape `(batch, local_seq)`. To rebuild the full sequence the shards must be concatenated along the sequence dim:

- `torch.cat(shards, dim=1)` → `(batch, full_seq)` ✅ correct
- `torch.cat(shards, dim=0)` → `(batch * sp_size, local_seq)` ❌ — the sequence is never rebuilt

With `dim=0`, `get_placeholder_mask` produces a mask whose sequence length does not match `inputs_embeds`, causing a shape-mismatch crash at `masked_scatter` / `expand_as` (e.g. `RuntimeError: The expanded size of the tensor must match the existing size`) once SP is enabled with multimodal inputs.

### Test

This is an analysis-level fix, not yet re-run end-to-end on this branch:

- With `dim=0`, the gathered tensor is `(batch * sp_size, local_seq)`, so the sequence is never rebuilt and the resulting mask's sequence length does not match `inputs_embeds` — consistent with the `masked_scatter` / `expand_as` shape-mismatch crash described above.
- With `dim=1`, the tensor is correctly restored to `(batch, full_seq)`, matching the layout `get_placeholder_mask` expects.

The change is a single-token fix (`dim=0` → `dim=1`) in the patch-gen forward functions, device-agnostic, and behavior-preserving when SP is disabled. Happy to add an SP + multimodal reproduction/regression test if maintainers prefer.

### Design & Code Changes

- `qwen2_5_vl_gpu_patch_gen_config.py`, `qwen3_5_gpu_patch_gen_config.py`, `qwen3_5_moe_gpu_patch_gen_config.py`: `dim=0` → `dim=1`.
- Regenerated the corresponding `generated/*.py` and `.diff` patch files.

Note: the SP gather logic lives in the shared (GPU) patch-gen configs; the NPU configs import and reuse those forward functions, so a single source edit fixes both the GPU and NPU generated files.

### Checklist Before Submitting

- [x] Single-token, device-agnostic fix; behavior-preserving when SP is disabled.
- [ ] No new tests added — existing CI does not cover the SP + multimodal mask path; happy to add one if maintainers prefer.
