### PR TITLE
[ops] feat: add AscendC fused backend (npu_ascendc) for Qwen3.5 chunk gated delta rule

### DIFF
--- a/configs/multimodal/qwen3_5_moe/qwen3_5_moe_vl_ascendc.yaml
+++ b/configs/multimodal/qwen3_5_moe/qwen3_5_moe_vl_ascendc.yaml
@@ -1,0 +1,57 @@
+model:
+  model_path: Qwen/Qwen3.5-35B-A3B
+  ops_implementation:
+    attn_implementation: veomni_flash_attention_2_with_sp
+    rms_norm_implementation: npu
+    rotary_pos_emb_implementation: npu
+    cross_entropy_loss_implementation: chunk_loss
+    swiglu_mlp_implementation: eager
+    moe_implementation: fused_npu
+    rms_norm_gated_implementation: npu
+    causal_conv1d_implementation: npu
+    chunk_gated_delta_rule_implementation: npu_ascendc
+    load_balancing_loss_implementation: eager
+
+data:
+  train_path: configs/multimodal/data/tulu_sharegpt4v_llavavideo.yaml
+  data_type: conversation
+  chat_template: qwen3vl
+  max_seq_len: 16384
+  train_size: 80000000
+  mm_configs:
+    image_max_pixels: 602112 # 28 * 28 * 768
+    video_max_pixels: 602112 # 28 * 28 * 768
+    video_total_pixels: 2889523 # max_seq_len * 28^2 * 0.9, dynamic per-frame budget
+    max_frames: 16
+    fps: 2.0
+    use_audio_in_video: false
+
+train:
+  accelerator:
+    ulysses_size: 4
+    fsdp_config:
+      fsdp_mode: fsdp2
+  gradient_checkpointing:
+    enable_reentrant: false
+  wandb:
+    enable: false
+    project: VeOmni
+    name: Qwen3.5-35B-A3B-vl-sft
+  freeze_vit: false
+  optimizer:
+    lr: 1.0e-5
+    lr_decay_style: cosine
+  num_train_epochs: 2
+  micro_batch_size: 1
+  global_batch_size: 16
+  max_steps: 500
+  init_device: meta
+  profile:
+    enable: true
+    start_step: 20
+    end_step: 21
+    record_shapes: true
+  checkpoint:
+    output_dir: Qwen3.5-35B-A3B-vl-sft
+    manager: dcp
+    save_hf_weights: false

--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -25,7 +25,7 @@ selection knob.
 | Vision rotary embedding | `rotary_pos_emb_vision_implementation` | `eager`, `npu` | `"eager"` | Model registration via ops config singleton |
 | Gated RMSNorm | `rms_norm_gated_implementation` | `eager`, `fla`, `npu` | `"fla"` (GPU) | Qwen3.5 OpSlot binding |
 | Causal Conv1D | `causal_conv1d_implementation` | `eager`, `fla`, `npu` | `"fla"` (GPU) | Qwen3.5 OpSlot binding |
-| Gated delta rule | `chunk_gated_delta_rule_implementation` | `eager`, `fla`, `flash_qla` (SM90), `npu` | `"fla"` (GPU) | Qwen3.5 OpSlot binding |
+| Gated delta rule | `chunk_gated_delta_rule_implementation` | `eager`, `fla`, `flash_qla` (SM90), `npu`, `npu_ascendc` | `"fla"` (GPU) | Qwen3.5 OpSlot binding |
 | Load-balancing loss | `load_balancing_loss_implementation` | `eager`, `triton` (CUDA; NPU config normalizes this default to `eager`) | `"triton"` | `apply_ops_config()` (before model build) |
 | MoE experts | `moe_implementation` | `eager`, `fused_triton`, `fused_quack` (SM90+), `fused_npu` | `"fused_triton"` (GPU) | `build_foundation_model` |
 
@@ -292,12 +292,16 @@ model:
 |---|---|---|---|
 | `rms_norm_gated_implementation` | `fla` | `npu` | HuggingFace reference implementation |
 | `causal_conv1d_implementation` | `fla` | `npu` | No `cu_seqlens` path |
-| `chunk_gated_delta_rule_implementation` | `fla`, `flash_qla` (SM90 only) | `npu` | No `cu_seqlens` path |
+| `chunk_gated_delta_rule_implementation` | `fla`, `flash_qla` (SM90 only) | `npu`, `npu_ascendc` | No `cu_seqlens` path |
 
 The NPU gated RMSNorm uses `torch_npu`. The NPU causal Conv1D and gated
-delta-rule implementations additionally require `triton-ascend`. Registrations
-live in `veomni/ops/kernels/gated_delta_rule/__init__.py`; field defaults and
-allowed values are documented by `OpsImplementationConfig`.
+delta-rule implementations additionally require `triton-ascend`. For the gated
+delta rule there are two NPU backends: `npu` (the vendored MindSpeed-MM Triton
+kernel) and `npu_ascendc` (an AscendC fused `torch.ops.npu.*` path), the latter
+requiring a manual `fla_npu` install and `ASCEND_CUSTOM_OPP_PATH` exported before
+process start. Registrations live in
+`veomni/ops/kernels/gated_delta_rule/__init__.py`; field defaults and allowed
+values are documented by `OpsImplementationConfig`.
 
 ---
 

--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -298,8 +298,7 @@ The NPU gated RMSNorm uses `torch_npu`. The NPU causal Conv1D and gated
 delta-rule implementations additionally require `triton-ascend`. For the gated
 delta rule there are two NPU backends: `npu` (the vendored MindSpeed-MM Triton
 kernel) and `npu_ascendc` (an AscendC fused `torch.ops.npu.*` path), the latter
-requiring a manual `fla_npu` install and `ASCEND_CUSTOM_OPP_PATH` exported before
-process start. Registrations live in
+requiring a manual `fla_npu` install. Registrations live in
 `veomni/ops/kernels/gated_delta_rule/__init__.py`; field defaults and allowed
 values are documented by `OpsImplementationConfig`.
 

--- a/docs/design/unified_kernel_registry.md
+++ b/docs/design/unified_kernel_registry.md
@@ -298,7 +298,7 @@ PR — see `veomni/arguments/arguments_types.py`):
 | `load_balancing_loss_implementation` | `eager`, `triton` | `triton` is CUDA-only; current NPU config normalization maps the default-valued `triton` selection to `eager` before binding. |
 | `rms_norm_gated_implementation` | `eager`, `fla`, `npu` | Qwen3.5 GatedDeltaNet `self.norm`; default `fla` |
 | `causal_conv1d_implementation` | `eager`, `fla`, `npu` | Qwen3.5 GatedDeltaNet pre-mixer; `eager` has no `cu_seqlens` path |
-| `chunk_gated_delta_rule_implementation` | `eager`, `fla`, `flash_qla`, `npu` | Qwen3.5 linear attention; `flash_qla` is Hopper SM90-only, while `npu` uses the vendored MindSpeed-MM kernel |
+| `chunk_gated_delta_rule_implementation` | `eager`, `fla`, `flash_qla`, `npu`, `npu_ascendc` | Qwen3.5 linear attention; `flash_qla` is Hopper SM90-only. `npu` uses the vendored MindSpeed-MM Triton kernel; `npu_ascendc` is the AscendC fused `torch.ops.npu.*` path (requires a manual `fla_npu` install) |
 | `dsa_indexer_implementation` | `eager`, `cudnn`, `tilelang` | GLM-DSA supports `cudnn`; DeepSeek V4 supports `tilelang`. Optimized implementations require compatible NVIDIA hardware. |
 | `dsa_attention_implementation` | `eager`, `flashmla_cudnn`, `tilelang` | GLM-DSA supports `flashmla_cudnn`; DeepSeek V4 supports `tilelang`. Optimized implementations require compatible NVIDIA hardware. |
 | `mhc_implementation` | `eager`, `tilelang` | DeepSeek V4 manifold-constrained Hyper-Connection pre/post/head kernels provided by the `tile-kernels` package. The three `OpSlot("mhc", variant)` instances share this selection and require NVIDIA SM90+ for `tilelang`. |

--- a/docs/examples/qwen3_5.md
+++ b/docs/examples/qwen3_5.md
@@ -207,6 +207,53 @@ model:
     chunk_gated_delta_rule_implementation: flash_qla
 ```
 
+#### `npu_ascendc` — AscendC fused backend (NPU, `chunk_gated_delta_rule` only)
+
+`npu_ascendc` is a second NPU backend for `chunk_gated_delta_rule` that delegates the heavy GDN
+compute to the external [`fla_npu`](https://github.com/flashserve/flash-linear-attention-npu)
+package (registered as `torch.ops.npu.*` fused ops); only the Triton glue stays vendored under
+`_ascend/triton_core`. It coexists with `npu` (pure vendored Triton), which remains the fallback.
+Set only `chunk_gated_delta_rule` to `npu_ascendc`; keep `rms_norm_gated` / `causal_conv1d` on `npu`:
+
+```yaml
+model:
+  ops_implementation:
+    rms_norm_gated_implementation: npu
+    causal_conv1d_implementation: npu
+    chunk_gated_delta_rule_implementation: npu_ascendc
+```
+
+`fla_npu` is not a declared VeOmni dependency (same as `triton-ascend`). It supports Ascend
+910B (A2) / 910_93 (A3) / 950 (A5); on non-arch35 chips the `solve_tril` step auto-falls-back to
+the vendored Triton kernel via `is_arch35()`.
+
+The prebuilt NPU images on [quay.io](https://quay.io/repository/ascend/veomni?tab=tags) already
+bundle `fla_npu`:
+
+- A2: `quay.io/ascend/veomni:v0.1.11-cann9.0.0-torch_npu2.10.0.post2-A2-ubuntu22.04-py3.11-veomni-latest`
+- A3: `quay.io/ascend/veomni:v0.1.11-cann9.0.0-torch_npu2.10.0.post2-A3-ubuntu22.04-py3.11-veomni-latest`
+
+To build on a bare host instead, install from the
+[`flash-linear-attention-npu`](https://github.com/flashserve/flash-linear-attention-npu) sources:
+
+```bash
+git clone https://github.com/flashserve/flash-linear-attention-npu
+cd flash-linear-attention-npu
+git checkout c2e3d83f
+
+source /usr/local/Ascend/cann/set_env.sh          # source your actual CANN path
+
+# --soc must match the chip: {ascend910b, ascend910_93, ascend950}
+bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu
+bash build_out/fla-npu_*.run
+cd torch_custom/fla_npu/ && bash build.sh
+
+pip list | grep fla_npu   # verify it is installed
+```
+
+If `fla_npu` is absent when `npu_ascendc` is selected, the backend raises an actionable error at
+`OpSlot.bind()` time (pointing back to the install step or to `npu` / `eager`).
+
 ### How It Works
 
 Qwen3.5 is a hybrid model alternating between softmax and linear attention layers:

--- a/docs/examples/qwen3_5.md
+++ b/docs/examples/qwen3_5.md
@@ -223,9 +223,14 @@ model:
     chunk_gated_delta_rule_implementation: npu_ascendc
 ```
 
+A ready-to-run MoE-VL training config wired for this backend (plus `fused_npu` MoE and
+Ulysses SP) is provided at
+[`configs/multimodal/qwen3_5_moe/qwen3_5_moe_vl_ascendc.yaml`](../../configs/multimodal/qwen3_5_moe/qwen3_5_moe_vl_ascendc.yaml).
+
 `fla_npu` is not a declared VeOmni dependency (same as `triton-ascend`). It supports Ascend
