### PR TITLE
[perf, config, docs] feat: defer NPU profiler analysis

### DIFF
--- a/docs/hardware_support/profiling_analysis.md
+++ b/docs/hardware_support/profiling_analysis.md
@@ -19,6 +19,7 @@ VeOmni's profiling configuration is located under the `train.profile.*` namespac
 | with_stack | bool | True | Whether to record stack traces |
 | with_modules | bool | False | Whether to record module hierarchy in profiling traces |
 | rank0_only | bool | True | Whether to profile only rank 0 |
+| npu_offline_analysis | bool | False | Whether to finalize Ascend raw data during training and analyze it offline |
 
 ### Configuration Items That May Affect Performance
 
@@ -28,6 +29,7 @@ The following configuration items will impact training performance and need to b
 - **profile_memory**: Enabling memory profiling adds additional overhead
 - **with_stack**: Recording stack traces significantly increases profiling overhead
 - **rank0_only**: When set to False, all ranks will be profiled, generating a large number of files and consuming significant disk space and time
+- **npu_offline_analysis**: When set to True on Ascend, the training process finalizes raw profiling data without generating the Chrome trace. Parse the finalized `*_ascend_pt` directory later with the torch_npu offline analysis API or `msprof`. This avoids blocking the training step on a large trace export.
 
 ### Typical Configuration Method
 
@@ -41,7 +43,42 @@ train:
         end_step: 6
         record_shapes: true
         trace_dir: ./profiling
+        npu_offline_analysis: true
 ```
+
+The same option can be enabled from the command line:
+
+```bash
+--train.profile.enable true \
+--train.profile.start_step 5 \
+--train.profile.end_step 6 \
+--train.profile.trace_dir /tmp/veomni_npu_profile \
+--train.profile.rank0_only true \
+--train.profile.record_shapes false \
+--train.profile.profile_memory false \
+--train.profile.with_stack false \
+--train.profile.with_modules false \
+--train.profile.npu_offline_analysis true
+```
+
+Use pod-local storage for large Ascend captures, then copy the finalized raw directory to durable storage before parsing it offline.
+
+For distributed Ascend training, use the following options together:
+
+```yaml
+train:
+  profile:
+    enable: true
+    rank0_only: true
+    npu_offline_analysis: true
+    trace_dir: /tmp/veomni_npu_profile
+```
+
+VeOmni synchronizes all ranks immediately before and after the final profiler step in this mode. This prevents non-profiled ranks from entering the next collective while rank 0 finalizes its raw capture. All ranks must execute the profile callback at the same global step. `start_step` and `end_step` are absolute global steps; VeOmni rebases the remaining schedule after checkpoint resume or a hot update and skips a window that has already elapsed.
+
+Using an `hdfs://` trace directory is supported, but not recommended for large Ascend captures: it still copies the raw directory synchronously before releasing the other ranks and can therefore stall training. Prefer `/tmp` or another pod-local SSD path, then copy the finalized `*_ascend_pt` directory to durable storage from a separate process.
+
+The current trainer callback and `tasks/omni/train_omni_model.py` support this option. Deprecated standalone training entrypoints reject it explicitly instead of falling back to online analysis.
 
 ## Profiling Analysis Tool - MindStudio Insight
 

--- a/docs/hardware_support/profiling_analysis.md
+++ b/docs/hardware_support/profiling_analysis.md
@@ -74,7 +74,7 @@ train:
     trace_dir: /tmp/veomni_npu_profile
 ```
 
-VeOmni synchronizes all ranks immediately before and after the final profiler step in this mode. This prevents non-profiled ranks from entering the next collective while rank 0 finalizes its raw capture. All ranks must execute the profile callback at the same global step. `start_step` and `end_step` are absolute global steps; VeOmni rebases the remaining schedule after checkpoint resume or a hot update and skips a window that has already elapsed.
+VeOmni synchronizes all ranks immediately before and after the final profiler step on Ascend (both online and offline analysis). This prevents non-profiled ranks from entering the next collective while rank 0 finalizes its capture. Prefer `npu_offline_analysis: true` so that barrier only covers raw finalization rather than a long Chrome/DB export. All ranks must execute the profile callback at the same global step. `start_step` and `end_step` are absolute global steps; VeOmni rebases the remaining schedule after checkpoint resume or a hot update and skips a window that has already elapsed.
 
 Using an `hdfs://` trace directory is supported, but not recommended for large Ascend captures: it still copies the raw directory synchronously before releasing the other ranks and can therefore stall training. Prefer `/tmp` or another pod-local SSD path, then copy the finalized `*_ascend_pt` directory to durable storage from a separate process.
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -340,7 +340,7 @@ NPU validation runs at two times:
 | with_stack | `bool` | `True` | Record stack traces. |
 | with_modules | `bool` | `False` | Record module hierarchy in profiler traces. |
 | rank0_only | `bool` | `True` | Profile rank 0 only. |
