### PR TITLE
[data, perf] feat: expose dataloader scheduling knobs

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -231,6 +231,8 @@ NPU validation runs at two times:
 | type | `str` | `"native"` | Type of the dataloader. |
 | num_workers | `int` | `2` | Number of workers for data loading. |
 | prefetch_factor | `int` | `2` | Number of batches loaded in advance per worker. |
+| persistent_workers | `bool` | `False` | Keep DataLoader worker processes alive between iterator recreations. |
+| in_order | `bool` | `True` | Return worker-loaded batches in first-in, first-out order. Set `False` to avoid slow worker head-of-line blocking for uneven sample decode costs; checkpoint/resume ordering is not guaranteed in this mode. |
 | drop_last | `bool` | `True` | Whether to drop the last incomplete batch. |
 | pin_memory | `bool` | `True` | Whether to pin memory for the dataloader. |
 | worker_num_threads | `Optional[int]` | `None` | Number of PyTorch threads used by each DataLoader worker. |

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -186,6 +186,85 @@ def test_build_dataloader_dyn_bsz_physical_overflow_ratio(monkeypatch, dummy_dat
     assert dl.batching_strategy.physical_token_cap == 40
 
 
+def test_build_dataloader_suppresses_persistent_workers_with_zero_workers(monkeypatch, dummy_dataset_ci):
+    import veomni.data.data_loader as m_dl
+    import veomni.data.dataset as m_ds
+
+    ps = _fake_ps(sp_size=1)
+    monkeypatch.setattr(m_dl, "get_parallel_state", lambda: ps)
+    monkeypatch.setattr(m_ds, "get_parallel_state", lambda: ps)
+
+    dataset = build_dataset(
+        dataset_name="iterable",
+        train_path=dummy_dataset_ci.save_path,
+        transform=partial(process_dummy_example, max_seq_len=16),
+        seed=0,
+    )
+    dl = build_dataloader(
+        "native",
+        dataset=dataset,
+        micro_batch_size=2,
+        global_batch_size=4,
+        dataloader_batch_size=1,
+        max_seq_len=16,
+        train_steps=1,
+        num_workers=0,
+        dyn_bsz=True,
+        dyn_bsz_runtime="main",
+        dyn_bsz_buffer_size=1,
+        drop_last=True,
+        prefetch_factor=None,
+        persistent_workers=True,
+        in_order=False,
+        seed=0,
+    )
+
+    assert dl._dataloader.persistent_workers is False
+    assert dl._dataloader.in_order is False
+
+
+def test_build_dataloader_forwards_worker_scheduling_kwargs(monkeypatch, dummy_dataset_ci):
+    import veomni.data.data_loader as m_dl
+    import veomni.data.dataset as m_ds
+
+    captured = {}
+
+    class FakeDistributedDataloader:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+    ps = _fake_ps(sp_size=1)
+    monkeypatch.setattr(m_dl, "get_parallel_state", lambda: ps)
+    monkeypatch.setattr(m_ds, "get_parallel_state", lambda: ps)
+    monkeypatch.setattr(m_dl, "DistributedDataloader", FakeDistributedDataloader)
+
+    dataset = build_dataset(
+        dataset_name="iterable",
+        train_path=dummy_dataset_ci.save_path,
+        transform=partial(process_dummy_example, max_seq_len=16),
+        seed=0,
+    )
+    build_dataloader(
+        "native",
+        dataset=dataset,
+        micro_batch_size=2,
+        global_batch_size=4,
+        dataloader_batch_size=1,
+        max_seq_len=16,
+        train_steps=1,
+        num_workers=2,
+        dyn_bsz=False,
+        drop_last=True,
+        prefetch_factor=2,
+        persistent_workers=True,
+        in_order=False,
+        seed=0,
+    )
+
+    assert captured["persistent_workers"] is True
+    assert captured["in_order"] is False
+
+
 def test_build_dataloader_rejects_invalid_physical_overflow_ratio(monkeypatch, dummy_dataset_ci):
     import veomni.data.data_loader as m_dl
     import veomni.data.dataset as m_ds

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -1309,6 +1309,14 @@ class DataloaderConfig:
         default=2,
         metadata={"help": "Number of batches loaded in advance by each worker."},
     )
