### PR TITLE
[trainer, data] feat: add per-source step data metrics

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -347,7 +347,11 @@ NPU validation runs at two times:
 
 This is an observability-only side channel. It computes detached per-token CE
 from the model loss inputs, aggregates by packed-sequence source metadata, and
-adds metrics such as `channel_loss/<source-id>__<source>` to the normal step metrics. It does
+adds metrics such as `channel_loss/<source-id>__<source>` to the normal step metrics. The same
+sampled steps also report source-level data composition as `samples/<source>`,
+`input_tokens/<source>`, `label_tokens/<source>`, and
+`label_tokens_per_sample/<source>`. These counters use the packed segments already
+aligned for channel loss; they do not require per-sample IDs. This side channel does
 not change the returned training loss or gradients. Fused-loss backends may
 recompute the LM-head projection on sampled steps, so the default interval is
 10 steps; set `interval=1` for per-step metrics. DiT trainers and

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -107,8 +107,20 @@ def test_channel_loss_computer_aggregates_packed_logits_by_source():
     loss_0, tokens_0 = _expected_segment(logits, labels, 0, 2)
     loss_1, tokens_1 = _expected_segment(logits, labels, 3, 4)
     assert result == [
-        {"source_id": 0, "loss_sum": pytest.approx(loss_0), "token_count": tokens_0},
-        {"source_id": 1, "loss_sum": pytest.approx(loss_1), "token_count": tokens_1},
+        {
+            "source_id": 0,
+            "loss_sum": pytest.approx(loss_0),
+            "token_count": tokens_0,
+            "sample_count": 1,
+            "input_token_count": 3,
+        },
+        {
+            "source_id": 1,
+            "loss_sum": pytest.approx(loss_1),
+            "token_count": tokens_1,
+            "sample_count": 1,
+            "input_token_count": 2,
+        },
     ]
 
 
@@ -151,6 +163,46 @@ def test_channel_loss_computer_hidden_states_path_matches_logits_path():
     )
 
     assert hs_result == logits_result
