### PR TITLE
[docker] refactor: add ascend 9.0.0 a2.x86 to matrix.yaml and regenerate from template

### DIFF
--- a/docker/ascend/Dockerfile.ascend_9.0.0_a2.x86
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_a2.x86
@@ -58,6 +58,7 @@ RUN pip3 install --no-cache-dir -U pip setuptools requests
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /uvx /bin/
 ENV PATH="/bin/:$PATH"
+ENV UV_CACHE_DIR=/home/tiger/.cache/uv
 
 # uv sync
 WORKDIR /app

--- a/docker/ascend/Dockerfile.ascend_9.0.0_a2.x86
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_a2.x86
@@ -1,17 +1,36 @@
-# docker hub: https://hub.docker.com/layers/ascendai/cann/8.3.rc2-910b-ubuntu22.04-py3.11/images/sha256-9efee6a0bb1e8cb6d5dd5170a4a51837d3783e79e2c57c6f4cb5b9ed58598e3e
+# docker hub: https://hub.docker.com/layers/ascendai/cann/9.0.0-910b-ubuntu22.04-py3.11/images/sha256-latest
 # cann web: https://www.hiascend.com/developer/ascendhub/detail/17da20d1c2b6493cb38765adeba85884
 # git repo: https://gitcode.com/Ascend/pytorch
 FROM swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0.0-910b-ubuntu22.04-py3.11
-
-# Set default pip index
-ARG PIP_INDEX=https://pypi.org/simple
 
 # Define environments
 ENV MAX_JOBS=16
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_ROOT_USER_ACTION=ignore
 
-# Set timezone
+# Define installation arguments
+ARG APT_SOURCE=http://archive.ubuntu.com/ubuntu/
+ARG PIP_INDEX=https://pypi.org/simple
+
+# ubuntu 22.04 line-format /etc/apt/sources.list (not the deb822 format used
+# by 24.04+). Only override on non-default APT_SOURCE. Wider regex matches any
+# `…/ubuntu[/]` URL so CANN bases preconfigured with Huawei Cloud / Aliyun
+# mirrors get rewritten too — anchoring on archive.ubuntu.com would silently
+# no-op there.
+RUN if [ "${APT_SOURCE}" != "http://archive.ubuntu.com/ubuntu/" ]; then \
+    cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
+    sed -E -i "s#https?://[^[:space:]]+/ubuntu/?#${APT_SOURCE}#g" /etc/apt/sources.list; \
+    fi
+
+# Change pip source (only when --build-arg PIP_INDEX=... is overridden)
+RUN if [ "${PIP_INDEX}" != "https://pypi.org/simple" ]; then \
+        pip config set global.index-url "${PIP_INDEX}" && \
+        pip config set global.extra-index-url "${PIP_INDEX}"; \
+    fi && \
+    pip config set global.no-cache-dir "true" && \
+    python -m pip install --upgrade pip
+
+# Ubuntu 22.04 base does not preinstall tzdata, unlike the CUDA base.
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata && \
     echo "Setting timezone to CST (China Standard Time)..." && \
@@ -19,16 +38,16 @@ RUN apt-get update -y && \
     echo "Asia/Shanghai" > /etc/timezone && \
     dpkg-reconfigure -f noninteractive tzdata
 
-# Install apt packages.
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc g++ cmake libnuma-dev sudo wget git curl jq vim build-essential ssh ca-certificates ffmpeg && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    pip install --upgrade pip setuptools packaging && \
-    pip cache purge
+# gcc/g++/cmake/build-essential — compile sdists with no NPU/aarch64 wheel.
+# libnuma-dev — required by the Ascend runtime.
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        gcc g++ cmake libnuma-dev sudo wget git curl jq vim build-essential ssh ca-certificates ffmpeg \
+    && apt-get clean
 
-# Add tiger user
-RUN groupadd --non-unique -g 1000 tiger && \
+# Add tiger user, remove default user if uid=1000 is occupied
+RUN userdel -r $(id -un 1000) 2>/dev/null || true && \
+    groupadd --non-unique -g 1000 tiger && \
     useradd -g 1000 -u 1000 -d /home/tiger -m tiger && \
     mkdir -p /home/tiger/.service/ && \
     mkdir -p /home/tiger/.local/share/code-server/User/ && \
@@ -40,31 +59,38 @@ RUN groupadd --non-unique -g 1000 tiger && \
     mkdir -p /var/log/tiger && \
     chown tiger:tiger /var/log/tiger
 
+# enable VFS (Virtual File System) used by UCX for tiger user
+RUN mkdir -p /run/user/1000 && chown tiger:tiger /run/user/1000
+
 # Enable sudo for tiger user
 RUN mkdir -p /etc/sudoers.d && \
     echo "tiger ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/tiger && \
     chmod 0440 /etc/sudoers.d/tiger
 