-| npu_offline_analysis | `bool` | `False` | Set Ascend `analyse_flag=False`, synchronize distributed finalization, and defer trace analysis to an offline process. Use a pod-local `trace_dir`. NPU only. |
+| npu_offline_analysis | `bool` | `False` | Set Ascend `analyse_flag=False` and defer Chrome/DB analysis to an offline process. Use a pod-local `trace_dir`. NPU only. Distributed finalization barriers run for all Ascend profiles. |
 
 ### ChannelLossConfig
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -340,6 +340,7 @@ NPU validation runs at two times:
 | with_stack | `bool` | `True` | Record stack traces. |
 | with_modules | `bool` | `False` | Record module hierarchy in profiler traces. |
 | rank0_only | `bool` | `True` | Profile rank 0 only. |
+| npu_offline_analysis | `bool` | `False` | Set Ascend `analyse_flag=False`, synchronize distributed finalization, and defer trace analysis to an offline process. Use a pod-local `trace_dir`. NPU only. |
 
 ### ChannelLossConfig
 

--- a/tasks/deprecated_task/train_flux.py
+++ b/tasks/deprecated_task/train_flux.py
@@ -154,6 +154,10 @@ def get_param_groups(model: torch.nn.Module, default_lr: float, vit_lr: float):
 
 def main():
     args = parse_args(Arguments)
+    if args.train.profile.npu_offline_analysis:
+        raise ValueError(
+            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
+        )
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend())
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)

--- a/tasks/deprecated_task/train_qwen_vl.py
+++ b/tasks/deprecated_task/train_qwen_vl.py
@@ -98,6 +98,10 @@ class Arguments(VeOmniArguments):
 
 def main():
     args = parse_args(Arguments)
+    if args.train.profile.npu_offline_analysis:
+        raise ValueError(
+            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
+        )
     logger.info(f"Process rank: {args.train.global_rank}, world size: {args.train.world_size}")
     logger.info_rank0(json.dumps(asdict(args), indent=2))
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")

--- a/tasks/deprecated_task/train_torch.py
+++ b/tasks/deprecated_task/train_torch.py
@@ -50,6 +50,10 @@ def main():
     dist.init_process_group(backend=get_dist_comm_backend(), timeout=pg_nccl_timeout)
 
     args = parse_args(VeOmniArguments)
+    if args.train.profile.npu_offline_analysis:
+        raise ValueError(
+            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
+        )
     logger.info(f"Process rank: {args.train.global_rank}, world size: {args.train.world_size}")
     logger.info_rank0(json.dumps(asdict(args), indent=2))
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")

--- a/tasks/deprecated_task/train_wan.py
+++ b/tasks/deprecated_task/train_wan.py
@@ -90,6 +90,10 @@ def get_param_groups(model: torch.nn.Module, default_lr: float, vit_lr: float):
 
 def main():
     args = parse_args(Arguments)
+    if args.train.profile.npu_offline_analysis:
+        raise ValueError(
+            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
+        )
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend())
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -296,19 +296,6 @@ def main():
         model_assets = [model_config, processor]
         save_model_assets(args.train.checkpoint.model_assets_dir, model_assets)
 
