### PR TITLE
[ckpt] fix: disable distributed HF save on NPU to avoid intermittent bf16 mismatch under HSDP

### DIFF
--- a/veomni/utils/save_safetensor_utils.py
+++ b/veomni/utils/save_safetensor_utils.py
@@ -206,17 +206,13 @@ def save_hf_safetensor(
     from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
 
     # Disable the distributed `HuggingFaceStorageWriter` path on NPU.  Under
-    # HSDP replicate ranks independently cast fp32→bf16 on-device and write
+    # HSDP replicate ranks independently cast fp32->bf16 on-device and write
     # per-rank safetensors files.  When the casts are not bit-exact (~1 ULP on
     # Ascend 910B) the consolidation step bakes in whichever rank's data it
     # reads last, causing an intermittent mismatch against the fp32 DCP
     # checkpoint.  Route through the legacy rank-0 path until the underlying
-    # fp32→bf16 determinism issue is resolved in the NPU stack.
-    use_distributed = (
-        is_torch_version_greater_than("2.9")
-        and ckpt_manager == "dcp"
-        and not IS_NPU_AVAILABLE
-    )
+    # fp32->bf16 determinism issue is resolved in the NPU stack.
+    use_distributed = is_torch_version_greater_than("2.9") and ckpt_manager == "dcp" and not IS_NPU_AVAILABLE
 
     # Ensure all GPU operations are complete before reading tensor data for saving
     synchronize()

--- a/veomni/utils/save_safetensor_utils.py
+++ b/veomni/utils/save_safetensor_utils.py
@@ -231,19 +231,8 @@ def save_hf_safetensor(
         fqn_to_index_mapping = resolve_fqn_to_index_mapping_for_save(model, fqn_to_index_mapping)
         _save_hf_safetensor_distributed(model, save_hf_safetensor_path, fqn_to_index_mapping, model_assets)
     else:
-        # Legacy path is rank-0 only; non-rank-0 waits at the barrier below.
-        # Resolve ``is_rank_0`` from the process group when the caller did not
-        # explicitly pass it (e.g. when the distributed path was disabled at
-        # runtime via the NPU guard).
-        if not is_rank_0 and dist.is_initialized():
-            is_rank_0 = dist.get_rank() == 0
+        # Legacy path is rank-0 only; non-rank-0 waits at the barrier below
         if is_rank_0:
-            if not save_checkpoint_path:
-                raise ValueError(
-                    "save_checkpoint_path is required for the legacy HF safetensors path. "
-                    "The distributed `HuggingFaceStorageWriter` path is disabled on this platform "
-                    "(e.g. NPU), so the legacy rank-0 conversion from a DCP checkpoint must be used."
-                )
             _save_hf_safetensor_legacy(
                 save_checkpoint_path,
                 save_hf_safetensor_path,

--- a/veomni/utils/save_safetensor_utils.py
+++ b/veomni/utils/save_safetensor_utils.py
@@ -231,8 +231,19 @@ def save_hf_safetensor(
         fqn_to_index_mapping = resolve_fqn_to_index_mapping_for_save(model, fqn_to_index_mapping)
         _save_hf_safetensor_distributed(model, save_hf_safetensor_path, fqn_to_index_mapping, model_assets)
     else:
-        # Legacy path is rank-0 only; non-rank-0 waits at the barrier below
+        # Legacy path is rank-0 only; non-rank-0 waits at the barrier below.
+        # Resolve ``is_rank_0`` from the process group when the caller did not
+        # explicitly pass it (e.g. when the distributed path was disabled at
+        # runtime via the NPU guard).
+        if not is_rank_0 and dist.is_initialized():
+            is_rank_0 = dist.get_rank() == 0
         if is_rank_0:
+            if not save_checkpoint_path:
+                raise ValueError(
+                    "save_checkpoint_path is required for the legacy HF safetensors path. "
+                    "The distributed `HuggingFaceStorageWriter` path is disabled on this platform "
+                    "(e.g. NPU), so the legacy rank-0 conversion from a DCP checkpoint must be used."
+                )
             _save_hf_safetensor_legacy(
                 save_checkpoint_path,
                 save_hf_safetensor_path,

--- a/veomni/utils/save_safetensor_utils.py
+++ b/veomni/utils/save_safetensor_utils.py
@@ -26,7 +26,7 @@ from veomni.checkpoint import ckpt_to_state_dict
 from veomni.models import save_model_assets, save_model_weights
 from veomni.models.module_utils import _save_state_dict
 from veomni.utils import helper
-from veomni.utils.device import synchronize
+from veomni.utils.device import IS_NPU_AVAILABLE, synchronize
 from veomni.utils.import_utils import is_torch_version_greater_than
 
 
@@ -205,7 +205,18 @@ def save_hf_safetensor(
     """
     from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
 
-    use_distributed = is_torch_version_greater_than("2.9") and ckpt_manager == "dcp"
+    # Disable the distributed `HuggingFaceStorageWriter` path on NPU.  Under
+    # HSDP replicate ranks independently cast fp32→bf16 on-device and write
+    # per-rank safetensors files.  When the casts are not bit-exact (~1 ULP on
+    # Ascend 910B) the consolidation step bakes in whichever rank's data it
+    # reads last, causing an intermittent mismatch against the fp32 DCP
+    # checkpoint.  Route through the legacy rank-0 path until the underlying
+    # fp32→bf16 determinism issue is resolved in the NPU stack.
+    use_distributed = (
+        is_torch_version_greater_than("2.9")
+        and ckpt_manager == "dcp"
+        and not IS_NPU_AVAILABLE
+    )
 
     # Ensure all GPU operations are complete before reading tensor data for saving
     synchronize()


### PR DESCRIPTION
### What does this PR do?

Disable the `HuggingFaceStorageWriter` distributed save path on NPU,
falling back to the legacy rank-0 path that loads from DCP files and
converts to HF safetensors on a single rank.

### Why?

Under HSDP (`dp_replicate_size > 1`) replicate ranks independently cast
fp32→bf16 on-device and write per-rank safetensors files.  On Ascend 910B
the fp32→bf16 cast is not guaranteed bit-exact across ranks (~1 ULP).
When two replicate ranks produce slightly different bf16 values for the
same fp32 input, the consolidation step bakes in whichever rank's data it
reads last, causing the final safetensors to differ from the fp32 DCP
checkpoint.

This results in an intermittent CI failure (~30% rate) in
`test_trainer_saveload_hsdp[2]` where `verify_dcp_to_hf_conversion`
reports a 1-ULP mismatch (max_diff ~6e-5) on an expert weight tensor.

### Checklist Before Starting

- Search for relative PRs/issues and link here: https://github.com/ByteDance-Seed/VeOmni/actions/runs/28851422179 (first failure on main)
- PR title follows `[{modules}] {type}: {description}` format ✅

### Test

- Verified on Ascend 910B + CANN 9.0.0: `test_trainer_saveload_hsdp[2]`
  passes consistently on the legacy path (was already stable under torch
  2.7.1 on CANN 8.3.rc2 before the HSDP test was merged).
- GPU path is unaffected (`IS_NPU_AVAILABLE` guard).

### Design & Code Changes

- `veomni/utils/save_safetensor_utils.py`: add `and not IS_NPU_AVAILABLE`
  to the `use_distributed` guard so NPU always takes the legacy rank-0 path.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md) ✅
- Applied pre-commit checks ✅
- Added/updated documentation: N/A (one-line guard, self-explanatory)
- Added tests to CI workflow: N/A (fix stabilizes existing CI test)