### PR TITLE
[model] feat: support bagel on npu

### DIFF
--- a/tests/distributed/test_apply_weights_load_step.py
+++ b/tests/distributed/test_apply_weights_load_step.py
@@ -32,6 +32,7 @@ from veomni.distributed.torch_parallelize import (
     _load_one,
     _resolve_weights_path_mapping,
 )
+from veomni.utils.device import get_device_type
 
 
 # ── Test fixtures: a model with named children and a fake init_weights ─────
@@ -184,7 +185,7 @@ def test_apply_load_step_str_with_rank0_broadcast(monkeypatch):
     _apply_weights_load_step(
         model=model,
         weights_path="/snap/full",
-        materialize_device="cuda",
+        materialize_device=get_device_type(),
         broadcast_from_rank0=True,
         is_peft_model=False,
         adapter_path=None,
@@ -198,7 +199,7 @@ def test_apply_load_step_str_with_rank0_broadcast(monkeypatch):
     # Positional args: model, weights_path, materialize_device.
     assert args[0] is model
     assert args[1] == "/snap/full"
-    assert args[2] == "cuda"
+    assert args[2] == get_device_type()
     assert kwargs["cpu_load_param_name"] == ["embed.weight"]
     assert kwargs["max_load_broadcast_size"] == 15.0
     assert kwargs["is_peft_model"] is False
@@ -218,7 +219,7 @@ def test_apply_load_step_str_without_rank0_broadcast(monkeypatch):
     _apply_weights_load_step(
         model=model,
         weights_path="/snap/full",
-        materialize_device="cuda",
+        materialize_device=get_device_type(),
         broadcast_from_rank0=False,
         is_peft_model=True,
         adapter_path="/snap/lora",

--- a/tests/models/test_omni_fsdp.py
+++ b/tests/models/test_omni_fsdp.py
@@ -16,6 +16,8 @@ import subprocess
 
 import pytest
 
+from veomni.utils.device import IS_CUDA_AVAILABLE, IS_NPU_AVAILABLE, get_torch_device
+
 from ..tools.launch_utils import find_free_port
 
 
@@ -47,9 +49,7 @@ def _tmp_dir(tmp_path):
 @pytest.mark.parametrize("nproc", [1, 2])
 def test_omni_fsdp_pipeline(nproc, tmp_path):
     """Two separately FSDP2-wrapped models should train correctly end-to-end."""
-    import torch
-
-    gpu_count = torch.cuda.device_count() if torch.cuda.is_available() else 0
+    gpu_count = get_torch_device().device_count() if (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE) else 0
     if nproc > gpu_count:
         pytest.skip(f"nproc={nproc} but only {gpu_count} GPU(s) available")
 

--- a/veomni/models/seed_omni/graphs/profiling.py
+++ b/veomni/models/seed_omni/graphs/profiling.py
@@ -24,9 +24,7 @@ from contextlib import contextmanager
 from time import perf_counter
 from typing import Iterator
 
-import torch
-
-from ....utils.device import get_torch_device
+from ....utils.device import IS_CUDA_AVAILABLE, IS_NPU_AVAILABLE, get_torch_device
 
 
 class GraphProfiler:
@@ -50,9 +48,10 @@ class GraphProfiler:
     def node(self, line: str) -> Iterator[None]:
         start_wall = perf_counter() if self.enable_wall_time else None
         start_event = end_event = None
-        if self.enable_cuda_events and torch.cuda.is_available():
-            start_event = torch.cuda.Event(enable_timing=True)
-            end_event = torch.cuda.Event(enable_timing=True)
+        if self.enable_cuda_events and (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE):
+            device = get_torch_device()
+            start_event = device.Event(enable_timing=True)
+            end_event = device.Event(enable_timing=True)
             start_event.record()
 
         try:

--- a/veomni/models/seed_omni/modules/bagel/flow_connector/modeling.py
+++ b/veomni/models/seed_omni/modules/bagel/flow_connector/modeling.py
@@ -123,7 +123,14 @@ class PositionEmbedding(nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        self.pos_embed.data.copy_(_get_2d_sincos_pos_embed(self.hidden_size, self.max_num_patch_per_side))
+        new_data = _get_2d_sincos_pos_embed(self.hidden_size, self.max_num_patch_per_side)
+        if hasattr(self.pos_embed.data, "to_local"):
+            self.pos_embed.data.to_local().copy_(new_data)
+        else:
+            self.pos_embed.data.copy_(new_data)
+
+    def _init_weights(self) -> None:
+        self.reset_parameters()
 
     def forward(self, position_ids: torch.LongTensor) -> torch.Tensor:
         return self.pos_embed[position_ids.to(device=self.pos_embed.device)]

--- a/veomni/models/seed_omni/modules/bagel/qwen2_mot/modeling.py
+++ b/veomni/models/seed_omni/modules/bagel/qwen2_mot/modeling.py
@@ -1,13 +1,22 @@
 """BAGEL Qwen2 MoT backbone."""
 
+import math
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 import torch
 import torch.nn as nn
-from flash_attn import flash_attn_varlen_func
 from torch.nn.attention import SDPBackend, sdpa_kernel
 from torch.nn.functional import scaled_dot_product_attention
+
+from veomni.utils.device import IS_CUDA_AVAILABLE, IS_NPU_AVAILABLE
+
+
+if IS_CUDA_AVAILABLE:
+    from flash_attn import flash_attn_varlen_func
+
+if IS_NPU_AVAILABLE:
+    import torch_npu
 from transformers import PreTrainedModel
 from transformers.models.qwen2.modeling_qwen2 import Qwen2MLP, Qwen2RMSNorm
 from transformers.utils import ModelOutput
@@ -446,16 +455,53 @@ class BagelQwen2MoTAttention(nn.Module):
 
         cu_seqlens_q = torch.nn.functional.pad(torch.cumsum(query_lens, dim=0), (1, 0))
         cu_seqlens_k = torch.nn.functional.pad(torch.cumsum(key_values_lens, dim=0), (1, 0))
-        packed_attn_output = flash_attn_varlen_func(
-            q=packed_query_states,
-            k=merged_key_states,
-            v=merged_value_states,
-            cu_seqlens_q=cu_seqlens_q.to(torch.int32),
-            cu_seqlens_k=cu_seqlens_k.to(torch.int32),
-            max_seqlen_q=int(query_lens.max().item()),
-            max_seqlen_k=int(key_values_lens.max().item()),
-            causal=is_causal,
-        )
+        max_seqlen_q = int(query_lens.max().item())
+        max_seqlen_k = int(key_values_lens.max().item())
+        if IS_CUDA_AVAILABLE:
+            packed_attn_output = flash_attn_varlen_func(
+                q=packed_query_states,
+                k=merged_key_states,
+                v=merged_value_states,
+                cu_seqlens_q=cu_seqlens_q.to(torch.int32),
+                cu_seqlens_k=cu_seqlens_k.to(torch.int32),
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
+                causal=is_causal,
+            )
+        else:
+            head_num = packed_query_states.shape[1]
+            if is_causal:
+                atten_mask_npu = torch.triu(torch.ones([2048, 2048]), diagonal=1).bool().to(packed_query_states.device)
+                packed_attn_output = torch_npu.npu_fusion_attention(
+                    packed_query_states,
+                    merged_key_states,
+                    merged_value_states,
+                    head_num,
+                    pse=None,
+                    padding_mask=None,
+                    atten_mask=atten_mask_npu,
+                    scale=1.0 / math.sqrt(packed_query_states.shape[-1]),
+                    keep_prob=1,
+                    input_layout="TND",
+                    actual_seq_qlen=tuple(cu_seqlens_q[1:].cpu().numpy().tolist()),
+                    actual_seq_kvlen=tuple(cu_seqlens_k[1:].cpu().numpy().tolist()),
+                    sparse_mode=3,
+                )[0]
+            else:
+                packed_attn_output = torch_npu.npu_fusion_attention(
+                    packed_query_states,
+                    merged_key_states,
+                    merged_value_states,
+                    head_num,
+                    pse=None,
+                    atten_mask=None,
+                    scale=1.0 / math.sqrt(packed_query_states.shape[-1]),
+                    keep_prob=1,
+                    input_layout="TND",
+                    actual_seq_qlen=tuple(cu_seqlens_q[1:].cpu().numpy().tolist()),
+                    actual_seq_kvlen=tuple(cu_seqlens_k[1:].cpu().numpy().tolist()),
+                )[0]
+
         packed_attn_output = packed_attn_output.reshape(-1, self.hidden_size)
         if not is_gen:
             packed_attn_output = self.o_proj(packed_attn_output)

--- a/veomni/models/seed_omni/modules/bagel/siglip_navit/modeling.py
+++ b/veomni/models/seed_omni/modules/bagel/siglip_navit/modeling.py
@@ -9,13 +9,22 @@ those feature spans back to the image ``ConversationItem.value`` fields.
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 import numpy as np
 import torch
 import torch.nn as nn
-from flash_attn import flash_attn_varlen_func
 from transformers import PreTrainedModel
+
+from veomni.utils.device import IS_CUDA_AVAILABLE, IS_NPU_AVAILABLE
+
+
+if IS_CUDA_AVAILABLE:
+    from flash_attn import flash_attn_varlen_func
+
+if IS_NPU_AVAILABLE:
+    import torch_npu
 from transformers.activations import ACT2FN
 
 from .configuration import BagelSiglipNavitConfig
@@ -170,7 +179,14 @@ class PositionEmbedding(nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        self.pos_embed.data.copy_(_get_2d_sincos_pos_embed(self.hidden_size, self.max_num_patch_per_side))
+        new_data = _get_2d_sincos_pos_embed(self.hidden_size, self.max_num_patch_per_side)
+        if hasattr(self.pos_embed.data, "to_local"):
+            self.pos_embed.data.to_local().copy_(new_data)
+        else:
+            self.pos_embed.data.copy_(new_data)
+
+    def _init_weights(self) -> None:
+        self.reset_parameters()
 
     def forward(self, position_ids: torch.LongTensor) -> torch.Tensor:
         return self.pos_embed[position_ids.to(device=self.pos_embed.device)]
@@ -267,18 +283,31 @@ class BagelSiglipAttention(nn.Module):
             query_states = torch.cat([qh, qw], dim=-1)
             key_states = torch.cat([kh, kw], dim=-1)
 
-        if not query_states.is_cuda:
-            raise RuntimeError("BagelSiglipNavit attention requires CUDA flash-attn.")
-        attn_output = flash_attn_varlen_func(
-            query_states.to(torch.bfloat16),
-            key_states.to(torch.bfloat16),
-            value_states.to(torch.bfloat16),
-            cu_seqlens_q=cu_seqlens,
-            cu_seqlens_k=cu_seqlens,
-            max_seqlen_q=max_seqlen,
-            max_seqlen_k=max_seqlen,
-            causal=False,
-        )
+        if IS_CUDA_AVAILABLE:
+            attn_output = flash_attn_varlen_func(
+                query_states.to(torch.bfloat16),
+                key_states.to(torch.bfloat16),
+                value_states.to(torch.bfloat16),
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=False,
+            )
+        else:
+            attn_output = torch_npu.npu_fusion_attention(
+                query_states.to(torch.bfloat16),
+                key_states.to(torch.bfloat16),
+                value_states.to(torch.bfloat16),
+                query_states.shape[1],
+                pse=None,
+                atten_mask=None,
+                scale=1.0 / math.sqrt(query_states.shape[-1]),
+                keep_prob=1,
+                input_layout="TND",
+                actual_seq_qlen=tuple(cu_seqlens[1:].cpu().numpy().tolist()),
+                actual_seq_kvlen=tuple(cu_seqlens[1:].cpu().numpy().tolist()),
+            )[0]
         return self.out_proj(attn_output.reshape(total_q_len, -1).to(hidden_states.dtype))
 
 

--- a/veomni/models/seed_omni/modules/bagel/vae/modeling.py
+++ b/veomni/models/seed_omni/modules/bagel/vae/modeling.py
@@ -76,8 +76,8 @@ class BagelVAE(BagelVAEModuleMixin, PreTrainedModel):
             grad_context = torch.no_grad()
 
         autocast_context = nullcontext()
-        if tensor.device.type == "cuda" and self.dtype != torch.float32:
-            autocast_context = torch.amp.autocast("cuda", enabled=True, dtype=self.dtype)
+        if self.dtype != torch.float32:
+            autocast_context = torch.amp.autocast(tensor.device.type, enabled=True, dtype=self.dtype)
 
         with grad_context, autocast_context:
             yield


### PR DESCRIPTION
### What does this PR do?

> Adds NPU (Ascend) support for the BAGEL model in SeedOmni. Previously the BAGEL modules (flow_connector, qwen2_mot, siglip_navit, vae) were CUDA-only due to hard dependencies on flash_attn and CUDA-specific APIs. This PR introduces a runtime device dispatch (IS_CUDA_AVAILABLE) that falls back to torch_npu.npu_fusion_attention on NPU, and fixes sharded-parameter initialization and autocast context to be device-agnostic.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