-    if args.train.profile.this_rank:
-        profiler = helper.create_profiler(
-            start_step=args.train.profile.start_step,
-            end_step=args.train.profile.end_step,
-            trace_dir=args.train.profile.trace_dir,
-            record_shapes=args.train.profile.record_shapes,
-            profile_memory=args.train.profile.profile_memory,
-            with_stack=args.train.profile.with_stack,
-            with_modules=args.train.profile.with_modules,
-            global_rank=args.train.global_rank,
-        )
-        profiler.start()
-
     start_epoch, start_step, global_step = 0, 0, 0
     save_checkpoint_path = None
     environ_meter = helper.EnvironMeter(
@@ -337,6 +324,30 @@ def main():
 
         dist.barrier()
         logger.info_rank0(f"Load distributed checkpoint from {args.train.checkpoint.load_path} successfully!")
+
+    profiler = None
+    profile_active = False
+    if args.train.profile.enable:
+        first_profile_step = max(args.train.profile.start_step, global_step + 1)
+        profile_active = first_profile_step < args.train.profile.end_step
+        if not profile_active:
+            logger.warning_rank0(
+                f"Profiling window [{args.train.profile.start_step}, {args.train.profile.end_step}) "
+                f"has no remaining steps after global step {global_step}; profiling is skipped."
+            )
+        elif args.train.profile.this_rank:
+            profiler = helper.create_profiler(
+                start_step=first_profile_step - global_step,
+                end_step=args.train.profile.end_step - global_step,
+                trace_dir=args.train.profile.trace_dir,
+                record_shapes=args.train.profile.record_shapes,
+                profile_memory=args.train.profile.profile_memory,
+                with_stack=args.train.profile.with_stack,
+                with_modules=args.train.profile.with_modules,
+                global_rank=args.train.global_rank,
+                npu_offline_analysis=args.train.profile.npu_offline_analysis,
+            )
+            profiler.start()
 
     helper.empty_cache()
     model_fwd_context, model_bwd_context = build_activation_offloading_context(
@@ -446,11 +457,24 @@ def main():
                     train_metrics.update({f"training/{k}": v for k, v in step_info.items()})
                     wandb.log(train_metrics, step=global_step)
 
-            if args.train.profile.this_rank and global_step <= args.train.profile.end_step:
+            synchronize_profile_finalize = (
+                profile_active
+                and args.train.profile.npu_offline_analysis
+                and helper.IS_NPU_AVAILABLE
+                and global_step == args.train.profile.end_step - 1
+                and dist.is_available()
+                and dist.is_initialized()
+            )
+            if synchronize_profile_finalize:
+                dist.barrier()
+
+            if profiler is not None and global_step <= args.train.profile.end_step:
                 profiler.step()
                 if global_step == args.train.profile.end_step:
                     profiler.stop()
-                    helper.upload_trace(args.train.wandb.project, args.train.wandb.name, args.train.profile.trace_dir)
+
+            if synchronize_profile_finalize:
+                dist.barrier()
 
             if args.train.checkpoint.save_steps and global_step % args.train.checkpoint.save_steps == 0:
                 helper.empty_cache()

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -457,9 +457,10 @@ def main():
                     train_metrics.update({f"training/{k}": v for k, v in step_info.items()})
                     wandb.log(train_metrics, step=global_step)
 
+            # Align with ProfileTraceCallback: barrier around Ascend finalize for
+            # both online and offline analysis so rank0 dump cannot race peers.
             synchronize_profile_finalize = (
                 profile_active
-                and args.train.profile.npu_offline_analysis
                 and helper.IS_NPU_AVAILABLE
                 and global_step == args.train.profile.end_step - 1
                 and dist.is_available()
@@ -472,6 +473,9 @@ def main():
                 profiler.step()
                 if global_step == args.train.profile.end_step:
                     profiler.stop()
+                    # Persistence/upload is owned by create_profiler.on_trace_ready
+                    # (hdfs copy / VEOMNI_UPLOAD_CMD). Do not call helper.upload_trace:
+                    # that helper was never defined on main and would AttributeError.
 
             if synchronize_profile_finalize:
                 dist.barrier()

--- a/tests/utils/test_profiler_config.py
+++ b/tests/utils/test_profiler_config.py
@@ -197,6 +197,7 @@ def test_npu_offline_analysis_reports_failed_hdfs_copy(monkeypatch, tmp_path):
     ]
 
 
+@pytest.mark.parametrize("npu_offline_analysis", [True, False])
 @pytest.mark.parametrize(
     ("this_rank", "expected_events"),
     [
@@ -204,11 +205,11 @@ def test_npu_offline_analysis_reports_failed_hdfs_copy(monkeypatch, tmp_path):
         (False, ["barrier", "barrier"]),
     ],
 )
-def test_npu_offline_analysis_synchronizes_finalization(monkeypatch, this_rank, expected_events):
+def test_npu_profile_synchronizes_finalization(monkeypatch, npu_offline_analysis, this_rank, expected_events):
     events = []
     profile_config = SimpleNamespace(
         enable=True,
-        npu_offline_analysis=True,
+        npu_offline_analysis=npu_offline_analysis,
         end_step=6,
         this_rank=this_rank,
     )
@@ -234,9 +235,9 @@ def test_npu_offline_analysis_synchronizes_finalization(monkeypatch, this_rank, 
     assert events == expected_events
 
 
-def test_npu_offline_analysis_stops_without_finalize_barrier_at_end_step(monkeypatch):
+def test_npu_profile_stops_without_finalize_barrier_at_end_step(monkeypatch):
     events = []
-    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=True, end_step=6, this_rank=True)
+    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=False, end_step=6, this_rank=True)
     callback = object.__new__(trace_callback.ProfileTraceCallback)
     callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
     callback._profile_active = True
@@ -252,7 +253,7 @@ def test_npu_offline_analysis_stops_without_finalize_barrier_at_end_step(monkeyp
     assert events == ["step", "stop"]
 
 
-def test_npu_offline_analysis_does_not_synchronize_before_finalize_step(monkeypatch):
+def test_npu_profile_does_not_synchronize_before_finalize_step(monkeypatch):
     events = []
     profile_config = SimpleNamespace(enable=True, npu_offline_analysis=True, end_step=6, this_rank=True)
     callback = object.__new__(trace_callback.ProfileTraceCallback)
@@ -266,6 +267,24 @@ def test_npu_offline_analysis_does_not_synchronize_before_finalize_step(monkeypa
     monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
 
     callback.on_step_end(TrainerState(global_step=4))
+
+    assert events == ["step"]
+
+
+def test_cuda_profile_does_not_use_npu_finalize_barrier(monkeypatch):
+    events = []
+    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=False, end_step=6, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+    callback._profile_active = True
+    callback.profiler = SimpleNamespace(step=lambda: events.append("step"), stop=lambda: events.append("stop"))
+
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", False)
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+
+    callback.on_step_end(TrainerState(global_step=5))
 
     assert events == ["step"]
 

--- a/tests/utils/test_profiler_config.py
+++ b/tests/utils/test_profiler_config.py
@@ -1,0 +1,340 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from veomni.arguments.arguments_types import ProfileConfig
+from veomni.trainer.callbacks import trace_callback
+from veomni.trainer.callbacks.base import TrainerState
+from veomni.utils import helper
+
+
+class _FakeNpuProfiler:
+    class ProfilerActivity:
+        CPU = "cpu"
+        NPU = "npu"
+
+    class AiCMetrics:
+        PipeUtilization = "pipe_utilization"
+
+    class ProfilerLevel:
+        Level1 = "level1"
+
+    def __init__(self):
+        self.trace_handler_calls = []
+
+    def tensorboard_trace_handler(self, trace_dir, **kwargs):
+        self.trace_handler_calls.append((trace_dir, kwargs))
+        return lambda profiler: None
+
+    def _ExperimentalConfig(self, **kwargs):
+        return kwargs
+
+    def schedule(self, **kwargs):
+        return kwargs
+
+    def profile(self, **kwargs):
+        return SimpleNamespace(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("offline_analysis", "expected_kwargs"),
+    [(False, {}), (True, {"analyse_flag": False})],
+)
+def test_npu_offline_analysis_controls_trace_handler(monkeypatch, tmp_path, offline_analysis, expected_kwargs):
+    fake_profiler = _FakeNpuProfiler()
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+
+    helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=offline_analysis,
+    )
+
+    assert fake_profiler.trace_handler_calls == [(str(tmp_path), expected_kwargs)]
+
+
+def test_npu_offline_analysis_is_disabled_by_default():
+    assert ProfileConfig().npu_offline_analysis is False
+
+
+def test_npu_offline_analysis_does_not_record_unused_memory_history(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=True,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=True,
+    )
+
+    assert not isinstance(profiler, helper.ProfilerWithMem)
+
+
+def test_npu_offline_analysis_skips_file_upload_hook(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    warnings = []
+    upload_calls = []
+    raw_dir = tmp_path / "rank0_ascend_pt"
+    raw_dir.mkdir()
+
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper, "get_torch_device", lambda: pytest.fail("offline mode must not dump memory snapshots"))
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+    monkeypatch.setattr(helper.subprocess, "run", lambda *args, **kwargs: upload_calls.append((args, kwargs)))
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=True,
+    )
+    profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
+
+    assert upload_calls == []
+    assert warnings == [
+        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
+        f"Copy {raw_dir} to durable storage outside the training process, then parse it offline."
+    ]
+
+
+def test_npu_offline_analysis_reports_automatic_hdfs_copy(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    warnings = []
+    copies = []
+    trace_dir = "hdfs://haruna/profile"
+    raw_dir = tmp_path / "rank0_ascend_pt"
+    raw_dir.mkdir()
+
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper.hdfs_io, "makedirs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(helper, "copy", lambda source, target: (copies.append((source, target)), True)[1])
+    monkeypatch.setattr(helper, "get_torch_device", lambda: pytest.fail("offline mode must not dump memory snapshots"))
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=trace_dir,
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=True,
+    )
+    profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
+
+    assert copies == [(str(raw_dir), trace_dir)]
+    assert warnings == [
+        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
+        f"The raw directory has already been copied to {trace_dir}; parse it offline."
+    ]
+
+
+def test_npu_offline_analysis_reports_failed_hdfs_copy(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    warnings = []
+    trace_dir = "hdfs://haruna/profile"
+    raw_dir = tmp_path / "rank0_ascend_pt"
+    raw_dir.mkdir()
+
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper.hdfs_io, "makedirs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(helper, "copy", lambda source, target: False)
+    monkeypatch.setattr(helper, "get_torch_device", lambda: pytest.fail("offline mode must not dump memory snapshots"))
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=trace_dir,
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=True,
+    )
+    profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
+
+    assert warnings == [
+        f"Failed to copy profiling result to {trace_dir}; the raw capture remains at {raw_dir}.",
+        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory, "
+        f"and the automatic copy to {trace_dir} failed. Preserve {raw_dir} before the pod exits.",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("this_rank", "expected_events"),
+    [
+        (True, ["barrier", "step", "barrier"]),
+        (False, ["barrier", "barrier"]),
+    ],
+)
+def test_npu_offline_analysis_synchronizes_finalization(monkeypatch, this_rank, expected_events):
+    events = []
+    profile_config = SimpleNamespace(
+        enable=True,
+        npu_offline_analysis=True,
+        end_step=6,
+        this_rank=this_rank,
+    )
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+    callback._profile_active = True
+    callback.profiler = (
+        SimpleNamespace(
+            step=lambda: events.append("step"),
+            stop=lambda: events.append("stop"),
+        )
+        if this_rank
+        else None
+    )
+
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+
+    callback.on_step_end(TrainerState(global_step=5))
+
+    assert events == expected_events
+
+
+def test_npu_offline_analysis_stops_without_finalize_barrier_at_end_step(monkeypatch):
+    events = []
+    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=True, end_step=6, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+    callback._profile_active = True
+    callback.profiler = SimpleNamespace(step=lambda: events.append("step"), stop=lambda: events.append("stop"))
+
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+
+    callback.on_step_end(TrainerState(global_step=6))
+
+    assert events == ["step", "stop"]
+
+
+def test_npu_offline_analysis_does_not_synchronize_before_finalize_step(monkeypatch):
+    events = []
+    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=True, end_step=6, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+    callback._profile_active = True
+    callback.profiler = SimpleNamespace(step=lambda: events.append("step"), stop=lambda: events.append("stop"))
+
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+
+    callback.on_step_end(TrainerState(global_step=4))
+
+    assert events == ["step"]
+
+
+def test_profile_schedule_finalizes_at_end_step_minus_one():
+    handler_steps = []
+    current_global_step = [0]
+    profiler = torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU],
+        schedule=torch.profiler.schedule(wait=3, warmup=1, active=1, repeat=1),
+        on_trace_ready=lambda _: handler_steps.append(current_global_step[0]),
+        acc_events=True,
+    )
+    profiler.start()
+    for step in range(1, 6):
+        current_global_step[0] = step
+        profiler.step()
+    profiler.stop()
+
+    # create_profiler(start_step=5, end_step=6) builds wait=3,
+    # warmup=1, active=1. Exiting RECORD_AND_SAVE invokes the handler in
+    # profiler.step() at global step 5, i.e. end_step - 1.
+    assert handler_steps == [5]
+
+
+def test_profile_callback_rebases_absolute_steps_after_resume(monkeypatch, tmp_path):
+    create_calls = []
+    profiler = SimpleNamespace(start=lambda: None)
+    profile_config = SimpleNamespace(
+        enable=True,
+        start_step=5,
+        end_step=6,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        npu_offline_analysis=True,
+        this_rank=True,
+    )
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(profile=profile_config, global_rank=0))
+    )
+
+    monkeypatch.setattr(
+        trace_callback.helper,
+        "create_profiler",
+        lambda **kwargs: (create_calls.append(kwargs), profiler)[1],
+    )
+
+    callback.on_train_begin(TrainerState(global_step=4))
+
+    assert callback._profile_active is True
+    assert create_calls[0]["start_step"] == 1
+    assert create_calls[0]["end_step"] == 2
+
+
+def test_profile_callback_skips_elapsed_window(monkeypatch):
+    warnings = []
+    profile_config = SimpleNamespace(enable=True, start_step=5, end_step=6, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+
+    monkeypatch.setattr(trace_callback.logger, "warning_rank0", warnings.append)
+    monkeypatch.setattr(trace_callback.helper, "create_profiler", lambda **kwargs: pytest.fail("window elapsed"))
+
+    callback.on_train_begin(TrainerState(global_step=5))
+
+    assert callback._profile_active is False
+    assert callback.profiler is None
+    assert warnings == ["Profiling window [5, 6) has no remaining steps after global step 5; profiling is skipped."]

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -217,6 +217,15 @@ class ProfileConfig:
             "help": "whether to profile rank0 only. When false, every rank will be profiled; Please expect many files to save, which can be slow and take a lot of disk space."
         },
     )
