### PR TITLE
[BREAKING][config, model, ops] refactor: unify DeepSeek V4 kernel naming

### DIFF
--- a/configs/text/deepseek_v4.yaml
+++ b/configs/text/deepseek_v4.yaml
@@ -4,9 +4,9 @@ model:
     attn_implementation: eager
     moe_implementation: fused_triton
     cross_entropy_loss_implementation: liger_kernel
-    dsa_attention_backend: tilelang_sparse
-    dsa_indexer_backend: tilelang
-    mhc_backend: tile_kernels
+    dsa_attention_implementation: tilelang
+    dsa_indexer_implementation: tilelang
+    mhc_implementation: tilelang
     rms_norm_implementation: liger_kernel
     swiglu_mlp_implementation: liger_kernel
 

--- a/docs/design/kernel_selection.md
+++ b/docs/design/kernel_selection.md
@@ -15,9 +15,9 @@ selection knob.
 | Kernel | Config field | Available values | Default | Selection time |
 |--------|-------------|------------------|---------|----------------|
 | Attention | `attn_implementation` | `eager`, `sdpa`, `flash_attention_2`, `flash_attention_3`, `flash_attention_4`, `native-sparse` | `"flash_attention_2"` | Config `__post_init__` + `build_foundation_model` |
-| DSA indexer | `dsa_indexer_backend` | `eager`, `cudnn` (GLM-DSA), `tilelang` (DeepSeek-V4) | `"eager"` | Model build via `OpsConfigSlot` |
-| DSA attention | `dsa_attention_backend` | `eager`, `flashmla_cudnn` (GLM-DSA), `tilelang_sparse` (DeepSeek-V4) | `"eager"` | Model build via `OpsConfigSlot` |
-| mHC | `mhc_backend` | `eager`, `tile_kernels` (DeepSeek-V4, SM90+) | `"eager"` | Model build via three `OpSlot`s (`pre`, `post`, `head`) |
+| DSA indexer | `dsa_indexer_implementation` | `eager`, `cudnn` (GLM-DSA), `tilelang` (DeepSeek-V4) | `"eager"` | Model build via `OpsConfigSlot` |
+| DSA attention | `dsa_attention_implementation` | `eager`, `flashmla_cudnn` (GLM-DSA), `tilelang` (DeepSeek-V4) | `"eager"` | Model build via `OpsConfigSlot` |
+| mHC | `mhc_implementation` | `eager`, `tilelang` (DeepSeek-V4, SM90+) | `"eager"` | Model build via three `OpSlot`s (`pre`, `post`, `head`) |
 | Cross-entropy loss | `cross_entropy_loss_implementation` | `eager`, `liger_kernel`, `chunk_loss`, `npu` | `"liger_kernel"` (GPU) | `apply_ops_config()` (before model build) |
 | RMSNorm | `rms_norm_implementation` | `eager`, `liger_kernel`, `npu`, `triton` (per-model; DeepSeek-V3) | `"liger_kernel"` (GPU) | Model registration via ops config singleton |
 | SwiGLU MLP | `swiglu_mlp_implementation` | `eager`, `liger_kernel` | `"liger_kernel"` (GPU) | Model registration via ops config singleton |
@@ -142,13 +142,14 @@ and final head collapse through registry-backed `OpSlot`s:
 ```yaml
 model:
   ops_implementation:
-    dsa_indexer_backend: tilelang
-    dsa_attention_backend: tilelang_sparse
-    mhc_backend: tile_kernels
+    dsa_indexer_implementation: tilelang
+    dsa_attention_implementation: tilelang
+    mhc_implementation: tilelang
 ```
 
-All three optimized paths require NVIDIA SM90 or later. `mhc_backend` defaults
-to `eager` and never silently falls back after `tile_kernels` is selected.
+All three optimized paths require NVIDIA SM90 or later. `mhc_implementation` defaults
+to `eager` and never silently falls back after `tilelang` is selected. The mHC
+implementation is provided by the `tile-kernels` package.
 TileKernels' training path supports forward and backward with BF16 activations
 and DeepSeek V4's `hc_mult=4` layout.
 
@@ -370,7 +371,7 @@ raise during config validation or kernel binding.
 | `fused_npu` | NPU group-gemm | Ascend NPU | Yes |
 
 DeepSeek-V4 keeps eager DSA indexer and attention as its defaults, with optional
-SM90+ `tilelang` indexer and `tilelang_sparse` attention backends. Its MoE path
+SM90+ `tilelang` indexer and attention implementations. Its MoE path
 uses the independent `moe_implementation` selection and therefore defaults to
 `fused_triton` on GPU.
 The v4-specific patched experts path passes the merged `gate_up_proj` tensor

--- a/docs/design/unified_kernel_registry.md
+++ b/docs/design/unified_kernel_registry.md
@@ -279,9 +279,9 @@ class OpsImplementationConfig:
     rms_norm_gated_implementation: str = "fla"
     causal_conv1d_implementation: str = "fla"
     chunk_gated_delta_rule_implementation: str = "fla"
