### PR TITLE
[trainer, perf] feat: reuse reduced loss denominators

### DIFF
--- a/tests/utils/test_loss_utils.py
+++ b/tests/utils/test_loss_utils.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import veomni.utils.loss_utils as loss_utils
+
+
+def test_reduce_global_loss_token_reduces_each_denominator_once(monkeypatch):
+    calls = []
+
+    def fake_all_reduce(value, op="mean", group=None):
+        calls.append((value, op, group))
+        return value + 10
+
+    monkeypatch.setattr(loss_utils, "all_reduce", fake_all_reduce)
+
+    reduced = loss_utils.reduce_global_loss_token(
+        {
+            "foundation_tokens": torch.tensor(3),
+            "image_decoder_tokens": torch.tensor(0),
+        }
+    )
+
+    assert reduced == {"foundation_tokens": 13, "image_decoder_tokens": 10}
+    assert calls == [(3, "sum", None), (0, "sum", None)]
+
+
+def test_mean_global_loss_reuses_pre_reduced_denominator(monkeypatch):
+    def fail_all_reduce(*args, **kwargs):
+        raise AssertionError("denominator should already be reduced")
+
+    monkeypatch.setattr(loss_utils, "all_reduce", fail_all_reduce)
+    monkeypatch.setattr(
+        loss_utils,
+        "get_parallel_state",
+        lambda: SimpleNamespace(sp_enabled=False, fsdp_size=2),
+    )
+
+    loss_dict = loss_utils.mean_global_loss(
+        {"foundation_loss": torch.tensor(4.0)},
+        {"foundation_tokens": torch.tensor(3)},
+        {"foundation_tokens": torch.tensor(5)},
+        {"foundation_tokens": 6},
+    )
+
+    assert loss_dict["foundation_loss"].item() == pytest.approx(4.0)
+
+
+def test_mean_global_loss_falls_back_to_reducing_denominator(monkeypatch):
+    calls = []
+
+    def fake_all_reduce(value, op="mean", group=None):
+        calls.append((value, op, group))
+        return value * 2
+
+    monkeypatch.setattr(loss_utils, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(
+        loss_utils,
+        "get_parallel_state",
+        lambda: SimpleNamespace(sp_enabled=False, fsdp_size=1),
+    )
+
+    loss_dict = loss_utils.mean_global_loss(
+        {"foundation_loss": torch.tensor(4.0)},
+        {"foundation_tokens": torch.tensor(2)},
+        {"foundation_tokens": torch.tensor(5)},
+    )
+
+    assert loss_dict["foundation_loss"].item() == pytest.approx(0.8)
+    assert calls == [(5, "sum", None)]

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -73,7 +73,7 @@ from ..utils.device import (
     is_nccl_backend,
     synchronize,
 )
-from ..utils.loss_utils import count_loss_token, mean_global_loss
+from ..utils.loss_utils import count_loss_token, mean_global_loss, reduce_global_loss_token
 from ..utils.model_utils import pretty_print_trainable_parameters
 from .callbacks import (
     ChannelLossCallback,
@@ -675,7 +675,10 @@ class BaseTrainer(Stateful, ABC):
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Postprocess model outputs after forward pass."""
         loss_dict: Dict[str, torch.Tensor] = mean_global_loss(
-            outputs.loss, self.micro_batch_token_len, self.micro_batches_token_len
+            outputs.loss,
+            self.micro_batch_token_len,
+            self.micro_batches_token_len,
+            getattr(self, "global_micro_batches_token_len", None),
         )
         loss = torch.stack(list(loss_dict.values())).sum()
         return loss, loss_dict
@@ -766,6 +769,7 @@ class BaseTrainer(Stateful, ABC):
 
         # token num for fixed_ce_loss in postforward
         self.micro_batches_token_len = count_loss_token(micro_batches)
+        self.global_micro_batches_token_len = reduce_global_loss_token(self.micro_batches_token_len)
         num_micro_steps = len(micro_batches)
         # forward and backward pass with gradient_accumulationsteps
         for micro_step, micro_batch in enumerate(micro_batches):

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -28,7 +28,7 @@ from ..distributed.torch_compile import mark_compile_step_begin
 from ..models import build_tokenizer
 from ..utils import helper
 from ..utils.device import synchronize
-from ..utils.loss_utils import count_loss_token
+from ..utils.loss_utils import count_loss_token, reduce_global_loss_token
 from .base import BaseTrainer, VeOmniIter
 
 
@@ -127,6 +127,7 @@ class TextTrainer:
 
         # token num for fixed_ce_loss in postforward
         self.base.micro_batches_token_len = count_loss_token(micro_batches)
+        self.base.global_micro_batches_token_len = reduce_global_loss_token(self.base.micro_batches_token_len)
         num_micro_steps = len(micro_batches)
         # forward and backward pass with gradient_accumulationsteps
         for micro_step, micro_batch in enumerate(micro_batches):

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -26,7 +26,7 @@ from ..models import build_foundation_model, build_processor
 from ..optim import build_optimizer
 from ..utils import helper
 from ..utils.device import synchronize
-from ..utils.loss_utils import count_loss_token
+from ..utils.loss_utils import count_loss_token, reduce_global_loss_token
 from ..utils.model_utils import pretty_print_trainable_parameters
 from .base import BaseTrainer, VeOmniIter, _collect_muon_kwargs
 
@@ -301,6 +301,7 @@ class VLMTrainer:
 
         # token num for fixed_ce_loss in postforward
         self.base.micro_batches_token_len = count_loss_token(micro_batches)
+        self.base.global_micro_batches_token_len = reduce_global_loss_token(self.base.micro_batches_token_len)
         num_micro_steps = len(micro_batches)
         # forward and backward pass with gradient_accumulationsteps
         for micro_step, micro_batch in enumerate(micro_batches):

--- a/veomni/utils/loss_utils.py
+++ b/veomni/utils/loss_utils.py
@@ -55,6 +55,7 @@ def mean_global_loss(
     losses: Union[dict[str, torch.Tensor], torch.Tensor],
     micro_batch_token_len: dict[str, torch.Tensor],
     micro_batches_token_len: dict[str, torch.Tensor],
+    global_micro_batches_token_len: dict[str, float] | None = None,
 ):
     """Calcuate the global mean loss. Avg on all_reduced_token_num instead of on dp_size.
     - cur_losses[key] = cur_loss * cur_token_num / global_batches_token_num * get_parallel_state().fsdp_size
@@ -72,7 +73,10 @@ def mean_global_loss(
         if get_parallel_state().sp_enabled:
             cur_token_len = all_reduce(cur_token_len.item(), op="sum", group=get_parallel_state().sp_group)
 
-        all_reduced_len = all_reduce((micro_batches_token_len[f"{loss_name}_tokens"].item()), op="sum")
+        if global_micro_batches_token_len is None:
+            all_reduced_len = all_reduce((micro_batches_token_len[f"{loss_name}_tokens"].item()), op="sum")
+        else:
+            all_reduced_len = global_micro_batches_token_len[f"{loss_name}_tokens"]
 
         if all_reduced_len != 0:
             cur_loss = cur_loss * cur_token_len / all_reduced_len * get_parallel_state().fsdp_size
@@ -88,3 +92,8 @@ def mean_global_loss(
         loss_dict[key] = cur_loss
 
     return loss_dict
+
+
+def reduce_global_loss_token(micro_batches_token_len: dict[str, torch.Tensor]) -> dict[str, float]:
+    """All-reduce per-step loss-token denominators once for reuse across micro-batches."""
+    return {key: all_reduce(value.item(), op="sum") for key, value in micro_batches_token_len.items()}


### PR DESCRIPTION
## Summary

- Add `reduce_global_loss_token()` to reduce per-step loss-token denominators once per optimizer step.
- Reuse the pre-reduced denominators in `mean_global_loss()` across gradient-accumulation micro-batches.
- Keep `mean_global_loss()` backward-compatible by falling back to the previous per-call denominator reduction when no cached denominator is supplied.

## Performance Rationale

Before this change, each micro-batch loss normalization all-reduced the same global denominator for the whole optimizer step. With gradient accumulation and multiple loss keys, that repeats small control-plane reductions in the inner training loop. This PR keeps the same math but moves the step-level denominator reduction out of the micro-batch loop for Base/Text/VLM training paths.

## Validation

- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-loss-denom PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH pytest tests/utils/test_loss_utils.py -q` -> `3 passed`
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-loss-denom PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH make quality` -> ruff check and format passed
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-loss-denom PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH python tests/special_sanity/check_device_api_usage.py --directory ./veomni` -> passed
- `/veomni-review` verdict: safe

Notes: local CPU cannot run meaningful distributed SP/VLM smoke tests. The hardware-side follow-up is an SP run with `ulysses_size>1` and a multi-loss VLM/omni batch to confirm denominator reductions drop from per-micro-batch to per-step.
