### PR TITLE
[dist, lora] feat: MoE ep_sharded_stream_load for PEFT models + NPU fused MoE-LoRA EP

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -148,6 +148,11 @@ jobs:
       - name: Run fsdp2 all ranks or rank0 load model weights
         run: |
           uv run --frozen pytest -s -x tests/utils/test_rank0_load_and_broadcast_weights.py
+      - name: Run MoE ep_sharded_stream_load matrix (non-PEFT)
+        # Fake EP MoE model: {plain, rank0 broadcast, ep_sharded} x {merged,
+        # per-expert} bit-identical load + the per-expert->fused streaming bail.
+        run: |
+          uv run --frozen pytest -s -x tests/utils/test_moe_ep_sharded_load_matrix.py
       - name: Run checkpoint callback unit tests
         run: |
           uv run --frozen pytest -s -x tests/checkpoints/test_checkpoint_callback.py
@@ -184,6 +189,8 @@ jobs:
         #     bit-exact LoRA reload, also covers linear LoRA on q_proj/v_proj since the
         #     yaml enables both lora_modules and target_parameters)
         #   - moe_lora_ep2: EP=1 vs EP=2 trainer-driven integration + per-step loss/grad_norm alignment
+        #   - moe_lora_ep_sharded_stream_load: PEFT ep_sharded_stream_load vs broadcast, bit-exact
+        #     post-load LoRA weights (independent + shared) on a fused-base Qwen3-MoE at EP=2
         # Order: cheap unit tests first to fail fast, trainer/ep2 last (multi-subprocess, ~5-10 min each).
         run: |
           uv run --frozen pytest -s -x tests/lora/test_target_mapping.py
@@ -192,3 +199,4 @@ jobs:
           uv run --frozen pytest -s -x tests/lora/test_moe_lora_fused.py
           uv run --frozen pytest -s -x tests/lora/test_moe_lora_trainer.py
           uv run --frozen pytest -s -x tests/lora/test_moe_lora_ep2.py
+          uv run --frozen pytest -s -x tests/lora/test_moe_lora_ep_sharded_stream_load.py

--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -183,6 +183,8 @@ jobs:
         # `uv sync --frozen --extra gpu --group dev` step is sufficient — no extra sync needed here.
         # Coverage:
         #   - lora_trainer_saveload: dense Qwen3 + linear LoRA save/load smoke test
+        #   - veomni_lora_moe_native: CPU MoE-LoRA injection/save-load + init_lora_parameter
+        #     preserve/partial/fresh reset contract (catches to_empty clobber regressions)
         #   - moe_lora_eager: wrapper layout + autograd parity (Mode 1 + Mode 2, all v5 MoE configs)
         #   - moe_lora_fused: triton kernel parity vs eager (forward + backward, EP autograd classes)
         #   - moe_lora_trainer: production save/load/resume round-trip (DCP shard + HF adapter,
@@ -194,6 +196,7 @@ jobs:
         # Order: cheap unit tests first to fail fast, trainer/ep2 last (multi-subprocess, ~5-10 min each).
         run: |
           uv run --frozen pytest -s -x tests/lora/test_target_mapping.py
+          uv run --frozen pytest -s -x tests/lora/test_veomni_lora_moe_native.py
           uv run --frozen pytest -s -x tests/lora/test_lora_trainer_saveload.py
           uv run --frozen pytest -s -x tests/lora/test_moe_lora_eager.py
           uv run --frozen pytest -s -x tests/lora/test_moe_lora_fused.py

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -163,6 +163,12 @@ jobs:
       - name: Run fsdp2/extra_parallel+fsdp2 (e.g. ep+fsdp2, mb+fsdp2, ep+emb+fsdp2) clip grad norm test
         run: |
           uv run --frozen pytest -v -s -x tests/utils/test_extra_parallel_clip_grad_norm.py
+      - name: Run MoE ep_sharded_stream_load matrix (non-PEFT)
+        # Device-agnostic loader matrix (build_parallelize_model + the 3 weight
+        # loaders over EP+FSDP2 on a fake MoE model; no Triton / MoE kernel, so
+        # it runs on NPU via hccl).
+        run: |
+          uv run --frozen pytest -v -s -x tests/utils/test_moe_ep_sharded_load_matrix.py
       - name: Run checkpoint callback unit tests
         run: |
           uv run --frozen pytest -v -s -x tests/checkpoints/test_checkpoint_callback.py
@@ -189,3 +195,10 @@ jobs:
         # sync needed here.
         run: |
           uv run --frozen pytest -v -s -x tests/lora/test_lora_trainer_saveload.py
+      - name: Run MoE-LoRA ep_sharded_stream_load (PEFT, EP=2)
+        # Exercises the PEFT ep_sharded adapter streaming *and* the NPU
+        # fused MoE-LoRA EP kernel (fused_npu): the test auto-selects
+        # fused_npu on Ascend, so both the loader path and the EP forward
+        # are validated on NPU here.
+        run: |
+          uv run --frozen pytest -v -s -x tests/lora/test_moe_lora_ep_sharded_stream_load.py

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -195,6 +195,12 @@ jobs:
         # sync needed here.
         run: |
           uv run --frozen pytest -v -s -x tests/lora/test_lora_trainer_saveload.py
+      - name: Run MoE-LoRA NPU fused vs eager parity
+        # Numerical gate for the new NPU fused MoE-LoRA autograd composition
+        # (shared + independent; forward + A/B grads; EP=1 vs non-EP).
+        # Cheap single-process; run before the multi-process stream-load test.
+        run: |
+          uv run --frozen pytest -v -s -x tests/lora/test_moe_lora_fused_npu.py
       - name: Run MoE-LoRA ep_sharded_stream_load (PEFT, EP=2)
         # Exercises the PEFT ep_sharded adapter streaming *and* the NPU
         # fused MoE-LoRA EP kernel (fused_npu): the test auto-selects

--- a/docs/key_features/lora.md
+++ b/docs/key_features/lora.md
@@ -159,9 +159,10 @@ VeOmni LoRA training uses FSDP2 with `init_device: meta`. Weight loading goes th
 
 3. **Adapter weight initialisation from scratch**: `post_process_after_weight_loading`
    calls `_init_lora_parameter` for any LoRA parameter not yet filled, invoking
-   `reset_lora_parameters` (kaiming `A` / zero `B`). For MoE wrappers the reset only fires
-   when every wrapper parameter is still on meta device, so a partially-loaded wrapper is
-   never clobbered.
+   `reset_lora_parameters` (kaiming `A` / zero `B`). For MoE wrappers the decision is made
+   against the missing-name set: reset only when *all* of that wrapper's LoRA tensors are
+   still missing; skip when none are missing; raise on a partial load so already-loaded
+   `A`/`B` tensors are never clobbered.
 
 **Key difference from base model loading:** the on-disk adapter keys omit the adapter-name
 infix (PEFT convention — e.g. `lora_A.weight`), whereas the live model stores them as

--- a/tests/lora/test_moe_lora_ep2.py
+++ b/tests/lora/test_moe_lora_ep2.py
@@ -203,10 +203,17 @@ def _parse_ep_slices(stdout: str) -> tuple[set, dict[str, tuple[int, int, int]]]
 
 
 def _load_adapter(adapter_dir: str) -> dict[str, torch.Tensor]:
-    """Load the consolidated ``adapter_model.bin`` written by HFLoraCkptCallback."""
-    path = os.path.join(adapter_dir, "adapter_model.bin")
-    assert os.path.isfile(path), f"Missing adapter_model.bin at {path}"
-    return torch.load(path, map_location="cpu", weights_only=False)
+    """Load the consolidated ``adapter_model.safetensors`` written by HFLoraCkptCallback.
+
+    ``save_lora_adapter_with_dcp`` consolidates on rank 0 with
+    ``safe_serialization=True``, so the adapter is always safetensors
+    (sliceable per-rank by the ep_sharded streaming loader).
+    """
+    from safetensors.torch import load_file
+
+    path = os.path.join(adapter_dir, "adapter_model.safetensors")
+    assert os.path.isfile(path), f"Missing adapter_model.safetensors at {path}"
+    return load_file(path, device="cpu")
 
 
 def _make_seeder_yaml(base_yaml: str, dest: str, *, max_steps: int, dcp_save_steps: int) -> str:
@@ -393,7 +400,7 @@ def test_ep2_trainer_integration(tmp_path, toy_base_dir, mode):
     * for ``mode="shared"``, NO LoRA tensor shows up in the EP slice
       log (proves the per-expert extension is correctly gated to
       Independent mode and shared LoRA stays replicated);
-    * the saved ``adapter_model.bin`` has the same key set and the
+    * the saved ``adapter_model.safetensors`` has the same key set and the
       same per-tensor shapes as the EP=1 reference (proves DCP
       gathered the EP shards before the PEFT save helper consumed
       them; per-expert tensors come back as ``[16, ...]`` not
@@ -552,7 +559,7 @@ def test_moe_lora_ep_save_load_parallel_align(tmp_path, toy_base_dir, mode):
          * ``HFLoraCkptCallback`` at step ``_ALIGN_MAX_STEPS`` calls
            ``save_lora_adapter_with_dcp`` which uses DCP to gather
            the EP shards back into the full ``[E, r, H]`` tensor on
-           rank 0 before writing ``adapter_model.bin``.
+           rank 0 before writing ``adapter_model.safetensors``.
          * ``CheckpointerCallback`` at steps
            ``_DCP_SAVE_STEP`` (intermediate) and
            ``_ALIGN_MAX_STEPS`` writes sharded DCP shards
@@ -663,7 +670,7 @@ def test_moe_lora_ep_save_load_parallel_align(tmp_path, toy_base_dir, mode):
     )
     seeder_adapter = _writer_adapter_path(seeder_dir, save_step=_ALIGN_MAX_STEPS)
     seeder_dcp = os.path.join(seeder_dir, "checkpoints", f"global_step_{_DCP_SAVE_STEP}")
