### PR TITLE
[ckpt, ci, agent] fix: handle integer tensors in HF consolidation

### DIFF
--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -143,35 +143,40 @@ Core files:
     - DCP operations are collective — all ranks must call save/load simultaneously.
     - Calling checkpoint operations from only rank 0 causes deadlocks.
 
+18. **Distributed HF safetensors consolidation must support non-floating tensors**
+    - PyTorch 2.9–2.11 computes consolidated tensor byte sizes with `torch.finfo`, which crashes for valid integer and boolean buffers such as DeepSeek V4 `tid2eid`.
+    - `apply_dcp_consolidation_patch()` in `veomni/checkpoint/dcp_consolidation.py` replaces the metadata parser with `Tensor.element_size()` and verifies the upstream private-function source hash before patching.
+    - Do not remove this patch during torch upgrades until the new upstream consolidator is verified with sharded integer-tensor save/load coverage.
+
 ## Code Quality
 
-18. **Ruff must pass before commit**
+19. **Ruff must pass before commit**
     - `make quality` runs `ruff check` and `ruff format --check`.
     - Pre-commit hooks enforce this automatically (`pre-commit run --all-files`).
 
-19. **All comments and docstrings must be in English**
+20. **All comments and docstrings must be in English**
     - No Chinese or other non-English text in code comments. This is enforced by project convention.
 
-20. **PR title must follow format: `[{modules}] {type}: {description}`**
+21. **PR title must follow format: `[{modules}] {type}: {description}`**
     - Allowed modules and types are defined in `.github/workflows/check_pr_title.yml` (single source of truth).
     - CI checks PR titles automatically on every PR.
 
 ## Hardware
 
-21. **NPU (Ascend) code paths require guards**
+22. **NPU (Ascend) code paths require guards**
     - NPU-specific code must be guarded with `is_torch_npu_available()` or `IS_NPU_AVAILABLE`.
     - NPU kernels live in `veomni/ops/kernels/{rms_norm,rotary}/npu.py` and `veomni/ops/platform/npu/` — they must not be imported on GPU-only environments.
 
-22. **Device-agnostic code must use `veomni.utils.device` helpers**
+23. **Device-agnostic code must use `veomni.utils.device` helpers**
    - Use `get_device_type()`, `get_torch_device()`, `synchronize()`, `empty_cache()` instead of direct `torch.cuda.*` calls.
    - Direct CUDA calls break NPU compatibility.
 
 ## Trainer Extensions
 
-23. **Trainer callback lifecycle changes must cover composed trainers**
+24. **Trainer callback lifecycle changes must cover composed trainers**
    - `TextDPOTrainer` and `DiTTrainer` compose a `BaseTrainer` and override `forward_backward_step()`; they do not inherit the base implementation.
    - Lifecycle work added only inside `BaseTrainer.forward_backward_step()` is skipped by these trainers. Update every supported override or reject the unsupported trainer explicitly.
 
-24. **Module-level OpSlots are shared by every model instance**
+25. **Module-level OpSlots are shared by every model instance**
    - Modeling modules expose `OpSlot` objects such as `veomni_causal_lm_loss` as globals. Policy/reference models in DPO can therefore use the same slot.
    - Temporary interception must use forward-scoped ownership and reference-counted dispatch. A closure bound to one model or callback can observe another model's forward and corrupt side-channel state.

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -146,6 +146,7 @@ Core files:
 18. **Distributed HF safetensors consolidation must support non-floating tensors**
     - PyTorch 2.9–2.11 computes consolidated tensor byte sizes with `torch.finfo`, which crashes for valid integer and boolean buffers such as DeepSeek V4 `tid2eid`.
     - `apply_dcp_consolidation_patch()` in `veomni/checkpoint/dcp_consolidation.py` replaces the metadata parser with `Tensor.element_size()` and verifies the upstream private-function source hash before patching.
+    - Offline DCP-to-HF conversion may cast `save_dtype` only onto floating tensors; integer and boolean buffers must retain their original dtype, and shard-size planning must use their original element sizes.
     - Do not remove this patch during torch upgrades until the new upstream consolidator is verified with sharded integer-tensor save/load coverage.
 
 ## Code Quality

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -216,6 +216,75 @@ class TestWaitForPendingSave:
         mock_dist.barrier.assert_not_called()
 
 