-910B (A2) / 910_93 (A3) / 950 (A5); on non-arch35 chips the `solve_tril` step auto-falls-back to
-the vendored Triton kernel via `is_arch35()`.
+910B (A2) / 910_93 (A3), both non-arch35 chips where the `solve_tril` step runs the vendored
+Triton kernel (the arch35 native path is gated behind `is_arch35()`). arch35 (`Ascend910_95` /
+`Ascend950`) is not supported end-to-end: the vendored `causal_conv1d` raises there (see above).
 
 The prebuilt NPU images on [quay.io](https://quay.io/repository/ascend/veomni?tab=tags) already
 bundle `fla_npu`:

--- a/tests/ops/test_gdn_ascend_gate.py
+++ b/tests/ops/test_gdn_ascend_gate.py
@@ -34,6 +34,7 @@ import pytest
 import veomni.ops  # noqa: F401 — trigger KERNEL_REGISTRY registrations
 from veomni.ops.dispatch import OpSlot
 from veomni.ops.kernel_registry import KERNEL_REGISTRY
+from veomni.utils.import_utils import is_torch_npu_available
 
 
 _REGISTRY_MODULE = "veomni.ops.kernel_registry"
@@ -103,3 +104,36 @@ def test_gdn_registry_has_fla_and_npu(op_name):
     available = KERNEL_REGISTRY.list_available(op_name, "standard")
     assert "fla" in available
     assert "npu" in available
+
+
+# ---------------------------------------------------------------------------
+# npu_ascendc — the second NPU backend on chunk_gated_delta_rule only
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_gdr_registry_has_npu_ascendc():
+    available = KERNEL_REGISTRY.list_available("chunk_gated_delta_rule", "standard")
+    assert "npu_ascendc" in available
+    # npu_ascendc is scoped to chunk_gated_delta_rule; causal_conv1d keeps a single npu backend.
+    assert "npu_ascendc" not in KERNEL_REGISTRY.list_available("causal_conv1d", "standard")
+
+
+@patch(f"{_REGISTRY_MODULE}.IS_CUDA_AVAILABLE", True)
+@patch(f"{_REGISTRY_MODULE}.IS_NPU_AVAILABLE", False)
+def test_opslot_npu_ascendc_backend_on_gpu_raises():
+    slot = OpSlot("chunk_gated_delta_rule", "standard")
+    with pytest.raises(RuntimeError, match="device_type='npu'"):
+        slot.bind("npu_ascendc")
+
+
+@pytest.mark.skipif(
+    is_torch_npu_available(),
+    reason="guard only fires when torch_npu/fla_npu/triton are absent; on NPU the factory imports the real kernel",
+)
+def test_npu_ascendc_factory_missing_dep_raises_actionable():
+    """Absent ``fla_npu`` / ``torch_npu`` / ``triton-ascend`` surfaces a RuntimeError with
+    install guidance, not a bare ModuleNotFoundError from the transitive imports."""
+    from veomni.ops.kernels.gated_delta_rule import _npu_ascendc_chunk_gated_delta_rule_factory
+
+    with pytest.raises(RuntimeError, match="npu_ascendc"):
+        _npu_ascendc_chunk_gated_delta_rule_factory()

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -1047,6 +1047,8 @@ class OpsImplementationConfig:
             "'eager' uses transformers' torch_chunk_gated_delta_rule, which does NOT support "
             "cu_seqlens; varlen training therefore raises at runtime. "
             "'npu' uses the vendored Triton kernel (requires triton-ascend, NPU). "
+            "'npu_ascendc' uses the AscendC fused ops (requires fla_npu + triton-ascend, NPU; "
+            "delegates heavy GDN compute to torch.ops.npu.*). "
             "A non-eager value on hardware without a matching backend raises at OpSlot bind time."
         },
     )

--- a/veomni/ops/kernels/gated_delta_rule/__init__.py
+++ b/veomni/ops/kernels/gated_delta_rule/__init__.py
@@ -36,11 +36,18 @@ Backends per op:
 - ``rms_norm_gated``: ``fla`` (GPU), ``npu``.
 - ``causal_conv1d``: ``fla`` (GPU), ``npu``.
 - ``chunk_gated_delta_rule``: ``fla`` (GPU), ``flash_qla`` (GPU ``gpu`` extra,
-  Hopper SM90), ``npu``.
+  Hopper SM90), ``npu`` (vendored Triton), ``npu_ascendc`` (AscendC fused ops).
 
 The ``npu`` ``causal_conv1d`` backend is a thin adapter (``npu_causal_conv1d``)
 over the vendored kernel; the ``npu`` ``chunk_gated_delta_rule`` binds the
 vendored kernel directly (its signature already matches the call site).
+
+The ``npu_ascendc`` ``chunk_gated_delta_rule`` backend is a second NPU path that
+delegates the heavy compute to the external ``fla_npu`` package
+(``torch.ops.npu.*`` fused ops, installed manually on NPU), using a few Triton
+kernels from ``_ascend/triton_core`` (a newer generation of Triton kernels) as
+glue around them. It coexists with the pure-Triton ``npu`` backend, which stays
+as the fallback.
 """
 
 from __future__ import annotations
@@ -233,5 +240,52 @@ KERNEL_REGISTRY.register(
         factory=_npu_chunk_gated_delta_rule_factory,
         hardware=HardwareRequirement(device_type="npu"),
         description="NPU vendored Triton chunk gated delta rule (varlen-aware, MindSpeed-MM)",
+    )
+)
+
+
+# ── chunk_gated_delta_rule (NPU AscendC fused) ───────────────────────────────
+
+
+def _npu_ascendc_chunk_gated_delta_rule_factory():
+    """Return the AscendC chunk gated delta rule (``npu_ascendc_gated_delta_rule``).
+
+    Unlike the pure-Triton ``npu`` backend above, this path offloads the heavy
+    GDN compute to the external ``fla_npu`` package (registered as
+    ``torch.ops.npu.*`` fused ops), wrapping a few ``_ascend/triton_core`` Triton
+    kernels around them as glue. The underlying ``flash_gated_delta_rule`` entry
+    expects ``q/k/v`` in ``[B, H, T, D]``, but the ``Qwen3_5GatedDeltaNet.forward``
+    call site feeds the FLA layout ``[B, T, H, D]`` — so a thin adapter
+    (``npu_ascendc_gated_delta_rule``) transposes the seq/head dims at the op
+    boundary rather than replicating MM's per-implementation forward branching.
+
+    Lazily imported so the transitive ``torch_npu`` / ``fla_npu`` / triton-ascend
+    imports only fire when this backend is selected. ``fla_npu`` is installed
+    manually on NPU (not a declared dependency); re-raise its absence with an
+    actionable message instead of a bare ``ModuleNotFoundError``.
+    """
+    try:
+        from .npu_ascendc_gated_delta_rule import chunk_gated_delta_rule
+    except ModuleNotFoundError as e:
+        if e.name in ("fla_npu", "torch_npu"):
+            raise RuntimeError(
+                f"chunk_gated_delta_rule 'npu_ascendc' backend requires the '{e.name}' package, "
+                "which is not installed. Install fla_npu manually on NPU "
+                "(https://github.com/flashserve/flash-linear-attention-npu), or set "
+                "chunk_gated_delta_rule_implementation to 'npu' (vendored Triton) or 'eager'."
+            ) from e
+        raise
+
+    return chunk_gated_delta_rule
+
+
+KERNEL_REGISTRY.register(
+    KernelSpec(
+        name="npu_ascendc",
+        op_name="chunk_gated_delta_rule",
+        variant="standard",
+        factory=_npu_ascendc_chunk_gated_delta_rule_factory,
+        hardware=HardwareRequirement(device_type="npu"),
+        description="NPU AscendC fused chunk gated delta rule (torch.ops.npu.* via fla_npu, varlen-aware, MindSpeed-MM triton_core)",
     )
 )

--- a/veomni/ops/kernels/gated_delta_rule/__init__.py
+++ b/veomni/ops/kernels/gated_delta_rule/__init__.py
@@ -267,6 +267,17 @@ def _npu_ascendc_chunk_gated_delta_rule_factory():
     try:
         from .npu_ascendc_gated_delta_rule import chunk_gated_delta_rule
     except ModuleNotFoundError as e:
+        if e.name == "triton":
+            # triton-ascend (imported as `triton`) backs the `triton_core` glue
+            # kernels; it is a separate install from fla_npu. `npu` needs it too,
+            # so the only dep-free fallback here is `eager`.
+            raise RuntimeError(
+                "chunk_gated_delta_rule 'npu_ascendc' backend requires the 'triton-ascend' "
+                "package (imported as 'triton'), which is not installed. Install it on NPU "
+                "(pip install triton-ascend==3.2.1 "
+                "--extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple), or set "
+                "chunk_gated_delta_rule_implementation to 'eager'."
+            ) from e
         if e.name in ("fla_npu", "torch_npu"):
             raise RuntimeError(
                 f"chunk_gated_delta_rule 'npu_ascendc' backend requires the '{e.name}' package, "

--- a/veomni/ops/kernels/gated_delta_rule/_ascend/__init__.py
+++ b/veomni/ops/kernels/gated_delta_rule/_ascend/__init__.py
@@ -11,16 +11,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Vendored NPU Triton kernels for Qwen3.5's gated delta-rule linear attention.
+"""Vendored NPU kernels for Qwen3.5's gated delta-rule linear attention.
 
