### PR TITLE
[data, model] fix: coalesce pad_to_length FA cu-seqlens on NPU

### DIFF
--- a/tests/data/test_collators.py
+++ b/tests/data/test_collators.py
@@ -99,8 +99,8 @@ def test_data_collator_pad_to_length_sp_disabled(monkeypatch, features_two_sampl
     exp_attn = torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1]], dtype=torch.long)
     exp_pos = torch.tensor([[0, 1, 2, 0, 1, 0, 0, 0]], dtype=torch.long)
     exp_labels = torch.tensor([[2, 3, 4, IGNORE_INDEX, 2, IGNORE_INDEX, IGNORE_INDEX, IGNORE_INDEX]], dtype=torch.long)
-    exp_cu_seq_lens = torch.tensor([0, 3, 5, 6, 7, 8], dtype=torch.int32)
-    exp_linear_attn_cu_seq_lens = torch.tensor([0, 3, 5, 8], dtype=torch.int32)
+    # pad_to_length tail is coalesced for both FA and linear-attn cu-seqlens.
+    exp_cu_seq_lens = torch.tensor([0, 3, 5, 8], dtype=torch.int32)
     exp_max_length = 3
 
     assert torch.equal(out["input_ids"], exp_input_ids)
@@ -109,7 +109,8 @@ def test_data_collator_pad_to_length_sp_disabled(monkeypatch, features_two_sampl
     assert torch.equal(out["labels"], exp_labels)
     assert torch.equal(out["cu_seq_lens_q"], exp_cu_seq_lens)
     assert torch.equal(out["cu_seq_lens_k"], exp_cu_seq_lens)
-    assert torch.equal(out["linear_attn_cu_seq_lens_q"], exp_linear_attn_cu_seq_lens)
+    assert torch.equal(out["linear_attn_cu_seq_lens_q"], exp_cu_seq_lens)
+    assert int(out["tail_padding_length"]) == 3
     assert out["max_length_q"] == exp_max_length
     assert out["max_length_k"] == exp_max_length
 
@@ -138,8 +139,7 @@ def test_seqcls_collator_pad_to_length_sp_enabled(monkeypatch, features_two_samp
     exp_attn = torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1]], dtype=torch.long)
     exp_pos = torch.tensor([[0, 1, 2, 0]], dtype=torch.long)
     exp_labels = torch.tensor([[3, 4, IGNORE_INDEX, 2]], dtype=torch.long)
-    exp_cu_seq_lens = torch.tensor([0, 3, 5, 6, 7, 8], dtype=torch.int32)
-    exp_linear_attn_cu_seq_lens = torch.tensor([0, 3, 5, 8], dtype=torch.int32)
+    exp_cu_seq_lens = torch.tensor([0, 3, 5, 8], dtype=torch.int32)
     exp_max_length = 3
 
     assert torch.equal(out["input_ids"], exp_input_ids)
@@ -148,7 +148,8 @@ def test_seqcls_collator_pad_to_length_sp_enabled(monkeypatch, features_two_samp
     assert torch.equal(out["labels"], exp_labels)
     assert torch.equal(out["cu_seq_lens_q"], exp_cu_seq_lens)
     assert torch.equal(out["cu_seq_lens_k"], exp_cu_seq_lens)
-    assert torch.equal(out["linear_attn_cu_seq_lens_q"], exp_linear_attn_cu_seq_lens)
+    assert torch.equal(out["linear_attn_cu_seq_lens_q"], exp_cu_seq_lens)
+    assert int(out["tail_padding_length"]) == 3
     assert out["max_length_q"] == exp_max_length
     assert out["max_length_k"] == exp_max_length
 
@@ -161,8 +162,7 @@ def test_seqcls_collator_pad_to_length_sp_enabled(monkeypatch, features_two_samp
     exp_attn = torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1]], dtype=torch.long)
     exp_pos = torch.tensor([[1, 0, 0, 0]], dtype=torch.long)
     exp_labels = torch.tensor([[IGNORE_INDEX, IGNORE_INDEX, IGNORE_INDEX, IGNORE_INDEX]], dtype=torch.long)
