### PR TITLE
[perf, config, docs, trainer, task, ci] feat: defer NPU profiler analysis

### DIFF
--- a/.agents/skills/veomni-profile/SKILL.md
+++ b/.agents/skills/veomni-profile/SKILL.md
@@ -89,6 +89,7 @@ train:
     with_stack: true      # capture Python call stacks
     with_modules: true    # annotate with nn.Module names
     rank0_only: true      # profile only rank 0 to reduce overhead
+    npu_analysis_mode: offline  # Ascend only: offline | async
 ```
 
 Or pass via CLI overrides: `--train.profile.enable=true --train.profile.start_step=5 ...`
@@ -149,4 +150,6 @@ On NPU, `create_profiler()` uses `torch_npu.profiler` instead of `torch.profiler
 - Output format includes AiC (Ascend insight Counters) metrics.
 - Memory profiling uses NPU-specific APIs.
 - Analysis tools differ — use Ascend Insight instead of Chrome tracing.
+- `npu_analysis_mode: offline` leaves finalized raw data for later parsing; `async` runs official online analysis in torch_npu's background process pool.
+- `async` requires a pod-local trace directory and may contend with training for CPU/disk. Use `offline` for the smallest training-side critical path.
 - Always guard NPU-specific analysis code with `is_torch_npu_available()`.

--- a/.agents/skills/veomni-profile/SKILL.md
+++ b/.agents/skills/veomni-profile/SKILL.md
@@ -15,6 +15,7 @@ Key components:
 | `VeomniFlopsCounter` | `veomni/utils/count_flops.py` | Analytical FLOPs/MFU computation per model family |
 | `EnvironMeter` | `veomni/utils/helper.py` | Step-level throughput metrics (tokens/s, FLOPs, MFU) |
 | `merge_chrome_trace.py` | `scripts/profile/merge_chrome_trace.py` | Merge multi-rank Chrome traces for unified viewing |
+| `npu_offline_postprocess` | `veomni/utils/npu_offline_postprocess.py` | Async Ascend offline analyse / durable copy / Merlin upload sidecar |
 
 Output formats:
 - **Chrome trace**: `veomni_rank{R}_{timestamp}.pt.trace.json.gz` — viewable in `chrome://tracing` or Perfetto

--- a/docs/hardware_support/profiling_analysis.md
+++ b/docs/hardware_support/profiling_analysis.md
@@ -19,6 +19,7 @@ VeOmni's profiling configuration is located under the `train.profile.*` namespac
 | with_stack | bool | True | Whether to record stack traces |
 | with_modules | bool | False | Whether to record module hierarchy in profiling traces |
 | rank0_only | bool | True | Whether to profile only rank 0 |
+| npu_offline_analysis | bool | False | Whether to finalize Ascend raw data during training and analyze it offline |
 
 ### Configuration Items That May Affect Performance
 
@@ -28,6 +29,7 @@ The following configuration items will impact training performance and need to b
 - **profile_memory**: Enabling memory profiling adds additional overhead
 - **with_stack**: Recording stack traces significantly increases profiling overhead
 - **rank0_only**: When set to False, all ranks will be profiled, generating a large number of files and consuming significant disk space and time
+- **npu_offline_analysis**: When set to True on Ascend, the training process finalizes raw profiling data without generating the Chrome trace. Parse the finalized `*_ascend_pt` directory later with the torch_npu offline analysis API or `msprof`. This avoids blocking the training step on a large trace export.
 
 ### Typical Configuration Method
 
@@ -41,7 +43,42 @@ train:
         end_step: 6
         record_shapes: true
         trace_dir: ./profiling
+        npu_offline_analysis: true
 ```
+
+The same option can be enabled from the command line:
+
+```bash
+--train.profile.enable true \
+--train.profile.start_step 5 \
+--train.profile.end_step 6 \
+--train.profile.trace_dir /tmp/veomni_npu_profile \
+--train.profile.rank0_only true \
+--train.profile.record_shapes false \
+--train.profile.profile_memory false \
+--train.profile.with_stack false \
+--train.profile.with_modules false \
+--train.profile.npu_offline_analysis true
+```
+
+Use pod-local storage for large Ascend captures, then copy the finalized raw directory to durable storage before parsing it offline.
+
+For distributed Ascend training, use the following options together:
+
+```yaml
+train:
+  profile:
+    enable: true
+    rank0_only: true
+    npu_offline_analysis: true
+    trace_dir: /tmp/veomni_npu_profile
+```
+
+VeOmni synchronizes all ranks immediately before and after the final profiler step on Ascend (both online and offline analysis). This prevents non-profiled ranks from entering the next collective while rank 0 finalizes its capture. Prefer `npu_offline_analysis: true` so that barrier only covers raw finalization rather than a long Chrome/DB export. All ranks must execute the profile callback at the same global step. `start_step` and `end_step` are absolute global steps; VeOmni rebases the remaining schedule after checkpoint resume or a hot update and skips a window that has already elapsed.
+
+Using an `hdfs://` trace directory is supported, but not recommended for large Ascend captures: it still copies the raw directory synchronously before releasing the other ranks and can therefore stall training. Prefer `/tmp` or another pod-local SSD path, then copy the finalized `*_ascend_pt` directory to durable storage from a separate process.
+
+The current trainer callback and `tasks/omni/train_omni_model.py` support this option. Deprecated standalone training entrypoints reject it explicitly instead of falling back to online analysis.
 
 ## Profiling Analysis Tool - MindStudio Insight
 

--- a/docs/hardware_support/profiling_analysis.md
+++ b/docs/hardware_support/profiling_analysis.md
@@ -19,7 +19,7 @@ VeOmni's profiling configuration is located under the `train.profile.*` namespac
 | with_stack | bool | True | Whether to record stack traces |
 | with_modules | bool | False | Whether to record module hierarchy in profiling traces |
 | rank0_only | bool | True | Whether to profile only rank 0 |
-| npu_offline_analysis | bool | False | Whether to finalize Ascend raw data during training and analyze it offline |
+| npu_analysis_mode | `offline` \| `async` | `offline` | How Ascend trace analysis runs after raw finalization |
 
 ### Configuration Items That May Affect Performance
 
@@ -29,7 +29,9 @@ The following configuration items will impact training performance and need to b
 - **profile_memory**: Enabling memory profiling adds additional overhead
 - **with_stack**: Recording stack traces significantly increases profiling overhead
 - **rank0_only**: When set to False, all ranks will be profiled, generating a large number of files and consuming significant disk space and time
-- **npu_offline_analysis**: When set to True on Ascend, the training process finalizes raw profiling data without generating the Chrome trace. Parse the finalized `*_ascend_pt` directory later with the torch_npu offline analysis API or `msprof`. This avoids blocking the training step on a large trace export.
+- **npu_analysis_mode**:
+  - `offline` finalizes only the raw `*_ascend_pt` capture during training. Parse it later with `torch_npu`, `msprof`, or the VeOmni postprocessor. This is the default and safest mode for large captures.
+  - `async` calls the official torch_npu online handler with `analyse_flag=True, async_mode=True`. Raw finalization and parser submission are synchronous, but Chrome/DB analysis continues in torch_npu's process pool while training advances.
 
 ### Typical Configuration Method
 
@@ -43,7 +45,7 @@ train:
         end_step: 6
         record_shapes: true
         trace_dir: ./profiling
-        npu_offline_analysis: true
+        npu_analysis_mode: offline  # offline | async
 ```
 
 The same option can be enabled from the command line:
@@ -58,19 +60,21 @@ The same option can be enabled from the command line:
 --train.profile.profile_memory false \
 --train.profile.with_stack false \
 --train.profile.with_modules false \
---train.profile.npu_offline_analysis true
+--train.profile.npu_analysis_mode async
 ```
 
 Use pod-local storage for large Ascend captures, then copy / parse / upload outside the training barrier.
 
-VeOmni can spawn an async sidecar after raw finalization:
+In `offline` mode, VeOmni can spawn a detached postprocess sidecar after raw finalization:
 
 | Env | Effect |
 |-----|--------|
 | `VEOMNI_UPLOAD_CMD=...` | Auto-spawn sidecar: analyse → run the command on `trace_view.json.gz` (`{trace}` placeholder supported) |
 | `VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD=1` | Auto-spawn sidecar: analyse → `merlin-cli profiling upload` (Perfetto; job/trial inferred from Merlin env) |
-| `VEOMNI_NPU_OFFLINE_POSTPROCESS=1` | Force-spawn sidecar (analyse; also async-copy when `trace_dir` is `hdfs://`) |
-| `VEOMNI_NPU_OFFLINE_POSTPROCESS=0` | Disable sidecar; keep sync HDFS copy and skip in-process upload |
+| `VEOMNI_NPU_OFFLINE_POSTPROCESS=1` | Force-spawn sidecar analysis; also copy when `trace_dir` is `hdfs://` |
+| `VEOMNI_NPU_OFFLINE_POSTPROCESS=0` | Disable automatic postprocessing; raw data remains pod-local, with no synchronous fallback |
+
+VeOmni waits for an automatically spawned sidecar for up to 300 seconds when training ends. A timeout is non-fatal and leaves the raw local capture in place; for very large captures, use the manual postprocess command below while the pod remains alive.
 
 Manual / external postprocess (recommended when the train pod may exit soon after capture):
 
@@ -91,15 +95,21 @@ train:
   profile:
     enable: true
     rank0_only: true
-    npu_offline_analysis: true
+    npu_analysis_mode: offline
     trace_dir: /tmp/veomni_npu_profile
 ```
 
-VeOmni synchronizes all ranks immediately before and after the final profiler step on Ascend (both online and offline analysis). This prevents non-profiled ranks from entering the next collective while rank 0 finalizes its capture. Prefer `npu_offline_analysis: true` so that barrier only covers raw finalization rather than a long Chrome/DB export. All ranks must execute the profile callback at the same global step. `start_step` and `end_step` are absolute global steps; VeOmni rebases the remaining schedule after checkpoint resume or a hot update and skips a window that has already elapsed.
+VeOmni synchronizes all ranks immediately before and after the final profiler step on Ascend. This prevents non-profiled ranks from entering the next collective while rank 0 finalizes its capture. In both modes the barrier covers raw finalization; in `async` it also covers the short process-pool submission, never the full analysis. All ranks must execute the profile callback at the same global step. `start_step` and `end_step` are absolute global steps; VeOmni rebases the remaining schedule after checkpoint resume or a hot update and skips a window that has already elapsed.
 
-Using an `hdfs://` trace directory is supported, but not recommended for large Ascend captures unless the async sidecar is enabled (`VEOMNI_UPLOAD_CMD` / `VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD=1` / `VEOMNI_NPU_OFFLINE_POSTPROCESS=1`): without the sidecar, VeOmni still copies the raw directory synchronously before releasing the other ranks. Prefer `/tmp` or another pod-local SSD path, then let the sidecar (or a separate process) copy / analyse / upload.
+Use `/tmp` or another pod-local SSD for `async`: automatic HDFS copy/upload is intentionally rejected or skipped because the background parser may still be writing its outputs. Wait for training to exit, then copy or upload the completed trace.
 
-The current trainer callback and `tasks/omni/train_omni_model.py` support this option. Deprecated standalone training entrypoints reject it explicitly instead of falling back to online analysis.
+An `hdfs://` trace directory is supported in `offline` mode. VeOmni captures locally and automatically starts a sidecar to copy the raw directory; it never falls back to copying a large directory inside the distributed finalization barrier. If sidecar startup fails or is disabled, the raw local path is logged for recovery.
+
+Async analysis can compete with training for host CPU and disk bandwidth, and torch_npu waits for its process pool during interpreter exit. Use `offline` for the lowest training interference or very large traces. If the training process is a multiprocessing daemon, VeOmni logs a warning and safely falls back from `async` to `offline` because torch_npu refuses daemon-process analysis.
+
+The former `npu_offline_analysis: true` setting remains as a deprecated alias for `npu_analysis_mode: offline`. Explicit `npu_offline_analysis: false` is rejected because it selected the removed synchronous online parser; choose `async` or `offline` explicitly.
+
+The current trainer callback and `tasks/omni/train_omni_model.py` support both modes. Deprecated standalone training entrypoints reject NPU profiling explicitly because they cannot honor the distributed synchronization contract.
 
 ## Profiling Analysis Tool - MindStudio Insight
 

--- a/docs/hardware_support/profiling_analysis.md
+++ b/docs/hardware_support/profiling_analysis.md
@@ -61,7 +61,28 @@ The same option can be enabled from the command line:
 --train.profile.npu_offline_analysis true
 ```
 
-Use pod-local storage for large Ascend captures, then copy the finalized raw directory to durable storage before parsing it offline.
+Use pod-local storage for large Ascend captures, then copy / parse / upload outside the training barrier.
+
+VeOmni can spawn an async sidecar after raw finalization:
+
+| Env | Effect |
+|-----|--------|
+| `VEOMNI_UPLOAD_CMD=...` | Auto-spawn sidecar: analyse → run the command on `trace_view.json.gz` (`{trace}` placeholder supported) |
+| `VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD=1` | Auto-spawn sidecar: analyse → `merlin-cli profiling upload` (Perfetto; job/trial inferred from Merlin env) |
+| `VEOMNI_NPU_OFFLINE_POSTPROCESS=1` | Force-spawn sidecar (analyse; also async-copy when `trace_dir` is `hdfs://`) |
+| `VEOMNI_NPU_OFFLINE_POSTPROCESS=0` | Disable sidecar; keep sync HDFS copy and skip in-process upload |
+
+Manual / external postprocess (recommended when the train pod may exit soon after capture):
+
+```bash
+python -m veomni.utils.npu_offline_postprocess \
+  --raw-dir /tmp/veomni_npu_profile \
+  --copy-to hdfs://haruna/.../profile/ \
+  --analyse \
+  --merlin-upload
+```
+
+Sidecar logs are written next to the raw directory as `veomni_npu_offline_postprocess.log`.
 
 For distributed Ascend training, use the following options together:
 
@@ -76,7 +97,7 @@ train:
 
 VeOmni synchronizes all ranks immediately before and after the final profiler step on Ascend (both online and offline analysis). This prevents non-profiled ranks from entering the next collective while rank 0 finalizes its capture. Prefer `npu_offline_analysis: true` so that barrier only covers raw finalization rather than a long Chrome/DB export. All ranks must execute the profile callback at the same global step. `start_step` and `end_step` are absolute global steps; VeOmni rebases the remaining schedule after checkpoint resume or a hot update and skips a window that has already elapsed.
 
-Using an `hdfs://` trace directory is supported, but not recommended for large Ascend captures: it still copies the raw directory synchronously before releasing the other ranks and can therefore stall training. Prefer `/tmp` or another pod-local SSD path, then copy the finalized `*_ascend_pt` directory to durable storage from a separate process.
+Using an `hdfs://` trace directory is supported, but not recommended for large Ascend captures unless the async sidecar is enabled (`VEOMNI_UPLOAD_CMD` / `VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD=1` / `VEOMNI_NPU_OFFLINE_POSTPROCESS=1`): without the sidecar, VeOmni still copies the raw directory synchronously before releasing the other ranks. Prefer `/tmp` or another pod-local SSD path, then let the sidecar (or a separate process) copy / analyse / upload.
 
 The current trainer callback and `tasks/omni/train_omni_model.py` support this option. Deprecated standalone training entrypoints reject it explicitly instead of falling back to online analysis.
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -340,6 +340,7 @@ NPU validation runs at two times:
 | with_stack | `bool` | `True` | Record stack traces. |
 | with_modules | `bool` | `False` | Record module hierarchy in profiler traces. |
 | rank0_only | `bool` | `True` | Profile rank 0 only. |
+| npu_offline_analysis | `bool` | `False` | Set Ascend `analyse_flag=False` and defer Chrome/DB analysis to an offline process. Use a pod-local `trace_dir`. NPU only. Distributed finalization barriers run for all Ascend profiles. |
 
 ### ChannelLossConfig
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -340,7 +340,7 @@ NPU validation runs at two times:
 | with_stack | `bool` | `True` | Record stack traces. |
 | with_modules | `bool` | `False` | Record module hierarchy in profiler traces. |
 | rank0_only | `bool` | `True` | Profile rank 0 only. |
-| npu_offline_analysis | `bool` | `False` | Set Ascend `analyse_flag=False` and defer Chrome/DB analysis to an offline process. Use a pod-local `trace_dir`. NPU only. Distributed finalization barriers run for all Ascend profiles. |
+| npu_offline_analysis | `bool` | `False` | Set Ascend `analyse_flag=False` and defer Chrome/DB analysis to an offline process. Use a pod-local `trace_dir`. NPU only. Distributed finalization barriers run for all Ascend profiles. With `VEOMNI_UPLOAD_CMD` or `VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD=1`, VeOmni spawns an async sidecar (`python -m veomni.utils.npu_offline_postprocess`) for analyse/copy/upload so training is not blocked. |
 
 ### ChannelLossConfig
 

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -340,7 +340,8 @@ NPU validation runs at two times:
 | with_stack | `bool` | `True` | Record stack traces. |
 | with_modules | `bool` | `False` | Record module hierarchy in profiler traces. |
 | rank0_only | `bool` | `True` | Profile rank 0 only. |
-| npu_offline_analysis | `bool` | `False` | Set Ascend `analyse_flag=False` and defer Chrome/DB analysis to an offline process. Use a pod-local `trace_dir`. NPU only. Distributed finalization barriers run for all Ascend profiles. With `VEOMNI_UPLOAD_CMD` or `VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD=1`, VeOmni spawns an async sidecar (`python -m veomni.utils.npu_offline_postprocess`) for analyse/copy/upload so training is not blocked. |
+| npu_analysis_mode | `Literal["offline", "async"]` | `"offline"` | Ascend only. `offline` finalizes raw data for later postprocessing; `async` uses torch_npu's online process pool (`analyse_flag=True, async_mode=True`). Use a pod-local directory for `async`. Distributed barriers cover raw finalization and handler submission, not background analysis. |
+| npu_offline_analysis | `Optional[bool]` | `None` | Deprecated migration alias. `true` maps to `npu_analysis_mode="offline"`; `false` is rejected because synchronous online parsing was removed. |
 
 ### ChannelLossConfig
 