+    npu_offline_analysis: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Defer online Ascend analysis by setting analyse_flag=False, so training only finalizes raw data. "
+                "Parse the raw data offline with torch_npu or msprof. This option only affects NPU profiling."
+            )
+        },
+    )
 
 
 @dataclass

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -194,19 +194,19 @@ class ProfileTraceCallback(Callback):
 
     def on_step_end(self, state: TrainerState, **kwargs) -> None:
         args: "VeOmniArguments" = self.trainer.args
+        # on_trace_ready runs synchronously when the schedule exits its active
+        # window, in profiler.step() at global step end_step - 1. Keep
+        # non-profiled ranks out of the next collective until NPU finalization
+        # (raw dump and optional online analyse) completes on the profiled rank(s).
+        # This applies to both online and offline Ascend analysis.
         synchronize_finalize = (
             self._profile_active
-            and args.train.profile.npu_offline_analysis
             and helper.IS_NPU_AVAILABLE
             and state.global_step == args.train.profile.end_step - 1
             and dist.is_available()
             and dist.is_initialized()
         )
 
-        # on_trace_ready runs synchronously when the schedule exits its active
-        # window, in profiler.step() at global step end_step - 1. Keep
-        # non-profiled ranks out of the next collective until raw finalization
-        # completes on the profiled rank(s).
         if synchronize_finalize:
             dist.barrier()
 

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -15,6 +15,7 @@
 import time
 from typing import TYPE_CHECKING, Any, Dict, List
 
