### PR TITLE
[ci] chore: update NPU test images to torch2.10.0-latest

### DIFF
--- a/.github/workflows/npu_e2e_test.yml
+++ b/.github/workflows/npu_e2e_test.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: [self-hosted, 910b-8]
     timeout-minutes: 90
     container:
-      image: quay.io/ascend/veomni:veomni-9.0.0-910b-ubuntu22.04-py3.11-torch2.9.0-latest
+      image: quay.io/ascend/veomni:veomni-9.0.0-910b-ubuntu22.04-py3.11-torch2.10.0-latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: [self-hosted, 910b-8]
     timeout-minutes: 90
     container:
-      image: quay.io/ascend/veomni:veomni-9.0.0-910b-ubuntu22.04-py3.11-torch2.9.0-latest
+      image: quay.io/ascend/veomni:veomni-9.0.0-910b-ubuntu22.04-py3.11-torch2.10.0-latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi


### PR DESCRIPTION
### What does this PR do?

Update NPU e2e and unit test workflow images from `torch2.9.0-latest` to `torch2.10.0-latest` to align with the torch 2.10.0 dependency bump. The new image also ships a newer version of `uv` which resolves the `uv sync` timeout issue that was causing intermittent CI failures.

### Checklist Before Starting

- Search for relative PRs/issues and link here: related to #904
- PR title follows `[{modules}] {type}: {description}` format ✅

### Test

- NPU CI will validate with the new image on 910B runners

### Design & Code Changes

- `.github/workflows/npu_e2e_test.yml`: update container image tag from `torch2.9.0-latest` to `torch2.10.0-latest`
- `.github/workflows/npu_unit_tests.yml`: same change

### Checklist Before Submitting

- Applied pre-commit checks ✅
- Added/updated documentation: N/A (CI image tag only)
- Added tests to CI workflow: N/A (this IS the CI update)