-    exp_cu_seq_lens = torch.tensor([0, 3, 5, 6, 7, 8], dtype=torch.int32)
-    exp_linear_attn_cu_seq_lens = torch.tensor([0, 3, 5, 8], dtype=torch.int32)
+    exp_cu_seq_lens = torch.tensor([0, 3, 5, 8], dtype=torch.int32)
     exp_max_length = 3
 
     assert torch.equal(out["input_ids"], exp_input_ids)
@@ -171,7 +171,8 @@ def test_seqcls_collator_pad_to_length_sp_enabled(monkeypatch, features_two_samp
     assert torch.equal(out["labels"], exp_labels)
     assert torch.equal(out["cu_seq_lens_q"], exp_cu_seq_lens)
     assert torch.equal(out["cu_seq_lens_k"], exp_cu_seq_lens)
-    assert torch.equal(out["linear_attn_cu_seq_lens_q"], exp_linear_attn_cu_seq_lens)
+    assert torch.equal(out["linear_attn_cu_seq_lens_q"], exp_cu_seq_lens)
+    assert int(out["tail_padding_length"]) == 3
     assert out["max_length_q"] == exp_max_length
     assert out["max_length_k"] == exp_max_length
 

--- a/tests/data/test_prepare_fa_kwargs.py
+++ b/tests/data/test_prepare_fa_kwargs.py
@@ -1,5 +1,6 @@
 import torch
 
+from veomni.data.data_collator import add_flash_attention_kwargs_from_position_ids
 from veomni.utils.seqlen_pos_transform_utils import (
     coalesce_tail_padding_cu_seqlens,
     prepare_fa_kwargs_from_position_ids,
@@ -93,12 +94,11 @@ def test_linear_attn_cu_seqlens_coalesces_tail_padding():
     ).unsqueeze(0)
 
     (cu_seq_lens_q, _), _ = prepare_fa_kwargs_from_position_ids(pos)
-    linear_attn_cu_seq_lens_q = coalesce_tail_padding_cu_seqlens(cu_seq_lens_q, tail_padding_length)
+    coalesced = coalesce_tail_padding_cu_seqlens(cu_seq_lens_q, tail_padding_length)
 
-    # FlashAttention still sees the zero-padded tail exactly as encoded by position_ids.
+    # Raw prepare_fa_kwargs still encodes one segment per pad token.
     assert torch.equal(cu_seq_lens_q, torch.tensor([0, 4, 7, 8, 9, 10], dtype=torch.int32))
-    # Linear-attention kernels see one independent padding segment instead of one segment per pad token.
-    assert torch.equal(linear_attn_cu_seq_lens_q, torch.tensor([0, 4, 7, 10], dtype=torch.int32))
+    assert torch.equal(coalesced, torch.tensor([0, 4, 7, 10], dtype=torch.int32))
 
 
 def test_linear_attn_cu_seqlens_preserves_real_one_token_sequence():
@@ -112,10 +112,47 @@ def test_linear_attn_cu_seqlens_preserves_real_one_token_sequence():
     ).unsqueeze(0)
 
     (cu_seq_lens_q, _), _ = prepare_fa_kwargs_from_position_ids(pos)
-    linear_attn_cu_seq_lens_q = coalesce_tail_padding_cu_seqlens(cu_seq_lens_q, tail_padding_length)
+    coalesced = coalesce_tail_padding_cu_seqlens(cu_seq_lens_q, tail_padding_length)
 
     assert torch.equal(cu_seq_lens_q, torch.tensor([0, 4, 5, 6, 7, 8], dtype=torch.int32))
