### PR TITLE
[dist, perf] feat: skip disabled grad clipping

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -303,7 +303,7 @@ NPU validation runs at two times:
 | weight_decay | `float` | `0` | L2 regularization strength. |
 | no_decay_modules | `List[str]` | `[]` | Modules excluded from weight decay (e.g. `RMSNorm`). |
 | no_decay_params | `List[str]` | `[]` | Parameters excluded from weight decay (e.g. `bias`). |
-| max_grad_norm | `float` | `1.0` | Gradient clipping norm. |
+| max_grad_norm | `float` | `1.0` | Gradient clipping norm. Values `<= 0` disable gradient clipping and skip the grad-norm pass. |
 | muon_lr | `float` | `2e-2` | Learning rate for Muon-managed 2-D hidden weights and 3-D expert stacks. |
 | muon_momentum | `float` | `0.95` | Momentum factor for Muon. |
 | muon_nesterov | `bool` | `True` | Enable Nesterov momentum for Muon. |

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -33,6 +33,23 @@ from veomni.utils.device import (
 logger = helper.create_logger(__name__)
 
 
+def test_clip_grad_norm_non_positive_max_norm_skips_parallel_state(monkeypatch):
+    model = nn.Linear(2, 2)
+    model(torch.ones(1, 2)).sum().backward()
+    original_grads = [param.grad.detach().clone() for param in model.parameters()]
+
+    def fail_get_parallel_state():
+        raise AssertionError("disabled grad clipping should not query parallel state")
+
+    monkeypatch.setattr("veomni.distributed.clip_grad_norm.get_parallel_state", fail_get_parallel_state)
+
+    grad_norm = veomni_clip_grad_norm(model, max_norm=0.0)
+
+    assert grad_norm == 0.0
+    for param, original_grad in zip(model.parameters(), original_grads):
+        torch.testing.assert_close(param.grad, original_grad)
+
+
 def _torch_npu_version() -> str:
     """Return the version of torch_npu if installed, otherwise return "0.0.0"."""
     if importlib.util.find_spec("torch_npu") is None:

--- a/veomni/distributed/clip_grad_norm.py
+++ b/veomni/distributed/clip_grad_norm.py
@@ -7,6 +7,9 @@ from .parallel_state import get_parallel_state
 def veomni_clip_grad_norm(
     model, max_norm: float, norm_type: float = 2.0, error_if_nonfinite: bool = False, foreach: bool | None = None
 ):
+    if max_norm <= 0:
+        return 0.0
+
     parallel_state = get_parallel_state()
     dp_mode = parallel_state.dp_mode
     if dp_mode == "fsdp2":


### PR DESCRIPTION
## Summary

- Treat `train.optimizer.max_grad_norm <= 0` as disabled gradient clipping.
- Return `0.0` before querying `ParallelState` or dispatching DDP/FSDP2/ExtraParallel grad-norm logic.
- Document the disabled-clipping convention for `max_grad_norm`.

## Performance Rationale

When users intentionally disable gradient clipping, VeOmni currently still scans gradients and, under FSDP2/ExtraParallel, can perform small distributed reductions before the optimizer step. DeepSpeed-style training configs commonly use a non-positive clipping threshold to skip this work. This PR makes that path explicit and avoids unnecessary parameter walks and scalar collectives.

## Validation

- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-grad-clip PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH pytest tests/utils/test_extra_parallel_clip_grad_norm.py::test_clip_grad_norm_non_positive_max_norm_skips_parallel_state -q` -> `1 passed`
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-grad-clip PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH make quality` -> ruff check and format passed
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-grad-clip PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH python tests/special_sanity/check_device_api_usage.py --directory ./veomni` -> passed
- `/veomni-review` verdict: safe

Notes: a distributed FSDP2/DDP smoke with `train.optimizer.max_grad_norm=0` is the hardware-side follow-up to confirm the logged `grad_norm` is `0.0` in full trainer runs.