+import torch.distributed as dist
 from tqdm import trange
 
 from ...utils import helper
@@ -160,27 +161,64 @@ class WandbTraceCallback(Callback):
 class ProfileTraceCallback(Callback):
     def on_train_begin(self, state: TrainerState, **kwargs) -> None:
         args: "VeOmniArguments" = self.trainer.args
+        self.profiler = None
+        self._profile_active = False
+        if not args.train.profile.enable:
+            return
+
+        # ProfileConfig uses absolute global steps, while torch profiler's
+        # schedule starts at zero for each process. Rebase the remaining window
+        # when resuming from a checkpoint or hot-updating a running job.
+        first_profile_step = max(args.train.profile.start_step, state.global_step + 1)
+        if first_profile_step >= args.train.profile.end_step:
+            logger.warning_rank0(
+                f"Profiling window [{args.train.profile.start_step}, {args.train.profile.end_step}) "
+                f"has no remaining steps after global step {state.global_step}; profiling is skipped."
+            )
+            return
+
+        self._profile_active = True
         if args.train.profile.this_rank:
             self.profiler = helper.create_profiler(
-                start_step=args.train.profile.start_step,
-                end_step=args.train.profile.end_step,
+                start_step=first_profile_step - state.global_step,
+                end_step=args.train.profile.end_step - state.global_step,
                 trace_dir=args.train.profile.trace_dir,
                 record_shapes=args.train.profile.record_shapes,
                 profile_memory=args.train.profile.profile_memory,
                 with_stack=args.train.profile.with_stack,
                 with_modules=args.train.profile.with_modules,
                 global_rank=args.train.global_rank,
+                npu_offline_analysis=args.train.profile.npu_offline_analysis,
             )
             self.profiler.start()
 
     def on_step_end(self, state: TrainerState, **kwargs) -> None:
         args: "VeOmniArguments" = self.trainer.args
