### PR TITLE
[ops] fix: disable Quack GEMM autotuning

### DIFF
--- a/veomni/ops/kernels/moe/quack_gemm.py
+++ b/veomni/ops/kernels/moe/quack_gemm.py
@@ -87,10 +87,10 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         fc2_w_t = fc2_weight.transpose(1, 2)
 
         # fc1_1: [T*topk, I] (expert-sorted via A_idx)
-        fc1_1_output = gemm(hidden_states, fc1_1_w_t, cu_seqlens_m=cu_seqlens_m, A_idx=A_idx)
+        fc1_1_output = gemm(hidden_states, fc1_1_w_t, cu_seqlens_m=cu_seqlens_m, A_idx=A_idx, tuned=False)
 
         # fc1_2: [T*topk, I]
-        fc1_2_output = gemm(hidden_states, fc1_2_w_t, cu_seqlens_m=cu_seqlens_m, A_idx=A_idx)
+        fc1_2_output = gemm(hidden_states, fc1_2_w_t, cu_seqlens_m=cu_seqlens_m, A_idx=A_idx, tuned=False)
 
         # gpt-oss / DeepSeek-V4 style clamped SwiGLU pre-activation.
         fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2 = _apply_swiglu_clamp(
@@ -112,7 +112,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         fc1_weighted_output = fc1_activation * scattered_gate_weight
 
         # fc2: input is already expert-sorted, no A_idx needed
-        fc2_output = gemm(fc1_weighted_output, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
+        fc2_output = gemm(fc1_weighted_output, fc2_w_t, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # Gather output tokens back to original order
         expert_output = moe_gather(fc2_output, scatter_index)
@@ -166,7 +166,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
 
         # Step 9 dgrad: grad @ fc2_weight (original layout [E, H, I] is already [K, N] for quack)
-        grad_fc1_weighted_output = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
+        grad_fc1_weighted_output = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # Step 9 wgrad: grad_fc2_output.T @ fc1_weighted_output → [E, H, I]
         # cu_seqlens_k mode: A=[M, total_K] @ B=[total_K, N] → [L, M, N] per expert group.
@@ -200,7 +200,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
             grad_fc1_2_output.masked_fill_(~mask_fc1_2, 0)
 
         # Step 6 dgrad: fc1_2_weight [E, I, H] is already [K, N] for quack
-        grad_scatter_output_2 = gemm(grad_fc1_2_output, fc1_2_weight, cu_seqlens_m=cu_seqlens_m)
+        grad_scatter_output_2 = gemm(grad_fc1_2_output, fc1_2_weight, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # Step 5: SiLU backward
         grad_fc1_1_output = torch.ops.aten.silu_backward(grad_fc1_1_activation, fc1_1_output)
@@ -209,7 +209,7 @@ class QuackFusedMoeExpertFunction(torch.autograd.Function):
             grad_fc1_1_output.masked_fill_(~mask_fc1_1, 0)
 
         # Step 4 dgrad: fc1_1_weight [E, I, H] is already [K, N] for quack
-        grad_scatter_output_1 = gemm(grad_fc1_1_output, fc1_1_weight, cu_seqlens_m=cu_seqlens_m)
+        grad_scatter_output_1 = gemm(grad_fc1_1_output, fc1_1_weight, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # Recompute scatter_output for wgrad
         scatter_output = moe_scatter(hidden_states, scatter_index)
@@ -267,7 +267,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         fc2_w_t = fc2_weight.transpose(1, 2)
 
         # Single fc1 GEMM: output [T*topk, 2I]
-        fc1_output = gemm(hidden_states, fc1_1_2_w_t, cu_seqlens_m=cu_seqlens_m, A_idx=A_idx)
+        fc1_output = gemm(hidden_states, fc1_1_2_w_t, cu_seqlens_m=cu_seqlens_m, A_idx=A_idx, tuned=False)
 
         fc1_1_output, fc1_2_output = fc1_output.chunk(2, dim=-1)
 
@@ -287,7 +287,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
 
         fc1_weighted_output = fc1_activation * scattered_gate_weight
 
-        fc2_output = gemm(fc1_weighted_output, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
+        fc2_output = gemm(fc1_weighted_output, fc2_w_t, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         expert_output = moe_gather(fc2_output, scatter_index)
         del fc2_output
@@ -338,7 +338,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         grad_fc2_output = moe_scatter(grad_output, scatter_index)
 
         # Step 9 dgrad
-        grad_fc1_weighted_output = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
+        grad_fc1_weighted_output = gemm(grad_fc2_output, fc2_weight, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # Step 9 wgrad: grad_fc2_output.T @ fc1_weighted_output → [E, H, I]
         # cu_seqlens_k mode: A=[M, total_K] @ B=[total_K, N] → [L, M, N] per expert group.
@@ -381,7 +381,7 @@ class MergedFc1QuackFusedMoeExpertFunction(torch.autograd.Function):
         del grad_fc1_1_output, grad_fc1_2_output
 
         # Step 4 dgrad: fc1_1_2_weight [E, 2I, H] is [K, N] for quack
-        grad_scatter_output = gemm(grad_fc1_output, fc1_1_2_weight, cu_seqlens_m=cu_seqlens_m)
+        grad_scatter_output = gemm(grad_fc1_output, fc1_1_2_weight, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # Step 4 wgrad: grad_fc1_output.T @ scatter_output → [E, 2I, H]
         grad_fc1_1_2_weight = None
@@ -432,8 +432,8 @@ class EPQuackGroupGemm(torch.autograd.Function):
         fc1_2_w_t = fc1_2_weight.transpose(1, 2)
         fc2_w_t = fc2_weight.transpose(1, 2)
 
-        fc1_1_output = gemm(permute_tokens, fc1_1_w_t, cu_seqlens_m=cu_seqlens_m)
-        fc1_2_output = gemm(permute_tokens, fc1_2_w_t, cu_seqlens_m=cu_seqlens_m)
+        fc1_1_output = gemm(permute_tokens, fc1_1_w_t, cu_seqlens_m=cu_seqlens_m, tuned=False)
+        fc1_2_output = gemm(permute_tokens, fc1_2_w_t, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         fc1_1_output, fc1_2_output, mask_fc1_1, mask_fc1_2 = _apply_swiglu_clamp(
             fc1_1_output, fc1_2_output, swiglu_limit
@@ -442,7 +442,7 @@ class EPQuackGroupGemm(torch.autograd.Function):
         fc1_1_activation = torch.ops.aten.silu(fc1_1_output)
         fc1_result = fc1_1_activation * fc1_2_output
 
-        fc2_output = gemm(fc1_result, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
+        fc2_output = gemm(fc1_result, fc2_w_t, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         ctx.swiglu_limit = swiglu_limit
         ctx.save_for_backward(
@@ -481,7 +481,7 @@ class EPQuackGroupGemm(torch.autograd.Function):
         fc1_result = fc1_1_activation * fc1_2_output
 
         # dgrad fc2
-        grad_fc1_result = gemm(grad_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
+        grad_fc1_result = gemm(grad_output, fc2_weight, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # wgrad fc2
         grad_fc2_weight = None
@@ -498,7 +498,7 @@ class EPQuackGroupGemm(torch.autograd.Function):
             grad_fc1_2_output.masked_fill_(~mask_fc1_2, 0)
 
         # dgrad fc1_2
-        grad_scatter_output_2 = gemm(grad_fc1_2_output, fc1_2_weight, cu_seqlens_m=cu_seqlens_m)
+        grad_scatter_output_2 = gemm(grad_fc1_2_output, fc1_2_weight, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # wgrad fc1_2
         grad_fc1_2_weight = None
@@ -512,7 +512,7 @@ class EPQuackGroupGemm(torch.autograd.Function):
             grad_fc1_1_output.masked_fill_(~mask_fc1_1, 0)
 
         # dgrad fc1_1
-        grad_scatter_output_1 = gemm(grad_fc1_1_output, fc1_1_weight, cu_seqlens_m=cu_seqlens_m)
+        grad_scatter_output_1 = gemm(grad_fc1_1_output, fc1_1_weight, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # wgrad fc1_1
         grad_fc1_1_weight = None
@@ -554,7 +554,7 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
         fc2_w_t = fc2_weight.transpose(1, 2)
 
         # Single fc1 GEMM: output [T, 2I]
-        fc1_output = gemm(permute_tokens, fc1_1_2_w_t, cu_seqlens_m=cu_seqlens_m)
+        fc1_output = gemm(permute_tokens, fc1_1_2_w_t, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # chunk is a view, no copy
         fc1_1_output, fc1_2_output = fc1_output.chunk(2, dim=-1)
@@ -567,7 +567,7 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
         fc1_result = fc1_1_activation * fc1_2_output
 
         # fc2
-        fc2_output = gemm(fc1_result, fc2_w_t, cu_seqlens_m=cu_seqlens_m)
+        fc2_output = gemm(fc1_result, fc2_w_t, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         ctx.swiglu_limit = swiglu_limit
         ctx.save_for_backward(
@@ -604,7 +604,7 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
         fc1_result = fc1_1_activation * fc1_2_output
 
         # dgrad fc2: fc2_weight [E, H, I] is [K, N] for quack
-        grad_fc1_result = gemm(grad_output, fc2_weight, cu_seqlens_m=cu_seqlens_m)
+        grad_fc1_result = gemm(grad_output, fc2_weight, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # wgrad fc2
         grad_fc2_weight = None
@@ -629,7 +629,7 @@ class EPMergedFc1QuackGroupGemm(torch.autograd.Function):
         del grad_fc1_1_output, grad_fc1_2_output
 
         # single dgrad for merged fc1: fc1_1_2_weight [E, 2I, H] is [K, N] for quack
-        grad_permute_tokens = gemm(grad_fc1_output, fc1_1_2_weight, cu_seqlens_m=cu_seqlens_m)
+        grad_permute_tokens = gemm(grad_fc1_output, fc1_1_2_weight, cu_seqlens_m=cu_seqlens_m, tuned=False)
 
         # single wgrad for merged fc1
         grad_fc1_1_2_weight = None


### PR DESCRIPTION
## What

- pass `tuned=False` explicitly to every Quack `gemm()` call in the standard fused-MoE backend
- cover split/merged FC1, expert-parallel, forward, dgrad, and wgrad paths
- leave the GPT-OSS interleaved gate/up implementation unchanged

## Why

Quack GEMM tuning introduces warm-up/autotuning work and can select different kernel configurations across runs. DeepSeek-V4 parity experiments need deterministic, non-tuned Quack execution at every standard fused-MoE call site.

## Validation

- `pytest -q tests/ops/test_quack_fused_moe.py` (10 passed)
- `pytest -q tests/ops/test_fused_moe_split_vs_merged.py -k quack` (12 passed, 26 deselected)
- `make quality`
- AST audit: all 30 standard Quack `gemm()` calls pass `tuned=False`

Draft PR to track the Quack integration work.
