### PR TITLE
[model] test: add DeepSeek V4 parity diagnostics

### DIFF
--- a/scripts/deepseek_v4/check_fused_moe.py
+++ b/scripts/deepseek_v4/check_fused_moe.py
@@ -1,0 +1,114 @@
+"""Compare VeOmni's Triton fused MoE against an eager actual-weight reference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+from veomni.models.transformers.deepseek_v4.checkpoint_tensor_converter import _dequantize_scaled_weight
+from veomni.ops.kernels.moe.group_gemm import MergedFc1TritonFusedMoeExpertFunction
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--layer", type=int, default=3)
+    parser.add_argument("--experts", type=int, default=4)
+    parser.add_argument("--tokens", type=int, default=64)
+    parser.add_argument("--top-k", type=int, default=2)
+    return parser.parse_args()
+
+
+def load_tensor(checkpoint: Path, weight_map: dict[str, str], name: str) -> torch.Tensor:
+    with safe_open(checkpoint / weight_map[name], framework="pt", device="cpu") as handle:
+        return handle.get_tensor(name)
+
+
+def load_expert_weight(
+    checkpoint: Path,
+    weight_map: dict[str, str],
+    layer: int,
+    expert: int,
+    projection: str,
+) -> torch.Tensor:
+    prefix = f"layers.{layer}.ffn.experts.{expert}.{projection}"
+    weight = load_tensor(checkpoint, weight_map, f"{prefix}.weight").cuda()
+    scale = load_tensor(checkpoint, weight_map, f"{prefix}.scale").cuda()
+    return _dequantize_scaled_weight(weight, scale, packed_fp4=True).to(torch.bfloat16)
+
+
+def eager_reference(
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    gate_up: torch.Tensor,
+    down: torch.Tensor,
+    limit: float,
+) -> torch.Tensor:
+    output = torch.zeros_like(hidden_states)
+    for expert in range(gate_up.shape[0]):
+        token, topk_position = torch.where(selected_experts == expert)
+        if token.numel() == 0:
+            continue
+        projected = F.linear(hidden_states[token], gate_up[expert])
+        gate, up = projected.chunk(2, dim=-1)
+        activated = F.silu(gate.clamp(max=limit)) * up.clamp(min=-limit, max=limit)
+        activated *= routing_weights[token, topk_position, None]
+        output.index_add_(0, token, F.linear(activated, down[expert]))
+    return output
+
+
+def main() -> None:
+    args = parse_args()
+    with (args.checkpoint / "model.safetensors.index.json").open() as handle:
+        weight_map = json.load(handle)["weight_map"]
+
+    gate, up, down = [], [], []
+    for expert in range(args.experts):
+        gate.append(load_expert_weight(args.checkpoint, weight_map, args.layer, expert, "w1"))
+        up.append(load_expert_weight(args.checkpoint, weight_map, args.layer, expert, "w3"))
+        down.append(load_expert_weight(args.checkpoint, weight_map, args.layer, expert, "w2"))
+    gate_up = torch.cat((torch.stack(gate), torch.stack(up)), dim=1)
+    down_weight = torch.stack(down)
+
+    torch.manual_seed(20260715)
+    hidden = torch.randn(args.tokens, gate_up.shape[-1], device="cuda", dtype=torch.bfloat16)
+    selected = torch.randint(args.experts, (args.tokens, args.top_k), device="cuda")
+    routing = torch.rand(args.tokens, args.top_k, device="cuda", dtype=torch.bfloat16)
+    routing /= routing.sum(dim=-1, keepdim=True)
+    limit = 10.0
+
+    with torch.no_grad():
+        expected = eager_reference(hidden, selected, routing, gate_up, down_weight, limit)
+        actual = MergedFc1TritonFusedMoeExpertFunction.apply(
+            args.experts,
+            routing,
+            selected,
+            hidden,
+            gate_up,
+            down_weight,
+            limit,
+        )
+    diff = (actual.float() - expected.float()).abs()
+    cosine = F.cosine_similarity(actual.float().flatten(), expected.float().flatten(), dim=0)
+    print(
+        json.dumps(
+            {
+                "max_abs_diff": float(diff.max()),
+                "mean_abs_diff": float(diff.mean()),
+                "p99_abs_diff": float(diff.quantile(0.99)),
+                "reference_rms": float(expected.float().square().mean().sqrt()),
+                "cosine_similarity": float(cosine),
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deepseek_v4/compare_lm_head.py
+++ b/scripts/deepseek_v4/compare_lm_head.py
@@ -1,0 +1,55 @@
+"""Replay the DeepSeek V4 LM head on an official terminal hidden tensor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--trace", type=Path, required=True)
+    parser.add_argument("--chunk-size", type=int, default=64)
+    args = parser.parse_args()
+
+    trace = torch.load(args.trace, map_location="cpu", weights_only=True)
+    hidden_states = trace["terminal"]["normalized"].cuda()
+    input_ids = trace["input_ids"].cuda()
+    reference = trace["logprobs"].float().cuda()
+
+    index = json.loads((args.checkpoint / "model.safetensors.index.json").read_text())
+    weight_key = "head.weight"
+    with safe_open(args.checkpoint / index["weight_map"][weight_key], framework="pt", device="cpu") as checkpoint:
+        weight = checkpoint.get_tensor(weight_key).cuda()
+    weight_fp32 = weight.float()
+
+    pieces = []
+    for start in range(0, hidden_states.shape[1] - 1, args.chunk_size):
+        end = min(hidden_states.shape[1] - 1, start + args.chunk_size)
+        logits = F.linear(hidden_states[:, start:end].float(), weight_fp32)
+        targets = input_ids[:, start + 1 : end + 1]
+        pieces.append(logits.log_softmax(dim=-1).gather(-1, targets.unsqueeze(-1)).squeeze(-1))
+    replay = torch.cat(pieces, dim=1)
+    diff = (replay - reference).abs()
+    print(
+        json.dumps(
+            {
+                "shape": list(replay.shape),
+                "mean_abs_diff": float(diff.mean()),
+                "rms_diff": float(diff.square().mean().sqrt()),
+                "max_abs_diff": float(diff.max()),
+                "p99_abs_diff": float(diff.quantile(0.99)),
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deepseek_v4/compare_sparse_attention_kernels.py
+++ b/scripts/deepseek_v4/compare_sparse_attention_kernels.py
@@ -1,0 +1,180 @@
+"""Compare official and VeOmni sparse-attention kernels on identical traced Q/KV inputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from transformers import AutoConfig
+
+from veomni.models.transformers.deepseek_v4.generated.patched_modeling_deepseek_v4_gpu import (
+    DeepseekV4RotaryEmbedding,
+    apply_rotary_pos_emb,
+)
+from veomni.ops.kernels.deepseek_v4 import sparse_attn_tilelang
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--trace", type=Path, required=True)
+    parser.add_argument("--layer", type=int, default=0)
+    args = parser.parse_args()
+
+    sys.path.insert(0, str(args.repo / "inference"))
+    import kernel as official_kernel  # noqa: PLC0415
+    import model as official_model  # noqa: PLC0415
+
+    with (args.repo / "inference" / "config.json").open() as handle:
+        config = official_model.ModelArgs(**json.load(handle))
+
+    trace = torch.load(args.trace, map_location="cpu", weights_only=True)
+    detail = trace["details"][args.layer]
+    device = torch.device("cuda")
+    q_b_proj = detail["q_b_proj"].to(device)
+    if q_b_proj.shape[-1] % config.head_dim:
+        raise ValueError(f"Traced q_b_proj width {q_b_proj.shape[-1]} is not divisible by head_dim {config.head_dim}")
+    local_heads = q_b_proj.shape[-1] // config.head_dim
+    q_raw = q_b_proj.view(*q_b_proj.shape[:-1], local_heads, config.head_dim)
+    q_official_norm_unrotated = q_raw.clone()
+    q_official_norm_unrotated *= torch.rsqrt(
+        q_official_norm_unrotated.square().mean(-1, keepdim=True) + config.norm_eps
+    )
+    q_fp32_norm_unrotated = q_raw * torch.rsqrt(q_raw.float().square().mean(-1, keepdim=True) + config.norm_eps).to(
+        q_raw.dtype
+    )
+    q_norm_diff = (q_official_norm_unrotated.float() - q_fp32_norm_unrotated.float()).abs()
+    kv_raw = detail["kv_norm"].to(device)
+
+    ratio = config.compress_ratios[args.layer]
+    original_seq_len = config.original_seq_len if ratio else 0
+    rope_theta = config.compress_rope_theta if ratio else config.rope_theta
+    freqs = official_model.precompute_freqs_cis(
+        config.rope_head_dim,
+        q_raw.shape[1],
+        original_seq_len,
+        rope_theta,
+        config.rope_factor,
+        config.beta_fast,
+        config.beta_slow,
+    ).to(device)
+    q_official_rope = q_official_norm_unrotated.clone()
+    q_fp32_norm_official_rope = q_fp32_norm_unrotated.clone()
+    official_model.apply_rotary_emb(q_official_rope[..., -config.rope_head_dim :], freqs)
+    official_model.apply_rotary_emb(q_fp32_norm_official_rope[..., -config.rope_head_dim :], freqs)
+    kv_official_rope = kv_raw.clone()
+    official_model.apply_rotary_emb(kv_official_rope[..., -config.rope_head_dim :], freqs)
+
+    hf_config = AutoConfig.from_pretrained(args.checkpoint)
+    layer_type = "compress" if ratio else "main"
+    rotary = DeepseekV4RotaryEmbedding(hf_config).to(device)
+    position_ids = torch.arange(q_raw.shape[1], device=device).unsqueeze(0)
+    cos, sin = rotary(q_raw, position_ids, layer_type=layer_type)
+    cos_fp32, sin_fp32 = rotary(q_raw.float(), position_ids, layer_type=layer_type)
+    q_hf_rope_official_norm = apply_rotary_pos_emb(q_official_norm_unrotated.transpose(1, 2), cos, sin).transpose(1, 2)
+    q_hf_rope_fp32_norm = apply_rotary_pos_emb(q_fp32_norm_unrotated.transpose(1, 2), cos, sin).transpose(1, 2)
+    q_hf_fp32_rope_official_norm = apply_rotary_pos_emb(
+        q_official_norm_unrotated.transpose(1, 2), cos_fp32, sin_fp32
+    ).transpose(1, 2)
+    kv_hf_rope = apply_rotary_pos_emb(kv_raw.unsqueeze(1), cos, sin)[:, 0]
+    kv_hf_fp32_rope = apply_rotary_pos_emb(kv_raw.unsqueeze(1), cos_fp32, sin_fp32)[:, 0]
+
+    official_kernel.act_quant(
+        kv_official_rope[..., : -config.rope_head_dim],
+        64,
+        config.scale_fmt,
+        torch.float8_e8m0fnu,
+        True,
+    )
+    official_kernel.act_quant(
+        kv_hf_rope[..., : -config.rope_head_dim],
+        64,
+        config.scale_fmt,
+        torch.float8_e8m0fnu,
+        True,
+    )
+    official_kernel.act_quant(
+        kv_hf_fp32_rope[..., : -config.rope_head_dim],
+        64,
+        config.scale_fmt,
+        torch.float8_e8m0fnu,
+        True,
+    )
+
+    index = json.loads((args.checkpoint / "model.safetensors.index.json").read_text())
+    sink_key = f"layers.{args.layer}.attn.attn_sink"
+    sink_file = index["weight_map"][sink_key]
+    with safe_open(args.checkpoint / sink_file, framework="pt", device="cpu") as checkpoint_file:
+        sinks = checkpoint_file.get_tensor(sink_key)[: q_raw.shape[2]].float().to(device)
+    topk = trace["attention_topk"][args.layer].int().to(device)
+    scale = config.head_dim**-0.5
+
+    official = official_kernel.sparse_attn(q_official_rope, kv_official_rope, sinks, topk, scale)
+    veomni_official_norm = sparse_attn_tilelang(
+        q_official_rope.contiguous(), kv_official_rope.contiguous(), sinks.contiguous(), topk.contiguous(), scale
+    )
+    veomni_fp32_norm = sparse_attn_tilelang(
+        q_fp32_norm_official_rope.contiguous(),
+        kv_official_rope.contiguous(),
+        sinks.contiguous(),
+        topk.contiguous(),
+        scale,
+    )
+    veomni_hf_rope_official_norm = sparse_attn_tilelang(
+        q_hf_rope_official_norm.contiguous(),
+        kv_hf_rope.contiguous(),
+        sinks.contiguous(),
+        topk.contiguous(),
+        scale,
+    )
+    veomni_hf_rope_fp32_norm = sparse_attn_tilelang(
+        q_hf_rope_fp32_norm.contiguous(),
+        kv_hf_rope.contiguous(),
+        sinks.contiguous(),
+        topk.contiguous(),
+        scale,
+    )
+    veomni_hf_fp32_rope_official_norm = sparse_attn_tilelang(
+        q_hf_fp32_rope_official_norm.contiguous(),
+        kv_hf_fp32_rope.contiguous(),
+        sinks.contiguous(),
+        topk.contiguous(),
+        scale,
+    )
+
+    def diff_stats(left, right):
+        diff = (left.float() - right.float()).abs()
+        return {
+            "mean_abs_diff": float(diff.mean()),
+            "rms_diff": float(diff.square().mean().sqrt()),
+            "max_abs_diff": float(diff.max()),
+        }
+
+    print(
+        {
+            "shape": list(official.shape),
+            "query_norm": {
+                "mean_abs_diff": float(q_norm_diff.mean()),
+                "rms_diff": float(q_norm_diff.square().mean().sqrt()),
+                "max_abs_diff": float(q_norm_diff.max()),
+            },
+            "query_rope": diff_stats(q_official_rope, q_hf_rope_official_norm),
+            "query_fp32_rope": diff_stats(q_official_rope, q_hf_fp32_rope_official_norm),
+            "kv_rope": diff_stats(kv_official_rope, kv_hf_rope),
+            "kv_fp32_rope": diff_stats(kv_official_rope, kv_hf_fp32_rope),
+            "same_official_norm": diff_stats(official, veomni_official_norm),
+            "fp32_norm_vs_official": diff_stats(official, veomni_fp32_norm),
+            "hf_rope_official_norm_vs_official": diff_stats(official, veomni_hf_rope_official_norm),
+            "hf_rope_fp32_norm_vs_official": diff_stats(official, veomni_hf_rope_fp32_norm),
+            "hf_fp32_rope_official_norm_vs_official": diff_stats(official, veomni_hf_fp32_rope_official_norm),
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deepseek_v4/compare_traces.py
+++ b/scripts/deepseek_v4/compare_traces.py
@@ -1,0 +1,156 @@
+"""Compare official and VeOmni DeepSeek-V4 trace files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("official", type=Path)
+    parser.add_argument("veomni", type=Path)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def topk_set_match(left: torch.Tensor, right: torch.Tensor) -> dict[str, float | int]:
+    if left.shape != right.shape:
+        return {"shape_match": 0, "left_numel": left.numel(), "right_numel": right.numel()}
+    ordered_per_token = (left == right).all(dim=-1)
+    left = left.long().sort(dim=-1).values
+    right = right.long().sort(dim=-1).values
+    per_token = (left == right).all(dim=-1)
+    insertion = torch.searchsorted(right.contiguous(), left.contiguous(), side="left")
+    found = insertion < right.shape[-1]
+    candidates = right.gather(-1, insertion.clamp_max(right.shape[-1] - 1))
+    overlap = (found & (candidates == left)).float().mean(dim=-1)
+    mismatching_tokens = (~per_token).flatten().nonzero(as_tuple=False).flatten().tolist()
+    return {
+        "shape_match": 1,
+        "matching_tokens": int(per_token.sum()),
+        "ordered_matching_tokens": int(ordered_per_token.sum()),
+        "total_tokens": per_token.numel(),
+        "match_rate": float(per_token.float().mean()),
+        "mean_topk_overlap": float(overlap.mean()),
+        "min_topk_overlap": float(overlap.min()),
+        "p01_topk_overlap": float(overlap.quantile(0.01)),
+        "mismatching_tokens": mismatching_tokens,
+    }
+
+
+def compare_topk_group(official: dict, veomni: dict) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for layer_id in sorted(set(official) | set(veomni)):
+        if layer_id not in official or layer_id not in veomni:
+            result[str(layer_id)] = {"missing": "official" if layer_id not in official else "veomni"}
+        else:
+            result[str(layer_id)] = topk_set_match(official[layer_id], veomni[layer_id])
+    return result
+
+
+def main() -> None:
+    args = parse_args()
+    official = torch.load(args.official, map_location="cpu", weights_only=True)
+    veomni = torch.load(args.veomni, map_location="cpu", weights_only=True)
+    if not torch.equal(official["input_ids"], veomni["input_ids"]):
+        raise ValueError("Trace input IDs differ")
+
+    left_logprobs = official["logprobs"].float()
+    right_logprobs = veomni["logprobs"].float()
+    logprob_shape_match = left_logprobs.shape == right_logprobs.shape
+    logprob_diff = None if not logprob_shape_match else (left_logprobs - right_logprobs).abs()
+    report = {
+        "tokens": int(official["input_ids"].numel()),
+        "logprobs": {
+            "shape_match": logprob_shape_match,
+            "official_shape": list(left_logprobs.shape),
+            "veomni_shape": list(right_logprobs.shape),
+            "max_abs_diff": None if logprob_diff is None else float(logprob_diff.max()),
+            "mean_abs_diff": None if logprob_diff is None else float(logprob_diff.mean()),
+            "p99_abs_diff": None if logprob_diff is None else float(logprob_diff.quantile(0.99)),
+        },
+        "moe_topk": compare_topk_group(official["moe_topk"], veomni["moe_topk"]),
+        "indexer_topk": compare_topk_group(official["indexer_topk"], veomni["indexer_topk"]),
+        "attention_topk": compare_topk_group(official["attention_topk"], veomni["attention_topk"]),
+    }
+
+    hidden_report = {}
+    for layer_id in sorted(set(official["hidden"]) & set(veomni["hidden"])):
+        layer_report = {}
+        for name in ("mean", "rms", "sample"):
+            diff = (official["hidden"][layer_id][name].float() - veomni["hidden"][layer_id][name].float()).abs()
+            layer_report[name] = {"max_abs_diff": float(diff.max()), "mean_abs_diff": float(diff.mean())}
+        hidden_report[str(layer_id)] = layer_report
+    report["hidden"] = hidden_report
+
+    terminal_report = {}
+    official_terminal = official.get("terminal", {})
+    veomni_terminal = veomni.get("terminal", {})
+    for name in sorted(set(official_terminal) | set(veomni_terminal)):
+        if name not in official_terminal or name not in veomni_terminal:
+            terminal_report[name] = {"missing": "official" if name not in official_terminal else "veomni"}
+            continue
+        left = official_terminal[name].float()
+        right = veomni_terminal[name].float()
+        if left.shape != right.shape:
+            terminal_report[name] = {
+                "shape_match": False,
+                "official_shape": list(left.shape),
+                "veomni_shape": list(right.shape),
+            }
+            continue
+        diff = (left - right).abs()
+        terminal_report[name] = {
+            "shape_match": True,
+            "max_abs_diff": float(diff.max()),
+            "mean_abs_diff": float(diff.mean()),
+            "rms_diff": float(diff.square().mean().sqrt()),
+        }
+    report["terminal"] = terminal_report
+
+    detail_report = {}
+    official_details = official.get("details", {})
+    veomni_details = veomni.get("details", {})
+    for layer_id in sorted(set(official_details) | set(veomni_details)):
+        if layer_id not in official_details or layer_id not in veomni_details:
+            detail_report[str(layer_id)] = {"missing": "official" if layer_id not in official_details else "veomni"}
+            continue
+        layer_report = {}
+        official_layer = official_details[layer_id]
+        veomni_layer = veomni_details[layer_id]
+        for name in sorted(set(official_layer) | set(veomni_layer)):
+            if name not in official_layer or name not in veomni_layer:
+                layer_report[name] = {"missing": "official" if name not in official_layer else "veomni"}
+                continue
+            left = official_layer[name].float()
+            right = veomni_layer[name].float()
+            if left.shape != right.shape:
+                layer_report[name] = {
+                    "shape_match": False,
+                    "official_shape": list(left.shape),
+                    "veomni_shape": list(right.shape),
+                }
+                continue
+            diff = (left - right).abs()
+            layer_report[name] = {
+                "shape_match": True,
+                "max_abs_diff": float(diff.max()),
+                "mean_abs_diff": float(diff.mean()),
+                "rms_diff": float(diff.square().mean().sqrt()),
+            }
+        detail_report[str(layer_id)] = layer_report
+    report["details"] = detail_report
+
+    rendered = json.dumps(report, indent=2)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deepseek_v4/trace_official.py
+++ b/scripts/deepseek_v4/trace_official.py
@@ -1,0 +1,306 @@
+"""Trace the official DeepSeek-V4-Flash inference implementation.
+
+Run from the VeOmni environment with four ranks, for example::
+
+    .venv/bin/torchrun --standalone --nproc-per-node=4 \
+      scripts/deepseek_v4/trace_official.py \
+      --repo /tmp/DeepSeek-V4-Flash \
+      --checkpoint /tmp/DeepSeek-V4-Flash-official-mp4 \
+      --output /tmp/deepseek-v4-traces/official.pt \
+      --seq-len 4096
+
+The script imports, but does not modify, the official ``inference/model.py``
+shipped in the safetensors repository. Only rank 0 writes the trace because
+the reference model-parallel implementation produces identical routing and
+attention indices on every rank.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import types
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from safetensors.torch import load_model
+from transformers import AutoTokenizer
+
+
+_TRACE_TEXT = (
+    "Numerical parity in distributed inference requires identical routing, "
+    "sparse attention selection, normalization, and quantization semantics. "
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--seq-len", type=int, default=4096)
+    parser.add_argument("--logprob-chunk-size", type=int, default=64)
+    parser.add_argument(
+        "--detail-layers",
+        type=int,
+        nargs="*",
+        default=(),
+        help="Store full intermediate tensors for the selected layer IDs",
+    )
+    return parser.parse_args()
+
+
+def build_input_ids(tokenizer: AutoTokenizer, seq_len: int, device: torch.device) -> torch.Tensor:
+    seed_tokens = tokenizer.encode(_TRACE_TEXT, add_special_tokens=False)
+    if not seed_tokens:
+        raise RuntimeError("Trace text unexpectedly encoded to zero tokens")
+    bos = tokenizer.bos_token_id
+    prefix = [] if bos is None else [bos]
+    repeats = (seq_len - len(prefix) + len(seed_tokens) - 1) // len(seed_tokens)
+    tokens = (prefix + (seed_tokens * repeats))[:seq_len]
+    if len(tokens) != seq_len:
+        raise RuntimeError(f"Could not construct {seq_len} input tokens")
+    return torch.tensor(tokens, dtype=torch.long, device=device).unsqueeze(0)
+
+
+def hidden_fingerprint(hidden_states: torch.Tensor) -> dict[str, torch.Tensor]:
+    flat = hidden_states.detach().float().flatten(start_dim=2)
+    return {
+        "mean": flat.mean(dim=-1).cpu(),
+        "rms": flat.square().mean(dim=-1).sqrt().cpu(),
+        "sample": flat[..., :8].cpu(),
+    }
+
+
+def distributed_target_logprobs(
+    hidden_states: torch.Tensor,
+    targets: torch.Tensor,
+    local_weight: torch.Tensor,
+    chunk_size: int,
+) -> torch.Tensor:
+    """Compute exact next-token log-probs without gathering the sharded head."""
+    rank = dist.get_rank()
+    part_vocab = local_weight.shape[0]
+    vocab_start = rank * part_vocab
+    pieces: list[torch.Tensor] = []
+    for start in range(0, hidden_states.shape[1] - 1, chunk_size):
+        end = min(hidden_states.shape[1] - 1, start + chunk_size)
+        local_logits = F.linear(hidden_states[:, start:end].float(), local_weight.float())
+        local_max = local_logits.amax(dim=-1)
+        dist.all_reduce(local_max, op=dist.ReduceOp.MAX)
+
+        denominator = (local_logits - local_max.unsqueeze(-1)).exp().sum(dim=-1)
+        dist.all_reduce(denominator, op=dist.ReduceOp.SUM)
+
+        chunk_targets = targets[:, start + 1 : end + 1]
+        local_target = torch.zeros_like(local_max)
+        owned = (chunk_targets >= vocab_start) & (chunk_targets < vocab_start + part_vocab)
+        if owned.any():
+            local_ids = (chunk_targets - vocab_start).clamp(0, part_vocab - 1)
+            gathered = local_logits.gather(-1, local_ids.unsqueeze(-1)).squeeze(-1)
+            local_target = torch.where(owned, gathered, local_target)
+        dist.all_reduce(local_target, op=dist.ReduceOp.SUM)
+        pieces.append((local_target - local_max - denominator.log()).cpu())
+    return torch.cat(pieces, dim=1)
+
+
+def main() -> None:
+    args = parse_args()
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    local_rank = int(__import__("os").environ["LOCAL_RANK"])
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    torch.set_default_dtype(torch.bfloat16)
+    torch.manual_seed(33377335)
+
+    inference_dir = args.repo / "inference"
+    sys.path.insert(0, str(inference_dir))
+    import model as official_model  # noqa: PLC0415
+
+    with (inference_dir / "config.json").open() as handle:
+        model_args = official_model.ModelArgs(**json.load(handle))
+    model_args.max_batch_size = 1
+    model_args.max_seq_len = args.seq_len
+
+    with torch.device(device):
+        model = official_model.Transformer(model_args)
+    load_model(model, str(args.checkpoint / f"model{rank}-mp{dist.get_world_size()}.safetensors"), strict=False)
+    model.eval()
+    # The official generate.py sets this after checkpoint loading. Its cached
+    # window/compression index helpers intentionally rely on the default device.
+    torch.set_default_device("cuda")
+
+    tokenizer = AutoTokenizer.from_pretrained(args.checkpoint)
+    input_ids = build_input_ids(tokenizer, args.seq_len, device)
+    trace: dict[str, object] = {
+        "format_version": 1,
+        "implementation": "official",
+        "input_ids": input_ids.cpu(),
+        "moe_topk": {},
+        "moe_weights": {},
+        "indexer_topk": {},
+        "attention_topk": {},
+        "hidden": {},
+        "details": {},
+        "terminal": {},
+    }
+
+    if rank == 0:
+        for layer_id, layer in enumerate(model.layers):
+
+            def gate_hook(_module, _inputs, output, *, layer_id=layer_id):
+                trace["moe_weights"][layer_id] = output[0].detach().cpu()
+                trace["moe_topk"][layer_id] = output[1].detach().to(torch.int32).cpu()
+
+            def layer_hook(_module, _inputs, output, *, layer_id=layer_id):
+                trace["hidden"][layer_id] = hidden_fingerprint(output)
+
+            layer.ffn.gate.register_forward_hook(gate_hook)
+            layer.register_forward_hook(layer_hook)
+            if layer_id in args.detail_layers:
+                trace["details"][layer_id] = {}
+                details = trace["details"][layer_id]
+
+                def save_tensor(name, tensor, *, details=details):
+                    details[name] = tensor.detach().cpu()
+
+                def layer_detail_hook(_module, inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("layer_input", inputs[0])
+                    save_tensor("layer_output", output)
+
+                def attn_input_hook(_module, _inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("attn_input", output)
+
+                def attn_output_hook(_module, _inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("attn_output", output)
+
+                def mlp_input_hook(_module, _inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("mlp_input", output)
+
+                def mlp_output_hook(_module, _inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("mlp_output", output)
+
+                def gate_detail_hook(_module, _inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("router_weights", output[0])
+
+                def tensor_output_hook(name, *, save_tensor=save_tensor):
+                    def hook(_module, _inputs, output):
+                        save_tensor(name, output)
+
+                    return hook
+
+                def tensor_input_hook(name, *, save_tensor=save_tensor):
+                    def hook(_module, inputs):
+                        save_tensor(name, inputs[0])
+
+                    return hook
+
+                layer.register_forward_hook(layer_detail_hook)
+                layer.attn_norm.register_forward_hook(attn_input_hook)
+                layer.attn.register_forward_hook(attn_output_hook)
+                layer.ffn_norm.register_forward_hook(mlp_input_hook)
+                layer.ffn.register_forward_hook(mlp_output_hook)
+                layer.ffn.gate.register_forward_hook(gate_detail_hook)
+                layer.ffn.shared_experts.register_forward_hook(tensor_output_hook("shared_expert_output"))
+                layer.ffn.shared_experts.w1.register_forward_hook(tensor_output_hook("shared_gate_proj"))
+                layer.ffn.shared_experts.w3.register_forward_hook(tensor_output_hook("shared_up_proj"))
+                layer.ffn.shared_experts.w2.register_forward_pre_hook(tensor_input_hook("shared_down_input"))
+                layer.ffn.shared_experts.w2.register_forward_hook(tensor_output_hook("shared_down_proj"))
+                layer.attn.wq_a.register_forward_hook(tensor_output_hook("q_a_proj"))
+                layer.attn.q_norm.register_forward_hook(tensor_output_hook("q_a_norm"))
+                layer.attn.wq_b.register_forward_hook(tensor_output_hook("q_b_proj"))
+                layer.attn.wkv.register_forward_hook(tensor_output_hook("kv_proj"))
+                layer.attn.kv_norm.register_forward_hook(tensor_output_hook("kv_norm"))
+                layer.attn.wo_b.register_forward_hook(tensor_output_hook("o_b_proj"))
+            if getattr(layer.attn, "indexer", None) is not None:
+
+                def indexer_hook(_module, _inputs, output, *, layer_id=layer_id):
+                    relative = torch.where(output >= 0, output - args.seq_len, output)
+                    trace["indexer_topk"][layer_id] = relative.detach().to(torch.int32).cpu()
+
+                layer.attn.indexer.register_forward_hook(indexer_hook)
+
+    active_layer = {"id": -1}
+    original_sparse_attn = official_model.sparse_attn
+
+    def traced_sparse_attn(q, kv, attn_sink, topk_idxs, softmax_scale):
+        if rank == 0:
+            trace["attention_topk"][active_layer["id"]] = topk_idxs.detach().to(torch.int32).cpu()
+        output = original_sparse_attn(q, kv, attn_sink, topk_idxs, softmax_scale)
+        if rank == 0 and active_layer["id"] in args.detail_layers:
+            trace["details"][active_layer["id"]]["sparse_attn_output"] = output.detach().cpu()
+        return output
+
+    official_model.sparse_attn = traced_sparse_attn
+    original_einsum = torch.einsum
+    local_projection_details: dict[int, dict[str, torch.Tensor]] = {}
+
+    def traced_einsum(equation, *operands):
+        output = original_einsum(equation, *operands)
+        if equation == "bsgd,grd->bsgr" and active_layer["id"] in args.detail_layers:
+            local_projection_details[active_layer["id"]] = {
+                "o_a_input": operands[0].detach(),
+                "o_a_proj": output.detach(),
+            }
+            if rank == 0:
+                details = trace["details"][active_layer["id"]]
+                details["o_a_input"] = operands[0].detach().cpu()
+                details["o_a_proj"] = output.detach().cpu()
+        return output
+
+    official_model.torch.einsum = traced_einsum
+    for layer_id, layer in enumerate(model.layers):
+        original_forward = layer.attn.forward
+
+        def attention_forward(self, *forward_args, _original=original_forward, _layer_id=layer_id, **forward_kwargs):
+            active_layer["id"] = _layer_id
+            return _original(*forward_args, **forward_kwargs)
+
+        layer.attn.forward = types.MethodType(attention_forward, layer.attn)
+
+    with torch.inference_mode():
+        hidden_states = model.embed(input_ids)
+        hidden_states = hidden_states.unsqueeze(2).repeat(1, 1, model.hc_mult, 1)
+        for layer in model.layers:
+            hidden_states = layer(hidden_states, 0, input_ids)
+        collapsed = model.head.hc_head(
+            hidden_states,
+            model.hc_head_fn,
+            model.hc_head_scale,
+            model.hc_head_base,
+        )
+        normalized = model.norm(collapsed)
+        if rank == 0:
+            trace["terminal"]["collapsed"] = collapsed.detach().cpu()
+            trace["terminal"]["normalized"] = normalized.detach().cpu()
+        logprobs = distributed_target_logprobs(
+            normalized,
+            input_ids,
+            model.head.weight,
+            args.logprob_chunk_size,
+        )
+
+    for layer_id in args.detail_layers:
+        local_details = local_projection_details[layer_id]
+        for name in ("o_a_input", "o_a_proj"):
+            local_tensor = local_details[name].contiguous()
+            gathered = [torch.empty_like(local_tensor) for _ in range(dist.get_world_size())]
+            dist.all_gather(gathered, local_tensor)
+            if rank == 0:
+                trace["details"][layer_id][f"{name}_full"] = torch.cat(gathered, dim=2).cpu()
+
+    if rank == 0:
+        trace["logprobs"] = logprobs
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(trace, args.output)
+        print(f"saved official trace to {args.output}")
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deepseek_v4/trace_veomni.py
+++ b/scripts/deepseek_v4/trace_veomni.py
@@ -1,0 +1,536 @@
+"""Trace VeOmni's DeepSeek-V4 TileLang + fused-Triton execution path.
+
+The input token tensor is read from the trace produced by
+``trace_official.py`` so both implementations receive bit-identical inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+
+from veomni.arguments.arguments_types import MixedPrecisionConfig, OpsImplementationConfig
+from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.torch_parallelize import build_parallelize_model
+from veomni.models import build_foundation_model
+from veomni.models.transformers.deepseek_v4.generated import patched_modeling_deepseek_v4_gpu as modeling_module
+from veomni.ops.kernels.deepseek_v4 import linear_bf16_fp32
+from veomni.utils import helper
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--official-trace", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--logprob-chunk-size", type=int, default=64)
+    parser.add_argument(
+        "--detail-layers",
+        type=int,
+        nargs="*",
+        default=(),
+        help="Store full intermediate tensors for the selected layer IDs",
+    )
+    parser.add_argument(
+        "--force-official-attention-inputs",
+        action="store_true",
+        help="Replace selected layers' normalized attention inputs with tensors from --official-trace",
+    )
+    parser.add_argument(
+        "--force-official-mlp-inputs",
+        action="store_true",
+        help="Replace selected layers' normalized MLP inputs with tensors from --official-trace",
+    )
+    parser.add_argument("--moe-backend", choices=("eager", "fused_triton", "fused_quack"), default="fused_triton")
+    parser.add_argument("--indexer-implementation", choices=("eager", "tilelang"), default="tilelang")
+    parser.add_argument("--attention-implementation", choices=("eager", "tilelang"), default="tilelang")
+    parser.add_argument("--mhc-implementation", choices=("eager", "tilelang"), default="tilelang")
+    parser.add_argument("--eager-moe-output", type=Path)
+    parser.add_argument("--eager-dsa-output", type=Path)
+    parser.add_argument("--eager-mhc-output", type=Path)
+    parser.add_argument("--same-input-indexer-reference", action="store_true")
+    parser.add_argument(
+        "--reference-moe-topk",
+        action="store_true",
+        help="Replay official MoE expert IDs while retaining VeOmni router weights and expert execution",
+    )
+    parser.add_argument(
+        "--reference-moe-router-weights",
+        action="store_true",
+        help="Replay official MoE router weights during a top-k reference pass",
+    )
+    parser.add_argument(
+        "--official-moe-topk-output",
+        type=Path,
+        help="Write a second pass that replays official MoE expert IDs after the primary pass",
+    )
+    parser.add_argument(
+        "--fp8-activation-qat",
+        action="store_true",
+        help="Enable the Miles-style DeepSeek-V4 FP8 activation QAT forward path",
+    )
+    parser.add_argument(
+        "--reference-compressor-fp32",
+        action="store_true",
+        help="Match the official compressor's BF16-input/weight GEMMs with FP32 outputs and pooling",
+    )
+    return parser.parse_args()
+
+
+def hidden_fingerprint(hidden_states: torch.Tensor) -> dict[str, torch.Tensor]:
+    flat = hidden_states.detach().float().flatten(start_dim=2)
+    return {
+        "mean": flat.mean(dim=-1).cpu(),
+        "rms": flat.square().mean(dim=-1).sqrt().cpu(),
+        "sample": flat[..., :8].cpu(),
+    }
+
+
+def make_ops_config(args: argparse.Namespace) -> OpsImplementationConfig:
+    return OpsImplementationConfig(
+        attn_implementation="eager",
+        moe_implementation=args.moe_backend,
+        cross_entropy_loss_implementation="chunk_loss",
+        rms_norm_implementation="eager",
+        swiglu_mlp_implementation="eager",
+        rotary_pos_emb_implementation="eager",
+        load_balancing_loss_implementation="eager",
+        dsa_indexer_implementation=args.indexer_implementation,
+        dsa_attention_implementation=args.attention_implementation,
+        mhc_implementation=args.mhc_implementation,
+        deepseek_v4_fp8_activation_qat=args.fp8_activation_qat,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    if args.reference_moe_topk and args.official_moe_topk_output is not None:
+        raise ValueError("--reference-moe-topk and --official-moe-topk-output are mutually exclusive")
+    if args.reference_moe_router_weights and not (args.reference_moe_topk or args.official_moe_topk_output):
+        raise ValueError("--reference-moe-router-weights requires --reference-moe-topk or --official-moe-topk-output")
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    helper.enable_high_precision_for_bf16()
+    torch.manual_seed(33377335)
+
+    init_parallel_state(
+        dp_size=world_size,
+        dp_shard_size=world_size,
+        dp_mode="fsdp2",
+        extra_parallel_names=("ep",),
+        extra_parallel_sizes=(world_size,),
+        extra_parallel_placement_innermost=(False,),
+    )
+
+    ops = make_ops_config(args)
+    model = build_foundation_model(
+        config_path=str(args.checkpoint),
+        weights_path=str(args.checkpoint),
+        torch_dtype="bfloat16",
+        init_device="meta",
+        ops_implementation=ops,
+    )
+    model = build_parallelize_model(
+        model,
+        init_device="meta",
+        weights_path=str(args.checkpoint),
+        enable_reshard_after_forward=True,
+        mixed_precision=MixedPrecisionConfig(enable=False),
+        enable_gradient_checkpointing=False,
+        basic_modules=list(set(getattr(model, "_no_split_modules", None) or [])),
+        # DeepSeek-V4's raw FP4 checkpoint requires key and tensor conversion.
+        # The EP streaming loader intentionally rejects that combination today.
+        ep_sharded_stream_load=False,
+    )
+    model.eval()
+
+    if args.reference_compressor_fp32:
+        projection_count = 0
+        for layer in model.model.layers:
+            compressor = getattr(layer.self_attn, "compressor", None)
+            components = (compressor, getattr(compressor, "indexer", None))
+            for component in components:
+                if component is None:
+                    continue
+                for projection_name in ("kv_proj", "gate_proj"):
+                    projection = getattr(component, projection_name, None)
+                    if projection is None:
+                        continue
+
+                    def fp32_projection_hook(module, inputs, _output):
+                        weight = module.weight.to_local() if hasattr(module.weight, "to_local") else module.weight
+                        return linear_bf16_fp32(inputs[0], weight)
+
+                    projection.register_forward_hook(fp32_projection_hook)
+                    projection_count += 1
+
+                kv_norm = getattr(component, "kv_norm", None)
+                if kv_norm is not None:
+
+                    def compressor_norm_pre_hook(_module, inputs):
+                        return (inputs[0].to(torch.bfloat16), *inputs[1:])
+
+                    kv_norm.register_forward_pre_hook(compressor_norm_pre_hook)
+        if rank == 0:
+            print(f"enabled FP32-output compressor projections on {projection_count} linear modules")
+
+    official_trace = torch.load(args.official_trace, map_location="cpu", weights_only=True)
+    if args.force_official_attention_inputs and not args.detail_layers:
+        raise ValueError("--force-official-attention-inputs requires --detail-layers")
+    input_ids = official_trace["input_ids"].to(device)
+
+    def make_trace(implementation: str) -> dict[str, object]:
+        return {
+            "format_version": 1,
+            "implementation": implementation,
+            "input_ids": input_ids.cpu(),
+            "moe_topk": {},
+            "moe_weights": {},
+            "indexer_topk": {},
+            "indexer_eager_same_input": {},
+            "attention_topk": {},
+            "hidden": {},
+            "details": {},
+            "terminal": {},
+        }
+
+    implementation = (
+        f"veomni_moe={args.moe_backend}_indexer={args.indexer_implementation}"
+        f"_attention={args.attention_implementation}_mhc={args.mhc_implementation}"
+    )
+    if args.reference_moe_topk:
+        implementation += "_official_moe_topk"
+    if args.reference_moe_router_weights and args.reference_moe_topk:
+        implementation += "_official_moe_router_weights"
+    if args.fp8_activation_qat:
+        implementation += "_fp8_activation_qat"
+    if args.reference_compressor_fp32:
+        implementation += "_compressor_fp32"
+    trace = make_trace(implementation)
+
+    layers = model.model.layers
+    replay_moe_topk = {"enabled": args.reference_moe_topk}
+    replay_moe_router_weights = {"enabled": args.reference_moe_topk and args.reference_moe_router_weights}
+    if args.reference_moe_topk or args.official_moe_topk_output is not None:
+        missing_layers = set(range(len(layers))) - set(official_trace["moe_topk"])
+        if missing_layers:
+            raise ValueError(f"Official trace is missing MoE top-k tensors for layers {sorted(missing_layers)}")
+        if args.reference_moe_router_weights:
+            missing_weight_layers = set(range(len(layers))) - set(official_trace.get("moe_weights", {}))
+            if missing_weight_layers:
+                raise ValueError(
+                    f"Official trace is missing MoE router-weight tensors for layers {sorted(missing_weight_layers)}"
+                )
+        for layer_id, layer in enumerate(layers):
+            official_indices = official_trace["moe_topk"][layer_id].to(device=device, dtype=torch.long)
+            official_weights = None
+            if args.reference_moe_router_weights:
+                official_weights = official_trace["moe_weights"][layer_id].to(device=device)
+
+            def replay_official_topk(
+                module,
+                _inputs,
+                output,
+                *,
+                layer_id=layer_id,
+                official_indices=official_indices,
+                official_weights=official_weights,
+            ):
+                if not replay_moe_topk["enabled"]:
+                    return output
+                logits, _weights, veomni_indices = output
+                if veomni_indices.shape != official_indices.shape:
+                    raise ValueError(
+                        f"Layer {layer_id} router shape mismatch: VeOmni {tuple(veomni_indices.shape)} "
+                        f"vs official {tuple(official_indices.shape)}"
+                    )
+                if official_weights is not None and replay_moe_router_weights["enabled"]:
+                    if _weights.shape != official_weights.shape:
+                        raise ValueError(
+                            f"Layer {layer_id} router-weight shape mismatch: VeOmni {tuple(_weights.shape)} "
+                            f"vs official {tuple(official_weights.shape)}"
+                        )
+                    weights = official_weights.to(dtype=_weights.dtype)
+                else:
+                    scores = module.score_fn(logits)
+                    weights = scores.gather(1, official_indices)
+                    weights = weights / (weights.sum(dim=-1, keepdim=True) + 1e-20)
+                    weights = weights * module.routed_scaling_factor
+                return logits, weights, official_indices
+
+            layer.mlp.gate.register_forward_hook(replay_official_topk)
+    if rank == 0:
+
+        def terminal_hook(name):
+            def hook(_module, _inputs, output):
+                trace["terminal"][name] = output.detach().cpu()
+
+            return hook
+
+        model.model.hc_head.register_forward_hook(terminal_hook("collapsed"))
+        model.model.norm.register_forward_hook(terminal_hook("normalized"))
+    if args.force_official_attention_inputs:
+        for layer_id in args.detail_layers:
+            official_attention_input = official_trace["details"][layer_id]["attn_input"].to(device)
+
+            def force_attention_input_hook(
+                _module,
+                inputs,
+                *,
+                official_attention_input=official_attention_input,
+            ):
+                return (official_attention_input, *inputs[1:])
+
+            layers[layer_id].self_attn.register_forward_pre_hook(force_attention_input_hook)
+    if args.force_official_mlp_inputs:
+        for layer_id in args.detail_layers:
+            official_mlp_input = official_trace["details"][layer_id]["mlp_input"].to(device)
+
+            def force_mlp_input_hook(
+                _module,
+                _inputs,
+                _output,
+                *,
+                official_mlp_input=official_mlp_input,
+            ):
+                return official_mlp_input
+
+            layers[layer_id].post_attention_layernorm.register_forward_hook(force_mlp_input_hook)
+
+    if rank == 0:
+        for layer_id, layer in enumerate(layers):
+
+            def gate_hook(_module, _inputs, output, *, layer_id=layer_id):
+                trace["moe_weights"][layer_id] = output[1].detach().cpu()
+                trace["moe_topk"][layer_id] = output[2].detach().to(torch.int32).cpu()
+
+            def layer_hook(_module, _inputs, output, *, layer_id=layer_id):
+                trace["hidden"][layer_id] = hidden_fingerprint(output)
+
+            layer.mlp.gate.register_forward_hook(gate_hook)
+            layer.register_forward_hook(layer_hook)
+            if layer_id in args.detail_layers:
+                trace["details"][layer_id] = {}
+
+                def save_tensor(name, tensor, *, layer_id=layer_id):
+                    trace["details"].setdefault(layer_id, {})[name] = tensor.detach().cpu()
+
+                def layer_detail_hook(_module, inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("layer_input", inputs[0])
+                    save_tensor("layer_output", output)
+
+                def attn_input_hook(_module, _inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("attn_input", output)
+
+                def attn_output_hook(_module, _inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("attn_output", output[0])
+
+                def mlp_input_hook(_module, _inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("mlp_input", output)
+
+                def mlp_output_hook(_module, _inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("mlp_output", output)
+
+                def gate_detail_hook(_module, _inputs, output, *, save_tensor=save_tensor):
+                    save_tensor("router_weights", output[1])
+
+                def tensor_output_hook(name, *, save_tensor=save_tensor, shard_last_dim=False):
+                    def hook(_module, _inputs, output):
+                        if shard_last_dim:
+                            output = output[..., : output.shape[-1] // world_size]
+                        save_tensor(name, output)
+
+                    return hook
+
+                def tensor_input_hook(name, *, save_tensor=save_tensor):
+                    def hook(_module, inputs):
+                        save_tensor(name, inputs[0])
+
+                    return hook
+
+                def o_a_proj_hook(_module, inputs, output, *, save_tensor=save_tensor):
+                    if output.shape[-2] % world_size:
+                        raise ValueError(f"o_a group count {output.shape[-2]} is not divisible by {world_size=}")
+                    local_groups = output.shape[-2] // world_size
+                    save_tensor("o_a_input", inputs[0][..., :local_groups, :])
+                    save_tensor("o_a_proj", output[..., :local_groups, :])
+
+                layer.register_forward_hook(layer_detail_hook)
+                layer.input_layernorm.register_forward_hook(attn_input_hook)
+                layer.self_attn.register_forward_hook(attn_output_hook)
+                layer.post_attention_layernorm.register_forward_hook(mlp_input_hook)
+                layer.mlp.register_forward_hook(mlp_output_hook)
+                layer.mlp.gate.register_forward_hook(gate_detail_hook)
+                layer.mlp.shared_experts.register_forward_hook(tensor_output_hook("shared_expert_output"))
+                layer.mlp.shared_experts.gate_proj.register_forward_hook(tensor_output_hook("shared_gate_proj"))
+                layer.mlp.shared_experts.up_proj.register_forward_hook(tensor_output_hook("shared_up_proj"))
+                layer.mlp.shared_experts.down_proj.register_forward_pre_hook(tensor_input_hook("shared_down_input"))
+                layer.mlp.shared_experts.down_proj.register_forward_hook(tensor_output_hook("shared_down_proj"))
+                layer.self_attn.q_a_proj.register_forward_hook(tensor_output_hook("q_a_proj"))
+                layer.self_attn.q_a_norm.register_forward_hook(tensor_output_hook("q_a_norm"))
+                layer.self_attn.q_b_proj.register_forward_hook(tensor_output_hook("q_b_proj", shard_last_dim=True))
+                layer.self_attn.kv_proj.register_forward_hook(tensor_output_hook("kv_proj"))
+                layer.self_attn.kv_norm.register_forward_hook(tensor_output_hook("kv_norm"))
+                layer.self_attn.o_a_proj.register_forward_hook(o_a_proj_hook)
+                layer.self_attn.o_b_proj.register_forward_hook(tensor_output_hook("o_b_proj"))
+            indexer = getattr(getattr(layer.self_attn, "compressor", None), "indexer", None)
+            if indexer is not None:
+
+                def indexer_hook(_module, _inputs, output, *, layer_id=layer_id):
+                    trace["indexer_topk"][layer_id] = output.detach().to(torch.int32).cpu()
+
+                indexer.register_forward_hook(indexer_hook)
+
+    active_layer = {"id": -1}
+    original_indexer = modeling_module.v4_lighting_indexer
+
+    def traced_indexer(
+        q,
+        k,
+        weights,
+        compress_ratio,
+        topk,
+        topk_indices=None,
+        cu_seqlen_ks=None,
+        cu_seqlen_ke=None,
+    ):
+        result = original_indexer(
+            q,
+            k,
+            weights,
+            compress_ratio,
+            topk,
+            topk_indices,
+            cu_seqlen_ks,
+            cu_seqlen_ke,
+        )
+        if rank == 0 and args.same_input_indexer_reference and topk_indices is None:
+            reference_chunks = []
+            key_positions = torch.arange(k.shape[0], device=k.device)
+            for start in range(0, q.shape[0], 64):
+                end = min(q.shape[0], start + 64)
+                scores = torch.einsum("sbhd,tbd->bsht", q[start:end].float(), k.float())
+                scores = (scores.relu() * weights[start:end].permute(1, 0, 2).float().unsqueeze(-1)).sum(dim=2)
+                if cu_seqlen_ks is None:
+                    valid_start = torch.zeros(end - start, device=k.device, dtype=torch.long)
+                    valid_end = (torch.arange(start, end, device=k.device) + 1) // compress_ratio
+                else:
+                    valid_start = cu_seqlen_ks[start:end].long()
+                    valid_end = cu_seqlen_ke[start:end].long()
+                valid = (key_positions >= valid_start[:, None]) & (key_positions < valid_end[:, None])
+                values, indices = scores.masked_fill(~valid.unsqueeze(0), float("-inf")).topk(topk, dim=-1)
+                reference_chunks.append(indices.masked_fill(values == -torch.inf, -1).to(torch.int32).cpu())
+            trace["indexer_eager_same_input"][active_layer["id"]] = torch.cat(reference_chunks, dim=1)
+        return result
+
+    modeling_module.v4_lighting_indexer = traced_indexer
+    original_sparse_attn = modeling_module.sparse_attn_tilelang
+
+    def traced_sparse_attn(q, kv, attn_sink, topk_idxs, sm_scale=None):
+        if rank == 0:
+            trace["attention_topk"][active_layer["id"]] = topk_idxs.detach().to(torch.int32).cpu()
+        output = original_sparse_attn(q, kv, attn_sink, topk_idxs, sm_scale)
+        if rank == 0 and active_layer["id"] in args.detail_layers:
+            if output.shape[-2] % world_size:
+                raise ValueError(f"attention head count {output.shape[-2]} is not divisible by {world_size=}")
+            local_heads = output.shape[-2] // world_size
+            trace["details"][active_layer["id"]]["sparse_attn_output"] = output[..., :local_heads, :].detach().cpu()
+        return output
+
+    modeling_module.sparse_attn_tilelang = traced_sparse_attn
+    for layer_id, layer in enumerate(layers):
+
+        def attention_pre_hook(_module, _inputs, *, layer_id=layer_id):
+            active_layer["id"] = layer_id
+
+        layer.self_attn.register_forward_pre_hook(attention_pre_hook)
+
+    # chunk_logprobs_function applies the causal labels[..., 1:] shift.
+    # Passing pre-shifted labels here would compare token t against t+2.
+    labels = input_ids
+
+    def run_pass(output_path: Path) -> None:
+        # FSDP2's unshard hooks preserve tensor version counters, which are
+        # deliberately absent under inference_mode. no_grad is the supported
+        # evaluation context for fully_shard models.
+        with torch.no_grad():
+            outputs = model(
+                input_ids=input_ids,
+                attention_mask=torch.ones_like(input_ids),
+                labels=labels,
+                use_cache=False,
+                return_log_probs=True,
+                chunk_size=args.logprob_chunk_size,
+            )
+        if outputs.log_probs is None:
+            raise RuntimeError("VeOmni did not return per-token log-probabilities")
+        if rank == 0:
+            trace["logprobs"] = outputs.log_probs[:, :-1].detach().cpu()
+            trace["entropy"] = None if outputs.entropy is None else outputs.entropy[:, :-1].detach().cpu()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            torch.save(trace, output_path)
+            print(f"saved VeOmni trace to {output_path}")
+
+    run_pass(args.output)
+
+    if args.official_moe_topk_output is not None:
+        replay_moe_topk["enabled"] = True
+        replay_moe_router_weights["enabled"] = args.reference_moe_router_weights
+        replay_suffix = "_official_moe_routing" if args.reference_moe_router_weights else "_official_moe_topk"
+        trace = make_trace(implementation + replay_suffix)
+        run_pass(args.official_moe_topk_output)
+        replay_moe_topk["enabled"] = False
+        replay_moe_router_weights["enabled"] = False
+
+    if args.eager_dsa_output is not None:
+        modeling_module.veomni_dsa_indexer_implementation.bind(
+            SimpleNamespace(dsa_indexer_implementation="eager")
+        )
+        modeling_module.veomni_dsa_attention_implementation.bind(
+            SimpleNamespace(dsa_attention_implementation="eager")
+        )
+        trace = make_trace(
+            implementation.replace(f"indexer={args.indexer_implementation}", "indexer=eager").replace(
+                f"attention={args.attention_implementation}", "attention=eager"
+            )
+        )
+        run_pass(args.eager_dsa_output)
+        modeling_module.veomni_dsa_indexer_implementation.bind(
+            SimpleNamespace(dsa_indexer_implementation=args.indexer_implementation)
+        )
+        modeling_module.veomni_dsa_attention_implementation.bind(
+            SimpleNamespace(dsa_attention_implementation=args.attention_implementation)
+        )
+
+    if args.eager_mhc_output is not None:
+        for slot in (modeling_module.veomni_mhc_pre, modeling_module.veomni_mhc_post, modeling_module.veomni_mhc_head):
+            slot.bind("eager")
+        trace = make_trace(implementation.replace(f"mhc={args.mhc_implementation}", "mhc=eager"))
+        run_pass(args.eager_mhc_output)
+
+    if args.eager_moe_output is not None:
+        # This script always enables EP when world_size > 1. The ordinary
+        # eager loop expects all expert weights locally and cannot consume
+        # global router IDs with an EP-sharded [E/world_size, ...] tensor.
+        if world_size > 1:
+            if rank == 0:
+                print("skipping eager MoE pass: the eager expert loop is not EP-aware")
+        else:
+            modeling_module.veomni_moe_experts_forward.bind("eager")
+            trace = make_trace(implementation.replace(f"moe={args.moe_backend}", "moe=eager"))
+            run_pass(args.eager_moe_output)
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add the investigation tools used to compare official DeepSeek-V4 inference with VeOmni without mixing approximately 1,300 lines of diagnostics into the production and training changes.

- trace official and VeOmni intermediate activations
- compare the LM head and sparse-attention kernels
- check fused-MoE behavior
- replay official top-k routing results
- compare aligned traces and corrected causal log probabilities
- exercise the opt-in FP8 activation QAT forward path

Inference-only FP4, quantized-GEMM, weight-repacking, output-projection, and on-demand expert modes were removed from this PR because they are not used by training.

## Findings encoded by the tools

The earlier 12 to 16 log-probability gap was inflated by a double label shift in the comparison harness. Corrected comparisons show that replaying official routing materially reduces the remaining model-body difference, while the LM head itself is exact.

## Review scope

This is stack 3 of 3 and should be reviewed against #929 / branch agent/deepseek-v4-fp8-activation-qat. It contains diagnostic scripts only.

Tracking issue: #927
Original integration draft: #917

## Validation

- uv run python -m compileall -q scripts/deepseek_v4
- uv run ruff check on all included scripts
- git diff --check

## Stack navigation

Tracked by #927. Merge and review in this order:

1. #928 — runtime parity
2. #929 — FP8 activation QAT
3. #931 — parity diagnostics

#930 is closed as superseded because its inference-only FP4/GEMM paths are not used by training. The original #917 remains the integration and CI baseline; it is not the merge target for this stack.