### PR TITLE
[ops, perf] refactor: reuse chunk loss denominator

### DIFF
--- a/tests/ops/test_chunk_loss.py
+++ b/tests/ops/test_chunk_loss.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+import torch
+
+import veomni.ops.kernels.cross_entropy.chunk_loss as chunk_loss_module
+
+
+def test_chunk_loss_reuses_valid_token_denominator(monkeypatch):
+    monkeypatch.setattr(chunk_loss_module, "get_parallel_state", lambda: SimpleNamespace(sp_enabled=False))
+
+    original_sum = torch.Tensor.sum
+    denominator_sum_calls = 0
+
+    def counting_sum(self, *args, **kwargs):
+        nonlocal denominator_sum_calls
+        if self.dtype == torch.bool and self.shape == (1, 5):
+            denominator_sum_calls += 1
+        return original_sum(self, *args, **kwargs)
+
+    monkeypatch.setattr(torch.Tensor, "sum", counting_sum)
+
+    hidden_states = torch.randn(1, 6, 4, requires_grad=True)
+    weights = torch.randn(8, 4, requires_grad=True)
+    labels = torch.tensor([[1, 2, -100, 3, 4, 5]])
+
+    loss, _ = chunk_loss_module.chunk_loss_function(
+        hidden_states,
+        weights,
+        labels,
+        chunk_size=2,
+    )
+    loss.backward()
+
+    assert denominator_sum_calls == 1
+    assert hidden_states.grad is not None
+    assert weights.grad is not None

--- a/veomni/ops/kernels/cross_entropy/chunk_loss.py
+++ b/veomni/ops/kernels/cross_entropy/chunk_loss.py
@@ -127,9 +127,10 @@ def chunk_loss_function(
         return loss, logits
 
     chunk_labels = torch.split(labels, chunk_size, dim=1)
+    num_items_in_batch = (labels != ignore_index).sum()
 
     loss_kwargs_chunks = [
-        {"labels": chunk_labels[i], "ignore_index": ignore_index, "num_items_in_batch": (labels != ignore_index).sum()}
+        {"labels": chunk_labels[i], "ignore_index": ignore_index, "num_items_in_batch": num_items_in_batch}
         for i in range(len(chunk_labels))
     ]
 


### PR DESCRIPTION
## Summary

- Compute the shifted-label valid-token denominator once in `chunk_loss_function`.
- Reuse that scalar across all chunk loss calls instead of recomputing `(labels != ignore_index).sum()` for every chunk.
- Add a focused regression test that counts denominator reductions across multiple chunks.

## Performance Rationale

The chunked CE path uses the full post-shift label denominator for every chunk. Previously each chunk rebuilt the same boolean mask sum, adding repeated tensor work in the inner chunk loop. This keeps the math and scaling identical while reducing repeated work to one denominator calculation per loss call.

## Validation

- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-chunk-loss-denom PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH pytest tests/ops/test_chunk_loss.py -q` -> `1 passed`
- `PYTHONPATH=/Users/bytedance/Documents/VeOmni-chunk-loss-denom PATH=/Users/bytedance/Documents/VeOmni/.venv/bin:$PATH make quality` -> ruff check and format passed
- `/veomni-review` verdict: safe

Notes: `tests/ops/test_seqcls_loss.py` is blocked locally because `liger_kernel` is not installed; this is unrelated to the chunk-loss path.
