### PR TITLE
[ci] test: stabilize DeepSeek V4 compressor test

### DIFF
--- a/tests/ops/test_deepseek_v4_kernels.py
+++ b/tests/ops/test_deepseek_v4_kernels.py
@@ -375,6 +375,12 @@ def test_deepseek_v4_packed_compressors_match_independent_sequences():
     modeling.veomni_dsa_indexer_backend.bind(SimpleNamespace(dsa_indexer_backend="eager"))
     for compressor_cls in (modeling.DeepseekV4HCACompressor, modeling.DeepseekV4CSACompressor):
         compressor = compressor_cls(config)
+        # Direct construction bypasses DeepseekV4PreTrainedModel._init_weights,
+        # which zeros the torch.empty-backed position biases in production.
+        with torch.no_grad():
+            compressor.position_bias.zero_()
+            if isinstance(compressor, modeling.DeepseekV4CSACompressor):
+                compressor.indexer.position_bias.zero_()
         packed_kv, packed_bias = compressor(
             hidden_states,
             q_residual,


### PR DESCRIPTION
### What does this PR do?

Fix the flaky DeepSeek V4 packed-compressor unit test that failed in the postmerge GPU unit workflow: https://github.com/ByteDance-Seed/VeOmni/actions/runs/29341032223.

The test constructed HCA and CSA compressor submodules directly, bypassing the production model initializer that zeros their `torch.empty`-backed position biases. Depending on allocator contents, those parameters could contain NaNs and make an otherwise equivalent packed-versus-independent comparison fail.

### Checklist Before Starting

- Related change: #912
- PR title follows `[{modules}] {type}: {description}` format.

### Test

- `pytest -q tests/ops/test_deepseek_v4_kernels.py::test_deepseek_v4_packed_compressors_match_independent_sequences` — passed
- Same targeted test with `torch.use_deterministic_algorithms(True, warn_only=True)` — passed
- `pytest -q tests/ops/test_deepseek_v4_kernels.py` — 7 passed, 7 skipped
- `make quality` — passed

### API and Usage Example

N/A — test-only change.

### Design & Code Changes

- Explicitly zero the HCA/CSA compressor position bias after direct construction.
- Also zero the CSA compressor's nested indexer position bias.
- Leave production and patchgen-generated model code unchanged.

### Checklist Before Submitting

- [x] Applied pre-commit quality checks.
- [x] Added deterministic regression coverage through the existing unit test.
- [x] Documentation is not required for this test-only change.