+class TestDcpToHfDtypeConversion:
+    def test_save_dtype_only_casts_floating_tensors(self):
+        import tempfile
+
+        import torch.distributed.checkpoint as dcp
+
+        from veomni.checkpoint.dcp_checkpointer import _get_sharding_plan, _process_shard
+
+        fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+        if fp8_dtype is None:
+            pytest.skip("torch.float8_e4m3fn is unavailable")
+
+        state_dict = {
+            "model.weight": torch.ones(4, dtype=torch.float32),
+            "model.tid2eid": torch.arange(8, dtype=torch.int64),
+            "model.flag": torch.tensor([True, False]),
+            "model.fp8": torch.tensor([1.0, 2.0], dtype=fp8_dtype),
+        }
+
+        with tempfile.TemporaryDirectory() as checkpoint_path:
+            dcp.save(state_dict, checkpoint_id=checkpoint_path)
+            bf16_shards, bf16_total_size, _ = _get_sharding_plan(
+                checkpoint_path,
+                shard_size=5,
+                save_dtype="bfloat16",
+            )
+            native_shards, native_total_size, _ = _get_sharding_plan(
+                checkpoint_path,
+                shard_size=5,
+                save_dtype=None,
+            )
+
+            bf16_state = {}
+            for shard in bf16_shards:
+                bf16_state.update(_process_shard(shard, checkpoint_path, save_dtype="bfloat16"))
+
+            native_state = {}
+            for shard in native_shards:
+                native_state.update(_process_shard(shard, checkpoint_path, save_dtype=None))
+
+        expected_bf16_size = 0
+        expected_native_size = 0
+        for tensor in state_dict.values():
+            expected_native_size += tensor.numel() * tensor.element_size()
+            output_element_size = (
+                torch.empty((), dtype=torch.bfloat16).element_size()
+                if tensor.is_floating_point()
+                else tensor.element_size()
+            )
+            expected_bf16_size += tensor.numel() * output_element_size
+
+        assert bf16_total_size == expected_bf16_size
+        assert native_total_size == expected_native_size
+        assert len(bf16_shards) == 4
+        assert len(native_shards) == 3
+        assert set(native_shards[0]) == {"flag", "fp8"}
+
+        assert bf16_state["weight"].dtype == torch.bfloat16
+        assert bf16_state["fp8"].dtype == torch.bfloat16
+        assert bf16_state["tid2eid"].dtype == torch.int64
+        assert bf16_state["flag"].dtype == torch.bool
+        torch.testing.assert_close(bf16_state["tid2eid"], state_dict["model.tid2eid"])
+
+        assert native_state["weight"].dtype == torch.float32
+        assert native_state["fp8"].dtype == fp8_dtype
+        assert native_state["tid2eid"].dtype == torch.int64
+        assert native_state["flag"].dtype == torch.bool
+
+
 # ---------------------------------------------------------------------------
 # Partial save/load (LoRA / trainable_only path)
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_save_safetensor_utils.py
+++ b/tests/utils/test_save_safetensor_utils.py
@@ -114,11 +114,13 @@ class TestGetModelSaveState(unittest.TestCase):
             "fp32": torch.randn(4, 4, dtype=torch.float32),
             "bf16": torch.randn(4, 4, dtype=torch.bfloat16),
             "fp16": torch.randn(4, 4, dtype=torch.float16),
+            "int64": torch.randint(0, 8, (4, 4), dtype=torch.int64),
         }
         result = _call_get_model_save_state(self.model, None, fake)
         self.assertEqual(result["fp32"].dtype, torch.bfloat16)
         self.assertEqual(result["bf16"].dtype, torch.bfloat16)
         self.assertEqual(result["fp16"].dtype, torch.float16)
