### PR TITLE
[ops, perf] feat: single-pass fwd + fused bwd for deterministic RMSNorm on H100

### DIFF
--- a/veomni/ops/kernels/rms_norm/triton_batch_invariant.py
+++ b/veomni/ops/kernels/rms_norm/triton_batch_invariant.py
@@ -16,11 +16,57 @@
 
 Originally adapted from https://github.com/thinking-machines-lab/batch_invariant_ops.
 Used by the DeepSeek V3 deterministic RMSNorm path.
+
+H100 optimization (single-pass): when the hidden dimension fits in one block
+(``n_cols <= MAX_FUSED_COLS``), the row is loaded from HBM **once** into
+registers, the inverse RMS is computed, and the same cached values are
+normalized in place. This halves input HBM reads (3x -> 2x total traffic on
+the dominant tensors) and removes the Python-level reduction loop, which is the
+dominant cost in the short-sequence (seqlen 100-200) regime where the kernel is
+launch/occupancy bound. The reduction stays within a single program (one row
+per program), so results remain batch-invariant / deterministic. For hidden
+dims larger than ``MAX_FUSED_COLS`` the original two-pass loop is used.
 """
 
 import torch
 import triton
 import triton.language as tl
+
+
+# Largest hidden dim handled by the single-pass path. Covers all common LLM
+# hidden sizes (<= 16384). Larger dims fall back to the streaming two-pass loop.
+MAX_FUSED_COLS = 16384
+
+
+@triton.jit
+def _rms_norm_kernel_single_pass(
+    input_ptr,
+    weight_ptr,
+    output_ptr,
+    input_row_stride,
+    output_row_stride,
+    n_cols,
+    eps,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Single-pass RMSNorm: load the row once, reduce, normalize from registers."""
+    row_idx = tl.program_id(0).to(tl.int64)
+    row_start_ptr = input_ptr + row_idx * input_row_stride
+    output_row_start_ptr = output_ptr + row_idx * output_row_stride
+
+    col_idx = tl.arange(0, BLOCK_SIZE)
+    mask = col_idx < n_cols
+
+    # Single HBM read of the row, kept in registers for the whole kernel.
+    vals = tl.load(row_start_ptr + col_idx, mask=mask, other=0.0)
+    vals_f32 = vals.to(tl.float32)
+
+    sum_sq = tl.sum(vals_f32 * vals_f32, axis=0)
+    inv_rms = 1.0 / tl.sqrt(sum_sq / n_cols + eps)
+
+    w = tl.load(weight_ptr + col_idx, mask=mask, other=1.0)
+    out = vals_f32 * inv_rms * w.to(tl.float32)
+    tl.store(output_row_start_ptr + col_idx, out.to(vals.dtype), mask=mask)
 
 
 @triton.jit
@@ -34,7 +80,10 @@ def _rms_norm_kernel(
     eps,
     BLOCK_SIZE: tl.constexpr,
 ):
-    """Batch-invariant RMS normalization: each row processed independently."""
+    """Batch-invariant RMS normalization: each row processed independently.
+
+    Streaming two-pass fallback for hidden dims that do not fit in one block.
+    """
     row_idx = tl.program_id(0).to(tl.int64)
     row_start_ptr = input_ptr + row_idx * input_row_stride
     output_row_start_ptr = output_ptr + row_idx * output_row_stride
