### PR TITLE
[trainer, perf] refactor: coalesce train metric reductions

### DIFF
--- a/tests/trainer/test_trace_callback_metrics.py
+++ b/tests/trainer/test_trace_callback_metrics.py
@@ -1,0 +1,32 @@
+import veomni.trainer.callbacks.trace_callback as trace_callback
+
+
+def test_reduce_training_metrics_coalesces_numeric_values(monkeypatch):
+    calls = []
+
+    def fake_all_reduce(value, group=None):
+        calls.append((value, group))
+        return [item + 1 for item in value]
+
+    monkeypatch.setattr(trace_callback, "all_reduce", fake_all_reduce)
+
+    reduced = trace_callback._reduce_training_metrics({"loss": 2.0, "grad_norm": 3.0}, group="fsdp")
+
+    assert reduced == {"loss": 3.0, "grad_norm": 4.0}
+    assert calls == [([2.0, 3.0], "fsdp")]
+
+
+def test_reduce_training_metrics_falls_back_for_non_numeric_values(monkeypatch):
+    calls = []
+
+    def fake_all_reduce(value, group=None):
+        calls.append((value, group))
+        return value
+
+    monkeypatch.setattr(trace_callback, "all_reduce", fake_all_reduce)
+
+    metrics = {"loss": 2.0, "custom": object()}
+    reduced = trace_callback._reduce_training_metrics(metrics, group="fsdp")
+
+    assert reduced == metrics
+    assert calls == [(metrics["loss"], "fsdp"), (metrics["custom"], "fsdp")]

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -30,6 +30,18 @@ if TYPE_CHECKING:
     from ..base import BaseTrainer, VeOmniArguments
 
 
+def _reduce_training_metrics(metrics: Dict[str, float], group) -> Dict[str, float]:
+    """Reduce scalar training metrics with one collective when possible."""
+    if not metrics:
+        return {}
+    keys = list(metrics)
+    values = [metrics[key] for key in keys]
+    if not all(isinstance(value, (int, float)) for value in values):
+        return {key: all_reduce(value, group=group) for key, value in metrics.items()}
+    reduced_values = all_reduce(values, group=group)
+    return dict(zip(keys, reduced_values))
+
+
 class MoERouterMonitorCallback(Callback):
     """Monitors MoE expert load distribution and logs heatmaps to wandb.
 
@@ -218,7 +230,8 @@ class EnvironMeterCallback(Callback):
 
         # gather training_step_info from all ranks
         step_train_metrics = {
-            f"training/{k}": all_reduce(v, group=self.parallel_state.fsdp_group) for k, v in step_train_metrics.items()
+            f"training/{k}": v
+            for k, v in _reduce_training_metrics(step_train_metrics, group=self.parallel_state.fsdp_group).items()
         }
 
         if self.trainer.lr_scheduler is not None:


### PR DESCRIPTION
## Summary

- Coalesce scalar training metric all-reduces in `EnvironMeterCallback` into a single collective when possible.
- Preserve the previous per-key fallback for non-numeric/custom metric values.
- Add focused tests for coalesced numeric reductions and fallback behavior.

## Performance Rationale

`EnvironMeterCallback` previously reduced `total_loss`, every loss entry, and `grad_norm` with one scalar all-reduce per key on every step. These are small control-plane collectives on the hot path. Coalescing numeric scalar metrics into one list all-reduce preserves the logged values while reducing per-step collective count.

## Validation

- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-metric-reduce PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH pytest tests/trainer/test_trace_callback_metrics.py -q` -> `2 passed`
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-metric-reduce PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH make quality` -> ruff check and format passed
- `/veomni-review` verdict: safe

Notes: local CPU cannot run a meaningful distributed trainer smoke. The hardware-side follow-up is a small distributed run that exercises `EnvironMeterCallback` with tqdm/wandb consuming `step_train_metrics` and `step_env_metrics`.