+        self.assertEqual(result["int64"].dtype, torch.int64)
 
     def test_tied_weight_filtered_out(self):
         fake = {
@@ -209,7 +211,11 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
         self.assertEqual(writer_cls.call_args.kwargs["fqn_to_index_mapping"], mapping)
 
     def test_save_state_passed_to_dcp_save(self):
-        fake = {"w": torch.randn(4, 4, dtype=torch.bfloat16)}
+        fake = {
+            "weight": torch.randn(4, 4, dtype=torch.bfloat16),
+            "int64_buffer": torch.randint(0, 8, (4, 4), dtype=torch.int64),
+            "bool_buffer": torch.tensor([True, False]),
+        }
         _, _, dcp_save, _ = _call_save_distributed(
             self.model,
             "/tmp/test",
@@ -218,7 +224,67 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
             fake,
         )
         dcp_save.assert_called_once()
-        self.assertEqual(set(dcp_save.call_args.kwargs["state_dict"]), {"w"})
+        saved_state = dcp_save.call_args.kwargs["state_dict"]
+        self.assertEqual(set(saved_state), {"weight", "int64_buffer", "bool_buffer"})
+        self.assertEqual(saved_state["int64_buffer"].dtype, torch.int64)
+
+        import json
+        import tempfile
+        from pathlib import Path
+
+        import torch.distributed.checkpoint as dcp
+        from safetensors.torch import load_file
+        from torch.distributed.checkpoint import HuggingFaceStorageWriter
+        from torch.distributed.checkpoint._hf_utils import CUSTOM_METADATA_KEY
+
+        from veomni.checkpoint.dcp_consolidation import apply_dcp_consolidation_patch
+
+        apply_dcp_consolidation_patch()
+        with tempfile.TemporaryDirectory() as output_dir:
+            storage_writer = HuggingFaceStorageWriter(
+                path=output_dir,
+                save_distributed=True,
+                enable_consolidation=True,
+                fqn_to_index_mapping=dict.fromkeys(fake, 1),
+            )
+            dcp.save(fake, storage_writer=storage_writer)
+
+            consolidated_files = list(Path(output_dir).glob("*.safetensors"))
+            self.assertEqual(len(consolidated_files), 1)
+            loaded_state = load_file(consolidated_files[0])
+
+        torch.testing.assert_close(loaded_state["int64_buffer"], fake["int64_buffer"])
+        torch.testing.assert_close(loaded_state["bool_buffer"], fake["bool_buffer"])
+
+        import torch.distributed.checkpoint._consolidate_hf_safetensors as hf_module
+
+        input_files_data = {
+            "shard_0": hf_module._InputFileData(
+                metadata={
+                    "int64_buffer": {hf_module.SHAPE_KEY: [2, 4], hf_module.DTYPE_KEY: "I64"},
+                    hf_module.DEFAULT_EXTRA_METADATA_KEY: {
+                        CUSTOM_METADATA_KEY: json.dumps({"int64_buffer": {hf_module.SAVED_OFFSETS_KEY: [0, 0]}})
+                    },
+                }
+            ),
+            "shard_1": hf_module._InputFileData(
+                metadata={
+                    "int64_buffer": {hf_module.SHAPE_KEY: [2, 4], hf_module.DTYPE_KEY: "I64"},
+                    hf_module.DEFAULT_EXTRA_METADATA_KEY: {
+                        CUSTOM_METADATA_KEY: json.dumps({"int64_buffer": {hf_module.SAVED_OFFSETS_KEY: [2, 0]}})
+                    },
+                }
+            ),
+        }
+        output_files_data = {
+            "model.safetensors": hf_module._OutputFileData(fqn_data={"int64_buffer": hf_module._FqnData()})
+        }
+
+        hf_module._parse_input_metadata(input_files_data, output_files_data)
+
+        int64_buffer_data = output_files_data["model.safetensors"].fqn_data["int64_buffer"]
+        self.assertEqual(int64_buffer_data.shape_in_file, [4, 4])
+        self.assertEqual(int64_buffer_data.dtype_size, torch.empty((), dtype=torch.int64).element_size())
 
     def test_model_assets_saved(self):
         fake = {"w": torch.randn(2, 2, dtype=torch.bfloat16)}

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -642,18 +642,7 @@ class DistributedCheckpointer(CheckpointerBase):
 
 def get_dtype_size(dtype: torch.dtype) -> int:
     """Return size in bytes for a given dtype."""
-    size_map = {
-        torch.float32: 4,
-        torch.float16: 2,
-        torch.bfloat16: 2,
-        torch.int64: 8,
-        torch.int32: 4,
-        torch.int16: 2,
-        torch.int8: 1,
-        torch.uint8: 1,
-        torch.bool: 1,
-    }
-    return size_map.get(dtype, 4)
+    return torch.empty((), dtype=dtype).element_size()
 
 
 def _normalize_key(key: str) -> Optional[str]:
@@ -721,14 +710,15 @@ def _get_sharding_plan(
         hf_key = _normalize_key(key)
         if hf_key:
             # Determine dtype for size calculation
-            if save_dtype:
+            if not hasattr(tensor_meta.properties, "dtype"):
+                raise ValueError(
+                    f"Cannot determine dtype for tensor '{key}': metadata does not contain dtype information"
+                )
+            source_dtype = tensor_meta.properties.dtype
+            if save_dtype and source_dtype.is_floating_point:
                 dtype = getattr(torch, save_dtype) if isinstance(save_dtype, str) else save_dtype
             else:
-                if not hasattr(tensor_meta.properties, "dtype"):
-                    raise ValueError(
-                        f"Cannot determine dtype for tensor '{key}': metadata does not contain dtype information"
-                    )
-                dtype = tensor_meta.properties.dtype
+                dtype = source_dtype
 
             # Calculate tensor size in bytes
             numel = 1
@@ -812,7 +802,7 @@ def _process_shard(
         if hasattr(tensor, "full_tensor"):
             tensor = tensor.full_tensor()
 
-        if target_dtype:
+        if target_dtype and tensor.is_floating_point():
             tensor = tensor.to(dtype=target_dtype)
 
         # Explicitly move to CPU and detach to avoid memory retention

--- a/veomni/checkpoint/dcp_consolidation.py
+++ b/veomni/checkpoint/dcp_consolidation.py
@@ -17,11 +17,13 @@
 # with __globals__ bound to the target module. Variables like DATA_OFFSETS_KEY,
 # _read_tensor_data_mmap, etc. are resolved at runtime from torch.distributed.checkpoint.
 
-"""Patch for PyTorch DCP (Distributed Checkpoint) safetensors consolidation.
+"""Patches for PyTorch DCP (Distributed Checkpoint) safetensors consolidation.
 
-This module provides a monkey patch to fix compatibility issues with distributed
-file systems (e.g., HDFS via FUSE) that do not support r+b (read-write binary)
-file mode for random write access.
+This module provides monkey patches for:
+- Distributed file systems (e.g., HDFS via FUSE) that do not support r+b
+  (read-write binary) file mode for random write access.
+- Integer and boolean tensors, whose byte sizes PyTorch's consolidator computes
+  with ``torch.finfo`` even though it only accepts floating-point dtypes.
 """
 
 import hashlib
@@ -34,6 +36,7 @@ _dcp_consolidation_patch_applied = False
 # Fixed torch versions for this patch - update when upgrading torch
 _SUPPORTED_TORCH_VERSION_PREFIXES = ("2.9", "2.10", "2.11")
 _EXPECTED_PROCESS_OUTPUT_FILE_ARGS = ("output_file", "output_data", "input_files_data")
+_EXPECTED_PARSE_INPUT_METADATA_ARGS = ("input_files_data", "output_files_data")
 _SUPPORTED_PROCESS_OUTPUT_FILE_SHA256 = {
     # torch 2.9.1
     "0837813477b4ca319890ef671b954f83bbe966f21a751875606b74e4e8e30ea8",
@@ -44,10 +47,14 @@ _SUPPORTED_PROCESS_OUTPUT_FILE_SHA256 = {
     # torch 2.11.0+cu130 CI wheel
     "433c9d026092f48f5ba02631975294de1a8ae98e020d5cb6ffd0f5db760476fe",
 }
+_SUPPORTED_PARSE_INPUT_METADATA_SHA256 = {
+    # torch 2.9.1, 2.10.0, and 2.11.0 (upstream source and cu130 CI wheel)
+    "f6c476c9467a32928c8b29c211988c78a14a934bc4cbc5763a3882a7fc3b11f0",
+}
 
 
 def apply_dcp_consolidation_patch():
-    """Patch DCP safetensors consolidation to use append mode for HDFS FUSE compatibility.
+    """Patch DCP safetensors consolidation for HDFS FUSE and non-floating tensors.
 
     The original implementation in PyTorch uses r+b mode for random write access:
         with open(output_file, "r+b") as output_stream:
@@ -60,8 +67,13 @@ def apply_dcp_consolidation_patch():
         with open(output_file, "ab") as output_stream:
             ...
 
-    Note: Append mode requires tensors to be processed in offset order, which is
-    already ensured by sorting tensors before writing.
+    PyTorch also computes every tensor's byte size with ``torch.finfo`` during
+    consolidation. This fails for valid safetensors dtypes such as int64 and
+    bool. The patched metadata parser uses ``Tensor.element_size()`` instead,
+    which handles every torch dtype supported by safetensors.
+
+    Note: Append mode requires tensors to be processed in offset order, which
+    is already ensured by sorting tensors before writing.
 
     The patch uses types.FunctionType to create a new function with __globals__
     bound to the target module, enabling access to internal functions like
@@ -89,6 +101,12 @@ def apply_dcp_consolidation_patch():
             f"_process_output_file attribute. Please verify torch {_SUPPORTED_TORCH_VERSION_PREFIXES} compatibility."
         )
 
+    if not hasattr(hf_module, "_parse_input_metadata"):
+        raise RuntimeError(
+            "torch.distributed.checkpoint._consolidate_hf_safetensors does not have "
+            f"_parse_input_metadata attribute. Please verify torch {_SUPPORTED_TORCH_VERSION_PREFIXES} compatibility."
+        )
+
     process_output_file = hf_module._process_output_file
     process_output_file_args = tuple(inspect.signature(process_output_file).parameters)
     if process_output_file_args != _EXPECTED_PROCESS_OUTPUT_FILE_ARGS:
@@ -104,6 +122,24 @@ def apply_dcp_consolidation_patch():
         raise RuntimeError(
             "torch.distributed.checkpoint._consolidate_hf_safetensors._process_output_file "
             f"source hash {process_output_file_hash} is not in the verified set. "
+            "Please update the DCP consolidation patch."
+        )
+
+    parse_input_metadata = hf_module._parse_input_metadata
+    parse_input_metadata_args = tuple(inspect.signature(parse_input_metadata).parameters)
+    if parse_input_metadata_args != _EXPECTED_PARSE_INPUT_METADATA_ARGS:
+        raise RuntimeError(
+            "torch.distributed.checkpoint._consolidate_hf_safetensors._parse_input_metadata "
+            f"signature changed from {_EXPECTED_PARSE_INPUT_METADATA_ARGS} to {parse_input_metadata_args}. "
+            "Please update the DCP consolidation patch."
+        )
+
+    parse_input_metadata_source = inspect.getsource(parse_input_metadata)
+    parse_input_metadata_hash = hashlib.sha256(parse_input_metadata_source.encode()).hexdigest()
+    if parse_input_metadata_hash not in _SUPPORTED_PARSE_INPUT_METADATA_SHA256:
+        raise RuntimeError(
+            "torch.distributed.checkpoint._consolidate_hf_safetensors._parse_input_metadata "
+            f"source hash {parse_input_metadata_hash} is not in the verified set. "
             "Please update the DCP consolidation patch."
         )
 
@@ -152,6 +188,46 @@ def apply_dcp_consolidation_patch():
 
                 output_stream.write(full_tensor_mv)
 
+    def _parse_input_metadata_impl(input_files_data, output_files_data):
+        from safetensors.torch import _getdtype
+
+        fqn_to_size_mapping = {}
+
+        for file_data in input_files_data.values():
+            safetensors_metadata = file_data.metadata
+            dcp_sharding_info = _get_dcp_custom_metadata(safetensors_metadata)
+            if not dcp_sharding_info:
+                raise ValueError(
+                    "No DCP custom metadata found in safetensors file. "
+                    "The file must be saved with DCP to be consolidated."
+                )
+
+            for key, val in safetensors_metadata.items():
+                if key == DEFAULT_EXTRA_METADATA_KEY:
+                    continue
+
+                sizes = val[SHAPE_KEY]
+                offsets = dcp_sharding_info[key][SAVED_OFFSETS_KEY]
+
+                if key not in fqn_to_size_mapping:
+                    cur_size = [size + offset for size, offset in zip(sizes, offsets)]
+                    fqn_to_size_mapping[key] = (cur_size, val[DTYPE_KEY])
+                else:
+                    cur_size = fqn_to_size_mapping[key][0]
+                    for i in range(len(sizes)):
+                        cur_size[i] = max(cur_size[i], sizes[i] + offsets[i])
+
+        for fqn, tensor_info in fqn_to_size_mapping.items():
+            tensor_size, dtype_str = tensor_info
+            dtype_size = torch.empty((), dtype=_getdtype(dtype_str)).element_size()
+            for output_data in output_files_data.values():
+                if fqn in output_data.fqn_data:
+                    output_data.fqn_data[fqn] = _FqnData(
+                        shape_in_file=tensor_size,
+                        dtype_size=dtype_size,
+                        dtype_str=dtype_str,
+                    )
+
     # Create a new function with the target module's globals
     # This ensures that internal functions like _read_tensor_data_mmap are resolved correctly
     patched_func = types.FunctionType(
@@ -162,5 +238,14 @@ def apply_dcp_consolidation_patch():
         _process_output_file_impl.__closure__,
     )
 
+    patched_parse_input_metadata = types.FunctionType(
+        _parse_input_metadata_impl.__code__,
+        hf_module.__dict__,
+        _parse_input_metadata_impl.__name__,
+        _parse_input_metadata_impl.__defaults__,
+        _parse_input_metadata_impl.__closure__,
+    )
+
     hf_module._process_output_file = patched_func
+    hf_module._parse_input_metadata = patched_parse_input_metadata
     _dcp_consolidation_patch_applied = True


### PR DESCRIPTION
### What does this PR do?

Fix distributed HuggingFace safetensors consolidation and offline DCP-to-HF conversion for checkpoints containing non-floating tensors, such as DeepSeek V4's persistent `tid2eid` routing buffers.

PyTorch 2.9-2.11 computes consolidated tensor byte sizes with `torch.finfo`, which raises a `TypeError` for valid integer and boolean safetensors dtypes. This caused training to finish and the DCP checkpoint to save successfully, but the final HF checkpoint export to fail. The standalone merge path also applied `save_dtype` to every tensor and planned shards using the converted dtype, which incorrectly changed integer buffers to BF16 and undercounted their byte sizes.

### Checklist Before Starting

- Searched the repository history and existing DCP consolidation compatibility patch.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

- `PATH="/opt/tiger/Open-VeOmni/.venv/bin:$PATH" make quality`
- `.venv/bin/pytest -q tests/checkpoints/test_dcp_checkpointer.py tests/utils/test_save_safetensor_utils.py` (`36 passed, 2 xfailed`)
- Four-GPU GB200 DeepSeek V4 Flash Base 4L training smoke test with EP4 and 2 steps.
- Verified DCP checkpoint save completed successfully.
- Verified distributed HF safetensors consolidation completed successfully in 30.92 seconds.
- Loaded all three exported `tid2eid` tensors and verified dtype `torch.int64` and shape `(129280, 6)`.

### API and Usage Example

No public API changes.

### Design & Code Changes

- Extend the existing DCP consolidation compatibility patch to replace PyTorch's floating-only dtype size calculation with `Tensor.element_size()`.
- Validate the patched private function's signature and source hash before applying the replacement.
- Apply offline merge `save_dtype` conversion only to floating tensors; preserve integer and boolean buffers.
- Plan offline merge shards with each tensor's actual output element size, including FP8 and non-floating dtypes.
- Extend existing tests with real DCP-to-HF consolidation/readback, multi-shard offset aggregation, dtype preservation, and shard-boundary coverage.
- Document the PyTorch DCP non-floating tensor constraints.

### Checklist Before Submitting

- Read the Contribute Guide.
- Applied pre-commit quality checks.
- Added/updated checkpoint constraint documentation.
- Added regression coverage to existing checkpoint tests.