-    assert torch.equal(linear_attn_cu_seq_lens_q, torch.tensor([0, 4, 5, 8], dtype=torch.int32))
+    assert torch.equal(coalesced, torch.tensor([0, 4, 5, 8], dtype=torch.int32))
+
+
+def test_add_flash_attention_kwargs_coalesces_fa_and_linear_cu_seqlens():
+    real_lengths = [4, 3]
+    tail_padding_length = 3
+    pos = torch.cat(
+        (
+            make_pos_ids_concat(real_lengths),
+            torch.zeros(tail_padding_length, dtype=torch.long),
+        )
+    ).unsqueeze(0)
+    batch = {"position_ids": pos}
+
+    cu_q, cu_k, max_q, max_k = add_flash_attention_kwargs_from_position_ids(batch, tail_padding_length)
+    expected = torch.tensor([0, 4, 7, 10], dtype=torch.int32)
+
+    assert torch.equal(cu_q, expected)
+    assert torch.equal(cu_k, expected)
+    assert torch.equal(batch["cu_seq_lens_q"], expected)
+    assert torch.equal(batch["cu_seq_lens_k"], expected)
+    assert torch.equal(batch["linear_attn_cu_seq_lens_q"], expected)
+    assert int(batch["tail_padding_length"]) == tail_padding_length
+    assert max_q == 4 and max_k == 4
+    assert torch.equal(
+        valid_seqlens_from_cu_seqlens(cu_q, tail_padding_length=tail_padding_length),
+        torch.tensor([4, 3], dtype=torch.int32),
+    )
+
+
+def test_valid_seqlens_strips_coalesced_pad_segment():
+    coalesced = torch.tensor([0, 4, 7, 10], dtype=torch.int32)
+    expected = torch.tensor([4, 3], dtype=torch.int32)
+
+    assert torch.equal(
+        valid_seqlens_from_cu_seqlens(coalesced, tail_padding_length=3),
+        expected,
+    )
 
 
 def test_valid_seqlens_with_exact_tail_padding_preserves_real_one_token_sequence():
@@ -137,6 +174,11 @@ if __name__ == "__main__":
         "linear_attn_cu_seqlens_preserves_real_one_token_sequence",
         test_linear_attn_cu_seqlens_preserves_real_one_token_sequence,
     )