-Copied verbatim from MindSpeed-MM (https://gitcode.com/Ascend/MindSpeed-MM),
-which in turn ports flash-linear-attention (FLA) to Ascend NPU; all files keep
-their original Apache-2.0 headers. Do not hand-edit the kernel logic here —
-treat this as a drop-in vendor blob so it stays diff-able against upstream. VeOmni's registry-facing wrappers live one level up
-(``npu_causal_conv1d.py`` and the ``chunk_gated_delta_rule`` factory in the
-package ``__init__``); those are the only entry points other code should call.
+Copied from MindSpeed-MM (https://gitcode.com/Ascend/MindSpeed-MM), which ports
+flash-linear-attention (FLA) to Ascend NPU; the newer ``triton_core`` kernels
+derive from fla_npu commit c2e3d83f as redistributed by MindSpeed-MM. The verbatim
+kernels keep their upstream headers; VeOmni-authored glue (the ``triton_core``
+package ``__init__`` and the adapted ``flash_gated_delta_rule.py``) carries
+VeOmni's own header. Treat the kernels as a drop-in vendor blob so they stay
+diff-able against upstream — do not hand-edit kernel logic. VeOmni's registry-facing
+wrappers live one level up (``npu_causal_conv1d.py`` and the
+``chunk_gated_delta_rule`` factories in the package ``__init__``); those are the
+only entry points other code should call.
 
-These modules require ``triton`` (``triton-ascend`` on NPU) and are imported
-lazily by the kernel factories, so importing the parent package on a host
-without triton-ascend does not pull them in.
+Two generations of the gated delta-rule stack live here:
+
+- ``triton/`` — the original pure-Triton (``triton-ascend``) kernels, backing
+  the ``npu`` backend (``chunk_gated_delta_rule_mm.py``).
+- ``triton_core/`` + ``flash_gated_delta_rule.py`` — the newer AscendC path
+  (``npu_ascendc`` backend). The heavy GDN compute is delegated to the external
+  ``fla_npu`` package (``torch.ops.npu.*`` fused ops, installed manually on NPU);
+  ``triton_core`` (a newer *generation* of Triton kernels) supplies the glue
+  around the fused ops on the chunk path. ``flash_gated_delta_rule.py`` is
+  adapted from upstream — see its module docstring for the exact diffs.
+
+These modules require ``triton`` (``triton-ascend`` on NPU) — and ``flash_gated_delta_rule``
+additionally requires ``fla_npu`` — and are imported lazily by the kernel
+factories, so importing the parent package on a host without those does not
+pull them in.
 """

--- a/veomni/ops/kernels/gated_delta_rule/_ascend/flash_gated_delta_rule.py
+++ b/veomni/ops/kernels/gated_delta_rule/_ascend/flash_gated_delta_rule.py
@@ -1,0 +1,623 @@
+"""AscendC port of Qwen3.5's chunk gated delta-rule.
+
+Adapted from MindSpeed-MM's ``mindspeed_mm/fsdp/ops/gdn/flash_gated_delta_rule.py``,
+which in turn derives from fla_npu commit c2e3d83f
+(https://github.com/flashserve/flash-linear-attention-npu):
+the heavy GDN compute is provided by the external ``fla_npu`` package as
+``torch.ops.npu.*`` fused ops; the Triton glue lives under ``triton_core``.
+
+VeOmni adaptations vs. upstream (keep this list in sync when re-syncing):
+- MM-absolute imports rewritten to package-relative.
+- Dropped MM's async-offload / ``skip_recompute`` machinery
+  (``TrainingContext`` / ``OffloadManager`` / ``SwapTensor`` / ``get_current_stream``):
+  VeOmni has no such framework, so only the plain compute path remains.
+"""
+
+import warnings
+from typing import Dict, Optional
+
+import torch
+import torch_npu
+import fla_npu
+
+from .triton_core.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+from .triton_core.l2norm import l2norm_bwd, l2norm_fwd
+from .triton.cumsum import chunk_local_cumsum
+from .triton_core.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+
+from .triton.utils import is_arch35
+if is_arch35():
+    from .triton_core.solve_tril import solve_tril
+else:
+    from .triton.solve_tril import solve_tril
+
+_disable_compile = getattr(getattr(torch, "compiler", None), "disable", lambda fn: fn)
+_DEFAULT_VARLEN_CHUNK_SIZES = (16, 32, 64, 128, 608 * 2)
+
+
+def cdiv_torch(a, b):
+    return (a + b - 1) // b
+
+
+def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+def prepare_chunk_indices(cu_seqlens: torch.LongTensor, chunk_size: int) -> torch.LongTensor:
+    indices = torch.cat(
+        [torch.arange(n) for n in cdiv_torch(prepare_lens(cu_seqlens), chunk_size).tolist()]
+    )
+    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
+
+
+def prepare_chunk_indices_list(cu_seqlens: list[int] | torch.LongTensor, chunk_size: int) -> list[int]:
+    if isinstance(cu_seqlens, torch.Tensor):
+        cu_seqlens = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+
+    indices: list[int] = []
+    for seq_idx in range(len(cu_seqlens) - 1):
+        length = int(cu_seqlens[seq_idx + 1]) - int(cu_seqlens[seq_idx])
+        if length <= 0:
+            continue
+        for chunk_idx in range((length + chunk_size - 1) // chunk_size):
+            indices.extend([seq_idx, chunk_idx])
+    return indices
+
+
+def _as_int_list(value: Optional[list[int] | torch.Tensor]) -> Optional[list[int]]:
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        return [int(x) for x in value.detach().cpu().flatten().tolist()]
+    return [int(x) for x in value]
+
+
+def _as_chunk_dict(
+    value: Optional[Dict[str, Optional[torch.LongTensor]] | torch.LongTensor],
+    chunk_size: int,
+) -> Dict[str, Optional[torch.LongTensor]]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    return {str(chunk_size): value}
+
+
+def _as_chunk_list_dict(
+    value: Optional[Dict[str, Optional[list[int]]] | list[int] | torch.Tensor],
+    chunk_size: int,
+) -> Dict[str, Optional[list[int]]]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return {str(k): _as_int_list(v) for k, v in value.items()}
+    return {str(chunk_size): _as_int_list(value)}
+
+
+def _next_power_of_2(value: int) -> int:
+    value = max(1, int(value))
+    return 1 << (value - 1).bit_length()
+
+
+def _cumsum_block_t(g: torch.Tensor, chunk_size: int) -> int:
+    # Keep this aligned with mindspeed_mm.fsdp.ops.gdn.triton_core.cumsum.chunk_local_cumsum_scalar.
+    h = int(g.shape[-1])
+    return _next_power_of_2((1 << 17) // max(1, h * int(chunk_size)))
+
+
+def _ensure_varlen_metadata(
+    g: torch.Tensor,
+    cu_seqlens: Optional[torch.LongTensor],
+    cu_seqlens_list: Optional[list[int]],
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]] | torch.LongTensor],
+    chunk_indices_list: Optional[Dict[str, Optional[list[int]]] | list[int] | torch.Tensor],
+    chunk_size: int,
+) -> tuple[
+    Optional[torch.LongTensor],
+    Optional[list[int]],
+    Optional[Dict[str, Optional[torch.LongTensor]]],
+    Optional[Dict[str, Optional[list[int]]]],
+]:
+    if cu_seqlens is None:
+        return None, None, None, None
+
+    cu_seqlens = cu_seqlens.to(device=g.device, dtype=torch.int64)
+    cu_seqlens_list = _as_int_list(cu_seqlens_list) or _as_int_list(cu_seqlens)
+    assert cu_seqlens_list is not None
+
+    tensor_indices = _as_chunk_dict(chunk_indices, chunk_size)
+    list_indices = _as_chunk_list_dict(chunk_indices_list, chunk_size)
+
+    required_sizes = set(_DEFAULT_VARLEN_CHUNK_SIZES)
+    required_sizes.add(int(chunk_size))
+    required_sizes.add(_cumsum_block_t(g, chunk_size))
+
+    for size in required_sizes:
+        key = str(size)
+        if key not in tensor_indices or tensor_indices[key] is None:
+            tensor_indices[key] = prepare_chunk_indices(cu_seqlens, size)
+        if key not in list_indices or list_indices[key] is None:
+            list_indices[key] = prepare_chunk_indices_list(cu_seqlens_list, size)
+
+    return cu_seqlens, cu_seqlens_list, tensor_indices, list_indices
+
+
+def _chunk_tensor(
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]]],
+    chunk_size: int,
+) -> Optional[torch.LongTensor]:
+    if chunk_indices is None:
+        return None
+    return chunk_indices.get(str(chunk_size))
+
+
+def _chunk_list(
+    chunk_indices_list: Optional[Dict[str, Optional[list[int]]]],
+    chunk_size: int,
+) -> Optional[list[int]]:
+    if chunk_indices_list is None:
+        return None
+    return chunk_indices_list.get(str(chunk_size))
+
+
+def flash_chunk_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: Optional[torch.Tensor],
+    output_final_state: bool,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_list: Optional[list[int]] = None,
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]]] = None,
+    chunk_indices_list: Optional[Dict[str, Optional[list[int]]]] = None,
+    chunk_size: int = 64,
+):
+    g = chunk_local_cumsum(
+        g,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+        head_first=False,
+    )
+
+    # A is the WY lower-triangular representation before inversion.
+    A = chunk_scaled_dot_kkt_fwd(
+        k=k,
+        g=g,
+        beta=beta,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=_chunk_tensor(chunk_indices, chunk_size),
+        chunk_size=chunk_size,
+        output_dtype=torch.float32,
+    )
+
+    if is_arch35():
+        A = solve_tril(
+            A=A,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            output_dtype=k.dtype,
+        )
+    else:
+        A = solve_tril(
+            A=A,
+            cu_seqlens=cu_seqlens,
+            output_dtype=k.dtype,
+        )
+
+    g = g.transpose(1, 2).contiguous()
+    beta = beta.transpose(1, 2).contiguous().float()
+    A = A.transpose(1, 2).contiguous()
+
+    w, u = torch.ops.npu.npu_recompute_w_u_fwd(
+        k,
+        v,
+        beta,
+        A,
+        chunk_size,
+        g=g,
+        gk=None,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    h, v_new, final_state = torch.ops.npu.npu_chunk_gated_delta_rule_fwd_h(
+        k,
+        w,
+        u,
+        g=g,
+        gk=None,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        chunk_size=chunk_size,
+        save_new_value=True,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+    if not output_final_state:
+        final_state = None
+
+    o = torch.ops.npu.npu_chunk_fwd_o(
+        q,
+        k,
+        v_new,
+        h,
+        scale,
+        g=g,
+        g_gamma=None,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        chunk_size=chunk_size,
+        transpose_state_layout=False,
+    )
+
+    g = g.transpose(1, 2).contiguous()
+    o = o.transpose(1, 2).contiguous()
+    return g, o, A, final_state
+
+
+def flash_chunk_gated_delta_rule_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    scale: float,
+    initial_state: Optional[torch.Tensor],
+    do: torch.Tensor,
+    dht: Optional[torch.Tensor],
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_list: Optional[list[int]] = None,
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]]] = None,
+    chunk_indices_list: Optional[Dict[str, Optional[list[int]]]] = None,
+    chunk_size: int = 64,
+):
+    g = g.transpose(1, 2).contiguous()
+    beta = beta.transpose(1, 2).contiguous().float()
+
+    w, u = torch.ops.npu.npu_recompute_w_u_fwd(
+        k,
+        v,
+        beta,
+        A,
+        chunk_size,
+        g=g,
+        gk=None,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    do = do.transpose(1, 2).contiguous()
+
+    h, v_new, _ = torch.ops.npu.npu_chunk_gated_delta_rule_fwd_h(
+        k,
+        w,
+        u,
+        g=g,
+        gk=None,
+        initial_state=initial_state,
+        output_final_state=False,
+        chunk_size=chunk_size,
+        save_new_value=True,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+
+    dv = torch.ops.npu.npu_chunk_bwd_dv_local(
+        q,
+        k,
+        do,
+        g,
+        scale,
+        chunk_size,
+        g_gamma=None,
+        A=A,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    dh, dh0, dv = torch.ops.npu.npu_chunk_gated_delta_rule_bwd_dhu(
+        q,
+        k,
+        w,
+        do,
+        dv,
+        scale,
+        chunk_size,
+        g=g,
+        gK=None,
+        h0=None,
+        dht=None,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+    dh0 = None
+
+    dq, dk, dw, dg = torch.ops.npu.npu_chunk_bwd_dqkwg(
+        q,
+        k,
+        v_new,
+        g,
+        h,
+        do,
+        dh,
+        dv,
+        chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        w=None,
+        g_gamma=None,
+        scale=scale,
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+
+    dA = torch.ops.npu.npu_prepare_wy_repr_bwd_da(
+        k,
+        v,
+        beta.float(),
+        A,
+        dw,
+        dv,
+        g.float(),
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    dk2, dv, db, dg2 = torch.ops.npu.npu_prepare_wy_repr_bwd_full(
+        k,
+        v,
+        beta,
+        A,
+        dA,
+        dw,
+        dv,
+        g,
+        chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    db = db.transpose(1, 2).contiguous()
+    dg2 = dg2.transpose(1, 2).contiguous()
+    dg = dg.transpose(1, 2).contiguous()
+
+    dk.add_(dk2)
+    dg.add_(dg2)
+    if dg.dtype != torch.float32:
+        raise ValueError(f"dg current type is {dg.dtype}, should be float32")
+
+    dg = chunk_local_cumsum(
+        dg,
+        chunk_size=chunk_size,
+        reverse=True,
+        cu_seqlens=cu_seqlens,
+        head_first=False,
+    )
+
+    return dq, dk, dv, db, dg, dh0
+
+
+class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
+    @staticmethod
+    @input_guard
+    @autocast_custom_fwd
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float,
+        initial_state: Optional[torch.Tensor],
+        output_final_state: bool,
+        cu_seqlens: Optional[torch.LongTensor] = None,
+        cu_seqlens_list: Optional[list[int]] = None,
+        chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]]] = None,
+        chunk_indices_list: Optional[Dict[str, Optional[list[int]]]] = None,
+        use_qk_l2norm_in_kernel: bool = False,
+        chunk_size: int = 64,
+    ):
+
+        if use_qk_l2norm_in_kernel:
+            q, q_rstd = l2norm_fwd(q)
+            k, k_rstd = l2norm_fwd(k)
+        else:
+            q_rstd, k_rstd = None, None
+
+        g, o, A, final_state = flash_chunk_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_list=cu_seqlens_list,
+            chunk_indices=chunk_indices,
+            chunk_indices_list=chunk_indices_list,
+            chunk_size=chunk_size,
+        )
+
+        ctx.save_for_backward(q, k, v, g, beta, A)
+        ctx.q_rstd = q_rstd
+        ctx.k_rstd = k_rstd
+        ctx.initial_state = initial_state
+        ctx.cu_seqlens = cu_seqlens
+        ctx.scale = scale
+        ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+        ctx.chunk_size = chunk_size
+        ctx.cu_seqlens_list = cu_seqlens_list
+        ctx.chunk_indices = chunk_indices
+        ctx.chunk_indices_list = chunk_indices_list
+        return o.to(q.dtype), final_state
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_bwd
+    def backward(ctx, do: torch.Tensor, dht: Optional[torch.Tensor]):
+        q, k, v, g, beta, A = ctx.saved_tensors
+        dq, dk, dv, db, dg, dh0 = flash_chunk_gated_delta_rule_bwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            A=A,
+            scale=ctx.scale,
+            initial_state=ctx.initial_state,
+            do=do,
+            dht=dht,
+            cu_seqlens=ctx.cu_seqlens,
+            cu_seqlens_list=ctx.cu_seqlens_list,
+            chunk_indices=ctx.chunk_indices,
+            chunk_indices_list=ctx.chunk_indices_list,
+            chunk_size=ctx.chunk_size,
+        )
+        if ctx.use_qk_l2norm_in_kernel:
+            dq = l2norm_bwd(q, ctx.q_rstd, dq)
+            dk = l2norm_bwd(k, ctx.k_rstd, dk)
+        return (
+            dq.to(q),
+            dk.to(k),
+            dv.to(v),
+            dg.to(g),
+            db.to(beta),
+            None,
+            dh0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+@_disable_compile
+def flash_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_list: Optional[list[int]] = None,
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]] | torch.LongTensor] = None,
+    chunk_indices_list: Optional[Dict[str, Optional[list[int]]] | list[int] | torch.Tensor] = None,
+    chunk_size: int = 64,
+    head_first: bool = False,
+):
+    r"""
+    Flash-linear-attention NPU port of xtuner's GDN entry.
+
+    This port keeps the xtuner NPU layout:
+        q, k: [B, H, T, K]
+        v:    [B, H, T, V]
+        g:    [B, T, H]
+        beta: [B, T, H]
+
+    It returns:
+        o: [B, T, H, V]
+        final_state: [N, H, K, V] when output_final_state=True, else None
+    """
+    if q.dtype != k.dtype or k.dtype != v.dtype:
+        raise ValueError(
+            f"q current type is {q.dtype}, k current type is {k.dtype}, "
+            f"v current type is {v.dtype}; they should be equal"
+        )
+    if q.dtype == torch.float32:
+        raise ValueError("ChunkGatedDeltaRuleFunction does not support float32. Please use float16/bfloat16.")
+    if beta.ndim != 3 or g.ndim != 3:
+        raise ValueError("g and beta must be rank-3 tensors with shape [B, T, H].")
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        raise ValueError("q, k and v must be rank-4 tensors with shape [B, H, T, D].")
+    if q.shape[:3] != k.shape[:3] or q.shape[:3] != v.shape[:3]:
+        raise ValueError(f"q/k/v shape prefixes must match, got {q.shape}, {k.shape}, {v.shape}.")
+    if g.shape != beta.shape:
+        raise ValueError(f"g and beta shapes must match, got {g.shape} and {beta.shape}.")
+    if g.shape[0] != q.shape[0] or g.shape[1] != q.shape[2] or g.shape[2] != q.shape[1]:
+        raise ValueError(
+            "Expected q/k/v in [B, H, T, D] and g/beta in [B, T, H]; "
+            f"got q={tuple(q.shape)}, g={tuple(g.shape)}."
+        )
+
+    if head_first:
+        warnings.warn(
+            "head_first is kept only for API compatibility. This NPU port always expects q/k/v as [B, H, T, D].",
+            stacklevel=2,
+        )
+    if chunk_size != 2 ** (chunk_size.bit_length() - 1):
+        raise ValueError(f"chunk_size must be a power of 2, got {chunk_size}.")
+
+    if cu_seqlens is not None:
+        cu_seqlens, cu_seqlens_list, chunk_indices, chunk_indices_list = _ensure_varlen_metadata(
+            g=g,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_list=cu_seqlens_list,
+            chunk_indices=chunk_indices,
+            chunk_indices_list=chunk_indices_list,
+            chunk_size=chunk_size,
+        )
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using cu_seqlens. "
+                "Please flatten variable-length inputs before processing."
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens_list) - 1:
+            raise ValueError(
+                "The number of initial states is expected to match the number of input sequences, "
+                f"got initial_state.shape[0]={initial_state.shape[0]} and sequences={len(cu_seqlens_list) - 1}."
+            )
+    else:
+        cu_seqlens_list = None
+        chunk_indices = None
+        chunk_indices_list = None
+
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    o, final_state = ChunkGatedDeltaRuleFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        float(scale),
+        initial_state,
+        output_final_state,
+        cu_seqlens,
+        cu_seqlens_list,
+        chunk_indices,
+        chunk_indices_list,
+        use_qk_l2norm_in_kernel,
+        chunk_size,
+    )
+    return o, final_state
+
+
+__all__ = [
+    "flash_gated_delta_rule",
+    "flash_chunk_gated_delta_rule_fwd",
+    "flash_chunk_gated_delta_rule_bwd",
+    "prepare_chunk_indices",
+    "prepare_chunk_indices_list",
+]

--- a/veomni/ops/kernels/gated_delta_rule/_ascend/flash_gated_delta_rule.py
+++ b/veomni/ops/kernels/gated_delta_rule/_ascend/flash_gated_delta_rule.py
@@ -18,7 +18,10 @@ from typing import Dict, Optional
 
 import torch
 import torch_npu
-import fla_npu
+
+# Load-bearing despite being unused: importing fla_npu registers the fused
+# torch.ops.npu.* GDN ops this file dispatches to. Do not prune.
+import fla_npu  # noqa: F401
 
 from .triton_core.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .triton_core.l2norm import l2norm_bwd, l2norm_fwd
@@ -197,7 +200,7 @@ def flash_chunk_gated_delta_rule_fwd(
         A = solve_tril(
             A=A,
             cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
+            chunk_indices=_chunk_tensor(chunk_indices, chunk_size),
             output_dtype=k.dtype,
         )
     else:
@@ -429,6 +432,19 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         use_qk_l2norm_in_kernel: bool = False,
         chunk_size: int = 64,
     ):
+        # The AscendC backward (npu_chunk_gated_delta_rule_bwd_dhu) hardcodes
+        # h0/dht=None and returns dh0=None, so it produces no gradient w.r.t.
+        # initial_state — this matches upstream MindSpeed-MM's AscendC path (its
+        # Triton `npu` backend does thread h0/dht, but this AscendC one does not).
+        # Forward-only use of initial_state (recurrent-state carry) is fine; guard
+        # only the grad-requiring case so it fails loud instead of silently
+        # returning a None/zero gradient.
+        if torch.is_grad_enabled() and initial_state is not None and initial_state.requires_grad:
+            raise NotImplementedError(
+                "npu_ascendc chunk_gated_delta_rule cannot differentiate initial_state "
+                "(the AscendC backward returns no dh0, same as MindSpeed-MM). Detach "
+                "initial_state, or use the 'npu' (Triton) backend if you need that gradient."
+            )
 
         if use_qk_l2norm_in_kernel:
             q, q_rstd = l2norm_fwd(q)

--- a/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/__init__.py
+++ b/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Newer-generation Triton (``triton-ascend``) kernels for gated delta-rule
+(vendored via MindSpeed-MM's ``triton_core``, derived from fla_npu commit c2e3d83f —
+https://github.com/flashserve/flash-linear-attention-npu).
+
+This is a distinct, newer kernel generation from the sibling ``triton/`` package
+(e.g. a rewritten ``solve_tril``, an autotuned ``chunk_scaled_dot_kkt``) — the
+name ``triton_core`` refers to that kernel generation, not to the ``fla_npu``
+runtime package. These kernels are used by the ``flash_gated_delta_rule`` chunk
+path as glue *around* the heavy ``fla_npu`` ``torch.ops.npu.*`` fused ops:
+``chunk_scaled_dot_kkt``, ``l2norm``, ``solve_tril`` (arch35 only), and ``utils``.
+"""

--- a/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/chunk_scaled_dot_kkt.py
+++ b/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/chunk_scaled_dot_kkt.py
@@ -1,0 +1,346 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.heuristics({
+    'USE_G': lambda args: args['g'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def chunk_scaled_dot_kkt_fwd_kernel(
+    k,
+    g,
+    beta,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_G: tl.constexpr,
+    NT,
+    B,
+    TOTAL_TASKS,
+):
+    core_id = tl.program_id(0)
+    num_blocks = tl.num_programs(0)
+    T_max = T
+
+    base_tasks_per_block = TOTAL_TASKS // num_blocks
+    remainder_tasks = TOTAL_TASKS % num_blocks
+
+    if core_id < remainder_tasks:
+        tasks_this_core = base_tasks_per_block + 1
+        start_idx = core_id * tasks_this_core
+    else:
+        tasks_this_core = base_tasks_per_block
+        start_idx = core_id * base_tasks_per_block + remainder_tasks
+
+    for idx in range(start_idx, start_idx + tasks_this_core):
+        i_b = idx // NT
+        local_idx = idx % NT
+
+        if IS_VARLEN:
+            i_n = tl.load(chunk_indices + local_idx * 2).to(tl.int32)
+            i_t = tl.load(chunk_indices + local_idx * 2 + 1).to(tl.int32)
+            bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+            eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+            T_local = eos - bos
+        else:
+            bos, eos = 0, T
+            i_t = local_idx
+            T_local = T
+
+        for i_h in range(H):
+            k_batch_off = i_b * T_max * H * K
+            beta_batch_off = i_b * H * T_max
+            g_batch_off = i_b * H * T_max
+            A_batch_off = i_b * T_max * H * BT
+
+            p_beta = tl.make_block_ptr(beta + beta_batch_off + bos + i_h * T_max, (T_local,), (1,), (i_t * BT,), (BT,), (0,))
+            b_beta = tl.load(p_beta, boundary_check=(0,))
+
+            b_A = tl.zeros([BT, BT], dtype=tl.float32)
+            for i_k in range(tl.cdiv(K, BK)):
+                p_k = tl.make_block_ptr(k + k_batch_off + i_h * T_max * K + bos * K, (T_local, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+                b_k = tl.load(p_k, boundary_check=(0, 1))
+                dot_product = tl.dot(b_k, tl.trans(b_k))
+
+                o_t = i_t * BT + tl.arange(0, BT)
+                o_t = o_t.to(tl.float32)
+                T_mask = (o_t < T_local).to(tl.float32)
+
+                row_indices = tl.arange(0, BT)[:, None]
+                col_indices = tl.arange(0, BT)[None, :]
+                tril_mask = (row_indices > col_indices).to(tl.float32)
+                tril_mask = tril_mask * T_mask[:, None]
+                masked_dot = dot_product * tril_mask
+                b_A += masked_dot
+
+            if USE_G:
+                p_g = tl.make_block_ptr(g + g_batch_off + bos + i_h * T_max, (T_local,), (1,), (i_t * BT,), (BT,), (0,))
+                b_g = tl.load(p_g, boundary_check=(0,))
+                b_g_diff = b_g[:, None] - b_g[None, :]
+                b_g_diff = tl.minimum(tl.maximum(b_g_diff, -50.0), 50.0)
+                b_A *= tl.exp(b_g_diff)
+            b_A *= b_beta[:, None]
+
+            p_A = tl.make_block_ptr(A + A_batch_off + (bos * H + i_h) * BT, (T_local, BT), (BT * H, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+            tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BK': BK}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64]
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BC"]
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_scaled_dot_kkt_fwd_kernel_intra_sub_inter(
+    k,
+    g,
+    beta,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_c, i_b = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_i, i_j = i_c // NC, i_c % NC
+
+    for i_h in range(H):
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+            T_val = eos - bos
+        else:
+            bos, eos = i_b * T, i_b * T + T
+            T_val = T
+
+        should_compute = (i_t * BT + i_i * BC < T_val) and (i_i > i_j)
+
+        if should_compute:
+            k_ptr = k + (bos * H + i_h) * K
+            g_ptr = g + (bos * H + i_h) * K
+            A_ptr = A + (bos * H + i_h) * BT
+
+            p_beta = tl.make_block_ptr(beta + bos * H + i_h, (T_val,), (H,), (i_t * BT + i_i * BC,), (BC,), (0,))
+            b_beta = tl.load(p_beta, boundary_check=(0,))
+
+            b_A = tl.zeros([BC, BC], dtype=tl.float32)
+            for i_k in range(tl.cdiv(K, BK)):
+                p_k = tl.make_block_ptr(k_ptr, (T_val, K), (H * K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK),
+                                        (1, 0))
+                p_g = tl.make_block_ptr(g_ptr, (T_val, K), (H * K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK),
+                                        (1, 0))
+                b_kt = tl.make_block_ptr(k_ptr, (K, T_val), (1, H * K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC),
+                                         (0, 1))
+                p_gk = tl.make_block_ptr(g_ptr, (K, T_val), (1, H * K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC),
+                                         (0, 1))
+
+                o_k = i_k * BK + tl.arange(0, BK)
+                m_k = o_k < K
+                b_gn = tl.load(g_ptr + (i_t * BT + i_i * BC) * H * K + o_k, mask=m_k, other=0)
+                b_g = tl.load(p_g, boundary_check=(0, 1))
+                b_k = tl.load(p_k, boundary_check=(0, 1)) * tl.exp(b_g - b_gn[None, :])
+                b_gk = tl.load(p_gk, boundary_check=(0, 1))
+                b_kt = tl.load(b_kt, boundary_check=(0, 1)) * tl.exp(b_gn[:, None] - b_gk)
+                b_A += tl.dot(b_k, b_kt)
+            b_A *= b_beta[:, None]
+
+            p_A = tl.make_block_ptr(A_ptr, (T_val, BT), (H * BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
+            tl.store(p_A, b_A.to(A.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1),
+        triton.Config({}, num_warps=2),
+        triton.Config({}, num_warps=4),
+        triton.Config({}, num_warps=8),
+    ],
+    key=["BK", "BT"]
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_scaled_dot_kkt_fwd_kernel_intra_sub_intra(
+    k,
+    g,
+    beta,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_i, i_b = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+
+    for i_h in range(H):
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+            T_val = eos - bos
+        else:
+            bos, eos = i_b * T, i_b * T + T
+            T_val = T
+
+        should_compute = (i_t * BT + i_i * BC < T_val)
+
+        if should_compute:
+            o_i = tl.arange(0, BC)
+            o_k = tl.arange(0, BK)
+            m_k = o_k < K
+            m_A = (i_t * BT + i_i * BC + o_i) < T_val
+            o_A = (bos + i_t * BT + i_i * BC + o_i) * H * BT + i_h * BT + i_i * BC
+
+            p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T_val, K), (H * K, 1), (i_t * BT + i_i * BC, 0), (BC, BK),
+                                    (1, 0))
+            p_g = tl.make_block_ptr(g + (bos * H + i_h) * K, (T_val, K), (H * K, 1), (i_t * BT + i_i * BC, 0), (BC, BK),
+                                    (1, 0))
+            p_beta = beta + (bos + i_t * BT + i_i * BC + o_i) * H + i_h
+
+            b_k = tl.load(p_k, boundary_check=(0, 1)) * tl.load(p_beta, mask=m_A, other=0)[:, None]
+            b_g = tl.load(p_g, boundary_check=(0, 1))
+
+            p_kt = k + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+            p_gk = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+
+            for j in range(0, min(BC, T_val - i_t * BT - i_i * BC)):
+                b_kt = tl.load(p_kt, mask=m_k, other=0).to(tl.float32)
+                b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
+                b_A = tl.sum(b_k * b_kt[None, :] * tl.exp(b_g - b_gk[None, :]), 1)
+                # 转化成f32
+                o_i_tmp = o_i.to(tl.float32)
+                b_A = tl.where(o_i_tmp > j, b_A, 0.)
+
+                tl.store(A + o_A + j, b_A, mask=m_A)
+                p_kt += H * K
+                p_gk += H * K
+
+
+def chunk_scaled_dot_kkt_fwd(
+    k: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    gk: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_indices: Optional[torch.Tensor] = None,
+    chunk_size: int = 64,
+    output_dtype: torch.dtype = torch.float32
+) -> torch.Tensor:
+    r"""
+    Compute beta * K * K^T.
+
+    Args:
+        k (torch.Tensor):
+            The key tensor of shape `[B, H, T, K]`.
+        beta (torch.Tensor):
+            The beta tensor of shape `[B, T, H]`.
+        g (torch.Tensor):
+            The cumulative sum of the gate tensor of shape `[B, T, H]`. Default: `None`.
+        gk (torch.Tensor):
+            The cumulative sum of the gate tensor of shape `[B, T, H, K]` applied to the key tensor. Default: `None`.
+        cu_seqlens (torch.LongTensor):
+            The cumulative sequence lengths of the input tensor.
+            Default: None
+        chunk_size (int):
+            The chunk size. Default: 64.
+        output_dtype (torch.dtype):
+            The dtype of the output tensor. Default: `torch.float32`
+
+    Returns:
+        beta * K * K^T of shape `[B, T, H, BT]` where `BT` is the chunk size.
+    """
+    B, H, T, K = k.shape
+    BT = chunk_size
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    beta = beta.transpose(1, 2).contiguous()
+    g = g.transpose(1, 2).contiguous()
+    BK = 128
+    kernel_num = 24
+
+    if gk is None:
+        A = torch.empty(B, T, H, BT, device=k.device, dtype=output_dtype)
+        chunk_scaled_dot_kkt_fwd_kernel[(kernel_num,)](
+            k=k,
+            g=g,
+            beta=beta,
+            A=A,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            H=H,
+            K=K,
+            BT=BT,
+            BK=BK,
+            NT=NT,
+            B=B,
+            TOTAL_TASKS=B * NT,
+        )
+        return A
+
+    BC = min(16, BT)
+    NC = triton.cdiv(BT, BC)
+    BK = max(triton.next_power_of_2(K), 16)
+    A = torch.zeros(B, T, H, BT, device=k.device, dtype=output_dtype)
+    grid = (NT, NC * NC, B)
+    chunk_scaled_dot_kkt_fwd_kernel_intra_sub_inter[grid](
+        k=k,
+        g=gk,
+        beta=beta,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+        NC=NC,
+    )
+
+    grid = (NT, NC, B)
+    chunk_scaled_dot_kkt_fwd_kernel_intra_sub_intra[grid](
+        k=k,
+        g=gk,
+        beta=beta,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+        BK=BK,
+    )
+    return A

--- a/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/l2norm.py
+++ b/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/l2norm.py
@@ -107,7 +107,11 @@ def l2norm_bwd_kernel(
     i_t_start = tl.program_id(0)
     num_blocks = bt_size
 
-    total_i_t = T // BT
+    # VeOmni fix: ceil, not floor. Floor drops the partial last block when T is
+    # not a multiple of BT (varlen/ragged segments), so its rows in `dx` are
+    # never written and keep uninitialized garbage. The block_start < T guard
+    # plus boundary_check below already handle the partial block once scheduled.
+    total_i_t = (T + BT - 1) // BT
     base_tasks_per_block = total_i_t // num_blocks
     remainder_tasks = total_i_t % num_blocks
 

--- a/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/l2norm.py
+++ b/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/l2norm.py
@@ -1,0 +1,286 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import triton
+import triton.language as tl
+
+from .utils import input_guard, is_amd
+
+BT_LIST = [8, 16, 32, 64, 128]
+NUM_WARPS_AUTOTUNE = [1, 2, 4, 8, 16] if is_amd else [1, 2, 4, 8, 16, 32]
+
+
+@triton.jit
+def l2norm_fwd_kernel1(
+    x,
+    y,
+    rstd,
+    eps,
+    D,
+    BD: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    x += i_t * D
+    y += i_t * D
+    # Compute mean and variance
+    cols = tl.arange(0, BD)
+    mask = cols < D
+
+    b_x = tl.load(x + cols, mask=mask, other=0.0).to(tl.float32)
+    b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x) + eps)
+    b_y = b_x * b_rstd
+    tl.store(y + cols, b_y, mask=mask)
+    tl.store(rstd + i_t, b_rstd)
+
+
+@triton.jit
+def l2norm_bwd_kernel1(
+    y,
+    rstd,
+    dy,
+    dx,
+    eps,
+    D,
+    BD: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    y += i_t * D
+    dx += i_t * D
+    dy += i_t * D
+
+    cols = tl.arange(0, BD)
+    mask = cols < D
+    b_y = tl.load(y + cols, mask=mask, other=0.0).to(tl.float32)
+    b_rstd = tl.load(rstd + i_t).to(tl.float32)
+    b_dy = tl.load(dy + cols, mask=mask, other=0.0).to(tl.float32)
+    b_dx = b_dy * b_rstd - tl.sum(b_dy * b_y) * b_y * b_rstd
+    tl.store(dx + cols, b_dx, mask=mask)
+
+
+@triton.jit
+def l2norm_fwd_kernel(
+    x,
+    y,
+    rstd,
+    eps,
+    T: tl.constexpr,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    NB: tl.constexpr,
+    BT: tl.constexpr,
+    bt_size,
+):
+    i_t = tl.program_id(0)
+    for offset in range(0, bt_size):
+        block_start = (i_t * bt_size + offset) * BT
+        if block_start < T:
+            p_x = tl.make_block_ptr(x, (T, D), (D, 1), (block_start, 0), (BT, BD), (1, 0))
+            p_y = tl.make_block_ptr(y, (T, D), (D, 1), (block_start, 0), (BT, BD), (1, 0))
+            p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (block_start,), (BT,), (0,))
+
+            b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+            b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x, 1) + eps)
+            b_y = b_x * b_rstd[:, None]
+
+            tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.jit
+def l2norm_bwd_kernel(
+    y,
+    rstd,
+    dy,
+    dx,
+    eps,
+    T: tl.constexpr,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    NB: tl.constexpr,
+    BT: tl.constexpr,
+    bt_size,
+):
+    i_t_start = tl.program_id(0)
+    num_blocks = bt_size
+
+    total_i_t = T // BT
+    base_tasks_per_block = total_i_t // num_blocks
+    remainder_tasks = total_i_t % num_blocks
+
+    if i_t_start < remainder_tasks:
+        tasks_this_block = base_tasks_per_block + 1
+        start_i_t = i_t_start * tasks_this_block
+    else:
+        tasks_this_block = base_tasks_per_block
+        start_i_t = i_t_start * base_tasks_per_block + remainder_tasks
+
+    for task_idx in range(tasks_this_block):
+        i_t = start_i_t + task_idx
+        block_start = i_t * BT
+        if block_start < T:
+            p_y = tl.make_block_ptr(y, (T, D), (D, 1), (block_start, 0), (BT, BD), (1, 0))
+            p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (block_start,), (BT,), (0,))
+            p_dy = tl.make_block_ptr(dy, (T, D), (D, 1), (block_start, 0), (BT, BD), (1, 0))
+            p_dx = tl.make_block_ptr(dx, (T, D), (D, 1), (block_start, 0), (BT, BD), (1, 0))
+
+            b_y = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
+            b_rstd = tl.load(p_rstd, boundary_check=(0,)).to(tl.float32)
+            b_dy = tl.load(p_dy, boundary_check=(0, 1)).to(tl.float32)
+            b_dx = b_dy * b_rstd[:, None] - tl.sum(b_dy * b_y, 1)[:, None] * b_y * b_rstd[:, None]
+            tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), boundary_check=(0, 1))
+
+
+def l2norm_fwd(
+    x: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: Optional[torch.dtype] = None
+):
+    x_shape_og = x.shape
+    x = x.view(-1, x.shape[-1])
+    # allocate output
+    if output_dtype is None:
+        y = torch.empty_like(x)
+    else:
+        y = torch.empty_like(x, dtype=output_dtype)
+    assert y.stride(-1) == 1
+    T, D = x.shape[0], x.shape[-1]
+    # Less than 64KB per feature: enqueue fused kernel
+    MAX_FUSED_SIZE = 65536 // x.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
+
+    rstd = torch.empty((T,), dtype=torch.float32, device=x.device)
+    if D <= 512:
+        NB = triton.cdiv(T, 2048)
+        bt_size = 32
+
+        def grid(meta):
+            new_bt = meta['BT'] * bt_size
+            return (triton.cdiv(T, new_bt), )
+
+        l2norm_fwd_kernel[grid](
+            x=x,
+            y=y,
+            rstd=rstd,
+            eps=eps,
+            T=T,
+            D=D,
+            BD=BD,
+            NB=NB,
+            BT=32,
+            bt_size=bt_size,
+        )
+    else:
+        l2norm_fwd_kernel1[(T,)](
+            x=x,
+            y=y,
+            rstd=rstd,
+            eps=eps,
+            D=D,
+            BD=BD,
+        )
+    return y.view(x_shape_og), rstd.view(x_shape_og[:-1])
+
+
+def l2norm_bwd(
+    y: torch.Tensor,
+    rstd: torch.Tensor,
+    dy: torch.Tensor,
+    eps: float = 1e-6
+):
+    y_shape_og = y.shape
+    y = y.view(-1, dy.shape[-1])
+    dy = dy.view(-1, dy.shape[-1])
+    assert dy.shape == y.shape
+    # allocate output
+    dx = torch.empty_like(y)
+    T, D = y.shape[0], y.shape[-1]
+    # Less than 64KB per feature: enqueue fused kernel
+    MAX_FUSED_SIZE = 65536 // y.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+
+    if D <= 512:
+        NB = triton.cdiv(T, 2048)
+        bt_size = 40
+        l2norm_bwd_kernel[(bt_size,)](
+            y=y,
+            rstd=rstd,
+            dy=dy,
+            dx=dx,
+            eps=eps,
+            T=T,
+            D=D,
+            BD=BD,
+            NB=NB,
+            BT=64,
+            bt_size=bt_size,
+        )
+    else:
+        l2norm_bwd_kernel1[(T,)](
+            y=y,
+            rstd=rstd,
+            dy=dy,
+            dx=dx,
+            eps=eps,
+            D=D,
+            BD=BD,
+        )
+
+    return dx.view(y_shape_og)
+
+
+class L2NormFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    def forward(
+        ctx,
+        x,
+        eps=1e-6,
+        output_dtype=None
+    ):
+        y, rstd = l2norm_fwd(x, eps, output_dtype)
+        ctx.eps = eps
+        ctx.x_dtype = x.dtype
+        ctx.save_for_backward(y, rstd)
+        return y
+
+    @staticmethod
+    @input_guard
+    def backward(ctx, dy):
+        y, rstd = ctx.saved_tensors
+        dx = l2norm_bwd(y, rstd, dy, ctx.eps)
+        return dx, None, None
+
+
+def l2norm(
+    x: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: Optional[torch.dtype] = None
+) -> torch.Tensor:
+    return L2NormFunction.apply(x, eps, output_dtype)
+
+
+l2_norm = l2norm
+
+
+class L2Norm(nn.Module):
+
+    def __init__(
+        self,
+        eps: float = 1e-6,
+        output_dtype: Optional[torch.dtype] = None
+    ):
+        super().__init__()
+        self.eps = eps
+        self.output_dtype = output_dtype
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return l2norm(x, self.eps, self.output_dtype)

--- a/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/solve_tril.py
+++ b/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/solve_tril.py
@@ -1,0 +1,366 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from .utils import prepare_chunk_indices
+from .utils import input_guard
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def solve_tril_16x16_kernel(
+    A,
+    Ai,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    USE_TMA: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    DOT_PRECISION: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    o_i = tl.arange(0, 16)
+    m_A = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    A = A + (bos * H + i_h) * BT
+    Ai = Ai + (bos * H + i_h) * 16
+
+    offset = (i_t * 16) % BT
+    p_A = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * 16, offset), (16, 16), (1, 0))
+    # [16, 16]
+    b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
+    b_A = tl.where(m_A, b_A, 0)
+    b_A = -b_A
+
+    for i in range(2, min(16, T - i_t * 16)):
+        # [16]
+        b_a = -tl.load(A + (i_t * 16 + i) * H * BT + o_i + offset)
+        b_a = tl.where(o_i < i, b_a, 0.)
+        b_a = b_a + tl.sum(b_a[:, None] * b_A, 0)
+        b_A = tl.where((o_i == i)[:, None], b_a, b_A)
+    b_A += m_I
+    p_Ai = tl.make_block_ptr(Ai, (T, 16), (H * 16, 1), (i_t * 16, 0), (16, 16), (1, 0))
+    tl.store(p_Ai, b_A.to(p_Ai.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def merge_16x16_to_32x32_inverse_kernel(
+    A,
+    Ai,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    USE_TMA: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    DOT_PRECISION: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    o_i = tl.arange(0, 16)
+    m_A = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+    A += (bos * H + i_h) * BT
+    Ai += (bos * H + i_h) * BT
+
+    p_A_11 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT, 0), (16, 16), (1, 0))
+    p_A_22 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
+    b_Ai_11 = tl.load(p_A_11, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai_22 = tl.load(p_A_22, boundary_check=(0, 1)).to(tl.float32)
+
+    # [16, 16]
+    b_Ai_11 = -tl.where(m_A, b_Ai_11, 0)
+    b_Ai_22 = -tl.where(m_A, b_Ai_22, 0)
+
+    for i in range(2, min(16, T - i_t * BT)):
+        b_a_11 = -tl.load(A + (i_t * BT + i) * H * BT + o_i)
+        b_a_11 += tl.sum(b_a_11[:, None] * b_Ai_11, 0)
+        b_Ai_11 = tl.where((o_i == i)[:, None], b_a_11, b_Ai_11)
+    for i in range(16 + 2, min(32, T - i_t * BT)):
+        b_a_22 = -tl.load(A + (i_t * BT + i) * H * BT + o_i + 16)
+        b_a_22 += tl.sum(b_a_22[:, None] * b_Ai_22, 0)
+        b_Ai_22 = tl.where((o_i == i - 16)[:, None], b_a_22, b_Ai_22)
+
+    b_Ai_11 += m_I
+    b_Ai_22 += m_I
+
+    p_A_21 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
+    b_A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
+
+    b_Ai_21 = -tl.dot(tl.dot(b_Ai_22, b_A_21, input_precision=DOT_PRECISION), b_Ai_11, input_precision=DOT_PRECISION)
+
+    p_Ai_11 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT, 0), (16, 16), (1, 0))
+    p_Ai_21 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
+    p_Ai_22 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
+    tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def merge_16x16_to_64x64_inverse_kernel(
+    A,
+    Ai,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    USE_TMA: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    DOT_PRECISION: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2), tl.load(chunk_indices + i_t * 2 + 1)
+        bos, eos = tl.load(cu_seqlens + i_n), tl.load(cu_seqlens + i_n + 1)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    o_i = tl.arange(0, 16)
+    o_j = tl.arange(0, 16)
+    m_A = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+    A += (bos * H + i_h) * BT
+    Ai += (bos * H + i_h) * BT
+
+    r_off_11 = i_t * BT
+    r_off_22 = i_t * BT + 16
+    r_off_33 = i_t * BT + 32
+    r_off_44 = i_t * BT + 48
+    m_diag = (r_off_11 + o_i[:, None] < T) & (o_j[None, :] < BT)
+    m_diag_22 = (r_off_22 + o_i[:, None] < T) & (16 + o_j[None, :] < BT)
+    m_diag_33 = (r_off_33 + o_i[:, None] < T) & (32 + o_j[None, :] < BT)
+    m_diag_44 = (r_off_44 + o_i[:, None] < T) & (48 + o_j[None, :] < BT)
+    b_Ai_11 = tl.load(A + (r_off_11 + o_i[:, None]) * H * BT + o_j[None, :], mask=m_diag, other=0.0).to(tl.float32)
+    b_Ai_22 = tl.load(A + (r_off_22 + o_i[:, None]) * H * BT + 16 + o_j[None, :], mask=m_diag_22, other=0.0).to(tl.float32)
+    b_Ai_33 = tl.load(A + (r_off_33 + o_i[:, None]) * H * BT + 32 + o_j[None, :], mask=m_diag_33, other=0.0).to(tl.float32)
+    b_Ai_44 = tl.load(A + (r_off_44 + o_i[:, None]) * H * BT + 48 + o_j[None, :], mask=m_diag_44, other=0.0).to(tl.float32)
+
+    # [16, 16]
+    b_Ai_11 = -tl.where(m_A, b_Ai_11, 0)
+    b_Ai_22 = -tl.where(m_A, b_Ai_22, 0)
+    b_Ai_33 = -tl.where(m_A, b_Ai_33, 0)
+    b_Ai_44 = -tl.where(m_A, b_Ai_44, 0)
+
+    # tri_inv_mch for diagonal block 11
+    # X = I - A = I + b_Ai_11,  Y = A@A = b_Ai_11 @ b_Ai_11
+    # 3 iterations: X += X@Y; Y = Y@Y
+
+    remaining_rows = T - i_t * BT
+    f_I = m_I.to(tl.float32)
+    if (not IS_VARLEN) or remaining_rows >= 16:
+        X_11 = f_I + b_Ai_11
+        Y_11 = tl.dot(b_Ai_11, b_Ai_11, input_precision=DOT_PRECISION)
+        X_11 = X_11 + tl.dot(X_11, Y_11, input_precision=DOT_PRECISION)
+        Y_11 = tl.dot(Y_11, Y_11, input_precision=DOT_PRECISION)
+        X_11 = X_11 + tl.dot(X_11, Y_11, input_precision=DOT_PRECISION)
+        Y_11 = tl.dot(Y_11, Y_11, input_precision=DOT_PRECISION)
+        X_11 = X_11 + tl.dot(X_11, Y_11, input_precision=DOT_PRECISION)
+        b_Ai_11 = X_11
+    else:
+        for i in range(2, min(16, T - i_t * BT)):
+            b_a_11 = -tl.load(A + (i_t * BT + i) * H * BT + o_i)
+            b_a_11 = tl.where(o_i < i, b_a_11, 0.)
+            b_a_11 += tl.sum(b_a_11[:, None] * b_Ai_11, 0)
+            b_Ai_11 = tl.where((o_i == i)[:, None], b_a_11, b_Ai_11)
+        b_Ai_11 += m_I
+
+    if (not IS_VARLEN) or remaining_rows >= 32:
+        # tri_inv_mch for diagonal block 22
+        X_22 = f_I + b_Ai_22
+        Y_22 = tl.dot(b_Ai_22, b_Ai_22, input_precision=DOT_PRECISION)
+        X_22 = X_22 + tl.dot(X_22, Y_22, input_precision=DOT_PRECISION)
+        Y_22 = tl.dot(Y_22, Y_22, input_precision=DOT_PRECISION)
+        X_22 = X_22 + tl.dot(X_22, Y_22, input_precision=DOT_PRECISION)
+        Y_22 = tl.dot(Y_22, Y_22, input_precision=DOT_PRECISION)
+        X_22 = X_22 + tl.dot(X_22, Y_22, input_precision=DOT_PRECISION)
+        b_Ai_22 = X_22
+    else:
+        for i in range(16 + 2, min(32, T - i_t * BT)):
+            b_a_22 = -tl.load(A + (i_t * BT + i) * H * BT + o_i + 16)
+            b_a_22 = tl.where(o_i < i - 16, b_a_22, 0.)
+            b_a_22 += tl.sum(b_a_22[:, None] * b_Ai_22, 0)
+            b_Ai_22 = tl.where((o_i == i - 16)[:, None], b_a_22, b_Ai_22)
+        b_Ai_22 += m_I
+
+    if (not IS_VARLEN) or remaining_rows >= 48:
+        # tri_inv_mch for diagonal block 33
+        X_33 = f_I + b_Ai_33
+        Y_33 = tl.dot(b_Ai_33, b_Ai_33, input_precision=DOT_PRECISION)
+        X_33 = X_33 + tl.dot(X_33, Y_33, input_precision=DOT_PRECISION)
+        Y_33 = tl.dot(Y_33, Y_33, input_precision=DOT_PRECISION)
+        X_33 = X_33 + tl.dot(X_33, Y_33, input_precision=DOT_PRECISION)
+        Y_33 = tl.dot(Y_33, Y_33, input_precision=DOT_PRECISION)
+        X_33 = X_33 + tl.dot(X_33, Y_33, input_precision=DOT_PRECISION)
+        b_Ai_33 = X_33
+    else:
+        for i in range(32 + 2, min(48, T - i_t * BT)):
+            b_a_33 = -tl.load(A + (i_t * BT + i) * H * BT + o_i + 32)
+            b_a_33 = tl.where(o_i < i - 32, b_a_33, 0.)
+            b_a_33 += tl.sum(b_a_33[:, None] * b_Ai_33, 0)
+            b_Ai_33 = tl.where((o_i == i - 32)[:, None], b_a_33, b_Ai_33)
+        b_Ai_33 += m_I
+
+    if (not IS_VARLEN) or remaining_rows >= 64:
+        # tri_inv_mch for diagonal block 44
+        X_44 = f_I + b_Ai_44
+        Y_44 = tl.dot(b_Ai_44, b_Ai_44, input_precision=DOT_PRECISION)
+        X_44 = X_44 + tl.dot(X_44, Y_44, input_precision=DOT_PRECISION)
+        Y_44 = tl.dot(Y_44, Y_44, input_precision=DOT_PRECISION)
+        X_44 = X_44 + tl.dot(X_44, Y_44, input_precision=DOT_PRECISION)
+        Y_44 = tl.dot(Y_44, Y_44, input_precision=DOT_PRECISION)
+        X_44 = X_44 + tl.dot(X_44, Y_44, input_precision=DOT_PRECISION)
+        b_Ai_44 = X_44
+    else:
+        for i in range(48 + 2, min(64, T - i_t * BT)):
+            b_a_44 = -tl.load(A + (i_t * BT + i) * H * BT + o_i + 48)
+            b_a_44 = tl.where(o_i < i - 48, b_a_44, 0.)
+            b_a_44 += tl.sum(b_a_44[:, None] * b_Ai_44, 0)
+            b_Ai_44 = tl.where((o_i == i - 48)[:, None], b_a_44, b_Ai_44)
+        b_Ai_44 += m_I
+
+
+    m_off_21 = (i_t * BT + 16 + o_i[:, None] < T) & (o_j[None, :] < BT)
+    m_off_31 = (i_t * BT + 32 + o_i[:, None] < T) & (o_j[None, :] < BT)
+    m_off_32 = (i_t * BT + 32 + o_i[:, None] < T) & (16 + o_j[None, :] < BT)
+    m_off_41 = (i_t * BT + 48 + o_i[:, None] < T) & (o_j[None, :] < BT)
+    m_off_42 = (i_t * BT + 48 + o_i[:, None] < T) & (16 + o_j[None, :] < BT)
+    m_off_43 = (i_t * BT + 48 + o_i[:, None] < T) & (32 + o_j[None, :] < BT)
+    b_A_21 = tl.load(A + (i_t * BT + 16 + o_i[:, None]) * H * BT + o_j[None, :], mask=m_off_21, other=0.0).to(tl.float32)
+    b_A_31 = tl.load(A + (i_t * BT + 32 + o_i[:, None]) * H * BT + o_j[None, :], mask=m_off_31, other=0.0).to(tl.float32)
+    b_A_32 = tl.load(A + (i_t * BT + 32 + o_i[:, None]) * H * BT + 16 + o_j[None, :], mask=m_off_32, other=0.0).to(tl.float32)
+    b_A_41 = tl.load(A + (i_t * BT + 48 + o_i[:, None]) * H * BT + o_j[None, :], mask=m_off_41, other=0.0).to(tl.float32)
+    b_A_42 = tl.load(A + (i_t * BT + 48 + o_i[:, None]) * H * BT + 16 + o_j[None, :], mask=m_off_42, other=0.0).to(tl.float32)
+    b_A_43 = tl.load(A + (i_t * BT + 48 + o_i[:, None]) * H * BT + 32 + o_j[None, :], mask=m_off_43, other=0.0).to(tl.float32)
+
+    # MBH off-diagonal: recursive 2x2 block inversion
+    # Level 2: 16x16 -> 32x32 pairs — X21 = -X22@A21@X11, X43 = -X44@A43@X33
+    b_Ai_21 = -tl.dot(tl.dot(b_Ai_22, b_A_21, input_precision=DOT_PRECISION), b_Ai_11, input_precision=DOT_PRECISION)
+    b_Ai_43 = -tl.dot(tl.dot(b_Ai_44, b_A_43, input_precision=DOT_PRECISION), b_Ai_33, input_precision=DOT_PRECISION)
+
+    # Level 1: 32x32 -> 64x64 cross terms — intermediates B21 @ X_UL
+    P00 = tl.dot(b_A_31, b_Ai_11, input_precision=DOT_PRECISION) + tl.dot(b_A_32, b_Ai_21, input_precision=DOT_PRECISION)
+    P01 = tl.dot(b_A_32, b_Ai_22, input_precision=DOT_PRECISION)
+    P10 = tl.dot(b_A_41, b_Ai_11, input_precision=DOT_PRECISION) + tl.dot(b_A_42, b_Ai_21, input_precision=DOT_PRECISION)
+    P11 = tl.dot(b_A_42, b_Ai_22, input_precision=DOT_PRECISION)
+
+    b_Ai_31 = -tl.dot(b_Ai_33, P00, input_precision=DOT_PRECISION)
+    b_Ai_32 = -tl.dot(b_Ai_33, P01, input_precision=DOT_PRECISION)
+    b_Ai_41 = -tl.dot(b_Ai_43, P00, input_precision=DOT_PRECISION) - tl.dot(b_Ai_44, P10, input_precision=DOT_PRECISION)
+    b_Ai_42 = -tl.dot(b_Ai_43, P01, input_precision=DOT_PRECISION) - tl.dot(b_Ai_44, P11, input_precision=DOT_PRECISION)
+
+    Ai_dt = Ai.dtype.element_ty
+    m_s11 = (i_t * BT + o_i[:, None] < T) & (o_j[None, :] < BT)
+    m_s22 = (i_t * BT + 16 + o_i[:, None] < T) & (16 + o_j[None, :] < BT)
+    m_s33 = (i_t * BT + 32 + o_i[:, None] < T) & (32 + o_j[None, :] < BT)
+    m_s44 = (i_t * BT + 48 + o_i[:, None] < T) & (48 + o_j[None, :] < BT)
+    m_s21 = (i_t * BT + 16 + o_i[:, None] < T) & (o_j[None, :] < BT)
+    m_s31 = (i_t * BT + 32 + o_i[:, None] < T) & (o_j[None, :] < BT)
+    m_s32 = (i_t * BT + 32 + o_i[:, None] < T) & (16 + o_j[None, :] < BT)
+    m_s41 = (i_t * BT + 48 + o_i[:, None] < T) & (o_j[None, :] < BT)
+    m_s42 = (i_t * BT + 48 + o_i[:, None] < T) & (16 + o_j[None, :] < BT)
+    m_s43 = (i_t * BT + 48 + o_i[:, None] < T) & (32 + o_j[None, :] < BT)
+    tl.store(Ai + (i_t * BT + o_i[:, None]) * H * BT + o_j[None, :], b_Ai_11.to(Ai_dt, fp_downcast_rounding="rtne"), mask=m_s11)
+    tl.store(Ai + (i_t * BT + 16 + o_i[:, None]) * H * BT + 16 + o_j[None, :], b_Ai_22.to(Ai_dt, fp_downcast_rounding="rtne"), mask=m_s22)
+    tl.store(Ai + (i_t * BT + 32 + o_i[:, None]) * H * BT + 32 + o_j[None, :], b_Ai_33.to(Ai_dt, fp_downcast_rounding="rtne"), mask=m_s33)
+    tl.store(Ai + (i_t * BT + 48 + o_i[:, None]) * H * BT + 48 + o_j[None, :], b_Ai_44.to(Ai_dt, fp_downcast_rounding="rtne"), mask=m_s44)
+    tl.store(Ai + (i_t * BT + 16 + o_i[:, None]) * H * BT + o_j[None, :], b_Ai_21.to(Ai_dt, fp_downcast_rounding="rtne"), mask=m_s21)
+    tl.store(Ai + (i_t * BT + 32 + o_i[:, None]) * H * BT + o_j[None, :], b_Ai_31.to(Ai_dt, fp_downcast_rounding="rtne"), mask=m_s31)
+    tl.store(Ai + (i_t * BT + 32 + o_i[:, None]) * H * BT + 16 + o_j[None, :], b_Ai_32.to(Ai_dt, fp_downcast_rounding="rtne"), mask=m_s32)
+    tl.store(Ai + (i_t * BT + 48 + o_i[:, None]) * H * BT + o_j[None, :], b_Ai_41.to(Ai_dt, fp_downcast_rounding="rtne"), mask=m_s41)
+    tl.store(Ai + (i_t * BT + 48 + o_i[:, None]) * H * BT + 16 + o_j[None, :], b_Ai_42.to(Ai_dt, fp_downcast_rounding="rtne"), mask=m_s42)
+    tl.store(Ai + (i_t * BT + 48 + o_i[:, None]) * H * BT + 32 + o_j[None, :], b_Ai_43.to(Ai_dt, fp_downcast_rounding="rtne"), mask=m_s43)
+
+
+@input_guard
+def solve_tril(
+    A: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    output_dtype: torch.dtype = torch.float,
+) -> torch.Tensor:
+    """
+    Compute the inverse of the matrix I + A
+    A should be strictly lower triangular, i.e., A.triu() == 0.
+
+    Args:
+        A (torch.Tensor):
+            [B, T, H, BT], where BT should only be 16, 32, or 64.
+        cu_seqlens (torch.Tensor):
+            The cumulative sequence lengths of the input tensor. Default: `None`.
+        output_dtype (torch.dtype):
+            The dtype of the output tensor. Default: `torch.float`.
+            If `None`, the output dtype will be the same as the input dtype.
+
+    Returns:
+        (I + A)^-1 with the same shape as A
+    """
+    assert A.shape[-1] in [16, 32, 64]
+    output_dtype = A.dtype if output_dtype is None else output_dtype
+
+    B, T, H, BT = A.shape
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, BT)
+
+    Ai = torch.zeros_like(A, dtype=output_dtype)
+    if BT == 16:
+        merge_fn = solve_tril_16x16_kernel
+    elif BT == 32:
+        merge_fn = merge_16x16_to_32x32_inverse_kernel
+    elif BT == 64:
+        merge_fn = merge_16x16_to_64x64_inverse_kernel
+
+    merge_fn[NT, B * H](
+        A=A,
+        Ai=Ai,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        BT=BT,
+        USE_TMA=False,
+        DOT_PRECISION="ieee",
+        multibuffer=True,
+        limit_auto_multi_buffer_of_local_buffer="no-limit",
+        sync_solver=True,
+        num_stages=2,
+        enable_dynamic_cv_pipeline=True,
+    )
+    return Ai

--- a/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/utils.py
+++ b/veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/utils.py
@@ -1,0 +1,366 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import itertools
+import contextlib
+import os
+import functools
+import warnings
+import logging
+from enum import Enum
+from functools import lru_cache
+from typing import Any, Callable, Dict, Optional, Tuple
+from packaging import version
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+import triton.language.extra.libdevice as tldevice
+import triton.runtime.driver as driver
+
+logger = logging.getLogger(__name__)
+
+FLA_CI_ENV = os.getenv("FLA_CI_ENV") == "1"
+
+
+def tensor_cache(
+    fn: Callable[..., torch.Tensor]
+) -> Callable[..., torch.Tensor]:
+    """
+    A decorator that caches the most recent result of a function with tensor inputs.
+
+    This decorator will store the output of the decorated function for the most recent set of input tensors.
+    If the function is called again with the same input tensors, it will return the cached result.
+
+
+    Args:
+        fn (Callable[..., torch.Tensor]):
+            The function to be decorated. It should take tensor inputs and return tensor outputs.
+
+    Returns:
+        Callable[..., torch.Tensor]:
+            A wrapped version of the input function with single-entry caching.
+    """
+    last_args: Optional[Tuple] = None
+    last_kwargs: Optional[Dict] = None
+    last_result: Any = None
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        nonlocal last_args, last_kwargs, last_result
+
+        if last_args is not None and last_kwargs is not None:
+            if len(args) == len(last_args) and len(kwargs) == len(last_kwargs):
+                if all(a is b for a, b in zip(args, last_args)) and \
+                        all(k in last_kwargs and v is last_kwargs[k] for k, v in kwargs.items()):
+                    return last_result
+
+        result = fn(*args, **kwargs)
+        last_args, last_kwargs, last_result = args, kwargs, result
+        return result
+
+    return wrapper
+
+
+@tensor_cache
+def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+@tensor_cache
+def prepare_chunk_indices(
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int
+) -> torch.LongTensor:
+    indices = torch.cat([torch.arange(n) for n in triton.cdiv(prepare_lens(cu_seqlens), chunk_size).tolist()])
+    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
+
+
+@tensor_cache
+def prepare_chunk_indices_list(
+    cu_seqlens: list[int],
+    chunk_size: int
+ ) -> list[int]:
+    indices = []
+
+    for i in range(len(cu_seqlens) - 1):
+        start = cu_seqlens[i]
+        end = cu_seqlens[i + 1]
+        length = end - start
+
+        if length <= 0:
+            continue
+
+        num_chunks = (length + chunk_size - 1) // chunk_size
+
+        for chunk_id in range(num_chunks):
+            indices.append((i))
+            indices.append((chunk_id))
+
+    return indices
+
+
+def get_abs_err(x, y):
+    return (x.detach() - y.detach()).flatten().abs().max().item()
+
+
+def get_err_ratio(x, y):
+    err = (x.detach() - y.detach()).flatten().square().mean().sqrt().item()
+    base = (x.detach()).flatten().square().mean().sqrt().item()
+    return err / (base + 1e-8)
+
+
+def assert_close(prefix, ref, tri, ratio, warning=False, err_atol=1e-6):
+    abs_atol = get_abs_err(ref, tri)
+    msg = f"{prefix:>16} diff: {abs_atol:.6f} ratio: {get_err_ratio(ref, tri):.6f}"
+    logger.info(msg)
+    error_rate = get_err_ratio(ref, tri)
+    if abs_atol <= err_atol:
+        return
+    if warning or (FLA_CI_ENV and (error_rate < 0.01 or abs_atol <= 0.3)):
+        if error_rate > ratio:
+            warnings.warn(msg)
+    else:
+        assert error_rate < ratio, msg
+
+
+if hasattr(triton.language, '_experimental_make_tensor_descriptor'):
+    # For Triton 3.3.x
+    make_tensor_descriptor = triton.language._experimental_make_tensor_descriptor
+elif hasattr(triton.language, 'make_tensor_descriptor'):
+    # For Triton 3.4.x and later
+    make_tensor_descriptor = triton.language.make_tensor_descriptor
+else:
+    """
+    Fallback implementation when TMA is not supported.
+    Returns None to indicate TMA descriptors are unavailable.
+    Just make triton compiler happy.
+    """
+
+
+    @triton.jit
+    def make_tensor_descriptor(
+        base,
+        shape,
+        strides,
+        block_shape,
+        _builder=None,
+    ):
+        return None
+
+
+@lru_cache(maxsize=None)
+def get_available_device() -> str:
+    try:
+        return triton.runtime.driver.active.get_current_target().backend
+    except BaseException:
+        _cpu_device_warning()
+        return 'cpu'
+
+
+def map_triton_backend_to_torch_device() -> str:
+    backend = get_available_device()        # 'cuda' | 'hip' | 'xpu' | 'cpu' | ...
+    return {'cuda': 'cuda', 'hip': 'cuda', 'xpu': 'xpu'}.get(backend, backend)
+
+
+device = get_available_device() if get_available_device() != 'hip' else 'cuda'
+device_torch_lib = getattr(torch, device)
+device_platform = get_available_device()
+is_amd = (device_platform == 'hip')
+is_nvidia = (device_platform == 'cuda')
+is_nvidia_hopper = (
+            is_nvidia and ('NVIDIA H' in torch.cuda.get_device_name(0) or torch.cuda.get_device_capability()[0] >= 9))
+
+is_tf32_supported = (is_nvidia and torch.cuda.get_device_capability(0)[0] >= 8)
+is_tma_supported = (is_nvidia and torch.cuda.get_device_capability(0)[0] >= 9) \
+                   and os.environ.get('FLA_NO_USE_TMA', '0') != '1' and \
+                   (hasattr(triton.language, '_experimental_make_tensor_descriptor') or hasattr(triton.language,
+                                                                                                'make_tensor_descriptor'))
+
+if is_nvidia and not is_tf32_supported:
+    # Make old card happy, since triton will use tf32 by default.
+    # This is a workaround for old nvidia card.
+    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+
+
+@lru_cache(maxsize=None)
+def check_pytorch_version(version_s: str = '2.4') -> bool:
+    return version.parse(torch.__version__) >= version.parse(version_s)
+
+if check_pytorch_version('2.4'):
+    device = 'cuda' if device == 'cpu' else device
+    autocast_custom_fwd = functools.partial(torch.amp.custom_fwd, device_type=device)
+    autocast_custom_bwd = functools.partial(torch.amp.custom_bwd, device_type=device)
+
+    def custom_device_ctx(index: int):
+        return device_torch_lib.device(index)
+else:
+    assert device == 'cuda', 'Only cuda device is supported for PyTorch version < 2.4.0.'
+    autocast_custom_fwd = device_torch_lib.amp.custom_fwd
+    autocast_custom_bwd = device_torch_lib.amp.custom_bwd
+
+    def custom_device_ctx(index: int):
+        return torch.cuda.device(index)
+
+
+def input_guard(
+    fn: Callable[..., torch.Tensor]
+) -> Callable[..., torch.Tensor]:
+    """
+    A decorator to make sure all input tensors are contiguous and set the device based on input tensors.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        contiguous_args = (i if not isinstance(i, torch.Tensor) else i.contiguous() for i in args)
+        contiguous_kwargs = {k: (v if not isinstance(v, torch.Tensor) else v.contiguous()) for k, v in kwargs.items()}
+
+        tensor = None
+        for arg in args:
+            if isinstance(arg, torch.Tensor):
+                tensor = arg
+                break
+        if tensor is None:
+            for value in kwargs.values():
+                if isinstance(value, torch.Tensor):
+                    tensor = value
+                    break
+
+        if tensor is not None:
+            ctx = custom_device_ctx(tensor.device.index)
+        else:
+            ctx = contextlib.nullcontext()
+
+        with ctx:
+            return fn(*contiguous_args, **contiguous_kwargs)
+
+    return wrapper
+
+
+def _cpu_device_warning():
+    warnings.warn(('Triton is not supported on current platform, roll back to CPU.'), stacklevel=1)
+
+
+@tensor_cache
+def prepare_chunk_offsets(
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int
+) -> torch.LongTensor:
+    return torch.cat([cu_seqlens.new_tensor([0]), triton.cdiv(prepare_lens(cu_seqlens), chunk_size)]).cumsum(-1)
+
+
+if os.environ.get('FLA_USE_FAST_OPS', '0') == '1':
+    exp = tldevice.fast_expf
+    exp2 = tldevice.exp2
+    log = tldevice.fast_logf
+    log2 = tldevice.fast_log2f
+else:
+    exp = tl.exp
+    exp2 = tl.math.exp2
+    log = tl.log
+    log2 = tl.log2
+
+
+def get_all_max_shared_mem():
+    try:
+        return [
+            triton.runtime.driver.active.utils.get_device_properties(i)['max_shared_mem']
+            for i in range(device_torch_lib.device_count())
+        ]
+    except BaseException:
+        _cpu_device_warning()
+        return [-1]
+
+
+class Backend(Enum):
+
+    @classmethod
+    def get_shared_memory(cls, arch: str) -> int:
+        try:
+            return cls[arch.upper()].value
+        except KeyError:
+            return cls.DEFAULT.value
+
+
+@lru_cache(maxsize=None)
+def check_shared_mem(arch: str = "none", tensor_idx: int = 0) -> bool:
+    try:
+        device_shared_mem_list = get_all_max_shared_mem()
+        max_shared_memory = device_shared_mem_list[tensor_idx]
+        return max_shared_memory >= Backend.get_shared_memory(arch)
+    except Exception:
+        return False
+
+
+@tensor_cache
+def prepare_chunk_offsets(
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int
+) -> torch.LongTensor:
+    return torch.cat([cu_seqlens.new_tensor([0]), triton.cdiv(prepare_lens(cu_seqlens), chunk_size)]).cumsum(-1)
+
+
+def get_autotune_config(
+    multibuffer_list: tuple = (False,),
+    unit_flag_list: tuple = (False,),
+    limit_auto_multi_buffer_only_for_local_buffer_list: tuple = (False,),
+    limit_auto_multi_buffer_of_local_buffer_list: tuple = ("no-l0c",),
+    set_workspace_multibuffer_list: tuple = (2, 4),
+    enable_hivm_auto_cv_balance_list: tuple = (True,),
+    tile_mix_vector_loop_num_list: tuple = (2, 4),
+    tile_mix_cube_loop_num_list: tuple = (2, 4),
+):
+    configs = []
+    for (
+        multibuffer,
+        unit_flag,
+        limit_auto_multi_buffer_only_for_local_buffer,
+        limit_auto_multi_buffer_of_local_buffer,
+    ) in itertools.product(
+        list(multibuffer_list),
+        list(unit_flag_list),
+        list(limit_auto_multi_buffer_only_for_local_buffer_list),
+        list(limit_auto_multi_buffer_of_local_buffer_list),
+    ):
+
+        if limit_auto_multi_buffer_only_for_local_buffer:
+            configs.append(
+                triton.Config(
+                    {},
+                    multibuffer=multibuffer,
+                    unit_flag=unit_flag,
+                    limit_auto_multi_buffer_only_for_local_buffer=limit_auto_multi_buffer_only_for_local_buffer,
+                    limit_auto_multi_buffer_of_local_buffer=limit_auto_multi_buffer_of_local_buffer,
+                )
+            )
+        else:
+            for (
+                set_workspace_multibuffer,
+                enable_hivm_auto_cv_balance,
+                tile_mix_vector_loop,
+                tile_mix_cube_loop,
+            ) in itertools.product(
+                list(set_workspace_multibuffer_list),
+                list(enable_hivm_auto_cv_balance_list),
+                list(tile_mix_vector_loop_num_list),
+                list(tile_mix_cube_loop_num_list),
+            ):
+                configs.append(
+                    triton.Config(
+                        {},
+                        multibuffer=multibuffer,
+                        unit_flag=unit_flag,
+                        limit_auto_multi_buffer_only_for_local_buffer=limit_auto_multi_buffer_only_for_local_buffer,
+                        limit_auto_multi_buffer_of_local_buffer=limit_auto_multi_buffer_of_local_buffer,
+                        set_workspace_multibuffer=set_workspace_multibuffer,
+                        enable_hivm_auto_cv_balance=enable_hivm_auto_cv_balance,
+                        tile_mix_vector_loop=tile_mix_vector_loop,
+                        tile_mix_cube_loop=tile_mix_cube_loop,
+                    )
+                )
+    return configs
+
+
+def get_npu_properties():
+    return driver.active.utils.get_device_properties(torch.npu.current_device())

--- a/veomni/ops/kernels/gated_delta_rule/npu_ascendc_gated_delta_rule.py
+++ b/veomni/ops/kernels/gated_delta_rule/npu_ascendc_gated_delta_rule.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""NPU AscendC chunk gated delta rule: layout adapter over ``flash_gated_delta_rule``.
+
+The generated ``Qwen3_5GatedDeltaNet.forward`` feeds ``q/k/v`` in the FLA layout
+``[B, T, H, D]`` (split on the channel dim, then reshaped to heads) — this is what
+the ``fla`` GPU kernel and the vendored ``npu`` Triton kernel consume. The AscendC
+entry ``flash_gated_delta_rule`` instead expects ``[B, H, T, D]`` (and validates the
+shape, raising otherwise), because MindSpeed-MM's AscendC path produces that layout
+directly from its ``triton_with_transpose`` conv + head-dim split.
+
+Rather than replicate MM's per-implementation ``forward`` branching (which would
+require patchgen modeling changes), this thin adapter absorbs the layout difference
+at the op boundary: it transposes ``q/k/v`` from ``[B, T, H, D]`` to ``[B, H, T, D]``
+on the way in. ``g``/``beta`` are already ``[B, T, H]`` (what the entry wants) and the
+returned ``o`` is already ``[B, T, H, V]``, so no output transpose is needed. Numerically
+this equals MM's AscendC path; the only cost is the input transpose (a copy).
+
+``flash_gated_delta_rule`` is imported at module top so that binding the ``npu_ascendc``
+backend surfaces a missing ``fla_npu``/``torch_npu`` as an actionable error at
+``OpSlot.bind()`` time (the package ``__init__`` factory only imports this module when
+the backend is selected).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from ._ascend.flash_gated_delta_rule import flash_gated_delta_rule
+
+
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    **kwargs,
+):
+    # q/k/v arrive as [B, T, H, D]; the AscendC entry wants [B, H, T, D].
+    q = q.transpose(1, 2).contiguous()
+    k = k.transpose(1, 2).contiguous()
+    v = v.transpose(1, 2).contiguous()
+    return flash_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        cu_seqlens=cu_seqlens,
+        **kwargs,
+    )


### PR DESCRIPTION
### What does this PR do?

Adds a new **`npu_ascendc`** backend for Qwen3.5 GatedDeltaNet's
`chunk_gated_delta_rule`, backed by the AscendC fused kernels from upstream
`fla_npu`. It complements the `fla` (GPU) and `npu` (Triton) backends added in
#879, giving NPU users a fused AscendC path for `chunk_gated_delta_rule`.

> **Draft** — numerically verified and running end-to-end on Ascend 910B; opened
> as draft for provenance/design review.

### Checklist Before Starting

- Related PR: #879 (added the `fla` / `npu` GDN backends this builds on).
- PR title follows `[{modules}] {type}: {description}` —
  `[ops] feat: add AscendC fused backend (npu_ascendc) for Qwen3.5 chunk gated delta rule`.

### Test

- [x] `make quality` (ruff check + format) passes.
- [x] End-to-end training runs on Ascend 910B with
  `chunk_gated_delta_rule_implementation=npu_ascendc`.
- [x] Numerical parity (`get_err_ratio`) vs GPU `fla` on the Qwen3.5
  GatedDeltaNet forward/backward.

No CI e2e covers the AscendC GDN path; the kernels are manually verified on
Ascend 910B via the end-to-end run and numerical-parity check above.

### API and Usage Example

New enum value `npu_ascendc` for `chunk_gated_delta_rule_implementation`. On NPU,
set all three GDN op implementations explicitly (the `fla` default raises when
bound on NPU):

```yaml
model:
  chunk_gated_delta_rule_implementation: npu_ascendc
  causal_conv1d_implementation: npu
  rms_norm_gated_implementation: npu
```

The AscendC path additionally requires the `fla_npu` package. The prebuilt NPU
images on [quay.io](https://quay.io/repository/ascend/veomni?tab=tags) already
bundle it (A2 and A3); manual install instructions are in
`docs/examples/qwen3_5.md`.

### Design & Code Changes

Split into two commits so vendored vs authored code review separately (same
convention as #879):

**1. `chore` — vendor the gated delta-rule Triton kernels**

4 kernels under the ruff-excluded
`veomni/ops/kernels/gated_delta_rule/_ascend/triton_core/` tree —
`{chunk_scaled_dot_kkt, l2norm, solve_tril, utils}.py`.
Vendored via MindSpeed-MM's `triton_core`, which redistributes **fla_npu commit
`c2e3d83f`** (https://github.com/flashserve/flash-linear-attention-npu). No VeOmni
logic; kept
as a drop-in vendor blob so they stay diff-able against upstream — any
kernel-logic change must go upstream. (The one intentional deviation, the
`l2norm_bwd` fix below, lives in the `feat` commit, not here.)

**2. `feat` — VeOmni integration**

- **AscendC entry** (`_ascend/flash_gated_delta_rule.py`): adapted from
  MindSpeed-MM's wrapper (itself derived from fla_npu commit `c2e3d83f`) — strips MM's
  async-offload / `skip_recompute` machinery down to the plain compute path, and
  rewrites imports to package-relative. Delegates the heavy GDN compute to the
  external `fla_npu` `torch.ops.npu.*` fused ops. This is an *adapted* file, so
  it lives here rather than in the verbatim `chore` commit.
- **Package init** (`_ascend/triton_core/__init__.py`): VeOmni-authored init for
  the vendored kernels.
- **Layout adapter** (`npu_ascendc_gated_delta_rule.py`): the generated modeling
  emits `q/k/v` as `[B, T, H, D]` (FLA layout), but `flash_gated_delta_rule`
  expects — and validates — `[B, H, T, D]`. Rather than fork the generated
  `forward` into per-implementation branching (a patchgen change), the adapter
  transposes `q/k/v` at the op boundary. `g`/`beta` (`[B, T, H]`) and the
  returned `o` (`[B, T, H, V]`) already match, so no output transpose.
  Numerically equal to MindSpeed-MM's AscendC path; cost is one input transpose.
- **Registration**: `_ascend/__init__.py` exposes the `npu_ascendc` KernelSpec;
  `gated_delta_rule/__init__.py` + `arguments/arguments_types.py` surface and
  validate the selection. Lazy factory import — non-NPU hosts don't pull
  `fla_npu` / Triton.
- **Docs**: `docs/examples/qwen3_5.md`, `docs/design/kernel_selection.md`,
  `docs/design/unified_kernel_registry.md`.

**One intentional deviation from vendored — `l2norm_bwd` (in the `feat` commit)**

`l2norm_bwd_kernel` computed its task count as `T // BT` (floor), dropping the
partial last block when `T` (the flattened `B·H·seq` row count) isn't a multiple
of `BT=64`. Those rows are never scheduled, so their `dx` keeps uninitialized
`torch.empty_like` memory and explodes in the l2norm backward for non-64-aligned
(packed/varlen ragged) segments — grad_norm ~11× high. Forward already
ceil-covers all blocks; the fix aligns backward (`floor -> ceil`) so the existing
`block_start < T` guard + `boundary_check` handle the partial block. Reported
upstream to `fla_npu`.

**Limitation — arch35:** upstream guards `is_arch35()`
(`Ascend910_95` / `Ascend950`) with `NotImplementedError`; validated target is
910B, where the guard doesn't fire. arch35 support needs upstream.

### Checklist Before Submitting

- [x] Applied pre-commit checks (`make quality`).
- [x] Added/updated documentation (`docs/examples/qwen3_5.md`,
  `docs/design/unified_kernel_registry.md`).
- [x] Manually verified on Ascend 910B (end-to-end run + numerical parity vs
  eager); no CI e2e for the AscendC GDN path (needs NPU hardware).
- [x] No `tasks/` training scripts moved or renamed.