+
+
+def test_channel_loss_computer_counts_attention_masked_input_tokens():
+    computer = ChannelLossComputer()
+    computer._source_ids = ["repoqa"]
+    computer._position_ids = torch.tensor([[0, 1, 2, 3]])
+
+    result = computer._compute_channel_loss(
+        logits=torch.randn(1, 4, 8),
+        labels=torch.tensor([[1, 2, 3, 4]]),
+        vocab_size=8,
+        hidden_states=None,
+        weights=None,
+        attention_mask=torch.tensor([[1, 1, 1, 0]]),
+        shift_labels=None,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    assert result[0]["sample_count"].item() == 1
+    assert result[0]["input_token_count"].item() == 3
+    assert result[0]["token_count"].item() == 3
+
+
+def test_channel_loss_computer_counts_data_metrics_with_sequence_parallel():
+    result = ChannelLossComputer._aggregate_by_source(
+        per_token_loss=torch.ones(4),
+        labels_flat=torch.tensor([1, 2, 3, IGNORE_INDEX]),
+        attention_mask_flat=torch.tensor([1, 1, 1, 0]),
+        source_ids=["repoqa", "other"],
+        position_ids=torch.tensor([[0, 1, 0, 1]]),
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=SimpleNamespace(sp_group=None, sp_size=1),
+        strict=True,
+        include_data_stats=True,
+    )
+
+    assert [item["sample_count"].item() for item in result] == [1, 1]
+    assert [item["input_token_count"].item() for item in result] == [2, 1]
+    assert [item["token_count"].item() for item in result] == [2, 1]
 
 
 def test_channel_loss_wrapper_forwards_original_call_unchanged():
@@ -841,9 +893,27 @@ def test_channel_loss_computer_aggregates_step_results_locally():
     computer = ChannelLossComputer()
     computer.begin_step([], [], [])
     computer._result = [
-        {"source_id": "a", "loss_sum": torch.tensor(2.0), "token_count": torch.tensor(1)},
-        {"source_id": "a", "loss_sum": torch.tensor(4.0), "token_count": torch.tensor(2)},
-        {"source_id": "b", "loss_sum": torch.tensor(3.0), "token_count": torch.tensor(1)},
+        {
+            "source_id": "a",
+            "loss_sum": torch.tensor(2.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(3),
+        },
+        {
+            "source_id": "a",
+            "loss_sum": torch.tensor(4.0),
+            "token_count": torch.tensor(2),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(4),
+        },
+        {
+            "source_id": "b",
+            "loss_sum": torch.tensor(3.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(2),
+        },
     ]
 
     computer.after_micro_step()
@@ -851,6 +921,51 @@ def test_channel_loss_computer_aggregates_step_results_locally():
     assert set(computer.step_totals) == {"a", "b"}
     assert computer.step_totals["a"][0].item() == 6.0
     assert computer.step_totals["a"][1].item() == 3
+    assert tuple(value.item() for value in computer.step_data_totals["a"]) == (2, 7, 3)
+
+
+def test_base_step_begin_captures_channel_metadata_before_multisource_meter():
+    calls = []
+
+    class RecordingCallback:
+        def __init__(self, name, consume_metadata=False):
+            self.name = name
+            self.consume_metadata = consume_metadata
+
+        def on_step_begin(self, state, micro_batches=None, **kwargs):
+            calls.append((self.name, "ds_idx" in micro_batches[0]))
+            if self.consume_metadata:
+                micro_batches[0].pop("ds_idx")
+                micro_batches[0].pop("source_name")
+
+    trainer = object.__new__(BaseTrainer)
+    trainer.state = TrainerState(global_step=1)
+    trainer.channel_loss_callback = RecordingCallback("channel")
+    meter = RecordingCallback("meter", consume_metadata=True)
+    tail = RecordingCallback("tail")
+    trainer._callbacks = [meter, trainer.channel_loss_callback, tail]
+    micro_batches = [{"ds_idx": torch.tensor([7]), "source_name": ["repoqa"]}]
+
+    BaseTrainer.on_step_begin(trainer, micro_batches=micro_batches)
+
+    assert calls == [("channel", True), ("meter", True), ("tail", False)]
+
+
+def test_base_step_begin_allows_missing_channel_loss_callback():
+    calls = []
+
+    class RecordingCallback:
+        def on_step_begin(self, state, micro_batches=None, **kwargs):
+            calls.append(micro_batches)
+
+    trainer = object.__new__(BaseTrainer)
+    trainer.state = TrainerState(global_step=1)
+    trainer._callbacks = [RecordingCallback()]
+    micro_batches = [{"input_ids": torch.tensor([1, 2])}]
+
+    BaseTrainer.on_step_begin(trainer, micro_batches=micro_batches)
+
+    assert calls == [micro_batches]
 
 
 def test_base_forward_backward_allows_missing_channel_loss_callback():
@@ -1268,6 +1383,52 @@ def test_channel_loss_metric_name_is_source_qualified_from_first_emission():
     assert "channel_loss/train_a" not in metrics
 
 
+def test_channel_loss_builds_per_step_data_metrics_with_source_name():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+
+    metrics = callback._build_data_metrics(
+        {7: (2, 11, 5)},
+        {7: "repoqa"},
+    )
+
+    assert metrics == {
+        "samples/repoqa": 2.0,
+        "input_tokens/repoqa": 11.0,
+        "label_tokens/repoqa": 5.0,
+        "label_tokens_per_sample/repoqa": 2.5,
+    }
+
+
+def test_channel_loss_data_metric_name_collisions_remain_distinct():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+
+    metrics = callback._build_data_metrics(
+        {1: (1, 3, 2), 2: (1, 4, 3)},
+        {1: "train/a", 2: "train_a"},
+    )
+
+    assert metrics["samples/source-i-1__train_a"] == 1.0
+    assert metrics["samples/source-i-2__train_a"] == 1.0
+
+
+def test_channel_loss_data_metric_collision_registry_persists_across_steps():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+
+    first = callback._build_data_metrics({1: (1, 3, 2)}, {1: "train/a"})
+    second = callback._build_data_metrics({2: (1, 4, 3)}, {2: "train_a"})
+    third = callback._build_data_metrics({1: (1, 3, 2)}, {1: "train/a"})
+
+    assert "samples/train_a" in first
+    assert "samples/source-i-2__train_a" in second
+    assert "samples/source-i-1__train_a" in third
+
+
 def test_channel_loss_metric_name_collision_registry_persists_across_steps():
     cfg = ChannelLossConfig(enable=True)
     trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
@@ -1381,6 +1542,10 @@ def test_channel_loss_callback_updates_trainer_metrics():
         0: (torch.tensor(6.0), torch.tensor(3)),
         1: (torch.tensor(3.0), torch.tensor(1)),
     }
+    callback.computer.step_data_totals = {
+        0: (torch.tensor(2), torch.tensor(10), torch.tensor(3)),
+        1: (torch.tensor(1), torch.tensor(4), torch.tensor(1)),
+    }
     callback._collect_step = True
 
     callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
@@ -1389,6 +1554,10 @@ def test_channel_loss_callback_updates_trainer_metrics():
     assert math.isclose(trainer.step_env_metrics["channel_loss/source-i-1__source-b"], 3.0)
     assert math.isclose(trainer.step_env_metrics["channel_loss_weighted/source-i-0__source_a"], 1.5)
     assert math.isclose(trainer.step_env_metrics["channel_tokens/source-i-1__source-b"], 1.0)
+    assert trainer.step_env_metrics["samples/source_a"] == 2.0
+    assert trainer.step_env_metrics["input_tokens/source_a"] == 10.0
+    assert trainer.step_env_metrics["label_tokens/source_a"] == 3.0
+    assert trainer.step_env_metrics["label_tokens_per_sample/source_a"] == 1.5
     assert trainer.step_train_metrics == trainer.step_env_metrics
 
 

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -606,9 +606,11 @@ class BaseTrainer(Stateful, ABC):
         # (EnvironMeter, DCP checkpointer) are handed the state directly, so
         # no ambient ``use_parallel_state`` scope is needed around hook dispatch.
         #
-        # ``channel_loss_callback`` is ordered after the meter (which resets
-        # ``step_*_metrics`` in ``on_step_end``) and before ``wandb`` (which
-        # logs them), so its per-source metrics survive into the logged payload.
+        # ``channel_loss_callback`` is ordered after the meter for
+        # ``on_step_end`` (the meter resets ``step_*_metrics``) and before
+        # ``wandb`` (which logs them), so its per-source metrics survive into
+        # the logged payload. ``on_step_begin`` snapshots channel metadata first
+        # because multi-source accounting consumes it.
         self._callbacks = [
             self.environ_meter_callback,
             self.tqdm_callback,
@@ -639,7 +641,16 @@ class BaseTrainer(Stateful, ABC):
             callback.on_epoch_end(self.state)
 
     def on_step_begin(self, micro_batches=None, **kwargs):
+        # Multi-source accounting consumes ``ds_idx`` / ``source_name`` from the
+        # micro-batches. Channel loss must snapshot that metadata first, while
+        # keeping its on_step_end position after the meter so its metrics are not
+        # overwritten by the meter's per-step reset.
+        channel_loss_callback = getattr(self, "channel_loss_callback", None)
+        if channel_loss_callback is not None:
+            channel_loss_callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
         for callback in self._callbacks:
+            if callback is channel_loss_callback:
+                continue
             callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
 
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):

--- a/veomni/trainer/callbacks/channel_loss_callback.py
+++ b/veomni/trainer/callbacks/channel_loss_callback.py
@@ -103,6 +103,7 @@ class ChannelLossComputer:
         self._per_mb_attention_masks: list[torch.Tensor | None] = []
         self._micro_step = 0
         self.step_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor]] = {}