-    assert os.path.isfile(os.path.join(seeder_adapter, "adapter_model.bin")), (
+    assert os.path.isfile(os.path.join(seeder_adapter, "adapter_model.safetensors")), (
         f"{mode}: seeder failed to write adapter at {seeder_adapter}"
     )
     assert os.path.isdir(seeder_dcp), f"{mode}: seeder failed to write DCP at {seeder_dcp}"

--- a/tests/lora/test_moe_lora_ep_sharded_stream_load.py
+++ b/tests/lora/test_moe_lora_ep_sharded_stream_load.py
@@ -1,0 +1,302 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Trainer-driven EP=2 test for the **PEFT** ``ep_sharded_stream_load`` path.
+
+Companion to ``tests/utils/test_moe_ep_sharded_load_matrix.py`` (which
+covers the *non-PEFT* MoE load matrix with a fake model). This one
+exercises the real veomni LoRA stack on the Qwen3-MoE toy and asserts
+that streaming a LoRA-wrapped MoE checkpoint reconstructs **bit-identical**
+weights to the reference broadcast loader.
+
+What ``ep_sharded_stream_load`` does for a PEFT model
+-----------------------------------------------------
+``load_model_weights_ep_sharded`` under ``is_peft_model=True`` (wired in
+``veomni/models/module_utils.py``):
+
+  * **Base experts** — the fused ``...experts.gate_up_proj`` /
+    ``down_proj`` tensors are streamed from the base checkpoint straight
+    into the wrapped ``...experts.<spec>.base_layer.weight`` destinations;
+    each rank reads only its ``[E/ep, ...]`` dim-0 slice.
+  * **Adapter** — ``_stream_lora_adapter_ep_sharded`` reads
+    ``adapter_model.safetensors``: *independent* MoE-LoRA tensors
+    (EP-sharded in the runtime plan) are read per-rank as their
+    ``[E/ep, r, ...]`` slice; *shared* / dense LoRA tensors are read whole
+    by every rank (FSDP then shards them).
+
+The reference path (``broadcast_model_weights_from_rank0=True``) reads the
+full tensors on rank 0 and broadcasts / EP-slices them in-memory. Both
+paths must land on the same local weights, so a post-load LoRA snapshot
+(``lora_snapshot_pre.pt``, gathered full-tensors on rank 0) must be
+bit-exact between them.
+
+Both LoRA flavours are covered:
+  * ``independent`` — the per-expert adapter EP-slice branch of
+    ``_stream_lora_adapter_ep_sharded`` fires.
+  * ``shared`` — the whole-tensor adapter branch fires; only the base
+    experts are EP-streamed.
+
+Run (2 GPUs):
+    pytest -v -s tests/lora/test_moe_lora_ep_sharded_stream_load.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+import pytest
+import yaml
+
+# Reuse the battle-tested trainer harness. The trainer subprocess entry
+# point + snapshot comparator + CLI helpers are shared; the base-model
+# fixture is *not* -- see ``fused_toy_base_dir`` below for why.
+from .test_moe_lora_ep2 import _torchrun_capture
+from .test_moe_lora_trainer import (
+    _TOY_CONFIG_PATH,
+    SNAPSHOT_PRE,
+    _compare_snapshots_bit_exact,
+    _gpu_count_or_skip,
+    _writer_adapter_path,
+    _yaml_for_mode,
+)
+
+
+__all__ = [
+    "fused_toy_base_dir",
+    "test_peft_ep_sharded_stream_load_matches_broadcast",
+]
+
+
+# EP requires a fused MoE-LoRA kernel: the wrappers only implement the EP
+# dispatch on the fused path. The backend is device-specific — ``fused_triton``
+# on GPU, ``fused_npu`` on NPU (selecting the wrong one raises a hard error in
+# ``apply_veomni_fused_moe_patch``), so pick it from the active accelerator.
+def _fused_ops_override() -> str:
+    from veomni.utils.import_utils import is_torch_npu_available
+
+    backend = "fused_npu" if is_torch_npu_available() else "fused_triton"
+    return f"--model.ops_implementation.moe_implementation={backend}"
+
+
+# Seeder trains this many steps, then writes the HF adapter at the final
+# step. Kept tiny -- we only need a *non-trivial* adapter on disk, not a
+# converged one.
+_SEED_STEPS = 2
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fused base checkpoint fixture
+# ──────────────────────────────────────────────────────────────────────
+#
+# ``ep_sharded_stream_load`` streams each rank's dim-0 expert slice
+# straight from the checkpoint. That is only possible when the on-disk
+# expert layout *is* the model's fused layout
+# (``...experts.gate_up_proj`` / ``down_proj`` with shape ``[E, ...]``).
+# The shared ``toy_base_dir`` fixture in ``test_moe_lora_trainer`` writes
+# the standard HF **per-expert** layout (``...experts.<e>.gate_proj.weight``),
+# which needs the ``Qwen3MoeCheckpointTensorConverter`` per-expert->fused
+# fusion at load time -- a transform the stream loader explicitly refuses
+# (``NotImplementedError``; covered by the non-PEFT bail case in
+# ``tests/utils/test_moe_ep_sharded_load_matrix.py``).
+#
+# So this test builds its *own* base by dumping the fused
+# ``model.state_dict()`` directly (no ``save_pretrained`` re-split),
+# giving a converter-free, streamable checkpoint.
+
+
+def _build_and_save_fused_toy_base(dest_dir: str) -> None:
+    """Single-process (spawned): build the toy and save its **fused** state_dict.
+
+    Unlike ``test_moe_lora_trainer._build_and_save_toy_base`` (which uses
+    ``save_pretrained`` and therefore emits the per-expert HF layout), this
+    writes ``model.state_dict()`` verbatim via safetensors so the expert
+    tensors stay fused ``[E, ...]`` -- the layout the stream loader can
+    slice per-rank without a converter.
+    """
+    import shutil as _shutil
+
+    from safetensors.torch import save_file
+
+    from veomni.arguments.arguments_types import OpsImplementationConfig
+    from veomni.models import build_foundation_model
+    from veomni.utils import helper as _helper
+
+    _helper.set_seed(42)
+    ops = OpsImplementationConfig(
+        attn_implementation="eager",
+        moe_implementation="eager",
+        cross_entropy_loss_implementation="eager",
+        rms_norm_implementation="eager",
+        swiglu_mlp_implementation="eager",
+        rotary_pos_emb_implementation="eager",
+    )
+    model = build_foundation_model(
+        config_path=_TOY_CONFIG_PATH,
+        weights_path=None,
+        torch_dtype="bfloat16",
+        init_device="cpu",
+        ops_implementation=ops,
+    )
+    # ``.clone()`` breaks any tied-weight storage sharing (e.g.
+    # lm_head/embed_tokens) that safetensors refuses to serialise.
+    state = {k: v.detach().clone().contiguous() for k, v in model.state_dict().items()}
+    os.makedirs(dest_dir, exist_ok=True)
+    save_file(state, os.path.join(dest_dir, "model.safetensors"))
+    _shutil.copy(_TOY_CONFIG_PATH, os.path.join(dest_dir, "config.json"))
+
+
+@pytest.fixture(scope="module")
+def fused_toy_base_dir(tmp_path_factory):
+    """Module-scoped fused Qwen3-MoE toy base (streamable expert layout).
+
+    Built in a spawned child process so the pytest collection process
+    stays free of foundation-model imports / singleton state, matching
+    the ``toy_base_dir`` fixture's isolation rationale.
+    """
+    import multiprocessing as mp
+
+    base_dir = tmp_path_factory.mktemp("fused_toy_base") / "qwen3_moe_toy"
+    base_dir_str = str(base_dir)
+
+    ctx = mp.get_context("spawn")
+    proc = ctx.Process(target=_build_and_save_fused_toy_base, args=(base_dir_str,))
+    proc.start()
+    proc.join()
+    if proc.exitcode != 0:
+        raise RuntimeError(f"fused toy base-model build subprocess exited with code {proc.exitcode}")
+    return base_dir_str
+
+
+def _fused_model_path_overrides(fused_base: str) -> list[str]:
+    """Point ``model.model_path`` / ``config_path`` at the fused base dir."""
+    return [
+        f"--model.model_path={fused_base}",
+        f"--model.config_path={fused_base}",
+    ]
+
+
+def _make_seeder_yaml(base_yaml: str, dest: str, *, max_steps: int) -> str:
+    """Clone a mode yaml into an EP=2 seeder that emits the HF adapter."""
+    with open(base_yaml) as f:
+        cfg = yaml.safe_load(f)
+    cfg["train"]["max_steps"] = max_steps
+    cfg["train"]["checkpoint"]["save_steps"] = max_steps
+    cfg["train"]["checkpoint"]["save_hf_weights"] = True
+    cfg["train"]["checkpoint"]["hf_save_steps"] = max_steps
+    cfg["train"]["checkpoint"].pop("load_path", None)
+    with open(dest, "w") as f:
+        yaml.safe_dump(cfg, f)
+    return dest
+
+
+def _make_adapter_resume_yaml(base_yaml: str, adapter_path: str, dest: str) -> str:
+    """Clone a mode yaml to resume from ``adapter_path`` for a single step.
+
+    ``max_steps=1`` is enough to reach ``on_train_begin`` -> the
+    ``_SnapshotCallback`` post-load dump (``lora_snapshot_pre.pt``); all
+    saves are disabled so the resumers only produce that snapshot.
+    ``lora_config`` is an opaque ``Dict`` (its nested keys can't be set
+    via the CLI), so the adapter path is materialised into a yaml.
+    """
+    with open(base_yaml) as f:
+        cfg = yaml.safe_load(f)
+    cfg["model"]["lora_config"]["lora_adapter"] = adapter_path
+    cfg["train"]["max_steps"] = 1
+    cfg["train"]["checkpoint"]["save_steps"] = 0
+    cfg["train"]["checkpoint"]["save_hf_weights"] = False
+    cfg["train"]["checkpoint"]["hf_save_steps"] = 0
+    cfg["train"]["checkpoint"].pop("load_path", None)
+    with open(dest, "w") as f:
+        yaml.safe_dump(cfg, f)
+    return dest
+
+
+@pytest.mark.parametrize("mode", ["independent", "shared"])
+def test_peft_ep_sharded_stream_load_matches_broadcast(tmp_path, fused_toy_base_dir, mode):
+    """Streaming a LoRA-wrapped MoE checkpoint == broadcast loader, bit-exact.
+
+    Three EP=2 subprocesses on the Qwen3-MoE toy:
+
+    1. **Seeder** (default broadcast loader) trains ``_SEED_STEPS`` steps
+       and writes the HF adapter (``adapter_model.safetensors``) at the
+       final step.
+    2. **Reference resumer** loads base + adapter via the broadcast loader
+       (``broadcast_model_weights_from_rank0=True``) and dumps its
+       post-load LoRA snapshot.
+    3. **Stream resumer** loads base + adapter via
+       ``ep_sharded_stream_load=True``
+       (``broadcast_model_weights_from_rank0=False``) and dumps its
+       post-load LoRA snapshot.
+
+    The two snapshots must be **bit-exact** (bf16): both start from the
+    same base checkpoint and the same on-disk adapter, so the only
+    difference is *how* each rank obtained its local slice. For
+    ``independent`` the adapter's per-expert LoRA is EP-streamed; for
+    ``shared`` the adapter LoRA is read whole while the base experts are
+    still EP-streamed.
+    """
+    nproc = _gpu_count_or_skip(min_count=2, max_count=2)
+    yaml_path = _yaml_for_mode(mode)
+    base_overrides = _fused_model_path_overrides(fused_toy_base_dir) + [
+        _fused_ops_override(),
+        "--train.accelerator.ep_size=2",
+    ]
+
+    # ── 1. Seeder: produce the HF adapter (adapter_model.safetensors) ───
+    seeder_dir = str(tmp_path / "seeder")
+    seeder_yaml = _make_seeder_yaml(yaml_path, str(tmp_path / "seeder.yaml"), max_steps=_SEED_STEPS)
+    _torchrun_capture(seeder_yaml, seeder_dir, extra_overrides=base_overrides, nproc=nproc)
+
+    adapter_dir = _writer_adapter_path(seeder_dir, save_step=_SEED_STEPS)
+    adapter_file = os.path.join(adapter_dir, "adapter_model.safetensors")
+    assert os.path.isfile(adapter_file), (
+        f"{mode}: seeder did not write a safetensors adapter at {adapter_file} "
+        f"(dir contents: {sorted(os.listdir(adapter_dir)) if os.path.isdir(adapter_dir) else 'MISSING'}). "
+        "ep_sharded adapter streaming requires the safetensors format."
+    )
+
+    resume_yaml = _make_adapter_resume_yaml(yaml_path, adapter_dir, str(tmp_path / "resume.yaml"))
+
+    # ── 2. Reference resumer (broadcast loader) ─────────────────────────
+    ref_dir = str(tmp_path / "ref")
+    _torchrun_capture(resume_yaml, ref_dir, extra_overrides=base_overrides, nproc=nproc)
+
+    # ── 3. Stream resumer (ep_sharded_stream_load) ──────────────────────
+    stream_dir = str(tmp_path / "stream")
+    _torchrun_capture(
+        resume_yaml,
+        stream_dir,
+        extra_overrides=base_overrides
+        + [
+            "--train.broadcast_model_weights_from_rank0=False",
+            "--train.ep_sharded_stream_load=True",
+        ],
+        nproc=nproc,
+    )
+
+    # ── 4. Post-load LoRA weights must be bit-identical ─────────────────
+    _compare_snapshots_bit_exact(
+        actual_path=os.path.join(stream_dir, SNAPSHOT_PRE),
+        ref_path=os.path.join(ref_dir, SNAPSHOT_PRE),
+        label=f"{mode}/ep_sharded_stream_vs_broadcast",
+    )
+
+    for d in (ref_dir, stream_dir):
+        shutil.rmtree(d, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/tests/lora/test_moe_lora_fused_npu.py
+++ b/tests/lora/test_moe_lora_fused_npu.py
@@ -17,9 +17,9 @@ Counterpart of ``test_moe_lora_fused.py`` for Ascend. The NPU kernels compose
 ``npu_group_gemm`` + seed-style LoRA deltas under autograd (no hand-written
 backward), so this suite is the correctness gate for that composition:
 
-1. Wrapper fused_npu vs eager — forward hidden states + A/B grads.
+1. Wrapper fused_npu vs eager — forward outputs + ``h.grad`` + A/B grads.
 2. EP vs non-EP single-rank — ``_npu_ep_fused_lora_moe_forward(ep_group=None)``
-   must match ``_npu_fused_lora_moe_forward`` for outputs and LoRA grads.
+   must match ``_npu_fused_lora_moe_forward`` for outputs, ``h.grad``, and LoRA grads.
 
 Skipped on non-NPU hosts. Wired into ``npu_unit_tests.yml``.
 
@@ -169,23 +169,37 @@ def test_npu_fused_vs_eager_forward_parity(mode):
 
 @pytest.mark.parametrize("mode", list(_MODES.keys()))
 def test_npu_fused_vs_eager_backward_parity(mode):
-    """Gradients on <spec>.lora_A / <spec>.lora_B match between NPU fused and eager."""
+    """Gradients on hidden states + <spec>.lora_A / <spec>.lora_B match fused vs eager.
+
+    Hidden-state grad is required: A/B-only checks would miss bugs in
+    ``GmmFunction.backward``'s ``grad_input`` (or the all-to-all backward on the
+    EP path) while every adapter assertion stayed green.
+    """
 
     def _grads(*, fused: bool):
         model, fqn, exp, _ = _build_wrapped(mode=mode, fused=fused, lora_b_perturb_std=0.02)
         wrapper = model.get_submodule(fqn)
         wrapper.train()
         h, idx, w = _make_inputs(exp)
+        h = h.detach().requires_grad_(True)
         loss = wrapper(h, idx, w).float().pow(2).sum()
         loss.backward()
-        return {n: p.grad.detach().clone() for n, p in wrapper.named_parameters() if p.grad is not None}
+        assert h.grad is not None, f"[{mode}] expected grad on hidden-state leaf"
+        param_grads = {n: p.grad.detach().clone() for n, p in wrapper.named_parameters() if p.grad is not None}
+        return param_grads, h.grad.detach().clone()
 
-    grads_eager = _grads(fused=False)
-    grads_fused = _grads(fused=True)
+    grads_eager, hgrad_eager = _grads(fused=False)
+    grads_fused, hgrad_fused = _grads(fused=True)
 
     assert set(grads_eager) == set(grads_fused), (
         f"[{mode}] different param sets received grad: only-eager={set(grads_eager) - set(grads_fused)}, "
         f"only-fused={set(grads_fused) - set(grads_eager)}"
+    )
+    h_l2 = _l2_rel(hgrad_fused, hgrad_eager)
+    assert h_l2 <= _GRAD_L2REL_TOL, (
+        f"[{mode}] hidden-state grad parity broken — L2 relative error {h_l2:.4%} > {_GRAD_L2REL_TOL:.2%} "
+        f"(eager_norm={hgrad_eager.float().norm().item():.3e}, "
+        f"max|fused-eager|={(hgrad_eager - hgrad_fused).abs().max().item():.3e})"
     )
     lora_param_names = sorted(n for n in grads_eager if "lora_A" in n.split(".") or "lora_B" in n.split("."))
     assert lora_param_names, f"[{mode}] expected LoRA A/B params to receive gradients"
@@ -242,7 +256,7 @@ def _single_rank_dist():
 
 @pytest.mark.parametrize("mode", ["shared", "independent"])
 def test_npu_ep_vs_nonep_single_rank_parity(mode, _single_rank_dist):
-    """EP path with ``ep_group=None`` (EP=1) matches the non-EP NPU kernel on outputs + LoRA grads."""
+    """EP path with ``ep_group=None`` (EP=1) matches non-EP on outputs + h/LoRA grads."""
     from veomni.lora.ops.npu_moe_group_gemm import (
         _npu_ep_fused_lora_moe_forward,
         _npu_fused_lora_moe_forward,
@@ -253,22 +267,27 @@ def test_npu_ep_vs_nonep_single_rank_parity(mode, _single_rank_dist):
     B, H, I, E, top_k, r = 32, 64, 96, 4, 2, 8
     scale_gate = scale_up = scale_down = 0.5
     _LORA_KEYS = ("lora_a_gate", "lora_b_gate", "lora_a_up", "lora_b_up", "lora_a_down", "lora_b_down")
+    _GRAD_KEYS = ("hidden_states",) + _LORA_KEYS
 
     torch.manual_seed(0)
-    hidden_states = torch.randn(B, H, dtype=dtype, device=dev)
     selected_experts = torch.randint(0, E, (B, top_k), device=dev)
     routing_weights = torch.softmax(torch.randn(B, top_k, dtype=torch.float32, device=dev), dim=-1).to(dtype)
     gate_up_proj = (torch.randn(E, 2 * I, H, dtype=dtype, device=dev) * 0.05).detach()
     down_proj = (torch.randn(E, H, I, dtype=dtype, device=dev) * 0.05).detach()
+    # Shared base activations so both branches start from the same h values;
+    # each branch then clones its own leaf so autograd graphs stay isolated.
+    torch.manual_seed(1)
+    hidden_states_base = torch.randn(B, H, dtype=dtype, device=dev)
 
     def _run(*, ep: bool):
         torch.manual_seed(123)
         lora = _build_lora_leaves(mode, E=E, H=H, I=I, r=r, dtype=dtype, device=dev)
+        h = hidden_states_base.detach().clone().requires_grad_(True)
         kwargs = dict(
             num_experts=E,
             routing_weights=routing_weights,
             selected_experts=selected_experts,
-            hidden_states=hidden_states,
+            hidden_states=h,
             fc1_1_2_weight=gate_up_proj,
             fc2_weight=down_proj,
             lora_a_gate=lora["lora_a_gate"],
@@ -286,10 +305,10 @@ def test_npu_ep_vs_nonep_single_rank_parity(mode, _single_rank_dist):
             out = _npu_ep_fused_lora_moe_forward(ep_group=None, **kwargs)
         else:
             out = _npu_fused_lora_moe_forward(**kwargs)
-        return out, lora
+        return out, h, lora
 
-    nonep_out, nonep_lora = _run(ep=False)
-    ep_out, ep_lora = _run(ep=True)
+    nonep_out, nonep_h, nonep_lora = _run(ep=False)
+    ep_out, ep_h, ep_lora = _run(ep=True)
 
     fwd_l2 = _l2_rel(ep_out.detach(), nonep_out.detach())
     assert fwd_l2 <= _FWD_L2REL_TOL, (
@@ -301,18 +320,27 @@ def test_npu_ep_vs_nonep_single_rank_parity(mode, _single_rank_dist):
     grad_out = (torch.randn(B, H, dtype=dtype, device=dev) * 0.1).detach()
     nonep_grads = dict(
         zip(
-            _LORA_KEYS,
-            torch.autograd.grad(nonep_out, [nonep_lora[k] for k in _LORA_KEYS], grad_outputs=grad_out),
+            _GRAD_KEYS,
+            torch.autograd.grad(
+                nonep_out,
+                [nonep_h] + [nonep_lora[k] for k in _LORA_KEYS],
+                grad_outputs=grad_out,
+            ),
         )
     )
     ep_grads = dict(
         zip(
-            _LORA_KEYS,
-            torch.autograd.grad(ep_out, [ep_lora[k] for k in _LORA_KEYS], grad_outputs=grad_out),
+            _GRAD_KEYS,
+            torch.autograd.grad(
+                ep_out,
+                [ep_h] + [ep_lora[k] for k in _LORA_KEYS],
+                grad_outputs=grad_out,
+            ),
         )
     )
-    for name in _LORA_KEYS:
+    for name in _GRAD_KEYS:
         g_nonep, g_ep = nonep_grads[name], ep_grads[name]
+        assert g_nonep is not None and g_ep is not None, f"[{mode}] {name}: missing grad"
         assert g_nonep.shape == g_ep.shape, f"[{mode}] {name}: shape mismatch"
         l2 = _l2_rel(g_ep, g_nonep)
         assert l2 <= _GRAD_L2REL_TOL, (

--- a/tests/lora/test_moe_lora_fused_npu.py
+++ b/tests/lora/test_moe_lora_fused_npu.py
@@ -1,0 +1,325 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""NPU fused MoE-LoRA forward/backward parity vs eager (shared + independent).
+
+Counterpart of ``test_moe_lora_fused.py`` for Ascend. The NPU kernels compose
+``npu_group_gemm`` + seed-style LoRA deltas under autograd (no hand-written
+backward), so this suite is the correctness gate for that composition:
+
+1. Wrapper fused_npu vs eager — forward hidden states + A/B grads.
+2. EP vs non-EP single-rank — ``_npu_ep_fused_lora_moe_forward(ep_group=None)``
+   must match ``_npu_fused_lora_moe_forward`` for outputs and LoRA grads.
+
+Skipped on non-NPU hosts. Wired into ``npu_unit_tests.yml``.
+
+Run:
+    pytest -v tests/lora/test_moe_lora_fused_npu.py
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from veomni.lora import resolve_fused_moe_lora_targets
+from veomni.lora.moe_layers import (
+    LoraIndependentExperts,
+    LoraSharedExperts,
+    apply_independent_moe_lora,
+    apply_shared_moe_lora,
+)
+from veomni.utils.device import IS_NPU_AVAILABLE, get_device_type
+
+from .utils import (
+    build_toy,
+    experts_module_globs,
+    find_first_matching_module,
+    fused_npu_moe_ops,
+    load_lora_config,
+)
+
+
+pytestmark = pytest.mark.skipif(not IS_NPU_AVAILABLE, reason="NPU fused MoE-LoRA parity requires torch_npu")
+
+_TOY = "qwen3_moe_toy"
+# Same L2-relative rationale as ``test_moe_lora_fused.py`` (bf16 reduction order).
+_FWD_L2REL_TOL = 0.02
+_GRAD_L2REL_TOL = 0.02
+
+_MODES = {
+    "shared": (LoraSharedExperts, apply_shared_moe_lora, "_fused_lora_moe_forward"),
+    "independent": (LoraIndependentExperts, apply_independent_moe_lora, "_fused_independent_lora_moe_forward"),
+}
+
+
+def _l2_rel(actual: torch.Tensor, ref: torch.Tensor) -> float:
+    a = actual.float()
+    r = ref.float()
+    ref_norm = r.norm().item()
+    if ref_norm == 0.0:
+        return (a - r).norm().item()
+    return ((a - r).norm() / ref_norm).item()
+
+
+@pytest.fixture(autouse=True)
+def _restore_moe_pointers():
+    """Save / restore fused MoE + LoRA pointers mutated by ``fused_npu`` builds."""
+    from veomni.lora import ops as _lora_ops
+    from veomni.ops.kernels import moe as _moe_ops
+
+    saved_base = _moe_ops._fused_moe_forward
+    saved_lora = _lora_ops._fused_lora_moe_forward
+    saved_indep = _lora_ops._fused_independent_lora_moe_forward
+    try:
+        yield
+    finally:
+        _moe_ops._fused_moe_forward = saved_base
+        _lora_ops._fused_lora_moe_forward = saved_lora
+        _lora_ops._fused_independent_lora_moe_forward = saved_indep
+
+
+def _wrap_with_lora(model, lora_cfg, *, apply_fn, lora_b_perturb_std: float = 0.0):
+    apply_fn(
+        model,
+        target_parameter_patterns=lora_cfg["target_parameters"],
+        r=lora_cfg["rank"],
+        lora_alpha=lora_cfg["alpha"],
+        freeze_base_model=True,
+    )
+    if lora_b_perturb_std > 0:
+        with torch.no_grad():
+            for n, p in model.named_parameters():
+                if ".lora_B." in n:
+                    p.add_(torch.randn_like(p) * lora_b_perturb_std)
+
+
+def _make_inputs(experts_module, batch: int = 64, top_k: int = 2):
+    H, E = experts_module.hidden_dim, experts_module.num_experts
+    p0 = next(experts_module.parameters())
+    dtype, dev = p0.dtype, p0.device
+    h = torch.randn(batch, H, dtype=dtype, device=dev)
+    top_k_index = torch.randint(0, E, (batch, top_k), device=dev)
+    top_k_weights = torch.softmax(torch.randn(batch, top_k, dtype=torch.float32, device=dev), dim=-1).to(dtype)
+    return h, top_k_index, top_k_weights
+
+
+def _build_wrapped(*, mode: str, fused: bool, lora_b_perturb_std: float = 0.02):
+    _, apply_fn, _ = _MODES[mode]
+    torch.manual_seed(0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model = build_toy(_TOY, ops=fused_npu_moe_ops() if fused else None)
+    lora_cfg = resolve_fused_moe_lora_targets(model, load_lora_config(_TOY))
+    _wrap_with_lora(model, lora_cfg, apply_fn=apply_fn, lora_b_perturb_std=lora_b_perturb_std)
+    sample_fqn, exp = find_first_matching_module(model, experts_module_globs(lora_cfg["target_parameters"]))
+    return model, sample_fqn, exp, lora_cfg
+
+
+def test_npu_fused_pointer_bound_after_fused_npu_build():
+    """Building with ``moe_implementation=fused_npu`` binds both LoRA pointers."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        build_toy(_TOY, ops=fused_npu_moe_ops())
+    from veomni.lora import ops as _lora_ops
+    from veomni.ops.kernels import moe as _moe_ops
+
+    assert _lora_ops._fused_lora_moe_forward is not None
+    assert _lora_ops._fused_independent_lora_moe_forward is not None
+    assert _moe_ops._fused_moe_forward is not None
+
+
+@pytest.mark.parametrize("mode", list(_MODES.keys()))
+def test_npu_fused_vs_eager_forward_parity(mode):
+    """Forward output of the NPU fused path matches the eager wrapper (L2-rel)."""
+    model_e, fqn_e, exp_e, _ = _build_wrapped(mode=mode, fused=False, lora_b_perturb_std=0.02)
+    h, idx, w = _make_inputs(exp_e)
+    wrapper_e = model_e.get_submodule(fqn_e)
+    with torch.no_grad():
+        out_eager = wrapper_e(h, idx, w).clone()
+
+    model_f, fqn_f, _, _ = _build_wrapped(mode=mode, fused=True, lora_b_perturb_std=0.02)
+    wrapper_f = model_f.get_submodule(fqn_f)
+    for pname in wrapper_e._lora_specs:
+        assert torch.equal(wrapper_e.get_lora_A_weight(pname), wrapper_f.get_lora_A_weight(pname))
+        assert torch.equal(wrapper_e.get_lora_B_weight(pname), wrapper_f.get_lora_B_weight(pname))
+    with torch.no_grad():
+        out_fused = wrapper_f(h, idx, w)
+
+    l2 = _l2_rel(out_fused, out_eager)
+    assert l2 <= _FWD_L2REL_TOL, (
+        f"[{mode}] NPU forward parity broken: L2 relative error {l2:.4%} > {_FWD_L2REL_TOL:.2%} "
+        f"(eager_norm={out_eager.float().norm().item():.3e})"
+    )
+
+
+@pytest.mark.parametrize("mode", list(_MODES.keys()))
+def test_npu_fused_vs_eager_backward_parity(mode):
+    """Gradients on <spec>.lora_A / <spec>.lora_B match between NPU fused and eager."""
+
+    def _grads(*, fused: bool):
+        model, fqn, exp, _ = _build_wrapped(mode=mode, fused=fused, lora_b_perturb_std=0.02)
+        wrapper = model.get_submodule(fqn)
+        wrapper.train()
+        h, idx, w = _make_inputs(exp)
+        loss = wrapper(h, idx, w).float().pow(2).sum()
+        loss.backward()
+        return {n: p.grad.detach().clone() for n, p in wrapper.named_parameters() if p.grad is not None}
+
+    grads_eager = _grads(fused=False)
+    grads_fused = _grads(fused=True)
+
+    assert set(grads_eager) == set(grads_fused), (
+        f"[{mode}] different param sets received grad: only-eager={set(grads_eager) - set(grads_fused)}, "
+        f"only-fused={set(grads_fused) - set(grads_eager)}"
+    )
+    lora_param_names = sorted(n for n in grads_eager if "lora_A" in n.split(".") or "lora_B" in n.split("."))
+    assert lora_param_names, f"[{mode}] expected LoRA A/B params to receive gradients"
+    for n in lora_param_names:
+        ge, gf = grads_eager[n], grads_fused[n]
+        assert ge.shape == gf.shape, f"[{mode}] {n}: shape mismatch eager={ge.shape} fused={gf.shape}"
+        l2 = _l2_rel(gf, ge)
+        assert l2 <= _GRAD_L2REL_TOL, (
+            f"[{mode}] {n}: NPU grad parity broken — L2 relative error {l2:.4%} > {_GRAD_L2REL_TOL:.2%} "
+            f"(eager_norm={ge.float().norm().item():.3e}, max|fused-eager|={(ge - gf).abs().max().item():.3e})"
+        )
+
+
+def _make_lora_leaf(*shape: int, dtype: torch.dtype, device: torch.device, scale: float = 0.02) -> torch.Tensor:
+    return (torch.randn(*shape, dtype=dtype, device=device) * scale).detach().requires_grad_(True)
+
+
+def _build_lora_leaves(mode: str, *, E: int, H: int, I: int, r: int, dtype: torch.dtype, device: torch.device):
+    if mode == "shared":
+        return {
+            "lora_a_gate": _make_lora_leaf(r, H, dtype=dtype, device=device),
+            "lora_b_gate": _make_lora_leaf(I, r, dtype=dtype, device=device),
+            "lora_a_up": _make_lora_leaf(r, H, dtype=dtype, device=device),
+            "lora_b_up": _make_lora_leaf(I, r, dtype=dtype, device=device),
+            "lora_a_down": _make_lora_leaf(r, I, dtype=dtype, device=device),
+            "lora_b_down": _make_lora_leaf(H, r, dtype=dtype, device=device),
+        }
+    return {
+        "lora_a_gate": _make_lora_leaf(E, r, H, dtype=dtype, device=device),
+        "lora_b_gate": _make_lora_leaf(E, I, r, dtype=dtype, device=device),
+        "lora_a_up": _make_lora_leaf(E, r, H, dtype=dtype, device=device),
+        "lora_b_up": _make_lora_leaf(E, I, r, dtype=dtype, device=device),
+        "lora_a_down": _make_lora_leaf(E, r, I, dtype=dtype, device=device),
+        "lora_b_down": _make_lora_leaf(E, H, r, dtype=dtype, device=device),
+    }
+
+
+@pytest.fixture
+def _single_rank_dist():
+    """EP=1 identity path still calls ``all_to_all``; need a world_size=1 process group."""
+    created = False
+    if not dist.is_initialized():
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29611")
+        # gloo is fine for world_size=1 identity; avoids requiring HCCL for this unit check.
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+        created = True
+    try:
+        yield
+    finally:
+        if created and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("mode", ["shared", "independent"])
+def test_npu_ep_vs_nonep_single_rank_parity(mode, _single_rank_dist):
+    """EP path with ``ep_group=None`` (EP=1) matches the non-EP NPU kernel on outputs + LoRA grads."""
+    from veomni.lora.ops.npu_moe_group_gemm import (
+        _npu_ep_fused_lora_moe_forward,
+        _npu_fused_lora_moe_forward,
+    )
+
+    dev = torch.device(get_device_type())
+    dtype = torch.bfloat16
+    B, H, I, E, top_k, r = 32, 64, 96, 4, 2, 8
+    scale_gate = scale_up = scale_down = 0.5
+    _LORA_KEYS = ("lora_a_gate", "lora_b_gate", "lora_a_up", "lora_b_up", "lora_a_down", "lora_b_down")
+
+    torch.manual_seed(0)
+    hidden_states = torch.randn(B, H, dtype=dtype, device=dev)
+    selected_experts = torch.randint(0, E, (B, top_k), device=dev)
+    routing_weights = torch.softmax(torch.randn(B, top_k, dtype=torch.float32, device=dev), dim=-1).to(dtype)
+    gate_up_proj = (torch.randn(E, 2 * I, H, dtype=dtype, device=dev) * 0.05).detach()
+    down_proj = (torch.randn(E, H, I, dtype=dtype, device=dev) * 0.05).detach()
+
+    def _run(*, ep: bool):
+        torch.manual_seed(123)
+        lora = _build_lora_leaves(mode, E=E, H=H, I=I, r=r, dtype=dtype, device=dev)
+        kwargs = dict(
+            num_experts=E,
+            routing_weights=routing_weights,
+            selected_experts=selected_experts,
+            hidden_states=hidden_states,
+            fc1_1_2_weight=gate_up_proj,
+            fc2_weight=down_proj,
+            lora_a_gate=lora["lora_a_gate"],
+            lora_b_gate=lora["lora_b_gate"],
+            lora_a_up=lora["lora_a_up"],
+            lora_b_up=lora["lora_b_up"],
+            lora_a_down=lora["lora_a_down"],
+            lora_b_down=lora["lora_b_down"],
+            lora_scale_gate=scale_gate,
+            lora_scale_up=scale_up,
+            lora_scale_down=scale_down,
+            independent=(mode == "independent"),
+        )
+        if ep:
+            out = _npu_ep_fused_lora_moe_forward(ep_group=None, **kwargs)
+        else:
+            out = _npu_fused_lora_moe_forward(**kwargs)
+        return out, lora
+
+    nonep_out, nonep_lora = _run(ep=False)
+    ep_out, ep_lora = _run(ep=True)
+
+    fwd_l2 = _l2_rel(ep_out.detach(), nonep_out.detach())
+    assert fwd_l2 <= _FWD_L2REL_TOL, (
+        f"[{mode}] NPU EP-vs-non-EP forward parity broken: L2 rel {fwd_l2:.4%} > {_FWD_L2REL_TOL:.2%} "
+        f"(ref_norm={nonep_out.float().norm().item():.3e})"
+    )
+
+    torch.manual_seed(456)
+    grad_out = (torch.randn(B, H, dtype=dtype, device=dev) * 0.1).detach()
+    nonep_grads = dict(
+        zip(
+            _LORA_KEYS,
+            torch.autograd.grad(nonep_out, [nonep_lora[k] for k in _LORA_KEYS], grad_outputs=grad_out),
+        )
+    )
+    ep_grads = dict(
+        zip(
+            _LORA_KEYS,
+            torch.autograd.grad(ep_out, [ep_lora[k] for k in _LORA_KEYS], grad_outputs=grad_out),
+        )
+    )
+    for name in _LORA_KEYS:
+        g_nonep, g_ep = nonep_grads[name], ep_grads[name]
+        assert g_nonep.shape == g_ep.shape, f"[{mode}] {name}: shape mismatch"
+        l2 = _l2_rel(g_ep, g_nonep)
+        assert l2 <= _GRAD_L2REL_TOL, (
+            f"[{mode}] {name}: NPU EP-vs-non-EP backward parity broken — L2 rel {l2:.4%} > {_GRAD_L2REL_TOL:.2%} "
+            f"(nonep_norm={g_nonep.float().norm().item():.3e}, max|Δ|={(g_nonep - g_ep).abs().max().item():.3e})"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/lora/test_moe_lora_trainer.py
+++ b/tests/lora/test_moe_lora_trainer.py
@@ -23,7 +23,7 @@ emit, then validates both resume paths bit-exact (modulo bf16 storage):
          (model + optimizer + extra_state -- the format ``BaseTrainer``
          resumes via ``train.checkpoint.load_path``).
        - HF-format LoRA adapter under ``<output_dir>/global_step_<S>/``
-         (``adapter_model.bin`` + ``adapter_config.json``; the MoE mode +
+         (``adapter_model.safetensors`` + ``adapter_config.json``; the MoE mode +
          rank/alpha VeOmni's wrappers need to re-install themselves on resume
          live in the ``veomni_lora`` block of ``adapter_config.json``) -- the
          format ``BaseTrainer`` resumes via ``model.lora_config.lora_adapter``.
@@ -288,7 +288,7 @@ class MoeLoraTrainer(BaseTrainer):
         # ``train.checkpoint.load_path`` resume case in the resume test
         # depends on its ``on_train_begin`` reload hook.
         self.checkpointer_callback = CheckpointerCallback(self)
-        # HFLoraCkptCallback emits the HF-format LoRA adapter (adapter_model.bin
+        # HFLoraCkptCallback emits the HF-format LoRA adapter (adapter_model.safetensors
         # + adapter_config.json with the veomni_lora MoE block) at every
         # save_step. It also
         # extends DCP saves but no-ops if the DCP dir already exists, so
@@ -484,7 +484,7 @@ def _compare_snapshots_bit_exact(actual_path: str, ref_path: str, *, label: str)
     Both sides are cast to bf16 before ``torch.equal`` because that's the
     coarsest precision either resume path round-trips through:
 
-    * The HF LoRA-adapter path writes ``adapter_model.bin`` at the
+    * The HF LoRA-adapter path writes ``adapter_model.safetensors`` at the
       model's storage dtype (bf16 for the toy yaml -- PEFT's
       ``save_pretrained`` casts to ``model.dtype``), so the on-disk
       bytes are bf16.
@@ -609,7 +609,9 @@ def _assert_writer_artifacts_exist(writer_dir: str, mode: str, *, final_step: in
     assert os.path.isdir(hf_dir), f"[{mode}] missing HF LoRA adapter dir at {hf_dir}"
     # VeOmniLoraModel embeds MoE metadata inside adapter_config.json (under the
     # ``veomni_lora`` block) instead of the legacy ``veomni_moe_lora.json`` sidecar.
-    for fname in ("adapter_model.bin", "adapter_config.json"):
+    # The consolidated adapter is written as safetensors (sliceable per-rank by
+    # the ep_sharded streaming loader), not the legacy ``adapter_model.bin``.
+    for fname in ("adapter_model.safetensors", "adapter_config.json"):
         path = os.path.join(hf_dir, fname)
         assert os.path.isfile(path), f"[{mode}] missing {fname} in {hf_dir}: {os.listdir(hf_dir)}"
     with open(os.path.join(hf_dir, "adapter_config.json")) as f:

--- a/tests/lora/test_moe_lora_trainer.py
+++ b/tests/lora/test_moe_lora_trainer.py
@@ -237,7 +237,8 @@ class _LogDictSaveCallback(Callback):
         # callback runs on every rank inside ``train_step``'s
         # ``on_step_end`` so that invariant holds.
         device = self.trainer.device if hasattr(self.trainer, "device") else torch.device("cpu")
-        t = torch.tensor([float(value)], dtype=torch.float64, device=device)
+        # float32: HCCL allreduce does not support float64 (at::kDouble).
+        t = torch.tensor([float(value)], dtype=torch.float32, device=device)
         dist.all_reduce(t, op=dist.ReduceOp.AVG, group=dp_group)
         return float(t.item())
 

--- a/tests/lora/test_veomni_lora_moe_native.py
+++ b/tests/lora/test_veomni_lora_moe_native.py
@@ -211,12 +211,12 @@ def test_moe_mode_inferred_when_config_lacks_block(tmp_path, mode):
 def test_init_lora_parameter_preserves_loaded_weights(mode):
     """GAP-1 / BUG-3 guard: post-load init must NOT reset a populated wrapper.
 
-    ``post_process_after_weight_loading`` walks every LoRA param name through
+    ``post_process_after_weight_loading`` walks missing LoRA names through
     ``init_lora_parameter``. For a MoE wrapper the reset only fires when *all*
-    of its params are still on meta device (``_reset_moe_wrapper``); once
-    ``load_lora_weights`` has materialised them (non-meta, as on this CPU
-    model) the reset must be skipped so it cannot re-randomise ``lora_A`` /
-    re-zero ``lora_B``. Assert both the values survive and that the wrapper's
+    of its LoRA tensors are in ``parameter_names_left``; once
+    ``load_lora_weights`` has materialised them they are removed from that set,
+    so the reset must be skipped and cannot re-randomise ``lora_A`` / re-zero
+    ``lora_B``. Assert both the values survive and that the wrapper's
     ``reset_lora_parameters`` is never called.
     """
     model = VeOmniLoraModel(ToyMoE(), _moe_config(mode))
@@ -232,15 +232,53 @@ def test_init_lora_parameter_preserves_loaded_weights(mode):
     before = {n: p.detach().clone() for n, p in model.named_parameters() if ".lora_" in n}
     assert before, "expected LoRA params on the wrapped MoE model"
 
+    # Fully loaded adapter -> empty missing set (matches post_process after a
+    # successful load_lora_weights).
     with mock.patch.object(experts, "reset_lora_parameters", wraps=experts.reset_lora_parameters) as reset_spy:
         for name in before:
-            init_lora_parameter(model, name)
+            init_lora_parameter(model, name, parameter_names_left=set())
         reset_spy.assert_not_called()
 
     after = {n: p for n, p in model.named_parameters() if ".lora_" in n}
     assert set(after) == set(before)
     for n, prev in before.items():
         torch.testing.assert_close(after[n], prev, msg=lambda s, n=n: f"{n} was clobbered by init_lora_parameter\n{s}")
+
+
+@pytest.mark.parametrize("mode", ["independent", "shared"])
+def test_init_lora_parameter_resets_when_all_missing(mode):
+    """Fresh wrapper (every LoRA name still missing) must kaiming-A / zero-B once."""
+    model = VeOmniLoraModel(ToyMoE(), _moe_config(mode))
+    experts = _experts(model)
+    lora_names = {n for n, _ in model.named_parameters() if ".lora_A." in n or ".lora_B." in n}
+    assert lora_names
+
+    with torch.no_grad():
+        for name, p in model.named_parameters():
+            if name in lora_names:
+                p.fill_(float("nan"))
+
+    with mock.patch.object(experts, "reset_lora_parameters", wraps=experts.reset_lora_parameters) as reset_spy:
+        for name in sorted(lora_names):
+            init_lora_parameter(model, name, parameter_names_left=set(lora_names))
+        assert reset_spy.call_count == 1
+
+    for name, p in model.named_parameters():
+        if ".lora_B." in name:
+            assert torch.count_nonzero(p).item() == 0, name
+        if ".lora_A." in name:
+            assert torch.isfinite(p).all() and not torch.isnan(p).any(), name
+
+
+@pytest.mark.parametrize("mode", ["independent", "shared"])
+def test_init_lora_parameter_raises_on_partial_missing(mode):
+    """Partial adapter resume must fail closed instead of clobbering loaded A/B."""
+    model = VeOmniLoraModel(ToyMoE(), _moe_config(mode))
+    lora_names = sorted(n for n, _ in model.named_parameters() if ".lora_A." in n or ".lora_B." in n)
+    assert len(lora_names) >= 2
+    missing = {lora_names[0]}
+    with pytest.raises(RuntimeError, match="only partially loaded"):
+        init_lora_parameter(model, lora_names[0], parameter_names_left=missing)
 
 
 if __name__ == "__main__":

--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -146,6 +146,24 @@ def fused_triton_moe_ops() -> OpsImplementationConfig:
     )
 
 
+def fused_npu_moe_ops() -> OpsImplementationConfig:
+    """Eager everywhere *except* MoE, which uses the Ascend NPU group-gemm backend.
+
+    Selecting ``moe_implementation="fused_npu"`` triggers
+    ``apply_veomni_fused_moe_patch("npu")``, which binds both the base fused MoE
+    pointer and the LoRA-aware NPU kernels in ``veomni.lora.ops``.
+    """
+    return OpsImplementationConfig(
+        attn_implementation="eager",
+        moe_implementation="fused_npu",
+        cross_entropy_loss_implementation="eager",
+        rms_norm_implementation="eager",
+        swiglu_mlp_implementation="eager",
+        rotary_pos_emb_implementation="eager",
+        load_balancing_loss_implementation="eager",
+    )
+
+
 def build_toy(toy_dir: str, *, ops: OpsImplementationConfig | None = None):
     """Build a bf16 toy model from ``tests/toy_config/<toy_dir>/`` on the active device.
 

--- a/tests/utils/test_moe_ep_sharded_load_matrix.py
+++ b/tests/utils/test_moe_ep_sharded_load_matrix.py
@@ -1,0 +1,320 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Non-PEFT MoE weight-loading matrix on a self-contained fake EP model.
+
+Verifies that a MoE model (EP ``Shard(0)`` experts) loads **bit-identically**
+through all three weight loaders
+
+    * ``load_model_weights``            (every-rank-reads)
+    * ``rank0_load_and_broadcast_weights``
+    * ``load_model_weights_ep_sharded`` (per-rank ExtraParallel-slice stream)
+
+for both checkpoint expert layouts
+
+    * **merged**     -- experts already fused ``[E, out, in]`` (one key, no converter fires)
+    * **non-merged** -- one ``[out, in]`` tensor per expert key, needs a
+      fusion ``CheckpointTensorConverter`` (models the HF per-expert ->
+      fused-veomni case, e.g. Qwen3-MoE).
+
+Assertions:
+    * merged   x {plain, rank0, ep_sharded} -> gathered experts == reference.
+    * nonmerge x {plain, rank0}             -> converter fuses -> == reference.
+    * nonmerge x ep_sharded                 -> raises ``NotImplementedError``
+      up front (a fusion converter can't be streamed per-rank; the loader
+      must bail so the caller falls back to the whole-tensor loader). This
+      is the silent-corruption guard for Qwen3-MoE.
+
+Run directly (2 GPUs):
+    torchrun --nproc_per_node=2 --master_port=4331 \
+        tests/utils/test_moe_ep_sharded_load_matrix.py
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+from safetensors.torch import save_file
+from torch.distributed.tensor import DTensor, Shard
+
+from veomni.distributed.parallel_plan import ParallelPlan
+from veomni.distributed.parallel_state import get_parallel_state, init_parallel_state
+from veomni.distributed.torch_parallelize import build_parallelize_model
+from veomni.models.checkpoint_tensor_loading import ConvertedCheckpointTensor
+from veomni.utils import helper
+from veomni.utils.device import get_dist_comm_backend, get_torch_device
+
+
+logger = helper.create_logger(__name__)
+
+# ── model dims (tiny; E divisible by ep=2) ────────────────────────────
+E, OUT, IN = 8, 6, 4
+DENSE_OUT, DENSE_IN = 3, 4
+VOCAB, EMB = 10, 4
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Per-expert -> fused converter (models Qwen3MoeCheckpointTensorConverter)
+# ──────────────────────────────────────────────────────────────────────
+class _PerExpertFuseConverter:
+    """Accumulate per-expert ``moe.experts.<e>`` rows, emit fused ``moe.experts``.
+
+    ``is_dim0_zero_pad`` is intentionally NOT a pure dim-0 zero-pad (it stacks
+    E separate tensors into one), so the streaming loader must bail on it.
+    """
+
+    _PREFIX = "moe.experts."
+
+    def __init__(self) -> None:
+        self._buf: dict[int, torch.Tensor] = {}
+
+    def can_handle(self, name: str) -> bool:
+        if not name.startswith(self._PREFIX):
+            return False
+        return name[len(self._PREFIX) :].isdigit()
+
+    def convert(self, name: str, tensor: torch.Tensor) -> ConvertedCheckpointTensor | None:
+        idx = int(name[len(self._PREFIX) :])
+        self._buf[idx] = tensor.clone()
+        if len(self._buf) < E:
+            return None
+        return self._flush()
+
+    def finalize(self) -> list[ConvertedCheckpointTensor]:
+        return [self._flush()] if self._buf else []
+
+    def _flush(self) -> ConvertedCheckpointTensor:
+        fused = torch.stack([self._buf[i] for i in sorted(self._buf)], dim=0)
+        self._buf.clear()
+        return ConvertedCheckpointTensor(name="moe.experts", tensor=fused)
+
+    def is_dim0_zero_pad(self, name: str) -> bool:
+        return False  # fusion, not a pure zero-pad -> not streamable
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fake MoE model with an EP Shard(0) experts param
+# ──────────────────────────────────────────────────────────────────────
+class _FakeExperts(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.experts = nn.Parameter(torch.empty(E, OUT, IN))
+
+
+class FakeMoeModel(nn.Module):
+    _no_split_modules = ["_FakeExperts"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed = nn.Parameter(torch.empty(VOCAB, EMB))
+        self.linear = nn.Linear(DENSE_IN, DENSE_OUT, bias=True)
+        self.moe = _FakeExperts()
+        # tie_word_embeddings False -> skip the post-load embedding tie path.
+        self.config = SimpleNamespace(tie_word_embeddings=False)
+
+    # every-rank fresh init (build_parallelize_model calls this when no weights)
+    def init_weights(self) -> None:
+        with torch.no_grad():
+            self.embed.normal_()
+            nn.init.xavier_uniform_(self.linear.weight)
+            self.linear.bias.fill_(0.0)
+            nn.init.xavier_uniform_(self.moe.experts)
+
+    def get_parallel_plan(self) -> ParallelPlan:
+        plan = ParallelPlan(extra_parallel_plan={"ep": {"moe.experts": Shard(0)}})
+        plan.extra_parallel_fsdp_no_shard_module = {"ep": {"moe"}}
+        return plan
+
+    # A fusion converter is always registered; it only *fires* on the
+    # per-expert checkpoint (fused keys don't match ``can_handle``).
+    @staticmethod
+    def _create_checkpoint_tensor_converter(model):
+        return _PerExpertFuseConverter()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Reference weights + checkpoint writers
+# ──────────────────────────────────────────────────────────────────────
+def _reference_state() -> dict[str, torch.Tensor]:
+    g = torch.Generator().manual_seed(1234)
+    return {
+        "embed": torch.randn(VOCAB, EMB, generator=g),
+        "linear.weight": torch.randn(DENSE_OUT, DENSE_IN, generator=g),
+        "linear.bias": torch.randn(DENSE_OUT, generator=g),
+        "moe.experts": torch.randn(E, OUT, IN, generator=g),
+    }
+
+
+def _write_merged(ckpt_dir: Path, ref: dict[str, torch.Tensor]) -> str:
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    save_file({k: v.clone() for k, v in ref.items()}, str(ckpt_dir / "model.safetensors"))
+    return str(ckpt_dir)
+
+
+def _write_per_expert(ckpt_dir: Path, ref: dict[str, torch.Tensor]) -> str:
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    state = {k: v.clone() for k, v in ref.items() if k != "moe.experts"}
+    for e in range(E):
+        state[f"moe.experts.{e}"] = ref["moe.experts"][e].clone()
+    save_file(state, str(ckpt_dir / "model.safetensors"))
+    return str(ckpt_dir)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Gather helper (DTensor -> full replicated CPU tensor)
+# ──────────────────────────────────────────────────────────────────────
+def _full_cpu(t: torch.Tensor) -> torch.Tensor:
+    """Gather an FSDP DTensor (dense param) to its full replicated tensor."""
+    if isinstance(t, DTensor):
+        t = t.full_tensor()  # gather every mesh dim -> full replicated tensor
+    return t.detach().float().cpu()
+
+
+def _local_expert_shard(t: torch.Tensor) -> torch.Tensor:
+    """This rank's local ``[E/ep, ...]`` expert slice (EP params are plain local
+    tensors when ``ep_fsdp==1``, else DTensors sharded on the ep mesh)."""
+    if isinstance(t, DTensor):
+        t = t.to_local()
+    return t.detach().float().cpu()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Worker
+# ──────────────────────────────────────────────────────────────────────
+def _build_fresh(weights_path, *, loader: str):
+    """Build + parallelize a fresh FakeMoeModel, loading via the chosen loader."""
+    kwargs = dict(
+        weights_path=weights_path,
+        init_device="meta",
+        mixed_precision=SimpleNamespace(enable=False),
+        enable_gradient_checkpointing=False,
+        enable_fsdp_offload=False,
+        basic_modules=[],
+    )
+    if loader == "rank0":
+        kwargs["broadcast_model_weights_from_rank0"] = True
+    elif loader == "ep_sharded":
+        kwargs["ep_sharded_stream_load"] = True
+    # loader == "plain": defaults (every-rank-reads)
+    return build_parallelize_model(FakeMoeModel(), **kwargs)
+
+
+def run_worker() -> None:
+    rank = int(os.environ["RANK"])
+    world = int(os.environ["WORLD_SIZE"])
+    get_torch_device().set_device(rank)
+    import torch.distributed as dist
+
+    dist.init_process_group(backend=get_dist_comm_backend())
+    # world == ep: experts sharded across all ranks, dense FSDP-sharded.
+    init_parallel_state(dp_size=world, extra_parallel_sizes=(world,), extra_parallel_names=("ep",), dp_mode="fsdp2")
+
+    tmp = Path(os.environ["MOE_MATRIX_TMP"])
+    ref = _reference_state()
+    merged_dir = str(tmp / "merged")
+    per_expert_dir = str(tmp / "per_expert")
+    if rank == 0:
+        _write_merged(tmp / "merged", ref)
+        _write_per_expert(tmp / "per_expert", ref)
+    dist.barrier()
+
+    ps = get_parallel_state()
+    ep_rank = ps.extra_parallel_rank("ep")
+    ep_size = ps.extra_parallel_sizes["ep"]
+    per = E // ep_size
+
+    results = []
+
+    def check(model, tag):
+        params = dict(model.named_parameters())
+        # EP-sharded experts: compare this rank's local [E/ep, ...] slice.
+        got_experts = _local_expert_shard(params["moe.experts"])
+        want_experts = ref["moe.experts"][ep_rank * per : (ep_rank + 1) * per]
+        torch.testing.assert_close(got_experts, want_experts, atol=0.0, rtol=0.0)
+        # Dense/FSDP params: gather full and compare.
+        for name in ("linear.weight", "linear.bias", "embed"):
+            got = _full_cpu(params[name])
+            torch.testing.assert_close(got, ref[name], atol=0.0, rtol=0.0)
+        results.append(f"  [OK] {tag}: experts slice + dense params bit-identical to reference")
+
+    for fmt, path in [("merged", merged_dir), ("nonmerged", per_expert_dir)]:
+        for loader in ["plain", "rank0", "ep_sharded"]:
+            tag = f"{fmt} x {loader}"
+            expect_bail = fmt == "nonmerged" and loader == "ep_sharded"
+            try:
+                model = _build_fresh(path, loader=loader)
+            except NotImplementedError as e:
+                if expect_bail:
+                    results.append(f"  [OK] {tag}: bailed as expected ({str(e)[:60]}...)")
+                else:
+                    results.append(f"  [FAIL] {tag}: unexpected NotImplementedError: {e}")
+                dist.barrier()
+                continue
+            if expect_bail:
+                results.append(f"  [FAIL] {tag}: expected NotImplementedError bail, but load succeeded")
+                dist.barrier()
+                continue
+            check(model, tag)
+            del model
+            dist.barrier()
+
+    if rank == 0:
+        print(f"\n=== NON-PEFT MoE load matrix (world={world}, ep={world}) ===")
+        print("\n".join(results))
+    failed = [r for r in results if "[FAIL]" in r]
+    dist.barrier()
+    dist.destroy_process_group()
+    if failed:
+        raise SystemExit(f"{len(failed)} case(s) FAILED:\n" + "\n".join(failed))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# pytest wrapper
+# ──────────────────────────────────────────────────────────────────────
+# Device-agnostic gate: the worker itself only uses ``get_torch_device`` /
+# ``get_dist_comm_backend`` (no CUDA-only ops, no Triton), so it runs on any
+# >=2-device accelerator (CUDA / Ascend NPU) via the matching comm backend.
+_ACCEL = get_torch_device()
+
+
+@pytest.mark.skipif(
+    not _ACCEL.is_available() or _ACCEL.device_count() < 2,
+    reason="requires >= 2 accelerator devices (CUDA or NPU)",
+)
+def test_moe_ep_sharded_load_matrix(tmp_path):
+    port = 12345 + random.randint(0, 500)
+    env = dict(os.environ, MOE_MATRIX_TMP=str(tmp_path))
+    cmd = [
+        "torchrun",
+        "--nproc_per_node=2",
+        f"--master_port={port}",
+        os.path.abspath(__file__),
+    ]
+    subprocess.run(cmd, check=True, env=env)
+
+
+if __name__ == "__main__":
+    # Deterministic *shared* fixture dir so every rank resolves the same
+    # checkpoint path (rank0 writes it; a per-rank mkdtemp would leave the
+    # other ranks with an empty dir -> HF repo-id fallback).
+    os.environ.setdefault("MOE_MATRIX_TMP", "/tmp/moe_ep_matrix_fixture")
+    run_worker()
+    print("ALL CASES PASSED", file=sys.stderr)

--- a/veomni/distributed/parallel_plan.py
+++ b/veomni/distributed/parallel_plan.py
@@ -261,7 +261,10 @@ def get_runtime_parallel_plan(model: nn.Module) -> "ParallelPlan":
     ``rank0_load_and_broadcast_weights`` / ``load_model_weights``)
     pick up the same prefixed + extended plan via this helper.
     """
-    parallel_plan = model.get_parallel_plan()
+    get_plan = getattr(model, "get_parallel_plan", None)
+    if get_plan is None:
+        return None
+    parallel_plan = get_plan()
     if parallel_plan is None:
         return parallel_plan
 

--- a/veomni/lora/moe_layers.py
+++ b/veomni/lora/moe_layers.py
@@ -651,11 +651,12 @@ class LoraSharedExperts(nn.Module):
         self._ensure_ep_grad_sync_hooks()
         # Fused-kernel path: available when the user opted into a non-eager
         # ``moe_implementation`` whose patch function bound a LoRA-aware
-        # kernel (currently 'fused_triton'; Quack/NPU leave
+        # kernel ('fused_triton' on GPU, 'fused_npu' on NPU; Quack leaves
         # ``_fused_lora_moe_forward = None`` so we transparently fall back to
-        # eager). The bound kernel handles the EP branch internally via
+        # eager). The bound kernel handles the EP branch internally (Triton via
         # ``preprocess`` / ``token_pre_all2all`` / ``EPMergedFc1SharedLoRAGroupGemm``
-        # / ``tokens_post_all2all`` — no EP gating needed here.
+        # / ``tokens_post_all2all``; NPU via its all-to-all dispatch/combine) —
+        # no EP gating needed here.
         from ..distributed.parallel_state import get_parallel_state
         from . import ops as _lora_ops
 
@@ -670,8 +671,8 @@ class LoraSharedExperts(nn.Module):
         if get_parallel_state().ep_enabled:
             raise RuntimeError(
                 "LoraSharedExperts: eager forward does not support expert parallelism (EP). "
-                "Set ops_implementation.moe_implementation='fused_triton' to use the EP-aware "
-                "fused LoRA path, or disable EP."
+                "Set ops_implementation.moe_implementation='fused_triton' (GPU) or 'fused_npu' (NPU) "
+                "to use the EP-aware fused LoRA path, or disable EP."
             )
         return self._eager_forward(hidden_states, top_k_index, top_k_weights)
 
@@ -1012,10 +1013,11 @@ class LoraIndependentExperts(nn.Module):
     ) -> torch.Tensor:
         # Mirrors LoraSharedExperts.forward: prefer the fused branch whenever
         # the active ``moe_implementation`` bound a Mode 1 LoRA-aware kernel
-        # (currently only 'fused_triton'; Quack/NPU leave the pointer as
-        # ``None`` so we transparently fall back). The bound kernel handles
-        # the EP branch internally via ``preprocess`` / ``token_pre_all2all``
-        # / ``EPMergedFc1IndependentLoRAGroupGemm`` / ``tokens_post_all2all``.
+        # ('fused_triton' on GPU, 'fused_npu' on NPU; Quack leaves the pointer
+        # as ``None`` so we transparently fall back). The bound kernel handles
+        # the EP branch internally (Triton via ``preprocess`` /
+        # ``token_pre_all2all`` / ``EPMergedFc1IndependentLoRAGroupGemm`` /
+        # ``tokens_post_all2all``; NPU via its all-to-all dispatch/combine).
         from ..distributed.parallel_state import get_parallel_state
         from . import ops as _lora_ops
 
@@ -1026,8 +1028,8 @@ class LoraIndependentExperts(nn.Module):
         if get_parallel_state().ep_enabled:
             raise RuntimeError(
                 "LoraIndependentExperts: eager forward does not support expert parallelism (EP). "
-                "Set ops_implementation.moe_implementation='fused_triton' to use the EP-aware "
-                "fused LoRA path, or disable EP."
+                "Set ops_implementation.moe_implementation='fused_triton' (GPU) or 'fused_npu' (NPU) "
+                "to use the EP-aware fused LoRA path, or disable EP."
             )
         return self._eager_forward(hidden_states, top_k_index, top_k_weights)
 

--- a/veomni/lora/ops/__init__.py
+++ b/veomni/lora/ops/__init__.py
@@ -14,11 +14,18 @@
 
 """Fused MoE-LoRA kernels and their dispatch, owned by the native LoRA stack.
 
-The kernel implementation (four ``autograd.Function`` classes + their
-``group_gemm_fused_*`` entry points) lives in :mod:`.moe_group_gemm`. It reuses
-the shared grouped-gemm / scatter / gather Triton primitives under
-``veomni.ops.kernels.moe._kernels`` (the same primitives the non-LoRA fused MoE
-kernel uses), so only the LoRA math is owned here — not the low-level GEMM.
+There is one kernel implementation per hardware backend, both owned here so only
+the LoRA math lives in this package — never the low-level GEMM/dispatch:
+
+  * ``triton`` (GPU) — :mod:`.moe_group_gemm`: four ``autograd.Function``
+    classes (hand-written forward + backward) reusing the shared grouped-gemm /
+    scatter / gather Triton primitives under ``veomni.ops.kernels.moe._kernels``
+    (the same primitives the non-LoRA fused MoE kernel uses).
+  * ``npu`` — :mod:`.npu_moe_group_gemm`: composes the base NPU MoE primitives
+    (``dispatch_preprocess`` / ``alltoall_dispatch`` / ``alltoall_combine`` +
+    the ``npu_group_gemm`` autograd ``Function``) from
+    ``veomni.ops.kernels.moe.npu_group_gemm`` and injects the LoRA deltas;
+    backward is derived by autograd (no hand-written kernel).
 
 Dispatch model
 --------------
@@ -27,8 +34,10 @@ Whether a LoRA-aware fused kernel is available is a property of the active
 :func:`veomni.ops.kernels.moe.apply_veomni_fused_moe_patch`: after it selects a
 base backend it calls :func:`bind_lora_moe_kernels` here to point (or clear) the
 module-level ``_fused_lora_moe_forward`` / ``_fused_independent_lora_moe_forward``
-pointers. Only ``triton`` ships LoRA kernels today; ``quack`` / ``npu`` clear the
-pointers and the wrappers in :mod:`veomni.lora.moe_layers` fall back to eager.
+pointers. ``triton`` (GPU) and ``npu`` both ship LoRA kernels — including the
+EP-aware path — so LoRA + expert parallelism works on either backend; ``quack``
+clears the pointers and the wrappers in :mod:`veomni.lora.moe_layers` fall back
+to eager (which raises under EP).
 
 The MoE-LoRA wrappers read the pointers directly (``from . import ops`` inside
 their ``forward``); the public :func:`fused_lora_moe_forward` /
@@ -44,7 +53,7 @@ import torch
 # Function pointers for the LoRA-aware fused MoE paths. ``None`` means "no
 # fused-LoRA kernel bound for the active ``moe_implementation``" — in that case
 # the wrappers in ``veomni.lora.moe_layers`` keep using their eager forwards.
-# Both are bound only for ``triton``; ``quack`` / ``npu`` leave them ``None``.
+# Bound for ``triton`` (GPU) and ``npu``; ``quack`` leaves them ``None``.
 #
 # * ``_fused_lora_moe_forward`` — Mode 2 (shared LoRA across experts), used by
 #   ``LoraSharedExperts``.
@@ -74,8 +83,20 @@ def bind_lora_moe_kernels(fused_moe_kernel: str) -> None:
 
         _fused_lora_moe_forward = group_gemm_fused_lora_moe_forward
         _fused_independent_lora_moe_forward = group_gemm_fused_independent_lora_moe_forward
+    elif fused_moe_kernel == "npu":
+        # NPU reuses its base fused-MoE all-to-all EP dispatch/combine and adds
+        # the seed-style LoRA deltas on the dispatched tokens — MoE-LoRA and EP
+        # are orthogonal, so no LoRA-specific communication is introduced. The
+        # kernel lives alongside the Triton one under ``veomni.lora.ops``.
+        from .npu_moe_group_gemm import (
+            npu_fused_independent_lora_moe_forward,
+            npu_fused_lora_moe_forward,
+        )
+
+        _fused_lora_moe_forward = npu_fused_lora_moe_forward
+        _fused_independent_lora_moe_forward = npu_fused_independent_lora_moe_forward
     else:
-        # Quack / NPU have no LoRA-aware fused kernel yet → eager fallback.
+        # Quack has no LoRA-aware fused kernel yet → eager fallback.
         _fused_lora_moe_forward = None
         _fused_independent_lora_moe_forward = None
 
@@ -113,8 +134,8 @@ def fused_lora_moe_forward(
     if _fused_lora_moe_forward is None:
         raise NotImplementedError(
             "No fused MoE-LoRA kernel is bound. Set ops_implementation.moe_implementation "
-            "to a backend that ships a LoRA variant (currently 'fused_triton') or fall back "
-            "to the eager LoRA forward."
+            "to a backend that ships a LoRA variant ('fused_triton' on GPU, 'fused_npu' on NPU) "
+            "or fall back to the eager LoRA forward."
         )
 
     assert routing_weights.dtype in [torch.bfloat16, torch.float16], (
@@ -176,8 +197,8 @@ def fused_independent_lora_moe_forward(
     if _fused_independent_lora_moe_forward is None:
         raise NotImplementedError(
             "No fused independent MoE-LoRA kernel is bound. Set ops_implementation.moe_implementation "
-            "to a backend that ships a LoRA variant (currently 'fused_triton') or fall back "
-            "to the eager LoRA forward."
+            "to a backend that ships a LoRA variant ('fused_triton' on GPU, 'fused_npu' on NPU) "
+            "or fall back to the eager LoRA forward."
         )
 
     assert routing_weights.dtype in [torch.bfloat16, torch.float16], (

--- a/veomni/lora/ops/npu_moe_group_gemm.py
+++ b/veomni/lora/ops/npu_moe_group_gemm.py
@@ -1,0 +1,348 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NPU fused MoE-LoRA kernels (owned by the LoRA stack).
+
+The NPU counterpart of :mod:`veomni.lora.ops.moe_group_gemm` (the Triton
+implementation). It lives here — next to the Triton LoRA kernel — so both
+backends' LoRA-aware fused MoE forwards sit under ``veomni.lora.ops`` and are
+bound uniformly by :func:`veomni.lora.ops.bind_lora_moe_kernels`.
+
+Unlike the Triton kernel (which re-implements the whole EP dispatch/combine +
+grouped-gemm with hand-written ``autograd.Function`` backwards), the NPU path
+*composes* the base NPU MoE primitives that already live in
+``veomni.ops.kernels.moe.npu_group_gemm``:
+
+  * ``dispatch_preprocess`` / ``alltoall_dispatch`` / ``alltoall_combine`` —
+    the exact all-to-all EP dispatch/combine the base fused MoE uses, and
+  * ``npu_group_gemm`` — the grouped-matmul ``autograd.Function`` (its own
+    backward),
+
+then injects three seed-style LoRA deltas (gate, up, down). Backward is derived
+by autograd (no hand-written kernel), because every op in the composition is
+differentiable. MoE-LoRA and expert parallelism are orthogonal: the EP handling
+is identical to the base kernel, the only extra work is the LoRA delta on the
+*dispatched* tokens using the *local* (already EP-sharded) LoRA weights.
+
+Two LoRA layouts (mirroring ``veomni.lora.moe_layers``):
+  * shared (Mode 2, ``LoraSharedExperts``)     — one 2-D LoRA pair reused by
+    every expert ⇒ the delta is a plain matmul over *all* dispatched tokens
+    (expert-independent), so no per-expert grouping is needed.
+  * independent (Mode 1, ``LoraIndependentExperts``) — a 3-D per-expert LoRA
+    pair ⇒ the delta is a grouped-gemm over the same per-expert token groups
+    the base experts use, driven by the same ``group_list`` (token counts).
+
+The eager reference these must match line-for-line lives in
+``veomni.lora.moe_layers.{LoraSharedExperts,LoraIndependentExperts}._eager_forward``.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+import torch_npu
+
+from ...distributed.parallel_state import get_parallel_state
+from ...ops.kernels.moe.npu_group_gemm import (
+    alltoall_combine,
+    alltoall_dispatch,
+    dispatch_preprocess,
+    npu_group_gemm,
+)
+
+
+def _lora_gate_up_delta(
+    x: torch.Tensor,
+    lora_a_gate: torch.Tensor,
+    lora_b_gate: torch.Tensor,
+    lora_a_up: torch.Tensor,
+    lora_b_up: torch.Tensor,
+    lora_scale_gate: float,
+    lora_scale_up: float,
+    group_list: torch.Tensor,
+    independent: bool,
+) -> torch.Tensor:
+    """Seed-style gate+up LoRA delta on dispatched tokens ``x`` (``[N, H]``).
+
+    Returns ``[N, 2I]`` (gate half then up half) so it can be added straight
+    onto the base ``gate_up`` group-gemm output before ``npu_swiglu``. The two
+    halves keep separate rank-r adapters (see ``moe_layers`` for why).
+
+    ``group_list`` is the per-(local-)expert token count driving the grouped
+    gemm — identical to the count the base experts use, so the LoRA groups line
+    up with the base groups token-for-token.
+    """
+    if independent:
+        # 3-D per-expert LoRA: ``npu_group_gemm(x, W, counts)`` computes the
+        # per-expert ``x @ W`` (base kernel passes ``W.transpose(1, 2)`` to
+        # realise ``F.linear``, so we do the same for A/B).
+        gate = npu_group_gemm(
+            npu_group_gemm(x, lora_a_gate.transpose(1, 2), group_list),
+            lora_b_gate.transpose(1, 2),
+            group_list,
+        )
+        up = npu_group_gemm(
+            npu_group_gemm(x, lora_a_up.transpose(1, 2), group_list),
+            lora_b_up.transpose(1, 2),
+            group_list,
+        )
+    else:
+        # 2-D shared LoRA: identical for every expert ⇒ plain matmul over all
+        # dispatched tokens, no grouping.
+        gate = F.linear(F.linear(x, lora_a_gate), lora_b_gate)
+        up = F.linear(F.linear(x, lora_a_up), lora_b_up)
+    return torch.cat([gate * lora_scale_gate, up * lora_scale_up], dim=-1)
+
+
+def _lora_down_delta(
+    mid: torch.Tensor,
+    lora_a_down: torch.Tensor,
+    lora_b_down: torch.Tensor,
+    lora_scale_down: float,
+    group_list: torch.Tensor,
+    independent: bool,
+) -> torch.Tensor:
+    """Down-projection LoRA delta on the post-SwiGLU intermediate ``mid`` (``[N, I]`` -> ``[N, H]``)."""
+    if independent:
+        down = npu_group_gemm(
+            npu_group_gemm(mid, lora_a_down.transpose(1, 2), group_list),
+            lora_b_down.transpose(1, 2),
+            group_list,
+        )
+    else:
+        down = F.linear(F.linear(mid, lora_a_down), lora_b_down)
+    return down * lora_scale_down
+
+
+def _npu_fused_lora_moe_forward(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    lora_a_gate: torch.Tensor,
+    lora_b_gate: torch.Tensor,
+    lora_a_up: torch.Tensor,
+    lora_b_up: torch.Tensor,
+    lora_a_down: torch.Tensor,
+    lora_b_down: torch.Tensor,
+    lora_scale_gate: float,
+    lora_scale_up: float,
+    lora_scale_down: float,
+    independent: bool,
+) -> torch.Tensor:
+    """NPU single-device (non-EP) fused MoE forward + seed-style two-LoRA."""
+    hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+    # ``selected_experts`` is int64 (topk); NPU permute + the group-gemm group
+    # list both need int32. ``torch.histc`` only accepts float input and returns
+    # float, so bin on float32 and cast the counts back to int32.
+    selected_experts = selected_experts.to(torch.int32)
+    permuted_hidden_states, row_ids_map = torch_npu.npu_moe_token_permute(hidden_states, selected_experts)
+    tokens_per_expert = torch.histc(selected_experts.to(torch.float32), bins=num_experts, min=0, max=num_experts).to(
+        torch.int32
+    )
+
+    gate_up = npu_group_gemm(permuted_hidden_states, fc1_1_2_weight.transpose(1, 2), tokens_per_expert)
+    gate_up = gate_up + _lora_gate_up_delta(
+        permuted_hidden_states,
+        lora_a_gate,
+        lora_b_gate,
+        lora_a_up,
+        lora_b_up,
+        lora_scale_gate,
+        lora_scale_up,
+        tokens_per_expert,
+        independent,
+    )
+    intermediate = torch_npu.npu_swiglu(gate_up, dim=-1)
+    output = npu_group_gemm(intermediate, fc2_weight.transpose(1, 2), tokens_per_expert)
+    output = output + _lora_down_delta(
+        intermediate, lora_a_down, lora_b_down, lora_scale_down, tokens_per_expert, independent
+    )
+    return torch_npu.npu_moe_token_unpermute(output, row_ids_map, probs=routing_weights)
+
+
+def _npu_ep_fused_lora_moe_forward(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    lora_a_gate: torch.Tensor,
+    lora_b_gate: torch.Tensor,
+    lora_a_up: torch.Tensor,
+    lora_b_up: torch.Tensor,
+    lora_a_down: torch.Tensor,
+    lora_b_down: torch.Tensor,
+    lora_scale_gate: float,
+    lora_scale_up: float,
+    lora_scale_down: float,
+    independent: bool,
+    ep_group: dist.ProcessGroup | None = None,
+) -> torch.Tensor:
+    """NPU expert-parallel fused MoE forward + seed-style two-LoRA.
+
+    EP dispatch/combine is identical to
+    :func:`veomni.ops.kernels.moe.npu_group_gemm.npu_ep_fused_moe_forward`; the
+    LoRA deltas are added on the dispatched local tokens with the local (already
+    EP-sharded for independent, replicated for shared) LoRA weights, driven by
+    ``num_global_sum_tokens_per_local_expert`` — the same per-local-expert token
+    count the base group-gemm uses.
+    """
+    hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+    # NPU expert routing/indexing (dispatch_preprocess + alltoall_dispatch)
+    # expects int32; ``selected_experts`` is int64 (topk), so cast up front to
+    # match the non-EP path and avoid dtype mismatches in the dispatch.
+    selected_experts = selected_experts.to(torch.int32)
+    input_splits, output_splits, num_global_tokens_per_local_expert, num_global_sum_tokens_per_local_expert = (
+        dispatch_preprocess(selected_experts, num_experts, ep_group)
+    )
+    hidden_states, unpermute_indices = alltoall_dispatch(
+        hidden_states,
+        selected_experts,
+        input_splits,
+        output_splits,
+        num_experts,
+        num_global_tokens_per_local_expert,
+        ep_group,
+    )
+
+    group_list = num_global_sum_tokens_per_local_expert
+    gate_up = npu_group_gemm(hidden_states, fc1_1_2_weight.transpose(1, 2), group_list)
+    gate_up = gate_up + _lora_gate_up_delta(
+        hidden_states,
+        lora_a_gate,
+        lora_b_gate,
+        lora_a_up,
+        lora_b_up,
+        lora_scale_gate,
+        lora_scale_up,
+        group_list,
+        independent,
+    )
+    intermediate = torch_npu.npu_swiglu(gate_up, dim=-1)
+    output = npu_group_gemm(intermediate, fc2_weight.transpose(1, 2), group_list)
+    output = output + _lora_down_delta(
+        intermediate, lora_a_down, lora_b_down, lora_scale_down, group_list, independent
+    )
+
+    output = alltoall_combine(
+        output,
+        routing_weights,
+        unpermute_indices,
+        input_splits,
+        output_splits,
+        num_experts,
+        num_global_tokens_per_local_expert,
+        ep_group,
+    )
+    return output
+
+
+def _npu_lora_moe_dispatch(independent: bool, **kwargs) -> torch.Tensor:
+    """Route to the EP or non-EP NPU LoRA MoE forward based on parallel state."""
+    if get_parallel_state().ep_enabled:
+        return _npu_ep_fused_lora_moe_forward(
+            independent=independent, ep_group=get_parallel_state().ep_group, **kwargs
+        )
+    return _npu_fused_lora_moe_forward(independent=independent, **kwargs)
+
+
+def npu_fused_lora_moe_forward(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    lora_a_gate: torch.Tensor,
+    lora_b_gate: torch.Tensor,
+    lora_a_up: torch.Tensor,
+    lora_b_up: torch.Tensor,
+    lora_a_down: torch.Tensor,
+    lora_b_down: torch.Tensor,
+    lora_scale_gate: float,
+    lora_scale_up: float,
+    lora_scale_down: float,
+) -> torch.Tensor:
+    """NPU Mode-2 (shared) fused MoE-LoRA forward.
+
+    Signature matches ``veomni.lora.ops.fused_lora_moe_forward`` /
+    ``group_gemm_fused_lora_moe_forward`` so it is a drop-in ``triton``
+    replacement bound by :func:`veomni.lora.ops.bind_lora_moe_kernels`.
+    """
+    return _npu_lora_moe_dispatch(
+        independent=False,
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hidden_states,
+        fc1_1_2_weight=fc1_1_2_weight,
+        fc2_weight=fc2_weight,
+        lora_a_gate=lora_a_gate,
+        lora_b_gate=lora_b_gate,
+        lora_a_up=lora_a_up,
+        lora_b_up=lora_b_up,
+        lora_a_down=lora_a_down,
+        lora_b_down=lora_b_down,
+        lora_scale_gate=lora_scale_gate,
+        lora_scale_up=lora_scale_up,
+        lora_scale_down=lora_scale_down,
+    )
+
+
+def npu_fused_independent_lora_moe_forward(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    lora_a_gate: torch.Tensor,
+    lora_b_gate: torch.Tensor,
+    lora_a_up: torch.Tensor,
+    lora_b_up: torch.Tensor,
+    lora_a_down: torch.Tensor,
+    lora_b_down: torch.Tensor,
+    lora_scale_gate: float,
+    lora_scale_up: float,
+    lora_scale_down: float,
+) -> torch.Tensor:
+    """NPU Mode-1 (independent per-expert) fused MoE-LoRA forward.
+
+    Same shape contract as :func:`npu_fused_lora_moe_forward` except every LoRA
+    tensor carries a leading expert dim (``[E, r, ...]`` / ``[E, ..., r]``).
+    Drop-in replacement for ``group_gemm_fused_independent_lora_moe_forward``.
+    """
+    return _npu_lora_moe_dispatch(
+        independent=True,
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hidden_states,
+        fc1_1_2_weight=fc1_1_2_weight,
+        fc2_weight=fc2_weight,
+        lora_a_gate=lora_a_gate,
+        lora_b_gate=lora_b_gate,
+        lora_a_up=lora_a_up,
+        lora_b_up=lora_b_up,
+        lora_a_down=lora_a_down,
+        lora_b_down=lora_b_down,
+        lora_scale_gate=lora_scale_gate,
+        lora_scale_up=lora_scale_up,
+        lora_scale_down=lora_scale_down,
+    )

--- a/veomni/lora/ops/npu_moe_group_gemm.py
+++ b/veomni/lora/ops/npu_moe_group_gemm.py
@@ -1,0 +1,340 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NPU fused MoE-LoRA kernels (owned by the LoRA stack).
+
+The NPU counterpart of :mod:`veomni.lora.ops.moe_group_gemm` (the Triton
+implementation). It lives here — next to the Triton LoRA kernel — so both
+backends' LoRA-aware fused MoE forwards sit under ``veomni.lora.ops`` and are
+bound uniformly by :func:`veomni.lora.ops.bind_lora_moe_kernels`.
+
+Unlike the Triton kernel (which re-implements the whole EP dispatch/combine +
+grouped-gemm with hand-written ``autograd.Function`` backwards), the NPU path
+*composes* the base NPU MoE primitives that already live in
+``veomni.ops.kernels.moe.npu_group_gemm``:
+
+  * ``dispatch_preprocess`` / ``alltoall_dispatch`` / ``alltoall_combine`` —
+    the exact all-to-all EP dispatch/combine the base fused MoE uses, and
+  * ``npu_group_gemm`` — the grouped-matmul ``autograd.Function`` (its own
+    backward),
+
+then injects three seed-style LoRA deltas (gate, up, down). Backward is derived
+by autograd (no hand-written kernel), because every op in the composition is
+differentiable. MoE-LoRA and expert parallelism are orthogonal: the EP handling
+is identical to the base kernel, the only extra work is the LoRA delta on the
+*dispatched* tokens using the *local* (already EP-sharded) LoRA weights.
+
+Two LoRA layouts (mirroring ``veomni.lora.moe_layers``):
+  * shared (Mode 2, ``LoraSharedExperts``)     — one 2-D LoRA pair reused by
+    every expert ⇒ the delta is a plain matmul over *all* dispatched tokens
+    (expert-independent), so no per-expert grouping is needed.
+  * independent (Mode 1, ``LoraIndependentExperts``) — a 3-D per-expert LoRA
+    pair ⇒ the delta is a grouped-gemm over the same per-expert token groups
+    the base experts use, driven by the same ``group_list`` (token counts).
+
+The eager reference these must match line-for-line lives in
+``veomni.lora.moe_layers.{LoraSharedExperts,LoraIndependentExperts}._eager_forward``.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+import torch_npu
+
+from ...distributed.parallel_state import get_parallel_state
+from ...ops.kernels.moe.npu_group_gemm import (
+    alltoall_combine,
+    alltoall_dispatch,
+    dispatch_preprocess,
+    npu_group_gemm,
+)
+
+
+def _lora_gate_up_delta(
+    x: torch.Tensor,
+    lora_a_gate: torch.Tensor,
+    lora_b_gate: torch.Tensor,
+    lora_a_up: torch.Tensor,
+    lora_b_up: torch.Tensor,
+    lora_scale_gate: float,
+    lora_scale_up: float,
+    group_list: torch.Tensor,
+    independent: bool,
+) -> torch.Tensor:
+    """Seed-style gate+up LoRA delta on dispatched tokens ``x`` (``[N, H]``).
+
+    Returns ``[N, 2I]`` (gate half then up half) so it can be added straight
+    onto the base ``gate_up`` group-gemm output before ``npu_swiglu``. The two
+    halves keep separate rank-r adapters (see ``moe_layers`` for why).
+
+    ``group_list`` is the per-(local-)expert token count driving the grouped
+    gemm — identical to the count the base experts use, so the LoRA groups line
+    up with the base groups token-for-token.
+    """
+    if independent:
+        # 3-D per-expert LoRA: ``npu_group_gemm(x, W, counts)`` computes the
+        # per-expert ``x @ W`` (base kernel passes ``W.transpose(1, 2)`` to
+        # realise ``F.linear``, so we do the same for A/B).
+        gate = npu_group_gemm(
+            npu_group_gemm(x, lora_a_gate.transpose(1, 2), group_list),
+            lora_b_gate.transpose(1, 2),
+            group_list,
+        )
+        up = npu_group_gemm(
+            npu_group_gemm(x, lora_a_up.transpose(1, 2), group_list),
+            lora_b_up.transpose(1, 2),
+            group_list,
+        )
+    else:
+        # 2-D shared LoRA: identical for every expert ⇒ plain matmul over all
+        # dispatched tokens, no grouping.
+        gate = F.linear(F.linear(x, lora_a_gate), lora_b_gate)
+        up = F.linear(F.linear(x, lora_a_up), lora_b_up)
+    return torch.cat([gate * lora_scale_gate, up * lora_scale_up], dim=-1)
+
+
+def _lora_down_delta(
+    mid: torch.Tensor,
+    lora_a_down: torch.Tensor,
+    lora_b_down: torch.Tensor,
+    lora_scale_down: float,
+    group_list: torch.Tensor,
+    independent: bool,
+) -> torch.Tensor:
+    """Down-projection LoRA delta on the post-SwiGLU intermediate ``mid`` (``[N, I]`` -> ``[N, H]``)."""
+    if independent:
+        down = npu_group_gemm(
+            npu_group_gemm(mid, lora_a_down.transpose(1, 2), group_list),
+            lora_b_down.transpose(1, 2),
+            group_list,
+        )
+    else:
+        down = F.linear(F.linear(mid, lora_a_down), lora_b_down)
+    return down * lora_scale_down
+
+
+def _npu_fused_lora_moe_forward(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    lora_a_gate: torch.Tensor,
+    lora_b_gate: torch.Tensor,
+    lora_a_up: torch.Tensor,
+    lora_b_up: torch.Tensor,
+    lora_a_down: torch.Tensor,
+    lora_b_down: torch.Tensor,
+    lora_scale_gate: float,
+    lora_scale_up: float,
+    lora_scale_down: float,
+    independent: bool,
+) -> torch.Tensor:
+    """NPU single-device (non-EP) fused MoE forward + seed-style two-LoRA."""
+    hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+    permuted_hidden_states, row_ids_map = torch_npu.npu_moe_token_permute(
+        hidden_states, selected_experts.to(torch.int32)
+    )
+    tokens_per_expert = torch.histc(selected_experts, bins=num_experts, min=0, max=num_experts)
+
+    gate_up = npu_group_gemm(permuted_hidden_states, fc1_1_2_weight.transpose(1, 2), tokens_per_expert)
+    gate_up = gate_up + _lora_gate_up_delta(
+        permuted_hidden_states,
+        lora_a_gate,
+        lora_b_gate,
+        lora_a_up,
+        lora_b_up,
+        lora_scale_gate,
+        lora_scale_up,
+        tokens_per_expert,
+        independent,
+    )
+    intermediate = torch_npu.npu_swiglu(gate_up, dim=-1)
+    output = npu_group_gemm(intermediate, fc2_weight.transpose(1, 2), tokens_per_expert)
+    output = output + _lora_down_delta(
+        intermediate, lora_a_down, lora_b_down, lora_scale_down, tokens_per_expert, independent
+    )
+    return torch_npu.npu_moe_token_unpermute(output, row_ids_map, probs=routing_weights)
+
+
+def _npu_ep_fused_lora_moe_forward(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    lora_a_gate: torch.Tensor,
+    lora_b_gate: torch.Tensor,
+    lora_a_up: torch.Tensor,
+    lora_b_up: torch.Tensor,
+    lora_a_down: torch.Tensor,
+    lora_b_down: torch.Tensor,
+    lora_scale_gate: float,
+    lora_scale_up: float,
+    lora_scale_down: float,
+    independent: bool,
+    ep_group: dist.ProcessGroup | None = None,
+) -> torch.Tensor:
+    """NPU expert-parallel fused MoE forward + seed-style two-LoRA.
+
+    EP dispatch/combine is identical to
+    :func:`veomni.ops.kernels.moe.npu_group_gemm.npu_ep_fused_moe_forward`; the
+    LoRA deltas are added on the dispatched local tokens with the local (already
+    EP-sharded for independent, replicated for shared) LoRA weights, driven by
+    ``num_global_sum_tokens_per_local_expert`` — the same per-local-expert token
+    count the base group-gemm uses.
+    """
+    hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+    input_splits, output_splits, num_global_tokens_per_local_expert, num_global_sum_tokens_per_local_expert = (
+        dispatch_preprocess(selected_experts, num_experts, ep_group)
+    )
+    hidden_states, unpermute_indices = alltoall_dispatch(
+        hidden_states,
+        selected_experts,
+        input_splits,
+        output_splits,
+        num_experts,
+        num_global_tokens_per_local_expert,
+        ep_group,
+    )
+
+    group_list = num_global_sum_tokens_per_local_expert
+    gate_up = npu_group_gemm(hidden_states, fc1_1_2_weight.transpose(1, 2), group_list)
+    gate_up = gate_up + _lora_gate_up_delta(
+        hidden_states,
+        lora_a_gate,
+        lora_b_gate,
+        lora_a_up,
+        lora_b_up,
+        lora_scale_gate,
+        lora_scale_up,
+        group_list,
+        independent,
+    )
+    intermediate = torch_npu.npu_swiglu(gate_up, dim=-1)
+    output = npu_group_gemm(intermediate, fc2_weight.transpose(1, 2), group_list)
+    output = output + _lora_down_delta(
+        intermediate, lora_a_down, lora_b_down, lora_scale_down, group_list, independent
+    )
+
+    output = alltoall_combine(
+        output,
+        routing_weights,
+        unpermute_indices,
+        input_splits,
+        output_splits,
+        num_experts,
+        num_global_tokens_per_local_expert,
+        ep_group,
+    )
+    return output
+
+
+def _npu_lora_moe_dispatch(independent: bool, **kwargs) -> torch.Tensor:
+    """Route to the EP or non-EP NPU LoRA MoE forward based on parallel state."""
+    if get_parallel_state().ep_enabled:
+        return _npu_ep_fused_lora_moe_forward(
+            independent=independent, ep_group=get_parallel_state().ep_group, **kwargs
+        )
+    return _npu_fused_lora_moe_forward(independent=independent, **kwargs)
+
+
+def npu_fused_lora_moe_forward(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    lora_a_gate: torch.Tensor,
+    lora_b_gate: torch.Tensor,
+    lora_a_up: torch.Tensor,
+    lora_b_up: torch.Tensor,
+    lora_a_down: torch.Tensor,
+    lora_b_down: torch.Tensor,
+    lora_scale_gate: float,
+    lora_scale_up: float,
+    lora_scale_down: float,
+) -> torch.Tensor:
+    """NPU Mode-2 (shared) fused MoE-LoRA forward.
+
+    Signature matches ``veomni.lora.ops.fused_lora_moe_forward`` /
+    ``group_gemm_fused_lora_moe_forward`` so it is a drop-in ``triton``
+    replacement bound by :func:`veomni.lora.ops.bind_lora_moe_kernels`.
+    """
+    return _npu_lora_moe_dispatch(
+        independent=False,
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hidden_states,
+        fc1_1_2_weight=fc1_1_2_weight,
+        fc2_weight=fc2_weight,
+        lora_a_gate=lora_a_gate,
+        lora_b_gate=lora_b_gate,
+        lora_a_up=lora_a_up,
+        lora_b_up=lora_b_up,
+        lora_a_down=lora_a_down,
+        lora_b_down=lora_b_down,
+        lora_scale_gate=lora_scale_gate,
+        lora_scale_up=lora_scale_up,
+        lora_scale_down=lora_scale_down,
+    )
+
+
+def npu_fused_independent_lora_moe_forward(
+    num_experts: int,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    hidden_states: torch.Tensor,
+    fc1_1_2_weight: torch.Tensor,
+    fc2_weight: torch.Tensor,
+    lora_a_gate: torch.Tensor,
+    lora_b_gate: torch.Tensor,
+    lora_a_up: torch.Tensor,
+    lora_b_up: torch.Tensor,
+    lora_a_down: torch.Tensor,
+    lora_b_down: torch.Tensor,
+    lora_scale_gate: float,
+    lora_scale_up: float,
+    lora_scale_down: float,
+) -> torch.Tensor:
+    """NPU Mode-1 (independent per-expert) fused MoE-LoRA forward.
+
+    Same shape contract as :func:`npu_fused_lora_moe_forward` except every LoRA
+    tensor carries a leading expert dim (``[E, r, ...]`` / ``[E, ..., r]``).
+    Drop-in replacement for ``group_gemm_fused_independent_lora_moe_forward``.
+    """
+    return _npu_lora_moe_dispatch(
+        independent=True,
+        num_experts=num_experts,
+        routing_weights=routing_weights,
+        selected_experts=selected_experts,
+        hidden_states=hidden_states,
+        fc1_1_2_weight=fc1_1_2_weight,
+        fc2_weight=fc2_weight,
+        lora_a_gate=lora_a_gate,
+        lora_b_gate=lora_b_gate,
+        lora_a_up=lora_a_up,
+        lora_b_up=lora_b_up,
+        lora_a_down=lora_a_down,
+        lora_b_down=lora_b_down,
+        lora_scale_gate=lora_scale_gate,
+        lora_scale_up=lora_scale_up,
+        lora_scale_down=lora_scale_down,
+    )

--- a/veomni/lora/ops/npu_moe_group_gemm.py
+++ b/veomni/lora/ops/npu_moe_group_gemm.py
@@ -146,13 +146,14 @@ def _npu_fused_lora_moe_forward(
 ) -> torch.Tensor:
     """NPU single-device (non-EP) fused MoE forward + seed-style two-LoRA."""
     hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
-    # ``selected_experts`` is int64 (topk); NPU permute + the group-gemm group
-    # list both need int32. ``torch.histc`` only accepts float input and returns
-    # float, so bin on float32 and cast the counts back to int32.
+    # ``selected_experts`` is int64 (topk). ``npu_moe_token_permute`` wants
+    # int32 indices; ``npu_grouped_matmul``'s ``groupList`` wants int64 counts
+    # (int32 raises EZ1001). ``torch.histc`` only accepts float input and
+    # returns float, so bin on float32 then cast counts to int64.
     selected_experts = selected_experts.to(torch.int32)
     permuted_hidden_states, row_ids_map = torch_npu.npu_moe_token_permute(hidden_states, selected_experts)
     tokens_per_expert = torch.histc(selected_experts.to(torch.float32), bins=num_experts, min=0, max=num_experts).to(
-        torch.int32
+        torch.int64
     )
 
     gate_up = npu_group_gemm(permuted_hidden_states, fc1_1_2_weight.transpose(1, 2), tokens_per_expert)
@@ -221,7 +222,8 @@ def _npu_ep_fused_lora_moe_forward(
         ep_group,
     )
 
-    group_list = num_global_sum_tokens_per_local_expert
+    # ``npu_grouped_matmul`` requires int64 groupList (same as non-EP path).
+    group_list = num_global_sum_tokens_per_local_expert.to(torch.int64)
     gate_up = npu_group_gemm(hidden_states, fc1_1_2_weight.transpose(1, 2), group_list)
     gate_up = gate_up + _lora_gate_up_delta(
         hidden_states,

--- a/veomni/lora/weight_loading.py
+++ b/veomni/lora/weight_loading.py
@@ -94,6 +94,31 @@ def build_lora_key_overrides(model: nn.Module) -> dict[str, str]:
     return overrides
 
 
+def make_peft_key_mapper(model: nn.Module, is_peft_model: bool) -> Callable[[str], str]:
+    """Return a fn mapping a *bare* base-model FQN to its live-model destination.
+
+    Centralises the checkpoint-key remap every weight loader
+    (:func:`~veomni.models.module_utils.load_model_weights` /
+    ``load_model_weights_ep_sharded`` / ``rank0_load_and_broadcast_weights``)
+    needs when a base checkpoint is loaded into a LoRA-wrapped model:
+
+    * ``is_peft_model=False`` -> identity (the checkpoint key is already the
+      live-model key).
+    * ``is_peft_model=True``  -> :func:`build_lora_key_overrides` remap (wrapped
+      targets go to ``...base_layer.weight``) with a plain ``base_model.model.``
+      prefix fallback for un-wrapped params.
+
+    Apply it *after* ``maybe_convert_checkpoint_tensor`` so converter-produced
+    merged keys (e.g. the Qwen3-MoE per-expert -> fused ``...experts.gate_up_proj``)
+    also flow through the ``base_layer.weight`` rename when their experts module is
+    wrapped by ``LoraSharedExperts`` / ``LoraIndependentExperts``.
+    """
+    if not is_peft_model:
+        return lambda bare_name: bare_name
+    overrides = build_lora_key_overrides(model)
+    return lambda bare_name: overrides.get(bare_name, "base_model.model." + bare_name)
+
+
 @torch.no_grad()
 def load_lora_weights(
     model: nn.Module | PreTrainedModel,
@@ -227,6 +252,19 @@ def init_lora_parameter(model: nn.Module, name: str) -> None:
 
 
 def _reset_moe_wrapper(module: nn.Module) -> None:
-    """Reset a MoE wrapper only when all its params are still meta (BUG-3 guard)."""
-    if all(p.is_meta for _, p in module.named_parameters()):
-        module.reset_lora_parameters(init_lora_weights=True)
+    """Fresh-init a MoE wrapper's LoRA params (kaiming ``A`` / zero ``B``).
+
+    ``init_lora_parameter`` is only ever invoked for LoRA tensors the weight
+    loader left *un-loaded* (they stay in ``parameter_names_left``), so a wrapper
+    reaching here always needs initialisation. The previous ``all(p.is_meta)``
+    guard is dead under the standard loaders, which run ``model.to_empty(...)``
+    *before* init — after that no param is on meta, so the guard silently skipped
+    the reset and left the wrapper's ``lora_A`` / ``lora_B`` as the uninitialised
+    (garbage / NaN) storage ``to_empty`` produced. We reset once per wrapper
+    (idempotent); when an adapter *is* loaded, its LoRA tensors are removed from
+    the un-loaded set so this path is never taken for them (loaded weights are
+    never clobbered)."""
+    if getattr(module, "_lora_fresh_reset_done", False):
+        return
+    module.reset_lora_parameters(init_lora_weights=True)
+    module._lora_fresh_reset_done = True

--- a/veomni/lora/weight_loading.py
+++ b/veomni/lora/weight_loading.py
@@ -22,7 +22,7 @@ Native replacements for the ``peft``-based helpers previously in
 * :func:`load_lora_weights` — every rank reads the PEFT-format adapter file.
 * :func:`rank0_load_and_broadcast_lora_weights` — rank-0 reads then broadcasts.
 * :func:`init_lora_parameter` — post-load kaiming/zero init for un-loaded LoRA
-  params, with the meta-device guard that prevents clobbering loaded weights.
+  params, with a missing-name-set guard that prevents clobbering loaded weights.
 
 All adapter files are read natively (safetensors / torch), never via ``peft``.
 """
@@ -222,28 +222,34 @@ def rank0_load_and_broadcast_lora_weights(
     logger.info_rank0(f"rank0_load_and_broadcast_lora_weights: loaded {num_keys} adapter param(s)")
 
 
-def init_lora_parameter(model: nn.Module, name: str) -> None:
+def init_lora_parameter(
+    model: nn.Module,
+    name: str,
+    parameter_names_left: set[str] | None = None,
+) -> None:
     """Initialise one un-loaded LoRA tensor (kaiming ``A`` / zero ``B``).
 
     Walks ``model`` along ``name`` to the owning LoRA module and calls its
-    ``reset_lora_parameters``. For MoE wrappers the reset only fires when every
-    wrapper parameter is still on meta device, so a wrapper that already had
-    some tensors loaded is never clobbered (guards against re-randomising
-    loaded ``A`` / re-zeroing loaded ``B``).
+    ``reset_lora_parameters``. For MoE wrappers the decision is made at
+    *wrapper* granularity using ``parameter_names_left`` (see
+    :func:`_reset_moe_wrapper`): reset only when every LoRA tensor on that
+    wrapper is missing; never touch a fully- or partially-loaded wrapper.
     """
     module: nn.Module = model
+    prefix_parts: list[str] = []
     for piece in name.split("."):
         if _is_moe_lora_wrapper(module):
-            _reset_moe_wrapper(module)
+            _reset_moe_wrapper(module, ".".join(prefix_parts), parameter_names_left)
             return
         if piece.startswith("lora_"):
             break
         if not hasattr(module, piece):
             return
         module = getattr(module, piece)
+        prefix_parts.append(piece)
 
     if _is_moe_lora_wrapper(module):
-        _reset_moe_wrapper(module)
+        _reset_moe_wrapper(module, ".".join(prefix_parts), parameter_names_left)
         return
 
     if "lora_A" in name and hasattr(module, "reset_lora_parameters"):
@@ -251,20 +257,55 @@ def init_lora_parameter(model: nn.Module, name: str) -> None:
             module.reset_lora_parameters(adapter, init_lora_weights=True)
 
 
-def _reset_moe_wrapper(module: nn.Module) -> None:
+def _moe_wrapper_lora_names(module: nn.Module, wrapper_prefix: str) -> list[str]:
+    """FQNs of every LoRA ``A``/``B`` tensor owned by a MoE wrapper."""
+    names: list[str] = []
+    for local_name, _ in module.named_parameters():
+        parts = local_name.split(".")
+        if "lora_A" not in parts and "lora_B" not in parts:
+            continue
+        names.append(f"{wrapper_prefix}.{local_name}" if wrapper_prefix else local_name)
+    return names
+
+
+def _reset_moe_wrapper(
+    module: nn.Module,
+    wrapper_prefix: str,
+    parameter_names_left: set[str] | None,
+) -> None:
     """Fresh-init a MoE wrapper's LoRA params (kaiming ``A`` / zero ``B``).
 
-    ``init_lora_parameter`` is only ever invoked for LoRA tensors the weight
-    loader left *un-loaded* (they stay in ``parameter_names_left``), so a wrapper
-    reaching here always needs initialisation. The previous ``all(p.is_meta)``
-    guard is dead under the standard loaders, which run ``model.to_empty(...)``
-    *before* init — after that no param is on meta, so the guard silently skipped
-    the reset and left the wrapper's ``lora_A`` / ``lora_B`` as the uninitialised
-    (garbage / NaN) storage ``to_empty`` produced. We reset once per wrapper
-    (idempotent); when an adapter *is* loaded, its LoRA tensors are removed from
-    the un-loaded set so this path is never taken for them (loaded weights are
-    never clobbered)."""
+    Decision is at wrapper granularity against ``parameter_names_left`` (the
+    set of FQNs the weight loader did not fill). After ``model.to_empty(...)``
+    every param is non-meta garbage, so a meta-device guard cannot tell "fresh"
+    from "already loaded"; the missing-name set is the source of truth:
+
+    * **all** wrapper LoRA names missing → reset once (idempotent via
+      ``_lora_fresh_reset_done``);
+    * **none** missing → no-op (loaded weights must not be clobbered);
+    * **subset** missing → raise (partial adapter resume is fail-closed).
+    """
     if getattr(module, "_lora_fresh_reset_done", False):
         return
+
+    lora_names = _moe_wrapper_lora_names(module, wrapper_prefix)
+    if not lora_names:
+        return
+
+    left = parameter_names_left if parameter_names_left is not None else set()
+    missing = [n for n in lora_names if n in left]
+    if not missing:
+        return
+    if len(missing) != len(lora_names):
+        loaded = sorted(set(lora_names) - set(missing))
+        raise RuntimeError(
+            f"MoE LoRA wrapper {wrapper_prefix!r} is only partially loaded: "
+            f"{len(missing)}/{len(lora_names)} LoRA tensor(s) missing "
+            f"(e.g. {missing[0]!r}). Refusing to reset the wrapper because that "
+            f"would clobber already-loaded weights "
+            f"(e.g. {loaded[0]!r}). Provide a complete adapter or omit "
+            f"adapter_path for a fresh init."
+        )
+
     module.reset_lora_parameters(init_lora_weights=True)
     module._lora_fresh_reset_done = True

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -286,6 +286,7 @@ def _get_communication_device(init_device: Literal["cpu", "cuda", "npu"]) -> tor
 def _init_parameter(
     module: "nn.Module",
     name: str,
+    parameter_names_left: Optional[set[str]] = None,
 ) -> None:
     """
     Initializes parameter in model.
@@ -294,7 +295,7 @@ def _init_parameter(
     if any(p.startswith("lora_") for p in pieces):
         from ..lora.weight_loading import init_lora_parameter
 
-        init_lora_parameter(module, name)
+        init_lora_parameter(module, name, parameter_names_left=parameter_names_left)
         return
     init_func = None
     for piece in pieces[:-1]:
@@ -465,6 +466,64 @@ def _resolve_safetensors_shards(weights_path: str, **kwargs) -> Tuple[Dict[str, 
         return dict.fromkeys(keys, base), {base: resolved_file}
 
     raise ValueError(f"ep_sharded_stream_load: no safetensors checkpoint found under {weights_path}.")
+
+
+def _ep_dim0_slice_meta(parallel_state: Any, shard_group: str, target0: int) -> Tuple[int, int, int]:
+    """Return ``(para_size, para_rank, expected_full0)`` for a dim-0 EP shard."""
+    para_size = (
+        parallel_state.extra_parallel_sizes[shard_group] if parallel_state.extra_parallel_enabled(shard_group) else 1
+    )
+    para_rank = (
+        parallel_state.extra_parallel_rank(shard_group) if parallel_state.extra_parallel_enabled(shard_group) else 0
+    )
+    return para_size, para_rank, target0 * para_size
+
+
+def _read_ep_dim0_slice(
+    sl: Any,
+    *,
+    name: str,
+    target0: int,
+    para_rank: int,
+    expected_full0: int,
+    zero_pad: bool = False,
+    strict_mismatch_message: Optional[str] = None,
+) -> "torch.Tensor":
+    """Read this rank's dim-0 EP slice from a safetensors ``get_slice`` handle.
+
+    Shared by the base-checkpoint and PEFT-adapter ep_sharded loaders so the
+    group lookup / expected-full-dim validation / slice bounds stay in one place.
+
+    * ``zero_pad=False`` (strict, default): checkpoint dim0 must equal
+      ``expected_full0``; used for independent MoE-LoRA adapters.
+    * ``zero_pad=True``: allow ``real0 < expected_full0`` and zero-fill the
+      trailing rows (dim-0 zero-pad converters on the base path).
+    """
+    real0 = sl.get_shape()[0]
+    if real0 > expected_full0:
+        raise RuntimeError(f"{name}: checkpoint dim0={real0} exceeds model dim0={expected_full0}.")
+    if not zero_pad and real0 != expected_full0:
+        if strict_mismatch_message is not None:
+            raise RuntimeError(strict_mismatch_message)
+        raise RuntimeError(
+            f"{name}: checkpoint dim0={real0} != model dim0={expected_full0} "
+            f"(no dim-0 zero-pad converter for this key)."
+        )
+    start = para_rank * target0
+    end = start + target0
+    if not zero_pad:
+        return sl[start:end]
+    # Clamp both ends to real0 so a rank lying entirely in the zero-pad region
+    # (start >= real0) reads an in-bounds empty slice (sl[real0:real0]) instead of
+    # relying on out-of-bounds ``get_slice`` semantics, which vary by safetensors
+    # version. Missing tail rows are zero-filled.
+    read_start = min(start, real0)
+    read_end = min(end, real0)
+    tensor = sl[read_start:read_end]
+    if tensor.shape[0] < target0:
+        pad = torch.zeros((target0 - tensor.shape[0], *tuple(tensor.shape[1:])), dtype=tensor.dtype)
+        tensor = torch.cat([tensor, pad], dim=0)
+    return tensor
 
 
 @torch.no_grad()
@@ -649,41 +708,15 @@ def load_model_weights_ep_sharded(
                             f"transform to ExtraParallel key '{name}'."
                         )
                     target0 = param_shapes[name][0]
-                    para_size = (
-                        parallel_state.extra_parallel_sizes[shard_group]
-                        if parallel_state.extra_parallel_enabled(shard_group)
-                        else 1
+                    _, para_rank, expected_full0 = _ep_dim0_slice_meta(parallel_state, shard_group, target0)
+                    tensor = _read_ep_dim0_slice(
+                        f.get_slice(raw_name),
+                        name=name,
+                        target0=target0,
+                        para_rank=para_rank,
+                        expected_full0=expected_full0,
+                        zero_pad=zero_pad,
                     )
-                    para_rank = (
-                        parallel_state.extra_parallel_rank(shard_group)
-                        if parallel_state.extra_parallel_enabled(shard_group)
-                        else 0
-                    )
-                    sl = f.get_slice(raw_name)
-                    real0 = sl.get_shape()[0]
-                    expected_full0 = target0 * para_size
-                    if real0 > expected_full0:
-                        raise RuntimeError(f"{name}: checkpoint dim0={real0} exceeds model dim0={expected_full0}.")
-                    if not zero_pad and real0 != expected_full0:
-                        # No dim-0 zero-pad converter -> checkpoint must match exactly;
-                        # a silent zero-fill here would hide a real shape mismatch.
-                        raise RuntimeError(
-                            f"{name}: checkpoint dim0={real0} != model dim0={expected_full0} "
-                            f"(no dim-0 zero-pad converter for this key)."
-                        )
-                    start = para_rank * target0
-                    end = start + target0
-                    # Real checkpoint rows for this rank are [start, real0); clamp BOTH
-                    # ends to real0 so a rank lying entirely in the zero-pad region
-                    # (start >= real0) reads an in-bounds empty slice (sl[real0:real0])
-                    # instead of relying on out-of-bounds ``get_slice`` semantics, which
-                    # vary by safetensors version. Missing tail rows are zero-filled.
-                    read_start = min(start, real0)
-                    read_end = min(end, real0)
-                    tensor = sl[read_start:read_end]
-                    if tensor.shape[0] < target0:  # trailing zero rows (dim-0 zero-pad converter)
-                        pad = torch.zeros((target0 - tensor.shape[0], *tuple(tensor.shape[1:])), dtype=tensor.dtype)
-                        tensor = torch.cat([tensor, pad], dim=0)
                     # Already the local slice -> parallel_plan=None (do not slice
                     # again); dtensor_factory then shards over the ep_fsdp sub-mesh
                     # exactly as the whole-tensor path's post-shard_tensor half.
@@ -766,11 +799,10 @@ def _stream_lora_adapter_ep_sharded(
     """
     from ..lora.state_dict import _find_adapter_file, insert_adapter_name
 
-    try:
-        file_path, is_safetensors = _find_adapter_file(adapter_path)
-    except FileNotFoundError:
-        logger.warning_rank0(f"ep_sharded adapter: no adapter file under {adapter_path}; skipping.")
-        return
+    # Fail closed: an explicitly configured adapter_path must resolve. Soft-skip
+    # would let post_process fresh-init a random adapter and training would
+    # proceed as if resume succeeded (other loaders propagate FileNotFoundError).
+    file_path, is_safetensors = _find_adapter_file(adapter_path)
 
     if not is_safetensors:
         from ..lora.weight_loading import load_lora_weights
@@ -801,26 +833,21 @@ def _stream_lora_adapter_ep_sharded(
             if shard_group is not None:
                 # independent per-expert LoRA -> read only this rank's dim-0 slice.
                 target0 = param_shapes[name][0]
-                para_size = (
-                    parallel_state.extra_parallel_sizes[shard_group]
-                    if parallel_state.extra_parallel_enabled(shard_group)
-                    else 1
-                )
-                para_rank = (
-                    parallel_state.extra_parallel_rank(shard_group)
-                    if parallel_state.extra_parallel_enabled(shard_group)
-                    else 0
-                )
+                _, para_rank, expected_full0 = _ep_dim0_slice_meta(parallel_state, shard_group, target0)
                 sl = f.get_slice(raw_key)
                 real0 = sl.get_shape()[0]
-                expected_full0 = target0 * para_size
-                if real0 != expected_full0:
-                    raise RuntimeError(
+                tensor = _read_ep_dim0_slice(
+                    sl,
+                    name=name,
+                    target0=target0,
+                    para_rank=para_rank,
+                    expected_full0=expected_full0,
+                    zero_pad=False,
+                    strict_mismatch_message=(
                         f"ep_sharded adapter {name}: file dim0={real0} != model dim0={expected_full0} "
                         f"(independent LoRA expects the gathered [E, ...] tensor)."
-                    )
-                start = para_rank * target0
-                tensor = sl[start : start + target0]
+                    ),
+                )
                 _dispatch_parameter(model, name, tensor, dtensor_factory, None, dtensor_to_cpu)
                 n_ep += 1
             else:
@@ -1295,7 +1322,7 @@ def post_process_after_weight_loading(
     if parameter_names_left:
         logger.info_rank0(f"Find missing key(s) in state dict: {parameter_names_left}, initialize them.")
         for name in sorted(parameter_names_left):
-            _init_parameter(model, name)
+            _init_parameter(model, name, parameter_names_left=parameter_names_left)
 
     # to_empty() leaves embeddings untied (except under FSDP2 swap-tensor);
     # re-tie only when the config asks for it. Nested multimodal layouts can

--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -369,33 +369,18 @@ def load_model_weights(
 
         parallel_plan = get_runtime_parallel_plan(model)
 
-    # Build LoRA key remapping when loading a base checkpoint into a PEFT-wrapped model.
-    # Maps bare base-model param names to PEFT-namespaced FQNs, e.g.:
-    #   "layers.0.self_attn.q_proj.weight" -> "base_model.model.layers.0.self_attn.q_proj.base_layer.weight"
-    # Keys not found in the map receive a plain "base_model.model." prefix.
+    # Remap bare base-model checkpoint keys to their live (PEFT-wrapped) FQNs.
+    # Applied AFTER ``maybe_convert_checkpoint_tensor`` so converter-produced merged
+    # keys (e.g. Qwen3-MoE per-expert -> fused ``...experts.gate_up_proj``) also flow
+    # through the ``base_layer.weight`` rename. No-op when not PEFT.
     is_peft_model = kwargs.get("is_peft_model", False)
     adapter_path = kwargs.get("adapter_path", None)
-    if is_peft_model:
-        from ..lora.weight_loading import build_lora_key_overrides
+    from ..lora.weight_loading import make_peft_key_mapper
 
-        lora_key_overrides = build_lora_key_overrides(model)
-
-    def _apply_peft_override(bare_name: str) -> str:
-        """Map a *bare* base-model FQN to its PEFT-wrapped destination.
-
-        Applied AFTER ``maybe_convert_checkpoint_tensor`` so converter-produced
-        merged keys (e.g. ``model.layers.0.mlp.experts.gate_up_proj`` from the
-        Qwen3-MoE per-expert -> fused converter) also flow through the
-        ``base_layer.weight`` rename when the experts module is wrapped by
-        ``LoraSharedExperts`` / ``LoraIndependentExperts``. Keys without an
-        override entry receive the plain ``base_model.model.`` prefix.
-        """
-        if not is_peft_model:
-            return bare_name
-        return lora_key_overrides.get(bare_name, "base_model.model." + bare_name)
+    _apply_peft_override = make_peft_key_mapper(model, is_peft_model)
 
     converter = get_checkpoint_tensor_converter(model)
-    if converter is None and is_peft_model and hasattr(model, "get_base_model"):
+    if converter is None and is_peft_model:
         converter = get_checkpoint_tensor_converter(model.get_base_model())
     state_dict_iterators = _load_state_dict(weights_path)
 
@@ -515,26 +500,56 @@ def load_model_weights_ep_sharded(
     ``[E/ep, ...]`` with ``parallel_plan=None`` so it is not sliced again, then
     the FSDP ``dtensor_factory`` shards it over the ``ep_fsdp`` sub-mesh.
 
-    Raises ``NotImplementedError`` when the checkpoint/model is unsupported: PEFT,
-    no ExtraParallel ``get_parallel_plan``, or a checkpoint-tensor converter whose
+    Raises ``NotImplementedError`` when the checkpoint/model is unsupported: no
+    ExtraParallel ``get_parallel_plan``, or a checkpoint-tensor converter whose
     transform is not a pure dim-0 zero-pad (a fusion converter needs the whole
     tensor set). A converter that only zero-pads dim-0 stays streamable -- each
     rank reads its real-row slice and zero-fills the tail -- and opts in via the
     optional ``CheckpointTensorConverter.is_dim0_zero_pad`` capability (see
     :func:`checkpoint_converter_is_dim0_zero_pad`).
+
+    PEFT is supported. Base-checkpoint keys are remapped to their PEFT
+    ``base_layer`` FQNs (:func:`build_lora_key_overrides`) and streamed exactly
+    like the non-PEFT base -- each rank keeps only its ``[E/ep, ...]`` expert
+    slice (the fused MoE experts live under ``...experts.<spec>.base_layer.weight``
+    and stay EP ``Shard(0)`` in the runtime plan). The LoRA adapter then streams via
+    :func:`_stream_lora_adapter_ep_sharded` with that same runtime plan, which decides
+    sharding per tensor: **independent** MoE LoRA tensors are 3-D ``Shard(0)`` over the
+    ep group, so each rank reads only its own expert-row dim-0 slice from the
+    safetensors adapter; **shared** MoE LoRA (2-D) and dense LoRA tensors are not in
+    the plan, so every rank reads them whole (replicated). Un-loaded LoRA params -- a
+    fresh build (no ``adapter_path``) or any params the adapter omits -- are
+    kaiming-``A``/zero-``B`` initialised in ``post_process_after_weight_loading``.
     """
-    if kwargs.get("is_peft_model", False):
-        raise NotImplementedError("ep_sharded_stream_load does not support PEFT models.")
+    is_peft_model = kwargs.get("is_peft_model", False)
+    adapter_path = kwargs.get("adapter_path", None)
+
     # A checkpoint-tensor converter generally needs the whole tensor set (e.g.
     # per-expert-key fusion) which streaming can't provide. The one streamable
     # exception is a *pure dim-0 zero-pad* converter, which opts in via the
     # optional ``is_dim0_zero_pad`` capability; that is enforced per-key below
-    # (dim-0 zero-pad -> stream + tail zero-fill; anything else -> bail).
+    # (dim-0 zero-pad -> stream + tail zero-fill; anything else -> bail). Under
+    # PEFT the converter lives on the *base* model (the wrapper has none).
     converter = get_checkpoint_tensor_converter(model)
-    get_plan = getattr(model, "get_parallel_plan", None)
-    parallel_plan = get_plan() if get_plan is not None else None
+    if converter is None and is_peft_model:
+        converter = get_checkpoint_tensor_converter(model.get_base_model())
+
+    # Runtime plan: PEFT-prefixes every pattern with ``base_model.model.`` and
+    # registers the MoE-LoRA wrapper FQNs -- base experts under ``base_layer.weight``
+    # stay EP ``Shard(0)``, and ``LoraIndependentExperts`` per-expert LoRA tensors
+    # are added as ``Shard(0)`` (shared-LoRA tensors are left replicated). For a
+    # non-PEFT / non-LoRA model this is a passthrough of ``get_parallel_plan()``.
+    from ..distributed.parallel_plan import get_runtime_parallel_plan
+
+    parallel_plan = get_runtime_parallel_plan(model)
     if parallel_plan is None or not getattr(parallel_plan, "extra_parallel_plan", None):
         raise NotImplementedError("ep_sharded_stream_load requires a model with an ExtraParallel parallel_plan.")
+
+    # Base-checkpoint keys (bare base-model FQNs) -> their PEFT-wrapped destinations
+    # (``base_model.model.<...>.base_layer.weight``). No-op when not PEFT.
+    from ..lora.weight_loading import make_peft_key_mapper
+
+    _apply_peft_override = make_peft_key_mapper(model, is_peft_model)
 
     # This streaming loader reads each rank's ExtraParallel slice with a dim-0
     # ``get_slice()[start:end]`` -- the same dim-0 assumption upstream's
@@ -554,11 +569,43 @@ def load_model_weights_ep_sharded(
     buffer_dict = {name: buffer.clone() for name, buffer in model.named_buffers()}
     param_shapes = {name: tuple(p.shape) for name, p in model.named_parameters()}
     parameter_names_to_load = set(param_shapes.keys())
-    model.to_empty(device=init_device)
-    dtensor_to_cpu = init_device == "cpu"
 
     parallel_state = get_parallel_state()
     key_to_file, file_to_path = _resolve_safetensors_shards(weights_path, **kwargs)
+
+    # Up-front bail for a converter that needs a *non-dim0-zero-pad* transform to
+    # reach the modeling layout (per-expert -> fused MoE stacking/cat, reshape,
+    # dtype change). Only a pure dim-0 zero-pad commutes with per-rank Shard(0)
+    # streaming; anything else needs the whole tensor set, which this loader can't
+    # provide -- so raise here (before materialising anything) and let the caller
+    # fall back to the whole-tensor ``load_model_weights`` (which applies the
+    # converter then EP-shards via DTensor).
+    #
+    # This MUST be an up-front scan over the *raw checkpoint keys*, not the
+    # per-destination check the main loop does: a fusion converter's per-expert
+    # keys (e.g. ``model.layers.0.mlp.experts.3.gate_proj.weight``) do not map 1:1
+    # to a model param -- the model holds the fused ``...experts.gate_up_proj`` --
+    # so ``name`` is absent from ``parameter_names_to_load`` and the loop's
+    # "unexpected key" skip would silently drop every per-expert key, leaving the
+    # fused expert un-loaded (all-zero) and the model quietly broken. Qwen3-MoE
+    # (HF per-expert checkpoint + ``Qwen3MoeCheckpointTensorConverter``) is the
+    # canonical case this guards against.
+    if converter is not None:
+        for raw_name in key_to_file:
+            bare_name = _convert_weight_key(raw_name, model)
+            if converter.can_handle(bare_name) and not checkpoint_converter_is_dim0_zero_pad(converter, bare_name):
+                raise NotImplementedError(
+                    f"ep_sharded_stream_load: checkpoint-tensor converter "
+                    f"{type(converter).__name__} needs a non-dim0-zero-pad transform for key "
+                    f"'{bare_name}' (e.g. per-expert -> fused MoE experts). Per-rank slice "
+                    f"streaming cannot reconstruct the whole tensor set from a single shard, so "
+                    f"this model/checkpoint combination is unsupported. Either save the checkpoint "
+                    f"in the model's fused expert layout, or disable train.ep_sharded_stream_load "
+                    f"to use the whole-tensor loader (broadcast or every-rank-read)."
+                )
+
+    model.to_empty(device=init_device)
+    dtensor_to_cpu = init_device == "cpu"
 
     keys_by_file: Dict[str, List[str]] = {}
     for key, fname in key_to_file.items():
@@ -572,18 +619,16 @@ def load_model_weights_ep_sharded(
     ):
         with safe_open(file_to_path[fname], framework="pt", device="cpu") as f:
             for raw_name in keys_by_file[fname]:
-                name = _convert_weight_key(raw_name, model)
+                # ``bare_name`` is the base-model FQN the converter is keyed on;
+                # ``name`` is the live model destination (PEFT ``base_layer`` FQN
+                # under PEFT, else identical to ``bare_name``).
+                bare_name = _convert_weight_key(raw_name, model)
+                name = _apply_peft_override(bare_name)
                 if name in buffer_dict:  # persistent buffers: read whole
                     buffer_dict[name] = f.get_tensor(raw_name).clone()
                     n_buf += 1
                     continue
                 if name not in parameter_names_to_load:
-                    if converter is not None and converter.can_handle(name):
-                        raise NotImplementedError(
-                            "ep_sharded_stream_load does not support checkpoint tensor conversion for "
-                            f"unexpected key '{name}'. Use load_model_weights or rank0_load_and_broadcast_weights "
-                            "for FP8/int8 scaled checkpoints."
-                        )
                     logger.info_rank0(f"Unexpected key in state dict: {name}.")
                     continue
 
@@ -596,8 +641,8 @@ def load_model_weights_ep_sharded(
                     # may have more rows than the checkpoint (``real0``): read the
                     # overlap and zero-fill the tail. Otherwise the checkpoint must
                     # match the model exactly.
-                    zero_pad = checkpoint_converter_is_dim0_zero_pad(converter, name)
-                    if converter is not None and converter.can_handle(name) and not zero_pad:
+                    zero_pad = checkpoint_converter_is_dim0_zero_pad(converter, bare_name)
+                    if converter is not None and converter.can_handle(bare_name) and not zero_pad:
                         # A converter that fuses/reshapes this key can't be streamed.
                         raise NotImplementedError(
                             f"ep_sharded_stream_load: converter applies a non-dim0-zero-pad "
@@ -645,17 +690,15 @@ def load_model_weights_ep_sharded(
                     _dispatch_parameter(model, name, tensor, dtensor_factory, None, dtensor_to_cpu)
                     n_ep += 1
                 else:
-                    tensor = f.get_tensor(raw_name)
-                    converted = maybe_convert_checkpoint_tensor(name, tensor, converter)
-                    if converted is None:
+                    if converter is not None and converter.can_handle(bare_name):
+                        # A streamable (dim-0 zero-pad) converter must only touch
+                        # ExtraParallel tables; a dense key would need its conversion
+                        # applied here, which this path does not do -> bail.
                         raise NotImplementedError(
-                            "ep_sharded_stream_load does not support checkpoint tensor conversion that buffers "
-                            f"dense key '{name}'. Use load_model_weights or rank0_load_and_broadcast_weights "
-                            "for FP8/int8 scaled checkpoints."
+                            f"ep_sharded_stream_load: converter handles non-ExtraParallel key '{name}'."
                         )
-                    _dispatch_parameter(
-                        model, converted.name, converted.tensor, dtensor_factory, parallel_plan, dtensor_to_cpu
-                    )
+                    tensor = f.get_tensor(raw_name)
+                    _dispatch_parameter(model, name, tensor, dtensor_factory, parallel_plan, dtensor_to_cpu)
                     n_dense += 1
                 parameter_names_to_load.discard(name)
         empty_cache()
@@ -663,8 +706,133 @@ def load_model_weights_ep_sharded(
     logger.info_rank0(
         f"ep_sharded_stream_load: read {n_ep} ExtraParallel-sliced, {n_dense} dense, {n_buf} buffer tensors/rank."
     )
+
+    if is_peft_model and adapter_path:
+        # Stream the LoRA adapter the same per-rank way as the base: independent MoE
+        # LoRA (3-D ``Shard(0)`` in the runtime plan) is read one dim-0 expert slice
+        # per rank; shared/dense LoRA (not in the plan) is read whole on every rank
+        # (replicated). When ``adapter_path`` is None (fresh build) the LoRA params
+        # stay un-loaded and are kaiming-A/zero-B init'd below.
+        _stream_lora_adapter_ep_sharded(
+            model,
+            adapter_path,
+            init_device,
+            dtensor_factory,
+            parallel_plan,
+            parameter_names_to_load,
+            param_shapes,
+            parallel_state,
+            dtensor_to_cpu,
+        )
+
     post_process_after_weight_loading(
         model, buffer_dict, parameter_names_to_load, dtensor_factory, dtensor_to_cpu=dtensor_to_cpu
+    )
+
+
+@torch.no_grad()
+def _stream_lora_adapter_ep_sharded(
+    model: "nn.Module",
+    adapter_path: str,
+    init_device: str,
+    dtensor_factory: Optional[Callable[["torch.Tensor", Any, Any], "torch.Tensor"]],
+    parallel_plan: Any,
+    parameter_names_to_load: set,
+    param_shapes: Dict[str, tuple],
+    parallel_state: Any,
+    dtensor_to_cpu: bool,
+    adapter_name: str = "default",
+) -> None:
+    """Per-rank ExtraParallel-slice streaming of a PEFT adapter.
+
+    The adapter companion to :func:`load_model_weights_ep_sharded`. Reads the
+    consolidated PEFT adapter (``adapter_model.safetensors``, full gathered
+    ``[E, ...]`` tensors) and dispatches per tensor by the runtime ``parallel_plan``:
+
+    * **independent** MoE LoRA tensors (3-D, ``Shard(0)`` over the ep group) are read
+      one dim-0 expert slice per rank -- ``get_slice()[start:end]`` -- so each rank
+      only ever materialises its ``[E/ep, ...]`` chunk (no whole-tensor host copy),
+      then ``dtensor_factory`` shards it over the ``ep_fsdp`` sub-mesh (dispatch with
+      ``parallel_plan=None`` since it's already the local slice);
+    * **shared** MoE LoRA (2-D) and **dense** LoRA tensors are not in the plan, so
+      every rank reads them whole (replicated) and dispatches through the plan (FSDP
+      shards them normally) -- matching the user contract "shared 不用切分, each rank
+      reads the full adapter".
+
+    A pickled ``.bin`` adapter can't be partially read, so it falls back to the
+    whole-file :func:`load_lora_weights` (correct, but independent LoRA is not
+    streamed per-rank). Newly saved adapters are safetensors (see
+    :func:`save_lora_adapter_with_dcp`).
+    """
+    from ..lora.state_dict import _find_adapter_file, insert_adapter_name
+
+    try:
+        file_path, is_safetensors = _find_adapter_file(adapter_path)
+    except FileNotFoundError:
+        logger.warning_rank0(f"ep_sharded adapter: no adapter file under {adapter_path}; skipping.")
+        return
+
+    if not is_safetensors:
+        from ..lora.weight_loading import load_lora_weights
+
+        logger.warning_rank0(
+            f"ep_sharded adapter: {adapter_path} is a pickled .bin (not sliceable); falling back to "
+            "whole-file load_lora_weights (independent LoRA won't be streamed per-rank)."
+        )
+        load_lora_weights(
+            model,
+            adapter_path,
+            init_device,
+            dtensor_factory,
+            parameter_names_to_load=parameter_names_to_load,
+            parallel_plan=parallel_plan,
+            adapter_name=adapter_name,
+        )
+        return
+
+    n_ep = n_rep = 0
+    with safe_open(file_path, framework="pt", device="cpu") as f:
+        for raw_key in f.keys():
+            name = insert_adapter_name(raw_key, adapter_name)
+            if name not in parameter_names_to_load:
+                logger.info_rank0(f"ep_sharded adapter: unexpected key {name}.")
+                continue
+            shard_group = parallel_plan._get_shard_parameter_groupname(name)
+            if shard_group is not None:
+                # independent per-expert LoRA -> read only this rank's dim-0 slice.
+                target0 = param_shapes[name][0]
+                para_size = (
+                    parallel_state.extra_parallel_sizes[shard_group]
+                    if parallel_state.extra_parallel_enabled(shard_group)
+                    else 1
+                )
+                para_rank = (
+                    parallel_state.extra_parallel_rank(shard_group)
+                    if parallel_state.extra_parallel_enabled(shard_group)
+                    else 0
+                )
+                sl = f.get_slice(raw_key)
+                real0 = sl.get_shape()[0]
+                expected_full0 = target0 * para_size
+                if real0 != expected_full0:
+                    raise RuntimeError(
+                        f"ep_sharded adapter {name}: file dim0={real0} != model dim0={expected_full0} "
+                        f"(independent LoRA expects the gathered [E, ...] tensor)."
+                    )
+                start = para_rank * target0
+                tensor = sl[start : start + target0]
+                _dispatch_parameter(model, name, tensor, dtensor_factory, None, dtensor_to_cpu)
+                n_ep += 1
+            else:
+                # shared / dense LoRA -> read whole (replicated); FSDP shards via plan.
+                tensor = f.get_tensor(raw_key)
+                _dispatch_parameter(model, name, tensor, dtensor_factory, parallel_plan, dtensor_to_cpu)
+                n_rep += 1
+            parameter_names_to_load.discard(name)
+
+    logger.info_rank0(
+        f"ep_sharded adapter: streamed {n_ep} EP-sliced (independent) + {n_rep} whole "
+        "(shared/dense) adapter tensors/rank."
     )
 
 
@@ -705,13 +873,12 @@ def rank0_load_and_broadcast_weights(
     # lora-layer: xxx.xxx.weight -> base_model.model.xxx.xxx.base_layer.weight
     is_peft_model = kwargs.get("is_peft_model", False)
     adapter_path = kwargs.get("adapter_path", None)
-    if is_peft_model:
-        from ..lora.weight_loading import build_lora_key_overrides
+    from ..lora.weight_loading import make_peft_key_mapper
 
-        lora_key_overrides = build_lora_key_overrides(model)
+    _apply_peft_override = make_peft_key_mapper(model, is_peft_model)
 
     converter = get_checkpoint_tensor_converter(model)
-    if converter is None and is_peft_model and hasattr(model, "get_base_model"):
+    if converter is None and is_peft_model:
         converter = get_checkpoint_tensor_converter(model.get_base_model())
     global_rank = get_parallel_state().global_rank
     torch_device = _get_communication_device(init_device)
@@ -998,12 +1165,9 @@ def rank0_load_and_broadcast_weights(
                         # mapped to their PEFT-wrapped ``...base_layer.weight``
                         # destination when the experts module is wrapped by
                         # ``LoraSharedExperts`` / ``LoraIndependentExperts``.
-                        # Bare-key lookup intentionally: ``lora_key_overrides``
-                        # is keyed by base-model FQNs (no ``base_model.model.``
-                        # prefix), and the converter is given the bare key so
-                        # MoE per-expert pattern matches still fire.
-                        if is_peft_model:
-                            key = lora_key_overrides.get(key, "base_model.model." + key)
+                        # Bare key in (converter matches on base-model FQNs) ->
+                        # live-model key out; no-op when not PEFT.
+                        key = _apply_peft_override(key)
                         logger.info_rank0(f"loading {key=}")
                         if _is_all_zero_tensor(tensor):
                             logger.warning_rank0(
@@ -1065,9 +1229,7 @@ def rank0_load_and_broadcast_weights(
                 # above -- finalize() may emit merged keys after every shard
                 # has been read, e.g. the last gate/up pair for the
                 # Qwen3-MoE per-expert -> fused converter.
-                fin_name = result.name
-                if is_peft_model:
-                    fin_name = lora_key_overrides.get(fin_name, "base_model.model." + fin_name)
+                fin_name = _apply_peft_override(result.name)
                 metadata = BroadcastMetadata(False, fin_name, result.tensor.shape, result.tensor.dtype)
                 tensor = result.tensor
             else:

--- a/veomni/utils/save_safetensor_utils.py
+++ b/veomni/utils/save_safetensor_utils.py
@@ -247,7 +247,13 @@ def save_lora_adapter_with_dcp(
     All ranks must call this function. It performs:
     1. Extract LoRA-only state from the live model.
     2. Save with ``dcp.save`` in parallel to a temporary DCP directory.
-    3. Consolidate on rank 0 into ``adapter_model.bin`` and ``adapter_config.json``.
+    3. Consolidate on rank 0 into ``adapter_model.safetensors`` and ``adapter_config.json``.
+
+    The consolidated adapter is written as **safetensors** (not a pickled ``.bin``)
+    so a per-rank ExtraParallel-slice reader (``load_model_weights_ep_sharded`` under
+    ``is_peft_model``) can stream only each rank's expert rows of an *independent*
+    MoE-LoRA adapter instead of every rank reading the whole gathered ``[E, ...]``
+    tensor. ``load_adapter_state_dict`` already prefers ``adapter_model.safetensors``.
     """
     from veomni.lora import is_veomni_lora_model
     from veomni.lora.state_dict import get_lora_state_dict
@@ -328,8 +334,11 @@ def save_lora_adapter_with_dcp(
             save_checkpoint_path=dcp_save_path,
             ckpt_manager="dcp",
         )
-        adapter_model_file = os.path.join(save_path, "adapter_model.bin")
-        _save_state_dict(consolidated_state, adapter_model_file, safe_serialization=False)
+        # safetensors needs contiguous, non-aliased tensors; consolidation returns
+        # fresh tensors but ``.contiguous()`` is a cheap no-op when already so.
+        consolidated_state = {k: v.contiguous() for k, v in consolidated_state.items()}
+        adapter_model_file = os.path.join(save_path, "adapter_model.safetensors")
+        _save_state_dict(consolidated_state, adapter_model_file, safe_serialization=True)
 
         # VeOmniLoraModel writes a single PEFT-loadable adapter_config.json
         # (MoE metadata, if any, lives in its ``veomni_lora`` block -- no


### PR DESCRIPTION
## Summary

Extends the per-rank EP-slice weight loader (`ep_sharded_stream_load`) to **LoRA-wrapped (PEFT) MoE models**, and closes the last gap that kept MoE-LoRA + expert parallelism GPU-only by adding an **NPU fused MoE-LoRA kernel**. Net effect: an EP-sharded MoE model — with or without LoRA, on GPU or NPU — can be loaded via any of the three loaders (plain / rank-0 broadcast / `ep_sharded_stream_load`) and trained/inferred with EP.

## What's included

### 1. PEFT support for `ep_sharded_stream_load` (`veomni/models/module_utils.py`)
- **Base experts**: fused `...experts.gate_up_proj` / `down_proj` tensors stream from the base checkpoint straight into the wrapped `...base_layer.weight` destinations; each rank reads only its `[E/ep, …]` dim-0 slice.
- **Adapter** (`_stream_lora_adapter_ep_sharded`, reads `adapter_model.safetensors`):
  - *independent* MoE-LoRA (EP-sharded in the runtime plan) → each rank reads its `[E/ep, r, …]` slice;
  - *shared* / dense LoRA → read whole by every rank (FSDP then shards).
- **Safety guard**: if a model's `CheckpointTensorConverter` needs a non-dim0-zero-pad transform (e.g. Qwen3-MoE's per-expert→fused fusion), streaming raises a clear `NotImplementedError` instead of silently corrupting weights, pointing the user at a fused checkpoint or the whole-tensor loader.

### 2. NPU fused MoE-LoRA EP kernel (`veomni/lora/ops/npu_moe_group_gemm.py`, new)
- Adds `npu_fused_lora_moe_forward` (shared / Mode 2) and `npu_fused_independent_lora_moe_forward` (independent / Mode 1), drop-in matching the Triton kernels' signature.
- MoE-LoRA and EP are orthogonal: the kernel **reuses the base NPU MoE EP primitives** (`dispatch_preprocess` / `alltoall_dispatch` / `alltoall_combine` + the `npu_group_gemm` autograd `Function`) and only injects the three seed-style LoRA deltas (gate/up pre-SwiGLU, down post-mid). Backward is derived by autograd — no hand-written kernel. Math mirrors `moe_layers._eager_forward` line-for-line.
- `bind_lora_moe_kernels("npu")` now binds these (previously cleared the pointers → eager fallback, which can't do EP). Both backends' LoRA kernels now live side-by-side under `veomni/lora/ops/` (`moe_group_gemm.py` = Triton, `npu_moe_group_gemm.py` = NPU).

### 3. Supporting refactors
- `make_peft_key_mapper` centralized in `veomni/lora/weight_loading.py` (removes duplicate PEFT-key remap logic across the three loaders).
- `get_runtime_parallel_plan` hardened to return `None` gracefully when a model has no `get_parallel_plan`, collapsing redundant guards in `module_utils.py`.
- `_reset_moe_wrapper` fix so LoRA params reset to kaiming-A / zero-B correctly (`_lora_fresh_reset_done` flag).
- LoRA adapters now saved as **`adapter_model.safetensors`** (`save_safetensor_utils.py`), required for per-rank slicing.

### 4. Tests + CI
- `tests/utils/test_moe_ep_sharded_load_matrix.py` (new): device-agnostic non-PEFT matrix — a fake MoE model × {merged, per-expert} checkpoints × {plain, rank-0 broadcast, `ep_sharded`} loaders, including the `NotImplementedError` bail case.
- `tests/lora/test_moe_lora_ep_sharded_stream_load.py` (new): trainer-driven PEFT test asserting streamed LoRA weights are **bit-identical** to the broadcast loader, for both independent and shared LoRA. Auto-selects `fused_triton` (GPU) / `fused_npu` (NPU).
- Wired into `gpu_unit_tests.yml` (both) and `npu_unit_tests.yml` (both — the PEFT test now validates the NPU kernel forward + the loader on real Ascend hardware).