-    dsa_indexer_backend: Literal["eager", "cudnn", "tilelang"] = "eager"
-    dsa_attention_backend: Literal["eager", "flashmla_cudnn", "tilelang_sparse"] = "eager"
-    mhc_backend: Literal["eager", "tile_kernels"] = "eager"
+    dsa_indexer_implementation: Literal["eager", "cudnn", "tilelang"] = "eager"
+    dsa_attention_implementation: Literal["eager", "flashmla_cudnn", "tilelang"] = "eager"
+    mhc_implementation: Literal["eager", "tilelang"] = "eager"
 ```
 
 **Shipped today** (what is actually on `OpsImplementationConfig` as of this
@@ -299,9 +299,9 @@ PR — see `veomni/arguments/arguments_types.py`):
 | `rms_norm_gated_implementation` | `eager`, `fla`, `npu` | Qwen3.5 GatedDeltaNet `self.norm`; default `fla` |
 | `causal_conv1d_implementation` | `eager`, `fla`, `npu` | Qwen3.5 GatedDeltaNet pre-mixer; `eager` has no `cu_seqlens` path |
 | `chunk_gated_delta_rule_implementation` | `eager`, `fla`, `flash_qla`, `npu` | Qwen3.5 linear attention; `flash_qla` is Hopper SM90-only, while `npu` uses the vendored MindSpeed-MM kernel |
-| `dsa_indexer_backend` | `eager`, `cudnn`, `tilelang` | GLM-DSA supports `cudnn`; DeepSeek V4 supports `tilelang`. Optimized backends require compatible NVIDIA hardware. |
-| `dsa_attention_backend` | `eager`, `flashmla_cudnn`, `tilelang_sparse` | GLM-DSA supports `flashmla_cudnn`; DeepSeek V4 supports `tilelang_sparse`. Optimized backends require compatible NVIDIA hardware. |
-| `mhc_backend` | `eager`, `tile_kernels` | DeepSeek V4 manifold-constrained Hyper-Connection pre/post/head kernels. The three `OpSlot("mhc", variant)` instances share this selection and require NVIDIA SM90+ for `tile_kernels`. |
+| `dsa_indexer_implementation` | `eager`, `cudnn`, `tilelang` | GLM-DSA supports `cudnn`; DeepSeek V4 supports `tilelang`. Optimized implementations require compatible NVIDIA hardware. |
+| `dsa_attention_implementation` | `eager`, `flashmla_cudnn`, `tilelang` | GLM-DSA supports `flashmla_cudnn`; DeepSeek V4 supports `tilelang`. Optimized implementations require compatible NVIDIA hardware. |
+| `mhc_implementation` | `eager`, `tilelang` | DeepSeek V4 manifold-constrained Hyper-Connection pre/post/head kernels provided by the `tile-kernels` package. The three `OpSlot("mhc", variant)` instances share this selection and require NVIDIA SM90+ for `tilelang`. |
 
 No preset field was shipped. Configure each `OpsImplementationConfig` field
 explicitly; unknown fields such as `preset` are invalid.

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -197,9 +197,9 @@ NPU validation runs at two times:
 | rms_norm_gated_implementation | `str` | `"fla"` | Gated RMSNorm (Qwen3.5 GatedDeltaNet `self.norm`). Known values: `eager`, `fla` (FLA `FusedRMSNormGated`, GPU), `npu`. |
 | causal_conv1d_implementation | `str` | `"fla"` | Varlen depthwise causal conv1d (Qwen3.5 GatedDeltaNet pre-mixer). Known values: `eager`, `fla` (GPU), `npu` (requires `triton-ascend`). `eager` does not support the varlen path. |
 | chunk_gated_delta_rule_implementation | `str` | `"fla"` | Chunk gated delta-rule kernel for Qwen3.5 linear attention. Known values: `eager`, `fla` (GPU), `flash_qla` (Hopper SM90), `npu` (requires `triton-ascend`). `eager` does not support varlen training. |
-| dsa_indexer_backend | `Literal["eager", "cudnn", "tilelang"]` | `"eager"` | DeepSeek sparse-attention top-k indexer backend. `tilelang` selects the DeepSeek-V4 Lightning Indexer kernel and requires an SM90+ CUDA GPU. |
-| dsa_attention_backend | `Literal["eager", "flashmla_cudnn", "tilelang_sparse"]` | `"eager"` | DeepSeek sparse-attention backend. `tilelang_sparse` selects the DeepSeek-V4 sparse MQA kernel and requires an SM90+ CUDA GPU. |
-| mhc_backend | `Literal["eager", "tile_kernels"]` | `"eager"` | DeepSeek V4 manifold-constrained Hyper-Connection backend. `tile_kernels` enables the TileKernels forward/backward path and requires an SM90+ CUDA GPU. |
+| dsa_indexer_implementation | `Literal["eager", "cudnn", "tilelang"]` | `"eager"` | DeepSeek sparse-attention top-k indexer implementation. `tilelang` selects the DeepSeek-V4 Lightning Indexer kernel and requires an SM90+ CUDA GPU. |
+| dsa_attention_implementation | `Literal["eager", "flashmla_cudnn", "tilelang"]` | `"eager"` | DeepSeek sparse-attention implementation. `tilelang` selects the DeepSeek-V4 sparse MQA kernel and requires an SM90+ CUDA GPU. |
+| mhc_implementation | `Literal["eager", "tilelang"]` | `"eager"` | DeepSeek V4 manifold-constrained Hyper-Connection implementation. `tilelang` enables the forward/backward path provided by the `tile-kernels` package and requires an SM90+ CUDA GPU. |
 
 ### DataArguments
 

--- a/tests/e2e/test_e2e_parallel.py
+++ b/tests/e2e/test_e2e_parallel.py
@@ -50,9 +50,9 @@ _deepseek_v4_tilelang_skip = pytest.mark.skipif(
 
 _DEEPSEEK_V4_TILELANG_TRAINING_ARGS = [
     "--train.dyn_bsz=True",
-    "--model.ops_implementation.dsa_indexer_backend=tilelang",
-    "--model.ops_implementation.dsa_attention_backend=tilelang_sparse",
-    "--model.ops_implementation.mhc_backend=tile_kernels",
+    "--model.ops_implementation.dsa_indexer_implementation=tilelang",
+    "--model.ops_implementation.dsa_attention_implementation=tilelang",
+    "--model.ops_implementation.mhc_implementation=tilelang",
 ]
 
 

--- a/tests/ops/test_deepseek_v4_kernels.py
+++ b/tests/ops/test_deepseek_v4_kernels.py
@@ -268,9 +268,9 @@ def test_deepseek_v4_generated_attention_dispatch_matches_eager():
     )
 
     try:
-        modeling.veomni_dsa_attention_backend.bind(SimpleNamespace(dsa_attention_backend="eager"))
+        modeling.veomni_dsa_attention_implementation.bind(SimpleNamespace(dsa_attention_implementation="eager"))
         expected, _ = modeling.eager_attention_forward(module, query, key, key, causal_mask, dim**-0.5, dropout=0.0)
-        modeling.veomni_dsa_attention_backend.bind(SimpleNamespace(dsa_attention_backend="tilelang_sparse"))
+        modeling.veomni_dsa_attention_implementation.bind(SimpleNamespace(dsa_attention_implementation="tilelang"))
         actual, weights = modeling.eager_attention_forward(
             module, query, key, key, causal_mask, dim**-0.5, dropout=0.0
         )
@@ -284,7 +284,7 @@ def test_deepseek_v4_generated_attention_dispatch_matches_eager():
         assert fp32_weights is not None
         assert fp32_output.dtype == torch.float32
     finally:
-        modeling.veomni_dsa_attention_backend.bind(SimpleNamespace(dsa_attention_backend="eager"))
+        modeling.veomni_dsa_attention_implementation.bind(SimpleNamespace(dsa_attention_implementation="eager"))
 
 
 def test_deepseek_v4_generated_indexer_dispatch_and_position_fallback(monkeypatch):
@@ -311,7 +311,7 @@ def test_deepseek_v4_generated_indexer_dispatch_and_position_fallback(monkeypatc
 
     monkeypatch.setattr(modeling, "v4_lighting_indexer", fake_tilelang)
     try:
-        modeling.veomni_dsa_indexer_backend.bind(SimpleNamespace(dsa_indexer_backend="tilelang"))
+        modeling.veomni_dsa_indexer_implementation.bind(SimpleNamespace(dsa_indexer_implementation="tilelang"))
         tilelang_indices = indexer(hidden_states, q_residual, canonical_positions, None, 0)
         assert calls
         expected_topk = seq_len // config.compress_rates["compressed_sparse_attention"]
@@ -349,7 +349,7 @@ def test_deepseek_v4_generated_indexer_dispatch_and_position_fallback(monkeypatc
         assert len(calls) == 2
         assert eager_indices.shape == tilelang_indices.shape
     finally:
-        modeling.veomni_dsa_indexer_backend.bind(SimpleNamespace(dsa_indexer_backend="eager"))
+        modeling.veomni_dsa_indexer_implementation.bind(SimpleNamespace(dsa_indexer_implementation="eager"))
 
 
 def test_deepseek_v4_packed_compressors_match_independent_sequences():
@@ -374,7 +374,7 @@ def test_deepseek_v4_packed_compressors_match_independent_sequences():
         block_bias_rates=(config.compress_rates["heavily_compressed_attention"],),
     )
 
-    modeling.veomni_dsa_indexer_backend.bind(SimpleNamespace(dsa_indexer_backend="eager"))
+    modeling.veomni_dsa_indexer_implementation.bind(SimpleNamespace(dsa_indexer_implementation="eager"))
     for compressor_cls in (modeling.DeepseekV4HCACompressor, modeling.DeepseekV4CSACompressor):
         compressor = compressor_cls(config)
         # Compressors allocate ``position_bias`` with ``torch.empty``; the full

--- a/tests/ops/test_mhc_tile_kernels.py
+++ b/tests/ops/test_mhc_tile_kernels.py
@@ -143,13 +143,13 @@ def test_tile_kernels_mhc_head_forward_backward_matches_eager():
 
 @pytest.mark.parametrize("variant", ["pre", "post", "head"])
 def test_tile_kernels_mhc_registry_entries(variant):
-    assert "tile_kernels" in KERNEL_REGISTRY.list_available("mhc", variant)
+    assert "tilelang" in KERNEL_REGISTRY.list_available("mhc", variant)
 
 
 @patch(f"{_REGISTRY_MODULE}.IS_CUDA_AVAILABLE", True)
 @patch(f"{_REGISTRY_MODULE}.IS_NPU_AVAILABLE", False)
 @patch(f"{_REGISTRY_MODULE}.get_gpu_compute_capability", return_value=90)
-def test_bind_veomni_ops_uses_mhc_backend(_mock_cc):
+def test_bind_veomni_ops_uses_mhc_implementation(_mock_cc):
     from veomni.arguments.arguments_types import OpsImplementationConfig
     from veomni.models.auto import _bind_veomni_ops
 
@@ -170,7 +170,7 @@ def test_bind_veomni_ops_uses_mhc_backend(_mock_cc):
         rms_norm_gated_implementation="eager",
         causal_conv1d_implementation="eager",
         chunk_gated_delta_rule_implementation="eager",
-        mhc_backend="tile_kernels",
+        mhc_implementation="tilelang",
     )
 
     assert _bind_veomni_ops(fake_module, ops_config)

--- a/tests/ops/test_moe_hw_gate.py
+++ b/tests/ops/test_moe_hw_gate.py
@@ -196,14 +196,14 @@ def test_bind_veomni_ops_binds_model_registered_config_slots():
         rms_norm_gated_implementation="eager",
         causal_conv1d_implementation="eager",
         chunk_gated_delta_rule_implementation="eager",
-        dsa_indexer_backend="cudnn",
-        dsa_attention_backend="flashmla_cudnn",
+        dsa_indexer_implementation="cudnn",
+        dsa_attention_implementation="flashmla_cudnn",
     )
-    indexer_slot = OpsConfigSlot("dsa_indexer_backend")
-    attention_slot = OpsConfigSlot("dsa_attention_backend")
+    indexer_slot = OpsConfigSlot("dsa_indexer_implementation")
+    attention_slot = OpsConfigSlot("dsa_attention_implementation")
     fake_module = SimpleNamespace(
-        veomni_dsa_indexer_backend=indexer_slot,
-        veomni_dsa_attention_backend=attention_slot,
+        veomni_dsa_indexer_implementation=indexer_slot,
+        veomni_dsa_attention_implementation=attention_slot,
     )
 
     assert _bind_veomni_ops(fake_module, ops_config)

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -1041,18 +1041,18 @@ class OpsImplementationConfig:
             "A non-eager value on hardware without a matching backend raises at OpSlot bind time."
         },
     )
-    dsa_indexer_backend: Literal["eager", "cudnn", "tilelang"] = field(
+    dsa_indexer_implementation: Literal["eager", "cudnn", "tilelang"] = field(
         default="eager",
-        metadata={"help": "DeepSeek sparse attention top-k indexer backend: 'eager', 'cudnn', or 'tilelang'."},
+        metadata={"help": "DeepSeek sparse attention top-k indexer implementation: 'eager', 'cudnn', or 'tilelang'."},
     )
-    dsa_attention_backend: Literal["eager", "flashmla_cudnn", "tilelang_sparse"] = field(
+    dsa_attention_implementation: Literal["eager", "flashmla_cudnn", "tilelang"] = field(
         default="eager",
-        metadata={"help": "DeepSeek sparse attention backend: 'eager', 'flashmla_cudnn', or 'tilelang_sparse'."},
+        metadata={"help": "DeepSeek sparse attention implementation: 'eager', 'flashmla_cudnn', or 'tilelang'."},
     )
-    mhc_backend: Literal["eager", "tile_kernels"] = field(
+    mhc_implementation: Literal["eager", "tilelang"] = field(
         default="eager",
         metadata={
-            "help": "Manifold-constrained Hyper-Connection backend. 'tile_kernels' enables the "
+            "help": "Manifold-constrained Hyper-Connection implementation. 'tilelang' enables the "
             "DeepSeek V4 TileKernels forward/backward path on NVIDIA SM90+; 'eager' uses PyTorch."
         },
     )

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -88,8 +88,6 @@ def _bind_veomni_ops(modeling_module, ops_config: OpsImplementationConfig) -> bo
             )
             if impl_name != "eager" and obj.variant == "standard":
                 moe_experts_kernel = impl_name
-        elif obj.op_name == "mhc":
-            impl_name = ops_config.mhc_backend
         else:
             impl_name = getattr(ops_config, f"{obj.op_name}_implementation", "eager")
         obj.bind(impl_name)

--- a/veomni/models/transformers/deepseek_v4/deepseek_v4_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/deepseek_v4/deepseek_v4_gpu_patch_gen_config.py
@@ -20,9 +20,9 @@ patchgen veomni.models.transformers.deepseek_v4.deepseek_v4_gpu_patch_gen_config
 Patches:
 1. ``DeepseekV4Indexer.forward`` — optional TileLang Lightning Indexer for
    canonical CUDA prefill/training positions, selected by
-   ``dsa_indexer_backend=tilelang`` with eager cache/decode fallback.
+   ``dsa_indexer_implementation=tilelang`` with eager cache/decode fallback.
 2. ``eager_attention_forward`` — optional TileLang sparse MQA attention,
-   selected by ``dsa_attention_backend=tilelang_sparse``. Converts the
+   selected by ``dsa_attention_implementation=tilelang``. Converts the
    upstream additive sliding/compressor mask into compact indices.
 3. ``DeepseekV4Experts`` — drops upstream ``@use_experts_implementation``
    (which would otherwise dispatch to ``grouped_mm`` and bypass VeOmni's
@@ -116,8 +116,8 @@ veomni_load_balancing_loss = OpSlot("load_balancing_loss", "standard")
 veomni_mhc_pre = OpSlot("mhc", "pre")
 veomni_mhc_post = OpSlot("mhc", "post")
 veomni_mhc_head = OpSlot("mhc", "head")
-veomni_dsa_indexer_backend = OpsConfigSlot("dsa_indexer_backend")
-veomni_dsa_attention_backend = OpsConfigSlot("dsa_attention_backend")
+veomni_dsa_indexer_implementation = OpsConfigSlot("dsa_indexer_implementation")
+veomni_dsa_attention_implementation = OpsConfigSlot("dsa_attention_implementation")
 
 
 config = PatchConfig(
@@ -163,8 +163,8 @@ config.add_post_import_block(
     veomni_mhc_pre = OpSlot("mhc", "pre")
     veomni_mhc_post = OpSlot("mhc", "post")
     veomni_mhc_head = OpSlot("mhc", "head")
-    veomni_dsa_indexer_backend = OpsConfigSlot("dsa_indexer_backend")
-    veomni_dsa_attention_backend = OpsConfigSlot("dsa_attention_backend")
+    veomni_dsa_indexer_implementation = OpsConfigSlot("dsa_indexer_implementation")
+    veomni_dsa_attention_implementation = OpsConfigSlot("dsa_attention_implementation")
     """
 )
 
@@ -445,7 +445,7 @@ def deepseek_v4_csa_compressor_forward_patched(
 # ================================================================
 # Patch: DeepseekV4Indexer.forward
 # 1. Dispatch CUDA prefill/training index scoring to the TileLang Lightning
-#    Indexer when ``dsa_indexer_backend=tilelang``. Cache/decode and unusual
+#    Indexer when ``dsa_indexer_implementation=tilelang``. Cache/decode and unusual
 #    position layouts retain the upstream eager implementation.
 # ================================================================
 @config.override_method("DeepseekV4Indexer.forward", description="Optional TileLang Lightning Indexer dispatch")
@@ -529,17 +529,18 @@ def deepseek_v4_indexer_forward_patched(
     top_k = min(self.index_topk, compressed_len)
 
     # --- Patch.1 ---
-    indexer_backend = veomni_dsa_indexer_backend.value
-    if indexer_backend not in {"eager", "tilelang"}:
+    indexer_implementation = veomni_dsa_indexer_implementation.value
+    if indexer_implementation not in {"eager", "tilelang"}:
         raise ValueError(
-            f"DeepSeek-V4 does not support dsa_indexer_backend={indexer_backend!r}; expected 'eager' or 'tilelang'"
+            "DeepSeek-V4 does not support "
+            f"dsa_indexer_implementation={indexer_implementation!r}; expected 'eager' or 'tilelang'"
         )
     canonical_positions = torch.arange(seq_len, device=position_ids.device).unsqueeze(0).expand_as(position_ids)
     packed_ranges = None
     if packed_compression_metadata is not None and cache_layer is None:
         packed_ranges = packed_compressed_causal_ranges(packed_compression_metadata[self.compress_rate])
     use_tilelang = (
-        indexer_backend == "tilelang"
+        indexer_implementation == "tilelang"
         and hidden_states.is_cuda
         and q.dtype == torch.bfloat16
         and compressed_kv.dtype == torch.bfloat16
@@ -662,7 +663,7 @@ def deepseek_v4_attention_forward_patched(
 # ================================================================
 # Patch: eager_attention_forward
 # 1. Dispatch DeepSeek-V4 attention to the TileLang sparse MQA kernel when
-#    ``dsa_attention_backend=tilelang_sparse``. The existing additive mask is
+#    ``dsa_attention_implementation=tilelang``. The existing additive mask is
 #    converted to a compact fixed-width index list, preserving sliding-window,
 #    compressor, causal, and invalid-index semantics.
 # 2. Preserve the upstream eager implementation as the default fallback.
@@ -679,14 +680,14 @@ def deepseek_v4_eager_attention_forward_patched(
     **kwargs,
 ):
     # --- Patch.1 ---
-    attention_backend = veomni_dsa_attention_backend.value
-    if attention_backend not in {"eager", "tilelang_sparse"}:
+    attention_implementation = veomni_dsa_attention_implementation.value
+    if attention_implementation not in {"eager", "tilelang"}:
         raise ValueError(
-            f"DeepSeek-V4 does not support dsa_attention_backend={attention_backend!r}; "
-            "expected 'eager' or 'tilelang_sparse'"
+            "DeepSeek-V4 does not support "
+            f"dsa_attention_implementation={attention_implementation!r}; expected 'eager' or 'tilelang'"
         )
     use_tilelang = (
-        attention_backend == "tilelang_sparse"
+        attention_implementation == "tilelang"
         and query.is_cuda
         and query.dtype == torch.bfloat16
         and key.dtype == torch.bfloat16

--- a/veomni/models/transformers/deepseek_v4/generated/patched_modeling_deepseek_v4_gpu.diff
+++ b/veomni/models/transformers/deepseek_v4/generated/patched_modeling_deepseek_v4_gpu.diff
@@ -117,8 +117,8 @@
 +veomni_mhc_pre = OpSlot("mhc", "pre")
 +veomni_mhc_post = OpSlot("mhc", "post")
 +veomni_mhc_head = OpSlot("mhc", "head")
-+veomni_dsa_indexer_backend = OpsConfigSlot("dsa_indexer_backend")
-+veomni_dsa_attention_backend = OpsConfigSlot("dsa_attention_backend")
++veomni_dsa_indexer_implementation = OpsConfigSlot("dsa_indexer_implementation")
++veomni_dsa_attention_implementation = OpsConfigSlot("dsa_attention_implementation")
 
 
  @use_kernel_forward_from_hub("RMSNorm")
@@ -220,7 +220,7 @@
 +    # ================================================================
 +    # Patch: DeepseekV4Indexer.forward
 +    # 1. Dispatch CUDA prefill/training index scoring to the TileLang Lightning
-+    #    Indexer when ``dsa_indexer_backend=tilelang``. Cache/decode and unusual
++    #    Indexer when ``dsa_indexer_implementation=tilelang``. Cache/decode and unusual
 +    #    position layouts retain the upstream eager implementation.
 +    # ================================================================
      def forward(
@@ -277,7 +277,7 @@
              new_kv = chunk_kv.new_zeros((batch, n_windows, 2 * ratio, self.head_dim))
              new_gate = chunk_gate.new_full((batch, n_windows, 2 * ratio, self.head_dim), float("-inf"))
              new_kv[:, :, ratio:] = chunk_kv[..., self.head_dim :]
-@@ -549,31 +658,71 @@
+@@ -549,31 +658,72 @@
          cos_q, sin_q = self.rotary_emb(hidden_states, position_ids=position_ids, layer_type=self.rope_layer_type)
          q = self.q_b_proj(q_residual).view(batch, seq_len, -1, self.head_dim).transpose(1, 2)
          q = apply_rotary_pos_emb(q, cos_q, sin_q).transpose(1, 2)
@@ -298,17 +298,18 @@
 -        # Picks that still point past `causal_threshold` (early queries with too few ready
 -        # blocks) are replaced with a `-1` sentinel that the compresser treats as invalid.
 +        # --- Patch.1 ---
-+        indexer_backend = veomni_dsa_indexer_backend.value
-+        if indexer_backend not in {"eager", "tilelang"}:
++        indexer_implementation = veomni_dsa_indexer_implementation.value
++        if indexer_implementation not in {"eager", "tilelang"}:
 +            raise ValueError(
-+                f"DeepSeek-V4 does not support dsa_indexer_backend={indexer_backend!r}; expected 'eager' or 'tilelang'"
++                "DeepSeek-V4 does not support "
++                f"dsa_indexer_implementation={indexer_implementation!r}; expected 'eager' or 'tilelang'"
 +            )
 +        canonical_positions = torch.arange(seq_len, device=position_ids.device).unsqueeze(0).expand_as(position_ids)
 +        packed_ranges = None
 +        if packed_compression_metadata is not None and cache_layer is None:
 +            packed_ranges = packed_compressed_causal_ranges(packed_compression_metadata[self.compress_rate])
 +        use_tilelang = (
-+            indexer_backend == "tilelang"
++            indexer_implementation == "tilelang"
 +            and hidden_states.is_cuda
 +            and q.dtype == torch.bfloat16
 +            and compressed_kv.dtype == torch.bfloat16
@@ -366,7 +367,7 @@
 
 
  class DeepseekV4CSACompressor(nn.Module):
-@@ -617,11 +766,47 @@
+@@ -617,11 +767,47 @@
          position_ids: torch.Tensor,
          past_key_values: Cache | None,
          layer_idx: int,
@@ -415,7 +416,7 @@
 
          if cache_layer is None:
              usable = (kv.shape[1] // self.compress_rate) * self.compress_rate
-@@ -634,13 +819,6 @@
+@@ -634,13 +820,6 @@
              ratio = self.compress_rate
              chunk_kv = chunk_kv.view(batch, n_windows, ratio, -1)
              chunk_gate = chunk_gate.view(batch, n_windows, ratio, -1) + self.position_bias.to(chunk_gate.dtype)
@@ -429,7 +430,7 @@
              new_kv = chunk_kv.new_zeros((batch, n_windows, 2 * ratio, self.head_dim))
              new_gate = chunk_gate.new_full((batch, n_windows, 2 * ratio, self.head_dim), float("-inf"))
              new_kv[:, :, ratio:] = chunk_kv[..., self.head_dim :]
-@@ -655,9 +833,6 @@
+@@ -655,9 +834,6 @@
                  if prior_kv is not None:
                      new_kv[:, 0, :ratio] = prior_kv.to(new_kv.dtype)
                      new_gate[:, 0, :ratio] = prior_gate.to(new_gate.dtype)
@@ -439,7 +440,7 @@
              compressed = self.kv_norm(
                  (new_kv * new_gate.softmax(dim=2, dtype=torch.float32).to(new_kv.dtype)).sum(dim=2)
              )
-@@ -672,18 +847,9 @@
+@@ -672,18 +848,9 @@
          if cache_layer is not None:
              compressed = cache_layer.update_compressor_states("compressor", compressed)
          compressed_kv = compressed.unsqueeze(1)
@@ -460,7 +461,7 @@
          safe_indices = torch.where(valid, top_k_indices, torch.full_like(top_k_indices, compressed_len))
          block_bias = compressed_kv.new_full((batch, 1, seq_len, compressed_len + 1), float("-inf"))
          block_bias.scatter_(-1, safe_indices.unsqueeze(1), 0.0)
-@@ -702,6 +868,19 @@
+@@ -702,6 +869,19 @@
      return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
@@ -472,7 +473,7 @@
 +# ================================================================
 +# Patch: eager_attention_forward
 +# 1. Dispatch DeepSeek-V4 attention to the TileLang sparse MQA kernel when
-+#    ``dsa_attention_backend=tilelang_sparse``. The existing additive mask is
++#    ``dsa_attention_implementation=tilelang``. The existing additive mask is
 +#    converted to a compact fixed-width index list, preserving sliding-window,
 +#    compressor, causal, and invalid-index semantics.
 +# 2. Preserve the upstream eager implementation as the default fallback.
@@ -480,19 +481,19 @@
  def eager_attention_forward(
      module: nn.Module,
      query: torch.Tensor,
-@@ -712,6 +891,52 @@
+@@ -712,6 +892,52 @@
      dropout: float | int = 0.0,
      **kwargs,
  ):
 +    # --- Patch.1 ---
-+    attention_backend = veomni_dsa_attention_backend.value
-+    if attention_backend not in {"eager", "tilelang_sparse"}:
++    attention_implementation = veomni_dsa_attention_implementation.value
++    if attention_implementation not in {"eager", "tilelang"}:
 +        raise ValueError(
-+            f"DeepSeek-V4 does not support dsa_attention_backend={attention_backend!r}; "
-+            "expected 'eager' or 'tilelang_sparse'"
++            "DeepSeek-V4 does not support "
++            f"dsa_attention_implementation={attention_implementation!r}; expected 'eager' or 'tilelang'"
 +        )
 +    use_tilelang = (
-+        attention_backend == "tilelang_sparse"
++        attention_implementation == "tilelang"
 +        and query.is_cuda
 +        and query.dtype == torch.bfloat16
 +        and key.dtype == torch.bfloat16
@@ -533,7 +534,7 @@
      key_states = repeat_kv(key, module.num_key_value_groups)
      value_states = repeat_kv(value, module.num_key_value_groups)
      attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
-@@ -720,17 +945,14 @@
+@@ -720,17 +946,14 @@
 
      sinks = module.sinks.reshape(1, -1, 1, 1).expand(query.shape[0], -1, query.shape[-2], -1)
      combined_logits = torch.cat([attn_weights, sinks], dim=-1)
@@ -553,7 +554,7 @@
 
 
  COMPRESSOR_CLASSES = {
-@@ -738,6 +960,12 @@
+@@ -738,6 +961,12 @@
      "compressed_sparse_attention": DeepseekV4CSACompressor,
      "heavily_compressed_attention": DeepseekV4HCACompressor,
  }
@@ -566,7 +567,7 @@
 
 
  class DeepseekV4Attention(nn.Module):
-@@ -786,6 +1014,10 @@
+@@ -786,6 +1015,10 @@
              COMPRESSOR_CLASSES[self.layer_type](config) if self.layer_type != "sliding_attention" else None
          )
 
@@ -577,7 +578,7 @@
      def forward(
          self,
          hidden_states: torch.Tensor,
-@@ -793,12 +1025,10 @@
+@@ -793,12 +1026,10 @@
          position_ids: torch.Tensor,
          attention_mask: torch.Tensor | None,
          past_key_values: Cache | None = None,
@@ -591,7 +592,7 @@
          cos, sin = position_embeddings[self.rope_layer_type]
 
          q_residual = self.q_a_norm(self.q_a_proj(hidden_states))
-@@ -809,29 +1039,29 @@
+@@ -809,29 +1040,29 @@
          kv = self.kv_norm(self.kv_proj(hidden_states)).view(*hidden_shape).transpose(1, 2)
          kv = apply_rotary_pos_emb(kv, cos, sin)
 
@@ -631,7 +632,7 @@
              self.config._attn_implementation, eager_attention_forward
          )
          attn_output, attn_weights = attention_interface(
-@@ -847,18 +1077,17 @@
+@@ -847,18 +1078,17 @@
              **kwargs,
          )
 
@@ -656,7 +657,7 @@
 
 
  class DeepseekV4HyperConnection(nn.Module):
-@@ -909,22 +1138,30 @@
+@@ -909,22 +1139,30 @@
          # doubly-stochastic manifold). Each output gets its own learned scale.
          self.scale = nn.Parameter(torch.empty(3))
 
@@ -698,7 +699,7 @@
          pre = torch.sigmoid(pre_w * pre_scale + pre_b) + self.hc_eps
          post = 2 * torch.sigmoid(post_w * post_scale + post_b)
          comb_logits = comb_w.view(*comb_w.shape[:-1], hc, hc) * comb_scale + comb_b.view(hc, hc)
-@@ -933,11 +1170,14 @@
+@@ -933,11 +1171,14 @@
          for _ in range(self.hc_sinkhorn_iters - 1):
              comb = comb / (comb.sum(dim=-1, keepdim=True) + self.hc_eps)
              comb = comb / (comb.sum(dim=-2, keepdim=True) + self.hc_eps)
@@ -716,7 +717,7 @@
 
 
  class DeepseekV4HyperHead(nn.Module):
-@@ -953,6 +1193,17 @@
+@@ -953,6 +1194,17 @@
          self.hc_scale = nn.Parameter(torch.empty(1))
 
      def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -734,7 +735,7 @@
          flat = self.input_norm(x.flatten(2).float())
          mixes = F.linear(flat, self.hc_fn.float())
          pre = torch.sigmoid(mixes * self.hc_scale.float() + self.hc_base.float()) + self.eps
-@@ -975,11 +1226,30 @@
+@@ -975,11 +1227,30 @@
          return down_proj
 
 
@@ -767,7 +768,7 @@
          super().__init__()
          self.num_experts = config.num_local_experts
          self.hidden_dim = config.hidden_size
-@@ -990,30 +1260,57 @@
+@@ -990,30 +1261,57 @@
          self.limit = config.swiglu_limit
 
      def forward(
@@ -838,7 +839,7 @@
 
 
  class DeepseekV4TopKRouter(nn.Module):
-@@ -1088,6 +1385,12 @@
+@@ -1088,6 +1386,12 @@
          return routed + self.shared_experts(residual)
 
 
@@ -851,7 +852,7 @@
  class DeepseekV4DecoderLayer(GradientCheckpointingLayer):
      r"""DeepSeek-V4 decoder block (paper §2). Differs from a classic residual block in
      two places:
-@@ -1118,22 +1421,20 @@
+@@ -1118,22 +1422,20 @@
          input_ids: torch.Tensor | None = None,
          **kwargs: Unpack[TransformersKwargs],
      ) -> torch.Tensor:
@@ -882,7 +883,7 @@
          return post.to(dtype).unsqueeze(-1) * mlp_output.unsqueeze(-2) + torch.matmul(
              comb.to(dtype).transpose(-1, -2), hidden_states
          )
-@@ -1233,6 +1534,12 @@
+@@ -1233,6 +1535,12 @@
                  init.copy_(getattr(module, f"{layer_type}_original_inv_freq"), curr_inv_freq)
 
 
@@ -895,7 +896,7 @@
  @auto_docstring
  class DeepseekV4Model(DeepseekV4PreTrainedModel):
      def __init__(self, config: DeepseekV4Config):
-@@ -1252,6 +1559,10 @@
+@@ -1252,6 +1560,10 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -906,7 +907,7 @@
      @merge_with_config_defaults
      @capture_outputs
      @auto_docstring
-@@ -1276,9 +1587,31 @@
+@@ -1276,9 +1588,31 @@
              past_seen = past_key_values.get_seq_length()
              position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen
              position_ids = position_ids.unsqueeze(0)
@@ -941,7 +942,7 @@
          if isinstance(attention_mask, dict):
              causal_mask = next(iter(attention_mask.values()))
          else:
-@@ -1289,6 +1622,8 @@
+@@ -1289,6 +1623,8 @@
                  past_key_values=past_key_values,
                  position_ids=position_ids,
              )
@@ -950,7 +951,7 @@
          hidden_states = inputs_embeds.unsqueeze(2).expand(-1, -1, self.config.hc_mult, -1).contiguous()
          position_embeddings = {
              "main": self.rotary_emb(inputs_embeds, position_ids=position_ids, layer_type="main"),
-@@ -1392,6 +1727,12 @@
+@@ -1392,6 +1728,12 @@
      return overall_loss * num_experts
 
 
@@ -963,7 +964,7 @@
  @auto_docstring
  class DeepseekV4ForCausalLM(DeepseekV4PreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -1410,49 +1751,36 @@
+@@ -1410,49 +1752,36 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -1033,7 +1034,7 @@
          outputs: MoeModelOutputWithPast = self.model(
              input_ids=input_ids,
              attention_mask=attention_mask,
-@@ -1465,26 +1793,64 @@
+@@ -1465,26 +1794,64 @@
          )
 
          hidden_states = outputs.last_hidden_state
@@ -1112,7 +1113,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1492,7 +1858,17 @@
+@@ -1492,7 +1859,17 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,

--- a/veomni/models/transformers/deepseek_v4/generated/patched_modeling_deepseek_v4_gpu.py
+++ b/veomni/models/transformers/deepseek_v4/generated/patched_modeling_deepseek_v4_gpu.py
@@ -80,8 +80,8 @@ veomni_load_balancing_loss = OpSlot("load_balancing_loss", "standard")
 veomni_mhc_pre = OpSlot("mhc", "pre")
 veomni_mhc_post = OpSlot("mhc", "post")
 veomni_mhc_head = OpSlot("mhc", "head")
-veomni_dsa_indexer_backend = OpsConfigSlot("dsa_indexer_backend")
-veomni_dsa_attention_backend = OpsConfigSlot("dsa_attention_backend")
+veomni_dsa_indexer_implementation = OpsConfigSlot("dsa_indexer_implementation")
+veomni_dsa_attention_implementation = OpsConfigSlot("dsa_attention_implementation")
 
 
 @use_kernel_forward_from_hub("RMSNorm")
@@ -576,7 +576,7 @@ class DeepseekV4Indexer(nn.Module):
     # ================================================================
     # Patch: DeepseekV4Indexer.forward
     # 1. Dispatch CUDA prefill/training index scoring to the TileLang Lightning
-    #    Indexer when ``dsa_indexer_backend=tilelang``. Cache/decode and unusual
+    #    Indexer when ``dsa_indexer_implementation=tilelang``. Cache/decode and unusual
     #    position layouts retain the upstream eager implementation.
     # ================================================================
     def forward(
@@ -663,17 +663,18 @@ class DeepseekV4Indexer(nn.Module):
         top_k = min(self.index_topk, compressed_len)
 
         # --- Patch.1 ---
-        indexer_backend = veomni_dsa_indexer_backend.value
-        if indexer_backend not in {"eager", "tilelang"}:
+        indexer_implementation = veomni_dsa_indexer_implementation.value
+        if indexer_implementation not in {"eager", "tilelang"}:
             raise ValueError(
-                f"DeepSeek-V4 does not support dsa_indexer_backend={indexer_backend!r}; expected 'eager' or 'tilelang'"
+                "DeepSeek-V4 does not support "
+                f"dsa_indexer_implementation={indexer_implementation!r}; expected 'eager' or 'tilelang'"
             )
         canonical_positions = torch.arange(seq_len, device=position_ids.device).unsqueeze(0).expand_as(position_ids)
         packed_ranges = None
         if packed_compression_metadata is not None and cache_layer is None:
             packed_ranges = packed_compressed_causal_ranges(packed_compression_metadata[self.compress_rate])
         use_tilelang = (
-            indexer_backend == "tilelang"
+            indexer_implementation == "tilelang"
             and hidden_states.is_cuda
             and q.dtype == torch.bfloat16
             and compressed_kv.dtype == torch.bfloat16
@@ -876,7 +877,7 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
 # ================================================================
 # Patch: eager_attention_forward
 # 1. Dispatch DeepSeek-V4 attention to the TileLang sparse MQA kernel when
-#    ``dsa_attention_backend=tilelang_sparse``. The existing additive mask is
+#    ``dsa_attention_implementation=tilelang``. The existing additive mask is
 #    converted to a compact fixed-width index list, preserving sliding-window,
 #    compressor, causal, and invalid-index semantics.
 # 2. Preserve the upstream eager implementation as the default fallback.
@@ -892,14 +893,14 @@ def eager_attention_forward(
     **kwargs,
 ):
     # --- Patch.1 ---
-    attention_backend = veomni_dsa_attention_backend.value
-    if attention_backend not in {"eager", "tilelang_sparse"}:
+    attention_implementation = veomni_dsa_attention_implementation.value
+    if attention_implementation not in {"eager", "tilelang"}:
         raise ValueError(
-            f"DeepSeek-V4 does not support dsa_attention_backend={attention_backend!r}; "
-            "expected 'eager' or 'tilelang_sparse'"
+            "DeepSeek-V4 does not support "
+            f"dsa_attention_implementation={attention_implementation!r}; expected 'eager' or 'tilelang'"
         )
     use_tilelang = (
-        attention_backend == "tilelang_sparse"
+        attention_implementation == "tilelang"
         and query.is_cuda
         and query.dtype == torch.bfloat16
         and key.dtype == torch.bfloat16

--- a/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_gpu.diff
+++ b/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_gpu.diff
@@ -87,8 +87,8 @@
 +
 +
 +veomni_causal_lm_loss = OpSlot("cross_entropy_loss", "causal")
-+veomni_dsa_indexer_backend = OpsConfigSlot("dsa_indexer_backend")
-+veomni_dsa_attention_backend = OpsConfigSlot("dsa_attention_backend")
++veomni_dsa_indexer_implementation = OpsConfigSlot("dsa_indexer_implementation")
++veomni_dsa_attention_implementation = OpsConfigSlot("dsa_attention_implementation")
 
 
  @use_kernel_forward_from_hub("RMSNorm")
@@ -105,7 +105,7 @@
  class GlmMoeDsaIndexer(nn.Module):
      """
      DeepSeek Sparse Attention (DSA) indexer for selecting top-k tokens.
-@@ -144,80 +162,96 @@
+@@ -144,80 +162,100 @@
      @torch.no_grad()
      def forward(
          self,
@@ -216,10 +216,12 @@
 +        else:
 +            has_standard_causal_mask = False
 +
-+        indexer_backend = veomni_dsa_indexer_backend.value
-+        if indexer_backend not in ("eager", "cudnn"):
-+            raise ValueError(f"Unknown dsa_indexer_backend={indexer_backend!r}; expected 'eager' or 'cudnn'")
-+        if indexer_backend == "cudnn":
++        indexer_implementation = veomni_dsa_indexer_implementation.value
++        if indexer_implementation not in ("eager", "cudnn"):
++            raise ValueError(
++                f"Unknown dsa_indexer_implementation={indexer_implementation!r}; expected 'eager' or 'cudnn'"
++            )
++        if indexer_implementation == "cudnn":
 +            from veomni.ops.kernels.deepseek_sparse_attention.flashmla_cudnn import indexer_select_topk
 +
 +            qhead_per_kv_head = self.n_heads
@@ -237,7 +239,9 @@
 +            if qhead_per_kv_head not in (32, 64):
 +                unsupported_reasons.append(f"qhead_per_kv_head must be 32 or 64, got {qhead_per_kv_head}")
 +            if unsupported_reasons:
-+                raise ValueError("dsa_indexer_backend='cudnn' is not supported: " + "; ".join(unsupported_reasons))
++                raise ValueError(
++                    "dsa_indexer_implementation='cudnn' is not supported: " + "; ".join(unsupported_reasons)
++                )
 +            return indexer_select_topk(
 +                q,
 +                k_cached,
@@ -254,7 +258,7 @@
          index_scores = torch.einsum("bsht,bsh->bst", scores, weights)
 
          if attention_mask is not None:
-@@ -225,8 +259,7 @@
+@@ -225,8 +263,7 @@
 
          total_len = index_scores.shape[-1]
          topk = min(self.index_topk, total_len)
@@ -264,7 +268,7 @@
 
 
  def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
-@@ -266,6 +299,12 @@
+@@ -266,6 +303,12 @@
      return attn_output, attn_weights
 
 
@@ -277,7 +281,7 @@
  class GlmMoeDsaAttention(nn.Module):
      """
      Multi-head Latent Attention (MLA) with DeepSeek Sparse Attention (DSA) indexer.
-@@ -382,6 +421,7 @@
+@@ -382,6 +425,7 @@
          # RoPE on k_pe (single-head rope stream)
          k_pe = k_pe.view(batch_size, 1, seq_length, self.qk_rope_head_dim)  # [B, 1, S, rope_D]
          k_pe = apply_rotary_pos_emb(k_pe, cos, sin, unsqueeze_dim=1)  # BHSD format
@@ -285,31 +289,31 @@
          k_pe = k_pe.expand(-1, k_nope.shape[1], -1, -1)  # [B, H, S, rope_D]
 
          # Assemble full Q and K
-@@ -411,6 +451,56 @@
+@@ -411,6 +455,56 @@
              )  # [B, S, topk]
          else:
              topk_indices = prev_topk_indices  # [B, S, topk]
 +
-+        attention_backend = veomni_dsa_attention_backend.value
-+        if attention_backend not in ("eager", "flashmla_cudnn"):
++        attention_implementation = veomni_dsa_attention_implementation.value
++        if attention_implementation not in ("eager", "flashmla_cudnn"):
 +            raise ValueError(
-+                f"Unknown dsa_attention_backend={attention_backend!r}; expected 'eager' or 'flashmla_cudnn'"
++                f"Unknown dsa_attention_implementation={attention_implementation!r}; expected 'eager' or 'flashmla_cudnn'"
 +            )
-+        if attention_backend == "flashmla_cudnn":
++        if attention_implementation == "flashmla_cudnn":
 +            from veomni.ops.kernels.deepseek_sparse_attention.flashmla_cudnn import (
 +                check_flash_mla_sparse_forward_compatible,
 +                flash_mla_sparse_attention_with_cudnn_backward,
 +            )
 +
 +            if not hidden_states.is_cuda:
-+                raise ValueError("dsa_attention_backend='flashmla_cudnn' requires CUDA hidden_states")
++                raise ValueError("dsa_attention_implementation='flashmla_cudnn' requires CUDA hidden_states")
 +            if past_key_values is not None:
-+                raise ValueError("dsa_attention_backend='flashmla_cudnn' does not support KV cache")
++                raise ValueError("dsa_attention_implementation='flashmla_cudnn' does not support KV cache")
 +            if self.training and self.attention_dropout != 0:
-+                raise ValueError("dsa_attention_backend='flashmla_cudnn' requires attention_dropout=0")
++                raise ValueError("dsa_attention_implementation='flashmla_cudnn' requires attention_dropout=0")
 +
 +            if not self.kv_b_proj.weight.is_contiguous():
-+                raise ValueError("dsa_attention_backend='flashmla_cudnn' requires contiguous kv_b_proj.weight")
++                raise ValueError("dsa_attention_implementation='flashmla_cudnn' requires contiguous kv_b_proj.weight")
 +            kv_b_weight = self.kv_b_proj.weight.view(
 +                self.num_heads,
 +                self.qk_nope_head_dim + self.v_head_dim,
@@ -326,7 +330,7 @@
 +                topk_indices,
 +            )
 +            if not compatible:
-+                raise ValueError("dsa_attention_backend='flashmla_cudnn' is not supported: " + reason)
++                raise ValueError("dsa_attention_implementation='flashmla_cudnn' is not supported: " + reason)
 +            compressed_attn_output = flash_mla_sparse_attention_with_cudnn_backward(
 +                q_pe.transpose(1, 2).contiguous(),
 +                k_pe_mqa.transpose(1, 2).contiguous(),
@@ -342,7 +346,7 @@
 
          # Build combined DSA + causal mask: -inf everywhere except selected top-k positions
          total_len = key_states.shape[2]
-@@ -818,6 +908,12 @@
+@@ -818,6 +912,12 @@
          )
 
 
@@ -355,7 +359,7 @@
  @auto_docstring
  class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -844,48 +940,59 @@
+@@ -844,48 +944,59 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,

--- a/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_gpu.py
+++ b/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_gpu.py
@@ -51,8 +51,8 @@ from veomni.utils.model_outputs import CausalLMOutputWithLogProbs
 
 
 veomni_causal_lm_loss = OpSlot("cross_entropy_loss", "causal")
-veomni_dsa_indexer_backend = OpsConfigSlot("dsa_indexer_backend")
-veomni_dsa_attention_backend = OpsConfigSlot("dsa_attention_backend")
+veomni_dsa_indexer_implementation = OpsConfigSlot("dsa_indexer_implementation")
+veomni_dsa_attention_implementation = OpsConfigSlot("dsa_attention_implementation")
 
 
 @use_kernel_forward_from_hub("RMSNorm")
@@ -218,10 +218,12 @@ class GlmMoeDsaIndexer(nn.Module):
         else:
             has_standard_causal_mask = False
 
-        indexer_backend = veomni_dsa_indexer_backend.value
-        if indexer_backend not in ("eager", "cudnn"):
-            raise ValueError(f"Unknown dsa_indexer_backend={indexer_backend!r}; expected 'eager' or 'cudnn'")
-        if indexer_backend == "cudnn":
+        indexer_implementation = veomni_dsa_indexer_implementation.value
+        if indexer_implementation not in ("eager", "cudnn"):
+            raise ValueError(
+                f"Unknown dsa_indexer_implementation={indexer_implementation!r}; expected 'eager' or 'cudnn'"
+            )
+        if indexer_implementation == "cudnn":
             from veomni.ops.kernels.deepseek_sparse_attention.flashmla_cudnn import indexer_select_topk
 
             qhead_per_kv_head = self.n_heads
@@ -239,7 +241,9 @@ class GlmMoeDsaIndexer(nn.Module):
             if qhead_per_kv_head not in (32, 64):
                 unsupported_reasons.append(f"qhead_per_kv_head must be 32 or 64, got {qhead_per_kv_head}")
             if unsupported_reasons:
-                raise ValueError("dsa_indexer_backend='cudnn' is not supported: " + "; ".join(unsupported_reasons))
+                raise ValueError(
+                    "dsa_indexer_implementation='cudnn' is not supported: " + "; ".join(unsupported_reasons)
+                )
             return indexer_select_topk(
                 q,
                 k_cached,
@@ -452,26 +456,26 @@ class GlmMoeDsaAttention(nn.Module):
         else:
             topk_indices = prev_topk_indices  # [B, S, topk]
 
-        attention_backend = veomni_dsa_attention_backend.value
-        if attention_backend not in ("eager", "flashmla_cudnn"):
+        attention_implementation = veomni_dsa_attention_implementation.value
+        if attention_implementation not in ("eager", "flashmla_cudnn"):
             raise ValueError(
-                f"Unknown dsa_attention_backend={attention_backend!r}; expected 'eager' or 'flashmla_cudnn'"
+                f"Unknown dsa_attention_implementation={attention_implementation!r}; expected 'eager' or 'flashmla_cudnn'"
             )
-        if attention_backend == "flashmla_cudnn":
+        if attention_implementation == "flashmla_cudnn":
             from veomni.ops.kernels.deepseek_sparse_attention.flashmla_cudnn import (
                 check_flash_mla_sparse_forward_compatible,
                 flash_mla_sparse_attention_with_cudnn_backward,
             )
 
             if not hidden_states.is_cuda:
-                raise ValueError("dsa_attention_backend='flashmla_cudnn' requires CUDA hidden_states")
+                raise ValueError("dsa_attention_implementation='flashmla_cudnn' requires CUDA hidden_states")
             if past_key_values is not None:
-                raise ValueError("dsa_attention_backend='flashmla_cudnn' does not support KV cache")
+                raise ValueError("dsa_attention_implementation='flashmla_cudnn' does not support KV cache")
             if self.training and self.attention_dropout != 0:
-                raise ValueError("dsa_attention_backend='flashmla_cudnn' requires attention_dropout=0")
+                raise ValueError("dsa_attention_implementation='flashmla_cudnn' requires attention_dropout=0")
 
             if not self.kv_b_proj.weight.is_contiguous():
-                raise ValueError("dsa_attention_backend='flashmla_cudnn' requires contiguous kv_b_proj.weight")
+                raise ValueError("dsa_attention_implementation='flashmla_cudnn' requires contiguous kv_b_proj.weight")
             kv_b_weight = self.kv_b_proj.weight.view(
                 self.num_heads,
                 self.qk_nope_head_dim + self.v_head_dim,
@@ -488,7 +492,7 @@ class GlmMoeDsaAttention(nn.Module):
                 topk_indices,
             )
             if not compatible:
-                raise ValueError("dsa_attention_backend='flashmla_cudnn' is not supported: " + reason)
+                raise ValueError("dsa_attention_implementation='flashmla_cudnn' is not supported: " + reason)
             compressed_attn_output = flash_mla_sparse_attention_with_cudnn_backward(
                 q_pe.transpose(1, 2).contiguous(),
                 k_pe_mqa.transpose(1, 2).contiguous(),

--- a/veomni/models/transformers/glm_moe_dsa/glm_moe_dsa_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/glm_moe_dsa/glm_moe_dsa_gpu_patch_gen_config.py
@@ -30,8 +30,8 @@ config.add_post_import_block(
     # Bound at model-build time by _bind_veomni_ops() in auto.py.
     from veomni.ops.dispatch import OpSlot, OpsConfigSlot
     veomni_causal_lm_loss = OpSlot("cross_entropy_loss", "causal")
-    veomni_dsa_indexer_backend = OpsConfigSlot("dsa_indexer_backend")
-    veomni_dsa_attention_backend = OpsConfigSlot("dsa_attention_backend")
+    veomni_dsa_indexer_implementation = OpsConfigSlot("dsa_indexer_implementation")
+    veomni_dsa_attention_implementation = OpsConfigSlot("dsa_attention_implementation")
     """
 )
 
@@ -98,10 +98,10 @@ def glm_moe_dsa_indexer_forward_patched(
     else:
         has_standard_causal_mask = False
 
-    indexer_backend = veomni_dsa_indexer_backend.value
-    if indexer_backend not in ("eager", "cudnn"):
-        raise ValueError(f"Unknown dsa_indexer_backend={indexer_backend!r}; expected 'eager' or 'cudnn'")
-    if indexer_backend == "cudnn":
+    indexer_implementation = veomni_dsa_indexer_implementation.value
+    if indexer_implementation not in ("eager", "cudnn"):
+        raise ValueError(f"Unknown dsa_indexer_implementation={indexer_implementation!r}; expected 'eager' or 'cudnn'")
+    if indexer_implementation == "cudnn":
         from veomni.ops.kernels.deepseek_sparse_attention.flashmla_cudnn import indexer_select_topk
 
         qhead_per_kv_head = self.n_heads
@@ -119,7 +119,7 @@ def glm_moe_dsa_indexer_forward_patched(
         if qhead_per_kv_head not in (32, 64):
             unsupported_reasons.append(f"qhead_per_kv_head must be 32 or 64, got {qhead_per_kv_head}")
         if unsupported_reasons:
-            raise ValueError("dsa_indexer_backend='cudnn' is not supported: " + "; ".join(unsupported_reasons))
+            raise ValueError("dsa_indexer_implementation='cudnn' is not supported: " + "; ".join(unsupported_reasons))
         return indexer_select_topk(
             q,
             k_cached,
@@ -216,24 +216,26 @@ def glm_moe_dsa_attention_forward_patched(
     else:
         topk_indices = prev_topk_indices  # [B, S, topk]
 
-    attention_backend = veomni_dsa_attention_backend.value
-    if attention_backend not in ("eager", "flashmla_cudnn"):
-        raise ValueError(f"Unknown dsa_attention_backend={attention_backend!r}; expected 'eager' or 'flashmla_cudnn'")
-    if attention_backend == "flashmla_cudnn":
+    attention_implementation = veomni_dsa_attention_implementation.value
+    if attention_implementation not in ("eager", "flashmla_cudnn"):
+        raise ValueError(
+            f"Unknown dsa_attention_implementation={attention_implementation!r}; expected 'eager' or 'flashmla_cudnn'"
+        )
+    if attention_implementation == "flashmla_cudnn":
         from veomni.ops.kernels.deepseek_sparse_attention.flashmla_cudnn import (
             check_flash_mla_sparse_forward_compatible,
             flash_mla_sparse_attention_with_cudnn_backward,
         )
 
         if not hidden_states.is_cuda:
-            raise ValueError("dsa_attention_backend='flashmla_cudnn' requires CUDA hidden_states")
+            raise ValueError("dsa_attention_implementation='flashmla_cudnn' requires CUDA hidden_states")
         if past_key_values is not None:
-            raise ValueError("dsa_attention_backend='flashmla_cudnn' does not support KV cache")
+            raise ValueError("dsa_attention_implementation='flashmla_cudnn' does not support KV cache")
         if self.training and self.attention_dropout != 0:
-            raise ValueError("dsa_attention_backend='flashmla_cudnn' requires attention_dropout=0")
+            raise ValueError("dsa_attention_implementation='flashmla_cudnn' requires attention_dropout=0")
 
         if not self.kv_b_proj.weight.is_contiguous():
-            raise ValueError("dsa_attention_backend='flashmla_cudnn' requires contiguous kv_b_proj.weight")
+            raise ValueError("dsa_attention_implementation='flashmla_cudnn' requires contiguous kv_b_proj.weight")
         kv_b_weight = self.kv_b_proj.weight.view(
             self.num_heads,
             self.qk_nope_head_dim + self.v_head_dim,
@@ -250,7 +252,7 @@ def glm_moe_dsa_attention_forward_patched(
             topk_indices,
         )
         if not compatible:
-            raise ValueError("dsa_attention_backend='flashmla_cudnn' is not supported: " + reason)
+            raise ValueError("dsa_attention_implementation='flashmla_cudnn' is not supported: " + reason)
         compressed_attn_output = flash_mla_sparse_attention_with_cudnn_backward(
             q_pe.transpose(1, 2).contiguous(),
             k_pe_mqa.transpose(1, 2).contiguous(),

--- a/veomni/ops/README.md
+++ b/veomni/ops/README.md
@@ -53,7 +53,7 @@ depending on when and where the kernel is bound:
 | RMSNorm | `rms_norm_implementation` | PER_MODEL | `eager` | `liger_kernel`, `npu`, `triton`\* |
 | Rotary pos emb | `rotary_pos_emb_implementation` | PER_MODEL | `eager` | `liger_kernel`, `npu`, `triton`\* |
 | SwiGLU MLP | `swiglu_mlp_implementation` | PER_MODEL | `eager` | `liger_kernel` |
-| mHC | `mhc_backend` | build-time `OpSlot` | `eager` | `tile_kernels` (DeepSeek V4, SM90+) |
+| mHC | `mhc_implementation` | build-time `OpSlot` | `eager` | `tilelang` (DeepSeek V4, SM90+; provided by `tile-kernels`) |
 | Fused MoE | `moe_implementation` | build-time | `eager` | `eager`, `fused_triton` (group-gemm, SM70+), `fused_quack` (CUTLASS/CuTe, SM90+), `fused_npu` (Ascend). Mismatches raise instead of falling back. |
 
 \* The `triton` backend is registered per-model via `extra_backends`: DeepSeek
@@ -72,7 +72,7 @@ own Triton RMSNorm/rotary. See the per-model table below.
 | `moe_implementation=fused_triton` | Triton, SM70+ | `is_fused_moe_available()` |
 | `moe_implementation=fused_quack` | `quack` package, SM90+ | `is_quack_gemm_available()` |
 | `moe_implementation=fused_npu` | `torch_npu` + Ascend NPU | `is_torch_npu_available()` |
-| `mhc_backend=tile_kernels` | `tile-kernels==1.0.0`, BF16, NVIDIA SM90+ | `KernelSpec(HardwareRequirement(..., min_compute_capability=90))` |
+| `mhc_implementation=tilelang` | `tile-kernels==1.0.0`, BF16, NVIDIA SM90+ | `KernelSpec(HardwareRequirement(..., min_compute_capability=90))` |
 
 ### Per-model PER_MODEL coverage
 
@@ -121,10 +121,10 @@ extra installed. The GPU extra pins `tilelang==0.1.9` and
 `tile-kernels==1.0.0`; the uv override resolves FlashQLA's older 0.1.8 metadata
 pin against the shared, validated TileLang version.
 
-DeepSeek-V4 selects these kernels with `dsa_indexer_backend: tilelang` and
-`dsa_attention_backend: tilelang_sparse`. Both default to `eager`; unsupported
+DeepSeek-V4 selects these kernels with `dsa_indexer_implementation: tilelang` and
+`dsa_attention_implementation: tilelang`. Both default to `eager`; unsupported
 cache, position, or dropout layouts retain the upstream eager implementation.
-DeepSeek V4 selects the mHC adapters with `mhc_backend: tile_kernels`; once
+DeepSeek V4 selects the mHC adapters with `mhc_implementation: tilelang`; once
 selected, unsupported dtype, layout, or hardware raises instead of falling
 back to eager.
 

--- a/veomni/ops/kernels/mhc/__init__.py
+++ b/veomni/ops/kernels/mhc/__init__.py
@@ -42,7 +42,7 @@ for variant, factory, description in (
 ):
     KERNEL_REGISTRY.register(
         KernelSpec(
-            name="tile_kernels",
+            name="tilelang",
             op_name="mhc",
             variant=variant,
             factory=factory,


### PR DESCRIPTION
### What does this PR do?

> Unifies the DeepSeek V4 kernel selection interface around the existing `<op>_implementation` convention and a single `tilelang` implementation name.
>
> This is a breaking configuration change. Replace `dsa_indexer_backend`, `dsa_attention_backend`, and `mhc_backend` with `dsa_indexer_implementation`, `dsa_attention_implementation`, and `mhc_implementation`. The DeepSeek V4 optimized value is now `tilelang` for all three operations.

### Checklist Before Starting

- Searched the repository for all affected configuration keys and generated model references.
- PR title follows the enforced `[{modules}] {type}: {description}` format with the required breaking prefix.

### Test

> - `pytest -q tests/ops/test_mhc_tile_kernels.py tests/ops/test_moe_hw_gate.py tests/ops/test_deepseek_v4_kernels.py`: 28 passed, 9 skipped
> - `make quality`: passed
> - `patchgen --check`: all 26 generated model files are up to date

### API and Usage Example

```yaml
model:
  ops_implementation:
    dsa_attention_implementation: tilelang
    dsa_indexer_implementation: tilelang
    mhc_implementation: tilelang
```

### Design & Code Changes

> - Renames the three DeepSeek DSA/mHC configuration fields to the common `<op>_implementation` convention.
> - Uses `tilelang` as the user-facing implementation and mHC registry name while retaining `tile-kernels` as the underlying mHC package.
> - Updates DeepSeek V4 and GLM-DSA patchgen sources, regenerated outputs, tests, examples, and kernel-selection documentation.
> - Removes the model-loader special case for `mhc_backend`; generic `OpSlot` binding now resolves `mhc_implementation` directly.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- Added targeted tests for the renamed selections and registry binding