+        self.step_data_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         self.source_names: dict[ChannelKey, str] = {}
         self.strict = False
 
@@ -299,6 +300,7 @@ class ChannelLossComputer:
         self._per_mb_attention_masks = per_mb_attention_masks
         self._micro_step = 0
         self.step_totals = {}
+        self.step_data_totals = {}
 
     def before_micro_step(self) -> None:
         step = self._micro_step
@@ -323,6 +325,18 @@ class ChannelLossComputer:
                     self.step_totals[source_id] = (loss_sum, token_count)
                 else:
                     self.step_totals[source_id] = (previous[0] + loss_sum, previous[1] + token_count)
+
+                sample_count = item.get("sample_count", token_count.new_ones(()).to(dtype=torch.int64)).detach()
+                input_token_count = item.get("input_token_count", token_count).detach()
+                data_previous = self.step_data_totals.get(source_id)
+                if data_previous is None:
+                    self.step_data_totals[source_id] = (sample_count, input_token_count, token_count)
+                else:
+                    self.step_data_totals[source_id] = (
+                        data_previous[0] + sample_count,
+                        data_previous[1] + input_token_count,
+                        data_previous[2] + token_count,
+                    )
         self._source_ids = []
         self._position_ids = None
         self._attention_mask = None
@@ -436,6 +450,7 @@ class ChannelLossComputer:
             sp_enabled=sp_enabled,
             parallel_state=self.parallel_state,
             strict=self.strict,