+# Add tiger python install permission
+RUN groupadd python-users && \
+    usermod -aG python-users root && \
+    usermod -aG python-users tiger && \
+    chown -R root:python-users /usr/local/python3.11.15/lib/python3.11/site-packages/ && \
+    chmod -R g+w /usr/local/python3.11.15/lib/python3.11/site-packages/ && \
+    chmod g+s /usr/local/python3.11.15/lib/python3.11/site-packages/
+
 USER tiger
 
-# Change pip source
-RUN pip config set global.index-url "${PIP_INDEX}" && \
-    pip config set global.extra-index-url "${PIP_INDEX}" && \
-    pip config set global.no-cache-dir "true" && \
-    python -m pip install --upgrade pip
-
-# Upgrade pip
-RUN pip3 install --no-cache-dir -U pip setuptools requests
-
+# Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /uvx /bin/
 ENV PATH="/bin/:$PATH"
 ENV UV_CACHE_DIR=/home/tiger/.cache/uv
 
 # uv sync
 WORKDIR /app
-COPY . ./
-# audio/video dependencies ship under the `npu` extra (rolled in from the
-# dropped `audio` extra), so no additional extra is needed here.
-RUN uv sync --locked --all-packages --extra npu --dev --allow-insecure-host github.com --allow-insecure-host pythonhosted.org
+COPY --chown=tiger:tiger . ./
+RUN uv sync \
+    --locked \
+    --all-packages \
+    --extra npu \
+    --dev \
+    --allow-insecure-host github.com \
+    --allow-insecure-host pythonhosted.org
 
 USER root

--- a/docker/matrix.yaml
+++ b/docker/matrix.yaml
@@ -54,3 +54,17 @@ images:
     uv_extra_flags:
       - "--allow-insecure-host github.com"
       - "--allow-insecure-host pythonhosted.org"
+
+  - name: ascend_9.0.0_a2.x86
+    output: docker/ascend/Dockerfile.ascend_9.0.0_a2.x86
+    template: ascend.Dockerfile.j2
+    base_image: "swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0.0-910b-ubuntu22.04-py3.11"
+    python_dist_packages: "/usr/local/python3.11.15/lib/python3.11/site-packages/"
+    header_comments:
+      - "docker hub: https://hub.docker.com/layers/ascendai/cann/9.0.0-910b-ubuntu22.04-py3.11/images/sha256-latest"
+      - "cann web: https://www.hiascend.com/developer/ascendhub/detail/17da20d1c2b6493cb38765adeba85884"
+      - "git repo: https://gitcode.com/Ascend/pytorch"
+    uv_extras_preset: ascend_x86
+    uv_extra_flags:
+      - "--allow-insecure-host github.com"
+      - "--allow-insecure-host pythonhosted.org"


### PR DESCRIPTION
### What does this PR do?

Add the ascend 9.0.0 a2.x86 Dockerfile to `docker/matrix.yaml` and regenerate
it from `docker/templates/ascend.Dockerfile.j2`, replacing the hand-maintained
version.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A
- PR title follows `[{modules}] {type}: {description}` format ✅

### Test

N/A (Dockerfile infrastructure change). CI with the rebuilt image should show
`uv sync` completing without re-downloading all packages.

### Design & Code Changes

- `docker/matrix.yaml`: add `ascend_9.0.0_a2.x86` entry pointing to the CANN
  9.0.0 base image (`python_dist_packages` adjusted for Python 3.11.15).
- `docker/ascend/Dockerfile.ascend_9.0.0_a2.x86`: regenerated from the shared
  template. Gains features previously missing from the hand-maintained copy:
  - `ENV UV_CACHE_DIR=/home/tiger/.cache/uv` (fixes `uv sync` timeout)
  - `COPY --chown=tiger:tiger` (permission fix)
  - `userdel -r $(id -un 1000)` (clean up default user)
  - VFS setup for UCX
  - `python-users` group for package install permissions
  - `ARG APT_SOURCE` / `ARG PIP_INDEX` for build-time mirror selection

### Why?

The 9.0.0 a2.x86 Dockerfile was manually maintained and missing several
configurations present in the template. Without `UV_CACHE_DIR`, `uv sync`
cannot find the pre-built cache at CI runtime (because GHA overrides
`HOME=/github/home`), forcing a re-download of all packages on every run.

Adding it to the matrix ensures it stays in sync with the shared template
going forward.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md) ✅
- Applied pre-commit checks ✅
- Added/updated documentation: N/A
- Added tests to CI workflow: N/A