--- a/scripts/profile/npu_offline_postprocess.py
+++ b/scripts/profile/npu_offline_postprocess.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI entry for Ascend offline profile post-processing.
+
+Prefer:
+
+    python -m veomni.utils.npu_offline_postprocess --raw-dir ... --analyse --merlin-upload
+"""
+
+from veomni.utils.npu_offline_postprocess import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/deprecated_task/train_flux.py
+++ b/tasks/deprecated_task/train_flux.py
@@ -154,10 +154,8 @@ def get_param_groups(model: torch.nn.Module, default_lr: float, vit_lr: float):
 
 def main():
     args = parse_args(Arguments)
-    if args.train.profile.npu_offline_analysis:
-        raise ValueError(
-            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
-        )
+    if args.train.profile.enable and helper.IS_NPU_AVAILABLE:
+        raise ValueError("NPU profiling is not supported by this deprecated entrypoint; use a current trainer.")
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend())
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)

--- a/tasks/deprecated_task/train_flux.py
+++ b/tasks/deprecated_task/train_flux.py
@@ -154,6 +154,10 @@ def get_param_groups(model: torch.nn.Module, default_lr: float, vit_lr: float):
 
 def main():
     args = parse_args(Arguments)
+    if args.train.profile.npu_offline_analysis:
+        raise ValueError(
+            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
+        )
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend())
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)

--- a/tasks/deprecated_task/train_qwen_vl.py
+++ b/tasks/deprecated_task/train_qwen_vl.py
@@ -98,6 +98,10 @@ class Arguments(VeOmniArguments):
 
 def main():
     args = parse_args(Arguments)
+    if args.train.profile.npu_offline_analysis:
+        raise ValueError(
+            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
+        )
     logger.info(f"Process rank: {args.train.global_rank}, world size: {args.train.world_size}")
     logger.info_rank0(json.dumps(asdict(args), indent=2))
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")

--- a/tasks/deprecated_task/train_qwen_vl.py
+++ b/tasks/deprecated_task/train_qwen_vl.py
@@ -98,10 +98,8 @@ class Arguments(VeOmniArguments):
 
 def main():
     args = parse_args(Arguments)
-    if args.train.profile.npu_offline_analysis:
-        raise ValueError(
-            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
-        )
+    if args.train.profile.enable and helper.IS_NPU_AVAILABLE:
+        raise ValueError("NPU profiling is not supported by this deprecated entrypoint; use a current trainer.")
     logger.info(f"Process rank: {args.train.global_rank}, world size: {args.train.world_size}")
     logger.info_rank0(json.dumps(asdict(args), indent=2))
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")

--- a/tasks/deprecated_task/train_torch.py
+++ b/tasks/deprecated_task/train_torch.py
@@ -50,6 +50,10 @@ def main():
     dist.init_process_group(backend=get_dist_comm_backend(), timeout=pg_nccl_timeout)
 
     args = parse_args(VeOmniArguments)
+    if args.train.profile.npu_offline_analysis:
+        raise ValueError(
+            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
+        )
     logger.info(f"Process rank: {args.train.global_rank}, world size: {args.train.world_size}")
     logger.info_rank0(json.dumps(asdict(args), indent=2))
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")

--- a/tasks/deprecated_task/train_torch.py
+++ b/tasks/deprecated_task/train_torch.py
@@ -50,10 +50,8 @@ def main():
     dist.init_process_group(backend=get_dist_comm_backend(), timeout=pg_nccl_timeout)
 
     args = parse_args(VeOmniArguments)
-    if args.train.profile.npu_offline_analysis:
-        raise ValueError(
-            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
-        )
+    if args.train.profile.enable and helper.IS_NPU_AVAILABLE:
+        raise ValueError("NPU profiling is not supported by this deprecated entrypoint; use a current trainer.")
     logger.info(f"Process rank: {args.train.global_rank}, world size: {args.train.world_size}")
     logger.info_rank0(json.dumps(asdict(args), indent=2))
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")

--- a/tasks/deprecated_task/train_wan.py
+++ b/tasks/deprecated_task/train_wan.py
@@ -90,10 +90,8 @@ def get_param_groups(model: torch.nn.Module, default_lr: float, vit_lr: float):
 
 def main():
     args = parse_args(Arguments)
-    if args.train.profile.npu_offline_analysis:
-        raise ValueError(
-            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
-        )
+    if args.train.profile.enable and helper.IS_NPU_AVAILABLE:
+        raise ValueError("NPU profiling is not supported by this deprecated entrypoint; use a current trainer.")
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend())
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)

--- a/tasks/deprecated_task/train_wan.py
+++ b/tasks/deprecated_task/train_wan.py
@@ -90,6 +90,10 @@ def get_param_groups(model: torch.nn.Module, default_lr: float, vit_lr: float):
 
 def main():
     args = parse_args(Arguments)
+    if args.train.profile.npu_offline_analysis:
+        raise ValueError(
+            "NPU offline profiling is not supported by this deprecated entrypoint; use a current trainer."
+        )
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend())
     helper.set_seed(args.train.seed, args.train.enable_full_determinism)

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -296,19 +296,6 @@ def main():
         model_assets = [model_config, processor]
         save_model_assets(args.train.checkpoint.model_assets_dir, model_assets)
 
-    if args.train.profile.this_rank:
-        profiler = helper.create_profiler(
-            start_step=args.train.profile.start_step,
-            end_step=args.train.profile.end_step,
-            trace_dir=args.train.profile.trace_dir,
-            record_shapes=args.train.profile.record_shapes,
-            profile_memory=args.train.profile.profile_memory,
-            with_stack=args.train.profile.with_stack,
-            with_modules=args.train.profile.with_modules,
-            global_rank=args.train.global_rank,
-        )
-        profiler.start()
-
     start_epoch, start_step, global_step = 0, 0, 0
     save_checkpoint_path = None
     environ_meter = helper.EnvironMeter(
@@ -337,6 +324,30 @@ def main():
 
         dist.barrier()
         logger.info_rank0(f"Load distributed checkpoint from {args.train.checkpoint.load_path} successfully!")
+
+    profiler = None
+    profile_active = False
+    if args.train.profile.enable:
+        first_profile_step = max(args.train.profile.start_step, global_step + 1)
+        profile_active = first_profile_step < args.train.profile.end_step
+        if not profile_active:
+            logger.warning_rank0(
+                f"Profiling window [{args.train.profile.start_step}, {args.train.profile.end_step}) "
+                f"has no remaining steps after global step {global_step}; profiling is skipped."
+            )
+        elif args.train.profile.this_rank:
+            profiler = helper.create_profiler(
+                start_step=first_profile_step - global_step,
+                end_step=args.train.profile.end_step - global_step,
+                trace_dir=args.train.profile.trace_dir,
+                record_shapes=args.train.profile.record_shapes,
+                profile_memory=args.train.profile.profile_memory,
+                with_stack=args.train.profile.with_stack,
+                with_modules=args.train.profile.with_modules,
+                global_rank=args.train.global_rank,
+                npu_offline_analysis=args.train.profile.npu_offline_analysis,
+            )
+            profiler.start()
 
     helper.empty_cache()
     model_fwd_context, model_bwd_context = build_activation_offloading_context(
@@ -446,11 +457,28 @@ def main():
                     train_metrics.update({f"training/{k}": v for k, v in step_info.items()})
                     wandb.log(train_metrics, step=global_step)
 
-            if args.train.profile.this_rank and global_step <= args.train.profile.end_step:
+            # Align with ProfileTraceCallback: barrier around Ascend finalize for
+            # both online and offline analysis so rank0 dump cannot race peers.
+            synchronize_profile_finalize = (
+                profile_active
+                and helper.IS_NPU_AVAILABLE
+                and global_step == args.train.profile.end_step - 1
+                and dist.is_available()
+                and dist.is_initialized()
+            )
+            if synchronize_profile_finalize:
+                dist.barrier()
+
+            if profiler is not None and global_step <= args.train.profile.end_step:
                 profiler.step()
                 if global_step == args.train.profile.end_step:
                     profiler.stop()
-                    helper.upload_trace(args.train.wandb.project, args.train.wandb.name, args.train.profile.trace_dir)
+                    # Persistence/upload is owned by create_profiler.on_trace_ready
+                    # (hdfs copy / VEOMNI_UPLOAD_CMD). Do not call helper.upload_trace:
+                    # that helper was never defined on main and would AttributeError.
+
+            if synchronize_profile_finalize:
+                dist.barrier()
 
             if args.train.checkpoint.save_steps and global_step % args.train.checkpoint.save_steps == 0:
                 helper.empty_cache()

--- a/tasks/omni/train_omni_model.py
+++ b/tasks/omni/train_omni_model.py
@@ -326,6 +326,7 @@ def main():
         logger.info_rank0(f"Load distributed checkpoint from {args.train.checkpoint.load_path} successfully!")
 
     profiler = None
+    profiler_stopped = False
     profile_active = False
     if args.train.profile.enable:
         first_profile_step = max(args.train.profile.start_step, global_step + 1)
@@ -345,7 +346,7 @@ def main():
                 with_stack=args.train.profile.with_stack,
                 with_modules=args.train.profile.with_modules,
                 global_rank=args.train.global_rank,
-                npu_offline_analysis=args.train.profile.npu_offline_analysis,
+                npu_analysis_mode=args.train.profile.npu_analysis_mode,
             )
             profiler.start()
 
@@ -457,8 +458,8 @@ def main():
                     train_metrics.update({f"training/{k}": v for k, v in step_info.items()})
                     wandb.log(train_metrics, step=global_step)
 
-            # Align with ProfileTraceCallback: barrier around Ascend finalize for
-            # both online and offline analysis so rank0 dump cannot race peers.
+            # Align with ProfileTraceCallback: barrier around Ascend raw finalize
+            # and optional async-analysis submission so rank0 cannot race peers.
             synchronize_profile_finalize = (
                 profile_active
                 and helper.IS_NPU_AVAILABLE
@@ -468,17 +469,16 @@ def main():
             )
             if synchronize_profile_finalize:
                 dist.barrier()
-
-            if profiler is not None and global_step <= args.train.profile.end_step:
-                profiler.step()
-                if global_step == args.train.profile.end_step:
-                    profiler.stop()
-                    # Persistence/upload is owned by create_profiler.on_trace_ready
-                    # (hdfs copy / VEOMNI_UPLOAD_CMD). Do not call helper.upload_trace:
-                    # that helper was never defined on main and would AttributeError.
-
-            if synchronize_profile_finalize:
-                dist.barrier()
+            try:
+                if profiler is not None and global_step <= args.train.profile.end_step:
+                    profiler.step()
+                    if global_step == args.train.profile.end_step:
+                        profiler.stop()
+                        profiler_stopped = True
+                        # Persistence/upload is owned by create_profiler.on_trace_ready.
+            finally:
+                if synchronize_profile_finalize:
+                    dist.barrier()
 
             if args.train.checkpoint.save_steps and global_step % args.train.checkpoint.save_steps == 0:
                 helper.empty_cache()
@@ -518,6 +518,21 @@ def main():
             Checkpointer.save(args.train.checkpoint.save_path, state, global_steps=global_step)
             dist.barrier()
             logger.info_rank0(f"Distributed checkpoint saved at {save_checkpoint_path} successfully!")
+
+    synchronize_profile_cleanup = (
+        profile_active and helper.IS_NPU_AVAILABLE and dist.is_available() and dist.is_initialized()
+    )
+    if synchronize_profile_cleanup:
+        dist.barrier()
+    try:
+        if profiler is not None and not profiler_stopped:
+            profiler.stop()
+            profiler_stopped = True
+    finally:
+        if synchronize_profile_cleanup:
+            dist.barrier()
+    if profiler is not None:
+        helper.wait_npu_profile_sidecars(profiler)
 
     synchronize()
     # release memory

--- a/tests/utils/test_npu_offline_postprocess.py
+++ b/tests/utils/test_npu_offline_postprocess.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from veomni.utils import npu_offline_postprocess as post
+
+
+def test_resolve_raw_dir_accepts_ascend_pt(tmp_path):
+    raw = tmp_path / "localhost_1_2_ascend_pt"
+    raw.mkdir()
+    assert post.resolve_raw_dir(raw) == raw.resolve()
+
+
+def test_resolve_raw_dir_finds_unique_child(tmp_path):
+    raw = tmp_path / "localhost_1_2_ascend_pt"
+    raw.mkdir()
+    assert post.resolve_raw_dir(tmp_path) == raw.resolve()
+
+
+def test_gzip_and_merlin_upload_cmd(tmp_path, monkeypatch):
+    raw = tmp_path / "rank0_ascend_pt"
+    out_dir = raw / "ASCEND_PROFILER_OUTPUT"
+    out_dir.mkdir(parents=True)
+    trace = out_dir / "trace_view.json"
+    trace.write_text('{"traceEvents":[]}', encoding="utf-8")
+
+    packed = post.gzip_trace(trace)
+    assert packed.is_file()
+    assert packed.name.endswith(".gz")
+
+    cmd = post.build_merlin_upload_cmd(packed, name="npu-trace")
+    assert cmd.startswith("merlin-cli profiling upload --json ")
+    payload = json.loads(cmd.split(" --json ", 1)[1])
+    assert payload["file_path"] == str(packed)
+    assert payload["asset_type"] == "perfetto"
+    assert payload["name"] == "npu-trace"
+
+
+def test_postprocess_upload_without_analyse_uses_existing_trace(tmp_path, monkeypatch):
+    raw = tmp_path / "rank0_ascend_pt"
+    out_dir = raw / "ASCEND_PROFILER_OUTPUT"
+    out_dir.mkdir(parents=True)
+    trace = out_dir / "trace_view.json"
+    trace.write_text("{}", encoding="utf-8")
+    uploads = []
+
+    monkeypatch.setattr(post, "run_upload_cmd", lambda cmd, path: uploads.append((cmd, path)))
+
+    packed = post.postprocess(raw, analyse=False, upload_cmd="upload-trace {trace}")
+    assert packed is not None
+    assert packed.name.endswith(".gz")
+    assert uploads == [("upload-trace {trace}", packed)]
+
+
+def test_postprocess_requires_action(tmp_path):
+    raw = tmp_path / "rank0_ascend_pt"
+    raw.mkdir()
+    assert post.main(["--raw-dir", str(raw)]) == 2

--- a/tests/utils/test_npu_offline_postprocess.py
+++ b/tests/utils/test_npu_offline_postprocess.py
@@ -1,10 +1,24 @@
 import json
 import shlex
+import sys
+import types
 
 import pytest
 
 from veomni.utils import hdfs_io
 from veomni.utils import npu_offline_postprocess as post
+
+
+def _install_fake_torch_npu(monkeypatch, analyse):
+    torch_npu = types.ModuleType("torch_npu")
+    profiler_package = types.ModuleType("torch_npu.profiler")
+    profiler_package.__path__ = []
+    profiler_module = types.ModuleType("torch_npu.profiler.profiler")
+    profiler_module.analyse = analyse
+    torch_npu.profiler = profiler_package
+    monkeypatch.setitem(sys.modules, "torch_npu", torch_npu)
+    monkeypatch.setitem(sys.modules, "torch_npu.profiler", profiler_package)
+    monkeypatch.setitem(sys.modules, "torch_npu.profiler.profiler", profiler_module)
 
 
 def test_resolve_raw_dir_accepts_ascend_pt(tmp_path):
@@ -34,6 +48,97 @@ def test_resolve_analyse_path_targets_only_requested_capture(tmp_path):
     sibling.mkdir()
 
     assert post.resolve_analyse_path(raw) == str(raw)
+
+
+def test_run_analyse_uses_public_torch_npu_entrypoint(tmp_path, monkeypatch):
+    raw = tmp_path / "localhost_1_2_ascend_pt"
+    raw.mkdir()
+    calls = []
+
+    def analyse(**kwargs):
+        calls.append(kwargs)
+        output = raw / "ASCEND_PROFILER_OUTPUT"
+        output.mkdir()
+        (output / "trace_view.json").write_text("[]", encoding="utf-8")
+
+    _install_fake_torch_npu(monkeypatch, analyse)
+
+    post.run_analyse(raw, max_process_number=7)
+
+    assert calls == [{"profiler_path": str(raw), "max_process_number": 7}]
+
+
+def test_run_analyse_rejects_silent_parser_failure(tmp_path, monkeypatch):
+    raw = tmp_path / "localhost_1_2_ascend_pt"
+    raw.mkdir()
+    _install_fake_torch_npu(monkeypatch, lambda **_kwargs: None)
+
+    with pytest.raises(FileNotFoundError, match="after analyse"):
+        post.run_analyse(raw)
+
+
+def test_run_analyse_rejects_empty_trace(tmp_path, monkeypatch):
+    raw = tmp_path / "localhost_1_2_ascend_pt"
+    raw.mkdir()
+
+    def analyse(**_kwargs):
+        output = raw / "ASCEND_PROFILER_OUTPUT"
+        output.mkdir()
+        (output / "trace_view.json").touch()
+
+    _install_fake_torch_npu(monkeypatch, analyse)
+
+    with pytest.raises(RuntimeError, match="empty trace"):
+        post.run_analyse(raw)
+
+
+def test_run_analyse_rejects_stale_existing_trace(tmp_path, monkeypatch):
+    raw = tmp_path / "localhost_1_2_ascend_pt"
+    output = raw / "ASCEND_PROFILER_OUTPUT"
+    output.mkdir(parents=True)
+    trace = output / "trace_view.json"
+    trace.write_text("[]", encoding="utf-8")
+    _install_fake_torch_npu(monkeypatch, lambda **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="did not create or update"):
+        post.run_analyse(raw)
+
+    assert trace.read_text(encoding="utf-8") == "[]"
+
+
+def test_run_analyse_does_not_fallback_to_stale_gzip(tmp_path, monkeypatch):
+    raw = tmp_path / "localhost_1_2_ascend_pt"
+    output = raw / "ASCEND_PROFILER_OUTPUT"
+    output.mkdir(parents=True)
+    trace = output / "trace_view.json"
+    trace.write_text("[]", encoding="utf-8")
+    packed = output / "trace_view.json.gz"
+    packed.write_bytes(b"old-gzip")
+
+    def analyse(**_kwargs):
+        trace.unlink()
+
+    _install_fake_torch_npu(monkeypatch, analyse)
+
+    with pytest.raises(FileNotFoundError, match="after analyse"):
+        post.run_analyse(raw)
+
+    assert packed.read_bytes() == b"old-gzip"
+
+
+def test_run_analyse_rejects_truncated_trace(tmp_path, monkeypatch):
+    raw = tmp_path / "localhost_1_2_ascend_pt"
+    raw.mkdir()
+
+    def analyse(**_kwargs):
+        output = raw / "ASCEND_PROFILER_OUTPUT"
+        output.mkdir()
+        (output / "trace_view.json").write_text('[{"partial": true}', encoding="utf-8")
+
+    _install_fake_torch_npu(monkeypatch, analyse)
+
+    with pytest.raises(RuntimeError, match="incomplete trace"):
+        post.run_analyse(raw)
 
 
 def test_copy_raw_dir_refuses_source_parent_and_existing_target(tmp_path):

--- a/tests/utils/test_npu_offline_postprocess.py
+++ b/tests/utils/test_npu_offline_postprocess.py
@@ -1,8 +1,9 @@
 import json
-from pathlib import Path
+import shlex
 
 import pytest
 
+from veomni.utils import hdfs_io
 from veomni.utils import npu_offline_postprocess as post
 
 
@@ -18,7 +19,58 @@ def test_resolve_raw_dir_finds_unique_child(tmp_path):
     assert post.resolve_raw_dir(tmp_path) == raw.resolve()
 
 
-def test_gzip_and_merlin_upload_cmd(tmp_path, monkeypatch):
+def test_resolve_raw_dir_rejects_ambiguous_parent(tmp_path):
+    (tmp_path / "rank0_1_ascend_pt").mkdir()
+    (tmp_path / "rank0_2_ascend_pt").mkdir()
+
+    with pytest.raises(FileNotFoundError, match="Multiple"):
+        post.resolve_raw_dir(tmp_path)
+
+
+def test_resolve_analyse_path_targets_only_requested_capture(tmp_path):
+    raw = tmp_path / "localhost_1_2_ascend_pt"
+    sibling = tmp_path / "localhost_3_4_ascend_pt"
+    raw.mkdir()
+    sibling.mkdir()
+
+    assert post.resolve_analyse_path(raw) == str(raw)
+
+
+def test_copy_raw_dir_refuses_source_parent_and_existing_target(tmp_path):
+    raw = tmp_path / "rank0_ascend_pt"
+    raw.mkdir()
+    marker = raw / "raw.bin"
+    marker.write_bytes(b"profile")
+
+    with pytest.raises(ValueError, match="source parent"):
+        post.copy_raw_dir(raw, str(tmp_path))
+    assert marker.read_bytes() == b"profile"
+
+    destination = tmp_path / "durable"
+    target = destination / raw.name
+    target.mkdir(parents=True)
+    keep = target / "keep.txt"
+    keep.write_text("do-not-delete", encoding="utf-8")
+    with pytest.raises(FileExistsError, match="already exists"):
+        post.copy_raw_dir(raw, str(destination))
+    assert keep.read_text(encoding="utf-8") == "do-not-delete"
+
+
+def test_copy_raw_dir_refuses_existing_hdfs_target(tmp_path, monkeypatch):
+    raw = tmp_path / "rank0_ascend_pt"
+    raw.mkdir()
+    copies = []
+    target = "hdfs://haruna/profile/rank0_ascend_pt"
+    monkeypatch.setattr(hdfs_io, "exists", lambda path: path == target)
+    monkeypatch.setattr(hdfs_io, "copy", lambda *args: copies.append(args))
+
+    with pytest.raises(FileExistsError, match="HDFS profile target"):
+        post.copy_raw_dir(raw, "hdfs://haruna/profile")
+
+    assert copies == []
+
+
+def test_gzip_and_merlin_upload_cmd(tmp_path):
     raw = tmp_path / "rank0_ascend_pt"
     out_dir = raw / "ASCEND_PROFILER_OUTPUT"
     out_dir.mkdir(parents=True)
@@ -30,8 +82,8 @@ def test_gzip_and_merlin_upload_cmd(tmp_path, monkeypatch):
     assert packed.name.endswith(".gz")
 
     cmd = post.build_merlin_upload_cmd(packed, name="npu-trace")
-    assert cmd.startswith("merlin-cli profiling upload --json ")
-    payload = json.loads(cmd.split(" --json ", 1)[1])
+    assert cmd[:4] == ["merlin-cli", "profiling", "upload", "--json"]
+    payload = json.loads(cmd[4])
     assert payload["file_path"] == str(packed)
     assert payload["asset_type"] == "perfetto"
     assert payload["name"] == "npu-trace"
@@ -51,6 +103,40 @@ def test_postprocess_upload_without_analyse_uses_existing_trace(tmp_path, monkey
     assert packed is not None
     assert packed.name.endswith(".gz")
     assert uploads == [("upload-trace {trace}", packed)]
+
+
+def test_custom_upload_preserves_json_braces_and_quotes_trace_path(tmp_path, monkeypatch):
+    trace = tmp_path / "trace with spaces.json.gz"
+    trace.write_bytes(b"trace")
+    calls = []
+    monkeypatch.setattr(post.subprocess, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    command = 'upload --json {"asset_type":"perfetto"} --file {trace}'
+    post.run_upload_cmd(command, trace)
+
+    assert calls == [
+        (
+            (f'upload --json {{"asset_type":"perfetto"}} --file {shlex.quote(str(trace))}',),
+            {"shell": True, "check": True, "executable": "/bin/bash"},
+        )
+    ]
+
+
+def test_merlin_upload_uses_argv_without_shell(tmp_path, monkeypatch):
+    raw = tmp_path / "rank0_ascend_pt"
+    out_dir = raw / "ASCEND_PROFILER_OUTPUT"
+    out_dir.mkdir(parents=True)
+    (out_dir / "trace_view.json").write_text("{}", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(post.subprocess, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    packed = post.postprocess(raw, merlin_upload=True, upload_name="npu trace")
+
+    assert packed is not None
+    argv = calls[0][0][0]
+    assert argv[:4] == ["merlin-cli", "profiling", "upload", "--json"]
+    assert json.loads(argv[4])["name"] == "npu trace"
+    assert calls[0][1] == {"check": True}
 
 
 def test_postprocess_requires_action(tmp_path):

--- a/tests/utils/test_profiler_config.py
+++ b/tests/utils/test_profiler_config.py
@@ -1,0 +1,359 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from veomni.arguments.arguments_types import ProfileConfig
+from veomni.trainer.callbacks import trace_callback
+from veomni.trainer.callbacks.base import TrainerState
+from veomni.utils import helper
+
+
+class _FakeNpuProfiler:
+    class ProfilerActivity:
+        CPU = "cpu"
+        NPU = "npu"
+
+    class AiCMetrics:
+        PipeUtilization = "pipe_utilization"
+
+    class ProfilerLevel:
+        Level1 = "level1"
+
+    def __init__(self):
+        self.trace_handler_calls = []
+
+    def tensorboard_trace_handler(self, trace_dir, **kwargs):
+        self.trace_handler_calls.append((trace_dir, kwargs))
+        return lambda profiler: None
+
+    def _ExperimentalConfig(self, **kwargs):
+        return kwargs
+
+    def schedule(self, **kwargs):
+        return kwargs
+
+    def profile(self, **kwargs):
+        return SimpleNamespace(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("offline_analysis", "expected_kwargs"),
+    [(False, {}), (True, {"analyse_flag": False})],
+)
+def test_npu_offline_analysis_controls_trace_handler(monkeypatch, tmp_path, offline_analysis, expected_kwargs):
+    fake_profiler = _FakeNpuProfiler()
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+
+    helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=offline_analysis,
+    )
+
+    assert fake_profiler.trace_handler_calls == [(str(tmp_path), expected_kwargs)]
+
+
+def test_npu_offline_analysis_is_disabled_by_default():
+    assert ProfileConfig().npu_offline_analysis is False
+
+
+def test_npu_offline_analysis_does_not_record_unused_memory_history(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=True,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=True,
+    )
+
+    assert not isinstance(profiler, helper.ProfilerWithMem)
+
+
+def test_npu_offline_analysis_skips_file_upload_hook(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    warnings = []
+    upload_calls = []
+    raw_dir = tmp_path / "rank0_ascend_pt"
+    raw_dir.mkdir()
+
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper, "get_torch_device", lambda: pytest.fail("offline mode must not dump memory snapshots"))
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+    monkeypatch.setattr(helper.subprocess, "run", lambda *args, **kwargs: upload_calls.append((args, kwargs)))
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=True,
+    )
+    profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
+
+    assert upload_calls == []
+    assert warnings == [
+        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
+        f"Copy {raw_dir} to durable storage outside the training process, then parse it offline."
+    ]
+
+
+def test_npu_offline_analysis_reports_automatic_hdfs_copy(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    warnings = []
+    copies = []
+    trace_dir = "hdfs://haruna/profile"
+    raw_dir = tmp_path / "rank0_ascend_pt"
+    raw_dir.mkdir()
+
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper.hdfs_io, "makedirs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(helper, "copy", lambda source, target: (copies.append((source, target)), True)[1])
+    monkeypatch.setattr(helper, "get_torch_device", lambda: pytest.fail("offline mode must not dump memory snapshots"))
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=trace_dir,
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=True,
+    )
+    profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
+
+    assert copies == [(str(raw_dir), trace_dir)]
+    assert warnings == [
+        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
+        f"The raw directory has already been copied to {trace_dir}; parse it offline."
+    ]
+
+
+def test_npu_offline_analysis_reports_failed_hdfs_copy(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    warnings = []
+    trace_dir = "hdfs://haruna/profile"
+    raw_dir = tmp_path / "rank0_ascend_pt"
+    raw_dir.mkdir()
+
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper.hdfs_io, "makedirs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(helper, "copy", lambda source, target: False)
+    monkeypatch.setattr(helper, "get_torch_device", lambda: pytest.fail("offline mode must not dump memory snapshots"))
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=trace_dir,
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=True,
+    )
+    profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
+
+    assert warnings == [
+        f"Failed to copy profiling result to {trace_dir}; the raw capture remains at {raw_dir}.",
+        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory, "
+        f"and the automatic copy to {trace_dir} failed. Preserve {raw_dir} before the pod exits.",
+    ]
+
+
+@pytest.mark.parametrize("npu_offline_analysis", [True, False])
+@pytest.mark.parametrize(
+    ("this_rank", "expected_events"),
+    [
+        (True, ["barrier", "step", "barrier"]),
+        (False, ["barrier", "barrier"]),
+    ],
+)
+def test_npu_profile_synchronizes_finalization(monkeypatch, npu_offline_analysis, this_rank, expected_events):
+    events = []
+    profile_config = SimpleNamespace(
+        enable=True,
+        npu_offline_analysis=npu_offline_analysis,
+        end_step=6,
+        this_rank=this_rank,
+    )
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+    callback._profile_active = True
+    callback.profiler = (
+        SimpleNamespace(
+            step=lambda: events.append("step"),
+            stop=lambda: events.append("stop"),
+        )
+        if this_rank
+        else None
+    )
+
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+
+    callback.on_step_end(TrainerState(global_step=5))
+
+    assert events == expected_events
+
+
+def test_npu_profile_stops_without_finalize_barrier_at_end_step(monkeypatch):
+    events = []
+    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=False, end_step=6, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+    callback._profile_active = True
+    callback.profiler = SimpleNamespace(step=lambda: events.append("step"), stop=lambda: events.append("stop"))
+
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+
+    callback.on_step_end(TrainerState(global_step=6))
+
+    assert events == ["step", "stop"]
+
+
+def test_npu_profile_does_not_synchronize_before_finalize_step(monkeypatch):
+    events = []
+    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=True, end_step=6, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+    callback._profile_active = True
+    callback.profiler = SimpleNamespace(step=lambda: events.append("step"), stop=lambda: events.append("stop"))
+
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+
+    callback.on_step_end(TrainerState(global_step=4))
+
+    assert events == ["step"]
+
+
+def test_cuda_profile_does_not_use_npu_finalize_barrier(monkeypatch):
+    events = []
+    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=False, end_step=6, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+    callback._profile_active = True
+    callback.profiler = SimpleNamespace(step=lambda: events.append("step"), stop=lambda: events.append("stop"))
+
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", False)
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+
+    callback.on_step_end(TrainerState(global_step=5))
+
+    assert events == ["step"]
+
+
+def test_profile_schedule_finalizes_at_end_step_minus_one():
+    handler_steps = []
+    current_global_step = [0]
+    profiler = torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU],
+        schedule=torch.profiler.schedule(wait=3, warmup=1, active=1, repeat=1),
+        on_trace_ready=lambda _: handler_steps.append(current_global_step[0]),
+        acc_events=True,
+    )
+    profiler.start()
+    for step in range(1, 6):
+        current_global_step[0] = step
+        profiler.step()
+    profiler.stop()
+
+    # create_profiler(start_step=5, end_step=6) builds wait=3,
+    # warmup=1, active=1. Exiting RECORD_AND_SAVE invokes the handler in
+    # profiler.step() at global step 5, i.e. end_step - 1.
+    assert handler_steps == [5]
+
+
+def test_profile_callback_rebases_absolute_steps_after_resume(monkeypatch, tmp_path):
+    create_calls = []
+    profiler = SimpleNamespace(start=lambda: None)
+    profile_config = SimpleNamespace(
+        enable=True,
+        start_step=5,
+        end_step=6,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        npu_offline_analysis=True,
+        this_rank=True,
+    )
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(profile=profile_config, global_rank=0))
+    )
+
+    monkeypatch.setattr(
+        trace_callback.helper,
+        "create_profiler",
+        lambda **kwargs: (create_calls.append(kwargs), profiler)[1],
+    )
+
+    callback.on_train_begin(TrainerState(global_step=4))
+
+    assert callback._profile_active is True
+    assert create_calls[0]["start_step"] == 1
+    assert create_calls[0]["end_step"] == 2
+
+
+def test_profile_callback_skips_elapsed_window(monkeypatch):
+    warnings = []
+    profile_config = SimpleNamespace(enable=True, start_step=5, end_step=6, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+
+    monkeypatch.setattr(trace_callback.logger, "warning_rank0", warnings.append)
+    monkeypatch.setattr(trace_callback.helper, "create_profiler", lambda **kwargs: pytest.fail("window elapsed"))
+
+    callback.on_train_begin(TrainerState(global_step=5))
+
+    assert callback._profile_active is False
+    assert callback.profiler is None
+    assert warnings == ["Profiling window [5, 6) has no remaining steps after global step 5; profiling is skipped."]

--- a/tests/utils/test_profiler_config.py
+++ b/tests/utils/test_profiler_config.py
@@ -1,9 +1,11 @@
+from dataclasses import dataclass, field
 from types import SimpleNamespace
 
 import pytest
 import torch
 
 from veomni.arguments.arguments_types import ProfileConfig
+from veomni.arguments.parser import parse_args
 from veomni.trainer.callbacks import trace_callback
 from veomni.trainer.callbacks.base import TrainerState
 from veomni.utils import helper
@@ -38,10 +40,13 @@ class _FakeNpuProfiler:
 
 
 @pytest.mark.parametrize(
-    ("offline_analysis", "expected_kwargs"),
-    [(False, {}), (True, {"analyse_flag": False})],
+    ("analysis_mode", "expected_kwargs"),
+    [
+        ("offline", {"analyse_flag": False}),
+        ("async", {"analyse_flag": True, "async_mode": True}),
+    ],
 )
-def test_npu_offline_analysis_controls_trace_handler(monkeypatch, tmp_path, offline_analysis, expected_kwargs):
+def test_npu_analysis_mode_controls_trace_handler(monkeypatch, tmp_path, analysis_mode, expected_kwargs):
     fake_profiler = _FakeNpuProfiler()
     monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
     monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
@@ -56,17 +61,83 @@ def test_npu_offline_analysis_controls_trace_handler(monkeypatch, tmp_path, offl
         with_stack=False,
         with_modules=False,
         global_rank=0,
-        npu_offline_analysis=offline_analysis,
+        npu_analysis_mode=analysis_mode,
     )
 
     assert fake_profiler.trace_handler_calls == [(str(tmp_path), expected_kwargs)]
 
 
-def test_npu_offline_analysis_is_disabled_by_default():
-    assert ProfileConfig().npu_offline_analysis is False
+def test_npu_analysis_mode_defaults_to_offline():
+    assert ProfileConfig().npu_analysis_mode == "offline"
 
 
-def test_npu_offline_analysis_does_not_record_unused_memory_history(monkeypatch, tmp_path):
+def test_npu_analysis_mode_rejects_invalid_yaml_value():
+    with pytest.raises(ValueError, match="npu_analysis_mode"):
+        ProfileConfig(npu_analysis_mode="sync")
+
+
+def test_legacy_npu_offline_true_maps_to_offline(monkeypatch):
+    warnings = []
+    monkeypatch.setattr("veomni.arguments.arguments_types.logger.warning", warnings.append)
+
+    config = ProfileConfig(npu_offline_analysis=True)
+
+    assert config.npu_analysis_mode == "offline"
+    assert any("deprecated" in warning for warning in warnings)
+
+
+def test_legacy_npu_offline_false_requires_explicit_safe_mode():
+    with pytest.raises(ValueError, match="removed synchronous online analysis"):
+        ProfileConfig(enable=True, npu_offline_analysis=False)
+
+
+def test_disabled_profile_loads_legacy_saved_false_value(monkeypatch, tmp_path):
+    @dataclass
+    class _TrainConfig:
+        profile: ProfileConfig = field(default_factory=ProfileConfig)
+
+    @dataclass
+    class _SavedConfig:
+        train: _TrainConfig = field(default_factory=_TrainConfig)
+
+    config_path = tmp_path / "legacy_veomni_cli.yaml"
+    config_path.write_text(
+        "train:\n  profile:\n    enable: false\n    npu_offline_analysis: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("sys.argv", ["test", str(config_path)])
+
+    parsed = parse_args(_SavedConfig)
+
+    assert parsed.train.profile.enable is False
+    assert parsed.train.profile.npu_offline_analysis is False
+    assert parsed.train.profile.npu_analysis_mode == "offline"
+
+
+def test_create_profiler_accepts_legacy_offline_true(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+
+    with pytest.deprecated_call(match="npu_offline_analysis"):
+        helper.create_profiler(
+            start_step=1,
+            end_step=2,
+            trace_dir=str(tmp_path),
+            record_shapes=False,
+            profile_memory=False,
+            with_stack=False,
+            with_modules=False,
+            global_rank=0,
+            npu_offline_analysis=True,
+        )
+
+    assert fake_profiler.trace_handler_calls == [(str(tmp_path), {"analyse_flag": False})]
+
+
+@pytest.mark.parametrize("analysis_mode", ["offline", "async"])
+def test_npu_analysis_does_not_record_unused_memory_history(monkeypatch, tmp_path, analysis_mode):
     fake_profiler = _FakeNpuProfiler()
     monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
     monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
@@ -81,13 +152,13 @@ def test_npu_offline_analysis_does_not_record_unused_memory_history(monkeypatch,
         with_stack=False,
         with_modules=False,
         global_rank=0,
-        npu_offline_analysis=True,
+        npu_analysis_mode=analysis_mode,
     )
 
     assert not isinstance(profiler, helper.ProfilerWithMem)
 
 
-def test_npu_offline_analysis_spawns_async_upload_sidecar(monkeypatch, tmp_path):
+def test_npu_offline_spawns_async_upload_sidecar(monkeypatch, tmp_path):
     fake_profiler = _FakeNpuProfiler()
     sidecar_calls = []
     raw_dir = tmp_path / "rank0_ascend_pt"
@@ -103,7 +174,7 @@ def test_npu_offline_analysis_spawns_async_upload_sidecar(monkeypatch, tmp_path)
     monkeypatch.setattr(
         helper,
         "spawn_npu_offline_sidecar",
-        lambda *args, **kwargs: sidecar_calls.append((args, kwargs)),
+        lambda *args, **kwargs: (sidecar_calls.append((args, kwargs)), SimpleNamespace(pid=123))[1],
     )
     monkeypatch.setattr(helper.subprocess, "run", lambda *args, **kwargs: pytest.fail("must not sync-upload"))
 
@@ -116,7 +187,7 @@ def test_npu_offline_analysis_spawns_async_upload_sidecar(monkeypatch, tmp_path)
         with_stack=False,
         with_modules=False,
         global_rank=0,
-        npu_offline_analysis=True,
+        npu_analysis_mode="offline",
     )
     profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
 
@@ -126,9 +197,48 @@ def test_npu_offline_analysis_spawns_async_upload_sidecar(monkeypatch, tmp_path)
             {"copy_to": None, "analyse": True, "upload_cmd": "upload-trace", "merlin_upload": False},
         )
     ]
+    assert [sidecar.pid for sidecar in profiler._veomni_npu_sidecars] == [123]
 
 
-def test_npu_offline_analysis_defers_hdfs_copy_to_sidecar(monkeypatch, tmp_path):
+def test_npu_sidecar_log_setup_failure_is_nonfatal(monkeypatch, tmp_path):
+    warnings = []
+    monkeypatch.setattr(helper.os, "makedirs", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")))
+    monkeypatch.setattr(helper.subprocess, "Popen", lambda *args, **kwargs: pytest.fail("must not spawn"))
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+
+    proc = helper.spawn_npu_offline_sidecar(str(tmp_path / "rank0_ascend_pt"), analyse=True)
+
+    assert proc is None
+    assert any("disk full" in warning for warning in warnings)
+
+
+def test_wait_npu_profile_sidecars_reports_completion_and_timeout(monkeypatch):
+    logs = []
+    warnings = []
+
+    class _Completed:
+        pid = 101
+
+        def wait(self, timeout):
+            return 0
+
+    class _Pending:
+        pid = 102
+
+        def wait(self, timeout):
+            raise helper.subprocess.TimeoutExpired(cmd="sidecar", timeout=timeout)
+
+    profiler = SimpleNamespace(_veomni_npu_sidecars=[_Completed(), _Pending()])
+    monkeypatch.setattr(helper.logger, "info", logs.append)
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+
+    helper.wait_npu_profile_sidecars(profiler, timeout_seconds=0.01)
+
+    assert any("pid=101 status=completed" in message for message in logs)
+    assert any("pid=102" in warning and "still running" in warning for warning in warnings)
+
+
+def test_npu_offline_defers_hdfs_copy_to_sidecar(monkeypatch, tmp_path):
     fake_profiler = _FakeNpuProfiler()
     sidecar_calls = []
     copies = []
@@ -138,7 +248,7 @@ def test_npu_offline_analysis_defers_hdfs_copy_to_sidecar(monkeypatch, tmp_path)
 
     monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
     monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
-    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", None)
     monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_POSTPROCESS", None)
     monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD", None)
     monkeypatch.setattr(helper, "CACHE_DIR", str(tmp_path / "cache"))
@@ -149,7 +259,7 @@ def test_npu_offline_analysis_defers_hdfs_copy_to_sidecar(monkeypatch, tmp_path)
     monkeypatch.setattr(
         helper,
         "spawn_npu_offline_sidecar",
-        lambda *args, **kwargs: sidecar_calls.append((args, kwargs)),
+        lambda *args, **kwargs: (sidecar_calls.append((args, kwargs)), SimpleNamespace(pid=123))[1],
     )
 
     profiler = helper.create_profiler(
@@ -161,7 +271,7 @@ def test_npu_offline_analysis_defers_hdfs_copy_to_sidecar(monkeypatch, tmp_path)
         with_stack=False,
         with_modules=False,
         global_rank=0,
-        npu_offline_analysis=True,
+        npu_analysis_mode="offline",
     )
     profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
 
@@ -169,12 +279,12 @@ def test_npu_offline_analysis_defers_hdfs_copy_to_sidecar(monkeypatch, tmp_path)
     assert sidecar_calls == [
         (
             (str(raw_dir),),
-            {"copy_to": trace_dir, "analyse": True, "upload_cmd": "upload-trace", "merlin_upload": False},
+            {"copy_to": trace_dir, "analyse": False, "upload_cmd": None, "merlin_upload": False},
         )
     ]
 
 
-def test_npu_offline_analysis_can_opt_out_of_sidecar(monkeypatch, tmp_path):
+def test_npu_offline_sidecar_opt_out_never_falls_back_to_sync_hdfs_copy(monkeypatch, tmp_path):
     fake_profiler = _FakeNpuProfiler()
     warnings = []
     sidecar_calls = []
@@ -185,7 +295,7 @@ def test_npu_offline_analysis_can_opt_out_of_sidecar(monkeypatch, tmp_path):
 
     monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
     monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
-    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", None)
     monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_POSTPROCESS", "0")
     monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD", None)
     monkeypatch.setattr(helper, "CACHE_DIR", str(tmp_path / "cache"))
@@ -209,16 +319,16 @@ def test_npu_offline_analysis_can_opt_out_of_sidecar(monkeypatch, tmp_path):
         with_stack=False,
         with_modules=False,
         global_rank=0,
-        npu_offline_analysis=True,
+        npu_analysis_mode="offline",
     )
     profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
 
     assert sidecar_calls == []
-    assert copies == [(str(raw_dir), trace_dir)]
-    assert any("VEOMNI_UPLOAD_CMD is skipped" in warning for warning in warnings)
+    assert copies == []
+    assert any("raw capture remains" in warning for warning in warnings)
 
 
-def test_npu_offline_analysis_spawns_merlin_upload_sidecar(monkeypatch, tmp_path):
+def test_npu_offline_spawns_merlin_upload_sidecar(monkeypatch, tmp_path):
     fake_profiler = _FakeNpuProfiler()
     sidecar_calls = []
     raw_dir = tmp_path / "rank0_ascend_pt"
@@ -234,7 +344,7 @@ def test_npu_offline_analysis_spawns_merlin_upload_sidecar(monkeypatch, tmp_path
     monkeypatch.setattr(
         helper,
         "spawn_npu_offline_sidecar",
-        lambda *args, **kwargs: sidecar_calls.append((args, kwargs)),
+        lambda *args, **kwargs: (sidecar_calls.append((args, kwargs)), SimpleNamespace(pid=123))[1],
     )
 
     profiler = helper.create_profiler(
@@ -246,7 +356,7 @@ def test_npu_offline_analysis_spawns_merlin_upload_sidecar(monkeypatch, tmp_path
         with_stack=False,
         with_modules=False,
         global_rank=0,
-        npu_offline_analysis=True,
+        npu_analysis_mode="offline",
     )
     profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
 
@@ -258,7 +368,196 @@ def test_npu_offline_analysis_spawns_merlin_upload_sidecar(monkeypatch, tmp_path
     ]
 
 
-@pytest.mark.parametrize("npu_offline_analysis", [True, False])
+def test_npu_offline_sidecar_failure_preserves_raw_without_sync_fallback(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    raw_dir = tmp_path / "rank0_ascend_pt"
+    raw_dir.mkdir()
+    warnings = []
+
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_POSTPROCESS", None)
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD", None)
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper, "spawn_npu_offline_sidecar", lambda *args, **kwargs: None)
+    monkeypatch.setattr(helper, "copy", lambda *args, **kwargs: pytest.fail("must not sync-copy"))
+    monkeypatch.setattr(helper.subprocess, "run", lambda *args, **kwargs: pytest.fail("must not sync-upload"))
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_analysis_mode="offline",
+    )
+    profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
+
+    assert raw_dir.is_dir()
+    assert any(str(raw_dir) in warning and "no synchronous fallback" in warning for warning in warnings)
+
+
+def test_npu_async_rejects_hdfs_trace_dir(monkeypatch):
+    fake_profiler = _FakeNpuProfiler()
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+
+    with pytest.raises(ValueError, match="pod-local"):
+        helper.create_profiler(
+            start_step=1,
+            end_step=2,
+            trace_dir="hdfs://haruna/profile",
+            record_shapes=False,
+            profile_memory=False,
+            with_stack=False,
+            with_modules=False,
+            global_rank=0,
+            npu_analysis_mode="async",
+        )
+
+
+def test_npu_async_does_not_race_background_analysis_with_upload(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    raw_dir = tmp_path / "rank0_ascend_pt"
+    raw_dir.mkdir()
+    sidecar_calls = []
+    warnings = []
+
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_POSTPROCESS", "1")
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD", "1")
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(
+        helper, "spawn_npu_offline_sidecar", lambda *args, **kwargs: sidecar_calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(helper, "copy", lambda *args, **kwargs: pytest.fail("must not copy before async analysis"))
+    monkeypatch.setattr(helper.subprocess, "run", lambda *args, **kwargs: pytest.fail("must not upload early"))
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_analysis_mode="async",
+    )
+    profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
+
+    assert sidecar_calls == []
+    assert any("async analysis" in warning for warning in warnings)
+
+
+def test_npu_async_submission_failure_preserves_raw_and_does_not_fail_training(monkeypatch, tmp_path):
+    class _FailingAsyncNpuProfiler(_FakeNpuProfiler):
+        def tensorboard_trace_handler(self, trace_dir, **kwargs):
+            self.trace_handler_calls.append((trace_dir, kwargs))
+
+            def handler(profiler):
+                raise RuntimeError("process pool unavailable")
+
+            return handler
+
+    fake_profiler = _FailingAsyncNpuProfiler()
+    raw_dir = tmp_path / "rank0_ascend_pt"
+    raw_dir.mkdir()
+    warnings = []
+    logs = []
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", None)
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_POSTPROCESS", None)
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD", None)
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+    monkeypatch.setattr(helper.logger, "info", logs.append)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_analysis_mode="async",
+    )
+    profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
+
+    assert raw_dir.is_dir()
+    assert any("training will continue" in warning and str(raw_dir) in warning for warning in warnings)
+    assert any("status=analysis_submit_failed" in message for message in logs)
+
+
+def test_npu_async_falls_back_to_offline_in_daemon_process(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    warnings = []
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper.multiprocessing, "current_process", lambda: SimpleNamespace(daemon=True))
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_analysis_mode="async",
+    )
+
+    assert fake_profiler.trace_handler_calls == [(str(tmp_path), {"analyse_flag": False})]
+    assert profiler._veomni_npu_analysis_mode == "offline"
+    assert any("daemon" in warning for warning in warnings)
+
+
+def test_npu_async_falls_back_when_torch_npu_does_not_support_it(monkeypatch, tmp_path):
+    class _LegacyNpuProfiler(_FakeNpuProfiler):
+        def tensorboard_trace_handler(self, trace_dir, analyse_flag=True):
+            self.trace_handler_calls.append((trace_dir, {"analyse_flag": analyse_flag}))
+            return lambda profiler: None
+
+    fake_profiler = _LegacyNpuProfiler()
+    warnings = []
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_analysis_mode="async",
+    )
+
+    assert fake_profiler.trace_handler_calls == [(str(tmp_path), {"analyse_flag": False})]
+    assert profiler._veomni_npu_analysis_mode == "offline"
+    assert any("does not support" in warning for warning in warnings)
+
+
+@pytest.mark.parametrize("npu_analysis_mode", ["offline", "async"])
 @pytest.mark.parametrize(
     ("this_rank", "expected_events"),
     [
@@ -266,11 +565,11 @@ def test_npu_offline_analysis_spawns_merlin_upload_sidecar(monkeypatch, tmp_path
         (False, ["barrier", "barrier"]),
     ],
 )
-def test_npu_profile_synchronizes_finalization(monkeypatch, npu_offline_analysis, this_rank, expected_events):
+def test_npu_profile_synchronizes_finalization(monkeypatch, npu_analysis_mode, this_rank, expected_events):
     events = []
     profile_config = SimpleNamespace(
         enable=True,
-        npu_offline_analysis=npu_offline_analysis,
+        npu_analysis_mode=npu_analysis_mode,
         end_step=6,
         this_rank=this_rank,
     )
@@ -296,9 +595,101 @@ def test_npu_profile_synchronizes_finalization(monkeypatch, npu_offline_analysis
     assert events == expected_events
 
 
+def test_npu_profile_finalize_error_still_releases_post_barrier(monkeypatch):
+    events = []
+    profile_config = SimpleNamespace(enable=True, npu_analysis_mode="offline", end_step=6, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
+    callback._profile_active = True
+
+    def fail_step():
+        events.append("step")
+        raise RuntimeError("raw dump failed")
+
+    callback.profiler = SimpleNamespace(step=fail_step, stop=lambda: None)
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+
+    with pytest.raises(RuntimeError, match="raw dump failed"):
+        callback.on_step_end(TrainerState(global_step=5))
+
+    assert events == ["barrier", "step", "barrier"]
+
+
+def test_npu_profile_logs_full_step_and_finalize_breakdown(monkeypatch):
+    events = []
+    logs = []
+    profile_config = SimpleNamespace(
+        enable=True,
+        npu_analysis_mode="async",
+        end_step=6,
+        this_rank=True,
+    )
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(profile=profile_config, global_rank=0))
+    )
+    callback._profile_active = True
+    callback._profile_timing_start_step = 5
+    callback.profiler = SimpleNamespace(
+        _veomni_npu_analysis_mode="async",
+        step=lambda: events.append("step"),
+        stop=lambda: events.append("stop"),
+    )
+    clock = iter([1.0, 2.0, 2.1, 3.0, 3.2, 4.0, 4.3, 5.0])
+
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+    monkeypatch.setattr(trace_callback.time, "perf_counter", lambda: next(clock))
+    monkeypatch.setattr(trace_callback.logger, "info", logs.append)
+    monkeypatch.setattr(trace_callback.logger, "info_rank0", logs.append)
+
+    callback.on_step_begin(TrainerState(global_step=5))
+    callback.on_step_end(TrainerState(global_step=5))
+
+    assert events == ["barrier", "step", "barrier"]
+    assert len(logs) == 1
+    assert "mode=async" in logs[0]
+    assert "total_seconds=4.000000" in logs[0]
+    assert "pre_barrier_seconds=0.100000" in logs[0]
+    assert "profiler_step_seconds=0.200000" in logs[0]
+    assert "post_barrier_seconds=0.300000" in logs[0]
+
+
+def test_npu_profile_timing_skips_steps_outside_profile_window(monkeypatch):
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(
+        args=SimpleNamespace(
+            train=SimpleNamespace(
+                profile=SimpleNamespace(enable=True, npu_analysis_mode="offline", end_step=6),
+                global_rank=0,
+            )
+        )
+    )
+    callback.profiler = None
+    callback._profile_active = True
+    callback._profile_timing_start_step = 4
+    callback._step_started_at = None
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+
+    callback.on_step_begin(TrainerState(global_step=3))
+    assert callback._step_started_at is None
+
+    callback.on_step_begin(TrainerState(global_step=4))
+    assert callback._step_started_at is not None
+
+    callback._step_started_at = None
+    callback.on_step_begin(TrainerState(global_step=7))
+    assert callback._step_started_at is None
+
+
 def test_npu_profile_stops_without_finalize_barrier_at_end_step(monkeypatch):
     events = []
-    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=False, end_step=6, this_rank=True)
+    profile_config = SimpleNamespace(enable=True, npu_analysis_mode="async", end_step=6, this_rank=True)
     callback = object.__new__(trace_callback.ProfileTraceCallback)
     callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
     callback._profile_active = True
@@ -316,7 +707,7 @@ def test_npu_profile_stops_without_finalize_barrier_at_end_step(monkeypatch):
 
 def test_npu_profile_does_not_synchronize_before_finalize_step(monkeypatch):
     events = []
-    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=True, end_step=6, this_rank=True)
+    profile_config = SimpleNamespace(enable=True, npu_analysis_mode="offline", end_step=6, this_rank=True)
     callback = object.__new__(trace_callback.ProfileTraceCallback)
     callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
     callback._profile_active = True
@@ -334,7 +725,7 @@ def test_npu_profile_does_not_synchronize_before_finalize_step(monkeypatch):
 
 def test_cuda_profile_does_not_use_npu_finalize_barrier(monkeypatch):
     events = []
-    profile_config = SimpleNamespace(enable=True, npu_offline_analysis=False, end_step=6, this_rank=True)
+    profile_config = SimpleNamespace(enable=True, npu_analysis_mode="async", end_step=6, this_rank=True)
     callback = object.__new__(trace_callback.ProfileTraceCallback)
     callback.trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(profile=profile_config)))
     callback._profile_active = True
@@ -348,6 +739,57 @@ def test_cuda_profile_does_not_use_npu_finalize_barrier(monkeypatch):
     callback.on_step_end(TrainerState(global_step=5))
 
     assert events == ["step"]
+
+
+def test_npu_profile_train_end_stops_early_window_and_waits_for_sidecar(monkeypatch):
+    events = []
+    logs = []
+    profile_config = SimpleNamespace(enable=True, npu_analysis_mode="offline", end_step=20, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(profile=profile_config, global_rank=0))
+    )
+    callback._profile_active = True
+    callback._profiler_stopped = False
+    callback.profiler = SimpleNamespace(
+        _veomni_npu_analysis_mode="offline",
+        stop=lambda: events.append("stop"),
+    )
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(trace_callback.helper, "wait_npu_profile_sidecars", lambda profiler: events.append("wait"))
+    monkeypatch.setattr(trace_callback.dist, "is_available", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(trace_callback.dist, "barrier", lambda: events.append("barrier"))
+    monkeypatch.setattr(trace_callback.logger, "info_rank0", logs.append)
+
+    callback.on_train_end(TrainerState(global_step=10))
+
+    assert events == ["barrier", "stop", "barrier", "wait"]
+    assert callback._profiler_stopped is True
+    assert callback._profile_active is False
+    assert any("NPU_PROFILE_TRAIN_END mode=offline step=10" in message for message in logs)
+
+
+def test_npu_profile_train_end_does_not_stop_twice(monkeypatch):
+    events = []
+    profile_config = SimpleNamespace(enable=True, npu_analysis_mode="async", end_step=6, this_rank=True)
+    callback = object.__new__(trace_callback.ProfileTraceCallback)
+    callback.trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(profile=profile_config, global_rank=0))
+    )
+    callback._profile_active = False
+    callback._profiler_stopped = True
+    callback.profiler = SimpleNamespace(
+        _veomni_npu_analysis_mode="async",
+        stop=lambda: pytest.fail("profiler already stopped"),
+    )
+    monkeypatch.setattr(trace_callback.helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(trace_callback.helper, "wait_npu_profile_sidecars", lambda profiler: events.append("wait"))
+    monkeypatch.setattr(trace_callback.logger, "info_rank0", lambda message: None)
+
+    callback.on_train_end(TrainerState(global_step=30))
+
+    assert events == ["wait"]
 
 
 def test_profile_schedule_finalizes_at_end_step_minus_one():
@@ -383,7 +825,7 @@ def test_profile_callback_rebases_absolute_steps_after_resume(monkeypatch, tmp_p
         profile_memory=False,
         with_stack=False,
         with_modules=False,
-        npu_offline_analysis=True,
+        npu_analysis_mode="offline",
         this_rank=True,
     )
     callback = object.__new__(trace_callback.ProfileTraceCallback)

--- a/tests/utils/test_profiler_config.py
+++ b/tests/utils/test_profiler_config.py
@@ -87,20 +87,25 @@ def test_npu_offline_analysis_does_not_record_unused_memory_history(monkeypatch,
     assert not isinstance(profiler, helper.ProfilerWithMem)
 
 
-def test_npu_offline_analysis_skips_file_upload_hook(monkeypatch, tmp_path):
+def test_npu_offline_analysis_spawns_async_upload_sidecar(monkeypatch, tmp_path):
     fake_profiler = _FakeNpuProfiler()
-    warnings = []
-    upload_calls = []
+    sidecar_calls = []
     raw_dir = tmp_path / "rank0_ascend_pt"
     raw_dir.mkdir()
 
     monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
     monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
     monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_POSTPROCESS", None)
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD", None)
     monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
     monkeypatch.setattr(helper, "get_torch_device", lambda: pytest.fail("offline mode must not dump memory snapshots"))
-    monkeypatch.setattr(helper.logger, "warning", warnings.append)
-    monkeypatch.setattr(helper.subprocess, "run", lambda *args, **kwargs: upload_calls.append((args, kwargs)))
+    monkeypatch.setattr(
+        helper,
+        "spawn_npu_offline_sidecar",
+        lambda *args, **kwargs: sidecar_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(helper.subprocess, "run", lambda *args, **kwargs: pytest.fail("must not sync-upload"))
 
     profiler = helper.create_profiler(
         start_step=1,
@@ -115,16 +120,17 @@ def test_npu_offline_analysis_skips_file_upload_hook(monkeypatch, tmp_path):
     )
     profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
 
-    assert upload_calls == []
-    assert warnings == [
-        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
-        f"Copy {raw_dir} to durable storage outside the training process, then parse it offline."
+    assert sidecar_calls == [
+        (
+            (str(raw_dir),),
+            {"copy_to": None, "analyse": True, "upload_cmd": "upload-trace", "merlin_upload": False},
+        )
     ]
 
 
-def test_npu_offline_analysis_reports_automatic_hdfs_copy(monkeypatch, tmp_path):
+def test_npu_offline_analysis_defers_hdfs_copy_to_sidecar(monkeypatch, tmp_path):
     fake_profiler = _FakeNpuProfiler()
-    warnings = []
+    sidecar_calls = []
     copies = []
     trace_dir = "hdfs://haruna/profile"
     raw_dir = tmp_path / "rank0_ascend_pt"
@@ -133,12 +139,18 @@ def test_npu_offline_analysis_reports_automatic_hdfs_copy(monkeypatch, tmp_path)
     monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
     monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
     monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_POSTPROCESS", None)
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD", None)
     monkeypatch.setattr(helper, "CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
     monkeypatch.setattr(helper.hdfs_io, "makedirs", lambda *args, **kwargs: None)
     monkeypatch.setattr(helper, "copy", lambda source, target: (copies.append((source, target)), True)[1])
     monkeypatch.setattr(helper, "get_torch_device", lambda: pytest.fail("offline mode must not dump memory snapshots"))
-    monkeypatch.setattr(helper.logger, "warning", warnings.append)
+    monkeypatch.setattr(
+        helper,
+        "spawn_npu_offline_sidecar",
+        lambda *args, **kwargs: sidecar_calls.append((args, kwargs)),
+    )
 
     profiler = helper.create_profiler(
         start_step=1,
@@ -153,16 +165,20 @@ def test_npu_offline_analysis_reports_automatic_hdfs_copy(monkeypatch, tmp_path)
     )
     profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
 
-    assert copies == [(str(raw_dir), trace_dir)]
-    assert warnings == [
-        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
-        f"The raw directory has already been copied to {trace_dir}; parse it offline."
+    assert copies == []
+    assert sidecar_calls == [
+        (
+            (str(raw_dir),),
+            {"copy_to": trace_dir, "analyse": True, "upload_cmd": "upload-trace", "merlin_upload": False},
+        )
     ]
 
 
-def test_npu_offline_analysis_reports_failed_hdfs_copy(monkeypatch, tmp_path):
+def test_npu_offline_analysis_can_opt_out_of_sidecar(monkeypatch, tmp_path):
     fake_profiler = _FakeNpuProfiler()
     warnings = []
+    sidecar_calls = []
+    copies = []
     trace_dir = "hdfs://haruna/profile"
     raw_dir = tmp_path / "rank0_ascend_pt"
     raw_dir.mkdir()
@@ -170,12 +186,19 @@ def test_npu_offline_analysis_reports_failed_hdfs_copy(monkeypatch, tmp_path):
     monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
     monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
     monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", "upload-trace")
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_POSTPROCESS", "0")
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD", None)
     monkeypatch.setattr(helper, "CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
     monkeypatch.setattr(helper.hdfs_io, "makedirs", lambda *args, **kwargs: None)
-    monkeypatch.setattr(helper, "copy", lambda source, target: False)
+    monkeypatch.setattr(helper, "copy", lambda source, target: (copies.append((source, target)), True)[1])
     monkeypatch.setattr(helper, "get_torch_device", lambda: pytest.fail("offline mode must not dump memory snapshots"))
     monkeypatch.setattr(helper.logger, "warning", warnings.append)
+    monkeypatch.setattr(
+        helper,
+        "spawn_npu_offline_sidecar",
+        lambda *args, **kwargs: sidecar_calls.append((args, kwargs)),
+    )
 
     profiler = helper.create_profiler(
         start_step=1,
@@ -190,10 +213,48 @@ def test_npu_offline_analysis_reports_failed_hdfs_copy(monkeypatch, tmp_path):
     )
     profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
 
-    assert warnings == [
-        f"Failed to copy profiling result to {trace_dir}; the raw capture remains at {raw_dir}.",
-        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory, "
-        f"and the automatic copy to {trace_dir} failed. Preserve {raw_dir} before the pod exits.",
+    assert sidecar_calls == []
+    assert copies == [(str(raw_dir), trace_dir)]
+    assert any("VEOMNI_UPLOAD_CMD is skipped" in warning for warning in warnings)
+
+
+def test_npu_offline_analysis_spawns_merlin_upload_sidecar(monkeypatch, tmp_path):
+    fake_profiler = _FakeNpuProfiler()
+    sidecar_calls = []
+    raw_dir = tmp_path / "rank0_ascend_pt"
+    raw_dir.mkdir()
+
+    monkeypatch.setattr(helper, "IS_NPU_AVAILABLE", True)
+    monkeypatch.setattr(helper, "IS_CUDA_AVAILABLE", False)
+    monkeypatch.setattr(helper, "VEOMNI_UPLOAD_CMD", None)
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_POSTPROCESS", None)
+    monkeypatch.setattr(helper, "VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD", "1")
+    monkeypatch.setattr(helper, "torch_npu", SimpleNamespace(profiler=fake_profiler), raising=False)
+    monkeypatch.setattr(helper, "get_torch_device", lambda: pytest.fail("offline mode must not dump memory snapshots"))
+    monkeypatch.setattr(
+        helper,
+        "spawn_npu_offline_sidecar",
+        lambda *args, **kwargs: sidecar_calls.append((args, kwargs)),
+    )
+
+    profiler = helper.create_profiler(
+        start_step=1,
+        end_step=2,
+        trace_dir=str(tmp_path),
+        record_shapes=False,
+        profile_memory=False,
+        with_stack=False,
+        with_modules=False,
+        global_rank=0,
+        npu_offline_analysis=True,
+    )
+    profiler.on_trace_ready(SimpleNamespace(prof_if=SimpleNamespace(prof_path=str(raw_dir))))
+
+    assert sidecar_calls == [
+        (
+            (str(raw_dir),),
+            {"copy_to": None, "analyse": True, "upload_cmd": None, "merlin_upload": True},
+        )
     ]
 
 

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -217,15 +217,44 @@ class ProfileConfig:
             "help": "whether to profile rank0 only. When false, every rank will be profiled; Please expect many files to save, which can be slow and take a lot of disk space."
         },
     )
-    npu_offline_analysis: bool = field(
-        default=False,
+    npu_analysis_mode: Literal["offline", "async"] = field(
+        default="offline",
         metadata={
             "help": (
-                "Defer online Ascend analysis by setting analyse_flag=False, so training only finalizes raw data. "
-                "Parse the raw data offline with torch_npu or msprof. This option only affects NPU profiling."
+                "Ascend trace analysis mode. 'offline' only finalizes raw data during training; 'async' starts "
+                "torch_npu online analysis in its background process pool. This option only affects NPU profiling."
             )
         },
     )
+    npu_offline_analysis: Optional[bool] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Deprecated compatibility alias. true maps to npu_analysis_mode=offline; false is rejected because "
+                "synchronous online analysis was removed. Use npu_analysis_mode explicitly."
+            )
+        },
+    )
+
+    def __post_init__(self) -> None:
+        if self.npu_analysis_mode not in {"offline", "async"}:
+            raise ValueError(f"Invalid npu_analysis_mode={self.npu_analysis_mode!r}; expected one of: offline, async.")
+        if self.npu_offline_analysis is True:
+            if self.npu_analysis_mode == "async":
+                raise ValueError(
+                    "Conflicting NPU profiler options: npu_offline_analysis=true and npu_analysis_mode=async."
+                )
+            logger.warning("train.profile.npu_offline_analysis is deprecated; use npu_analysis_mode=offline.")
+            self.npu_analysis_mode = "offline"
+        elif self.npu_offline_analysis is False:
+            if self.enable:
+                raise ValueError(
+                    "train.profile.npu_offline_analysis=false requested removed synchronous online analysis; "
+                    "choose npu_analysis_mode=async or npu_analysis_mode=offline explicitly."
+                )
+            logger.warning(
+                "Ignoring deprecated train.profile.npu_offline_analysis=false because NPU profiling is disabled."
+            )
 
 
 @dataclass

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -217,6 +217,15 @@ class ProfileConfig:
             "help": "whether to profile rank0 only. When false, every rank will be profiled; Please expect many files to save, which can be slow and take a lot of disk space."
         },
     )
+    npu_offline_analysis: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Defer online Ascend analysis by setting analyse_flag=False, so training only finalizes raw data. "
+                "Parse the raw data offline with torch_npu or msprof. This option only affects NPU profiling."
+            )
+        },
+    )
 
 
 @dataclass

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -15,6 +15,7 @@
 import time
 from typing import TYPE_CHECKING, Any, Dict, List
 
+import torch.distributed as dist
 from tqdm import trange
 
 from ...utils import helper
@@ -160,27 +161,64 @@ class WandbTraceCallback(Callback):
 class ProfileTraceCallback(Callback):
     def on_train_begin(self, state: TrainerState, **kwargs) -> None:
         args: "VeOmniArguments" = self.trainer.args
+        self.profiler = None
+        self._profile_active = False
+        if not args.train.profile.enable:
+            return
+
+        # ProfileConfig uses absolute global steps, while torch profiler's
+        # schedule starts at zero for each process. Rebase the remaining window
+        # when resuming from a checkpoint or hot-updating a running job.
+        first_profile_step = max(args.train.profile.start_step, state.global_step + 1)
+        if first_profile_step >= args.train.profile.end_step:
+            logger.warning_rank0(
+                f"Profiling window [{args.train.profile.start_step}, {args.train.profile.end_step}) "
+                f"has no remaining steps after global step {state.global_step}; profiling is skipped."
+            )
+            return
+
+        self._profile_active = True
         if args.train.profile.this_rank:
             self.profiler = helper.create_profiler(
-                start_step=args.train.profile.start_step,
-                end_step=args.train.profile.end_step,
+                start_step=first_profile_step - state.global_step,
+                end_step=args.train.profile.end_step - state.global_step,
                 trace_dir=args.train.profile.trace_dir,
                 record_shapes=args.train.profile.record_shapes,
                 profile_memory=args.train.profile.profile_memory,
                 with_stack=args.train.profile.with_stack,
                 with_modules=args.train.profile.with_modules,
                 global_rank=args.train.global_rank,
+                npu_offline_analysis=args.train.profile.npu_offline_analysis,
             )
             self.profiler.start()
 
     def on_step_end(self, state: TrainerState, **kwargs) -> None:
         args: "VeOmniArguments" = self.trainer.args
-        if args.train.profile.this_rank:
+        # on_trace_ready runs synchronously when the schedule exits its active
+        # window, in profiler.step() at global step end_step - 1. Keep
+        # non-profiled ranks out of the next collective until NPU finalization
+        # (raw dump and optional online analyse) completes on the profiled rank(s).
+        # This applies to both online and offline Ascend analysis.
+        synchronize_finalize = (
+            self._profile_active
+            and helper.IS_NPU_AVAILABLE
+            and state.global_step == args.train.profile.end_step - 1
+            and dist.is_available()
+            and dist.is_initialized()
+        )
+
+        if synchronize_finalize:
+            dist.barrier()
+
+        if self.profiler is not None:
             if state.global_step <= args.train.profile.end_step:
                 self.profiler.step()
 
             if state.global_step == args.train.profile.end_step:
                 self.profiler.stop()
+
+        if synchronize_finalize:
+            dist.barrier()
 
 
 class EnvironMeterCallback(Callback):

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -163,6 +163,9 @@ class ProfileTraceCallback(Callback):
         args: "VeOmniArguments" = self.trainer.args
         self.profiler = None
         self._profile_active = False
+        self._profiler_stopped = False
+        self._step_started_at = None
+        self._profile_timing_start_step = None
         if not args.train.profile.enable:
             return
 
@@ -178,6 +181,10 @@ class ProfileTraceCallback(Callback):
             return
 
         self._profile_active = True
+        # Include the one warmup transition immediately before the requested
+        # active window, but do not add timing/logging overhead to unrelated
+        # training steps.
+        self._profile_timing_start_step = first_profile_step - 1
         if args.train.profile.this_rank:
             self.profiler = helper.create_profiler(
                 start_step=first_profile_step - state.global_step,
@@ -188,9 +195,20 @@ class ProfileTraceCallback(Callback):
                 with_stack=args.train.profile.with_stack,
                 with_modules=args.train.profile.with_modules,
                 global_rank=args.train.global_rank,
-                npu_offline_analysis=args.train.profile.npu_offline_analysis,
+                npu_analysis_mode=args.train.profile.npu_analysis_mode,
             )
             self.profiler.start()
+
+    def on_step_begin(self, state: TrainerState, **kwargs) -> None:
+        args: "VeOmniArguments" = self.trainer.args
+        timing_start_step = getattr(self, "_profile_timing_start_step", None)
+        if (
+            self._profile_active
+            and helper.IS_NPU_AVAILABLE
+            and timing_start_step is not None
+            and timing_start_step <= state.global_step <= args.train.profile.end_step
+        ):
+            self._step_started_at = time.perf_counter()
 
     def on_step_end(self, state: TrainerState, **kwargs) -> None:
         args: "VeOmniArguments" = self.trainer.args
@@ -207,18 +225,87 @@ class ProfileTraceCallback(Callback):
             and dist.is_initialized()
         )
 
+        pre_barrier_seconds = 0.0
+        profiler_step_seconds = 0.0
+        post_barrier_seconds = 0.0
+
         if synchronize_finalize:
+            started = time.perf_counter()
             dist.barrier()
+            pre_barrier_seconds = time.perf_counter() - started
 
-        if self.profiler is not None:
-            if state.global_step <= args.train.profile.end_step:
-                self.profiler.step()
+        try:
+            if self.profiler is not None:
+                if state.global_step <= args.train.profile.end_step:
+                    started = time.perf_counter()
+                    self.profiler.step()
+                    profiler_step_seconds = time.perf_counter() - started
 
-            if state.global_step == args.train.profile.end_step:
+                if state.global_step == args.train.profile.end_step:
+                    self.profiler.stop()
+                    self._profiler_stopped = True
+        finally:
+            if synchronize_finalize:
+                started = time.perf_counter()
+                dist.barrier()
+                post_barrier_seconds = time.perf_counter() - started
+
+        if state.global_step == args.train.profile.end_step:
+            self._profile_active = False
+
+        step_started_at = getattr(self, "_step_started_at", None)
+        if step_started_at is not None:
+            effective_mode = getattr(
+                self.profiler,
+                "_veomni_npu_analysis_mode",
+                args.train.profile.npu_analysis_mode,
+            )
+            timing_message = (
+                "NPU_PROFILE_STEP "
+                f"mode={effective_mode} rank={getattr(args.train, 'global_rank', 0)} "
+                f"step={state.global_step} finalize={str(synchronize_finalize).lower()} "
+                f"total_seconds={time.perf_counter() - step_started_at:.6f} "
+                f"pre_barrier_seconds={pre_barrier_seconds:.6f} "
+                f"profiler_step_seconds={profiler_step_seconds:.6f} "
+                f"post_barrier_seconds={post_barrier_seconds:.6f}"
+            )
+            if synchronize_finalize:
+                logger.info(timing_message)
+            else:
+                logger.info_rank0(timing_message)
+            self._step_started_at = None
+
+    def on_train_end(self, state: TrainerState, **kwargs) -> None:
+        args: "VeOmniArguments" = self.trainer.args
+        if not (args.train.profile.enable and helper.IS_NPU_AVAILABLE):
+            return
+
+        synchronize_cleanup = self._profile_active and dist.is_available() and dist.is_initialized()
+        if synchronize_cleanup:
+            dist.barrier()
+        try:
+            if self.profiler is not None and not getattr(self, "_profiler_stopped", False):
                 self.profiler.stop()
+                self._profiler_stopped = True
+        finally:
+            if synchronize_cleanup:
+                dist.barrier()
+        self._profile_active = False
 
-        if synchronize_finalize:
-            dist.barrier()
+        effective_mode = getattr(
+            self.profiler,
+            "_veomni_npu_analysis_mode",
+            args.train.profile.npu_analysis_mode,
+        )
+        logger.info_rank0(
+            f"NPU_PROFILE_TRAIN_END mode={effective_mode} step={state.global_step} wall_time_seconds={time.time():.6f}"
+        )
+        if self.profiler is not None:
+            helper.wait_npu_profile_sidecars(self.profiler)
+        logger.info_rank0(
+            f"NPU_PROFILE_TEARDOWN_DONE mode={effective_mode} step={state.global_step} "
+            f"wall_time_seconds={time.time():.6f}"
+        )
 
 
 class EnvironMeterCallback(Callback):

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -671,6 +671,7 @@ def create_profiler(
     with_stack: bool,
     with_modules: bool,
     global_rank: int,
+    npu_offline_analysis: bool = False,
 ):
     """
     Creates a profiler to record the CPU and CUDA activities. Default export to trace.json.
