### PR TITLE
[trainer] fix: normalize DiT gradient accumulation loss

### DIFF
--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -444,7 +444,7 @@ class DiTTrainer:
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Postprocess model outputs after forward pass."""
         loss_dict: Dict[str, torch.Tensor] = outputs.loss
-        loss_dict = {k: v / self.base.args.train.micro_batch_size for k, v in loss_dict.items()}
+        loss_dict = {k: v / self.base.num_micro_batches for k, v in loss_dict.items()}
         loss = torch.stack(list(loss_dict.values())).sum()
         return loss, loss_dict
 


### PR DESCRIPTION
### What does this PR do?

> Normalize each DiT micro-batch loss by the number of accumulated micro-batches. Without this division, the accumulated gradient is scaled by `gradient_accumulation_steps`.

### Checklist Before Starting

- Search for relative PRs/issues and link here: no directly related issue or PR found
- PR title follows `[{modules}] {type}: {description}` format

### Test

> `make quality`

### API and Usage Example

> N/A

### Design & Code Changes

> Replace the `micro_batch_size` divisor with `num_micro_batches`. Diffusion model losses are already averaged within each micro-batch, while `DiTTrainer` performs backward once per accumulated micro-batch.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Documentation update is not required because no API or configuration semantics changed
- No CI test was added for this one-line loss normalization correction