+    persistent_workers: bool = field(
+        default=False,
+        metadata={"help": "Keep DataLoader worker processes alive between iterator recreations."},
+    )
+    in_order: bool = field(
+        default=True,
+        metadata={"help": "Return worker-loaded batches in first-in, first-out order."},
+    )
     drop_last: bool = field(
         default=True,
         metadata={"help": "Whether to drop the last incomplete batch."},

--- a/veomni/data/data_loader.py
+++ b/veomni/data/data_loader.py
@@ -82,6 +82,8 @@ def build_native_dataloader(
     drop_last: bool = True,
     pin_memory: bool = True,
     prefetch_factor: int = 2,
+    persistent_workers: bool = False,
+    in_order: bool = True,
     shuffle: bool = True,
     seed: int = 0,
     collate_fn: Optional[Callable] = None,
@@ -225,6 +227,11 @@ def build_native_dataloader(
         )
 
     worker_init_fn = _build_worker_init_fn(worker_num_threads) if worker_num_threads is not None else None
+    if not in_order and num_workers > 0:
+        logger.warning_rank0(
+            "data.dataloader.in_order=False can improve throughput for uneven worker loads, "
+            "but StatefulDataLoader does not guarantee exact checkpoint/resume ordering in this mode."
+        )
     # Snapshot is only consumed at save; widen to save_steps in worker mode (1:1 next/step), else keep the every-step default so resume sees a fresh snapshot.
     if save_steps and save_steps > 0 and not (dyn_bsz and dyn_bsz_runtime == "main"):
         snapshot_every_n_steps = save_steps
@@ -240,6 +247,8 @@ def build_native_dataloader(
         pin_memory_device=get_device_type(),
         drop_last=drop_last,
         prefetch_factor=prefetch_factor,
+        persistent_workers=persistent_workers and num_workers > 0,
+        in_order=in_order,
         worker_init_fn=worker_init_fn,
         multiprocessing_context=multiprocessing_context,
         snapshot_every_n_steps=snapshot_every_n_steps,

--- a/veomni/data/diffusion/data_loader.py
+++ b/veomni/data/diffusion/data_loader.py
@@ -43,6 +43,8 @@ def build_dit_dataloader(
     drop_last: bool = True,
     pin_memory: bool = True,
     prefetch_factor: int = 2,
+    persistent_workers: bool = False,
+    in_order: bool = True,
     seed: int = 0,
     build_collate_fn: bool = True,
     collate_fn_kwargs: Optional[Dict[str, Any]] = None,
@@ -79,6 +81,12 @@ def build_dit_dataloader(
             seed=seed,
         )
 
+    if not in_order and num_workers > 0:
+        logger.warning_rank0(
+            "data.dataloader.in_order=False can improve throughput for uneven worker loads, "
+            "but StatefulDataLoader does not guarantee exact checkpoint/resume ordering in this mode."
+        )
+
     dataloader = DistributedDataloader(
         dataset,
         batch_size=dataloader_batch_size,
@@ -89,6 +97,8 @@ def build_dit_dataloader(
         pin_memory_device=get_device_type(),
         drop_last=drop_last,
         prefetch_factor=prefetch_factor,
+        persistent_workers=persistent_workers and num_workers > 0,
+        in_order=in_order,
     )
 
     return dataloader

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -396,6 +396,8 @@ class DiTTrainer:
                 drop_last=args.data.dataloader.drop_last,
                 pin_memory=args.data.dataloader.pin_memory,
                 prefetch_factor=args.data.dataloader.prefetch_factor,
+                persistent_workers=args.data.dataloader.persistent_workers,
+                in_order=args.data.dataloader.in_order,
                 seed=args.train.seed,
                 collate_fn=DiTDataCollator(),
                 save_steps=args.train.checkpoint.save_steps,


### PR DESCRIPTION
## Summary

- Expose `data.dataloader.persistent_workers` and `data.dataloader.in_order` for the native DataLoader path.
- Forward the knobs into `DistributedDataloader` and the DiT dataloader construction path.
- Guard `persistent_workers` when `num_workers=0`, and warn when `in_order=False` is used because StatefulDataLoader does not guarantee exact checkpoint/resume ordering in that mode.

## Performance Rationale

Multimodal and video pipelines often have uneven per-sample decode/preprocess costs. `persistent_workers=True` avoids worker teardown/restart overhead when iterators are recreated, and `in_order=False` can reduce head-of-line blocking from slow workers. These are standard PyTorch DataLoader scheduling knobs, but VeOmni did not expose them through its config.

Defaults preserve current behavior.

## Validation

- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-dataloader-scheduling PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH pytest tests/data/test_dataloader.py::test_build_dataloader_suppresses_persistent_workers_with_zero_workers tests/data/test_dataloader.py::test_build_dataloader_forwards_worker_scheduling_kwargs -q` -> `2 passed`
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-dataloader-scheduling PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH pytest tests/data/test_dataloader.py -q` -> `20 passed, 2 skipped`
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-dataloader-scheduling PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH make quality` -> ruff check and format passed
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-dataloader-scheduling PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH python tests/special_sanity/check_device_api_usage.py --directory ./veomni` -> passed
- `/veomni-review` verdict: safe after adding the checkpoint/resume warning and docs caveat

Notes: `in_order=False` is a throughput knob, not an exact-resume knob. It should be enabled only when the user accepts non-FIFO worker return order.