-        if args.train.profile.this_rank:
+        synchronize_finalize = (
+            self._profile_active
+            and args.train.profile.npu_offline_analysis
+            and helper.IS_NPU_AVAILABLE
+            and state.global_step == args.train.profile.end_step - 1
+            and dist.is_available()
+            and dist.is_initialized()
+        )
+
+        # on_trace_ready runs synchronously when the schedule exits its active
+        # window, in profiler.step() at global step end_step - 1. Keep
+        # non-profiled ranks out of the next collective until raw finalization
+        # completes on the profiled rank(s).
+        if synchronize_finalize:
+            dist.barrier()
+
+        if self.profiler is not None:
             if state.global_step <= args.train.profile.end_step:
                 self.profiler.step()
 
             if state.global_step == args.train.profile.end_step:
                 self.profiler.stop()
+
+        if synchronize_finalize:
+            dist.barrier()
 
 
 class EnvironMeterCallback(Callback):

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -671,6 +671,7 @@ def create_profiler(
     with_stack: bool,
     with_modules: bool,
     global_rank: int,
+    npu_offline_analysis: bool = False,
 ):
     """
     Creates a profiler to record the CPU and CUDA activities. Default export to trace.json.
@@ -685,10 +686,12 @@ def create_profiler(
         record_shapes (bool): Whether to record the shapes of the tensors.
         profile_memory (bool): Whether to profile the memory usage.
         with_stack (bool): Whether to include the stack trace.
+        npu_offline_analysis (bool): Whether to defer Ascend profiler analysis to an offline process.
     """
 
     def handler_fn(p):
         time = int(datetime.datetime.now().timestamp())