@@ -685,10 +686,12 @@ def create_profiler(
         record_shapes (bool): Whether to record the shapes of the tensors.
         profile_memory (bool): Whether to profile the memory usage.
         with_stack (bool): Whether to include the stack trace.
+        npu_offline_analysis (bool): Whether to defer Ascend profiler analysis to an offline process.
     """
 
     def handler_fn(p):
         time = int(datetime.datetime.now().timestamp())
+        hdfs_copy_succeeded = False
 
         trace_file_extention = "pt.trace.json.gz"
         gpu_memory_file_extension = "pkl"
@@ -711,14 +714,37 @@ def create_profiler(
             p.export_chrome_trace(trace_file)
         logger.info(f"Profiling result saved at {trace_file}.")
 
-        get_torch_device().memory._dump_snapshot(gpu_memory_file)
-        logger.info(f"Profiling memory visualization saved at {gpu_memory_file}.")
+        if not (IS_NPU_AVAILABLE and npu_offline_analysis):
+            get_torch_device().memory._dump_snapshot(gpu_memory_file)
+            logger.info(f"Profiling memory visualization saved at {gpu_memory_file}.")
 
         if trace_dir.startswith("hdfs://"):
-            copy(trace_file, trace_dir)
-            logger.info(f"Profiling result uploaded to {trace_dir}.")
+            hdfs_copy_succeeded = bool(copy(trace_file, trace_dir))
+            if hdfs_copy_succeeded:
+                logger.info(f"Profiling result uploaded to {trace_dir}.")
+            else:
+                logger.warning(
+                    f"Failed to copy profiling result to {trace_dir}; the raw capture remains at {trace_file}."
+                )
 
-        if VEOMNI_UPLOAD_CMD:
+        if VEOMNI_UPLOAD_CMD and IS_NPU_AVAILABLE and npu_offline_analysis:
+            if trace_dir.startswith("hdfs://"):
+                if hdfs_copy_succeeded:
+                    logger.warning(
+                        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
+                        f"The raw directory has already been copied to {trace_dir}; parse it offline."
+                    )
+                else:
+                    logger.warning(
+                        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory, "
+                        f"and the automatic copy to {trace_dir} failed. Preserve {trace_file} before the pod exits."
+                    )
+            else:
+                logger.warning(
+                    "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
+                    f"Copy {trace_file} to durable storage outside the training process, then parse it offline."
+                )
+        elif VEOMNI_UPLOAD_CMD:
             try:
                 logger.info_rank0(f"upload trace file {trace_file}")
                 if IS_NPU_AVAILABLE:
@@ -738,8 +764,10 @@ def create_profiler(
     if IS_NPU_AVAILABLE:
         profiler_module = torch_npu.profiler
         activities = [profiler_module.ProfilerActivity.CPU, profiler_module.ProfilerActivity.NPU]
+        trace_handler_kwargs = {"analyse_flag": False} if npu_offline_analysis else {}
         npu_trace_handler = torch_npu.profiler.tensorboard_trace_handler(
-            CACHE_DIR if trace_dir.startswith("hdfs://") else trace_dir
+            CACHE_DIR if trace_dir.startswith("hdfs://") else trace_dir,
+            **trace_handler_kwargs,
         )
         experimental_config = torch_npu.profiler._ExperimentalConfig(
             aic_metrics=torch_npu.profiler.AiCMetrics.PipeUtilization,
@@ -772,7 +800,7 @@ def create_profiler(
         with_stack=with_stack,
         experimental_config=experimental_config,
     )
-    if (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE) and profile_memory:
+    if (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE) and profile_memory and not (IS_NPU_AVAILABLE and npu_offline_analysis):
         return ProfilerWithMem(base_profiler)
     else:
         return base_profiler

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -66,6 +66,69 @@ VALID_CONFIG_TYPE = None
 VEOMNI_UPLOAD_CMD = None
 FlopsCounter = None
 
+# Offline Ascend postprocess sidecar (analyse / durable copy / upload).
+# - unset / auto: spawn when VEOMNI_UPLOAD_CMD is set or VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD=1
+# - VEOMNI_NPU_OFFLINE_POSTPROCESS=1: always spawn after raw finalize
+# - VEOMNI_NPU_OFFLINE_POSTPROCESS=0: never spawn; sync HDFS copy + skip upload
+VEOMNI_NPU_OFFLINE_POSTPROCESS = os.getenv("VEOMNI_NPU_OFFLINE_POSTPROCESS")
+VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD = os.getenv("VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD")
+
+
+def _env_flag(value: Optional[str]) -> Optional[bool]:
+    if value is None or value == "":
+        return None
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def spawn_npu_offline_sidecar(
+    raw_dir: str,
+    *,
+    copy_to: Optional[str] = None,
+    analyse: bool = True,
+    upload_cmd: Optional[str] = None,
+    merlin_upload: bool = False,
+) -> Optional[subprocess.Popen]:
+    """Fire-and-forget offline Ascend postprocess so training is not blocked.
+
+    The sidecar runs in a new session so it can outlive a soft train shutdown.
+    Logs go to ``<raw_dir>/veomni_npu_offline_postprocess.log``.
+    """
+    cmd = [sys.executable, "-m", "veomni.utils.npu_offline_postprocess", "--raw-dir", raw_dir]
+    if copy_to:
+        cmd.extend(["--copy-to", copy_to])
+    if analyse:
+        cmd.append("--analyse")
+    if upload_cmd:
+        cmd.extend(["--upload-cmd", upload_cmd])
+    if merlin_upload:
+        cmd.append("--merlin-upload")
+
+    if not (copy_to or analyse or upload_cmd or merlin_upload):
+        logger.warning("spawn_npu_offline_sidecar called with nothing to do; skipping")
+        return None
+
+    log_dir = raw_dir if os.path.isdir(raw_dir) else os.path.dirname(raw_dir) or "."
+    os.makedirs(log_dir, exist_ok=True)
+    log_path = os.path.join(log_dir, "veomni_npu_offline_postprocess.log")
+    log_fh = open(log_path, "a", encoding="utf-8")
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as exc:
+        log_fh.close()
+        logger.warning(f"Failed to spawn NPU offline postprocess sidecar: {exc}")
+        return None
+
+    logger.info(
+        f"Spawned NPU offline postprocess sidecar pid={proc.pid} log={log_path} cmd={' '.join(cmd)}"
+    )
+    return proc
+
 
 def convert_hdfs_fuse_path(*args, **kwargs):
     if len(args) > 0:
@@ -718,48 +781,72 @@ def create_profiler(
             get_torch_device().memory._dump_snapshot(gpu_memory_file)
             logger.info(f"Profiling memory visualization saved at {gpu_memory_file}.")
 
-        if trace_dir.startswith("hdfs://"):
-            hdfs_copy_succeeded = bool(copy(trace_file, trace_dir))
-            if hdfs_copy_succeeded:
-                logger.info(f"Profiling result uploaded to {trace_dir}.")
-            else:
-                logger.warning(
-                    f"Failed to copy profiling result to {trace_dir}; the raw capture remains at {trace_file}."
-                )
+        offline_postprocess_flag = _env_flag(VEOMNI_NPU_OFFLINE_POSTPROCESS)
+        merlin_upload = _env_flag(VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD) is True
+        use_offline_sidecar = (
+            IS_NPU_AVAILABLE
+            and npu_offline_analysis
+            and offline_postprocess_flag is not False
+            and (offline_postprocess_flag is True or bool(VEOMNI_UPLOAD_CMD) or merlin_upload)
+        )
 
-        if VEOMNI_UPLOAD_CMD and IS_NPU_AVAILABLE and npu_offline_analysis:
+        if use_offline_sidecar:
+            # Keep barrier short: only raw finalize stays in-process. Durable copy,
+            # torch_npu analyse, and upload run in a detached sidecar.
+            spawn_npu_offline_sidecar(
+                str(trace_file),
+                copy_to=trace_dir if trace_dir.startswith("hdfs://") else None,
+                analyse=True,
+                upload_cmd=VEOMNI_UPLOAD_CMD,
+                merlin_upload=merlin_upload and not VEOMNI_UPLOAD_CMD,
+            )
+        else:
+            hdfs_copy_succeeded = False
             if trace_dir.startswith("hdfs://"):
+                hdfs_copy_succeeded = bool(copy(trace_file, trace_dir))
                 if hdfs_copy_succeeded:
+                    logger.info(f"Profiling result uploaded to {trace_dir}.")
+                else:
+                    logger.warning(
+                        f"Failed to copy profiling result to {trace_dir}; the raw capture remains at {trace_file}."
+                    )
+
+            if VEOMNI_UPLOAD_CMD and IS_NPU_AVAILABLE and npu_offline_analysis:
+                # Explicit opt-out of the sidecar; keep the old skip warning.
+                if trace_dir.startswith("hdfs://"):
+                    if hdfs_copy_succeeded:
+                        logger.warning(
+                            "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
+                            f"The raw directory has already been copied to {trace_dir}; parse it offline "
+                            "(or set VEOMNI_NPU_OFFLINE_POSTPROCESS=1 / leave it unset with VEOMNI_UPLOAD_CMD)."
+                        )
+                    else:
+                        logger.warning(
+                            "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory, "
+                            f"and the automatic copy to {trace_dir} failed. Preserve {trace_file} before the pod exits."
+                        )
+                else:
                     logger.warning(
                         "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
-                        f"The raw directory has already been copied to {trace_dir}; parse it offline."
+                        f"Copy {trace_file} to durable storage outside the training process, then parse it offline "
+                        "(or unset VEOMNI_NPU_OFFLINE_POSTPROCESS=0 so the async sidecar can run)."
                     )
-                else:
-                    logger.warning(
-                        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory, "
-                        f"and the automatic copy to {trace_dir} failed. Preserve {trace_file} before the pod exits."
-                    )
-            else:
-                logger.warning(
-                    "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
-                    f"Copy {trace_file} to durable storage outside the training process, then parse it offline."
-                )
-        elif VEOMNI_UPLOAD_CMD:
-            try:
-                logger.info_rank0(f"upload trace file {trace_file}")
-                if IS_NPU_AVAILABLE:
-                    import gzip
-                    import shutil
+            elif VEOMNI_UPLOAD_CMD:
+                try:
+                    logger.info_rank0(f"upload trace file {trace_file}")
+                    if IS_NPU_AVAILABLE:
+                        import gzip
+                        import shutil
 
-                    npu_trace_file = f"{trace_file}/ASCEND_PROFILER_OUTPUT/trace_view.json"
-                    with open(npu_trace_file, "rb") as f_in, gzip.open(f"{npu_trace_file}.gz", "wb") as f_out:
-                        shutil.copyfileobj(f_in, f_out)
-                    command2 = f"{VEOMNI_UPLOAD_CMD} {npu_trace_file}.gz"
-                else:
-                    command2 = f"{VEOMNI_UPLOAD_CMD} {trace_file}"
-                subprocess.run(command2, shell=True, check=True, executable="/bin/bash")
-            except Exception as e:
-                logger.warning(f"failed to upload trace file {trace_file}, error: {e}")
+                        npu_trace_file = f"{trace_file}/ASCEND_PROFILER_OUTPUT/trace_view.json"
+                        with open(npu_trace_file, "rb") as f_in, gzip.open(f"{npu_trace_file}.gz", "wb") as f_out:
+                            shutil.copyfileobj(f_in, f_out)
+                        command2 = f"{VEOMNI_UPLOAD_CMD} {npu_trace_file}.gz"
+                    else:
+                        command2 = f"{VEOMNI_UPLOAD_CMD} {trace_file}"
+                    subprocess.run(command2, shell=True, check=True, executable="/bin/bash")
+                except Exception as e:
+                    logger.warning(f"failed to upload trace file {trace_file}, error: {e}")
 
     if IS_NPU_AVAILABLE:
         profiler_module = torch_npu.profiler

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -18,10 +18,13 @@
 import datetime
 import gc
 import logging as builtin_logging
+import multiprocessing
 import os
 import random
+import shlex
 import subprocess
 import sys
+import time
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass
@@ -63,13 +66,13 @@ if IS_NPU_AVAILABLE:
 
 # internal use
 VALID_CONFIG_TYPE = None
-VEOMNI_UPLOAD_CMD = None
+VEOMNI_UPLOAD_CMD = os.getenv("VEOMNI_UPLOAD_CMD")
 FlopsCounter = None
 
 # Offline Ascend postprocess sidecar (analyse / durable copy / upload).
 # - unset / auto: spawn when VEOMNI_UPLOAD_CMD is set or VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD=1
 # - VEOMNI_NPU_OFFLINE_POSTPROCESS=1: always spawn after raw finalize
-# - VEOMNI_NPU_OFFLINE_POSTPROCESS=0: never spawn; sync HDFS copy + skip upload
+# - VEOMNI_NPU_OFFLINE_POSTPROCESS=0: never spawn; preserve the local raw capture only
 VEOMNI_NPU_OFFLINE_POSTPROCESS = os.getenv("VEOMNI_NPU_OFFLINE_POSTPROCESS")
 VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD = os.getenv("VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD")
 
@@ -107,11 +110,14 @@ def spawn_npu_offline_sidecar(
         logger.warning("spawn_npu_offline_sidecar called with nothing to do; skipping")
         return None
 
-    log_dir = raw_dir if os.path.isdir(raw_dir) else os.path.dirname(raw_dir) or "."
-    os.makedirs(log_dir, exist_ok=True)
-    log_path = os.path.join(log_dir, "veomni_npu_offline_postprocess.log")
-    log_fh = open(log_path, "a", encoding="utf-8")
+    log_path = os.path.join(
+        raw_dir if os.path.isdir(raw_dir) else os.path.dirname(raw_dir) or ".",
+        "veomni_npu_offline_postprocess.log",
+    )
+    log_fh = None
     try:
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        log_fh = open(log_path, "a", encoding="utf-8")
         proc = subprocess.Popen(
             cmd,
             stdout=log_fh,
@@ -120,14 +126,38 @@ def spawn_npu_offline_sidecar(
             close_fds=True,
         )
     except Exception as exc:
-        log_fh.close()
         logger.warning(f"Failed to spawn NPU offline postprocess sidecar: {exc}")
         return None
+    finally:
+        if log_fh is not None:
+            log_fh.close()
 
-    logger.info(
-        f"Spawned NPU offline postprocess sidecar pid={proc.pid} log={log_path} cmd={' '.join(cmd)}"
-    )
+    logger.info(f"Spawned NPU offline postprocess sidecar pid={proc.pid} log={log_path} cmd={shlex.join(cmd)}")
     return proc
+
+
+def wait_npu_profile_sidecars(profiler, timeout_seconds: float = 300.0) -> None:
+    """Wait briefly for detached NPU postprocess work after training is done."""
+    sidecars = getattr(profiler, "_veomni_npu_sidecars", ())
+    deadline = time.monotonic() + max(timeout_seconds, 0.0)
+    for proc in sidecars:
+        started = time.perf_counter()
+        try:
+            return_code = proc.wait(timeout=max(deadline - time.monotonic(), 0.0))
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                f"NPU profile sidecar pid={proc.pid} is still running after {timeout_seconds:.1f}s; "
+                "the raw local capture is preserved, but durable copy/upload may still be incomplete."
+            )
+            continue
+        duration = time.perf_counter() - started
+        if return_code == 0:
+            logger.info(f"NPU_PROFILE_SIDECAR_WAIT pid={proc.pid} status=completed duration_seconds={duration:.6f}")
+        else:
+            logger.warning(
+                f"NPU profile sidecar pid={proc.pid} exited with return code {return_code}; "
+                "inspect veomni_npu_offline_postprocess.log and preserve the raw capture."
+            )
 
 
 def convert_hdfs_fuse_path(*args, **kwargs):
@@ -734,7 +764,8 @@ def create_profiler(
     with_stack: bool,
     with_modules: bool,
     global_rank: int,
-    npu_offline_analysis: bool = False,
+    npu_analysis_mode: str = "offline",
+    npu_offline_analysis: Optional[bool] = None,
 ):
     """
     Creates a profiler to record the CPU and CUDA activities. Default export to trace.json.
@@ -749,113 +780,175 @@ def create_profiler(
         record_shapes (bool): Whether to record the shapes of the tensors.
         profile_memory (bool): Whether to profile the memory usage.
         with_stack (bool): Whether to include the stack trace.
-        npu_offline_analysis (bool): Whether to defer Ascend profiler analysis to an offline process.
+        npu_analysis_mode (str): Ascend analysis mode: ``offline`` or ``async``.
+        npu_offline_analysis (bool, optional): Deprecated alias; ``True`` maps to offline.
     """
 
+    if npu_offline_analysis is True:
+        if npu_analysis_mode == "async":
+            raise ValueError(
+                "Conflicting NPU profiler options: npu_offline_analysis=True and npu_analysis_mode='async'."
+            )
+        warnings.warn(
+            "npu_offline_analysis is deprecated; use npu_analysis_mode='offline'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        npu_analysis_mode = "offline"
+    elif npu_offline_analysis is False:
+        raise ValueError(
+            "npu_offline_analysis=False requested removed synchronous online analysis; choose "
+            "npu_analysis_mode='async' or npu_analysis_mode='offline' explicitly."
+        )
+
+    if npu_analysis_mode not in {"offline", "async"}:
+        raise ValueError(f"Invalid npu_analysis_mode={npu_analysis_mode!r}; expected one of: offline, async.")
+
+    is_hdfs_trace = trace_dir.startswith("hdfs://")
+    if IS_NPU_AVAILABLE and npu_analysis_mode == "async" and is_hdfs_trace:
+        raise ValueError(
+            "NPU async analysis requires a pod-local trace_dir. Background analysis is still writing its output, "
+            "so an hdfs:// destination cannot be copied safely from on_trace_ready."
+        )
+
+    effective_npu_analysis_mode = npu_analysis_mode
+    npu_sidecars: list[subprocess.Popen] = []
+
     def handler_fn(p):
-        time = int(datetime.datetime.now().timestamp())
-        hdfs_copy_succeeded = False
+        timestamp = int(datetime.datetime.now().timestamp())
 
         trace_file_extention = "pt.trace.json.gz"
         gpu_memory_file_extension = "pkl"
 
-        if trace_dir.startswith("hdfs://"):
-            hdfs_io.makedirs(trace_dir, exist_ok=True)
+        if is_hdfs_trace:
+            if not IS_NPU_AVAILABLE:
+                hdfs_io.makedirs(trace_dir, exist_ok=True)
             os.makedirs(CACHE_DIR, exist_ok=True)
-            trace_file = os.path.join(CACHE_DIR, f"veomni_rank{global_rank}_{time}.{trace_file_extention}")
-            gpu_memory_file = os.path.join(CACHE_DIR, f"veomni_rank{global_rank}_{time}.{gpu_memory_file_extension}")
+            trace_file = os.path.join(CACHE_DIR, f"veomni_rank{global_rank}_{timestamp}.{trace_file_extention}")
+            gpu_memory_file = os.path.join(
+                CACHE_DIR, f"veomni_rank{global_rank}_{timestamp}.{gpu_memory_file_extension}"
+            )
         else:
             os.makedirs(trace_dir, exist_ok=True)
-            trace_file = os.path.join(trace_dir, f"veomni_rank{global_rank}_{time}.{trace_file_extention}")
-            gpu_memory_file = os.path.join(trace_dir, f"veomni_rank{global_rank}_{time}.{gpu_memory_file_extension}")
+            trace_file = os.path.join(trace_dir, f"veomni_rank{global_rank}_{timestamp}.{trace_file_extention}")
+            gpu_memory_file = os.path.join(
+                trace_dir, f"veomni_rank{global_rank}_{timestamp}.{gpu_memory_file_extension}"
+            )
 
         if IS_NPU_AVAILABLE:
             nonlocal npu_trace_handler
-            npu_trace_handler(p)
             trace_file = p.prof_if.prof_path
+            handler_started = time.perf_counter()
+            handler_status = "ok"
+            try:
+                npu_trace_handler(p)
+            except Exception as exc:
+                if effective_npu_analysis_mode != "async":
+                    raise
+                # Raw finalization has already selected prof_path. A failure to
+                # submit optional background analysis must not take down the
+                # distributed training job or strand peers at the barrier.
+                handler_status = "analysis_submit_failed"
+                logger.warning(
+                    "NPU async analysis submission failed; training will continue and the finalized raw capture "
+                    f"remains at {trace_file}. Error: {exc}"
+                )
+            handler_seconds = time.perf_counter() - handler_started
+            logger.info(
+                "NPU_PROFILE_HANDLER "
+                f"mode={effective_npu_analysis_mode} status={handler_status} rank={global_rank} "
+                f"duration_seconds={handler_seconds:.6f} raw_dir={trace_file}"
+            )
         elif IS_CUDA_AVAILABLE:
             p.export_chrome_trace(trace_file)
         logger.info(f"Profiling result saved at {trace_file}.")
 
-        if not (IS_NPU_AVAILABLE and npu_offline_analysis):
-            get_torch_device().memory._dump_snapshot(gpu_memory_file)
-            logger.info(f"Profiling memory visualization saved at {gpu_memory_file}.")
+        if IS_NPU_AVAILABLE:
+            offline_postprocess_flag = _env_flag(VEOMNI_NPU_OFFLINE_POSTPROCESS)
+            merlin_upload = _env_flag(VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD) is True
 
-        offline_postprocess_flag = _env_flag(VEOMNI_NPU_OFFLINE_POSTPROCESS)
-        merlin_upload = _env_flag(VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD) is True
-        use_offline_sidecar = (
-            IS_NPU_AVAILABLE
-            and npu_offline_analysis
-            and offline_postprocess_flag is not False
-            and (offline_postprocess_flag is True or bool(VEOMNI_UPLOAD_CMD) or merlin_upload)
-        )
-
-        if use_offline_sidecar:
-            # Keep barrier short: only raw finalize stays in-process. Durable copy,
-            # torch_npu analyse, and upload run in a detached sidecar.
-            spawn_npu_offline_sidecar(
-                str(trace_file),
-                copy_to=trace_dir if trace_dir.startswith("hdfs://") else None,
-                analyse=True,
-                upload_cmd=VEOMNI_UPLOAD_CMD,
-                merlin_upload=merlin_upload and not VEOMNI_UPLOAD_CMD,
-            )
-        else:
-            hdfs_copy_succeeded = False
-            if trace_dir.startswith("hdfs://"):
-                hdfs_copy_succeeded = bool(copy(trace_file, trace_dir))
-                if hdfs_copy_succeeded:
-                    logger.info(f"Profiling result uploaded to {trace_dir}.")
-                else:
+            if effective_npu_analysis_mode == "async":
+                if offline_postprocess_flag is True or VEOMNI_UPLOAD_CMD or merlin_upload:
                     logger.warning(
-                        f"Failed to copy profiling result to {trace_dir}; the raw capture remains at {trace_file}."
+                        "Automatic copy/upload is skipped for NPU async analysis because the background parser may "
+                        f"still be writing {trace_file}. Upload the completed trace after training exits."
                     )
+                return
 
-            if VEOMNI_UPLOAD_CMD and IS_NPU_AVAILABLE and npu_offline_analysis:
-                # Explicit opt-out of the sidecar; keep the old skip warning.
-                if trace_dir.startswith("hdfs://"):
-                    if hdfs_copy_succeeded:
-                        logger.warning(
-                            "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
-                            f"The raw directory has already been copied to {trace_dir}; parse it offline "
-                            "(or set VEOMNI_NPU_OFFLINE_POSTPROCESS=1 / leave it unset with VEOMNI_UPLOAD_CMD)."
-                        )
-                    else:
-                        logger.warning(
-                            "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory, "
-                            f"and the automatic copy to {trace_dir} failed. Preserve {trace_file} before the pod exits."
-                        )
-                else:
+            needs_copy = is_hdfs_trace
+            needs_analysis = offline_postprocess_flag is True or bool(VEOMNI_UPLOAD_CMD) or merlin_upload
+            needs_sidecar = needs_copy or needs_analysis
+            if needs_sidecar and offline_postprocess_flag is not False:
+                proc = spawn_npu_offline_sidecar(
+                    str(trace_file),
+                    copy_to=trace_dir if needs_copy else None,
+                    analyse=needs_analysis,
+                    upload_cmd=VEOMNI_UPLOAD_CMD,
+                    merlin_upload=merlin_upload and not VEOMNI_UPLOAD_CMD,
+                )
+                if proc is None:
                     logger.warning(
-                        "VEOMNI_UPLOAD_CMD is skipped because offline NPU profiling produces a raw directory. "
-                        f"Copy {trace_file} to durable storage outside the training process, then parse it offline "
-                        "(or unset VEOMNI_NPU_OFFLINE_POSTPROCESS=0 so the async sidecar can run)."
+                        "NPU offline postprocess sidecar did not start; no synchronous fallback will run inside the "
+                        f"training barrier. The raw capture remains at {trace_file}."
                     )
-            elif VEOMNI_UPLOAD_CMD:
-                try:
-                    logger.info_rank0(f"upload trace file {trace_file}")
-                    if IS_NPU_AVAILABLE:
-                        import gzip
-                        import shutil
+                else:
+                    npu_sidecars.append(proc)
+            elif needs_sidecar:
+                logger.warning(
+                    "NPU offline postprocess sidecar is disabled; no synchronous copy, analysis, or upload will run "
+                    f"inside the training barrier. The raw capture remains at {trace_file}."
+                )
+            return
 
-                        npu_trace_file = f"{trace_file}/ASCEND_PROFILER_OUTPUT/trace_view.json"
-                        with open(npu_trace_file, "rb") as f_in, gzip.open(f"{npu_trace_file}.gz", "wb") as f_out:
-                            shutil.copyfileobj(f_in, f_out)
-                        command2 = f"{VEOMNI_UPLOAD_CMD} {npu_trace_file}.gz"
-                    else:
-                        command2 = f"{VEOMNI_UPLOAD_CMD} {trace_file}"
-                    subprocess.run(command2, shell=True, check=True, executable="/bin/bash")
-                except Exception as e:
-                    logger.warning(f"failed to upload trace file {trace_file}, error: {e}")
+        get_torch_device().memory._dump_snapshot(gpu_memory_file)
+        logger.info(f"Profiling memory visualization saved at {gpu_memory_file}.")
+
+        if is_hdfs_trace:
+            if copy(trace_file, trace_dir):
+                logger.info(f"Profiling result uploaded to {trace_dir}.")
+            else:
+                logger.warning(f"Failed to copy profiling result to {trace_dir}; trace remains at {trace_file}.")
+
+        if VEOMNI_UPLOAD_CMD:
+            try:
+                logger.info_rank0(f"upload trace file {trace_file}")
+                command = f"{VEOMNI_UPLOAD_CMD} {shlex.quote(str(trace_file))}"
+                subprocess.run(command, shell=True, check=True, executable="/bin/bash")
+            except Exception as exc:
+                logger.warning(f"failed to upload trace file {trace_file}, error: {exc}")
 
     if IS_NPU_AVAILABLE:
         profiler_module = torch_npu.profiler
         activities = [profiler_module.ProfilerActivity.CPU, profiler_module.ProfilerActivity.NPU]
-        trace_handler_kwargs = {"analyse_flag": False} if npu_offline_analysis else {}
-        npu_trace_handler = torch_npu.profiler.tensorboard_trace_handler(
-            CACHE_DIR if trace_dir.startswith("hdfs://") else trace_dir,
-            **trace_handler_kwargs,
-        )
+        npu_trace_dir = CACHE_DIR if is_hdfs_trace else trace_dir
+        if npu_analysis_mode == "async" and multiprocessing.current_process().daemon:
+            effective_npu_analysis_mode = "offline"
+            logger.warning(
+                "NPU async analysis is unavailable in a daemon process; falling back to offline raw capture."
+            )
+
+        if effective_npu_analysis_mode == "async":
+            try:
+                npu_trace_handler = torch_npu.profiler.tensorboard_trace_handler(
+                    npu_trace_dir,
+                    analyse_flag=True,
+                    async_mode=True,
+                )
+            except TypeError as exc:
+                effective_npu_analysis_mode = "offline"
+                logger.warning(
+                    "This torch_npu version does not support async tensorboard trace analysis; falling back to "
+                    f"offline raw capture. Error: {exc}"
+                )
+                npu_trace_handler = torch_npu.profiler.tensorboard_trace_handler(
+                    npu_trace_dir,
+                    analyse_flag=False,
+                )
+        else:
+            npu_trace_handler = torch_npu.profiler.tensorboard_trace_handler(
+                npu_trace_dir,
+                analyse_flag=False,
+            )
         experimental_config = torch_npu.profiler._ExperimentalConfig(
             aic_metrics=torch_npu.profiler.AiCMetrics.PipeUtilization,
             profiler_level=torch_npu.profiler.ProfilerLevel.Level1,
@@ -887,10 +980,13 @@ def create_profiler(
         with_stack=with_stack,
         experimental_config=experimental_config,
     )
-    if (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE) and profile_memory and not (IS_NPU_AVAILABLE and npu_offline_analysis):
-        return ProfilerWithMem(base_profiler)
-    else:
+    if IS_NPU_AVAILABLE:
+        base_profiler._veomni_npu_analysis_mode = effective_npu_analysis_mode
+        base_profiler._veomni_npu_sidecars = npu_sidecars
         return base_profiler
+    if IS_CUDA_AVAILABLE and profile_memory:
+        return ProfilerWithMem(base_profiler)
+    return base_profiler
 
 
 if os.getenv("DISABLE_WARNINGS", "0").lower() in ["true", "1"]:

--- a/veomni/utils/npu_offline_postprocess.py
+++ b/veomni/utils/npu_offline_postprocess.py
@@ -1,0 +1,238 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline Ascend profile post-processing (copy / analyse / upload).
+
+Designed to run outside the training critical path. Training can spawn this as a
+fire-and-forget sidecar after raw `*_ascend_pt` finalization so peer ranks are
+not blocked on Chrome/DB export or Merlin upload.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+logger = logging.getLogger("veomni.npu_offline_postprocess")
+
+
+def _is_ascend_pt_dir(path: Path) -> bool:
+    return path.is_dir() and path.name.endswith("_ascend_pt")
+
+
+def resolve_raw_dir(raw_dir: str | Path) -> Path:
+    """Return the concrete `*_ascend_pt` directory."""
+    path = Path(raw_dir).expanduser().resolve()
+    if _is_ascend_pt_dir(path):
+        return path
+    if path.is_dir():
+        matches = sorted(p for p in path.iterdir() if _is_ascend_pt_dir(p))
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise FileNotFoundError(
+                f"Multiple *_ascend_pt directories under {path}; pass one explicitly: {[p.name for p in matches]}"
+            )
+    raise FileNotFoundError(f"No *_ascend_pt directory found at {raw_dir}")
+
+
+def resolve_analyse_path(raw_dir: Path) -> str:
+    """torch_npu.profiler.analyse expects the parent of `*_ascend_pt`."""
+    return str(raw_dir.parent)
+
+
+def find_trace_view(raw_dir: Path) -> Path:
+    candidates = [
+        raw_dir / "ASCEND_PROFILER_OUTPUT" / "trace_view.json",
+        raw_dir / "ASCEND_PROFILER_OUTPUT" / "trace_view.json.gz",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    matches = sorted(raw_dir.rglob("trace_view.json"))
+    if matches:
+        return matches[0]
+    raise FileNotFoundError(f"trace_view.json not found under {raw_dir} after analyse")
+
+
+def gzip_trace(trace_path: Path) -> Path:
+    if trace_path.suffix == ".gz":
+        return trace_path
+    out = Path(f"{trace_path}.gz")
+    with open(trace_path, "rb") as src, gzip.open(out, "wb") as dst:
+        shutil.copyfileobj(src, dst)
+    return out
+
+
+def copy_raw_dir(raw_dir: Path, copy_to: str) -> None:
+    if copy_to.startswith("hdfs://"):
+        try:
+            from veomni.utils.hdfs_io import copy, makedirs
+        except Exception as exc:  # pragma: no cover - import path depends on install
+            raise RuntimeError(f"HDFS copy requires veomni.utils.hdfs_io: {exc}") from exc
+        makedirs(copy_to, exist_ok=True)
+        if not copy(str(raw_dir), copy_to):
+            raise RuntimeError(f"Failed to copy {raw_dir} to {copy_to}")
+        logger.info("Copied raw profile to %s", copy_to)
+        return
+
+    dest = Path(copy_to).expanduser()
+    dest.mkdir(parents=True, exist_ok=True)
+    target = dest / raw_dir.name
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(raw_dir, target)
+    logger.info("Copied raw profile to %s", target)
+
+
+def run_analyse(raw_dir: Path, max_process_number: Optional[int] = None) -> None:
+    try:
+        import torch_npu
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("torch_npu is required for --analyse") from exc
+
+    profiler_path = resolve_analyse_path(raw_dir)
+    kwargs = {}
+    if max_process_number is not None:
+        kwargs["max_process_number"] = max_process_number
+    logger.info("Running torch_npu.profiler.analyse(profiler_path=%s)", profiler_path)
+    torch_npu.profiler.analyse(profiler_path=profiler_path, **kwargs)
+
+
+def run_upload_cmd(upload_cmd: str, trace_file: Path) -> None:
+    if "{trace}" in upload_cmd:
+        command = upload_cmd.format(trace=str(trace_file))
+    else:
+        command = f"{upload_cmd} {trace_file}"
+    logger.info("Uploading with command: %s", command)
+    subprocess.run(command, shell=True, check=True, executable="/bin/bash")
+
+
+def build_merlin_upload_cmd(trace_file: Path, name: Optional[str] = None) -> str:
+    payload = {
+        "file_path": str(trace_file),
+        "asset_type": "perfetto",
+        "compress": False if str(trace_file).endswith(".gz") else True,
+    }
+    if name:
+        payload["name"] = name
+    # job_id / trial_id are inferred by merlin-cli from RH2_JOB_RUN_ID / ARNOLD_TRIAL_ID.
+    return "merlin-cli profiling upload --json " + json.dumps(payload, ensure_ascii=False)
+
+
+def postprocess(
+    raw_dir: str | Path,
+    *,
+    copy_to: Optional[str] = None,
+    analyse: bool = False,
+    upload_cmd: Optional[str] = None,
+    merlin_upload: bool = False,
+    upload_name: Optional[str] = None,
+    max_process_number: Optional[int] = None,
+) -> Optional[Path]:
+    resolved = resolve_raw_dir(raw_dir)
+    logger.info("Post-processing Ascend raw profile at %s", resolved)
+
+    if copy_to:
+        copy_raw_dir(resolved, copy_to)
+
+    if analyse:
+        run_analyse(resolved, max_process_number=max_process_number)
+
+    if not (upload_cmd or merlin_upload):
+        return None
+
+    if not analyse:
+        # Allow upload of an already-parsed capture.
+        logger.info("Upload requested without --analyse; expecting an existing trace_view.json")
+
+    trace_path = find_trace_view(resolved)
+    packed = gzip_trace(trace_path)
+    cmd = upload_cmd
+    if merlin_upload:
+        cmd = build_merlin_upload_cmd(packed, name=upload_name)
+    assert cmd is not None
+    run_upload_cmd(cmd, packed)
+    return packed
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Copy / analyse / upload an Ascend offline raw profile outside training."
+    )
+    parser.add_argument("--raw-dir", required=True, help="Path to *_ascend_pt or its parent directory")
+    parser.add_argument(
+        "--copy-to",
+        default=None,
+        help="Durable destination for the raw directory (local path or hdfs://...)",
+    )
+    parser.add_argument(
+        "--analyse",
+        action="store_true",
+        help="Run torch_npu.profiler.analyse to produce Chrome/DB outputs",
+    )
+    parser.add_argument(
+        "--upload-cmd",
+        default=None,
+        help="Shell command to upload the parsed trace. Use {trace} or append the path.",
+    )
+    parser.add_argument(
+        "--merlin-upload",
+        action="store_true",
+        help="Upload the parsed Chrome trace with merlin-cli profiling upload (Perfetto).",
+    )
+    parser.add_argument("--upload-name", default=None, help="Optional Merlin asset display name")
+    parser.add_argument("--max-process-number", type=int, default=None, help="torch_npu analyse parallelism")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    _configure_logging(args.verbose)
+    if not (args.copy_to or args.analyse or args.upload_cmd or args.merlin_upload):
+        logger.error("Nothing to do: pass --copy-to and/or --analyse and/or an upload option")
+        return 2
+    postprocess(
+        args.raw_dir,
+        copy_to=args.copy_to,
+        analyse=args.analyse,
+        upload_cmd=args.upload_cmd,
+        merlin_upload=args.merlin_upload,
+        upload_name=args.upload_name,
+        max_process_number=args.max_process_number,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veomni/utils/npu_offline_postprocess.py
+++ b/veomni/utils/npu_offline_postprocess.py
@@ -120,21 +120,52 @@ def copy_raw_dir(raw_dir: Path, copy_to: str) -> None:
 
 def run_analyse(raw_dir: Path, max_process_number: Optional[int] = None) -> None:
     try:
-        import torch_npu
+        from torch_npu.profiler.profiler import analyse as npu_analyse
     except ImportError as exc:  # pragma: no cover
         raise RuntimeError("torch_npu is required for --analyse") from exc
 
     profiler_path = resolve_analyse_path(raw_dir)
+    trace_path = raw_dir / "ASCEND_PROFILER_OUTPUT" / "trace_view.json"
+    if trace_path.is_file():
+        existing_stat = trace_path.stat()
+        existing_signature = (
+            existing_stat.st_ino,
+            existing_stat.st_size,
+            existing_stat.st_mtime_ns,
+            existing_stat.st_ctime_ns,
+        )
+    else:
+        existing_signature = None
     kwargs = {}
     if max_process_number is not None:
         kwargs["max_process_number"] = max_process_number
-    logger.info("Running torch_npu.profiler.analyse(profiler_path=%s)", profiler_path)
+    logger.info("Running torch_npu.profiler.profiler.analyse(profiler_path=%s)", profiler_path)
     started = time.perf_counter()
-    torch_npu.profiler.analyse(profiler_path=profiler_path, **kwargs)
+    npu_analyse(profiler_path=profiler_path, **kwargs)
+    if not trace_path.is_file():
+        raise FileNotFoundError(f"trace_view.json not found under {raw_dir} after analyse")
+    trace_stat = trace_path.stat()
+    if trace_stat.st_size == 0:
+        raise RuntimeError(f"torch_npu analyse produced an empty trace: {trace_path}")
+    trace_signature = (
+        trace_stat.st_ino,
+        trace_stat.st_size,
+        trace_stat.st_mtime_ns,
+        trace_stat.st_ctime_ns,
+    )
+    if trace_signature == existing_signature:
+        raise RuntimeError(f"torch_npu analyse did not create or update the existing trace: {trace_path}")
+    with open(trace_path, "rb") as trace_file:
+        head = trace_file.read(4096).lstrip()
+        trace_file.seek(max(0, trace_stat.st_size - 4096))
+        tail = trace_file.read().rstrip()
+    if not head.startswith(b"[") or not tail.endswith(b"]"):
+        raise RuntimeError(f"torch_npu analyse produced an incomplete trace: {trace_path}")
     logger.info(
-        "NPU_PROFILE_ANALYSE mode=offline duration_seconds=%.6f raw_dir=%s",
+        "NPU_PROFILE_ANALYSE mode=offline duration_seconds=%.6f raw_dir=%s trace=%s",
         time.perf_counter() - started,
         raw_dir,
+        trace_path,
     )
 
 
@@ -223,7 +254,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--analyse",
         action="store_true",
-        help="Run torch_npu.profiler.analyse to produce Chrome/DB outputs",
+        help="Run torch_npu.profiler.profiler.analyse to produce Chrome/DB outputs",
     )
     parser.add_argument(
         "--upload-cmd",

--- a/veomni/utils/npu_offline_postprocess.py
+++ b/veomni/utils/npu_offline_postprocess.py
@@ -25,10 +25,11 @@ import argparse
 import gzip
 import json
 import logging
-import os
+import shlex
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -57,8 +58,8 @@ def resolve_raw_dir(raw_dir: str | Path) -> Path:
 
 
 def resolve_analyse_path(raw_dir: Path) -> str:
-    """torch_npu.profiler.analyse expects the parent of `*_ascend_pt`."""
-    return str(raw_dir.parent)
+    """Target exactly one finalized ``*_ascend_pt`` capture."""
+    return str(raw_dir)
 
 
 def find_trace_view(raw_dir: Path) -> Path:
@@ -87,21 +88,33 @@ def gzip_trace(trace_path: Path) -> Path:
 def copy_raw_dir(raw_dir: Path, copy_to: str) -> None:
     if copy_to.startswith("hdfs://"):
         try:
-            from veomni.utils.hdfs_io import copy, makedirs
+            from veomni.utils.hdfs_io import copy, exists, makedirs
         except Exception as exc:  # pragma: no cover - import path depends on install
             raise RuntimeError(f"HDFS copy requires veomni.utils.hdfs_io: {exc}") from exc
+        target = f"{copy_to.rstrip('/')}/{raw_dir.name}"
+        if exists(target):
+            raise FileExistsError(f"Refusing to overwrite existing HDFS profile target: {target}")
         makedirs(copy_to, exist_ok=True)
-        if not copy(str(raw_dir), copy_to):
-            raise RuntimeError(f"Failed to copy {raw_dir} to {copy_to}")
-        logger.info("Copied raw profile to %s", copy_to)
+        if not copy(str(raw_dir), target):
+            raise RuntimeError(f"Failed to copy {raw_dir} to {target}")
+        logger.info("Copied raw profile to %s", target)
         return
 
-    dest = Path(copy_to).expanduser()
-    dest.mkdir(parents=True, exist_ok=True)
+    source = raw_dir.resolve()
+    dest = Path(copy_to).expanduser().resolve()
     target = dest / raw_dir.name
+    if target == source:
+        raise ValueError(f"copy_to cannot be the raw profile source parent: {dest}")
+    try:
+        dest.relative_to(source)
+    except ValueError:
+        pass
+    else:
+        raise ValueError(f"copy_to cannot be inside the raw profile directory: {dest}")
     if target.exists():
-        shutil.rmtree(target)
-    shutil.copytree(raw_dir, target)
+        raise FileExistsError(f"Refusing to overwrite existing profile target: {target} already exists")
+    dest.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, target)
     logger.info("Copied raw profile to %s", target)
 
 
@@ -116,19 +129,31 @@ def run_analyse(raw_dir: Path, max_process_number: Optional[int] = None) -> None
     if max_process_number is not None:
         kwargs["max_process_number"] = max_process_number
     logger.info("Running torch_npu.profiler.analyse(profiler_path=%s)", profiler_path)
+    started = time.perf_counter()
     torch_npu.profiler.analyse(profiler_path=profiler_path, **kwargs)
+    logger.info(
+        "NPU_PROFILE_ANALYSE mode=offline duration_seconds=%.6f raw_dir=%s",
+        time.perf_counter() - started,
+        raw_dir,
+    )
 
 
-def run_upload_cmd(upload_cmd: str, trace_file: Path) -> None:
+def run_upload_cmd(upload_cmd: str | list[str], trace_file: Path) -> None:
+    if isinstance(upload_cmd, list):
+        logger.info("Uploading with argv: %s", shlex.join(upload_cmd))
+        subprocess.run(upload_cmd, check=True)
+        return
+
+    quoted_trace = shlex.quote(str(trace_file))
     if "{trace}" in upload_cmd:
-        command = upload_cmd.format(trace=str(trace_file))
+        command = upload_cmd.replace("{trace}", quoted_trace)
     else:
-        command = f"{upload_cmd} {trace_file}"
+        command = f"{upload_cmd} {quoted_trace}"
     logger.info("Uploading with command: %s", command)
     subprocess.run(command, shell=True, check=True, executable="/bin/bash")
 
 
-def build_merlin_upload_cmd(trace_file: Path, name: Optional[str] = None) -> str:
+def build_merlin_upload_cmd(trace_file: Path, name: Optional[str] = None) -> list[str]:
     payload = {
         "file_path": str(trace_file),
         "asset_type": "perfetto",
@@ -137,7 +162,7 @@ def build_merlin_upload_cmd(trace_file: Path, name: Optional[str] = None) -> str
     if name:
         payload["name"] = name
     # job_id / trial_id are inferred by merlin-cli from RH2_JOB_RUN_ID / ARNOLD_TRIAL_ID.
-    return "merlin-cli profiling upload --json " + json.dumps(payload, ensure_ascii=False)
+    return ["merlin-cli", "profiling", "upload", "--json", json.dumps(payload, ensure_ascii=False)]
 
 
 def postprocess(


### PR DESCRIPTION
### What does this PR do?

> Adds an opt-in Ascend raw-only profiling mode so large NPU traces can be finalized during training and analyzed offline. Distributed finalization is synchronized for both online and offline Ascend paths, resumed global-step windows are rebased, and large captures can avoid training-side Chrome export and allocator-snapshot overhead.
>
> When upload is requested (`VEOMNI_UPLOAD_CMD` or `VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD=1`), VeOmni spawns a detached sidecar to analyse / durable-copy / upload after raw finalize, so peer ranks are not blocked.
>
> Supersedes #948 (closed to refresh review history).

### Checklist Before Starting

- Searched the local upstream history for an existing NPU offline-analysis option; none was present.
- Related: closes the noisy review thread on #948 by replacing that PR.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

> - Focused unit coverage in `tests/utils/test_profiler_config.py` and `tests/utils/test_npu_offline_postprocess.py` (handler kwargs, barriers, resume rebase, async sidecar spawn / opt-out, gzip + Merlin upload command shaping).
> - `git diff --check`: passed.
> - Validated the underlying torch_npu behavior on a 16-rank Ascend 910B2 Qwen MoE workload: raw finalization completed under rank0 + barrier + pod-local dump, offline CANN export produced a usable Chrome/Perfetto timeline, and training-side synchronous analysis was avoided.

### API and Usage Example

```bash
--train.profile.enable true \
--train.profile.start_step 5 \
--train.profile.end_step 6 \
--train.profile.trace_dir /tmp/veomni_npu_profile \
--train.profile.rank0_only true \
--train.profile.record_shapes false \
--train.profile.profile_memory false \
--train.profile.with_stack false \
--train.profile.with_modules false \
--train.profile.npu_offline_analysis true
```

Async upload to Merlin after offline finalize:

```bash
export VEOMNI_NPU_OFFLINE_MERLIN_UPLOAD=1
# or: export VEOMNI_UPLOAD_CMD='merlin-cli profiling upload --json {"file_path":"{trace}","asset_type":"perfetto"}'
```

Manual / external postprocess:

```bash
python -m veomni.utils.npu_offline_postprocess \
  --raw-dir /tmp/veomni_npu_profile \
  --analyse \
  --merlin-upload
```

Default remains `npu_offline_analysis=false`, so existing GPU and NPU profiling behavior is unchanged.

Prefer a pod-local `trace_dir` for large Ascend captures. With the sidecar enabled, an `hdfs://` `trace_dir` is copied asynchronously; without it, HDFS copy stays synchronous inside the finalize barrier.

### Design & Code Changes

> - Add `train.profile.npu_offline_analysis` with a backward-compatible `False` default.
> - Pass `analyse_flag=False` to `torch_npu.profiler.tensorboard_trace_handler` only when the option is enabled.
> - Barrier all distributed ranks around Ascend profiler finalization for both online and offline analysis so rank 0 cannot lag into the next collective.
> - Rebase absolute profile steps after checkpoint resume/hot update and skip elapsed windows.
> - Avoid the unused allocator-memory-history wrapper in NPU raw-only mode.
> - Add `veomni.utils.npu_offline_postprocess` (+ `spawn_npu_offline_sidecar`) for async analyse / durable copy / `VEOMNI_UPLOAD_CMD` / Merlin Perfetto upload; `VEOMNI_NPU_OFFLINE_POSTPROCESS=0` restores the previous skip-upload behavior.
> - Wire the Omni trainer (persistence stays on `create_profiler.on_trace_ready`; do not call undefined `helper.upload_trace`) and fail fast in deprecated standalone entrypoints that cannot honor the synchronization contract.
> - Document the safe option combination and add focused coverage for handler, barrier, resume, memory, upload, and HDFS boundaries.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added/updated documentation
- [x] Added focused unit tests; hardware validation is described above