+            include_data_stats=True,
         )
 
     def _per_token_ce(
@@ -511,6 +526,7 @@ class ChannelLossComputer:
         sp_enabled: bool = False,
         parallel_state: ParallelState | None = None,
         strict: bool = False,
+        include_data_stats: bool = False,
     ) -> list[dict[str, Any]]:
         if not source_ids:
             return []
@@ -542,6 +558,7 @@ class ChannelLossComputer:
                     ignore_index=ignore_index,
                     parallel_state=parallel_state,
                     strict=strict,
+                    include_data_stats=include_data_stats,
                 )
 
             row_width = pos_2d.size(1)
@@ -579,16 +596,24 @@ class ChannelLossComputer:
         for i, (_, start, end) in enumerate(segments):
             labels_slice = labels_flat[start : end + 1]
             loss_slice = per_token_loss[start : end + 1]
+            mask_slice = attention_mask_flat[start : end + 1] if attention_mask_flat is not None else None
             valid = labels_slice != ignore_index
             token_count = valid.sum()
             loss_sum = loss_slice[valid].sum()
-            channel_loss.append(
-                {
-                    "source_id": source_ids[i],
-                    "loss_sum": loss_sum,
-                    "token_count": token_count,
-                }
+            input_token_count = (
+                mask_slice.to(torch.bool).sum(dtype=torch.int64)
+                if mask_slice is not None
+                else torch.as_tensor(labels_slice.numel(), device=labels_slice.device, dtype=torch.int64)
             )
+            item = {
+                "source_id": source_ids[i],
+                "loss_sum": loss_sum,
+                "token_count": token_count,
+            }
+            if include_data_stats:
+                item["sample_count"] = torch.ones((), device=labels_slice.device, dtype=torch.int64)
+                item["input_token_count"] = input_token_count
+            channel_loss.append(item)
         return channel_loss
 
     @staticmethod
@@ -602,6 +627,7 @@ class ChannelLossComputer:
         ignore_index: int,
         parallel_state: ParallelState | None = None,
         strict: bool = False,
+        include_data_stats: bool = False,
     ) -> list[dict[str, Any]]:
         if parallel_state is None:
             raise ValueError("parallel_state is required for SP channel-loss aggregation.")
@@ -638,6 +664,11 @@ class ChannelLossComputer:
             valid = labels_slice != ignore_index
             token_count = valid.sum(dtype=torch.int64)
             loss_sum = loss_slice[valid].sum()