+    run_test(
+        "add_flash_attention_kwargs_coalesces_fa_and_linear_cu_seqlens",
+        test_add_flash_attention_kwargs_coalesces_fa_and_linear_cu_seqlens,
+    )
+    run_test("valid_seqlens_strips_coalesced_pad_segment", test_valid_seqlens_strips_coalesced_pad_segment)
     run_test(
         "valid_seqlens_with_exact_tail_padding_preserves_real_one_token_sequence",
         test_valid_seqlens_with_exact_tail_padding_preserves_real_one_token_sequence,

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -63,10 +63,15 @@ def add_flash_attention_kwargs_from_position_ids(
     Args:
         batch: The batch dictionary containing position_ids. Will be modified in-place to add
                cu_seq_lens_q, cu_seq_lens_k, max_length_q, max_length_k, and
-               linear_attn_cu_seq_lens_q.
+               linear_attn_cu_seq_lens_q. When ``linear_attn_tail_padding_length > 0``,
+               also stores ``tail_padding_length`` (0-d ``torch.int32`` tensor) so
+               downstream valid-seqlens helpers can strip the coalesced pad segment and
+               distributed/PP stages preserve the metadata.
         linear_attn_tail_padding_length: Number of known padding tokens appended at the tail by
-               collators. These are kept in FlashAttention cu-seqlens but coalesced into one segment
-               for linear-attention kernels that compile or allocate per segment.
+               collators (``pad_to_length`` / SP pad). ``position_ids == 0`` encodes each pad
+               token as its own 1-token boundary; both FlashAttention and linear-attention
+               cu-seqlens coalesce that tail into one segment. Ascend NPU
+               ``npu_fusion_attention`` SIGSEGVs on the uncoalesced per-token form.
 
     Returns:
         Tuple of (cu_seq_lens_q, cu_seq_lens_k, max_length_q, max_length_k) for additional use.
@@ -76,14 +81,24 @@ def add_flash_attention_kwargs_from_position_ids(
         position_ids = position_ids[:, 0, :]
     (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(position_ids)
 
+    if linear_attn_tail_padding_length > 0:
+        cu_seq_lens_q = coalesce_tail_padding_cu_seqlens(cu_seq_lens_q, linear_attn_tail_padding_length)
+        cu_seq_lens_k = cu_seq_lens_q
+        seqlens = cu_seq_lens_q[1:] - cu_seq_lens_q[:-1]
+        max_length_q = int(seqlens.max().item()) if seqlens.numel() else 0
+        max_length_k = max_length_q
+        # Keep as a 0-d tensor so PP / distributed stages preserve the metadata.
+        batch["tail_padding_length"] = torch.tensor(
+            linear_attn_tail_padding_length,
+            dtype=torch.int32,
+            device=cu_seq_lens_q.device,
+        )
+
     batch["cu_seq_lens_q"] = cu_seq_lens_q
     batch["cu_seq_lens_k"] = cu_seq_lens_k
     batch["max_length_q"] = max_length_q
     batch["max_length_k"] = max_length_k
-    batch["linear_attn_cu_seq_lens_q"] = coalesce_tail_padding_cu_seqlens(
-        cu_seq_lens_q,
-        linear_attn_tail_padding_length,
-    )
+    batch["linear_attn_cu_seq_lens_q"] = cu_seq_lens_q
 
     return cu_seq_lens_q, cu_seq_lens_k, max_length_q, max_length_k
 
@@ -523,7 +538,11 @@ class PostCollator(DataCollator):
 @dataclass
 class SeqlensComputePostCollator(DataCollator):
     def __call__(self, micro_batch: Dict[str, torch.Tensor]):
-        seq_lens = valid_seqlens_from_cu_seqlens(micro_batch["cu_seq_lens_q"]).tolist()
+        tail_padding_length = micro_batch.get("tail_padding_length")
+        seq_lens = valid_seqlens_from_cu_seqlens(
+            micro_batch["cu_seq_lens_q"],
+            tail_padding_length=int(tail_padding_length) if tail_padding_length is not None else None,
+        ).tolist()
         return seq_lens
 
 

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -86,8 +86,13 @@ CACHE_DIR = os.path.expanduser(os.getenv("CACHE_DIR", os.path.join("~/.cache", "
 def _compute_seqlens(micro_batch: Dict[str, "torch.Tensor"]) -> List[int]:
     if "cu_seq_lens_q" in micro_batch:
         # packed micro batch
-        seqlens = valid_seqlens_from_cu_seqlens(micro_batch["cu_seq_lens_q"]).tolist()
+        tail_padding_length = micro_batch.get("tail_padding_length")
+        seqlens = valid_seqlens_from_cu_seqlens(
+            micro_batch["cu_seq_lens_q"],
+            tail_padding_length=int(tail_padding_length) if tail_padding_length is not None else None,
+        ).tolist()
         return seqlens
+
     elif "attention_mask" in micro_batch:
         # unpacked sample
         attention_mask = micro_batch["attention_mask"]

--- a/veomni/utils/seqlen_pos_transform_utils.py
+++ b/veomni/utils/seqlen_pos_transform_utils.py
@@ -106,12 +106,12 @@ def coalesce_tail_padding_cu_seqlens(cu_seqlens: torch.Tensor, tail_padding_leng
     Coalesce per-token tail padding segments into one sequence segment.
 
     ``position_ids == 0`` marks packed sequence boundaries. When a collator pads
-    the tail with zero position ids, the FlashAttention cu-seqlens intentionally
-    contains one synthetic 1-token segment per padding token. Some linear
-    attention kernels compile or allocate per segment, so forwarding those
-    padding-only boundaries can create many unnecessary kernel shapes. This
-    helper preserves the padded tensor length while presenting the tail padding
-    as one independent segment for linear-attention style kernels.
+    the tail with zero position ids, ``prepare_fa_kwargs_from_position_ids`` builds
+    one synthetic 1-token segment per padding token. FlashAttention on Ascend NPU
+    (``npu_fusion_attention``) SIGSEGVs on that uncoalesced form, and some linear
+    attention kernels also compile or allocate per segment. This helper preserves
+    the padded tensor length while presenting the tail padding as one independent
+    segment for both FlashAttention and linear-attention style kernels.
     """
     if tail_padding_length <= 0:
         return cu_seqlens


### PR DESCRIPTION
[data, model] fix: coalesce pad_to_length FA cu-seqlens on NPU

### What does this PR do?

> Follow-up to #845. That PR coalesced `pad_to_length` / SP tail padding into one segment for **linear-attention** `cu_seqlens` only, while FlashAttention kept the per-token `position_ids==0` boundaries (`[..., n, n+1, ..., n+pad]`).
>
> On Ascend NPU, `npu_fusion_attention` **SIGSEGVs** when FA still receives that uncoalesced form (reproduced with Qwen3.6 dense/MoE, `pad_to_length=true`, FA2-NPU, ~optimizer step 2). Isolating with `pad_to_length=false` avoided the crash; restoring pad + this coalesce keeps fixed-length packing and is stable.
>
> This PR applies the same `coalesce_tail_padding_cu_seqlens` to **FA** `cu_seq_lens_q/k`, recomputes `max_length_*`, stores `tail_padding_length` on the batch, and threads it into `valid_seqlens_from_cu_seqlens` callers so the coalesced pad segment is not counted as a real sequence.

### Checklist Before Starting

- Search for relative PRs/issues and link here: #845 (GDN/linear-attn coalesce, merged)
- PR title follows `[{modules}] {type}: {description}` format

### Test

> Unit:
> - `tests/data/test_prepare_fa_kwargs.py` — FA+linear share coalesced cu-seqlens; valid seqlens strip coalesced pad
> - `tests/data/test_collators.py` — pad_to_length collator expectations updated
>
> Online (910B2 Ascend, canary, `pad_to_length=true` + this patch):
> - Qwen3.6-35B-A3B MoE 1×16 SP8: past old crash window, progressed through DCP `global_step_20+`
> - Qwen3.6-27B dense 1×16 SP8: past step-2 SIGSEGV, DCP through `global_step_6+`
> - Without patch / with uncoalesced FA seqlens: `exitcode: -11` in FA after ~optimizer step 2

### API and Usage Example

> No new public CLI flags. Behavior change when `pad_to_length` / SP adds known tail padding:
> - Before: FA `cu_seq_lens_*` uncoalesced; linear coalesced
> - After: both FA and linear use coalesced cu-seqlens; batch may include `tail_padding_length`

```python
# inside add_flash_attention_kwargs_from_position_ids(..., linear_attn_tail_padding_length=P)
# FA and linear_attn_cu_seq_lens_q both become coalesce_tail_padding_cu_seqlens(...)
# batch["tail_padding_length"] = P  # for valid_seqlens_from_cu_seqlens(..., tail_padding_length=P)
```

### Design & Code Changes

> Root cause: packed Qwen uses `position_ids==0` as sequence boundaries. `pad_to_length` appends zeros → FA builds one length-1 segment per pad token. GDN already coalesced (#845); FA did not → NPU FA kernel crash.
>
> Changes:
> 1. `veomni/data/data_collator.py` — coalesce FA cu-seqlens when tail pad > 0; set `tail_padding_length`; `SeqlensComputePostCollator` passes it through
> 2. `veomni/utils/helper.py` — `_compute_seqlens` honors `tail_padding_length`
> 3. `veomni/utils/seqlen_pos_transform_utils.py` — docstring: FA/NPU also needs coalesce
> 4. tests updated / extended

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks (`git diff --check` clean)
- Added/updated documentation (docstrings)
- Added tests to cover FA coalesce path
