### PR TITLE
[trainer, data] feat: add CUDA device batch prefetcher

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -235,6 +235,7 @@ NPU validation runs at two times:
 | pin_memory | `bool` | `True` | Whether to pin memory for the dataloader. |
 | worker_num_threads | `Optional[int]` | `None` | Number of PyTorch threads used by each DataLoader worker. |
 | use_background_prefetcher | `bool` | `False` | Enable background prefetching around the DataLoader. |
+| use_device_prefetcher | `bool` | `False` | Prefetch the next batch's device transfer on a side stream. |
 
 ### TrainingArguments
 

--- a/tests/trainer/test_device_prefetcher.py
+++ b/tests/trainer/test_device_prefetcher.py
@@ -1,0 +1,99 @@
+import copy
+from types import SimpleNamespace
+
+import torch
+
+import veomni.trainer.base as trainer_base
+from veomni.trainer.base import BaseTrainer, DevicePrefetcher, VeOmniIter, _move_batch_to_device
+from veomni.utils.constants import IGNORE_INDEX
+
+
+class _StatefulIterator:
+    def __init__(self, batches):
+        self.batches = list(batches)
+        self.idx = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.idx >= len(self.batches):
+            raise StopIteration
+        batch = self.batches[self.idx]
+        self.idx += 1
+        return copy.deepcopy(batch)
+
+    def state_dict(self):
+        return {"idx": self.idx}
+
+
+def _batch(value):
+    return [
+        {
+            "input_ids": torch.tensor([value, value + 1]),
+            "labels": torch.tensor([value + 2, IGNORE_INDEX]),
+            "cu_seq_lens_q": torch.tensor([0, 2], dtype=torch.int32),
+            "linear_attn_cu_seq_lens_q": torch.tensor([0, 2], dtype=torch.int32),
+            "multimodal_metadata": {
+                "pixel_values": torch.tensor([float(value)]),
+                "vit_image_cu_seqlens": torch.tensor([0, 1], dtype=torch.int32),
+            },
+        }
+    ]
+
+
+def test_move_batch_to_device_recurses_and_preserves_cpu_fa_kwargs():
+    batch = _batch(1)
+
+    moved = _move_batch_to_device(batch, torch.device("meta"))
+
+    assert moved[0]["input_ids"].device.type == "meta"
+    assert moved[0]["labels"].device.type == "cpu"
+    assert moved[0]["cu_seq_lens_q"].device.type == "cpu"
+    assert moved[0]["linear_attn_cu_seq_lens_q"].device.type == "cpu"
+    assert torch.equal(moved[0]["cu_seq_lens_q"], batch[0]["cu_seq_lens_q"])
+    assert torch.equal(moved[0]["linear_attn_cu_seq_lens_q"], batch[0]["linear_attn_cu_seq_lens_q"])
+    assert moved[0]["multimodal_metadata"]["pixel_values"].device.type == "meta"
+
+
+def test_device_prefetcher_returns_consumed_batch_state():
+    prefetcher = DevicePrefetcher(_StatefulIterator([_batch(1), _batch(10)]), device=torch.device("cpu"))
+
+    first = next(prefetcher)
+    assert first[0]["input_ids"].tolist() == [1, 2]
+    assert prefetcher.state_dict() == {"idx": 1}
+
+    second = next(prefetcher)
+    assert second[0]["input_ids"].tolist() == [10, 11]
+    assert prefetcher.state_dict() == {"idx": 2}
+
+
+def test_veomni_iter_device_prefetcher_is_cuda_only(monkeypatch):
+    monkeypatch.setattr(trainer_base, "IS_CUDA_AVAILABLE", False)
+    iterator = VeOmniIter(_StatefulIterator([_batch(1)]), use_device_prefetcher=True, device=torch.device("cpu"))
+
+    assert not isinstance(iterator.iterator, DevicePrefetcher)
+    assert next(iterator)[0]["input_ids"].tolist() == [1, 2]
+
+
+def test_build_data_iterator_passes_device_prefetch_flag(monkeypatch):
+    captured = {}
+
+    class _FakeIter:
+        def __init__(self, dataloader, **kwargs):
+            captured["dataloader"] = dataloader
+            captured.update(kwargs)
+
+    monkeypatch.setattr(trainer_base, "VeOmniIter", _FakeIter)
+    trainer = BaseTrainer.__new__(BaseTrainer)
+    trainer.train_dataloader = object()
+    trainer.device = torch.device("cpu")
+    trainer.args = SimpleNamespace(
+        data=SimpleNamespace(dataloader=SimpleNamespace(use_background_prefetcher=True, use_device_prefetcher=True))
+    )
+
+    assert isinstance(trainer.build_data_iterator(), _FakeIter)
+    assert captured["dataloader"] is trainer.train_dataloader
+    assert captured["use_background_prefetcher"] is True
+    assert captured["use_device_prefetcher"] is True
+    assert captured["device"] == torch.device("cpu")

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -1321,6 +1321,10 @@ class DataloaderConfig:
         default=False,
         metadata={"help": "Whether to use BackgroundPrefetcher for dataloader."},
     )