+            input_token_count = (
+                mask_slice.to(torch.bool).sum(dtype=torch.int64)
+                if mask_slice is not None
+                else torch.as_tensor(labels_slice.numel(), device=labels_slice.device, dtype=torch.int64)
+            )
             false_flag = torch.zeros((), dtype=torch.bool, device=labels_slice.device)
             has_explicit_padding_mask = (
                 ~mask_slice.to(torch.bool).any()
@@ -645,18 +676,20 @@ class ChannelLossComputer:
                 else false_flag
             )
             has_only_zero_positions = bool(pos_slice.eq(0).all().tolist()) if pos_slice.numel() > 0 else False
-            segments.append(
-                {
-                    "batch_idx": batch_idx,
-                    "sp_rank": sp_rank,
-                    "local_order": local_order,
-                    "is_start": is_start,
-                    "has_explicit_padding_mask": has_explicit_padding_mask,
-                    "has_only_zero_positions": has_only_zero_positions,
-                    "loss_sum": loss_sum,
-                    "token_count": token_count,
-                }
-            )
+            segment = {
+                "batch_idx": batch_idx,
+                "sp_rank": sp_rank,
+                "local_order": local_order,
+                "is_start": is_start,
+                "has_explicit_padding_mask": has_explicit_padding_mask,
+                "has_only_zero_positions": has_only_zero_positions,
+                "loss_sum": loss_sum,
+                "token_count": token_count,
+            }
+            if include_data_stats:
+                segment["sample_count"] = torch.as_tensor(int(is_start), device=labels_slice.device, dtype=torch.int64)
+                segment["input_token_count"] = input_token_count
+            segments.append(segment)
 
         for batch_idx, row_pos in enumerate(positions_cpu):
             row_len = min(local_width, max(seq_len - batch_idx * local_width, 0))
@@ -683,15 +716,24 @@ class ChannelLossComputer:
             device=per_token_loss.device,
             parallel_state=parallel_state,
             strict=strict,
+            include_data_stats=include_data_stats,
         )
