### PR TITLE
[docs] fix: refresh documentation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Our guiding principles when building VeOmni are:
 
 
 ## 📚 Key Features
-- **FSDP**, **FSDP2** backend for training.
+- **FSDP2** backend for training.
 - **Sequence Parallelism** with [Deepspeed Ulysess](https://arxiv.org/abs/2309.14509), support with non-async and async mode.
 - **Experts Parallelism** support large MOE model training, like [Qwen3-Moe](https://veomni.readthedocs.io/en/latest/key_features/ep_fsdp2.html).
 - Efficient **GroupGemm** kernel for Moe model, [Liger-Kernel](https://github.com/linkedin/Liger-Kernel).
 - Compatible with HuggingFace Transformers models. [Qwen3](https://veomni.readthedocs.io/en/latest/examples/qwen3.html), [Qwen3-VL](https://veomni.readthedocs.io/en/latest/examples/qwen3_vl.html), Qwen3-Moe, etc
 - Dynamic batching strategy, Omnidata processing
 - [**Torch Distributed Checkpoint**](https://docs.pytorch.org/docs/stable/distributed.checkpoint.html) for checkpoint.
-- Support for both Nvidia-GPU and Ascend-NPU training.
+- Support for NVIDIA GPU, AMD ROCm, and Ascend NPU training.
 - Experiment tracking with wandb
 
 ## 📝 Upcoming Features and Changes

--- a/docs/examples/wan2.1.md
+++ b/docs/examples/wan2.1.md
@@ -23,14 +23,14 @@ You can adjust parameter **num_files and video specifications (T, H, W)** in the
 ## Start training on GPU
 
 ```shell
-bash train.sh tasks/deprecated_task/train_wan.py configs/dit/wan_sft.yaml \
+bash train.sh tasks/train_dit.py configs/dit/wan_sft.yaml \
     --model.model_path Wan2.1-I2V-14B-480P-Diffusers/transformer
 ```
 
 ## Start training on NPU
 
 ```shell
-bash train.sh tasks/deprecated_task/train_wan.py configs/dit/wan_sft.yaml \
+bash train.sh tasks/train_dit.py configs/dit/wan_sft.yaml \
     --model.model_path Wan2.1-I2V-14B-480P-Diffusers/transformer \
     --train.init_device npu
 ```

--- a/docs/examples/wan2.1_I2V_1.3B.md
+++ b/docs/examples/wan2.1_I2V_1.3B.md
@@ -141,7 +141,7 @@ NPROC_PER_NODE=4 bash train.sh tasks/train_dit.py configs/dit/wan2.1_I2V_1.3B_lo
 
 ## 4. Training Configuration
 
-The default LoRA config (`configs/dit_new/wan_lora.yaml`) targets the attention and feed-forward projections:
+The default LoRA config (`configs/dit/wan2.1_I2V_1.3B_lora.yaml`) targets the attention and feed-forward projections:
 
 ```yaml
 model:

--- a/docs/get_started/installation/install.md
+++ b/docs/get_started/installation/install.md
@@ -2,7 +2,9 @@
 
 In this section, we provide the installation guide for Nvidia GPU.
 
-VeOmni also supports other hardware platform, please refer to [Ascend](install_ascend.md).
+VeOmni also supports other hardware platforms. See the installation guides for
+[Ascend x86](install_ascend_x86.md), [Ascend ARM](install_ascend_arm.md), and
+[AMD ROCm](../../hardware_support/rocm/README.md).
 
 ## Required Environment
 

--- a/docs/hardware_support/AscendDockerUsage/build_a3_docker.md
+++ b/docs/hardware_support/AscendDockerUsage/build_a3_docker.md
@@ -133,7 +133,7 @@ docker run --runtime=runc -it \
 After starting the container with appropriate mounts, you can run training commands. Here's an example for Qwen3-VL training using generic paths:
 
 ```bash
-bash train.sh tasks/deprecated_task/train_qwen_vl.py configs/multimodal/qwen3_vl/qwen3_vl_dense.yaml \
+bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_vl/qwen3_vl_dense.yaml \
     --model.model_path /app/ckpt/your-model-checkpoint \
     --data.train_path /app/dataset/your-dataset.json \
     --data.datasets_type iterable \

--- a/docs/hardware_support/get_started_npu.md
+++ b/docs/hardware_support/get_started_npu.md
@@ -68,20 +68,19 @@ The following table shows the supported software versions for VeOmni when runnin
 
 VeOmni supports a wide range of models on Ascend NPUs, including large language models, multimodal models, and diffusion models. Below is a comprehensive list of supported models with their features:
 
-| Model                | Model Size       | Support | FSDP1 | FSDP2 | EP | SP | Note                                           |
-|----------------------|------------------|---------|-------|-------|----|----|------------------------------------------------|
-| [Qwen3](../examples/qwen3.md) | 8B              | ✅       |       | ✅     |    | ✅   |
-|                      | 30B               | ✅       |       | ✅     | ✅    | ✅   |
-| [Qwen3.5](../examples/qwen3.md) | 9B    |          |         | ✅    |      |✅    | supporting   |
-|                      | 35B-A3B              |         |       | ✅     |✅    |✅    |  supporting                                   |
-| [Qwen3-VL](../examples/qwen3_vl.md) | 8B               | ✅       |       | ✅     |    | ✅  |                               |
-|                      | 30B              | ✅       |       | ✅     | ✅  | ✅  |                                                |
-| [Wan2.1](../examples/wan2.1.md)    | 1.3B              | ✅       | ✅     |       |    | ✅  | prototype                              |
-| [Qwen3Omni](../examples/qwen3_omni_moe.md)    | 30B              | ✅       |   | ✅        |    | ✅  | prototype                              |
+| Model | Model Size | Support | FSDP2 | EP | SP | Note |
+|---|---|---|---|---|---|---|
+| [Qwen3](../examples/qwen3.md) | 8B | ✅ | ✅ | | ✅ | |
+| | 30B | ✅ | ✅ | ✅ | ✅ | |
+| [Qwen3.5](../examples/qwen3_5.md) | 9B | ✅ | ✅ | | ✅ | |
+| | 35B-A3B | ✅ | ✅ | ✅ | ✅ | |
+| [Qwen3-VL](../examples/qwen3_vl.md) | 8B | ✅ | ✅ | | ✅ | |
+| | 30B | ✅ | ✅ | ✅ | ✅ | |
+| [Wan2.1](../examples/wan2.1.md) | 1.3B | ✅ | ✅ | | ✅ | Prototype |
+| [Qwen3-Omni](../examples/qwen3_omni_moe.md) | 30B | ✅ | ✅ | | ✅ | Prototype |
 
 **Legend:**
-- **FSDP1**: Fully Sharded Data Parallel version 1
-- **FSDP2**: Fully Sharded Data Parallel version 2 (recommended)
+- **FSDP2**: PyTorch composable Fully Sharded Data Parallel, the only FSDP backend supported by VeOmni
 - **EP**: Expert Parallel - for MoE models
 - **SP**: Sequence Parallel - enables longer sequence training
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,8 @@ usage/support_new_models/dit_model_guide.md
 usage/checkpoint_conversion.md
 usage/trainer.md
 usage/agent_workflow.md
+usage/hdfs_fuse_patch.md
+testing.md
 ```
 
 ```{toctree}
@@ -50,6 +52,7 @@ hardware_support/profiling_analysis.md
 hardware_support/AscendDockerUsage/build_a2_docker.md
 hardware_support/AscendDockerUsage/build_a3_docker.md
 hardware_support/FAQ.md
+hardware_support/rocm/README.md
 ```
 
 ```{toctree}
@@ -61,7 +64,9 @@ examples/qwen3_5.md
 examples/qwen3_moe.md
 examples/qwen3_vl.md
 examples/qwen3_omni_moe.md
+examples/qwen3_omni_offline_av.md
 examples/wan2.1.md
+examples/wan2.1_I2V_1.3B.md
 examples/qwen3_dpo.md
 ```
 
@@ -72,6 +77,7 @@ examples/qwen3_dpo.md
 key_features/model_loader.md
 key_features/preprocessor_registry.md
 key_features/ep_fsdp2.md
+key_features/extra_parallel.md
 key_features/ulysses.md
 key_features/lora.md
 
@@ -83,6 +89,8 @@ key_features/lora.md
 
 design/kernel_selection.md
 design/patchgen.md
+design/unified_kernel_registry.md
+design/verl_topk_distill_integration.md
 ```
 
 ```{toctree}

--- a/docs/key_features/extra_parallel.md
+++ b/docs/key_features/extra_parallel.md
@@ -11,11 +11,11 @@ As EP+FSDP2 is well supported in VeOmni, similar parallelism is also needed for 
 
 * Support any length of list of parallelism sizes for different parallism patterns in FSDP2 training.
 * Support checkpoint save and (resharding) load for different parallelism patterns.
-* Support prefetching to overlap communication and computation as [ep_fsdp2.md](./key_features/ep_fsdp2.md).
+* Support prefetching to overlap communication and computation as described in [ep_fsdp2.md](./ep_fsdp2.md).
 
 ## Design Overview
 
-The overall design of extra parallelism is similar to EP+FSDP2, except that it is applied on different parallel modules. Before reading this document, please read [ep_fsdp2.md](./key_features/ep_fsdp2.md). The key requirement:
+The overall design of extra parallelism is similar to EP+FSDP2, except that it is applied on different parallel modules. Before reading this document, please read [ep_fsdp2.md](./ep_fsdp2.md). The key requirement:
 
 * The sharded modules need to be sorted in reverse order from submodules to parent modules to avoid sharding twice, as `fully_shard` is applied from bottom to top.
 

--- a/docs/key_features/model_loader.md
+++ b/docs/key_features/model_loader.md
@@ -41,7 +41,7 @@ First, create new modeling file for your model implementation. Note that the cus
 
 ### 2. Register Your Model
 
-See [enable_new_models.md](support-new-models#in-your-model-file) for more details.
+See the [new-model guide](../usage/support_new_models/guide_and_checklist.md) for more details.
 
 
 ### 3. Model Configuration

--- a/docs/key_features/preprocessor_registry.md
+++ b/docs/key_features/preprocessor_registry.md
@@ -354,7 +354,7 @@ For a complete working example of how preprocessors integrate into the training 
    - Launches distributed training with torchrun
 
 **2. Training Script**: [tasks/train_vlm.py](../../tasks/train_vlm.py)
-   - [data/multimodal/data_transform.py](../../veomni/data/multimodal/data_transform.py) Imports `conv_preprocess` from the preprocessor registry
+   - [data/multimodal/multimodal_transform.py](../../veomni/data/multimodal/multimodal_transform.py) imports `conv_preprocess` from the preprocessor registry
    - Each transform function defines `process_sample()` function that:
      - Calls `conv_preprocess()` at to apply the registered preprocessor
      - Handles image processing and tokenization

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -114,6 +114,7 @@ Root config — assembles `model`, `data`, and `train`.
 | --- | --- | --- | --- |
 | config_path | `Optional[str]` | `None` | Path to the model HuggingFace config (e.g. `config.json`). Defaults to `model_path`. |
 | model_path | `Optional[str]` | `None` | Path to the pre-trained model weights. If unset, random init is used. |
+| model_config | `Optional[Dict]` | `{}` | Values used to override the loaded foundation-model config. |
 | tokenizer_path | `Optional[str]` | `None` | Path to the tokenizer. Defaults to `config_path`. |
 | safetensor_idx_path | `Optional[str]` | `None` | Path to `model.safetensors.index.json`. |
 | foundation | `Dict[str, str]` | `{}` | Foundation model extra config. |
@@ -123,6 +124,7 @@ Root config — assembles `model`, `data`, and `train`.
 | output_encoder | `Literal["encoder", "decoder"]` | `"decoder"` | Whether to use the encoder or decoder to encode output images. |
 | encode_target | `bool` | `False` | Whether to encode training targets with decoder (diffusion only). |
 | basic_modules | `Optional[List[str]]` | `[]` | Additional modules beyond `_no_split_modules` to shard in FSDP. |
+| lora_config | `Optional[Dict]` | `{}` | Native VeOmni LoRA configuration. See the LoRA feature guide. |
 | ops_implementation | `OpsImplementationConfig` | — | Attention / MoE kernel configuration. |
 
 ### OpsImplementationConfig
@@ -151,10 +153,8 @@ NPU validation runs at two times:
   `causal_conv1d`, `chunk_gated_delta_rule`). Validating these at config
   parse would force every NPU user to override them even when training
   non-Qwen3.5 models, so the check fires only when Qwen3.5's patched
-  modeling is actually loaded. **Qwen3.5 GatedDeltaNet has no NPU kernel
-  today** — varlen training (`dyn_bsz=True`, the default) is not supported
-  on NPU; non-varlen training works only with all three fields pinned to
-  `"eager"`.
+  modeling is actually loaded. Qwen3.5 on NPU should select the `"npu"`
+  backend for these three operations.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -164,10 +164,13 @@ NPU validation runs at two times:
 | rms_norm_implementation | `str` | `"liger_kernel"` | RMSNorm. Known values: `liger_kernel` (default, GPU only), `npu`, `triton` (DeepSeek-V3 only; GPU only), `eager`. |
 | swiglu_mlp_implementation | `str` | `"liger_kernel"` | SwiGLU MLP. Known values: `liger_kernel` (default, GPU only), `eager`. There is no NPU backend — NPU users must set this to `"eager"`. |
 | rotary_pos_emb_implementation | `str` | `"liger_kernel"` | Rotary pos emb. Known values: `liger_kernel` (default, GPU only), `npu`, `triton` (DeepSeek-V3 only; GPU only), `eager`. |
+| rotary_pos_emb_vision_implementation | `str` | `"eager"` | Vision rotary positional embedding. Known values: `eager`, `npu`. |
 | load_balancing_loss_implementation | `str` | `"triton"` | MoE load-balancing loss. `triton` (default) requires the `triton` Python package (or `triton-ascend` on NPU); raises at config validation time if the package is missing. `eager` is the pure-PyTorch reference. |
-| rms_norm_gated_implementation | `str` | `"fla"` | Gated RMSNorm (Qwen3.5 GatedDeltaNet `self.norm`). Known values: `eager`, `fla` (FLA `FusedRMSNormGated`, requires `flash-linear-attention`, GPU). No NPU backend — selecting any non-eager value on NPU raises at OpSlot bind time. |
-| causal_conv1d_implementation | `str` | `"fla"` | Varlen depthwise causal conv1d (Qwen3.5 GatedDeltaNet pre-mixer). Known values: `eager`, `fla` (FLA `causal_conv1d`, requires `flash-linear-attention`, GPU). `eager` raises at forward time for varlen training (no torch fallback handles `cu_seqlens`). No NPU backend. |
-| chunk_gated_delta_rule_implementation | `str` | `"fla"` | Chunk gated delta-rule kernel for Qwen3.5 linear attention. Known values: `eager`, `fla` (FLA `chunk_gated_delta_rule`, GPU), `flash_qla` (QwenLM FlashQLA, ships under the `gpu` extra, Hopper sm90 only). `eager` falls back to transformers' `torch_chunk_gated_delta_rule`, which raises at forward time for varlen training. No NPU backend. |
+| rms_norm_gated_implementation | `str` | `"fla"` | Gated RMSNorm (Qwen3.5 GatedDeltaNet `self.norm`). Known values: `eager`, `fla` (FLA `FusedRMSNormGated`, GPU), `npu`. |
+| causal_conv1d_implementation | `str` | `"fla"` | Varlen depthwise causal conv1d (Qwen3.5 GatedDeltaNet pre-mixer). Known values: `eager`, `fla` (GPU), `npu` (requires `triton-ascend`). `eager` does not support the varlen path. |
+| chunk_gated_delta_rule_implementation | `str` | `"fla"` | Chunk gated delta-rule kernel for Qwen3.5 linear attention. Known values: `eager`, `fla` (GPU), `flash_qla` (Hopper SM90), `npu` (requires `triton-ascend`). `eager` does not support varlen training. |
+| dsa_indexer_backend | `Literal["eager", "cudnn"]` | `"eager"` | DeepSeek sparse-attention top-k indexer backend. |
+| dsa_attention_backend | `Literal["eager", "flashmla_cudnn"]` | `"eager"` | DeepSeek sparse-attention backend. |
 
 ### DataArguments
 
@@ -201,6 +204,8 @@ NPU validation runs at two times:
 | prefetch_factor | `int` | `2` | Number of batches loaded in advance per worker. |
 | drop_last | `bool` | `True` | Whether to drop the last incomplete batch. |
 | pin_memory | `bool` | `True` | Whether to pin memory for the dataloader. |
+| worker_num_threads | `Optional[int]` | `None` | Number of PyTorch threads used by each DataLoader worker. |
+| use_background_prefetcher | `bool` | `False` | Enable background prefetching around the DataLoader. |
 
 ### TrainingArguments
 
@@ -230,6 +235,7 @@ NPU validation runs at two times:
 | eval_epochs | `int` | `1` | Epochs between evaluations. `0` to disable. |
 | seed | `int` | `42` | Random seed. |
 | max_steps | `Optional[int]` | `None` | Max training steps per epoch (debug only). |
+| moe_load_balance_monitor_interval | `int` | `0` | Log a globally reduced MoE expert-load heatmap every N steps. `0` disables monitoring. |
 | optimizer | `OptimizerConfig` | — | Optimizer and learning-rate schedule. |
 | wandb | `WandbConfig` | — | Weights & Biases logging. |
 | profile | `ProfileConfig` | — | Torch profiler settings. |
@@ -256,7 +262,7 @@ NPU validation runs at two times:
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| type | `Literal["adamw", "anyprecision_adamw"]` | `"adamw"` | Optimizer type. |
+| type | `Literal["adamw", "anyprecision_adamw", "muon"]` | `"adamw"` | Optimizer type. `muon` builds Muon and AdamW parameter groups. |
 | lr | `float` | `5e-5` | Maximum / default learning rate. |
 | lr_min | `float` | `1e-7` | Minimum learning rate. |
 | lr_start | `float` | `0.0` | Starting learning rate for warmup. |
@@ -267,6 +273,15 @@ NPU validation runs at two times:
 | no_decay_modules | `List[str]` | `[]` | Modules excluded from weight decay (e.g. `RMSNorm`). |
 | no_decay_params | `List[str]` | `[]` | Parameters excluded from weight decay (e.g. `bias`). |
 | max_grad_norm | `float` | `1.0` | Gradient clipping norm. |
+| muon_lr | `float` | `2e-2` | Learning rate for Muon-managed 2-D hidden weights and 3-D expert stacks. |
+| muon_momentum | `float` | `0.95` | Momentum factor for Muon. |
+| muon_nesterov | `bool` | `True` | Enable Nesterov momentum for Muon. |
+| muon_weight_decay | `float` | `0.0` | Decoupled weight decay for Muon parameter groups. |
+| muon_ns_steps | `int` | `5` | Number of Newton–Schulz iterations. |
+| muon_ns_coefficients | `List[float]` | `[3.4445, -4.7750, 2.0315]` | Quintic Newton–Schulz polynomial coefficients. |
+| muon_eps | `float` | `1e-7` | Numerical-stability epsilon used in spectral-norm normalization. |
+| muon_adjust_lr_fn | `Literal["original", "match_rms_adamw"]` | `"match_rms_adamw"` | Per-matrix learning-rate adjustment strategy. |
+| muon_expert_zero_comm | `bool` | `False` | Use whole-expert `Shard(0)` when the FSDP+ExtraParallel topology permits zero-communication expert Muon updates. |
 
 ### WandbConfig
 
@@ -292,6 +307,7 @@ NPU validation runs at two times:
 | record_shapes | `bool` | `True` | Record input tensor shapes. |
 | profile_memory | `bool` | `True` | Record memory usage. |
 | with_stack | `bool` | `True` | Record stack traces. |
+| with_modules | `bool` | `False` | Record module hierarchy in profiler traces. |
 | rank0_only | `bool` | `True` | Profile rank 0 only. |
 
 ### GradientCheckpointingConfig
@@ -315,6 +331,9 @@ NPU validation runs at two times:
 | tp_size | `int` | `1` | Tensor parallel size. |
 | ep_size | `int` | `1` | Expert parallel size, should be fit into dp_shard group if HSDP enabled |
 | ep_outside | `bool` | `False` | Expert parallelism outside in EP-FSDP. |
+| extra_parallel_sizes | `List[int]` | `[]` | Sizes of additional parallel dimensions; EP is appended automatically. |
+| extra_parallel_placement_innermost | `List[bool]` | `[]` | Whether each additional parallel dimension is placed innermost relative to FSDP. |
+| extra_parallel_names | `List[str]` | `[]` | Names of additional parallel dimensions; `ep` is appended automatically. |
 | pp_size | `int` | `1` | Pipeline parallel size. |
 | ulysses_size | `int` | `1` | Ulysses sequence parallel size. |
 | enable_async | `bool` | `False` | Enable async Ulysses. |

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -7,14 +7,10 @@
 2. **Run Example Script**  
    Verify training startup: (need download the dataset first)
 
-    - Use plain python scripts:
-        ```bash
-        bash train.sh tasks/deprecated_task/train_torch.py configs/text/qwen2_5.yaml
-        ```
-    - Use trainer:
-        ```bash
-        bash train.sh tasks/train_text.py configs/text/qwen2_5.yaml
-        ```
+    Use the text trainer entry point:
+    ```bash
+    bash train.sh tasks/train_text.py configs/text/qwen2_5.yaml
+    ```
 
 3. **Create Custom Task Directory**  
     [`train_text.py`](https://github.com/ByteDance-Seed/VeOmni/blob/main/tasks/train_text.py) can be used for most of task pre-training and post-training tasks, you can just modify the train config to complete your task. However, if you want to create a new task, you can copy the `train_text.py` file from the `tasks` directory and modify it. like [`tasks/train_vlm.py`](https://github.com/ByteDance-Seed/VeOmni/blob/main/tasks/train_vlm.py)

--- a/docs/usage/multimodal_data_processing.md
+++ b/docs/usage/multimodal_data_processing.md
@@ -6,7 +6,7 @@ This guide explains how VeOmni processes image and video inputs for vision-langu
 
 The multimodal data pipeline lives in `veomni/data/multimodal/` and handles:
 
-1. **Preprocessing** (`preprocess.py`) — converts raw data samples into a unified conversation format via the [Preprocessor Registry](../../key_features/preprocessor_registry.md).
+1. **Preprocessing** (`preprocess.py`) — converts raw data samples into a unified conversation format via the [Preprocessor Registry](../key_features/preprocessor_registry.md).
 2. **Image processing** (`image_utils.py`) — loads images, resizes them to fit pixel budgets while preserving aspect ratio and ViT patch alignment.
 3. **Video processing** (`video_utils.py`) — loads videos (via torchcodec), samples frames by FPS, resizes spatially, and optionally extracts audio.
 4. **Transform** (`multimodal_transform.py`) — orchestrates the above into tokenized model inputs with proper masking.

--- a/docs/usage/support_new_models/guide_and_checklist.md
+++ b/docs/usage/support_new_models/guide_and_checklist.md
@@ -13,7 +13,7 @@
 > read as describing what the *generated* file does, with the actual edits
 > happening in `<model>_gpu_patch_gen_config.py`. For step-by-step
 > instructions on the patchgen flow, see
-> [docs/transformers_v5/patchgen.md](../../transformers_v5/patchgen.md) and
+> [the patchgen design guide](../../design/patchgen.md) and
 > the `veomni-migrate-transformers-v5` agent skill.
 
 ---
@@ -143,7 +143,7 @@ Two common issues:
 
 ### Step 7: Write the Data Transform Function
 
-Add `process_sample_your_model()` to [veomni/data/multimodal/data_transform.py](../../../veomni/data/multimodal/data_transform.py). See the example docs for the full function signature and steps.
+Add `process_sample_your_model()` to [veomni/data/multimodal/multimodal_transform.py](../../../veomni/data/multimodal/multimodal_transform.py). See the example docs for the full function signature and steps.
 
 ### Step 8: Hook into the Trainer
 

--- a/docs/usage/support_new_models/guide_and_checklist.md
+++ b/docs/usage/support_new_models/guide_and_checklist.md
@@ -143,7 +143,7 @@ Two common issues:
 
 ### Step 7: Write the Data Transform Function
 
-Add `process_sample_your_model()` to [veomni/data/multimodal/multimodal_transform.py](../../../veomni/data/multimodal/multimodal_transform.py). See the example docs for the full function signature and steps.
+Add `process_sample_your_model()` to [veomni/data/data_transform.py](../../../veomni/data/data_transform.py). See the example docs for the full function signature and steps.
 
 ### Step 8: Hook into the Trainer
 

--- a/docs/usage/support_new_models/qwen3_omni_moe_example.md
+++ b/docs/usage/support_new_models/qwen3_omni_moe_example.md
@@ -12,7 +12,7 @@ This document provides in-depth implementation details for each patch applied in
 > are unchanged; what has changed is *where* the patches are declared
 > (declarative patchgen config emitted into `generated/`) rather than applied
 > at import time. See
-> [docs/transformers_v5/patchgen.md](../../transformers_v5/patchgen.md) and
+> [the patchgen design guide](../../design/patchgen.md) and
 > the `veomni-migrate-transformers-v5` agent skill for the current flow.
 
 ---

--- a/docs/usage/support_new_models/qwen3_vl_example.md
+++ b/docs/usage/support_new_models/qwen3_vl_example.md
@@ -11,7 +11,7 @@ This document walks through the specific patches applied to integrate **Qwen3-VL
 > patterns (FSDP dummy forward, SP slicing, fused MoE, EP plan) are unchanged;
 > what has changed is *where* the patches are declared (in the patchgen config
 > and emitted into `generated/`) rather than applied at import time. See
-> [docs/transformers_v5/patchgen.md](../../transformers_v5/patchgen.md) and
+> [the patchgen design guide](../../design/patchgen.md) and
 > the `veomni-migrate-transformers-v5` agent skill for the current flow.
 
 ---


### PR DESCRIPTION
### What does this PR do?

> Refreshes user-facing documentation against the current `main` implementation. It removes stale FSDP1 references, completes the argument reference, repairs local links and navigation, and replaces deprecated training entry points in examples.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))

### Test

> - `PATH="$PWD/.venv/bin:$PATH" make quality`
> - `.venv/bin/python scripts/ci/check_doc_task_paths.py`
> - Static comparison of documented argument fields against dataclasses
> - Static validation of local Markdown links and root documentation navigation
> - `git diff --check`

### API and Usage Example

> No API changes. Documentation now reflects existing configuration fields and current trainer entry points.

### Design & Code Changes

> - Document FSDP2 as VeOmni's only FSDP backend and add ROCm navigation.
> - Complete the argument reference for Muon, ExtraParallel, NPU ops, profiling, model, and DataLoader settings.
> - Repair broken local links and expose previously unlisted documentation pages.
> - Replace deprecated task paths in text, VLM, and Wan examples.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added/updated documentation
- [x] Updated docs examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes
- [x] Tests are documentation-only; no CI workflow changes are required