@@ -55,23 +104,130 @@ def _rms_norm_kernel(
         tl.store(output_row_start_ptr + col_idx, out.to(vals.dtype), mask=mask)
 
 
+def _num_warps_for(block_size: int) -> int:
+    # Tuned on H100 (seqlen 100-200 grid). num_warps depends ONLY on block_size
+    # (== next_pow2(hidden)) so results stay batch-invariant across row counts.
+    if block_size <= 2048:
+        return 4
+    if block_size <= 4096:
+        return 8
+    return 16
+
+
 def _rms_norm_forward(input: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
     original_shape = input.shape
     input_2d = input.reshape(-1, input.shape[-1]).contiguous()
     weight = weight.contiguous()
     n_rows, n_cols = input_2d.shape
     output = torch.empty_like(input_2d)
-    _rms_norm_kernel[(n_rows,)](
-        input_2d,
-        weight,
-        output,
-        input_2d.stride(0),
-        output.stride(0),
+    if n_cols <= MAX_FUSED_COLS:
+        block_size = triton.next_power_of_2(n_cols)
+        _rms_norm_kernel_single_pass[(n_rows,)](
+            input_2d,
+            weight,
+            output,
+            input_2d.stride(0),
+            output.stride(0),
+            n_cols,
+            eps,
+            BLOCK_SIZE=block_size,
+            num_warps=_num_warps_for(block_size),
+        )
+    else:
+        _rms_norm_kernel[(n_rows,)](
+            input_2d,
+            weight,
+            output,
+            input_2d.stride(0),
+            output.stride(0),
+            n_cols,
+            eps,
+            BLOCK_SIZE=1024,
+        )
+    return output.reshape(original_shape)
+
+
+@triton.jit
+def _rms_norm_bwd_kernel(
+    input_ptr,
+    grad_output_ptr,
+    weight_ptr,
+    grad_input_ptr,
+    prod_ptr,  # [N, n_cols] fp32: grad_output * normed (reduced over rows for grad_weight)
+    input_row_stride,
+    grad_output_row_stride,
+    grad_input_row_stride,
+    prod_row_stride,
+    n_cols,
+    eps,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Single-pass fused RMSNorm backward (grad_input + per-row grad_weight product).
+
+    Each program owns one row, so the per-row reductions use a fixed reduction
+    tree => batch-invariant / deterministic, matching the forward kernel. The
+    cross-row reduction for grad_weight is left to a deterministic ``sum(0)`` on
+    ``prod`` by the caller (identical reduction domain to the original torch
+    backward).
+    """
+    row_idx = tl.program_id(0).to(tl.int64)
+    x_ptr = input_ptr + row_idx * input_row_stride
+    go_ptr = grad_output_ptr + row_idx * grad_output_row_stride
+
+    col_idx = tl.arange(0, BLOCK_SIZE)
+    mask = col_idx < n_cols
+
+    x = tl.load(x_ptr + col_idx, mask=mask, other=0.0).to(tl.float32)
+    go = tl.load(go_ptr + col_idx, mask=mask, other=0.0).to(tl.float32)
+    w = tl.load(weight_ptr + col_idx, mask=mask, other=0.0).to(tl.float32)
+
+    # inv_rms recomputed from x (same as torch backward: variance = mean(x^2)).
+    sum_sq = tl.sum(x * x, axis=0)
+    inv_rms = 1.0 / tl.sqrt(sum_sq / n_cols + eps)
+    normed = x * inv_rms
+
+    # grad_weight contribution for this row (write out for deterministic sum(0)).
+    prod = go * normed
+    tl.store(prod_ptr + row_idx * prod_row_stride + col_idx, prod, mask=mask)
+
+    # grad_input = inv_rms * (d - normed * mean(d * normed)),  d = grad_output * weight
+    d = go * w
+    mean_dn = tl.sum(d * normed, axis=0) / n_cols
+    grad_input = inv_rms * (d - normed * mean_dn)
+    tl.store(
+        grad_input_ptr + row_idx * grad_input_row_stride + col_idx,
+        grad_input.to(grad_input_ptr.dtype.element_ty),
+        mask=mask,
+    )
+
+
+def _rms_norm_backward(input, weight, grad_output, eps):
+    """Fused backward when hidden fits one block; torch fallback otherwise."""
+    orig_shape = input.shape
+    x2d = input.reshape(-1, input.shape[-1])
+    go2d = grad_output.reshape(-1, input.shape[-1]).contiguous()
+    n_rows, n_cols = x2d.shape
+
+    grad_input = torch.empty_like(x2d)
+    prod = torch.empty(n_rows, n_cols, device=x2d.device, dtype=torch.float32)
+    block_size = triton.next_power_of_2(n_cols)
+    _rms_norm_bwd_kernel[(n_rows,)](
+        x2d,
+        go2d,
+        weight.contiguous(),
+        grad_input,
+        prod,
+        x2d.stride(0),
+        go2d.stride(0),
+        grad_input.stride(0),
+        prod.stride(0),
         n_cols,
         eps,
-        BLOCK_SIZE=1024,
+        BLOCK_SIZE=block_size,
+        num_warps=_num_warps_for(block_size),
     )
-    return output.reshape(original_shape)
+    grad_weight = prod.sum(0).to(weight.dtype)
+    return grad_input.reshape(orig_shape), grad_weight
 
 
 class BatchInvariantRMSNormFunction(torch.autograd.Function):
@@ -88,6 +244,10 @@ class BatchInvariantRMSNormFunction(torch.autograd.Function):
     def backward(ctx, grad_output):
         input, weight, output = ctx.saved_tensors
         eps = ctx.eps
+        if input.shape[-1] <= MAX_FUSED_COLS:
+            grad_input, grad_weight = _rms_norm_backward(input, weight, grad_output, eps)
+            return grad_input, grad_weight, None
+        # Streaming fallback (hidden dim larger than one block): original torch path.
         input_f32 = input.float()
         variance = input_f32.pow(2).mean(-1, keepdim=True)
         inv_rms = torch.rsqrt(variance + eps)


### PR DESCRIPTION
### What does this PR do?

Optimizes the batch-invariant RMSNorm kernel (DeepSeek V3 deterministic path) on H100. In the short-sequence regime (seqlen 100-200) the kernel was launch/occupancy bound:

- **Forward** read the input row from HBM **twice** (sum-sq pass + normalize pass) through a fixed `BLOCK_SIZE=1024` Python loop.
- **Backward** ran in pure PyTorch: ~10 kernel launches + ~6 full `[N, H]` fp32 intermediates, costing 16-31x the forward.

Changes (`hidden <= MAX_FUSED_COLS`; original two-pass path kept as fallback for larger):

- **Forward:** single-pass kernel loads the row **once** into registers, reduces, and normalizes in place. `BLOCK = next_pow2(hidden)`; `num_warps` tuned on H100 as a function of `BLOCK` only, so it stays batch-invariant across row counts.
- **Backward:** one fused per-row Triton kernel computes `grad_input` and writes the per-row `grad_output * normed` product; `grad_weight` is a deterministic `prod.sum(0)` (identical reduction domain to the original torch backward).

The row-level reduction stays inside one Triton program, so batch-invariant behavior is preserved. The main win is the **training step** (fused backward); forward-only is not a blanket win in the short-sequence regime — see the breakdown in **Test**.

### Checklist Before Starting

- Search for relative PRs/issues and link here: no existing PR touches `veomni/ops/kernels/rms_norm/triton_batch_invariant.py`.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

Added `tests/ops/test_triton_batch_invariant_rms_norm.py` (CUDA-only, skipped on non-CUDA hosts; CI enumerates `tests/ops/` individually, so it runs in `gpu_unit_tests.yml` without workflow changes). Coverage:

- bf16/fp16 **forward parity** vs eager PyTorch RMSNorm: 2D odd-hidden shape, 3D power-of-two hidden shape, short-sequence LLM-like shape;
- bf16/fp16 **backward parity** vs eager autograd;
- **batch invariance**: evaluating a batch whole vs split into chunks is bitwise identical;
- **fallback path**: `hidden > MAX_FUSED_COLS` still matches eager;
- optional benchmark matrix behind `VEOMNI_RUN_RMSNORM_BENCHMARK=1`.

Results:

- H100: `python -m pytest tests/ops/test_triton_batch_invariant_rms_norm.py -q -m "not benchmark"` → **10 passed, 1 deselected**
- non-CUDA devbox: same file → **11 skipped**

Determinism preserved: one program per row for fwd and bwd; `grad_weight` reduces over the same domain as before. Numerics within 1 bf16 ULP of the original kernel (`grad_input <= 3.125e-2`, `grad_weight <= 7.8e-3`); bitwise-deterministic across repeated runs.

#### Performance

Baseline: previous two-pass batch-invariant Triton forward + the original torch backward. Environment: H100-SXM-80GB (sm 9.0), torch 2.9.1+cu129, triton 3.5.1, bf16. Sweep: `hidden ∈ {4096, 7168, 8192, 16384}` (up to the `MAX_FUSED_COLS` boundary), `batch ∈ {1, 2, 4, 8}`, `seqlen 64-1024`.

Honest reading of the numbers:

- **Forward-only is not consistently faster** at small batch / short sequence — most such points land at ~0.6x-0.9x (the single-pass forward trades the second HBM read for a wider block). It breaks even around ~1.0x and pulls ahead up to ~1.3x once row count and hidden are large enough.
- **The training step is where the win is**: the fused backward removes most of the previous torch backward overhead, and the speedup grows with effective row count (`batch * seqlen`) and with hidden size.

Short-sequence regime (seqlen 100-200), hidden 4096/8192/16384:

- batch=1: ~1.3x-1.6x training speedup;
- batch=4: ~1.3x-2.8x;
- batch=8: ~1.2x-4.4x, depending on hidden and seqlen.

Larger row counts scale further: hidden=7168 reaches **3.47x** at batch=4/seqlen=512 and **5.64x** at batch=8/seqlen=1024; hidden=16384 reaches **5.94x** at batch=8/seqlen=512. The 8192-16384 band — including the `MAX_FUSED_COLS` boundary tier — is covered by the sweep.

Benchmark entry point (env-gated):

```bash
VEOMNI_RUN_RMSNORM_BENCHMARK=1 VEOMNI_RMSNORM_BENCH_HIDDEN=7168 \
python -m pytest tests/ops/test_triton_batch_invariant_rms_norm.py::test_single_pass_advantage_matrix -q -s
```

### API and Usage Example

No API change. `BatchInvariantRMSNormFunction` behaves identically; the single-pass path is selected automatically when `hidden <= MAX_FUSED_COLS` (16384), otherwise the original two-pass/torch path is used.

### Design & Code Changes

- Add `_rms_norm_kernel_single_pass` (register-resident single-pass forward).
- Add `_rms_norm_bwd_kernel` + `_rms_norm_backward` (fused per-row backward, deterministic `grad_weight` via `prod.sum(0)`).
- Add `_num_warps_for(block_size)` (H100-tuned, depends only on block size to preserve batch invariance).
- Route `_rms_norm_forward` / `backward` to the fused path for `hidden <= MAX_FUSED_COLS`, keeping the two-pass loop as fallback for larger.
- Add `tests/ops/test_triton_batch_invariant_rms_norm.py`: forward/backward parity, batch invariance (whole vs chunked), `MAX_FUSED_COLS` fallback coverage, plus an env-gated benchmark matrix.

### Checklist Before Submitting

- Applied pre-commit checks.
- Added a new test `tests/ops/test_triton_batch_invariant_rms_norm.py` (auto-enumerated by `gpu_unit_tests.yml` via `tests/ops/`); correctness and determinism additionally validated on H100 (see Test section).