+    use_device_prefetcher: bool = field(
+        default=False,
+        metadata={"help": "Whether to prefetch the next batch's device transfer on a side stream."},
+    )
 
 
 @dataclass

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -67,6 +67,7 @@ from ..ops.batch_invariant_ops import set_batch_invariant_mode
 from ..optim import build_lr_scheduler, build_optimizer
 from ..utils import helper, logging
 from ..utils.device import (
+    IS_CUDA_AVAILABLE,
     get_device_type,
     get_dist_comm_backend,
     get_torch_device,
@@ -91,6 +92,52 @@ from .callbacks import (
 
 
 logger = logging.get_logger(__name__)
+
+
+_DEVICE_PREFETCH_CPU_ONLY_KEYS = {
+    "labels",
+    "image_output_mask",
+    # FlashAttention / ChunkMBS metadata is consumed host-side for range
+    # construction, logging, or NPU compatibility before model code handles it.
+    "cu_seq_lens_q",
+    "cu_seq_lens_k",
+    "linear_attn_cu_seq_lens_q",
+}
+
+
+def _is_device_prefetch_cpu_only_key(key: Any) -> bool:
+    return isinstance(key, str) and (key in _DEVICE_PREFETCH_CPU_ONLY_KEYS or key.endswith("_labels"))
+
+
+def _move_batch_to_device(value: Any, device: torch.device, *, non_blocking: bool = True) -> Any:
+    if isinstance(value, torch.Tensor):
+        if value.device == device:
+            return value
+        return value.to(device, non_blocking=non_blocking)
+    if isinstance(value, dict):
+        return {
+            key: item
+            if _is_device_prefetch_cpu_only_key(key)
+            else _move_batch_to_device(item, device, non_blocking=non_blocking)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_move_batch_to_device(item, device, non_blocking=non_blocking) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_move_batch_to_device(item, device, non_blocking=non_blocking) for item in value)
+    return value
+
+
+def _record_batch_stream(value: Any, stream, device: torch.device) -> None:
+    if isinstance(value, torch.Tensor):
+        if value.device.type == device.type:
+            value.record_stream(stream)
+    elif isinstance(value, dict):
+        for item in value.values():
+            _record_batch_stream(item, stream, device)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _record_batch_stream(item, stream, device)
 
 
 class BackgroundPrefetcher:
@@ -172,13 +219,27 @@ class VeOmniIter:
     A unified iterator wrapper that handles both standard iteration and background prefetching.
     """
 
-    def __init__(self, dataloader, use_background_prefetcher: bool = False, maxsize: int = 1):
+    def __init__(
+        self,
+        dataloader,
+        use_background_prefetcher: bool = False,
+        maxsize: int = 1,
+        use_device_prefetcher: bool = False,
+        device: torch.device | None = None,
+    ):
         self.dataloader = dataloader
         self.use_background_prefetcher = use_background_prefetcher
+        self.use_device_prefetcher = False
         if use_background_prefetcher:
             self.iterator = BackgroundPrefetcher(dataloader, maxsize=maxsize)
         else:
             self.iterator = iter(dataloader)
+
+        if use_device_prefetcher and device is None:
+            raise ValueError("device must be set when use_device_prefetcher=True.")
+        if use_device_prefetcher and IS_CUDA_AVAILABLE and device.type == get_device_type():
+            self.iterator = DevicePrefetcher(self.iterator, device=device)
+            self.use_device_prefetcher = True
 
     def __iter__(self):
         return self
@@ -187,15 +248,79 @@ class VeOmniIter:
         return next(self.iterator)
 
     def stop(self, timeout: float = 5.0):
-        if self.use_background_prefetcher and hasattr(self.iterator, "stop"):
+        if hasattr(self.iterator, "stop"):
             self.iterator.stop(timeout=timeout)
 
     def state_dict(self):
-        if self.use_background_prefetcher and hasattr(self.iterator, "state_dict"):
+        if hasattr(self.iterator, "state_dict"):
             return self.iterator.state_dict()
         if hasattr(self.dataloader, "state_dict"):
             return self.dataloader.state_dict()
         return {}
+
+
+class DevicePrefetcher:
+    """
+    Prefetches the next batch's device transfer on a side stream.
+
+    This overlaps host-to-device copies with the previous step's compute when the
+    DataLoader uses pinned CPU tensors. The current dataloader state is captured
+    before prefetching the next batch so checkpoint resume still points to the
+    batch that was actually returned to the trainer.
+    """
+
+    def __init__(self, iterator, device: torch.device):
+        self.iterator = iterator
+        self.device = device
+        self.stream = torch.Stream(device=device) if IS_CUDA_AVAILABLE and device.type == get_device_type() else None
+        self.next_batch = None
+        self.next_state = None
+        self.current_state = None
+        self._prefetch()
+
+    def _iterator_state_dict(self):
+        return self.iterator.state_dict() if hasattr(self.iterator, "state_dict") else None
+
+    def _prefetch(self) -> None:
+        self.next_batch = None
+        self.next_state = None
+        try:
+            batch = next(self.iterator)
+        except StopIteration:
+            return
+
+        self.next_state = self._iterator_state_dict()
+        if self.stream is None:
+            self.next_batch = _move_batch_to_device(batch, self.device)
+            return
+
+        with get_torch_device().stream(self.stream):
+            self.next_batch = _move_batch_to_device(batch, self.device)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.next_batch is None:
+            raise StopIteration
+
+        if self.stream is not None:
+            current_stream = get_torch_device().current_stream()
+            current_stream.wait_stream(self.stream)
+            _record_batch_stream(self.next_batch, current_stream, self.device)
+        batch = self.next_batch
+        self.current_state = self.next_state
+        self._prefetch()
+        return batch
+
+    def state_dict(self):
+        if self.current_state is not None:
+            return self.current_state
+        return self._iterator_state_dict() or {}
+
+    def stop(self, timeout: float = 5.0):
+        if hasattr(self.iterator, "stop"):
+            self.iterator.stop(timeout=timeout)
 
 
 def _collect_muon_kwargs(optimizer_cfg) -> Dict[str, Any]:
@@ -793,6 +918,14 @@ class BaseTrainer(Stateful, ABC):
 
         self.on_step_end(loss=total_loss, loss_dict=total_loss_dict, grad_norm=grad_norm)
 
+    def build_data_iterator(self):
+        return VeOmniIter(
+            self.train_dataloader,
+            use_background_prefetcher=self.args.data.dataloader.use_background_prefetcher,
+            use_device_prefetcher=self.args.data.dataloader.use_device_prefetcher,
+            device=self.device,
+        )
+
     def destroy_distributed(self):
         if not dist.is_available() or not dist.is_initialized():
             return
@@ -831,9 +964,7 @@ class BaseTrainer(Stateful, ABC):
             self.on_epoch_begin()
 
             # Create a batch generator
-            self.data_iterator = VeOmniIter(
-                self.train_dataloader, use_background_prefetcher=args.data.dataloader.use_background_prefetcher
-            )
+            self.data_iterator = self.build_data_iterator()
 
             for _ in range(self.start_step, args.train_steps):
                 try:

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -39,7 +39,7 @@ from ..utils.device import (
     get_device_type,
     synchronize,
 )
-from .base import BaseTrainer, VeOmniIter
+from .base import BaseTrainer
 
 
 logger = helper.create_logger(__name__)
@@ -562,10 +562,7 @@ class DiTTrainer:
             self.on_epoch_begin()
 
             if self.base.train_dataloader is not None:
-                self.base.data_iterator = VeOmniIter(
-                    self.base.train_dataloader,
-                    use_background_prefetcher=args.data.dataloader.use_background_prefetcher,
-                )
+                self.base.data_iterator = self.base.build_data_iterator()
             else:
                 self.base.data_iterator = None
 

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -35,7 +35,7 @@ from ..ops.batch_invariant_ops import set_batch_invariant_mode
 from ..utils import helper, logging
 from ..utils.constants import IGNORE_INDEX
 from ..utils.device import synchronize
-from .base import BaseTrainer, VeOmniIter
+from .base import BaseTrainer
 
 
 logger = logging.get_logger(__name__)
@@ -458,9 +458,7 @@ class TextDPOTrainer:
             self.on_epoch_begin()
 
             # Create a batch generator
-            self.base.data_iterator = VeOmniIter(
-                self.base.train_dataloader, use_background_prefetcher=args.data.dataloader.use_background_prefetcher
-            )
+            self.base.data_iterator = self.base.build_data_iterator()
 
             for _ in range(self.base.start_step, args.train_steps):
                 try:

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -29,7 +29,7 @@ from ..models import build_tokenizer
 from ..utils import helper
 from ..utils.device import synchronize
 from ..utils.loss_utils import count_loss_token
-from .base import BaseTrainer, VeOmniIter
+from .base import BaseTrainer
 
 
 logger = helper.create_logger(__name__)
@@ -172,9 +172,7 @@ class TextTrainer:
             self.on_epoch_begin()
 
             # Create a batch generator
-            self.base.data_iterator = VeOmniIter(
-                self.base.train_dataloader, use_background_prefetcher=args.data.dataloader.use_background_prefetcher
-            )
+            self.base.data_iterator = self.base.build_data_iterator()
 
             for _ in range(self.base.start_step, args.train_steps):
                 try:

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -28,7 +28,7 @@ from ..utils import helper
 from ..utils.device import synchronize
 from ..utils.loss_utils import count_loss_token
 from ..utils.model_utils import pretty_print_trainable_parameters
-from .base import BaseTrainer, VeOmniIter, _collect_muon_kwargs
+from .base import BaseTrainer, _collect_muon_kwargs
 
 
 logger = helper.create_logger(__name__)
@@ -345,9 +345,7 @@ class VLMTrainer:
             self.on_epoch_begin()
 
             # Create a batch generator
-            self.base.data_iterator = VeOmniIter(
-                self.base.train_dataloader, use_background_prefetcher=args.data.dataloader.use_background_prefetcher
-            )
+            self.base.data_iterator = self.base.build_data_iterator()
 
             for _ in range(self.base.start_step, args.train_steps):
                 try:


### PR DESCRIPTION
## Summary

- Add an opt-in `data.dataloader.use_device_prefetcher` flag that wraps `VeOmniIter` with a CUDA side-stream batch transfer prefetcher.
- Centralize trainer iterator construction through `BaseTrainer.build_data_iterator()` so Text, VLM, DPO, DiT, and BaseTrainer loops share the same dataloader prefetch behavior.
- Keep CPU-only metadata (`cu_seq_lens_q/k`, `linear_attn_cu_seq_lens_q`, labels, and output masks) on the existing CPU path to avoid breaking ChunkMBS, FA metadata handling, or pre-forward token counting.

## Performance Rationale

This targets the common host-to-device input staging gap: with pinned DataLoader tensors, the next batch's H2D copy can run on a side stream while the current step computes. This is the same class of overlap used by mainstream CUDA training input pipelines. The expected win is workload-dependent and should show up most on multimodal or long-sequence batches where batch payload transfer is visible in the step timeline.

## Validation

- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-device-prefetch PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH pytest tests/trainer/test_device_prefetcher.py -q` -> `4 passed`
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-device-prefetch PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH make quality` -> ruff check and format passed
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-device-prefetch PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH python tests/special_sanity/check_device_api_usage.py --directory ./veomni` -> passed
- `/veomni-review` verdict: safe

Notes: broader model patch tests are not runnable on this local Mac CPU environment because they fail before the test body with `RuntimeError: No available distributed communication backend found on device type cpu.` A CUDA smoke/profile run with `data.dataloader.pin_memory=true` and `data.dataloader.use_device_prefetcher=true` is the right hardware-side follow-up.
