### PR TITLE
[config, dist, trainer, docs] feat: expose checkpoint early-stop setting

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -384,7 +384,7 @@ distinct from the first emission.
 | enable | `bool` | `True` | Enable gradient checkpointing. |
 | debug | `bool` | `False` | Enable [checkpoint debugging](https://docs.pytorch.org/docs/stable/checkpoint.html#torch.utils.checkpoint.set_checkpoint_debug_enabled). |
 | enable_reentrant | `bool` | `False` | Use reentrant gradient checkpointing. |
-| early_stop | `bool` | `True` | Stop non-reentrant checkpoint recomputation as soon as all needed tensors are computed. |
+| early_stop | `bool` | `True` | Stop non-reentrant checkpoint recomputation as soon as all needed tensors are computed. PyTorch ignores this option when `enable_reentrant=True`. |
 
 ### ChunkMBSConfig
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -384,6 +384,7 @@ distinct from the first emission.
 | enable | `bool` | `True` | Enable gradient checkpointing. |
 | debug | `bool` | `False` | Enable [checkpoint debugging](https://docs.pytorch.org/docs/stable/checkpoint.html#torch.utils.checkpoint.set_checkpoint_debug_enabled). |
 | enable_reentrant | `bool` | `False` | Use reentrant gradient checkpointing. |
+| early_stop | `bool` | `True` | Stop non-reentrant checkpoint recomputation as soon as all needed tensors are computed. |
 
 ### ChunkMBSConfig
 

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -378,6 +378,7 @@ model = build_parallelize_model(
     enable_fsdp_offload=args.train.accelerator.fsdp_config.offload, # enable fsdp offload
     basic_modules=list(set(getattr(model, "_no_split_modules", None) or []) | set(args.model.basic_modules)), # FSDP basic modules
     enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
+    early_stop=args.train.gradient_checkpointing.early_stop,
     enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
     broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0, # load model weights
     ep_sharded_stream_load=args.train.ep_sharded_stream_load,

--- a/tests/distributed/test_gradient_checkpointing.py
+++ b/tests/distributed/test_gradient_checkpointing.py
@@ -1,0 +1,47 @@
+import types
+
+import pytest
+import torch.nn as nn
+from torch.utils.checkpoint import noop_context_fn
+
+from veomni.arguments import GradientCheckpointingConfig, MixedPrecisionConfig
+from veomni.distributed.torch_parallelize import build_parallelize_model
+
+
+class _CheckpointingModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gradient_checkpointing_kwargs = None
+
+    def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs=None):
+        self.gradient_checkpointing_kwargs = gradient_checkpointing_kwargs
+
+
+@pytest.mark.parametrize("early_stop", [True, False])
+def test_build_parallelize_model_forwards_checkpoint_early_stop(monkeypatch, early_stop):
+    import veomni.distributed.torch_parallelize as torch_parallelize
+
+    monkeypatch.setattr(
+        torch_parallelize,
+        "get_parallel_state",
+        lambda: types.SimpleNamespace(fsdp_enabled=False, tp_enabled=False),
+    )
+    model = _CheckpointingModel()
+
+    result = build_parallelize_model(
+        model,
+        init_device="cuda",
+        mixed_precision=MixedPrecisionConfig(enable=False),
+        early_stop=early_stop,
+    )
+
+    assert result is model
+    assert model.gradient_checkpointing_kwargs == {
+        "use_reentrant": False,
+        "context_fn": noop_context_fn,
+        "early_stop": early_stop,
+    }
+
+
+def test_gradient_checkpointing_config_enables_early_stop_by_default():
+    assert GradientCheckpointingConfig().early_stop is True

--- a/tests/distributed/test_gradient_checkpointing.py
+++ b/tests/distributed/test_gradient_checkpointing.py
@@ -18,29 +18,33 @@ class _CheckpointingModel(nn.Module):
 
 
 @pytest.mark.parametrize("early_stop", [True, False])
-def test_build_parallelize_model_forwards_checkpoint_early_stop(monkeypatch, early_stop):
+@pytest.mark.parametrize("use_reentrant", [True, False])
+def test_build_parallelize_model_forwards_checkpoint_early_stop(monkeypatch, early_stop, use_reentrant):
     import veomni.distributed.torch_parallelize as torch_parallelize
 
     monkeypatch.setattr(
         torch_parallelize,
         "get_parallel_state",
-        lambda: types.SimpleNamespace(fsdp_enabled=False, tp_enabled=False),
+        lambda: types.SimpleNamespace(fsdp_enabled=True, tp_enabled=False, dp_mode="fsdp2"),
     )
+    monkeypatch.setattr(torch_parallelize, "parallelize_model_fsdp2", lambda model, **kwargs: model)
     model = _CheckpointingModel()
 
     result = build_parallelize_model(
         model,
-        init_device="cuda",
         mixed_precision=MixedPrecisionConfig(enable=False),
         early_stop=early_stop,
+        enable_reentrant=use_reentrant,
     )
 
     assert result is model
-    assert model.gradient_checkpointing_kwargs == {
-        "use_reentrant": False,
+    expected = {
+        "use_reentrant": use_reentrant,
         "context_fn": noop_context_fn,
-        "early_stop": early_stop,
     }
+    if not use_reentrant:
+        expected["early_stop"] = early_stop
+    assert model.gradient_checkpointing_kwargs == expected
 
 
 def test_gradient_checkpointing_config_enables_early_stop_by_default():

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -322,6 +322,10 @@ class GradientCheckpointingConfig:
         default=False,
         metadata={"help": "Use reentrant gradient checkpointing."},
     )
+    early_stop: bool = field(
+        default=True,
+        metadata={"help": "Stop non-reentrant checkpoint recomputation as soon as all needed tensors are computed."},
+    )
 
 
 @dataclass

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -324,7 +324,12 @@ class GradientCheckpointingConfig:
     )
     early_stop: bool = field(
         default=True,
-        metadata={"help": "Stop non-reentrant checkpoint recomputation as soon as all needed tensors are computed."},
+        metadata={
+            "help": (
+                "Stop non-reentrant checkpoint recomputation as soon as all needed tensors are computed. "
+                "PyTorch ignores this option when enable_reentrant=True."
+            )
+        },
     )
 
 

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -544,6 +544,7 @@ def build_parallelize_model(
             gradient_checkpointing_kwargs={
                 "use_reentrant": use_reentrant,
                 "context_fn": kwargs.pop("recompute_context_fn", noop_context_fn),
+                "early_stop": kwargs.pop("early_stop", True),
             },
         )
 

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -534,18 +534,22 @@ def build_parallelize_model(
     if mixed_precision.enable:  # upcast to float32 before feed it to optimizer
         model = model.float()
 
+    checkpoint_early_stop = kwargs.pop("early_stop", True)
     if enable_gradient_checkpointing and hasattr(model, "gradient_checkpointing_enable"):
         logger.info_rank0("Enable gradient checkpointing.")
         use_reentrant = kwargs.pop("enable_reentrant", False)
         if use_reentrant:
             torch.utils.checkpoint.CheckpointFunction = CheckpointFunction
 
+        gradient_checkpointing_kwargs = {
+            "use_reentrant": use_reentrant,
+            "context_fn": kwargs.pop("recompute_context_fn", noop_context_fn),
+        }
+        if not use_reentrant:
+            gradient_checkpointing_kwargs["early_stop"] = checkpoint_early_stop
+
         model.gradient_checkpointing_enable(
-            gradient_checkpointing_kwargs={
-                "use_reentrant": use_reentrant,
-                "context_fn": kwargs.pop("recompute_context_fn", noop_context_fn),
-                "early_stop": kwargs.pop("early_stop", True),
-            },
+            gradient_checkpointing_kwargs=gradient_checkpointing_kwargs,
         )
 
     if chunk_mbs_config is not None and chunk_mbs_config.enable:

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -536,6 +536,7 @@ class BaseTrainer(Stateful, ABC):
                 set(getattr(self.model, "_no_split_modules", None) or []) | set(args.model.basic_modules)
             ),
             enable_reentrant=args.train.gradient_checkpointing.enable_reentrant,
+            early_stop=args.train.gradient_checkpointing.early_stop,
             enable_forward_prefetch=args.train.accelerator.fsdp_config.forward_prefetch,
             enable_fsdp_offload=args.train.accelerator.fsdp_config.offload,
             broadcast_model_weights_from_rank0=args.train.broadcast_model_weights_from_rank0,


### PR DESCRIPTION
### What does this PR do?

Adds recipe-level control over PyTorch non-reentrant checkpoint early stopping and forwards the setting through VeOmni's model parallelization path.

The new option defaults to `true`, preserving the existing behavior. Users can disable it when a checkpointed function requires the complete forward function to be recomputed during backward.

### Checklist Before Starting

- PR title follows the required `[{modules}] {type}: {description}` format.

### Test

- `make quality`
- `pre-commit run --all-files`
- `python tests/special_sanity/check_device_api_usage.py --directory tests/distributed`
- `PYTHONPATH=. pytest -q tests/distributed/test_gradient_checkpointing.py tests/parallel/test_chunk_mbs.py` — 53 passed

### API and Usage Example

```yaml
train:
  gradient_checkpointing:
    enable: true
    enable_reentrant: false
    early_stop: false
```

### Design & Code Changes

- Add `early_stop: bool = True` to `GradientCheckpointingConfig`.
- Forward the value through `build_parallelize_model` into `gradient_checkpointing_kwargs`.
- Clarify in configuration help and documentation that PyTorch ignores `early_stop` in reentrant mode.
- Document the option in the argument reference and model parallelization example.
- Add device-independent tests covering reentrant and non-reentrant modes, both `early_stop` values, and the backward-compatible default.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied pre-commit checks.
- [x] Added or updated documentation.
- [x] Added focused tests covered by the existing unit-test suite.
