### PR TITLE
[docker] chore: install openssh server in CUDA 13 image

### DIFF
--- a/docker/cuda/Dockerfile.cu130
+++ b/docker/cuda/Dockerfile.cu130
@@ -41,7 +41,7 @@ RUN echo "Setting timezone to CST (China Standard Time)..." && \
 
 # Install apt packages.
 RUN apt-get update -y \
-    && apt-get install -y sudo ffmpeg curl wget vim \
+    && apt-get install -y sudo ffmpeg curl wget vim openssh-server \
     && apt-get clean
 
 # Add tiger user, remove default user

--- a/docker/templates/cuda.Dockerfile.j2
+++ b/docker/templates/cuda.Dockerfile.j2
@@ -41,7 +41,7 @@ RUN echo "Setting timezone to CST (China Standard Time)..." && \
 
 # Install apt packages.
 RUN apt-get update -y \
-    && apt-get install -y sudo ffmpeg curl wget vim \
+    && apt-get install -y sudo ffmpeg curl wget vim openssh-server \
     && apt-get clean
 
 # Add tiger user, remove default user


### PR DESCRIPTION
### What does this PR do?

> Installs the `openssh-server` package in the CUDA 13.0 development image.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A
- PR title follows `[{modules}] {type}: {description}` format

### Test

> - `uv run --no-project --script docker/generate.py --check`
> - `uv run --no-project --with 'ruff>=0.7.0,<1.0' make quality`

### API and Usage Example

> N/A. This change only installs the package; it does not configure or start `sshd`.

### Design & Code Changes

> - Add `openssh-server` to `docker/templates/cuda.Dockerfile.j2`.
> - Regenerate `docker/cuda/Dockerfile.cu130` from the template.

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] Applied pre-commit checks
- [x] Documentation is not required for this dependency-only change
- [x] Tests are not required for this Docker package-list change