+        hdfs_copy_succeeded = False
 
         trace_file_extention = "pt.trace.json.gz"
         gpu_memory_file_extension = "pkl"
@@ -711,14 +714,37 @@ def create_profiler(
             p.export_chrome_trace(trace_file)
         logger.info(f"Profiling result saved at {trace_file}.")
 
-        get_torch_device().memory._dump_snapshot(gpu_memory_file)
-        logger.info(f"Profiling memory visualization saved at {gpu_memory_file}.")
+        if not (IS_NPU_AVAILABLE and npu_offline_analysis):
+            get_torch_device().memory._dump_snapshot(gpu_memory_file)
+            logger.info(f"Profiling memory visualization saved at {gpu_memory_file}.")
 
         if trace_dir.startswith("hdfs://"):
-            copy(trace_file, trace_dir)
-            logger.info(f"Profiling result uploaded to {trace_dir}.")
+            hdfs_copy_succeeded = bool(copy(trace_file, trace_dir))
+            if hdfs_copy_succeeded:
+                logger.info(f"Profiling result uploaded to {trace_dir}.")
+            else:
+                logger.warning(
+                    f"Failed to copy profiling result to {trace_dir}; the raw capture remains at {trace_file}."
+                )
 
-        if VEOMNI_UPLOAD_CMD:
+        if VEOMNI_UPLOAD_CMD and IS_NPU_AVAILABLE and npu_offline_analysis:
+            if trace_dir.startswith("hdfs://"):
+                if hdfs_copy_succeeded:
+                    logger.warning(
+                        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
+                        f"The raw directory has already been copied to {trace_dir}; parse it offline."
+                    )
+                else:
+                    logger.warning(
+                        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory, "
+                        f"and the automatic copy to {trace_dir} failed. Preserve {trace_file} before the pod exits."
+                    )
+            else:
+                logger.warning(
+                    "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
+                    f"Copy {trace_file} to durable storage outside the training process, then parse it offline."
+                )
+        elif VEOMNI_UPLOAD_CMD:
             try:
                 logger.info_rank0(f"upload trace file {trace_file}")
                 if IS_NPU_AVAILABLE:
@@ -738,8 +764,10 @@ def create_profiler(
     if IS_NPU_AVAILABLE:
         profiler_module = torch_npu.profiler
         activities = [profiler_module.ProfilerActivity.CPU, profiler_module.ProfilerActivity.NPU]
+        trace_handler_kwargs = {"analyse_flag": False} if npu_offline_analysis else {}
         npu_trace_handler = torch_npu.profiler.tensorboard_trace_handler(
-            CACHE_DIR if trace_dir.startswith("hdfs://") else trace_dir
+            CACHE_DIR if trace_dir.startswith("hdfs://") else trace_dir,
+            **trace_handler_kwargs,
         )
         experimental_config = torch_npu.profiler._ExperimentalConfig(
             aic_metrics=torch_npu.profiler.AiCMetrics.PipeUtilization,
@@ -772,7 +800,7 @@ def create_profiler(
         with_stack=with_stack,
         experimental_config=experimental_config,
     )
-    if (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE) and profile_memory:
+    if (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE) and profile_memory and not (IS_NPU_AVAILABLE and npu_offline_analysis):
         return ProfilerWithMem(base_profiler)
     else:
         return base_profiler


### PR DESCRIPTION
### What does this PR do?

> Adds an opt-in Ascend raw-only profiling mode so large NPU traces can be analyzed outside the training process. Distributed finalization is synchronized, resumed global-step windows are rebased, and large captures can avoid training-side Chrome export and allocator-snapshot overhead.

### Checklist Before Starting

- Searched the local upstream history for an existing NPU offline-analysis option; none was present.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

> - CPU Torch focused test: `pytest -q tests/utils/test_profiler_config.py`: 14 passed.
> - `make quality` with the available Ruff environment: passed (602 files formatted).
> - `git diff --check`: passed.
> - Full `pytest tests/ -q` cannot collect in this checkout because its local `.venv` has no `torch`: 94 pre-change collection errors and the same errors plus the new test module after the change. The focused test passes in the available CPU Torch environment.
> - Validated the underlying torch_npu behavior on a 16-rank Ascend 910B2 Qwen MoE workload: raw finalization completed, exact-path offline CANN export produced a 6.63 GB Chrome/Perfetto timeline, and training-side synchronous analysis was avoided.

### API and Usage Example

```bash
--train.profile.enable true \
--train.profile.start_step 5 \
--train.profile.end_step 6 \
--train.profile.trace_dir /tmp/veomni_npu_profile \
--train.profile.rank0_only true \
--train.profile.record_shapes false \
--train.profile.profile_memory false \
--train.profile.with_stack false \
--train.profile.with_modules false \
--train.profile.npu_offline_analysis true
```

The default remains `false`, so existing GPU and NPU profiling behavior is unchanged.

### Design & Code Changes

> - Add `train.profile.npu_offline_analysis` with a backward-compatible `False` default.
> - Pass `analyse_flag=False` to `torch_npu.profiler.tensorboard_trace_handler` only when the option is enabled.
> - Synchronize all distributed ranks around raw finalization so rank 0 cannot lag into the next collective.
> - Rebase absolute profile steps after checkpoint resume/hot update and skip elapsed windows.
> - Avoid the unused allocator-memory-history wrapper in NPU raw-only mode.
> - Distinguish local and HDFS persistence, check HDFS copy failures, and skip the file-oriented `VEOMNI_UPLOAD_CMD` in raw-only mode.
> - Wire the Omni trainer and fail fast in deprecated standalone entrypoints that cannot honor the synchronization contract.
> - Document the safe option combination and add focused coverage for handler, barrier, resume, memory, upload, and HDFS boundaries.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added/updated documentation
- [x] Added focused unit tests; hardware validation is described above