-        return [
-            {
+        result = []
+        for item in reduced:
+            converted = {
                 "source_id": item["source_id"],
                 "loss_sum": torch.as_tensor(item["loss_sum"], device=per_token_loss.device, dtype=torch.float32),
                 "token_count": torch.as_tensor(item["token_count"], device=per_token_loss.device, dtype=torch.int64),
             }
-            for item in reduced
-        ]
+            if include_data_stats:
+                converted["sample_count"] = torch.as_tensor(
+                    item["sample_count"], device=per_token_loss.device, dtype=torch.int64
+                )
+                converted["input_token_count"] = torch.as_tensor(
+                    item["input_token_count"], device=per_token_loss.device, dtype=torch.int64
+                )
+            result.append(converted)
+        return result
 
     @staticmethod
     def _reduce_sp(
@@ -700,6 +742,7 @@ class ChannelLossComputer:
         device: torch.device,
         parallel_state: ParallelState | None = None,
         strict: bool = False,
+        include_data_stats: bool = False,
     ) -> list[dict[str, Any]]:
         if local_segments:
             local_zero_position_flags = torch.tensor(
@@ -747,12 +790,24 @@ class ChannelLossComputer:
                     local_zero_position_flags = torch.stack(
                         [segment["has_only_zero_positions"] for segment in local_segments]
                     ).to(device=device, dtype=torch.int64)
-                    local_integer_stats = torch.stack(
-                        [local_token_counts, local_explicit_padding_flags, local_zero_position_flags], dim=1
-                    )
+                    integer_columns = [local_token_counts]
+                    if include_data_stats:
+                        integer_columns.extend(
+                            [
+                                torch.stack([segment["sample_count"] for segment in local_segments]).to(
+                                    device=device, dtype=torch.int64
+                                ),
+                                torch.stack([segment["input_token_count"] for segment in local_segments]).to(
+                                    device=device, dtype=torch.int64
+                                ),
+                            ]
+                        )
+                    integer_columns.extend([local_explicit_padding_flags, local_zero_position_flags])
+                    local_integer_stats = torch.stack(integer_columns, dim=1)
                 else:
                     local_loss_sums = torch.empty(0, dtype=torch.float32, device=device)
-                    local_integer_stats = torch.empty((0, 3), dtype=torch.int64, device=device)
+                    integer_column_count = 5 if include_data_stats else 3
+                    local_integer_stats = torch.empty((0, integer_column_count), dtype=torch.int64, device=device)
 
                 loss_padding = local_loss_sums.new_zeros(max_segment_count - local_loss_sums.size(0))
                 integer_padding = local_integer_stats.new_zeros(
@@ -768,15 +823,18 @@ class ChannelLossComputer:
                 for rank_idx, rank_metadata in enumerate(gathered_metadata):
                     for segment_idx, metadata in enumerate(rank_metadata or []):
                         integer_stats = gathered_integer_stats[rank_idx][segment_idx]
-                        all_segments.append(
-                            {
-                                **metadata,
-                                "loss_sum": gathered_loss_sums[rank_idx][segment_idx],
-                                "token_count": integer_stats[0],
-                                "has_explicit_padding_mask": integer_stats[1].to(torch.bool),
-                                "has_only_zero_positions": integer_stats[2].to(torch.bool),
-                            }
-                        )
+                        stats_offset = 2 if include_data_stats else 0
+                        segment = {
+                            **metadata,
+                            "loss_sum": gathered_loss_sums[rank_idx][segment_idx],
+                            "token_count": integer_stats[0],
+                            "has_explicit_padding_mask": integer_stats[1 + stats_offset].to(torch.bool),
+                            "has_only_zero_positions": integer_stats[2 + stats_offset].to(torch.bool),
+                        }
+                        if include_data_stats:
+                            segment["sample_count"] = integer_stats[1]
+                            segment["input_token_count"] = integer_stats[2]
+                        all_segments.append(segment)
 
         all_segments.sort(
             key=lambda segment: (
@@ -808,13 +866,15 @@ class ChannelLossComputer:
         for segment in all_segments:
             batch_idx = int(segment.get("batch_idx", 0))
             if segment["is_start"]:
-                result.append(
-                    {
-                        "source_id": source_ids[doc_idx],
-                        "loss_sum": segment["loss_sum"],
-                        "token_count": segment["token_count"],
-                    }
-                )
+                item = {
+                    "source_id": source_ids[doc_idx],
+                    "loss_sum": segment["loss_sum"],
+                    "token_count": segment["token_count"],
+                }
+                if include_data_stats:
+                    item["sample_count"] = segment["sample_count"]
+                    item["input_token_count"] = segment["input_token_count"]
+                result.append(item)
                 last_result_idx_by_batch[batch_idx] = len(result) - 1
                 doc_idx += 1
                 continue
@@ -831,6 +891,9 @@ class ChannelLossComputer:
                 continue
             result[result_idx]["loss_sum"] += segment["loss_sum"]
             result[result_idx]["token_count"] += segment["token_count"]
+            if include_data_stats:
+                result[result_idx]["sample_count"] += segment["sample_count"]
+                result[result_idx]["input_token_count"] += segment["input_token_count"]
         return result
 
 
@@ -1027,6 +1090,8 @@ class ChannelLossCallback(Callback):
             return
 
         metrics = self._build_metrics(totals, source_names)
+        data_totals = self._reduce_step_data_totals(self.computer.step_data_totals, list(totals))
+        metrics.update(self._build_data_metrics(data_totals, source_names))
         if not metrics:
             return
 
@@ -1103,6 +1168,39 @@ class ChannelLossCallback(Callback):
         registered_names = self._register_sources(source_ids, synchronized_names)
         return totals, registered_names
 
+    def _reduce_step_data_totals(
+        self,
+        local_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+        source_ids: list[ChannelKey],
+    ) -> dict[ChannelKey, tuple[int, int, int]]:
+        if not source_ids:
+            return {}
+
+        device = self._data_totals_device(local_totals)
+        counts = torch.zeros((len(source_ids), 3), dtype=torch.int64, device=device)
+        source_indices = {source_id: index for index, source_id in enumerate(source_ids)}
+        for source_id, (sample_count, input_token_count, label_token_count) in local_totals.items():
+            index = source_indices.get(source_id)
+            if index is None:
+                continue
+            counts[index] = torch.stack(
+                [
+                    torch.as_tensor(sample_count, dtype=torch.int64, device=device),
+                    torch.as_tensor(input_token_count, dtype=torch.int64, device=device),
+                    torch.as_tensor(label_token_count, dtype=torch.int64, device=device),
+                ]
+            )
+
+        ps = self.parallel_state
+        if ps.dp_size > 1 and dist.is_available() and dist.is_initialized():
+            dist.all_reduce(counts, group=ps.dp_group)
+
+        values = counts.cpu().tolist()
+        return {
+            source_id: (int(values[index][0]), int(values[index][1]), int(values[index][2]))
+            for index, source_id in enumerate(source_ids)
+        }
+
     def _register_sources(
         self,
         source_ids: list[ChannelKey],
@@ -1157,6 +1255,16 @@ class ChannelLossCallback(Callback):
                 pass
         return torch.device("cpu")
 
+    def _data_totals_device(
+        self,
+        local_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+    ) -> torch.device:
+        for counts in local_totals.values():
+            for count in counts:
+                if isinstance(count, torch.Tensor):
+                    return count.device
+        return self._totals_device({})
+
     def _build_metrics(
         self,
         totals: dict[ChannelKey, tuple[float, int]],
@@ -1175,6 +1283,51 @@ class ChannelLossCallback(Callback):
             if self.config.log_token_count:
                 metrics[f"{self.config.token_count_metric_prefix}/{name}"] = float(token_count)
         return metrics
+
+    def _build_data_metrics(
+        self,
+        totals: dict[ChannelKey, tuple[int, int, int]],
+        source_names: dict[ChannelKey, str] | None = None,
+    ) -> dict[str, float]:
+        metric_names = self._render_data_metric_names(totals, source_names)
+        metrics: dict[str, float] = {}
+        for source_id, (sample_count, input_token_count, label_token_count) in sorted(
+            totals.items(), key=lambda item: _channel_sort_key(item[0])
+        ):
+            if sample_count <= 0:
+                continue
+            name = metric_names[source_id]
+            metrics[f"samples/{name}"] = float(sample_count)
+            metrics[f"input_tokens/{name}"] = float(input_token_count)
+            metrics[f"label_tokens/{name}"] = float(label_token_count)
+            metrics[f"label_tokens_per_sample/{name}"] = label_token_count / sample_count
+        return metrics
+
+    def _render_data_metric_names(
+        self,
+        totals: dict[ChannelKey, tuple[int, int, int]],
+        source_names: dict[ChannelKey, str] | None,
+    ) -> dict[ChannelKey, str]:
+        self._register_sources(list(totals), source_names)
+        base_names = {
+            source_id: (
+                _sanitize_metric_fragment(self._source_registry[source_id])
+                if self._source_registry[source_id] is not None
+                else _sanitize_metric_fragment(source_id)
+            )
+            for source_id in self._source_registry
+        }
+        name_counts: dict[str, int] = defaultdict(int)
+        for name in base_names.values():
+            name_counts[name] += 1
+        return {
+            source_id: (
+                base_names[source_id]
+                if name_counts[base_names[source_id]] == 1
+                else f"{_stable_source_metric_fragment(source_id)}__{base_names[source_id]}"
+            )
+            for source_id in totals
+        }
 
     def _render_metric_names(
         self,


### PR DESCRIPTION
## Summary

- add per-source, per-sampled-step data composition metrics alongside channel loss
- preserve channel-loss metadata for streaming multi-source batches before environment accounting consumes it
- keep packed-sequence and sequence-parallel alignment without introducing per-sample IDs

The new metrics are:

- `samples/<source>`
- `input_tokens/<source>`
- `label_tokens/<source>`
- `label_tokens_per_sample/<source>`

Set `train.channel_loss.interval=1` to emit them on every optimizer step.

## Tests

- `make quality`
- targeted channel-loss tests: 10 passed
- streaming/byted-loader integration tests in the downstream patch repository: 26 passed
