### PR TITLE
[trainer, perf] feat: make train step sync optional

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -258,6 +258,7 @@ NPU validation runs at two times:
 | ep_sharded_stream_load | `bool` | `False` | Opt-in fast/low-memory MoE loader: each rank reads only its ExtraParallel dim-0 slice from the checkpoint. Requires `broadcast_model_weights_from_rank0=False` and a model with an ExtraParallel parallel_plan. |
 | enable_full_determinism | `bool` | `False` | Enable full determinism (bitwise alignment). |
 | enable_batch_invariant_mode | `bool` | `False` | Enable batch invariant mode. |
+| sync_each_train_step | `bool` | `True` | Synchronize the accelerator before each training step's forward/backward work. Disable to allow async dataloader and H2D work to overlap with the next step. |
 | empty_cache_steps | `int` | `500` | Steps between device-cache cleanup calls. A non-positive value disables scheduled cleanup. |
 | gc_steps | `int` | `500` | When positive, disable automatic Python GC and run `gc.collect()` every N steps. A non-positive value leaves automatic GC enabled and disables scheduled collection. |
 | eval_steps | `int` | `0` | Steps between evaluations. `0` to disable. |

--- a/tests/trainer/test_step_sync.py
+++ b/tests/trainer/test_step_sync.py
@@ -1,0 +1,33 @@
+import inspect
+from types import SimpleNamespace
+
+import veomni.trainer.base as base_module
+from veomni.trainer.base import BaseTrainer
+from veomni.trainer.dit_trainer import DiTTrainer
+from veomni.trainer.text_dpo_trainer import TextDPOTrainer
+from veomni.trainer.text_trainer import TextTrainer
+from veomni.trainer.vlm_trainer import VLMTrainer
+
+
+def _trainer(sync_each_train_step: bool):
+    trainer = BaseTrainer.__new__(BaseTrainer)
+    trainer.args = SimpleNamespace(train=SimpleNamespace(sync_each_train_step=sync_each_train_step))
+    return trainer
+
+
+def test_sync_before_train_step_honors_training_flag(monkeypatch):
+    calls = []
+    monkeypatch.setattr(base_module, "synchronize", lambda: calls.append("sync"))
+
+    _trainer(True).sync_before_train_step()
+    _trainer(False).sync_before_train_step()
+
+    assert calls == ["sync"]
+
+
+def test_train_step_uses_sync_helper():
+    for wrapper_cls in (BaseTrainer, TextTrainer, VLMTrainer, TextDPOTrainer, DiTTrainer):
+        source = inspect.getsource(wrapper_cls.train_step)
+
+        assert "sync_before_train_step()" in source
+        assert "synchronize()" not in source

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -677,6 +677,15 @@ class TrainingArguments:
         default=False,
         metadata={"help": "Enable batch invariant mode."},
     )
+    sync_each_train_step: bool = field(
+        default=True,
+        metadata={
+            "help": (
+                "Synchronize the accelerator before each training step's forward/backward work. "
+                "Disable to allow asynchronous dataloader and H2D work to overlap with the next step."
+            )
+        },
+    )
     empty_cache_steps: int = field(
         default=500,
         metadata={"help": "Number of steps between two empty cache operations."},

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -747,6 +747,10 @@ class BaseTrainer(Stateful, ABC):
             elif micro_step == num_micro_steps - 1:
                 self.model.set_requires_all_reduce(True)
 
+    def sync_before_train_step(self):
+        if self.args.train.sync_each_train_step:
+            synchronize()
+
     def train_step(
         self,
         data_iterator: Any,
@@ -759,7 +763,7 @@ class BaseTrainer(Stateful, ABC):
         self.on_step_begin(micro_batches=micro_batches)
 
         # Forward and backward for each micro batch
-        synchronize()
+        self.sync_before_train_step()
 
         total_loss = 0.0
         total_loss_dict = defaultdict(int)

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -510,7 +510,7 @@ class DiTTrainer:
 
         self.on_step_begin(micro_batches=micro_batches)
 
-        synchronize()
+        self.base.sync_before_train_step()
 
         total_loss = 0.0
         total_loss_dict = defaultdict(float)

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -415,7 +415,7 @@ class TextDPOTrainer:
 
         self.on_step_begin(micro_batches=micro_batches)
 
-        synchronize()
+        self.base.sync_before_train_step()
 
         total_loss = 0.0
         total_loss_dict: Dict[str, float] = defaultdict(float)

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -120,7 +120,7 @@ class TextTrainer:
         self.on_step_begin(micro_batches=micro_batches)
 
         # Forward and backward for each micro batch
-        synchronize()
+        self.base.sync_before_train_step()
 
         total_loss = 0.0
         total_loss_dict = defaultdict(int)

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -294,7 +294,7 @@ class VLMTrainer:
         self.on_step_begin(micro_batches=micro_batches)
 
         # Forward and backward for each micro batch
-        synchronize()
+        self.base.sync_before_train_step()
 
         total_loss = 0.0
         total_loss_dict = defaultdict(int)


### PR DESCRIPTION
## Summary

- Add `train.sync_each_train_step` with default `true` to preserve current per-step synchronization behavior.
- Route the pre-forward training-step fence through `BaseTrainer.sync_before_train_step()` across Base/Text/VLM/DPO/DiT trainers.
- Allow throughput-oriented runs to set `train.sync_each_train_step=false` so async dataloader and H2D work are not fenced before every forward/backward step.

## Performance Rationale

The existing training loops call `synchronize()` after step-begin callbacks and before every forward/backward pass. That makes per-step timing straightforward, but it also fences outstanding device work and prevents useful overlap from dataloader/device-transfer prefetch paths. Mainstream high-throughput training loops generally avoid unconditional device-wide fences on the hot path and use profiler/timing-specific synchronization when needed.

This PR keeps the old default for metric stability and makes the throughput path opt-in.

## Validation

- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-step-sync PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH pytest tests/trainer/test_step_sync.py -q` -> `2 passed`
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-step-sync PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH make quality` -> ruff check and format passed
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-step-sync PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH python tests/special_sanity/check_device_api_usage.py --directory ./veomni` -> passed
- `/veomni-review` verdict: safe

Notes: the local Mac CPU environment cannot run meaningful CUDA timing or distributed training smoke tests. A CUDA profile comparing `train.sync_each_train_step=true` vs `false` is the hardware-side follow-up for measuring overlap and step-time impact.
