### PR TITLE
[data, trainer] feat: add canonical source metadata contract

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -354,7 +354,11 @@ sampled steps also report source-level data composition as `samples/<source>`,
 aligned for channel loss; they do not require per-sample IDs. This side channel does
 not change the returned training loss or gradients. Fused-loss backends may
 recompute the LM-head projection on sampled steps, so the default interval is
-10 steps; set `interval=1` for per-step metrics. DiT trainers and
+10 steps; set `interval=1` for per-step metrics. On memory-constrained
+profiles, `release_cache=true` synchronizes and releases the detached CE
+workspace after each sampled forward and before training backward. This does
+not change the objective or gradients, but adds synchronization and allocator
+churn. DiT trainers and
 `data.data_type="classification"` are not supported because they do not optimize
 a causal-LM objective. SeedOmni's `Qwen3MoeFoundationModel` is also unsupported
 because its legacy forward bypasses the observable loss dispatch. `BaseRLTrainer`
@@ -389,6 +393,7 @@ bounded).
 | token_count_metric_prefix | `str` | `"channel_tokens"` | Prefix for supervised token-count metrics. |
 | log_weighted_loss | `bool` | `True` | Log weighted loss metrics. |
 | log_token_count | `bool` | `True` | Log token-count metrics. |
+| release_cache | `bool` | `False` | Synchronize and release detached CE allocator cache after sampled forwards to lower memory carried into backward. |
 | strict | `bool` | `False` | Raise when source metadata is missing or cannot be aligned with packed segments; otherwise skip invalid batches. |
 
 ### GradientCheckpointingConfig

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -369,6 +369,62 @@ their preference pair's source metadata. If distinct source names sanitize to
 the same metric key, the stable source-ID prefix keeps their time series
 distinct from the first emission.
 
+#### Public loader metadata contract
+
+Public multi-source loaders attach a versioned raw envelope to every transformed
+feature before collation:
+
+```python
+{
+    "_veomni_source_metadata": {
+        "schema_version": 1,
+        "source_id": 7,  # an int or str; bool is rejected
+        "source_name": "repoqa",  # optional
+        # Optional diagnostics: row_id, sample_id, part_index
+    }
+}
+```
+
+Configured source IDs must be unique while preserving their type, so `7` and
+`"7"` are distinct. For channel-loss attribution, a custom loader only needs
+to attach this raw envelope before `MainCollator`; it does not need to
+implement packing or sequence-parallel handling. When VeOmni's multisource
+environment meter is enabled as well, the loader must continue to expose its
+integer `ds_idx` compatibility field.
+
+`MainCollator` consumes the raw envelope and emits
+`_veomni_packed_source_metadata` with `schema_version=1`,
+`coordinate_space="packed_pre_sp"`, `valid_token_count`, and an ordered
+`segments` list. Each segment records `segment_index`, `sample_index`,
+`subsegment_index`, `token_start`, and `token_length`, plus its source fields
+and any optional diagnostics. Coordinates describe the full packed sequence
+before sequence-parallel slicing. Fixed-length and sequence-parallel tail
+padding are excluded, and every sequence-parallel rank receives the same
+envelope. `source_name` is either present on every packed segment or omitted
+from every segment; mixed presence is rejected to prevent incorrect attribution.
+
+Channel loss prefers the canonical packed envelope and uses configured legacy
+metadata keys only as a compatibility fallback. If canonical and legacy
+metadata coexist, their typed source IDs and names must agree segment by
+segment or training fails closed. Fields owned by the canonical or VeOmni
+multisource contract are removed before model forward, including when channel
+loss is disabled; unrelated generic custom-model inputs are preserved.
+
+Fixed-sample batching requires each input transform to produce exactly one
+feature. A one-to-many transform must use dynamic batching; fixed batching
+fails explicitly instead of silently dropping transformed parts.
+
+Iterable interleave checkpoints now persist the ordered typed `source_ids`
+topology and reject a changed topology on resume. Legacy version-less
+checkpoints remain loadable, but did not record enough information for this
+validation.
+
+Version-0 weighted-multisource checkpoints whose IDs equal display names are
+interpreted as output from the historical builder behavior and migrated by
+unchanged source name. Renaming or otherwise changing that ambiguous v0
+topology cannot guarantee exact recovery; use strict reconciliation or an
+explicit offline migration instead.
+
 When W&B is enabled, rank 0 also publishes one final `channel_overview` HTML
 snapshot. It combines every source on one shared-axis loss chart with a
 raw/weighted toggle, shows the observed label-token mix as a 100% stacked

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -347,7 +347,11 @@ NPU validation runs at two times:
 
 This is an observability-only side channel. It computes detached per-token CE
 from the model loss inputs, aggregates by packed-sequence source metadata, and
-adds metrics such as `channel_loss/<source-id>__<source>` to the normal step metrics. It does
+adds metrics such as `channel_loss/<source-id>__<source>` to the normal step metrics. The same
+sampled steps also report source-level data composition as `samples/<source>`,
+`input_tokens/<source>`, `label_tokens/<source>`, and
+`label_tokens_per_sample/<source>`. These counters use the packed segments already
+aligned for channel loss; they do not require per-sample IDs. This side channel does
 not change the returned training loss or gradients. Fused-loss backends may
 recompute the LM-head projection on sampled steps, so the default interval is
 10 steps; set `interval=1` for per-step metrics. DiT trainers and

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -365,6 +365,18 @@ their preference pair's source metadata. If distinct source names sanitize to
 the same metric key, the stable source-ID prefix keeps their time series
 distinct from the first emission.
 
+When W&B is enabled, rank 0 also publishes one final `channel_overview` HTML
+snapshot. It combines every source on one shared-axis loss chart with a
+raw/weighted toggle, shows the observed label-token mix as a 100% stacked
+chart, and provides a step-selectable sample/token summary table. Native scalar
+metrics remain the live, machine-readable contract throughout training. The
+dashboard contains aggregate metrics only; optional dataloader adapters may call
+`trainer.set_channel_loss_trace_step_id(...)` once per step with an opaque ID,
+but sample content and physical locators remain in adapter-owned artifacts. Set
+`VEOMNI_CHANNEL_DASHBOARD_MAX_POINTS` to a positive
+integer to bound rendered points (default: 2000; retained history is also
+bounded).
+
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | enable | `bool` | `False` | Enable channel loss logging. |

--- a/tests/data/test_collators.py
+++ b/tests/data/test_collators.py
@@ -75,6 +75,130 @@ def test_seqcls_collator_sp_enabled(monkeypatch, features_two_samples):
     assert out["max_length_k"] == exp_max_length
 
 
+def test_main_collator_emits_packed_source_metadata_in_position_reset_order(monkeypatch):
+    import veomni.data.data_collator as m
+
+    monkeypatch.setattr(m, "get_parallel_state", lambda: _fake_ps(sp_enabled=False))
+    features = [
+        {
+            "input_ids": torch.tensor([11, 12, 13]),
+            "attention_mask": torch.ones(3, dtype=torch.long),
+            "labels": torch.tensor([11, 12, 13]),
+            "_veomni_source_metadata": {
+                "schema_version": 1,
+                "source_id": 7,
+                "source_name": "a",
+                "row_id": 42,
+                "sample_id": "sample-a",
+                "part_index": 1,
+            },
+        },
+        {
+            "input_ids": torch.tensor([21, 22]),
+            "attention_mask": torch.ones(2, dtype=torch.long),
+            "labels": torch.tensor([21, 22]),
+            "_veomni_source_metadata": {
+                "schema_version": 1,
+                "source_id": "7",
+                "source_name": "b",
+            },
+        },
+    ]
+
+    batch = m.MainCollator()(features)
+
+    assert "_veomni_source_metadata" not in batch
+    assert batch["_veomni_packed_source_metadata"] == {
+        "schema_version": 1,
+        "coordinate_space": "packed_pre_sp",
+        "valid_token_count": 5,
+        "segments": [
+            {
+                "source_id": 7,
+                "source_name": "a",
+                "row_id": 42,
+                "sample_id": "sample-a",
+                "part_index": 1,
+                "segment_index": 0,
+                "sample_index": 0,
+                "subsegment_index": 0,
+                "token_start": 0,
+                "token_length": 3,
+            },
+            {
+                "source_id": "7",
+                "source_name": "b",
+                "segment_index": 1,
+                "sample_index": 1,
+                "subsegment_index": 0,
+                "token_start": 3,
+                "token_length": 2,
+            },
+        ],
+    }
+
+
+def test_packed_source_metadata_excludes_padding_and_is_identical_across_sp_ranks(monkeypatch):
+    import veomni.data.data_collator as m
+
+    def make_features():
+        return [
+            {
+                "input_ids": torch.tensor([11, 12, 13]),
+                "attention_mask": torch.ones(3, dtype=torch.long),
+                "labels": torch.tensor([11, 12, 13]),
+                "_veomni_source_metadata": {
+                    "schema_version": 1,
+                    "source_id": "a",
+                    "source_name": "source-a",
+                },
+            },
+            {
+                "input_ids": torch.tensor([21, 22]),
+                "attention_mask": torch.ones(2, dtype=torch.long),
+                "labels": torch.tensor([21, 22]),
+                "_veomni_source_metadata": {
+                    "schema_version": 1,
+                    "source_id": "b",
+                    "source_name": "source-b",
+                },
+            },
+        ]
+
+    packed_by_rank = []
+    for sp_rank in (0, 1):
+        monkeypatch.setattr(
+            m,
+            "get_parallel_state",
+            lambda sp_rank=sp_rank: _fake_ps(sp_enabled=True, sp_size=2, sp_rank=sp_rank),
+        )
+        batch = m.MainCollator(pad_to_length=8)(make_features())
+        packed_by_rank.append(batch["_veomni_packed_source_metadata"])
+
+    assert packed_by_rank[0] == packed_by_rank[1]
+    assert packed_by_rank[0]["valid_token_count"] == 5
+    assert packed_by_rank[0]["segments"] == [
+        {
+            "source_id": "a",
+            "source_name": "source-a",
+            "segment_index": 0,
+            "sample_index": 0,
+            "subsegment_index": 0,
+            "token_start": 0,
+            "token_length": 3,
+        },
+        {
+            "source_id": "b",
+            "source_name": "source-b",
+            "segment_index": 1,
+            "sample_index": 1,
+            "subsegment_index": 0,
+            "token_start": 3,
+            "token_length": 2,
+        },
+    ]
+
+
 def test_data_collator_pad_to_length_sp_disabled(monkeypatch, features_two_samples):
     if IS_NPU_AVAILABLE:
         pytest.skip("NPU does not support this padding test yet.")

--- a/tests/data/test_dpo_data_processor.py
+++ b/tests/data/test_dpo_data_processor.py
@@ -92,6 +92,68 @@ def test_dpo_main_collator_sp_disabled(monkeypatch):
     assert batch["position_ids"].eq(0).sum().item() == 2 * batch["ds_idx"].numel()
 
 
+def test_dpo_canonical_source_metadata_expands_from_position_resets(monkeypatch):
+    """Canonical metadata expands chosen/rejected without trainer-side repetition."""
+    import veomni.data.data_collator as m
+
+    monkeypatch.setattr(m, "get_parallel_state", lambda: _fake_ps(sp_enabled=False))
+
+    s1 = _make_flat_dpo_sample([1, 2, 3], [4, 5, 6])
+    s2 = _make_flat_dpo_sample([7, 8], [9, 10])
+    s1["_veomni_source_metadata"] = {
+        "schema_version": 1,
+        "source_id": "A",
+        "source_name": "train/a",
+    }
+    s2["_veomni_source_metadata"] = {
+        "schema_version": 1,
+        "source_id": "B",
+        "source_name": "train/b",
+    }
+
+    batch = m.MainCollator()([s1, s2])
+
+    assert batch["_veomni_packed_source_metadata"]["valid_token_count"] == 10
+    assert batch["_veomni_packed_source_metadata"]["segments"] == [
+        {
+            "source_id": "A",
+            "source_name": "train/a",
+            "segment_index": 0,
+            "sample_index": 0,
+            "subsegment_index": 0,
+            "token_start": 0,
+            "token_length": 3,
+        },
+        {
+            "source_id": "A",
+            "source_name": "train/a",
+            "segment_index": 1,
+            "sample_index": 0,
+            "subsegment_index": 1,
+            "token_start": 3,
+            "token_length": 3,
+        },
+        {
+            "source_id": "B",
+            "source_name": "train/b",
+            "segment_index": 2,
+            "sample_index": 1,
+            "subsegment_index": 0,
+            "token_start": 6,
+            "token_length": 2,
+        },
+        {
+            "source_id": "B",
+            "source_name": "train/b",
+            "segment_index": 3,
+            "sample_index": 1,
+            "subsegment_index": 1,
+            "token_start": 8,
+            "token_length": 2,
+        },
+    ]
+
+
 def test_dpo_main_collator_sp_enabled(monkeypatch):
     """MainCollator packs and SP-slices flat DPO samples."""
     import veomni.data.data_collator as m

--- a/tests/data/test_multisource_dataset.py
+++ b/tests/data/test_multisource_dataset.py
@@ -36,7 +36,19 @@ from utils import (
 
 from veomni.arguments import VeOmniArguments, parse_args
 from veomni.data import build_dataloader
-from veomni.data.dataset import WeightedMultiSourceDataset
+from veomni.data.data_collator import MainCollator
+from veomni.data.dataset import (
+    DynamicBatchingSizeDataset,
+    InterleavedIterableDataset,
+    WeightedMultiSourceDataset,
+    build_dataset,
+)
+from veomni.data.source_metadata import (
+    attach_source_metadata,
+    make_source_metadata,
+    normalize_packed_source_metadata,
+    normalize_source_metadata,
+)
 from veomni.distributed.parallel_state import get_parallel_state
 from veomni.trainer.base import BaseTrainer
 from veomni.trainer.callbacks import Callback, TrainerState
@@ -155,7 +167,7 @@ class TrainerTest(BaseTrainer):
         dist.barrier()
 
         state = cast(WeightedMultiSourceDataset, self.train_dataset).state_dict()
-        assert state["version"] == 0
+        assert state["version"] == 1
         assert state["topology"]["stopping_strategy"] == "all_exhausted"
         assert state["topology"]["level"] == "token"
         assert state["topology"]["source_names"] == self.multisource_names
@@ -423,6 +435,430 @@ def _make_simple_dataset(
     )
 
 
+def test_weighted_multisource_builder_emits_configured_stable_source_id(tmp_path, monkeypatch):
+    config_path = tmp_path / "multisource.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "sources": ["source.jsonl"],
+                "names": ["display-name"],
+                "source_ids": [17],
+                "schedule": [{"schedule_type": "const", "weights": [1.0]}],
+                "upstream_sharded": False,
+            }
+        )
+    )
+
+    def fake_build_iterable_dataset(*, transform, **_kwargs):
+        transformed = transform({"input_ids": [1, 2]})
+        return MockIterableDataset([transformed])
+
+    monkeypatch.setattr("veomni.data.dataset.build_iterable_dataset", fake_build_iterable_dataset)
+    dataset = build_dataset(
+        "veomni_weighted_multisource",
+        train_path=str(config_path),
+        transform=lambda sample: {**sample, "source_id": "discarded-by-source-wrapper"},
+        shuffle=False,
+    )
+
+    sample = next(iter(dataset))
+
+    assert sample["source_id"] == 17
+    assert sample["source_name"] == "display-name"
+    assert sample["_veomni_source_metadata"] == {
+        "schema_version": 1,
+        "source_id": 17,
+        "source_name": "display-name",
+    }
+
+
+def test_weighted_multisource_rejects_boolean_source_id():
+    with pytest.raises(ValueError, match="source_ids must contain only int or str"):
+        _make_simple_dataset(
+            datasets=[MockIterableDataset([{"input_ids": [1]}])],
+            weights=[1.0],
+            source_ids=[True],
+        )
+
+
+def test_attach_source_metadata_assigns_missing_logical_part_index():
+    chunks = [
+        {"input_ids": [1]},
+        {"input_ids": [2], "part_index": 7},
+    ]
+
+    attach_source_metadata(chunks, source_id="stable-id", source_name="display-name")
+
+    assert [chunk["_veomni_source_metadata"]["part_index"] for chunk in chunks] == [0, 7]
+
+
+def test_attach_source_metadata_removes_stale_name_when_canonical_name_is_missing():
+    sample = {
+        "input_ids": [1],
+        "channel_name": "stale-channel",
+        "source_name": "stale-source",
+        "dataset_name": "stale-dataset",
+        "data_name": "stale-data",
+    }
+
+    attach_source_metadata(sample, source_id="stable-id", source_name=None)
+
+    assert not {"channel_name", "source_name", "dataset_name", "data_name"} & sample.keys()
+    assert "source_name" not in sample["_veomni_source_metadata"]
+
+
+def test_make_source_metadata_rejects_non_string_source_name():
+    with pytest.raises(ValueError, match="source_name must be a str or None"):
+        make_source_metadata("stable-id", True)
+
+
+def test_interleaved_iterable_preserves_source_metadata_after_transform():
+    dataset = InterleavedIterableDataset(
+        data=[
+            {
+                "input_ids": [1, 2],
+                "ds_idx": 0,
+                "source_id": "stable-id",
+                "source_name": "display-name",
+            }
+        ],
+        transform=lambda _sample, **_kwargs: {"input_ids": [3, 4]},
+    )
+
+    sample = next(iter(dataset))
+
+    assert sample["source_id"] == "stable-id"
+    assert sample["source_name"] == "display-name"
+    assert sample["_veomni_source_metadata"] == {
+        "schema_version": 1,
+        "source_id": "stable-id",
+        "source_name": "display-name",
+    }
+
+
+def test_interleaved_iterable_checkpoint_validates_typed_source_id_topology():
+    class StatefulRows:
+        def __init__(self):
+            self.cursor = 0
+
+        def __iter__(self):
+            return iter(())
+
+        def state_dict(self):
+            return {"cursor": self.cursor}
+
+        def load_state_dict(self, state):
+            self.cursor = state["cursor"]
+
+    rows = StatefulRows()
+    rows.cursor = 3
+    dataset = InterleavedIterableDataset(rows, source_ids=[7, "7"])
+
+    state = dataset.state_dict()
+
+    assert state == {
+        "version": 1,
+        "topology": {"source_ids": [7, "7"]},
+        "dataset": {"cursor": 3},
+    }
+
+    restored_rows = StatefulRows()
+    restored = InterleavedIterableDataset(restored_rows, source_ids=[7, "7"])
+    restored.load_state_dict(copy.deepcopy(state))
+    assert restored_rows.cursor == 3
+
+    reordered = InterleavedIterableDataset(StatefulRows(), source_ids=["7", 7])
+    with pytest.raises(ValueError, match="source_ids topology"):
+        reordered.load_state_dict(copy.deepcopy(state))
+
+    # Version-less states from the old wrapper remain loadable, but cannot
+    # provide topology validation retroactively.
+    restored.load_state_dict({"dataset": {"cursor": 4}})
+    assert restored_rows.cursor == 4
+
+
+def test_interleave_builder_preserves_typed_source_ids_after_transform(tmp_path, monkeypatch):
+    config_path = tmp_path / "interleave.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "sources": ["source-a.jsonl", "source-b.jsonl"],
+                "names": ["a", "b"],
+                "source_ids": [101, "101"],
+                "schedule": [{"schedule_type": "const", "weights": [0.5, 0.5]}],
+            }
+        )
+    )
+
+    class MappableRows:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def map(self, transform):
+            return MappableRows([transform(row) for row in self.rows])
+
+        def __iter__(self):
+            return iter(self.rows)
+
+    def fake_build_iterable_dataset(train_path, **_kwargs):
+        return type("DatasetWrapper", (), {"_data": MappableRows([{"input_ids": [len(train_path)]}])})()
+
+    monkeypatch.setattr("veomni.data.dataset.build_iterable_dataset", fake_build_iterable_dataset)
+    monkeypatch.setattr(
+        "veomni.data.dataset.interleave_datasets",
+        lambda *, datasets, **_kwargs: [row for dataset in datasets for row in dataset],
+    )
+    monkeypatch.setattr("veomni.data.dataset.split_dataset_by_node", lambda dataset, *_args: dataset)
+
+    dataset = build_dataset(
+        "interleave",
+        train_path=str(config_path),
+        datasets_type="iterable",
+        transform=lambda sample, **_kwargs: {"input_ids": sample["input_ids"]},
+    )
+
+    samples = list(dataset)
+
+    assert [sample["source_id"] for sample in samples] == [101, "101"]
+    assert [sample["_veomni_source_metadata"]["source_id"] for sample in samples] == [101, "101"]
+
+
+def test_interleave_mapping_builder_attaches_metadata_to_transformed_parts(tmp_path, monkeypatch):
+    config_path = tmp_path / "interleave-mapping.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "sources": ["source-a.jsonl", "source-b.jsonl"],
+                "names": ["a", "b"],
+                "source_ids": [202, "202"],
+                "schedule": [{"schedule_type": "const", "weights": [0.5, 0.5]}],
+            }
+        )
+    )
+
+    class ColumnRows:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def add_column(self, name, values):
+            return ColumnRows([{**row, name: value} for row, value in zip(self.rows, values)])
+
+        def __getitem__(self, index):
+            return self.rows[index]
+
+        def __len__(self):
+            return len(self.rows)
+
+    def fake_build_mapping_dataset(train_path, **_kwargs):
+        return type("DatasetWrapper", (), {"_data": ColumnRows([{"input_ids": [len(train_path)]}])})()
+
+    monkeypatch.setattr("veomni.data.dataset.build_mapping_dataset", fake_build_mapping_dataset)
+    monkeypatch.setattr(
+        "veomni.data.dataset.interleave_datasets",
+        lambda *, datasets, **_kwargs: ColumnRows([row for dataset in datasets for row in dataset.rows]),
+    )
+
+    dataset = build_dataset(
+        "interleave",
+        train_path=str(config_path),
+        datasets_type="mapping",
+        transform=lambda sample, **_kwargs: [
+            {"input_ids": sample["input_ids"]},
+            {"input_ids": sample["input_ids"]},
+        ],
+    )
+
+    first_parts = dataset[0]
+    second_parts = dataset[1]
+
+    assert [part["_veomni_source_metadata"]["source_id"] for part in first_parts] == [202, 202]
+    assert [part["_veomni_source_metadata"]["part_index"] for part in first_parts] == [0, 1]
+    assert [part["_veomni_source_metadata"]["source_id"] for part in second_parts] == ["202", "202"]
+
+
+def test_real_hf_streaming_interleave_reaches_canonical_main_collator(tmp_path):
+    source_a = tmp_path / "source-a.jsonl"
+    source_b = tmp_path / "source-b.jsonl"
+    source_a.write_text("\n".join(f'{{"tokens": [{token}, {token + 1}]}}' for token in (11, 21, 31, 41)) + "\n")
+    source_b.write_text('{"tokens": [101, 102]}\n')
+    config_path = tmp_path / "streaming-interleave.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "sources": [str(source_a), str(source_b)],
+                "names": ["a", "b"],
+                "source_ids": [303, "303"],
+                "schedule": [{"schedule_type": "const", "weights": [1.0, 0.0]}],
+            }
+        )
+    )
+
+    def transform(sample, **_kwargs):
+        input_ids = torch.tensor(sample["tokens"], dtype=torch.long)
+        return {
+            "input_ids": input_ids,
+            "attention_mask": torch.ones_like(input_ids),
+            "labels": input_ids.clone(),
+        }
+
+    dataset = build_dataset(
+        "interleave",
+        train_path=str(config_path),
+        datasets_type="iterable",
+        transform=transform,
+        shuffle=False,
+    )
+    features = list(dataset)
+
+    assert [feature["input_ids"].tolist() for feature in features[:4]] == [
+        [11, 12],
+        [21, 22],
+        [31, 32],
+        [41, 42],
+    ]
+    features = features[:4]
+    assert [feature["_veomni_source_metadata"]["source_id"] for feature in features] == [303] * 4
+
+    packed = MainCollator()(features)
+
+    assert packed["_veomni_packed_source_metadata"]["valid_token_count"] == 8
+    assert [segment["source_id"] for segment in packed["_veomni_packed_source_metadata"]["segments"]] == [303] * 4
+    assert [segment["sample_index"] for segment in packed["_veomni_packed_source_metadata"]["segments"]] == [
+        0,
+        1,
+        2,
+        3,
+    ]
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        lambda: make_source_metadata(True, "name"),
+        lambda: attach_source_metadata({}, source_id=1.5, source_name="name"),
+    ],
+)
+def test_public_source_metadata_helpers_validate_source_id(operation):
+    with pytest.raises(ValueError, match="source_ids must contain only int or str"):
+        operation()
+
+
+def test_public_source_metadata_schema_helpers_fail_closed():
+    with pytest.raises(ValueError, match="schema_version must be 1"):
+        normalize_source_metadata({"schema_version": 2, "source_id": "a"})
+
+    with pytest.raises(ValueError, match="valid_token_count must equal"):
+        normalize_packed_source_metadata(
+            {
+                "schema_version": 1,
+                "coordinate_space": "packed_pre_sp",
+                "valid_token_count": 3,
+                "segments": [
+                    {
+                        "source_id": "a",
+                        "segment_index": 0,
+                        "sample_index": 0,
+                        "subsegment_index": 0,
+                        "token_start": 0,
+                        "token_length": 2,
+                    }
+                ],
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "sample_coordinates",
+    [
+        [(1, 0), (1, 1)],
+        [(0, 0), (0, 2)],
+    ],
+)
+def test_packed_source_metadata_rejects_invalid_sample_subsegment_order(sample_coordinates):
+    segments = [
+        {
+            "source_id": "a",
+            "segment_index": segment_index,
+            "sample_index": sample_index,
+            "subsegment_index": subsegment_index,
+            "token_start": segment_index,
+            "token_length": 1,
+        }
+        for segment_index, (sample_index, subsegment_index) in enumerate(sample_coordinates)
+    ]
+
+    with pytest.raises(ValueError, match="sample_index/subsegment_index"):
+        normalize_packed_source_metadata(
+            {
+                "schema_version": 1,
+                "coordinate_space": "packed_pre_sp",
+                "valid_token_count": 2,
+                "segments": segments,
+            }
+        )
+
+
+def test_packed_source_metadata_rejects_partially_missing_source_names():
+    with pytest.raises(ValueError, match="source_name must be present on all segments or none"):
+        normalize_packed_source_metadata(
+            {
+                "schema_version": 1,
+                "coordinate_space": "packed_pre_sp",
+                "valid_token_count": 2,
+                "segments": [
+                    {
+                        "source_id": "a",
+                        "source_name": "source-a",
+                        "segment_index": 0,
+                        "sample_index": 0,
+                        "subsegment_index": 0,
+                        "token_start": 0,
+                        "token_length": 1,
+                    },
+                    {
+                        "source_id": "b",
+                        "segment_index": 1,
+                        "sample_index": 1,
+                        "subsegment_index": 0,
+                        "token_start": 1,
+                        "token_length": 1,
+                    },
+                ],
+            }
+        )
+
+
+def test_packed_source_metadata_rejects_conflicting_names_for_same_typed_source_id():
+    with pytest.raises(ValueError, match="same source_id must use one source_name"):
+        normalize_packed_source_metadata(
+            {
+                "schema_version": 1,
+                "coordinate_space": "packed_pre_sp",
+                "valid_token_count": 2,
+                "segments": [
+                    {
+                        "source_id": 7,
+                        "source_name": "source-a",
+                        "segment_index": 0,
+                        "sample_index": 0,
+                        "subsegment_index": 0,
+                        "token_start": 0,
+                        "token_length": 1,
+                    },
+                    {
+                        "source_id": 7,
+                        "source_name": "source-b",
+                        "segment_index": 1,
+                        "sample_index": 1,
+                        "subsegment_index": 0,
+                        "token_start": 1,
+                        "token_length": 1,
+                    },
+                ],
+            }
+        )
+
+
 def test_state_dict_structure():
     ds1 = MockIterableDataset([{"input_ids": [1, 2]}], name="a")
     ds2 = MockIterableDataset([{"input_ids": [3, 4, 5]}], name="b")
@@ -435,12 +871,284 @@ def test_state_dict_structure():
         source_ids=["id_a", "id_b"],
     )
     state = dataset.state_dict()
-    assert state["version"] == 0
+    assert state["version"] == 1
     assert state["topology"]["source_ids"] == ["id_a", "id_b"]
     assert sorted(state["runtime"]["avg_len_sum"].keys()) == ["id_a", "id_b"]
     assert sorted(state["runtime"]["avg_len_count"].keys()) == ["id_a", "id_b"]
     assert sorted(state["runtime"]["dataset_states"].keys()) == ["id_a", "id_b"]
     assert sorted(state["runtime"]["exhausted"].keys()) == ["id_a", "id_b"]
+
+
+def _legacy_weighted_state(
+    *,
+    source_names,
+    dataset_states,
+    avg_len_sum,
+    avg_len_count,
+    exhausted,
+    global_sample_idx=7,
+):
+    """Build the version-0 shape emitted while the public builder ignored source_ids."""
+    return {
+        "version": 0,
+        "topology": {
+            # The old builder typo made these aliases equal to source_names.
+            "source_ids": list(source_names),
+            "source_names": list(source_names),
+            "weights": [1.0 / len(source_names)] * len(source_names),
+            "level": "token",
+            "stopping_strategy": "all_exhausted",
+        },
+        "runtime": {
+            "random_state": np.random.RandomState(321).get_state(),
+            "avg_len_sum": dict(avg_len_sum),
+            "avg_len_count": dict(avg_len_count),
+            "exhausted": dict(exhausted),
+            "global_sample_idx": global_sample_idx,
+            "dataset_states": dict(dataset_states),
+        },
+    }
+
+
+def test_legacy_name_keyed_checkpoint_migrates_to_typed_stable_ids_and_roundtrips():
+    old_state = _legacy_weighted_state(
+        source_names=["integer-id-source", "string-id-source"],
+        dataset_states={
+            "integer-id-source": {"consumed": 3},
+            "string-id-source": {"consumed": 5},
+        },
+        avg_len_sum={"integer-id-source": 11.0, "string-id-source": 22.0},
+        avg_len_count={"integer-id-source": 2, "string-id-source": 4},
+        exhausted={"integer-id-source": True, "string-id-source": False},
+    )
+    restored_sources = [
+        MockIterableDataset([{"input_ids": [1]}], name="integer-id-source"),
+        MockIterableDataset([{"input_ids": [2]}], name="string-id-source"),
+    ]
+    restored = _make_simple_dataset(
+        datasets=restored_sources,
+        weights=[0.5, 0.5],
+        level="token",
+        stopping_strategy="all_exhausted",
+        source_names=["integer-id-source", "string-id-source"],
+        source_ids=[1, "1"],
+    )
+
+    restored.load_state_dict(copy.deepcopy(old_state))
+
+    assert restored._avg_len_sum == [11.0, 22.0]
+    assert restored._avg_len_count == [2, 4]
+    assert restored._exhausted == [True, False]
+    assert restored._global_sample_idx == 7
+    assert [source.state_dict() for source in restored_sources] == [{"consumed": 3}, {"consumed": 5}]
+
+    migrated_state = restored.state_dict()
+    assert migrated_state["version"] == 1
+    assert migrated_state["topology"]["source_ids"] == [1, "1"]
+    assert migrated_state["runtime"]["avg_len_sum"] == {1: 11.0, "1": 22.0}
+    assert migrated_state["runtime"]["avg_len_count"] == {1: 2, "1": 4}
+    assert migrated_state["runtime"]["exhausted"] == {1: True, "1": False}
+    assert migrated_state["runtime"]["dataset_states"] == {
+        1: {"consumed": 3},
+        "1": {"consumed": 5},
+    }
+
+    cold_sources = [
+        MockIterableDataset([{"input_ids": [1]}], name="integer-id-source"),
+        MockIterableDataset([{"input_ids": [2]}], name="string-id-source"),
+    ]
+    cold = _make_simple_dataset(
+        datasets=cold_sources,
+        weights=[0.5, 0.5],
+        level="token",
+        stopping_strategy="all_exhausted",
+        source_names=["integer-id-source", "string-id-source"],
+        source_ids=[1, "1"],
+    )
+    cold.load_state_dict(copy.deepcopy(migrated_state), reconcile_policy="strict")
+    assert cold.state_dict()["runtime"]["dataset_states"] == migrated_state["runtime"]["dataset_states"]
+
+
+def test_legacy_checkpoint_rejects_ambiguous_source_name_mapping():
+    old_state = _legacy_weighted_state(
+        source_names=["duplicate", "duplicate"],
+        dataset_states={"duplicate": {"consumed": 1}},
+        avg_len_sum={"duplicate": 1.0},
+        avg_len_count={"duplicate": 1},
+        exhausted={"duplicate": False},
+    )
+    restored = _make_simple_dataset(
+        datasets=[
+            MockIterableDataset([{"input_ids": [1]}]),
+            MockIterableDataset([{"input_ids": [2]}]),
+        ],
+        weights=[0.5, 0.5],
+        source_names=["duplicate", "other"],
+        source_ids=["stable-a", "stable-b"],
+    )
+
+    with pytest.raises(ValueError, match="ambiguous legacy source_names"):
+        restored.load_state_dict(old_state)
+
+
+def test_legacy_checkpoint_rejects_alias_collision_with_current_stable_id():
+    old_state = _legacy_weighted_state(
+        source_names=["legacy-a", "legacy-b"],
+        dataset_states={"legacy-a": {"consumed": 1}, "legacy-b": {"consumed": 2}},
+        avg_len_sum={"legacy-a": 1.0, "legacy-b": 2.0},
+        avg_len_count={"legacy-a": 1, "legacy-b": 1},
+        exhausted={"legacy-a": False, "legacy-b": False},
+    )
+    restored = _make_simple_dataset(
+        datasets=[
+            MockIterableDataset([{"input_ids": [1]}]),
+            MockIterableDataset([{"input_ids": [2]}]),
+        ],
+        weights=[0.5, 0.5],
+        source_names=["legacy-a", "legacy-b"],
+        # The legacy alias "legacy-b" would select source 0 through the new
+        # stable-ID table but source 1 through the version-0 name mapping.
+        source_ids=["legacy-b", "stable-b"],
+    )
+
+    with pytest.raises(ValueError, match="legacy source alias.*conflicts with current source_id"):
+        restored.load_state_dict(old_state)
+
+
+class _ResumeIndexDataset(IterableDataset):
+    def __init__(self):
+        self.rows = [
+            {"input_ids": [10], "attention_mask": [1]},
+            {"input_ids": [11], "attention_mask": [1]},
+            {"input_ids": [12], "attention_mask": [1]},
+        ]
+        self.output_index_for_resume = False
+        self.cursor = 0
+        self.loaded_cursor = None
+
+    def __iter__(self):
+        while self.cursor < len(self.rows):
+            row_idx = self.cursor
+            self.cursor += 1
+            row = copy.deepcopy(self.rows[row_idx])
+            if self.output_index_for_resume:
+                yield row, row_idx
+            else:
+                yield row
+
+    def get_item(self, row_idx):
+        # Buffer reconstruction must happen only after the upstream cursor was
+        # restored, otherwise exact cold resume can duplicate/skip rows.
+        if self.loaded_cursor is None:
+            raise RuntimeError("get_item called before upstream state restore")
+        return copy.deepcopy(self.rows[row_idx])
+
+    def state_dict(self):
+        return {"cursor": self.cursor}
+
+    def load_state_dict(self, state):
+        self.cursor = state["cursor"]
+        self.loaded_cursor = self.cursor
+
+
+def _make_dynamic_weighted_resume_dataset():
+    source = _ResumeIndexDataset()
+    weighted = WeightedMultiSourceDataset(
+        datasets=[source],
+        weights=[1.0],
+        source_names=["legacy-name"],
+        source_ids=["stable-id"],
+        upstream_sharded=True,
+        output_index_for_resume=True,
+    )
+    dynamic = DynamicBatchingSizeDataset(
+        dataset=weighted,
+        micro_batch_seq_length=1,
+        ready_for_micro_batch_threshold=1,
+        dynamic_batching_collate_fn=lambda samples: samples,
+        save_by_idx=True,
+        get_length_fn=lambda sample: len(sample["input_ids"]),
+    )
+    return source, weighted, dynamic
+
+
+def test_dynamic_save_by_idx_cold_resume_migrates_legacy_source_alias_before_buffer_rebuild():
+    legacy_upstream_state = _legacy_weighted_state(
+        source_names=["legacy-name"],
+        dataset_states={"legacy-name": {"cursor": 2}},
+        avg_len_sum={"legacy-name": 0.0},
+        avg_len_count={"legacy-name": 0},
+        exhausted={"legacy-name": False},
+        global_sample_idx=2,
+    )
+    old_dynamic_state = {
+        "save_by_idx": True,
+        "buffer_token_count": 1,
+        "buffer_physical_token_count": 1,
+        "buffer": [(("legacy-name", 1), 0)],
+        "dynamic_batch_upstream_dataset_state": legacy_upstream_state,
+    }
+    source, _weighted, dynamic = _make_dynamic_weighted_resume_dataset()
+
+    dynamic.load_state_dict(copy.deepcopy(old_dynamic_state))
+
+    assert source.loaded_cursor == 2
+    assert dynamic._buffer[0][0]["input_ids"] == [11]
+    assert dynamic._buffer[0][0]["source_id"] == "stable-id"
+    migrated = dynamic.state_dict()
+    assert migrated["buffer"] == [(("stable-id", 1), 0)]
+    assert migrated["dynamic_batch_upstream_dataset_state"]["version"] == 1
+    assert migrated["dynamic_batch_upstream_dataset_state"]["topology"]["source_ids"] == ["stable-id"]
+
+    cold_source, _cold_weighted, cold_dynamic = _make_dynamic_weighted_resume_dataset()
+    cold_dynamic.load_state_dict(copy.deepcopy(migrated))
+    resumed_rows = [sample["input_ids"][0] for micro_batch in cold_dynamic for sample in micro_batch]
+    assert cold_source.loaded_cursor == 2
+    assert resumed_rows == [11, 12]
+
+
+def test_dynamic_v0_buffer_rejects_removed_alias_reused_as_current_stable_id():
+    class StatelessResumeIndexDataset(_ResumeIndexDataset):
+        def get_item(self, row_idx):
+            return copy.deepcopy(self.rows[row_idx])
+
+    legacy_upstream_state = _legacy_weighted_state(
+        source_names=["removed-source"],
+        dataset_states={"removed-source": {"cursor": 2}},
+        avg_len_sum={"removed-source": 0.0},
+        avg_len_count={"removed-source": 0},
+        exhausted={"removed-source": False},
+        global_sample_idx=2,
+    )
+    old_dynamic_state = {
+        "save_by_idx": True,
+        "buffer_token_count": 1,
+        "buffer_physical_token_count": 1,
+        "buffer": [(("removed-source", 1), 0)],
+        "dynamic_batch_upstream_dataset_state": legacy_upstream_state,
+    }
+    new_source = StatelessResumeIndexDataset()
+    weighted = WeightedMultiSourceDataset(
+        datasets=[new_source],
+        weights=[1.0],
+        source_names=["new-source"],
+        # Reusing the removed v0 name as a new stable ID must not redirect
+        # the old buffer entry to this unrelated source.
+        source_ids=["removed-source"],
+        upstream_sharded=True,
+        output_index_for_resume=True,
+    )
+    dynamic = DynamicBatchingSizeDataset(
+        dataset=weighted,
+        micro_batch_seq_length=1,
+        ready_for_micro_batch_threshold=1,
+        dynamic_batching_collate_fn=lambda samples: samples,
+        save_by_idx=True,
+        get_length_fn=lambda sample: len(sample["input_ids"]),
+    )
+
+    with pytest.raises(ValueError, match="removed legacy source alias"):
+        dynamic.load_state_dict(copy.deepcopy(old_dynamic_state))
 
 
 def test_exhausted_state_save_restore_and_elastic():

--- a/tests/data/test_source_metadata_contract.py
+++ b/tests/data/test_source_metadata_contract.py
@@ -1,0 +1,128 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from veomni.arguments.arguments_types import ChannelLossConfig
+from veomni.data.data_collator import MakeMicroBatchCollator
+from veomni.trainer.base import BaseTrainer
+from veomni.trainer.callbacks.channel_loss_callback import ChannelLossCallback
+from veomni.trainer.dit_trainer import DiTTrainer
+
+
+class _IdentityCollator:
+    def __call__(self, features):
+        return list(features)
+
+
+def _canonical_metadata(source_id="stable-id"):
+    return {
+        "schema_version": 1,
+        "coordinate_space": "packed_pre_sp",
+        "valid_token_count": 1,
+        "segments": [
+            {
+                "source_id": source_id,
+                "segment_index": 0,
+                "sample_index": 0,
+                "subsegment_index": 0,
+                "token_start": 0,
+                "token_length": 1,
+            }
+        ],
+    }
+
+
+def test_fixed_batching_rejects_multiple_transform_parts_instead_of_dropping_them():
+    collator = MakeMicroBatchCollator(num_micro_batch=1, internal_data_collator=_IdentityCollator())
+    transformed = [[{"input_ids": torch.tensor([1])}, {"input_ids": torch.tensor([2])}]]
+
+    with pytest.raises(ValueError, match="exactly one output per input"):
+        collator(transformed)
+
+
+def test_base_preforward_preserves_generic_model_inputs_without_source_contract():
+    trainer = object.__new__(BaseTrainer)
+    trainer.device = torch.device("cpu")
+    trainer.args = SimpleNamespace(
+        data=SimpleNamespace(enable_multisource=False),
+        train=SimpleNamespace(chunk_mbs_config=None, local_rank=0),
+    )
+    trainer.LOG_SAMPLE = False
+    micro_batch = {
+        "x": torch.tensor(1),
+        "source_id": torch.tensor([7]),
+        "dataset_id": torch.tensor([8]),
+        "sample_id": torch.tensor([9]),
+    }
+
+    result = BaseTrainer.preforward(trainer, micro_batch)
+
+    assert set(result) == {"x", "source_id", "dataset_id", "sample_id"}
+
+
+def test_base_preforward_strips_legacy_fields_owned_by_multisource_loader():
+    trainer = object.__new__(BaseTrainer)
+    trainer.device = torch.device("cpu")
+    trainer.args = SimpleNamespace(
+        data=SimpleNamespace(enable_multisource=True),
+        train=SimpleNamespace(chunk_mbs_config=None, local_rank=0),
+    )
+    trainer.LOG_SAMPLE = False
+    micro_batch = {
+        "x": torch.tensor(1),
+        "ds_idx": torch.tensor([0]),
+        "source_name": ["train/a"],
+        "cur_token_num": torch.tensor([1]),
+    }
+
+    result = BaseTrainer.preforward(trainer, micro_batch)
+
+    assert set(result) == {"x"}
+
+
+def test_dit_preforward_strips_canonical_metadata_before_logging_and_model_use(monkeypatch):
+    import veomni.trainer.dit_trainer as dit_trainer_module
+
+    trainer = object.__new__(DiTTrainer)
+    trainer.base = SimpleNamespace(
+        device=torch.device("cpu"),
+        LOG_SAMPLE=True,
+        args=SimpleNamespace(
+            data=SimpleNamespace(enable_multisource=True),
+            train=SimpleNamespace(local_rank=0),
+        ),
+    )
+    logged_keys = []
+    monkeypatch.setattr(
+        dit_trainer_module.helper,
+        "print_example",
+        lambda *, example, **_kwargs: logged_keys.extend(example.keys()),
+    )
+    micro_batch = {
+        "latents": torch.tensor([1.0]),
+        "ds_idx": [0],
+        "source_name": ["train/a"],
+        "_veomni_packed_source_metadata": _canonical_metadata(),
+    }
+
+    result = DiTTrainer.preforward(trainer, micro_batch)
+
+    assert logged_keys == ["latents"]
+    assert set(result) == {"latents"}
+
+
+def test_disabled_channel_callback_preserves_custom_extra_strip_keys():
+    cfg = ChannelLossConfig(enable=False, extra_strip_keys=["model_aux"])
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "x": torch.tensor(1),
+        "model_aux": torch.tensor(2),
+        "source_id": ["stable-id"],
+        "_veomni_packed_source_metadata": _canonical_metadata(),
+    }
+
+    callback.strip_model_inputs(micro_batch)
+
+    assert set(micro_batch) == {"x", "model_aux"}

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -107,8 +107,20 @@ def test_channel_loss_computer_aggregates_packed_logits_by_source():
     loss_0, tokens_0 = _expected_segment(logits, labels, 0, 2)
     loss_1, tokens_1 = _expected_segment(logits, labels, 3, 4)
     assert result == [
-        {"source_id": 0, "loss_sum": pytest.approx(loss_0), "token_count": tokens_0},
-        {"source_id": 1, "loss_sum": pytest.approx(loss_1), "token_count": tokens_1},
+        {
+            "source_id": 0,
+            "loss_sum": pytest.approx(loss_0),
+            "token_count": tokens_0,
+            "sample_count": 1,
+            "input_token_count": 3,
+        },
+        {
+            "source_id": 1,
+            "loss_sum": pytest.approx(loss_1),
+            "token_count": tokens_1,
+            "sample_count": 1,
+            "input_token_count": 2,
+        },
     ]
 
 
@@ -151,6 +163,46 @@ def test_channel_loss_computer_hidden_states_path_matches_logits_path():
     )
 
     assert hs_result == logits_result
+
+
+def test_channel_loss_computer_counts_attention_masked_input_tokens():
+    computer = ChannelLossComputer()
+    computer._source_ids = ["repoqa"]
+    computer._position_ids = torch.tensor([[0, 1, 2, 3]])
+
+    result = computer._compute_channel_loss(
+        logits=torch.randn(1, 4, 8),
+        labels=torch.tensor([[1, 2, 3, 4]]),
+        vocab_size=8,
+        hidden_states=None,
+        weights=None,
+        attention_mask=torch.tensor([[1, 1, 1, 0]]),
+        shift_labels=None,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    assert result[0]["sample_count"].item() == 1
+    assert result[0]["input_token_count"].item() == 3
+    assert result[0]["token_count"].item() == 3
+
+
+def test_channel_loss_computer_counts_data_metrics_with_sequence_parallel():
+    result = ChannelLossComputer._aggregate_by_source(
+        per_token_loss=torch.ones(4),
+        labels_flat=torch.tensor([1, 2, 3, IGNORE_INDEX]),
+        attention_mask_flat=torch.tensor([1, 1, 1, 0]),
+        source_ids=["repoqa", "other"],
+        position_ids=torch.tensor([[0, 1, 0, 1]]),
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=SimpleNamespace(sp_group=None, sp_size=1),
+        strict=True,
+        include_data_stats=True,
+    )
+
+    assert [item["sample_count"].item() for item in result] == [1, 1]
+    assert [item["input_token_count"].item() for item in result] == [2, 1]
+    assert [item["token_count"].item() for item in result] == [2, 1]
 
 
 def test_channel_loss_wrapper_forwards_original_call_unchanged():
@@ -841,9 +893,27 @@ def test_channel_loss_computer_aggregates_step_results_locally():
     computer = ChannelLossComputer()
     computer.begin_step([], [], [])
     computer._result = [
-        {"source_id": "a", "loss_sum": torch.tensor(2.0), "token_count": torch.tensor(1)},
-        {"source_id": "a", "loss_sum": torch.tensor(4.0), "token_count": torch.tensor(2)},
-        {"source_id": "b", "loss_sum": torch.tensor(3.0), "token_count": torch.tensor(1)},
+        {
+            "source_id": "a",
+            "loss_sum": torch.tensor(2.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(3),
+        },
+        {
+            "source_id": "a",
+            "loss_sum": torch.tensor(4.0),
+            "token_count": torch.tensor(2),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(4),
+        },
+        {
+            "source_id": "b",
+            "loss_sum": torch.tensor(3.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(2),
+        },
     ]
 
     computer.after_micro_step()
@@ -851,6 +921,67 @@ def test_channel_loss_computer_aggregates_step_results_locally():
     assert set(computer.step_totals) == {"a", "b"}
     assert computer.step_totals["a"][0].item() == 6.0
     assert computer.step_totals["a"][1].item() == 3
+    assert tuple(value.item() for value in computer.step_data_totals["a"]) == (2, 7, 3)
+
+
+def test_channel_loss_computer_requires_data_stats_for_step_aggregation():
+    computer = ChannelLossComputer()
+    computer.begin_step([], [], [])
+    computer._result = [
+        {
+            "source_id": "a",
+            "loss_sum": torch.tensor(2.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+        }
+    ]
+
+    with pytest.raises(KeyError, match="input_token_count"):
+        computer.after_micro_step()
+
+
+def test_base_step_begin_captures_channel_metadata_before_multisource_meter():
+    calls = []
+
+    class RecordingCallback:
+        def __init__(self, name, consume_metadata=False):
+            self.name = name
+            self.consume_metadata = consume_metadata
+
+        def on_step_begin(self, state, micro_batches=None, **kwargs):
+            calls.append((self.name, "ds_idx" in micro_batches[0]))
+            if self.consume_metadata:
+                micro_batches[0].pop("ds_idx")
+                micro_batches[0].pop("source_name")
+
+    trainer = object.__new__(BaseTrainer)
+    trainer.state = TrainerState(global_step=1)
+    trainer.channel_loss_callback = RecordingCallback("channel")
+    meter = RecordingCallback("meter", consume_metadata=True)
+    tail = RecordingCallback("tail")
+    trainer._callbacks = [meter, trainer.channel_loss_callback, tail]
+    micro_batches = [{"ds_idx": torch.tensor([7]), "source_name": ["repoqa"]}]
+
+    BaseTrainer.on_step_begin(trainer, micro_batches=micro_batches)
+
+    assert calls == [("channel", True), ("meter", True), ("tail", False)]
+
+
+def test_base_step_begin_allows_missing_channel_loss_callback():
+    calls = []
+
+    class RecordingCallback:
+        def on_step_begin(self, state, micro_batches=None, **kwargs):
+            calls.append(micro_batches)
+
+    trainer = object.__new__(BaseTrainer)
+    trainer.state = TrainerState(global_step=1)
+    trainer._callbacks = [RecordingCallback()]
+    micro_batches = [{"input_ids": torch.tensor([1, 2])}]
+
+    BaseTrainer.on_step_begin(trainer, micro_batches=micro_batches)
+
+    assert calls == [micro_batches]
 
 
 def test_base_forward_backward_allows_missing_channel_loss_callback():
@@ -1268,6 +1399,52 @@ def test_channel_loss_metric_name_is_source_qualified_from_first_emission():
     assert "channel_loss/train_a" not in metrics
 
 
+def test_channel_loss_builds_per_step_data_metrics_with_source_name():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+
+    metrics = callback._build_data_metrics(
+        {7: (2, 11, 5)},
+        {7: "repoqa"},
+    )
+
+    assert metrics == {
+        "samples/repoqa": 2.0,
+        "input_tokens/repoqa": 11.0,
+        "label_tokens/repoqa": 5.0,
+        "label_tokens_per_sample/repoqa": 2.5,
+    }
+
+
+def test_channel_loss_data_metric_name_collisions_remain_distinct():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+
+    metrics = callback._build_data_metrics(
+        {1: (1, 3, 2), 2: (1, 4, 3)},
+        {1: "train/a", 2: "train_a"},
+    )
+
+    assert metrics["samples/source-i-1__train_a"] == 1.0
+    assert metrics["samples/source-i-2__train_a"] == 1.0
+
+
+def test_channel_loss_data_metric_collision_registry_persists_across_steps():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+
+    first = callback._build_data_metrics({1: (1, 3, 2)}, {1: "train/a"})
+    second = callback._build_data_metrics({2: (1, 4, 3)}, {2: "train_a"})
+    third = callback._build_data_metrics({1: (1, 3, 2)}, {1: "train/a"})
+
+    assert "samples/train_a" in first
+    assert "samples/source-i-2__train_a" in second
+    assert "samples/source-i-1__train_a" in third
+
+
 def test_channel_loss_metric_name_collision_registry_persists_across_steps():
     cfg = ChannelLossConfig(enable=True)
     trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
@@ -1381,6 +1558,10 @@ def test_channel_loss_callback_updates_trainer_metrics():
         0: (torch.tensor(6.0), torch.tensor(3)),
         1: (torch.tensor(3.0), torch.tensor(1)),
     }
+    callback.computer.step_data_totals = {
+        0: (torch.tensor(2), torch.tensor(10), torch.tensor(3)),
+        1: (torch.tensor(1), torch.tensor(4), torch.tensor(1)),
+    }
     callback._collect_step = True
 
     callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
@@ -1389,6 +1570,10 @@ def test_channel_loss_callback_updates_trainer_metrics():
     assert math.isclose(trainer.step_env_metrics["channel_loss/source-i-1__source-b"], 3.0)
     assert math.isclose(trainer.step_env_metrics["channel_loss_weighted/source-i-0__source_a"], 1.5)
     assert math.isclose(trainer.step_env_metrics["channel_tokens/source-i-1__source-b"], 1.0)
+    assert trainer.step_env_metrics["samples/source_a"] == 2.0
+    assert trainer.step_env_metrics["input_tokens/source_a"] == 10.0
+    assert trainer.step_env_metrics["label_tokens/source_a"] == 3.0
+    assert trainer.step_env_metrics["label_tokens_per_sample/source_a"] == 1.5
     assert trainer.step_train_metrics == trainer.step_env_metrics
 
 

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -1551,6 +1551,19 @@ def test_base_step_begin_captures_channel_metadata_before_multisource_meter():
     assert calls == [("channel", True), ("meter", True), ("tail", False)]
 
 
+def test_multisource_meter_reads_source_metadata_without_consuming_it():
+    from veomni.utils import helper
+
+    micro_batch = {
+        "ds_idx": torch.tensor([3, 4]),
+        "source_name": ["train/a", "train/b"],
+        "cur_token_num": torch.tensor([2, 2]),
+    }
+
+    assert helper._get_multisource_ds_idx(micro_batch) == [3, 4]
+    assert set(micro_batch) == {"ds_idx", "source_name", "cur_token_num"}
+
+
 def test_base_step_begin_allows_missing_channel_loss_callback():
     calls = []
 
@@ -1593,6 +1606,96 @@ def test_base_forward_backward_allows_missing_channel_loss_callback(monkeypatch)
     assert loss.item() == 2.0
     assert loss_dict["loss"].item() == 2.0
     assert trainer.model.weight.grad.item() == 2.0
+
+
+def test_base_forward_backward_strips_internal_source_metadata_without_channel_callback(monkeypatch):
+    _install_test_parallel_state(monkeypatch)
+    trainer = object.__new__(BaseTrainer)
+    trainer.state = TrainerState(global_step=1)
+    trainer.device = torch.device("cpu")
+    trainer.args = SimpleNamespace(
+        train=SimpleNamespace(
+            enable_batch_invariant_mode=False,
+            local_rank=0,
+        )
+    )
+    trainer.model = _TinyLossModel()
+    trainer.model_fwd_context = nullcontext()
+    trainer.model_bwd_context = nullcontext()
+    trainer.micro_batch_token_len = 1
+    trainer.micro_batches_token_len = 1
+    trainer.LOG_SAMPLE = False
+    trainer.channel_loss_callback = None
+    trainer.postforward = lambda outputs, micro_batch: (outputs.loss, {"loss": outputs.loss.detach()})
+    micro_batch = {
+        "x": torch.tensor(2.0),
+        "ds_idx": torch.tensor([3]),
+        "source_id": ["stable-id"],
+        "source_name": ["train/a"],
+        "cur_token_num": torch.tensor([1]),
+        "_veomni_source_metadata": {
+            "schema_version": 1,
+            "source_id": "stable-id",
+            "source_name": "train/a",
+        },
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 1,
+            "segments": [
+                {
+                    "source_id": "stable-id",
+                    "source_name": "train/a",
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 1,
+                }
+            ],
+        },
+    }
+
+    loss, loss_dict = BaseTrainer.forward_backward_step(trainer, micro_batch)
+
+    assert loss.item() == 2.0
+    assert loss_dict["loss"].item() == 2.0
+    assert trainer.model.weight.grad.item() == 2.0
+
+
+def test_base_preforward_strips_source_metadata_before_sample_logging(monkeypatch):
+    import veomni.trainer.base as base_trainer_module
+
+    trainer = object.__new__(BaseTrainer)
+    trainer.device = torch.device("cpu")
+    trainer.args = SimpleNamespace(
+        train=SimpleNamespace(chunk_mbs_config=None, local_rank=0),
+    )
+    trainer.LOG_SAMPLE = True
+    logged_keys = []
+    monkeypatch.setattr(
+        base_trainer_module.helper,
+        "print_example",
+        lambda *, example, **_kwargs: logged_keys.extend(example.keys()),
+    )
+
+    result = BaseTrainer.preforward(
+        trainer,
+        {
+            "x": torch.tensor(2.0),
+            "source_id": ["stable-id"],
+            "row_id": [7],
+            "_veomni_packed_source_metadata": {
+                "schema_version": 1,
+                "coordinate_space": "packed_pre_sp",
+                "valid_token_count": 1,
+                "segments": [],
+            },
+        },
+    )
+
+    assert logged_keys == ["x"]
+    assert set(result) == {"x"}
 
 
 def test_base_forward_backward_strips_channel_metadata_after_preforward(monkeypatch):
@@ -1912,6 +2015,504 @@ def test_dpo_channel_loss_real_base_dispatch_repeats_metadata_and_emits_policy_t
         assert reference_model.scale.grad is None
     finally:
         base.channel_loss_callback.computer.uninstall()
+
+
+def test_channel_loss_canonical_metadata_bypasses_dpo_source_repeat():
+    cfg = ChannelLossConfig(enable=True, interval=1)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "position_ids": torch.tensor([[0, 1, 0, 1, 0, 1, 0, 1]]),
+        "source_id": torch.tensor([3, 4]),
+        "source_name": ["train/a", "train/b"],
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 8,
+            "segments": [
+                {
+                    "source_id": 3,
+                    "source_name": "train/a",
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": 3,
+                    "source_name": "train/a",
+                    "segment_index": 1,
+                    "sample_index": 0,
+                    "subsegment_index": 1,
+                    "token_start": 2,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": 4,
+                    "source_name": "train/b",
+                    "segment_index": 2,
+                    "sample_index": 1,
+                    "subsegment_index": 0,
+                    "token_start": 4,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": 4,
+                    "source_name": "train/b",
+                    "segment_index": 3,
+                    "sample_index": 1,
+                    "subsegment_index": 1,
+                    "token_start": 6,
+                    "token_length": 2,
+                },
+            ],
+        },
+    }
+
+    callback.on_step_begin(
+        TrainerState(global_step=1),
+        micro_batches=[micro_batch],
+        source_repeat=2,
+    )
+
+    assert callback.computer._per_mb_source_ids == [[3, 3, 4, 4]]
+    assert callback.computer.source_names == {3: "train/a", 4: "train/b"}
+
+
+@pytest.mark.parametrize(
+    ("legacy_source_ids", "legacy_source_names"),
+    [
+        ([3], ["train/a"]),
+        ([3, 3], ["train/a", "train/a"]),
+    ],
+)
+def test_channel_loss_expands_per_sample_legacy_metadata_for_arbitrary_position_resets(
+    legacy_source_ids,
+    legacy_source_names,
+):
+    cfg = ChannelLossConfig(enable=True, interval=1)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "position_ids": torch.tensor([[0, 1, 0, 1]]),
+        "source_id": torch.tensor(legacy_source_ids),
+        "source_name": legacy_source_names,
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 4,
+            "segments": [
+                {
+                    "source_id": 3,
+                    "source_name": "train/a",
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": 3,
+                    "source_name": "train/a",
+                    "segment_index": 1,
+                    "sample_index": 0,
+                    "subsegment_index": 1,
+                    "token_start": 2,
+                    "token_length": 2,
+                },
+            ],
+        },
+    }
+
+    callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
+
+    assert callback.computer._per_mb_source_ids == [[3, 3]]
+    assert callback.computer.source_names == {3: "train/a"}
+
+
+def test_channel_loss_rejects_canonical_legacy_source_id_conflict():
+    cfg = ChannelLossConfig(enable=True, interval=2, strict=False)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "position_ids": torch.tensor([[0, 1, 0, 1, 0, 1, 0, 1]]),
+        "source_id": torch.tensor([3, 9]),
+        "source_name": ["train/a", "train/b"],
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 8,
+            "segments": [
+                {
+                    "source_id": 3,
+                    "source_name": "train/a",
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": 3,
+                    "source_name": "train/a",
+                    "segment_index": 1,
+                    "sample_index": 0,
+                    "subsegment_index": 1,
+                    "token_start": 2,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": 4,
+                    "source_name": "train/b",
+                    "segment_index": 2,
+                    "sample_index": 1,
+                    "subsegment_index": 0,
+                    "token_start": 4,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": 4,
+                    "source_name": "train/b",
+                    "segment_index": 3,
+                    "sample_index": 1,
+                    "subsegment_index": 1,
+                    "token_start": 6,
+                    "token_length": 2,
+                },
+            ],
+        },
+    }
+
+    with pytest.raises(ChannelLossMetadataError, match="canonical source IDs conflict with legacy"):
+        callback.on_step_begin(
+            TrainerState(global_step=1),
+            micro_batches=[micro_batch],
+            source_repeat=2,
+        )
+
+
+def test_channel_loss_rejects_canonical_boundaries_on_unsampled_non_strict_step():
+    cfg = ChannelLossConfig(enable=True, interval=2, strict=False)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "position_ids": torch.tensor([[0, 1, 0, 1]]),
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 4,
+            "segments": [
+                {
+                    "source_id": 3,
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 3,
+                },
+                {
+                    "source_id": 4,
+                    "segment_index": 1,
+                    "sample_index": 1,
+                    "subsegment_index": 0,
+                    "token_start": 3,
+                    "token_length": 1,
+                },
+            ],
+        },
+    }
+
+    with pytest.raises(ChannelLossMetadataError, match="token boundaries conflict"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
+
+
+def test_channel_loss_prefers_full_cu_seqlens_when_validating_canonical_boundaries():
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=False)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "position_ids": torch.tensor([[0, 1, 0, 1]]),
+        "cu_seq_lens_q": torch.tensor([0, 1, 4], dtype=torch.int32),
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 4,
+            "segments": [
+                {
+                    "source_id": 3,
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": 4,
+                    "segment_index": 1,
+                    "sample_index": 1,
+                    "subsegment_index": 0,
+                    "token_start": 2,
+                    "token_length": 2,
+                },
+            ],
+        },
+    }
+
+    with pytest.raises(ChannelLossMetadataError, match="cu_seq_lens_q"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
+
+
+def test_channel_loss_cross_checks_full_position_resets_against_canonical_cu_seqlens():
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=False)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        # cu-seqlens agree with canonical [2, 2], but the actual non-SP
+        # position resets describe [1, 3].
+        "position_ids": torch.tensor([[0, 0, 1, 2]]),
+        "cu_seq_lens_q": torch.tensor([0, 2, 4], dtype=torch.int32),
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 4,
+            "segments": [
+                {
+                    "source_id": 3,
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": 4,
+                    "segment_index": 1,
+                    "sample_index": 1,
+                    "subsegment_index": 0,
+                    "token_start": 2,
+                    "token_length": 2,
+                },
+            ],
+        },
+    }
+
+    with pytest.raises(ChannelLossMetadataError, match="full packed position_ids"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
+
+
+def test_channel_loss_rejects_nonzero_position_ids_in_declared_non_sp_padding_tail():
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=False)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "position_ids": torch.tensor([[0, 1, 2, 0, 1, 9, 9, 9]]),
+        "cu_seq_lens_q": torch.tensor([0, 3, 5, 8], dtype=torch.int32),
+        "tail_padding_length": 3,
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 5,
+            "segments": [
+                {
+                    "source_id": 3,
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 3,
+                },
+                {
+                    "source_id": 4,
+                    "segment_index": 1,
+                    "sample_index": 1,
+                    "subsegment_index": 0,
+                    "token_start": 3,
+                    "token_length": 2,
+                },
+            ],
+        },
+    }
+
+    with pytest.raises(ChannelLossMetadataError, match="padding tail.*position_ids == 0"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
+
+
+def test_channel_loss_requires_full_position_ids_for_non_sp_canonical_batch():
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=False)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "cu_seq_lens_q": torch.tensor([0, 2, 4], dtype=torch.int32),
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 4,
+            "segments": [
+                {
+                    "source_id": 3,
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": 4,
+                    "segment_index": 1,
+                    "sample_index": 1,
+                    "subsegment_index": 0,
+                    "token_start": 2,
+                    "token_length": 2,
+                },
+            ],
+        },
+    }
+
+    with pytest.raises(ChannelLossMetadataError, match="requires full position_ids"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
+
+
+@pytest.mark.parametrize(("sp_enabled", "sp_rank"), [(False, 0), (True, 1)])
+def test_channel_loss_accepts_main_collator_padding_and_full_pre_sp_boundaries(
+    monkeypatch,
+    sp_enabled,
+    sp_rank,
+):
+    import veomni.data.data_collator as data_collator_module
+
+    parallel_state = _install_test_parallel_state(
+        monkeypatch,
+        _test_parallel_state(
+            sp_enabled=sp_enabled,
+            sp_size=2 if sp_enabled else 1,
+            sp_rank=sp_rank,
+        ),
+    )
+    monkeypatch.setattr(data_collator_module, "get_parallel_state", lambda: parallel_state)
+    features = [
+        {
+            "input_ids": torch.tensor([11, 12, 13]),
+            "attention_mask": torch.ones(3, dtype=torch.long),
+            "labels": torch.tensor([11, 12, 13]),
+            "_veomni_source_metadata": {
+                "schema_version": 1,
+                "source_id": 7,
+                "source_name": "source-int",
+            },
+        },
+        {
+            "input_ids": torch.tensor([21, 22]),
+            "attention_mask": torch.ones(2, dtype=torch.long),
+            "labels": torch.tensor([21, 22]),
+            "_veomni_source_metadata": {
+                "schema_version": 1,
+                "source_id": "7",
+                "source_name": "source-string",
+            },
+        },
+    ]
+    micro_batch = data_collator_module.MainCollator(pad_to_length=8)(features)
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+
+    callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
+
+    assert callback.computer._per_mb_source_ids == [[7, "7"]]
+    assert callback.computer.source_names == {7: "source-int", "7": "source-string"}
+    assert micro_batch["_veomni_packed_source_metadata"]["valid_token_count"] == 5
+    assert micro_batch["cu_seq_lens_q"].tolist() == [0, 3, 5, 8]
+    assert int(micro_batch["tail_padding_length"]) == 3
+
+
+def test_channel_loss_rejects_ambiguous_single_legacy_name_for_multiple_typed_sources():
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=False)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "position_ids": torch.tensor([[0, 1, 0, 1]]),
+        "source_id": [7, "7"],
+        "source_name": ["ambiguous-name"],
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 4,
+            "segments": [
+                {
+                    "source_id": 7,
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": "7",
+                    "segment_index": 1,
+                    "sample_index": 1,
+                    "subsegment_index": 0,
+                    "token_start": 2,
+                    "token_length": 2,
+                },
+            ],
+        },
+    }
+
+    with pytest.raises(ChannelLossMetadataError, match="single legacy source name is ambiguous"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
+
+
+def test_channel_loss_rejects_ambiguous_single_name_in_legacy_only_metadata():
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=False)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "position_ids": torch.tensor([[0, 1, 0, 1]]),
+        "source_id": [7, "7"],
+        "source_name": ["ambiguous-name"],
+    }
+
+    with pytest.raises(ChannelLossMetadataError, match="single legacy source name is ambiguous"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
+
+
+def test_channel_loss_rejects_name_only_legacy_conflict_with_canonical_metadata():
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=False)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    micro_batch = {
+        "position_ids": torch.tensor([[0, 1, 0, 1]]),
+        "source_name": ["wrong-a", "train/b"],
+        "_veomni_packed_source_metadata": {
+            "schema_version": 1,
+            "coordinate_space": "packed_pre_sp",
+            "valid_token_count": 4,
+            "segments": [
+                {
+                    "source_id": 7,
+                    "source_name": "train/a",
+                    "segment_index": 0,
+                    "sample_index": 0,
+                    "subsegment_index": 0,
+                    "token_start": 0,
+                    "token_length": 2,
+                },
+                {
+                    "source_id": "7",
+                    "source_name": "train/b",
+                    "segment_index": 1,
+                    "sample_index": 1,
+                    "subsegment_index": 0,
+                    "token_start": 2,
+                    "token_length": 2,
+                },
+            ],
+        },
+    }
+
+    with pytest.raises(ChannelLossMetadataError, match="canonical source names conflict with legacy"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[micro_batch])
 
 
 def test_dit_rejects_channel_loss_before_initialization():

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -1,8 +1,12 @@
 import importlib.util
 import math
 import os
+import queue
 import sys
+import time
+import traceback
 from contextlib import nullcontext
+from datetime import timedelta
 from functools import partial
 from importlib.machinery import ModuleSpec
 from types import SimpleNamespace
@@ -28,8 +32,10 @@ def _find_spec_without_torch_npu(name: str, package: str | None = None) -> Modul
 
 importlib.util.find_spec = _find_spec_without_torch_npu  # type: ignore[assignment]
 try:
+    import veomni.distributed.parallel_state as parallel_state_module
     import veomni.trainer.callbacks.channel_loss_callback as channel_loss_module
     from veomni.arguments.arguments_types import ChannelLossConfig, ChunkMBSConfig
+    from veomni.distributed.parallel_state import use_parallel_state
     from veomni.models.seed_omni.foundation.qwen3_moe_foundation.modeling_qwen3_moe_foundation import (
         Qwen3MoeFoundationModel,
     )
@@ -45,6 +51,7 @@ try:
     from veomni.trainer.callbacks.base import TrainerState
     from veomni.trainer.callbacks.channel_loss_callback import (
         ChannelLossCallback,
+        ChannelLossCollectiveError,
         ChannelLossComputer,
         ChannelLossMetadataError,
     )
@@ -80,6 +87,32 @@ def _expected_segment(logits, labels, start, end):
     )
     valid = shifted[start : end + 1] != IGNORE_INDEX
     return losses[start : end + 1][valid].sum().item(), valid.sum().item()
+
+
+def _test_parallel_state(
+    *,
+    sp_enabled=False,
+    sp_group=None,
+    sp_size=1,
+    sp_rank=0,
+    dp_size=1,
+    dp_group=None,
+):
+    return SimpleNamespace(
+        sp_enabled=sp_enabled,
+        sp_group=sp_group,
+        sp_size=sp_size,
+        sp_rank=sp_rank,
+        dp_size=dp_size,
+        dp_group=dp_group,
+    )
+
+
+def _install_test_parallel_state(monkeypatch, parallel_state=None):
+    parallel_state = parallel_state or _test_parallel_state()
+    monkeypatch.setattr(parallel_state_module, "_PARALLEL_STATE", parallel_state)
+    monkeypatch.setitem(parallel_state_module._PARALLEL_STATE_REGISTRY, "base", parallel_state)
+    return parallel_state
 
 
 def test_channel_loss_computer_aggregates_packed_logits_by_source():
@@ -195,7 +228,7 @@ def test_channel_loss_computer_counts_data_metrics_with_sequence_parallel():
         position_ids=torch.tensor([[0, 1, 0, 1]]),
         ignore_index=IGNORE_INDEX,
         sp_enabled=True,
-        parallel_state=SimpleNamespace(sp_group=None, sp_size=1),
+        parallel_state=_test_parallel_state(sp_enabled=True),
         strict=True,
         include_data_stats=True,
     )
@@ -493,6 +526,8 @@ def test_channel_loss_opslot_dispatch_is_scoped_and_reference_counted():
 
 
 def test_channel_loss_sp_reduce_preserves_batch_order_for_multiple_sources(monkeypatch):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
     rank1_metadata = [
         {"batch_idx": 0, "sp_rank": 1, "local_order": 0, "is_start": False},
         {"batch_idx": 1, "sp_rank": 1, "local_order": 0, "is_start": False},
@@ -511,9 +546,6 @@ def test_channel_loss_sp_reduce_preserves_batch_order_for_multiple_sources(monke
             gathered[1].copy_(torch.tensor([[1, 0, 0], [1, 0, 0]], dtype=torch.int64))
         gather_inputs.append((local_values.dtype, tuple(local_values.shape)))
 
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: object())
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 2)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
 
@@ -525,6 +557,7 @@ def test_channel_loss_sp_reduce_preserves_batch_order_for_multiple_sources(monke
         positions=torch.tensor([[0, 1], [0, 1]]),
         seq_len=4,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -536,6 +569,7 @@ def test_channel_loss_sp_reduce_preserves_batch_order_for_multiple_sources(monke
 
 
 def test_channel_loss_sp_reduce_handles_empty_local_rank(monkeypatch):
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=object(), sp_size=2)
     rank1_metadata = [{"batch_idx": 0, "sp_rank": 1, "local_order": 0, "is_start": True}]
 
     def fake_all_gather_object(gathered, local_metadata, group=None):
@@ -550,8 +584,6 @@ def test_channel_loss_sp_reduce_handles_empty_local_rank(monkeypatch):
         else:
             gathered[1].copy_(torch.tensor([[2, 0, 0]], dtype=torch.int64))
 
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: object())
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 2)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
 
@@ -559,6 +591,7 @@ def test_channel_loss_sp_reduce_handles_empty_local_rank(monkeypatch):
         local_segments=[],
         source_ids=["remote"],
         device=torch.device("cpu"),
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -566,6 +599,7 @@ def test_channel_loss_sp_reduce_handles_empty_local_rank(monkeypatch):
 
 
 def test_channel_loss_sp_reduce_filters_uneven_remote_padding_segments(monkeypatch):
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=object(), sp_size=2)
     rank1_metadata = [
         {"batch_idx": 0, "sp_rank": 1, "local_order": 0, "is_start": True},
         {"batch_idx": 0, "sp_rank": 1, "local_order": 1, "is_start": True},
@@ -583,9 +617,6 @@ def test_channel_loss_sp_reduce_filters_uneven_remote_padding_segments(monkeypat
         else:
             gathered[1].copy_(torch.tensor([[0, 1, 1], [0, 1, 1]], dtype=torch.int64))
 
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: object())
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 2)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
 
@@ -597,6 +628,7 @@ def test_channel_loss_sp_reduce_filters_uneven_remote_padding_segments(monkeypat
         positions=torch.tensor([[0, 1]]),
         seq_len=2,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -604,9 +636,7 @@ def test_channel_loss_sp_reduce_filters_uneven_remote_padding_segments(monkeypat
 
 
 def test_channel_loss_sp_aggregation_does_not_extract_segment_scalars(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
 
     def fail_item(tensor):
         raise AssertionError(f"SP segment aggregation extracted a scalar with shape={tuple(tensor.shape)}")
@@ -621,6 +651,7 @@ def test_channel_loss_sp_aggregation_does_not_extract_segment_scalars(monkeypatc
             positions=torch.tensor([[0, 1, 0, 1, 0, 1]]),
             seq_len=6,
             ignore_index=IGNORE_INDEX,
+            parallel_state=parallel_state,
             strict=True,
         )
 
@@ -696,8 +727,7 @@ def test_channel_loss_preserves_zero_supervision_tail_when_later_row_has_padding
 
 
 def test_channel_loss_compute_uses_position_aligned_mask_for_padding_evidence(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "_is_sp_enabled", lambda: False)
-    computer = ChannelLossComputer()
+    computer = ChannelLossComputer(parallel_state=_test_parallel_state())
     computer.strict = True
     computer._source_ids = ["row0_normal", "row0_zero", "row1_normal"]
     computer._position_ids = torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]])
@@ -752,9 +782,7 @@ def test_channel_loss_keeps_zero_supervision_segment_before_tail_padding():
 
 
 def test_channel_loss_sp_ignores_padding_only_position_zero_segments(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
 
     result = ChannelLossComputer._aggregate_sp(
         per_token_loss=torch.tensor([1.0, 2.0, 100.0, 100.0]),
@@ -764,6 +792,7 @@ def test_channel_loss_sp_ignores_padding_only_position_zero_segments(monkeypatch
         positions=torch.tensor([[0, 1, 0, 0]]),
         seq_len=4,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -771,9 +800,7 @@ def test_channel_loss_sp_ignores_padding_only_position_zero_segments(monkeypatch
 
 
 def test_channel_loss_sp_filters_padding_tail_per_batch_row(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
 
     result = ChannelLossComputer._aggregate_sp(
         per_token_loss=torch.tensor([1.0, 2.0, 100.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
@@ -783,6 +810,7 @@ def test_channel_loss_sp_filters_padding_tail_per_batch_row(monkeypatch):
         positions=torch.tensor([[0, 1, 0, 0], [0, 1, 0, 0]]),
         seq_len=8,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -793,9 +821,7 @@ def test_channel_loss_sp_filters_padding_tail_per_batch_row(monkeypatch):
 
 
 def test_channel_loss_sp_preserves_zero_supervision_tail_when_later_row_has_padding(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
 
     result = ChannelLossComputer._aggregate_sp(
         per_token_loss=torch.tensor([1.0, 2.0, 3.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
@@ -805,6 +831,7 @@ def test_channel_loss_sp_preserves_zero_supervision_tail_when_later_row_has_padd
         positions=torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]]),
         seq_len=8,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -816,9 +843,7 @@ def test_channel_loss_sp_preserves_zero_supervision_tail_when_later_row_has_padd
 
 
 def test_channel_loss_sp_rejects_ambiguous_per_row_padding_without_mask_evidence(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
     kwargs = dict(
         per_token_loss=torch.tensor([1.0, 2.0, 3.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
         labels_flat=torch.tensor([1, 1, 1, IGNORE_INDEX, 1, 1, IGNORE_INDEX, IGNORE_INDEX]),
@@ -827,6 +852,7 @@ def test_channel_loss_sp_rejects_ambiguous_per_row_padding_without_mask_evidence
         positions=torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]]),
         seq_len=8,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
     )
 
     assert ChannelLossComputer._aggregate_sp(**kwargs, strict=False) == []
@@ -835,9 +861,7 @@ def test_channel_loss_sp_rejects_ambiguous_per_row_padding_without_mask_evidence
 
 
 def test_channel_loss_sp_keeps_zero_supervision_segment_before_tail_padding(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
 
     result = ChannelLossComputer._aggregate_sp(
         per_token_loss=torch.tensor([100.0, 2.0, 100.0]),
@@ -847,6 +871,7 @@ def test_channel_loss_sp_keeps_zero_supervision_segment_before_tail_padding(monk
         positions=torch.tensor([[0, 0, 0]]),
         seq_len=3,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -854,6 +879,336 @@ def test_channel_loss_sp_keeps_zero_supervision_segment_before_tail_padding(monk
         {"source_id": "one_token", "loss_sum": 0.0, "token_count": 0},
         {"source_id": "normal", "loss_sum": 2.0, "token_count": 1},
     ]
+
+
+def _ready_sp_observation(parallel_state, *, loss_sum=1.0):
+    segment = {
+        "batch_idx": 0,
+        "sp_rank": 0,
+        "local_order": 0,
+        "is_start": True,
+        "has_explicit_padding_mask": torch.tensor(False),
+        "has_only_zero_positions": torch.tensor(False),
+        "loss_sum": torch.tensor(loss_sum),
+        "token_count": torch.tensor(1),
+        "sample_count": torch.tensor(1),
+        "input_token_count": torch.tensor(2),
+    }
+    return ChannelLossComputer._prepare_sp_observation_payload(
+        [segment],
+        ["source-a"],
+        device=torch.device("cpu"),
+        payload_capacity=2,
+        parallel_state=parallel_state,
+        include_data_stats=True,
+    )
+
+
+def test_channel_loss_sp_capture_reuses_cached_parallel_state_descriptor():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    computer._position_ids = torch.tensor([[0, 1]])
+
+    with computer.capture():
+        descriptor = computer._capture_sp_descriptor
+        assert descriptor is not None
+        assert descriptor.parallel_state is parallel_state
+        parallel_state.sp_rank = 7
+        computer.compute_side_channel(
+            logits=torch.randn(1, 2, 4),
+            labels=torch.tensor([[1, 2]]),
+            vocab_size=4,
+            hidden_states=None,
+            weights=None,
+        )
+        observation = computer._pending_observations[0]
+        assert observation.capture_descriptor is descriptor
+        assert observation.integer_payload[0, 1].item() == 0
+
+    assert computer.strict_observation_errors == []
+    assert computer._micro_step_observation_count == 1
+    assert computer._result is not None
+
+
+def test_channel_loss_preserves_local_sp_descriptor_resolution_error(monkeypatch):
+    class _BrokenParallelState:
+        @property
+        def sp_enabled(self):
+            raise RuntimeError("broken cached state")
+
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: False)
+
+    descriptor = channel_loss_module._resolve_cached_sp_capture_descriptor(_BrokenParallelState())
+
+    assert descriptor.resolution_error == ("cached SP descriptor resolution failed: RuntimeError: broken cached state")
+
+
+def test_channel_loss_world_descriptor_preflight_validates_sp_group_partition():
+    statuses = [
+        {
+            "global_rank": rank,
+            "global_world": 4,
+            "enabled": True,
+            "sp_world": 2,
+            "sp_rank": rank % 2,
+            "group_ranks": (0, 1) if rank < 2 else (2, 3),
+            "errors": [],
+        }
+        for rank in range(4)
+    ]
+
+    assert ChannelLossComputer._validate_capture_descriptor_preflight(statuses) is None
+
+    statuses[1] = {**statuses[1], "group_ranks": (1, 2)}
+    assert "rank-local SP capture descriptor divergence" in (
+        ChannelLossComputer._validate_capture_descriptor_preflight(statuses) or ""
+    )
+
+
+def test_channel_loss_sp_preflight_precedes_all_ordered_payloads_and_cache_release(monkeypatch):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
+    observations = iter(
+        [_ready_sp_observation(parallel_state, loss_sum=1.0), _ready_sp_observation(parallel_state, loss_sum=3.0)]
+    )
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer.strict = True
+    computer.release_cache = True
+    computer._source_ids = ["source-a"]
+    events = []
+
+    monkeypatch.setattr(computer, "_preflight_capture_descriptor", lambda descriptor: None)
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: next(observations))
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_all_gather_object(gathered, local_value, group=None):
+        assert group is parallel_state.sp_group
+        if isinstance(local_value, dict):
+            events.append("preflight")
+            gathered[0] = local_value
+            gathered[1] = dict(local_value)
+            return
+
+    def fake_all_gather(gathered, local_value, group=None):
+        assert group is parallel_state.sp_group
+        events.append("loss" if local_value.dtype.is_floating_point else "integer")
+        for rank_idx, output in enumerate(gathered):
+            output.copy_(local_value)
+            if not local_value.dtype.is_floating_point and rank_idx == 1:
+                output[:, 1] = 1
+                output[:, 3] = 0
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
+    monkeypatch.setattr(channel_loss_module, "_release_observer_cache", lambda device: events.append("release"))
+
+    with computer.capture():
+        for _ in range(2):
+            computer.compute_side_channel(
+                logits=torch.randn(1, 2, 4),
+                labels=torch.tensor([[1, 2]]),
+                vocab_size=4,
+                hidden_states=None,
+                weights=None,
+            )
+
+    assert events == [
+        "preflight",
+        "loss",
+        "integer",
+        "loss",
+        "integer",
+        "release",
+    ]
+    assert computer._micro_step_observation_count == 2
+    assert [item["loss_sum"].item() for item in computer._result] == [2.0, 6.0]
+
+
+@pytest.mark.parametrize(
+    ("field", "remote_value"),
+    [
+        ("has_source", False),
+        ("observation_count", 2),
+        ("source_ids", (("str", "'source-b'"),)),
+        ("descriptor_spec", (True, 3, True)),
+        ("errors", [("generic", "rank-local observer failure")]),
+    ],
+)
+def test_channel_loss_sp_preflight_rejects_any_rank_mismatch_before_payload(
+    monkeypatch,
+    field,
+    remote_value,
+):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    prepared = _ready_sp_observation(parallel_state)
+    preflight_calls = 0
+
+    monkeypatch.setattr(computer, "_preflight_capture_descriptor", lambda descriptor: None)
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: prepared)
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_preflight(gathered, local_status, group=None):
+        nonlocal preflight_calls
+        preflight_calls += 1
+        assert isinstance(local_status, dict)
+        gathered[0] = local_status
+        remote_status = dict(local_status)
+        remote_status[field] = remote_value
+        gathered[1] = remote_status
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_preflight)
+    monkeypatch.setattr(
+        channel_loss_module.dist,
+        "all_gather",
+        lambda *args, **kwargs: pytest.fail("SP payload collective entered after a rejected preflight"),
+    )
+
+    with computer.capture():
+        computer.compute_side_channel(
+            logits=torch.randn(1, 2, 4),
+            labels=torch.tensor([[1, 2]]),
+            vocab_size=4,
+            hidden_states=None,
+            weights=None,
+        )
+
+    assert preflight_calls == 1
+    assert computer._result is None
+    assert "SP preflight rejected" in computer.strict_observation_errors[0][1]
+
+
+def test_channel_loss_sp_preflight_rejects_observation_descriptor_mismatch(monkeypatch):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    monkeypatch.setattr(computer, "_preflight_capture_descriptor", lambda descriptor: None)
+    prepared = _ready_sp_observation(parallel_state)
+    prepared.capture_descriptor = channel_loss_module._SPCaptureDescriptor(
+        enabled=True,
+        parallel_state=parallel_state,
+        group=group,
+        world=3,
+        rank=0,
+    )
+
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_preflight(gathered, local_status, group=None):
+        gathered[0] = local_status
+        gathered[1] = dict(local_status)
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_preflight)
+    monkeypatch.setattr(
+        channel_loss_module.dist,
+        "all_gather",
+        lambda *args, **kwargs: pytest.fail("descriptor mismatch must be rejected before payload collectives"),
+    )
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: prepared)
+
+    with computer.capture():
+        computer.compute_side_channel(
+            logits=torch.randn(1, 2, 4),
+            labels=torch.tensor([[1, 2]]),
+            vocab_size=4,
+            hidden_states=None,
+            weights=None,
+        )
+
+    assert computer._result is None
+    assert "different SP capture descriptor" in computer.strict_observation_errors[0][1]
+
+
+def test_channel_loss_sp_payload_failure_does_not_enter_later_observation(monkeypatch):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
+    observations = iter(
+        [_ready_sp_observation(parallel_state, loss_sum=1.0), _ready_sp_observation(parallel_state, loss_sum=3.0)]
+    )
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    payload_collective_calls = 0
+    monkeypatch.setattr(computer, "_preflight_capture_descriptor", lambda descriptor: None)
+
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: next(observations))
+
+    def fake_preflight(gathered, local_value, group=None):
+        gathered[0] = local_value
+        gathered[1] = dict(local_value)
+
+    def fail_first_payload(*args, **kwargs):
+        nonlocal payload_collective_calls
+        payload_collective_calls += 1
+        raise RuntimeError("payload collective failed locally")
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_preflight)
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather", fail_first_payload)
+
+    with pytest.raises(ChannelLossCollectiveError, match="process group must not be reused"):
+        with computer.capture():
+            for _ in range(2):
+                computer.compute_side_channel(
+                    logits=torch.randn(1, 2, 4),
+                    labels=torch.tensor([[1, 2]]),
+                    vocab_size=4,
+                    hidden_states=None,
+                    weights=None,
+                )
+
+    assert payload_collective_calls == 1
+    assert computer._result is None
+    assert computer.strict_observation_errors == []
+
+
+def test_channel_loss_sp_nonstrict_mismatch_skips_consistently(monkeypatch):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer._source_ids = ["source-a"]
+    prepared = _ready_sp_observation(parallel_state)
+
+    monkeypatch.setattr(computer, "_preflight_capture_descriptor", lambda descriptor: None)
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: prepared)
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_preflight(gathered, local_status, group=None):
+        gathered[0] = local_status
+        remote_status = dict(local_status)
+        remote_status["observation_count"] = 2
+        gathered[1] = remote_status
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_preflight)
+    monkeypatch.setattr(
+        channel_loss_module.dist,
+        "all_gather",
+        lambda *args, **kwargs: pytest.fail("nonstrict ranks must consistently skip rejected payloads"),
+    )
+
+    with computer.capture():
+        computer.compute_side_channel(
+            logits=torch.randn(1, 2, 4),
+            labels=torch.tensor([[1, 2]]),
+            vocab_size=4,
+            hidden_states=None,
+            weights=None,
+        )
+
+    assert computer._result is None
+    assert computer.strict_observation_errors == []
 
 
 def test_channel_loss_logits_path_computes_ce_in_chunks(monkeypatch):
@@ -885,8 +1240,237 @@ def test_channel_loss_logits_path_computes_ce_in_chunks(monkeypatch):
 
 def test_channel_loss_config_validates_sampling_interval():
     assert ChannelLossConfig().interval == 10
+    assert ChannelLossConfig().release_cache is False
     with pytest.raises(ValueError, match="interval must be at least 1"):
         ChannelLossConfig(interval=0)
+
+
+def test_channel_loss_releases_observer_cache_after_side_channel(monkeypatch):
+    events = []
+    computer = ChannelLossComputer()
+    computer.release_cache = True
+
+    def compute(**kwargs):
+        events.append("compute")
+        return []
+
+    def release(device):
+        assert device.type == "cpu"
+        assert events == ["compute"]
+        events.append("release")
+
+    monkeypatch.setattr(computer, "_compute_channel_loss", compute)
+    monkeypatch.setattr(channel_loss_module, "_release_observer_cache", release)
+    computer.compute_side_channel(
+        logits=torch.randn(1, 2, 4),
+        labels=torch.tensor([[1, 2]]),
+        vocab_size=4,
+        hidden_states=None,
+        weights=None,
+    )
+
+    assert events == ["compute", "release"]
+
+
+def test_channel_loss_observer_cache_cleanup_uses_device_helpers(monkeypatch):
+    events = []
+
+    device = SimpleNamespace(type="npu")
+    monkeypatch.setattr(channel_loss_module, "synchronize", lambda: events.append("synchronize"))
+    monkeypatch.setattr(channel_loss_module, "empty_cache", lambda: events.append("empty_cache"))
+
+    channel_loss_module._release_observer_cache(device)
+
+    assert events == ["synchronize", "empty_cache"]
+
+
+def test_channel_loss_observer_cache_cleanup_is_noop_on_cpu(monkeypatch):
+    monkeypatch.setattr(channel_loss_module, "synchronize", lambda: pytest.fail("CPU cleanup must not synchronize"))
+    monkeypatch.setattr(channel_loss_module, "empty_cache", lambda: pytest.fail("CPU cleanup must not empty cache"))
+
+    channel_loss_module._release_observer_cache(torch.device("cpu"))
+
+
+def test_channel_loss_cleanup_failure_does_not_abort_observation(monkeypatch):
+    computer = ChannelLossComputer()
+    computer.release_cache = True
+    computer._source_ids = ["source-a"]
+    observed = [
+        {
+            "source_id": "source-a",
+            "loss_sum": torch.tensor(2.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(2),
+        }
+    ]
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: observed)
+    monkeypatch.setattr(
+        channel_loss_module,
+        "_release_observer_cache",
+        lambda device: (_ for _ in ()).throw(RuntimeError("cleanup failed")),
+    )
+
+    computer.compute_side_channel(
+        logits=torch.randn(1, 2, 4),
+        labels=torch.tensor([[1, 2]]),
+        vocab_size=4,
+        hidden_states=None,
+        weights=None,
+    )
+
+    assert computer._result == observed
+
+
+def test_channel_loss_cleanup_failure_preserves_deferred_strict_metadata_error(monkeypatch):
+    computer = ChannelLossComputer()
+    computer.strict = True
+    computer.release_cache = True
+
+    def fail_compute(**kwargs):
+        raise ChannelLossMetadataError("metadata failed")
+
+    monkeypatch.setattr(computer, "_compute_channel_loss", fail_compute)
+    monkeypatch.setattr(
+        channel_loss_module,
+        "_release_observer_cache",
+        lambda device: (_ for _ in ()).throw(RuntimeError("cleanup failed")),
+    )
+
+    computer.compute_side_channel(
+        logits=torch.randn(1, 2, 4),
+        labels=torch.tensor([[1, 2]]),
+        vocab_size=4,
+        hidden_states=None,
+        weights=None,
+    )
+
+    assert computer._result is None
+    assert computer.strict_observation_errors
+    assert "metadata failed" in computer.strict_observation_errors[0][1]
+
+
+def test_channel_loss_multiple_observations_accumulate_all_totals(monkeypatch):
+    computer = ChannelLossComputer(parallel_state=_test_parallel_state())
+    computer._source_ids = ["source-a"]
+    computer._position_ids = torch.tensor([[0, 1]])
+    results = iter(
+        [
+            [
+                {
+                    "source_id": "source-a",
+                    "loss_sum": torch.tensor(2.0),
+                    "token_count": torch.tensor(1),
+                    "sample_count": torch.tensor(1),
+                    "input_token_count": torch.tensor(2),
+                }
+            ],
+            [
+                {
+                    "source_id": "source-a",
+                    "loss_sum": torch.tensor(5.0),
+                    "token_count": torch.tensor(2),
+                    "sample_count": torch.tensor(1),
+                    "input_token_count": torch.tensor(3),
+                }
+            ],
+        ]
+    )
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: next(results))
+
+    with computer.capture():
+        for _ in range(2):
+            computer.compute_side_channel(
+                logits=torch.randn(1, 2, 4),
+                labels=torch.tensor([[1, 2]]),
+                vocab_size=4,
+                hidden_states=None,
+                weights=None,
+            )
+    computer.after_micro_step()
+
+    loss_sum, token_count = computer.step_totals["source-a"]
+    sample_count, input_token_count, label_token_count = computer.step_data_totals["source-a"]
+    assert (loss_sum.item(), token_count.item()) == (7.0, 3)
+    assert (sample_count.item(), input_token_count.item(), label_token_count.item()) == (2, 5, 3)
+
+
+def test_channel_loss_strict_success_plus_failure_discards_partial_evidence(monkeypatch):
+    computer = ChannelLossComputer(parallel_state=_test_parallel_state())
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    successful = [
+        {
+            "source_id": "source-a",
+            "loss_sum": torch.tensor(2.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(2),
+        }
+    ]
+    calls = 0
+
+    def observe(**kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return successful
+        raise RuntimeError("second observation failed")
+
+    monkeypatch.setattr(computer, "_compute_channel_loss", observe)
+    with computer.capture():
+        for _ in range(2):
+            computer.compute_side_channel(
+                logits=torch.randn(1, 2, 4),
+                labels=torch.tensor([[1, 2]]),
+                vocab_size=4,
+                hidden_states=None,
+                weights=None,
+            )
+
+    assert computer._result is None
+    assert computer._micro_step_observation_count == 0
+    assert "second observation failed" in computer.strict_observation_errors[0][1]
+
+
+def test_channel_loss_strict_failure_blocks_later_capture_evidence(monkeypatch):
+    computer = ChannelLossComputer(parallel_state=_test_parallel_state())
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    successful = [
+        {
+            "source_id": "source-a",
+            "loss_sum": torch.tensor(2.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(2),
+        }
+    ]
+    outcomes = iter([successful, RuntimeError("middle capture failed"), successful])
+
+    def observe(**kwargs):
+        outcome = next(outcomes)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(computer, "_compute_channel_loss", observe)
+    for _ in range(3):
+        with computer.capture():
+            computer.compute_side_channel(
+                logits=torch.randn(1, 2, 4),
+                labels=torch.tensor([[1, 2]]),
+                vocab_size=4,
+                hidden_states=None,
+                weights=None,
+            )
+
+    assert computer._result is None
+    assert computer._micro_step_observation_count == 0
+    assert computer._micro_step_failed
+    computer.after_micro_step()
+    assert computer.step_totals == {}
+    assert computer.step_data_totals == {}
 
 
 def test_channel_loss_computer_aggregates_step_results_locally():
@@ -959,7 +1543,7 @@ def test_base_step_begin_captures_channel_metadata_before_multisource_meter():
     trainer.channel_loss_callback = RecordingCallback("channel")
     meter = RecordingCallback("meter", consume_metadata=True)
     tail = RecordingCallback("tail")
-    trainer._callbacks = [meter, trainer.channel_loss_callback, tail]
+    trainer._callbacks = [trainer.channel_loss_callback, meter, tail]
     micro_batches = [{"ds_idx": torch.tensor([7]), "source_name": ["repoqa"]}]
 
     BaseTrainer.on_step_begin(trainer, micro_batches=micro_batches)
@@ -976,6 +1560,7 @@ def test_base_step_begin_allows_missing_channel_loss_callback():
 
     trainer = object.__new__(BaseTrainer)
     trainer.state = TrainerState(global_step=1)
+    trainer.channel_loss_callback = None
     trainer._callbacks = [RecordingCallback()]
     micro_batches = [{"input_ids": torch.tensor([1, 2])}]
 
@@ -984,7 +1569,8 @@ def test_base_step_begin_allows_missing_channel_loss_callback():
     assert calls == [micro_batches]
 
 
-def test_base_forward_backward_allows_missing_channel_loss_callback():
+def test_base_forward_backward_allows_missing_channel_loss_callback(monkeypatch):
+    _install_test_parallel_state(monkeypatch)
     trainer = object.__new__(BaseTrainer)
     trainer.state = TrainerState(global_step=1)
     trainer.device = torch.device("cpu")
@@ -1009,7 +1595,8 @@ def test_base_forward_backward_allows_missing_channel_loss_callback():
     assert trainer.model.weight.grad.item() == 2.0
 
 
-def test_base_forward_backward_strips_channel_metadata_after_preforward():
+def test_base_forward_backward_strips_channel_metadata_after_preforward(monkeypatch):
+    _install_test_parallel_state(monkeypatch)
     cfg = ChannelLossConfig(enable=True)
     trainer = object.__new__(BaseTrainer)
     trainer.state = TrainerState(global_step=1)
@@ -1182,7 +1769,8 @@ def test_base_forward_backward_composes_channel_loss_and_chunk_mbs_contexts(monk
     assert chunk_mbs._chunk_mbs_ranges.get() is None
 
 
-def test_dpo_forward_backward_scopes_channel_loss_to_policy_model():
+def test_dpo_forward_backward_scopes_channel_loss_to_policy_model(monkeypatch):
+    _install_test_parallel_state(monkeypatch)
     cfg = ChannelLossConfig(enable=True, interval=1)
     state = TrainerState(global_step=1)
     policy_model = object()
@@ -1248,18 +1836,22 @@ def test_dpo_forward_backward_scopes_channel_loss_to_policy_model():
     assert base.channel_loss_callback.computer._source_ids == []
 
 
-def test_dpo_channel_loss_emits_policy_totals():
+def test_dpo_channel_loss_real_base_dispatch_repeats_metadata_and_emits_policy_totals(monkeypatch):
+    _install_test_parallel_state(monkeypatch)
+
     class DpoLossModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
             self.scale = torch.nn.Parameter(torch.tensor(1.0))
             self.loss_calls = 0
+            self.return_log_probs_calls = []
 
         def loss_function(self, logits, labels, vocab_size, **kwargs):
             self.loss_calls += 1
             return logits.sum() * 0
 
         def forward(self, labels=None, **kwargs):
+            self.return_log_probs_calls.append(kwargs.get("return_log_probs"))
             seq_len = labels.size(-1) if labels is not None else 8
             logits = torch.randn(1, seq_len, 8)
             if labels is not None:
@@ -1271,35 +1863,24 @@ def test_dpo_channel_loss_emits_policy_totals():
     state = TrainerState(global_step=1)
     policy_model = DpoLossModel()
     reference_model = DpoLossModel()
-    base = SimpleNamespace(
-        args=SimpleNamespace(
-            train=SimpleNamespace(channel_loss=cfg, enable_batch_invariant_mode=False),
-            dpo_config=SimpleNamespace(
-                beta=0.1,
-                label_smoothing=0.0,
-                loss_type="sigmoid",
-                reference_free=False,
-                average_log_prob=False,
-            ),
+    base = object.__new__(BaseTrainer)
+    base.args = SimpleNamespace(
+        train=SimpleNamespace(channel_loss=cfg, enable_batch_invariant_mode=False),
+        dpo_config=SimpleNamespace(
+            beta=0.1,
+            label_smoothing=0.0,
+            loss_type="sigmoid",
+            reference_free=False,
+            average_log_prob=False,
         ),
-        state=state,
-        model=policy_model,
-        model_fwd_context=nullcontext(),
-        model_bwd_context=nullcontext(),
-        preforward=lambda micro_batch: micro_batch,
     )
+    base.state = state
+    base.model = policy_model
+    base.model_fwd_context = nullcontext()
+    base.model_bwd_context = nullcontext()
+    base.preforward = lambda micro_batch: micro_batch
     base.channel_loss_callback = ChannelLossCallback(base)
-    step_begin_args = {}
-
-    def on_step_begin(micro_batches=None, **kwargs):
-        step_begin_args["source_repeat"] = kwargs.get("source_repeat", 1)
-        base.channel_loss_callback.on_step_begin(
-            state,
-            micro_batches=micro_batches,
-            **kwargs,
-        )
-
-    base.on_step_begin = on_step_begin
+    base._callbacks = [base.channel_loss_callback]
     trainer = object.__new__(TextDPOTrainer)
     trainer.base = base
     trainer.reference_model = reference_model
@@ -1316,12 +1897,13 @@ def test_dpo_channel_loss_emits_policy_totals():
     try:
         base.channel_loss_callback.computer.install(policy_model)
         TextDPOTrainer.on_step_begin(trainer, micro_batches=[micro_batch])
-        assert step_begin_args == {"source_repeat": 2}
         assert base.channel_loss_callback.computer._per_mb_source_ids == [[3, 3, 4, 4]]
         TextDPOTrainer.forward_backward_step(trainer, micro_batch)
 
         assert policy_model.loss_calls == 1
         assert reference_model.loss_calls == 1
+        assert policy_model.return_log_probs_calls == [True]
+        assert reference_model.return_log_probs_calls == [True]
         assert set(base.channel_loss_callback.computer.step_totals) == {3, 4}
         assert base.channel_loss_callback.computer.step_totals[3][1].item() == 2
         assert base.channel_loss_callback.computer.step_totals[4][1].item() == 2
@@ -1606,9 +2188,9 @@ def test_channel_loss_callback_reduces_compact_totals_and_syncs_names(monkeypatc
     callback.computer.source_names = {0: "source/a"}
     callback.computer.step_totals = {0: (torch.tensor(6.0), torch.tensor(3))}
     group = object()
+    callback.parallel_state = _test_parallel_state(dp_size=2, dp_group=group)
     observed = {}
 
-    monkeypatch.setattr(channel_loss_module, "get_parallel_state", lambda: SimpleNamespace(dp_size=2, dp_group=group))
     monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
     monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
 
@@ -1621,8 +2203,11 @@ def test_channel_loss_callback_reduces_compact_totals_and_syncs_names(monkeypatc
         assert group is not None
         if value.dtype.is_floating_point:
             value.add_(torch.tensor([0.0, 3.0]))
-        else:
+        elif value.ndim == 1:
             value.add_(torch.tensor([0, 1]))
+        else:
+            assert value.shape == (2, 3)
+            value.add_(torch.tensor([[0, 0, 0], [1, 4, 1]]))
 
     monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
     monkeypatch.setattr(channel_loss_module.dist, "all_reduce", fake_all_reduce)
@@ -1647,12 +2232,11 @@ def test_channel_loss_callback_strict_rejects_cross_rank_name_mismatch(monkeypat
     callback._collect_step = True
     callback.computer.source_names = {0: "source-a"}
     callback.computer.step_totals = {0: (torch.tensor(1.0), torch.tensor(1))}
+    callback.parallel_state = _test_parallel_state(dp_size=2, dp_group=object())
 
-    monkeypatch.setattr(
-        channel_loss_module, "get_parallel_state", lambda: SimpleNamespace(dp_size=2, dp_group=object())
-    )
     monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
     monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "all_reduce", lambda value, group=None: None)
 
     def fake_all_gather_object(gathered, local_metadata, group=None):
         gathered[0] = local_metadata
@@ -1664,9 +2248,470 @@ def test_channel_loss_callback_strict_rejects_cross_rank_name_mismatch(monkeypat
         callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
 
 
+def _strict_reduction_callback(*, source_name="source-a", with_totals=True):
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=True)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        device=torch.device("cpu"),
+        step_train_metrics={},
+        step_env_metrics={},
+    )
+    callback = ChannelLossCallback(trainer)
+    callback._collect_step = True
+    callback.computer.source_names = {0: source_name}
+    if with_totals:
+        callback.computer.step_totals = {0: (torch.tensor(1.0), torch.tensor(1))}
+        callback.computer.step_data_totals = {0: (torch.tensor(1), torch.tensor(2), torch.tensor(1))}
+    return callback, trainer
+
+
+def _mock_strict_reduction_collectives(
+    monkeypatch,
+    callback,
+    *,
+    remote_metadata=None,
+    fail_postflight=False,
+):
+    dp_group = object()
+    parallel_state = _test_parallel_state(dp_size=2, dp_group=dp_group)
+    callback.parallel_state = parallel_state
+    callback.computer.parallel_state = parallel_state
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+    events = []
+    world_calls = 0
+
+    def fake_all_gather_object(gathered, local_metadata, group=None):
+        assert group is dp_group
+        events.append("group-metadata")
+        gathered[0] = local_metadata
+        gathered[1] = local_metadata if remote_metadata is None else remote_metadata
+
+    def fake_all_reduce(value, group=None):
+        nonlocal world_calls
+        if group is None:
+            world_calls += 1
+            events.append(f"world-{world_calls}")
+            if fail_postflight and world_calls == 2:
+                value.fill_(1)
+        elif value.dtype.is_floating_point:
+            events.append("group-loss")
+        elif value.ndim == 1:
+            events.append("group-token")
+        else:
+            events.append("group-data")
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(channel_loss_module.dist, "all_reduce", fake_all_reduce)
+    return events
+
+
+def test_channel_loss_callback_strict_finishes_group_collectives_before_world_name_failure(monkeypatch):
+    callback, trainer = _strict_reduction_callback()
+    events = _mock_strict_reduction_collectives(
+        monkeypatch,
+        callback,
+        remote_metadata=[(0, "source-b")],
+    )
+
+    with pytest.raises(ChannelLossMetadataError, match="inconsistent names"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert events == [
+        "world-1",
+        "group-metadata",
+        "group-loss",
+        "group-token",
+        "group-data",
+        "world-2",
+    ]
+    assert trainer.step_env_metrics == {}
+
+
+def test_channel_loss_callback_strict_world_syncs_remote_group_reduction_failure(monkeypatch):
+    callback, trainer = _strict_reduction_callback()
+    events = _mock_strict_reduction_collectives(monkeypatch, callback, fail_postflight=True)
+
+    with pytest.raises(ChannelLossMetadataError, match="at least one rank"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert events == [
+        "world-1",
+        "group-metadata",
+        "group-loss",
+        "group-token",
+        "group-data",
+        "world-2",
+    ]
+    assert trainer.step_env_metrics == {}
+
+
+def test_channel_loss_callback_strict_world_syncs_no_totals_after_group_metadata(monkeypatch):
+    callback, _ = _strict_reduction_callback(with_totals=False)
+    callback.computer._per_mb_source_ids = [[0]]
+    events = _mock_strict_reduction_collectives(monkeypatch, callback)
+
+    with pytest.raises(ChannelLossMetadataError, match="no causal-LM CE totals"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert events == ["world-1", "group-metadata", "world-2"]
+
+
+def test_channel_loss_callback_strict_defers_cross_step_registry_conflict(monkeypatch):
+    callback, _ = _strict_reduction_callback(source_name="source-b")
+    callback._source_registry = {0: "source-a"}
+    events = _mock_strict_reduction_collectives(monkeypatch, callback)
+
+    with pytest.raises(ChannelLossMetadataError, match="inconsistent names across sampled steps"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert events == [
+        "world-1",
+        "group-metadata",
+        "group-loss",
+        "group-token",
+        "group-data",
+        "world-2",
+    ]
+
+
 def test_channel_loss_callback_strict_requires_source_id():
     cfg = ChannelLossConfig(enable=True, strict=True)
     trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
     callback = ChannelLossCallback(trainer)
     with pytest.raises(ValueError, match="no configured source ID"):
         callback.on_step_begin(TrainerState(global_step=1), micro_batches=[{"input_ids": torch.tensor([[1]])}])
+
+
+def test_channel_loss_callback_strict_syncs_missing_source_id_globally(monkeypatch):
+    cfg = ChannelLossConfig(enable=True, strict=True)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        device=torch.device("cpu"),
+    )
+    callback = ChannelLossCallback(trainer)
+    local_batch = {"position_ids": torch.tensor([[0, 1]]), "ds_idx": torch.tensor([3])}
+    observed_groups = []
+
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_all_reduce(value, group=None):
+        observed_groups.append(group)
+        value.fill_(1)
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_reduce", fake_all_reduce)
+
+    with pytest.raises(ValueError, match="no configured source ID"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[local_batch])
+
+    assert observed_groups == [None]
+
+
+def test_channel_loss_callback_strict_defers_observer_failure_until_step_end(monkeypatch):
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=True)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        step_train_metrics={},
+        step_env_metrics={},
+    )
+    callback = ChannelLossCallback(trainer)
+    batch = {"position_ids": torch.tensor([[0, 1]]), "ds_idx": torch.tensor([3])}
+    state = TrainerState(global_step=1)
+    callback.on_step_begin(state, micro_batches=[batch])
+    callback.on_micro_step_begin(state, micro_batch=batch)
+    monkeypatch.setattr(
+        callback.computer,
+        "_compute_channel_loss",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("observer failed")),
+    )
+
+    with callback.model_forward_context():
+        callback.computer.compute_side_channel(
+            logits=torch.randn(1, 2, 4),
+            labels=torch.tensor([[1, 2]]),
+            vocab_size=4,
+            hidden_states=None,
+            weights=None,
+        )
+    callback.on_micro_step_end(state)
+
+    assert callback.computer.strict_observation_errors
+    with pytest.raises(ChannelLossMetadataError, match="observation error"):
+        callback.on_step_end(state, loss=0.0, loss_dict={}, grad_norm=0.0)
+
+
+def test_channel_loss_callback_strict_syncs_missing_observation_before_group_collectives(monkeypatch):
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=True)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        device=torch.device("cpu"),
+        step_train_metrics={},
+        step_env_metrics={},
+    )
+    callback = ChannelLossCallback(trainer)
+    callback._collect_step = True
+    callback.computer.step_totals = {0: (torch.tensor(1.0), torch.tensor(1))}
+    observed_groups = []
+
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_all_reduce(value, group=None):
+        observed_groups.append(group)
+        value.fill_(1)
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(
+        callback,
+        "_reduce_step_totals",
+        lambda *args, **kwargs: pytest.fail("group collective entered after world preflight failure"),
+    )
+
+    with pytest.raises(ChannelLossMetadataError, match="sampled micro-step.*no causal-LM CE observation"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert observed_groups == [None]
+
+
+def _observe_real_sp_channel_loss(computer):
+    computer.compute_side_channel(
+        logits=torch.arange(16, dtype=torch.float32).reshape(1, 2, 8) / 10,
+        labels=torch.tensor([[1, 2]]),
+        vocab_size=8,
+        hidden_states=None,
+        weights=None,
+    )
+
+
+def _gloo_sp_preflight_worker(rank, world_size, init_file, result_queue):
+    try:
+        torch.distributed.init_process_group(
+            "gloo",
+            init_method=f"file://{init_file}",
+            rank=rank,
+            world_size=world_size,
+            timeout=timedelta(seconds=15),
+        )
+        parallel_state = _test_parallel_state(
+            sp_enabled=True,
+            sp_group=torch.distributed.group.WORLD,
+            sp_size=world_size,
+            sp_rank=rank,
+        )
+        singleton_groups = [
+            torch.distributed.new_group(ranks=[singleton_rank]) for singleton_rank in range(world_size)
+        ]
+
+        class _BrokenParallelState:
+            @property
+            def sp_enabled(self):
+                raise RuntimeError("cached parallel-state descriptor resolution failed")
+
+        for scenario in (
+            "valid",
+            "source",
+            "missing",
+            "generic",
+            "count",
+            "metadata",
+            "malformed",
+            "descriptor_resolution_failure",
+            "descriptor_mismatch",
+            "outer_descriptor_disabled",
+            "outer_descriptor_group",
+            "outer_descriptor_world",
+        ):
+            scenario_state = parallel_state
+            if scenario == "descriptor_resolution_failure":
+                scenario_state = _BrokenParallelState()
+            elif scenario == "outer_descriptor_disabled" and rank == 1:
+                scenario_state = _test_parallel_state()
+            elif scenario == "outer_descriptor_group" and rank == 1:
+                scenario_state = _test_parallel_state(
+                    sp_enabled=True,
+                    sp_group=singleton_groups[rank],
+                    sp_size=1,
+                    sp_rank=0,
+                )
+            elif scenario == "outer_descriptor_world" and rank == 1:
+                scenario_state = _test_parallel_state(
+                    sp_enabled=True,
+                    sp_group=torch.distributed.group.WORLD,
+                    sp_size=world_size + 1,
+                    sp_rank=rank,
+                )
+
+            computer = ChannelLossComputer(parallel_state=scenario_state)
+            computer.strict = True
+            computer._source_ids = ["source-a"]
+            computer._position_ids = torch.tensor([[0, 1]]) if rank == 0 else torch.tensor([[2, 3]])
+            prepare_descriptor = ChannelLossComputer.__dict__["_prepare_sp_observation_payload"]
+
+            if scenario == "source" and rank == 1:
+                computer._source_ids = ["source-b"]
+            elif scenario == "missing" and rank == 1:
+                computer._source_ids = []
+            elif scenario == "generic" and rank == 1:
+                computer._compute_channel_loss = lambda **kwargs: (_ for _ in ()).throw(
+                    RuntimeError("rank-local CE preparation failed")
+                )
+            elif scenario == "metadata" and rank == 1:
+                computer._position_ids = None
+            elif scenario == "malformed" and rank == 1:
+
+                def fail_ready_payload(**kwargs):
+                    raise RuntimeError("rank-local malformed segment stack")
+
+                ChannelLossComputer._prepare_sp_observation_payload = staticmethod(fail_ready_payload)
+
+            try:
+                with computer.capture():
+                    if computer._source_ids:
+                        _observe_real_sp_channel_loss(computer)
+                        if scenario == "count" and rank == 1:
+                            _observe_real_sp_channel_loss(computer)
+                        if scenario == "descriptor_mismatch" and rank == 1:
+                            observation = computer._pending_observations[0]
+                            observation.capture_descriptor = channel_loss_module._SPCaptureDescriptor(
+                                enabled=True,
+                                parallel_state=scenario_state,
+                                group=parallel_state.sp_group,
+                                world=world_size + 1,
+                                rank=rank,
+                            )
+            finally:
+                ChannelLossComputer._prepare_sp_observation_payload = prepare_descriptor
+
+            if scenario == "valid":
+                assert computer._result is not None
+                assert computer._micro_step_observation_count == 1
+                assert computer.strict_observation_errors == []
+                assert computer._result[0]["source_id"] == "source-a"
+                assert computer._result[0]["token_count"].item() == 4
+            else:
+                assert computer._result is None
+                assert computer._micro_step_observation_count == 0
+                assert computer.strict_observation_errors
+                if scenario == "descriptor_resolution_failure":
+                    assert (
+                        "cached parallel-state descriptor resolution failed"
+                        in (computer.strict_observation_errors[0][1])
+                    )
+            torch.distributed.barrier()
+        result_queue.put((rank, "ok"))
+    except Exception:
+        result_queue.put((rank, traceback.format_exc()))
+        raise
+    finally:
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+def _gloo_two_stripe_worker(rank, world_size, init_file, result_queue):
+    try:
+        torch.distributed.init_process_group(
+            "gloo",
+            init_method=f"file://{init_file}",
+            rank=rank,
+            world_size=world_size,
+            timeout=timedelta(seconds=15),
+        )
+        stripe_groups = [
+            torch.distributed.new_group(ranks=[0, 1]),
+            torch.distributed.new_group(ranks=[2, 3]),
+        ]
+        stripe_idx = rank // 2
+        local_sp_rank = rank % 2
+        parallel_state = _test_parallel_state(
+            sp_enabled=True,
+            sp_group=stripe_groups[stripe_idx],
+            sp_size=2,
+            sp_rank=local_sp_rank,
+        )
+        config = ChannelLossConfig(enable=True, interval=1, strict=True)
+        trainer = SimpleNamespace(
+            args=SimpleNamespace(train=SimpleNamespace(channel_loss=config)),
+            device=torch.device("cpu"),
+            step_train_metrics={},
+            step_env_metrics={},
+        )
+        with use_parallel_state(parallel_state):
+            callback = ChannelLossCallback(trainer)
+        batch = {
+            "position_ids": torch.tensor([[0, 1]]) if local_sp_rank == 0 else torch.tensor([[2, 3]]),
+            "ds_idx": torch.tensor([3]),
+        }
+        state = TrainerState(global_step=1)
+        callback.on_step_begin(state, micro_batches=[batch])
+        callback.on_micro_step_begin(state, micro_batch=batch)
+        with callback.model_forward_context():
+            if rank != 3:
+                _observe_real_sp_channel_loss(callback.computer)
+        callback.on_micro_step_end(state)
+
+        raised = False
+        try:
+            callback.on_step_end(state, loss=0.0, loss_dict={}, grad_norm=0.0)
+        except ChannelLossMetadataError:
+            raised = True
+        assert raised
+        assert trainer.step_env_metrics == {}
+        result_queue.put((rank, "ok"))
+    except Exception:
+        result_queue.put((rank, traceback.format_exc()))
+        raise
+    finally:
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+def _run_gloo_workers(worker, *, world_size, init_file, timeout_seconds=30):
+    context = torch.multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    processes = [
+        context.Process(target=worker, args=(rank, world_size, str(init_file), result_queue))
+        for rank in range(world_size)
+    ]
+    for process in processes:
+        process.start()
+
+    deadline = time.monotonic() + timeout_seconds
+    for process in processes:
+        process.join(max(deadline - time.monotonic(), 0))
+    hung = [process for process in processes if process.is_alive()]
+    if hung:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+        for process in processes:
+            process.join(5)
+        pytest.fail(f"distributed channel-loss test timed out on {len(hung)} process(es)")
+
+    results = []
+    for _ in range(world_size):
+        try:
+            results.append(result_queue.get(timeout=3))
+        except queue.Empty:
+            break
+    failures = [detail for _, detail in results if detail != "ok"]
+    exit_codes = [process.exitcode for process in processes]
+    assert len(results) == world_size, (results, exit_codes)
+    assert not failures, "\n".join(failures)
+    assert exit_codes == [0] * world_size
+
+
+def test_channel_loss_real_gloo_sp_preflight_avoids_divergent_payload_collectives(tmp_path):
+    _run_gloo_workers(
+        _gloo_sp_preflight_worker,
+        world_size=2,
+        init_file=tmp_path / "sp-preflight-init",
+    )
+
+
+def test_channel_loss_real_gloo_two_sp_stripes_propagate_strict_failure_worldwide(tmp_path):
+    _run_gloo_workers(
+        _gloo_two_stripe_worker,
+        world_size=4,
+        init_file=tmp_path / "sp-stripes-init",
+    )

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -1431,6 +1431,22 @@ def test_channel_loss_data_metric_name_collisions_remain_distinct():
     assert metrics["samples/source-i-2__train_a"] == 1.0
 
 
+def test_channel_loss_data_metric_names_avoid_short_qualified_cross_collision():
+    cfg = ChannelLossConfig(enable=True)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)
+    callback = ChannelLossCallback(trainer)
+
+    metrics = callback._build_data_metrics(
+        {0: (1, 3, 2), 1: (2, 8, 6), 2: (3, 15, 12)},
+        {0: "foo", 1: "foo", 2: "source-i-0__foo"},
+    )
+
+    assert metrics["samples/source-i-0__foo"] == 1.0
+    assert metrics["samples/source-i-1__foo"] == 2.0
+    assert metrics["samples/source-i-2__source-i-0__foo"] == 3.0
+    assert len([key for key in metrics if key.startswith("samples/")]) == 3
+
+
 def test_channel_loss_data_metric_collision_registry_persists_across_steps():
     cfg = ChannelLossConfig(enable=True)
     trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)), environ_meter=None)

--- a/tests/trainer/test_channel_loss_dashboard.py
+++ b/tests/trainer/test_channel_loss_dashboard.py
@@ -1,0 +1,481 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from types import SimpleNamespace
+
+import veomni.trainer.callbacks.channel_loss_dashboard as dashboard_module
+from veomni.trainer.base import BaseTrainer
+from veomni.trainer.callbacks.channel_loss_dashboard import (
+    ChannelLossDashboardCallback,
+    ChannelLossDashboardData,
+)
+from veomni.trainer.text_dpo_trainer import TextDPOTrainer
+from veomni.trainer.text_trainer import TextTrainer
+from veomni.trainer.vlm_trainer import VLMTrainer
+
+
+def _trainer(*, enabled: bool = True):
+    config = SimpleNamespace(
+        enable=enabled,
+        loss_metric_prefix="channel_loss",
+        weighted_loss_metric_prefix="channel_loss_weighted",
+        token_count_metric_prefix="channel_tokens",
+    )
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(
+            train=SimpleNamespace(
+                global_rank=0,
+                wandb=SimpleNamespace(enable=True),
+                channel_loss=config,
+            )
+        ),
+        channel_loss_callback=SimpleNamespace(config=config, _source_registry={0: "repo__qa", 1: "swecompass"}),
+        step_env_metrics={},
+        _channel_loss_trace_step_id=None,
+    )
+
+    def set_trace_step_id(trace_step_id):
+        trainer._channel_loss_trace_step_id = trace_step_id
+
+    def pop_trace_step_id():
+        trace_step_id = trainer._channel_loss_trace_step_id
+        trainer._channel_loss_trace_step_id = None
+        return trace_step_id
+
+    trainer.set_channel_loss_trace_step_id = set_trace_step_id
+    trainer.pop_channel_loss_trace_step_id = pop_trace_step_id
+    return trainer
+
+
+def _metrics(step: int = 1):
+    return {
+        "training/foundation_loss": 0.7 + step / 100,
+        "channel_loss/source-i-0__repo_qa": 2.0,
+        "channel_loss/source-i-1__swecompass": 0.5,
+        "channel_loss_weighted/source-i-0__repo_qa": 0.2,
+        "channel_loss_weighted/source-i-1__swecompass": 0.5,
+        "channel_tokens/source-i-0__repo_qa": 20,
+        "channel_tokens/source-i-1__swecompass": 80,
+        "samples/repo_qa": 2,
+        "samples/swecompass": 8,
+        "input_tokens/repo_qa": 100,
+        "input_tokens/swecompass": 400,
+        "label_tokens/repo_qa": 20,
+        "label_tokens/swecompass": 80,
+        "label_tokens_per_sample/repo_qa": 10,
+        "label_tokens_per_sample/swecompass": 10,
+    }
+
+
+def test_dashboard_records_scalar_contract_without_splitting_source_names():
+    trainer = _trainer()
+    data = ChannelLossDashboardData()
+
+    assert data.record(trainer, 1, _metrics())
+
+    assert data.labels == {
+        "source-i-0": "repo__qa",
+        "source-i-1": "swecompass",
+    }
+    assert data.points[0]["values"]["source-i-0"] == {
+        "raw": 2.0,
+        "weighted": 0.2,
+        "tokens": 20.0,
+        "samples": 2.0,
+        "input_tokens": 100.0,
+        "label_tokens": 20.0,
+        "label_tokens_per_sample": 10.0,
+    }
+
+
+def test_dashboard_resolves_adversarial_data_metric_suffixes_one_to_one():
+    trainer = _trainer()
+    trainer.channel_loss_callback._source_registry = {0: "foo", 1: "source-i-0__foo"}
+    metrics = {
+        "channel_loss/source-i-0__foo": 2.0,
+        "channel_loss/source-i-1__source-i-0__foo": 0.5,
+        "samples/foo": 2,
+        "samples/source-i-0__foo": 7,
+        "input_tokens/foo": 100,
+        "input_tokens/source-i-0__foo": 350,
+        "label_tokens/foo": 20,
+        "label_tokens/source-i-0__foo": 70,
+        "label_tokens_per_sample/foo": 10,
+        "label_tokens_per_sample/source-i-0__foo": 10,
+    }
+    data = ChannelLossDashboardData()
+
+    assert data.record(trainer, 1, metrics)
+
+    values = data.points[0]["values"]
+    assert values["source-i-0"]["samples"] == 2
+    assert values["source-i-0"]["input_tokens"] == 100
+    assert values["source-i-1"]["samples"] == 7
+    assert values["source-i-1"]["input_tokens"] == 350
+
+
+def test_dashboard_resolves_three_way_short_and_qualified_name_collision():
+    trainer = _trainer()
+    trainer.channel_loss_callback._source_registry = {0: "foo", 1: "foo", 2: "source-i-0__foo"}
+    metrics = {
+        "channel_loss/source-i-0__foo": 2.0,
+        "channel_loss/source-i-1__foo": 1.0,
+        "channel_loss/source-i-2__source-i-0__foo": 0.5,
+        "samples/source-i-0__foo": 2,
+        "samples/source-i-1__foo": 3,
+        "samples/source-i-2__source-i-0__foo": 7,
+        "input_tokens/source-i-0__foo": 100,
+        "input_tokens/source-i-1__foo": 150,
+        "input_tokens/source-i-2__source-i-0__foo": 350,
+        "label_tokens/source-i-0__foo": 20,
+        "label_tokens/source-i-1__foo": 30,
+        "label_tokens/source-i-2__source-i-0__foo": 70,
+        "label_tokens_per_sample/source-i-0__foo": 10,
+        "label_tokens_per_sample/source-i-1__foo": 10,
+        "label_tokens_per_sample/source-i-2__source-i-0__foo": 10,
+    }
+    data = ChannelLossDashboardData()
+
+    assert data.record(trainer, 1, metrics)
+
+    values = data.points[0]["values"]
+    assert values["source-i-0"]["samples"] == 2
+    assert values["source-i-1"]["samples"] == 3
+    assert values["source-i-2"]["samples"] == 7
+
+
+def test_dashboard_ignores_steps_without_channel_loss_and_replaces_duplicate_step():
+    trainer = _trainer()
+    data = ChannelLossDashboardData()
+
+    assert not data.record(trainer, 1, {"training/foundation_loss": 0.5})
+    assert data.record(trainer, 2, _metrics(2))
+    replacement = _metrics(2)
+    replacement["channel_loss/source-i-0__repo_qa"] = 1.5
+    assert data.record(trainer, 2, replacement)
+
+    assert len(data.points) == 1
+    assert data.points[0]["values"]["source-i-0"]["raw"] == 1.5
+
+
+def test_dashboard_derives_overall_text_loss_from_weighted_channels_not_total_objective():
+    trainer = _trainer()
+    metrics = _metrics()
+    metrics["training/foundation_loss"] = 7.0
+    metrics["training/total_loss"] = 99.0
+    data = ChannelLossDashboardData()
+
+    data.record(trainer, 1, metrics)
+
+    assert data.points[0]["overall"] == 0.7
+
+
+def test_dashboard_falls_back_only_to_explicit_foundation_loss_without_complete_weighted_channels():
+    trainer = _trainer()
+    metrics = _metrics()
+    del metrics["channel_loss_weighted/source-i-1__swecompass"]
+    metrics["training/foundation_loss"] = 0.73
+    metrics["training/total_loss"] = 99.0
+    data = ChannelLossDashboardData()
+
+    data.record(trainer, 1, metrics)
+
+    assert data.points[0]["overall"] == 0.73
+
+
+def test_dashboard_keeps_one_series_when_source_display_name_changes():
+    trainer = _trainer()
+    trainer.channel_loss_callback._source_registry[0] = None
+    initial = {
+        name.replace("source-i-0__repo_qa", "source-i-0__source_0"): value for name, value in _metrics().items()
+    }
+    data = ChannelLossDashboardData()
+    data.record(trainer, 1, initial)
+    trainer.channel_loss_callback._source_registry[0] = "repoqa"
+    data.record(trainer, 2, _metrics(2))
+
+    assert data.labels["source-i-0"] == "repoqa"
+    assert all("source-i-0" in point["values"] for point in data.points)
+    assert all("source-i-0__" not in key for point in data.points for key in point["values"])
+
+
+def test_dashboard_html_is_self_contained_interactive_and_script_safe():
+    trainer = _trainer()
+    trainer.channel_loss_callback._source_registry[0] = "repo</script><script>alert(1)</script>"
+    data = ChannelLossDashboardData()
+    data.record(trainer, 1, _metrics())
+
+    html = data.render_html()
+
+    assert "Raw CE" in html
+    assert "Weighted contribution" in html
+    assert "Actual data mix" in html
+    assert "Step sample summary" in html
+    assert "Sample-level details remain in optional dataloader-owned trace artifacts" in html
+    assert "dashboard renders aggregate metrics only" in html
+    assert "repo</script>" not in html
+    assert "repo\\u003c/script\\u003e" in html
+    assert "https://" not in html
+    assert "sampledMarkers(observations)" in html
+    assert "observations.length<=200" not in html
+    assert ".dashboard{width:100%;min-width:0" in html
+    assert "@media(max-width:520px)" in html
+    assert "min-width:min(150px,calc(100% - 16px))" in html
+    assert "Math.max(8,Math.min(left" in html
+    assert "min-width:620px" not in html
+    assert "overflow-x:hidden" not in html
+
+
+def test_dashboard_payload_decimates_but_keeps_endpoints():
+    trainer = _trainer()
+    data = ChannelLossDashboardData()
+    for step in range(1, 11):
+        data.record(trainer, step, _metrics(step))
+
+    payload = data.payload(max_points=4)
+
+    assert payload["sampled_points"] == 10
+    assert payload["rendered_points"] == 4
+    assert payload["points"][0]["step"] == 1
+    assert payload["points"][-1]["step"] == 10
+    assert payload["has_weighted"]
+    assert payload["has_tokens"]
+    assert payload["has_data_metrics"]
+
+
+def test_dashboard_decimation_preserves_a_rare_dynamic_source():
+    trainer = _trainer()
+    data = ChannelLossDashboardData()
+    for step in range(1, 11):
+        metrics = _metrics(step)
+        if step == 2:
+            trainer.channel_loss_callback._source_registry[2] = "rare"
+            metrics.update(
+                {
+                    "channel_loss/source-i-2__rare": 1.0,
+                    "channel_loss_weighted/source-i-2__rare": 0.01,
+                    "channel_tokens/source-i-2__rare": 1,
+                }
+            )
+        data.record(trainer, step, metrics)
+
+    payload = data.payload(max_points=3)
+
+    assert any(source["key"] == "source-i-2" for source in payload["sources"])
+    assert any("source-i-2" in point["values"] for point in payload["points"])
+
+
+def test_dashboard_marks_optional_weighted_and_token_views_unavailable():
+    trainer = _trainer()
+    metrics = {
+        name: value
+        for name, value in _metrics().items()
+        if not name.startswith(
+            (
+                "channel_loss_weighted/",
+                "channel_tokens/",
+                "samples/",
+                "input_tokens/",
+                "label_tokens/",
+                "label_tokens_per_sample/",
+            )
+        )
+    }
+    data = ChannelLossDashboardData()
+    data.record(trainer, 1, metrics)
+
+    payload = data.payload(max_points=10)
+
+    assert not payload["has_weighted"]
+    assert not payload["has_tokens"]
+    assert not payload["has_data_metrics"]
+    assert '"has_weighted":false' in data.render_html()
+    assert '"has_tokens":false' in data.render_html()
+
+
+def test_dashboard_compacts_retained_history_without_losing_latest_point(monkeypatch):
+    monkeypatch.setattr(dashboard_module, "_MAX_RETAINED_POINTS", 5)
+    trainer = _trainer()
+    data = ChannelLossDashboardData()
+    for step in range(1, 8):
+        metrics = _metrics(step)
+        if step == 2:
+            trainer.channel_loss_callback._source_registry[2] = "transient"
+            metrics["channel_loss/source-i-2__transient"] = 1.0
+        data.record(trainer, step, metrics)
+
+    assert data.sampled_points == 7
+    assert len(data.points) <= 5
+    assert data.points[-1]["step"] == 7
+    assert "source-i-2" in data.labels
+    assert any("source-i-2" in point["values"] for point in data.points)
+
+
+def test_dashboard_callback_is_disabled_without_channel_loss():
+    callback = ChannelLossDashboardCallback(_trainer(enabled=False))
+
+    assert not callback.enabled
+
+
+def test_dashboard_callback_publishes_one_complete_html_at_train_end(monkeypatch):
+    trainer = _trainer()
+    trainer.step_env_metrics = _metrics()
+    logged = []
+    fake_wandb = SimpleNamespace(
+        run=object(),
+        Html=lambda content, inject: {"content": content, "inject": inject},
+        log=lambda values, step: logged.append((values, step)),
+    )
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+    callback = ChannelLossDashboardCallback(trainer)
+
+    callback.on_step_end(SimpleNamespace(global_step=1))
+    callback.on_step_end(SimpleNamespace(global_step=2))
+
+    assert logged == []
+
+    callback.on_train_end(SimpleNamespace(global_step=2))
+
+    assert len(logged) == 1
+    values, step = logged[0]
+    assert step == 2
+    assert values["channel_overview"]["inject"] is False
+    assert "Channel loss · source overview" in values["channel_overview"]["content"]
+    assert '"step":1' in values["channel_overview"]["content"]
+    assert '"step":2' in values["channel_overview"]["content"]
+
+
+def test_dashboard_callback_does_not_publish_incomplete_media_snapshots(monkeypatch):
+    trainer = _trainer()
+    logged_steps = []
+    fake_wandb = SimpleNamespace(
+        run=object(),
+        Html=lambda content, inject: content,
+        log=lambda values, step: logged_steps.append(step),
+    )
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+    callback = ChannelLossDashboardCallback(trainer)
+    for step in range(1, 11):
+        trainer.step_env_metrics = _metrics(step)
+        callback.on_step_end(SimpleNamespace(global_step=step))
+
+    assert logged_steps == []
+
+    callback.on_train_end(SimpleNamespace(global_step=10))
+
+    assert logged_steps == [10]
+
+
+def test_dashboard_callback_flushes_latest_snapshot_once_at_interpreter_exit(monkeypatch):
+    trainer = _trainer()
+    trainer.step_env_metrics = _metrics()
+    logged_steps = []
+    registered = []
+    monkeypatch.setattr(dashboard_module.atexit, "register", registered.append)
+    monkeypatch.setitem(
+        sys.modules,
+        "wandb",
+        SimpleNamespace(
+            run=object(),
+            Html=lambda content, inject: content,
+            log=lambda values, step: logged_steps.append(step),
+        ),
+    )
+    callback = ChannelLossDashboardCallback(trainer)
+    assert registered == []
+    callback.on_step_end(SimpleNamespace(global_step=3))
+
+    assert registered == [callback._publish_latest_at_exit]
+
+    callback._publish_latest_at_exit()
+    callback._publish_latest_at_exit()
+
+    assert logged_steps == [3]
+
+
+def test_dashboard_exit_flush_uses_latest_completed_step_after_last_sample(monkeypatch):
+    trainer = _trainer()
+    trainer.step_env_metrics = _metrics()
+    logged_steps = []
+    monkeypatch.setattr(dashboard_module.atexit, "register", lambda hook: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "wandb",
+        SimpleNamespace(
+            run=object(),
+            Html=lambda content, inject: content,
+            log=lambda values, step: logged_steps.append(step),
+        ),
+    )
+    callback = ChannelLossDashboardCallback(trainer)
+    callback.on_step_end(SimpleNamespace(global_step=10))
+    trainer.step_env_metrics = {"training/loss": 0.5}
+    callback.on_step_end(SimpleNamespace(global_step=14))
+
+    callback._publish_latest_at_exit()
+    callback._publish_latest_at_exit()
+
+    assert logged_steps == [14]
+
+
+def test_dashboard_includes_falsey_optional_adapter_trace_step_without_sample_ids():
+    trainer = _trainer()
+    data = ChannelLossDashboardData()
+
+    data.record(trainer, 7, _metrics(7), trace_step_id=0)
+
+    point = data.payload(max_points=10)["points"][0]
+    assert point["trace_step_id"] == "0"
+    assert "global_sample_id" not in point
+
+
+def test_dashboard_callback_consumes_trace_id_on_every_step_without_stale_reuse(monkeypatch):
+    trainer = _trainer()
+    monkeypatch.setattr(dashboard_module.atexit, "register", lambda hook: None)
+    callback = ChannelLossDashboardCallback(trainer)
+    trainer.set_channel_loss_trace_step_id("snapshot-abc:step-1")
+    trainer.step_env_metrics = _metrics(1)
+    callback.on_step_end(SimpleNamespace(global_step=1))
+
+    trainer.set_channel_loss_trace_step_id("must-be-consumed")
+    trainer.step_env_metrics = {"training/loss": 0.5}
+    callback.on_step_end(SimpleNamespace(global_step=2))
+    trainer.step_env_metrics = _metrics(3)
+    callback.on_step_end(SimpleNamespace(global_step=3))
+
+    assert callback.data.points[0]["trace_step_id"] == "snapshot-abc:step-1"
+    assert callback.data.points[1]["trace_step_id"] is None
+    assert trainer._channel_loss_trace_step_id is None
+
+
+def test_base_trainer_trace_step_contract_is_one_shot_and_preserves_falsey_ids():
+    trainer = object.__new__(BaseTrainer)
+    trainer._channel_loss_trace_step_id = None
+
+    trainer.set_channel_loss_trace_step_id(0)
+
+    assert trainer.pop_channel_loss_trace_step_id() == 0
+    assert trainer.pop_channel_loss_trace_step_id() is None
+
+
+def test_composed_trainers_forward_the_public_trace_step_contract():
+    for trainer_type in (TextTrainer, VLMTrainer, TextDPOTrainer):
+        captured = []
+        trainer = object.__new__(trainer_type)
+        trainer.base = SimpleNamespace(set_channel_loss_trace_step_id=captured.append)
+
+        trainer.set_channel_loss_trace_step_id("trace-step")
+
+        assert captured == ["trace-step"]

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -288,6 +288,15 @@ class ChannelLossConfig:
         default=True,
         metadata={"help": "Log supervised token count for each channel."},
     )
+    release_cache: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Synchronize and release allocator cache after detached channel-loss CE on sampled steps. "
+                "This can lower peak memory before backward at the cost of extra synchronization."
+            )
+        },
+    )
     strict: bool = field(
         default=False,
         metadata={

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -31,6 +31,13 @@ from ..utils.seqlen_pos_transform_utils import (
     prepare_fa_kwargs_from_position_ids,
     valid_seqlens_from_cu_seqlens,
 )
+from .source_metadata import (
+    PACKED_SOURCE_METADATA_KEY,
+    SOURCE_DIAGNOSTIC_FIELDS,
+    SOURCE_METADATA_KEY,
+    make_packed_source_metadata,
+    normalize_source_metadata,
+)
 
 
 # A model-provided hook that derives ``multimodal_metadata`` from a packed +
@@ -194,13 +201,23 @@ class MakeMicroBatchCollator(DataCollator):
     internal_data_collator: "DataCollator"
 
     def __call__(self, features: Sequence[Tuple[Dict[str, "torch.Tensor"]]]) -> List[Dict[str, "torch.Tensor"]]:
-        micro_batch_size = len(features) // self.num_micro_batch
-        for i in range(len(features)):
-            features[i] = features[i][0]  # 1-to-N inverse transform
+        unwrapped_features = []
+        for transformed_parts in features:
+            if isinstance(transformed_parts, dict):
+                unwrapped_features.append(transformed_parts)
+                continue
+            if not isinstance(transformed_parts, (list, tuple)) or len(transformed_parts) != 1:
+                raise ValueError(
+                    "Fixed-sample batching requires exactly one output per input transform; "
+                    "use dynamic batching for one-to-many transforms."
+                )
+            unwrapped_features.append(transformed_parts[0])
+
+        micro_batch_size = len(unwrapped_features) // self.num_micro_batch
 
         micro_batches = []
-        for i in range(0, len(features), micro_batch_size):
-            micro_batches.append(self.internal_data_collator(features[i : i + micro_batch_size]))
+        for i in range(0, len(unwrapped_features), micro_batch_size):
+            micro_batches.append(self.internal_data_collator(unwrapped_features[i : i + micro_batch_size]))
 
         return micro_batches
 
@@ -264,7 +281,45 @@ class PackingCollator(DataCollator):
                 )
         return batch
 
-    def __call__(self, features: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
+    def _pack_source_metadata(self, features: List[Dict[str, Any]]) -> dict | None:
+        raw_metadata = [feature.pop(SOURCE_METADATA_KEY, None) for feature in features]
+        if not any(metadata is not None for metadata in raw_metadata):
+            return None
+        if not all(metadata is not None for metadata in raw_metadata):
+            raise ValueError(f"{SOURCE_METADATA_KEY} must be present on every packed feature")
+
+        segments: list[dict[str, Any]] = []
+        packed_offset = 0
+        for sample_index, (feature, metadata) in enumerate(zip(features, raw_metadata)):
+            normalized = normalize_source_metadata(metadata)
+            position_ids = feature["position_ids"]
+            if position_ids.dim() > 1:
+                position_ids = position_ids.reshape(-1, position_ids.size(-1))[0]
+            feature_length = int(feature["input_ids"].size(-1))
+            if position_ids.numel() != feature_length:
+                raise ValueError("position_ids and input_ids must have matching sequence lengths")
+
+            reset_offsets = torch.nonzero(position_ids == 0, as_tuple=False).flatten().tolist()
+            if not reset_offsets or reset_offsets[0] != 0:
+                raise ValueError("each packed feature must start with position_ids == 0")
+            boundaries = reset_offsets + [feature_length]
+            for subsegment_index, (start, end) in enumerate(zip(boundaries, boundaries[1:])):
+                segment = {
+                    "source_id": normalized["source_id"],
+                    **({"source_name": normalized["source_name"]} if "source_name" in normalized else {}),
+                    **{name: normalized[name] for name in SOURCE_DIAGNOSTIC_FIELDS if name in normalized},
+                    "segment_index": len(segments),
+                    "sample_index": sample_index,
+                    "subsegment_index": subsegment_index,
+                    "token_start": packed_offset + start,
+                    "token_length": end - start,
+                }
+                segments.append(segment)
+            packed_offset += feature_length
+        return make_packed_source_metadata(segments, valid_token_count=packed_offset)
+
+    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
+        packed_source_metadata = self._pack_source_metadata(features)
         batch = defaultdict(list)
         for feature in features:
             for key in feature.keys():
@@ -292,6 +347,9 @@ class PackingCollator(DataCollator):
                 batch[key] = torch.cat(batch[key], dim=pack_dim)
                 if pack_dim == -1:
                     batch[key] = batch[key].unsqueeze(0)
+
+        if packed_source_metadata is not None:
+            batch[PACKED_SOURCE_METADATA_KEY] = packed_source_metadata
 
         linear_attn_tail_padding_length = 0
         if self.pad_to_length:

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -40,6 +40,7 @@ from ..utils import logging
 from ..utils.constants import IGNORE_INDEX
 from ..utils.dist_utils import main_process_first
 from ..utils.multisource_utils import parse_multisource_config
+from .source_metadata import SourceId, attach_source_metadata, validate_source_id, validate_source_ids
 
 
 logger = logging.get_logger(__name__)
@@ -95,49 +96,114 @@ class IterativeDataset(IterableDataset):
 
 
 class InterleavedIterableDataset(IterativeDataset):
-    def __init__(self, data: "HFIterableDataset", transform: Optional[Callable] = None):
+    def __init__(
+        self,
+        data: "HFIterableDataset",
+        transform: Optional[Callable] = None,
+        source_ids: Optional[Sequence[SourceId]] = None,
+    ):
         self._data = data
         self._transform = transform
+        self._source_ids = (
+            validate_source_ids(source_ids, expected_count=len(source_ids)) if source_ids is not None else None
+        )
 
     def __iter__(self):
         for sample in self._data:
+            ds_idx = sample["ds_idx"]
+            source_id = validate_source_id(
+                self._source_ids[ds_idx] if self._source_ids is not None else sample.get("source_id", ds_idx)
+            )
+            source_name = sample.get("source_name", None)
             if self._transform is not None:
-                ds_idx = sample["ds_idx"]
-                source_name = sample.get("source_name", None)
                 transformed_sample = self._transform(sample, source_name=source_name)
-                if isinstance(transformed_sample, List):
-                    for idx in range(len(transformed_sample)):
-                        transformed_sample[idx]["ds_idx"] = ds_idx
-                    yield transformed_sample
-                else:
-                    transformed_sample["ds_idx"] = ds_idx
-                    yield transformed_sample
             else:
-                yield sample
+                transformed_sample = sample
+            yield attach_source_metadata(
+                transformed_sample,
+                source_id=source_id,
+                source_name=source_name,
+                ds_idx=ds_idx,
+            )
+
+    def state_dict(self):
+        """Save the iterable state together with its typed source-ID topology."""
+        return {
+            "version": 1,
+            "topology": {
+                "source_ids": list(self._source_ids) if self._source_ids is not None else None,
+            },
+            "dataset": self._data.state_dict(),
+        }
+
+    def load_state_dict(self, state_dict):
+        """Restore state and fail closed if the source-ID topology changed."""
+        if "version" not in state_dict:
+            # Backward compatibility for the previous wrapper shape. It did not
+            # persist source topology, so no retroactive validation is possible.
+            self._data.load_state_dict(state_dict["dataset"])
+            return
+
+        version = state_dict["version"]
+        if type(version) is not int or version != 1:
+            raise ValueError(f"unsupported interleaved iterable state version: {version!r}")
+        topology = state_dict.get("topology")
+        if not isinstance(topology, dict) or "source_ids" not in topology:
+            raise ValueError("interleaved iterable state missing topology.source_ids")
+        raw_saved_source_ids = topology["source_ids"]
+        saved_source_ids = (
+            validate_source_ids(raw_saved_source_ids, expected_count=len(raw_saved_source_ids))
+            if isinstance(raw_saved_source_ids, (list, tuple))
+            else None
+        )
+        if raw_saved_source_ids is not None and saved_source_ids is None:
+            raise ValueError("interleaved iterable topology.source_ids must be a list, tuple, or None")
+
+        current_signature = (
+            [(type(source_id), source_id) for source_id in self._source_ids] if self._source_ids is not None else None
+        )
+        saved_signature = (
+            [(type(source_id), source_id) for source_id in saved_source_ids] if saved_source_ids is not None else None
+        )
+        if saved_signature != current_signature:
+            raise ValueError(
+                "interleaved iterable source_ids topology changed across checkpoint resume "
+                f"(saved={raw_saved_source_ids!r}, current={self._source_ids!r})"
+            )
+        self._data.load_state_dict(state_dict["dataset"])
 
 
 class InterleavedMappingDataset(MappingDataset):
-    def __init__(self, data: "Dataset", transform: Optional[Callable] = None):
+    def __init__(
+        self,
+        data: "Dataset",
+        transform: Optional[Callable] = None,
+        source_ids: Optional[Sequence[SourceId]] = None,
+    ):
         super().__init__(data, transform)
+        self._source_ids = list(source_ids) if source_ids is not None else None
 
     def __getitem__(self, index: int) -> List[Dict[str, "torch.Tensor"]]:
         if index >= len(self.indices):
             random.shuffle(self.indices)
             index = index % len(self.indices)
         mapped_idx = self.indices[index]
+        sample = self._data[mapped_idx]
+        ds_idx = sample["ds_idx"]
+        source_id = validate_source_id(
+            self._source_ids[ds_idx] if self._source_ids is not None else sample.get("source_id", ds_idx)
+        )
+        source_name = sample.get("source_name", None)
         if self._transform is not None:
-            sample = self._data[mapped_idx]
-            ds_idx = sample["ds_idx"]
-            source_name = sample.get("source_name", None)
             transformed_sample = self._transform(sample, source_name=source_name)
-            if isinstance(transformed_sample, List):
-                for idx in range(len(transformed_sample)):
-                    transformed_sample[idx]["ds_idx"] = ds_idx
-            else:
-                transformed_sample["ds_idx"] = ds_idx
-            return transformed_sample
         else:
-            return self._data[mapped_idx]
+            transformed_sample = sample
+        return attach_source_metadata(
+            transformed_sample,
+            source_id=source_id,
+            source_name=source_name,
+            ds_idx=ds_idx,
+        )
 
 
 class EnergonDataset(IterativeDataset):
@@ -376,7 +442,7 @@ class WeightedMultiSourceDataset(IterableDataset):
         level: Literal["sample", "token"] = "sample",
         sample_token_len_fn: Optional[Callable[[Any], float]] = None,
         source_names: Optional[Sequence[str]] = None,
-        source_ids: Optional[Sequence[str]] = None,
+        source_ids: Optional[Sequence[SourceId]] = None,
         upstream_sharded: bool = False,
         stopping_strategy: Literal["first_exhausted", "all_exhausted", "never_exhausted"] = "first_exhausted",
         output_index_for_resume: bool = False,
@@ -413,7 +479,7 @@ class WeightedMultiSourceDataset(IterableDataset):
         self._level = level
         self._sample_token_len_fn = sample_token_len_fn or self._default_sample_token_len
         self._source_names = list(source_names) if source_names is not None else None
-        self._source_ids = list(source_ids) if source_ids is not None else []
+        self._source_ids: list[SourceId] = list(source_ids) if source_ids is not None else []
         self._upstream_sharded = upstream_sharded
         self._stopping_strategy = stopping_strategy
         self._ds_num = len(self._datasets)
@@ -427,7 +493,8 @@ class WeightedMultiSourceDataset(IterableDataset):
                     self._source_names.append(f"source_{i}")
 
         if not self._source_ids:
-            self._source_ids = copy.deepcopy(self._source_names)
+            assert self._source_names is not None
+            self._source_ids = list(self._source_names)
 
         self._id2dataset = {
             source_id: (dataset, ds_idx)
@@ -444,10 +511,7 @@ class WeightedMultiSourceDataset(IterableDataset):
             raise ValueError("weights length must match datasets length")
         if self._source_names is not None and len(self._source_names) != self._ds_num:
             raise ValueError("source_names length must match datasets length")
-        if len(self._source_ids) != self._ds_num:
-            raise ValueError("source_ids length must match datasets length")
-        if len(set(self._source_ids)) != self._ds_num:
-            raise ValueError("source_ids must be unique")
+        self._source_ids = validate_source_ids(self._source_ids, expected_count=self._ds_num)
         if self._level not in ("sample", "token"):
             raise ValueError("level must be 'sample' or 'token'")
         if self._stopping_strategy not in ("first_exhausted", "all_exhausted", "never_exhausted"):
@@ -460,6 +524,11 @@ class WeightedMultiSourceDataset(IterableDataset):
         self.output_index_for_resume = output_index_for_resume
 
         self._just_resumed = False
+        # Populated only while loading a version-0 checkpoint produced by the
+        # weighted-multisource builder bug that used source names as IDs.
+        # Removed aliases map to None so a newly reused stable ID cannot silently
+        # redirect an old dynamic-batching buffer entry to the wrong source.
+        self._legacy_resume_source_id_map: dict[SourceId, SourceId | None] = {}
 
     @property
     def output_index_for_resume(self) -> bool:
@@ -509,7 +578,7 @@ class WeightedMultiSourceDataset(IterableDataset):
         Raises:
             AttributeError: If the underlying sub-dataset does not provide an index-based fetch API.
         """
-        source_id, idx = resume_index
+        source_id, idx = self.canonicalize_output_index_for_resume(resume_index)
         dataset, ds_idx = self._id2dataset[source_id]
         get_item_fn = getattr(dataset, "get_item", None)
         if callable(get_item_fn):
@@ -517,6 +586,27 @@ class WeightedMultiSourceDataset(IterableDataset):
             sample = self._attach_meta(sample, ds_idx)
             return sample
         raise AttributeError(f"dataset '{source_id}' does not implement get_item")
+
+    def canonicalize_output_index_for_resume(self, resume_index):
+        """Translate a checkpoint buffer index to the current stable source ID.
+
+        Version-0 weighted-multisource checkpoints can contain source-name
+        aliases in dynamic-batching buffers.  ``load_state_dict`` records the
+        unambiguous legacy-name-to-stable-ID mapping so the outer batching
+        dataset can rewrite those entries before its next checkpoint.
+        """
+        if not isinstance(resume_index, (tuple, list)) or len(resume_index) != 2:
+            raise ValueError("weighted multisource resume index must be a (source_id, row_index) pair")
+        source_id, row_index = resume_index
+        source_id = validate_source_id(source_id)
+        if source_id in self._legacy_resume_source_id_map:
+            current_source_id = self._legacy_resume_source_id_map[source_id]
+            if current_source_id is None:
+                raise ValueError(f"checkpoint buffer references removed legacy source alias {source_id!r}")
+            return current_source_id, row_index
+        if source_id in self._id2dataset:
+            return source_id, row_index
+        raise ValueError(f"checkpoint buffer references unknown source_id {source_id!r}")
 
     def set_epoch(self, epoch: int) -> None:
         """Set the epoch for deterministic sampling.
@@ -648,7 +738,9 @@ class WeightedMultiSourceDataset(IterableDataset):
 
         Adds:
             - ``ds_idx``: the integer source index
+            - ``source_id``: the stable source identifier
             - ``source_name``: optional display name if provided
+            - ``_veomni_source_metadata``: the versioned source envelope
 
         Args:
             sample: A sample or list of samples.
@@ -658,18 +750,13 @@ class WeightedMultiSourceDataset(IterableDataset):
             The updated sample (mutated in place when possible).
         """
         source_name = self._source_names[ds_idx] if self._source_names is not None else None
-        if isinstance(sample, list):
-            for item in sample:
-                if isinstance(item, dict):
-                    item["ds_idx"] = ds_idx
-                    if source_name is not None:
-                        item["source_name"] = source_name
-            return sample
-        if isinstance(sample, dict):
-            sample["ds_idx"] = ds_idx
-            if source_name is not None:
-                sample["source_name"] = source_name
-        return sample
+        source_id = self._source_ids[ds_idx]
+        return attach_source_metadata(
+            sample,
+            source_id=source_id,
+            source_name=source_name,
+            ds_idx=ds_idx,
+        )
 
     def _default_sample_token_len(self, sample: Any) -> float:
         """Default heuristic to estimate token length of a sample.
@@ -718,7 +805,7 @@ class WeightedMultiSourceDataset(IterableDataset):
         # save _exhausted state
         exhausted_by_id = {source_id: self._exhausted[idx] for idx, source_id in enumerate(self._source_ids)}
         return {
-            "version": 0,
+            "version": 1,
             "topology": {
                 "source_ids": list(self._source_ids),
                 "source_names": list(self._source_names) if self._source_names is not None else None,
@@ -760,41 +847,116 @@ class WeightedMultiSourceDataset(IterableDataset):
         topology = state["topology"]
         if "source_ids" not in topology:
             raise ValueError("state_dict missing topology.source_ids")
-        saved_source_ids = topology["source_ids"]
-        added = []
-        removed = []
-        if saved_source_ids is not None:
+        version = state.get("version", 0)
+        if isinstance(version, bool) or not isinstance(version, int) or version not in (0, 1):
+            raise ValueError(f"unsupported weighted multisource state version: {version!r}")
+        raw_saved_source_ids = topology["source_ids"]
+        if not isinstance(raw_saved_source_ids, (list, tuple)):
+            raise ValueError("topology.source_ids must be a list or tuple")
+
+        self._legacy_resume_source_id_map = {}
+        saved_source_ids = [validate_source_id(source_id) for source_id in raw_saved_source_ids]
+        saved_runtime_key_by_current_id: dict[SourceId, SourceId] = {}
+
+        saved_source_names = topology.get("source_names")
+        legacy_name_keyed = (
+            version == 0
+            and isinstance(saved_source_names, (list, tuple))
+            and len(saved_source_names) == len(saved_source_ids)
+            and all(
+                type(source_id) is type(source_name) and source_id == source_name
+                for source_id, source_name in zip(saved_source_ids, saved_source_names)
+            )
+        )
+        if legacy_name_keyed:
+            if not all(isinstance(source_name, str) for source_name in saved_source_names):
+                raise ValueError("legacy weighted multisource source_names must contain only strings")
+            if len(set(saved_source_names)) != len(saved_source_names):
+                raise ValueError("ambiguous legacy source_names in version-0 checkpoint")
+            if self._source_names is None or not all(isinstance(name, str) for name in self._source_names):
+                raise ValueError("current weighted multisource source_names must contain only strings")
+            if len(set(self._source_names)) != len(self._source_names):
+                raise ValueError("ambiguous current source_names while migrating version-0 checkpoint")
+
+            current_id_by_name = dict(zip(self._source_names, self._source_ids))
+            current_index_by_id = {source_id: idx for idx, source_id in enumerate(self._source_ids)}
+            for legacy_name in saved_source_names:
+                current_id = current_id_by_name.get(legacy_name)
+                self._legacy_resume_source_id_map[legacy_name] = current_id
+                if current_id is None:
+                    continue
+                conflicting_idx = current_index_by_id.get(legacy_name)
+                if conflicting_idx is not None and self._source_ids[conflicting_idx] != current_id:
+                    raise ValueError(
+                        f"legacy source alias {legacy_name!r} conflicts with current source_id "
+                        f"owned by source_name {self._source_names[conflicting_idx]!r}"
+                    )
+                saved_runtime_key_by_current_id[current_id] = legacy_name
+
+            saved_names_set = set(saved_source_names)
+            current_names_set = set(self._source_names)
+            added = [
+                source_id
+                for source_name, source_id in zip(self._source_names, self._source_ids)
+                if source_name not in saved_names_set
+            ]
+            removed = [source_name for source_name in saved_source_names if source_name not in current_names_set]
+
+            for field_name in ("avg_len_sum", "avg_len_count", "dataset_states", "exhausted"):
+                field = runtime.get(field_name)
+                if field is None and field_name == "exhausted":
+                    continue
+                if isinstance(field, dict):
+                    unknown_keys = [key for key in field if key not in saved_names_set]
+                    if unknown_keys:
+                        raise ValueError(
+                            f"runtime.{field_name} contains keys outside legacy topology.source_ids: {unknown_keys}"
+                        )
+        else:
+            saved_source_ids = validate_source_ids(saved_source_ids, expected_count=len(saved_source_ids))
             saved_set = set(saved_source_ids)
+            current_set = set(self._source_ids)
             added = [source_id for source_id in self._source_ids if source_id not in saved_set]
-            removed = [source_id for source_id in saved_source_ids if source_id not in set(self._source_ids)]
-            if added or removed:
-                if reconcile_policy == "strict":
-                    raise ValueError(
-                        f"source_ids mismatch: added={added} removed={removed} with policy={reconcile_policy}"
-                    )
-                if reconcile_policy == "allow_add" and removed:
-                    raise ValueError(
-                        f"source_ids removed not allowed: removed={removed} with policy={reconcile_policy}"
-                    )
-                if reconcile_policy == "warn_only":
-                    logger.warning(
-                        f"source_ids changed: added={added} removed={removed} with policy={reconcile_policy}"
-                    )
+            removed = [source_id for source_id in saved_source_ids if source_id not in current_set]
+            saved_runtime_key_by_current_id = {
+                source_id: source_id for source_id in self._source_ids if source_id in saved_set
+            }
+
+        if added or removed:
+            if reconcile_policy == "strict":
+                raise ValueError(
+                    f"source_ids mismatch: added={added} removed={removed} with policy={reconcile_policy}"
+                )
+            if reconcile_policy == "allow_add" and removed:
+                raise ValueError(f"source_ids removed not allowed: removed={removed} with policy={reconcile_policy}")
+            if reconcile_policy == "warn_only":
+                logger.warning(f"source_ids changed: added={added} removed={removed} with policy={reconcile_policy}")
         random_state = runtime["random_state"]
         self._random_state.set_state(random_state)
         avg_len_sum = runtime["avg_len_sum"]
         avg_len_count = runtime["avg_len_count"]
         if not isinstance(avg_len_sum, dict) or not isinstance(avg_len_count, dict):
             raise ValueError("runtime.avg_len_sum and runtime.avg_len_count must be dicts keyed by source_id")
-        self._avg_len_sum = [float(avg_len_sum.get(source_id, 0.0)) for source_id in self._source_ids]
-        self._avg_len_count = [int(avg_len_count.get(source_id, 0)) for source_id in self._source_ids]
+        self._avg_len_sum = [
+            float(avg_len_sum.get(saved_runtime_key_by_current_id[source_id], 0.0))
+            if source_id in saved_runtime_key_by_current_id
+            else 0.0
+            for source_id in self._source_ids
+        ]
+        self._avg_len_count = [
+            int(avg_len_count.get(saved_runtime_key_by_current_id[source_id], 0))
+            if source_id in saved_runtime_key_by_current_id
+            else 0
+            for source_id in self._source_ids
+        ]
         self._global_sample_idx = runtime.get("global_sample_idx", 0)
         dataset_states = runtime["dataset_states"]
         if not isinstance(dataset_states, dict):
             raise ValueError("runtime.dataset_states must be a dict keyed by source_id")
         dataset_states_by_id = dataset_states
         for dataset, source_id in zip(self._datasets, self._source_ids):
-            ds_state = dataset_states_by_id.get(source_id)
+            saved_runtime_key = saved_runtime_key_by_current_id.get(source_id)
+            ds_state = dataset_states_by_id.get(saved_runtime_key) if saved_runtime_key is not None else None
             if ds_state is None:
                 continue
             load_state_fn = getattr(dataset, "load_state_dict", None)
@@ -805,7 +967,12 @@ class WeightedMultiSourceDataset(IterableDataset):
         # This is important when sources are added/removed during checkpoint resume
         if "exhausted" in runtime and isinstance(runtime["exhausted"], dict):
             exhausted_dict = runtime["exhausted"]
-            self._exhausted = [bool(exhausted_dict.get(source_id, False)) for source_id in self._source_ids]
+            self._exhausted = [
+                bool(exhausted_dict.get(saved_runtime_key_by_current_id[source_id], False))
+                if source_id in saved_runtime_key_by_current_id
+                else False
+                for source_id in self._source_ids
+            ]
         else:
             self._exhausted = [False for _ in range(self._ds_num)]
 
@@ -1149,11 +1316,20 @@ class DynamicBatchingSizeDataset(IterableDataset):
                 checkpoint buffer holds some full samples instead of indices (incompatible
                 checkpoint format).
         """
+        # Restore the upstream dataset before rebuilding an index-only buffer.
+        # In particular, a version-0 WeightedMultiSourceDataset checkpoint must
+        # first establish its legacy source-name -> stable-ID migration map, and
+        # some upstream get_item implementations depend on restored state.
+        if "dynamic_batch_upstream_dataset_state" in state_dict:
+            self.dataset.load_state_dict(state_dict["dynamic_batch_upstream_dataset_state"])
+
         # prev_save_by_idx does not have to be equal to self.save_by_idx, however, we still need to resume the buffer according to it.
         prev_save_by_idx = state_dict["save_by_idx"]
         if prev_save_by_idx:
             self._buffer = []
             self._buffer_of_output_index = []
+            self._buffer_token_count = 0
+            self._buffer_physical_token_count = 0
             cached_output_index = None
             cached_restored_samples = None
             for output_index_entry in state_dict["buffer"]:
@@ -1161,6 +1337,14 @@ class DynamicBatchingSizeDataset(IterableDataset):
                 # ``output_index`` identifies the upstream item and ``sample_idx``
                 # selects one sample after flattening a possible ``list[dict]``.
                 output_index, sample_idx = output_index_entry
+                canonicalize_output_index = getattr(
+                    self.dataset,
+                    "canonicalize_output_index_for_resume",
+                    None,
+                )
+                if callable(canonicalize_output_index):
+                    output_index = canonicalize_output_index(output_index)
+                canonical_output_index_entry = (output_index, sample_idx)
                 if output_index != cached_output_index:
                     restored_item = self.dataset.get_item(output_index)
                     cached_restored_samples = restored_item if isinstance(restored_item, list) else [restored_item]
@@ -1172,7 +1356,7 @@ class DynamicBatchingSizeDataset(IterableDataset):
                 )
                 self._buffer.append((restored_sample, length, physical_length))
                 if self.save_by_idx:
-                    self._buffer_of_output_index.append(output_index_entry)
+                    self._buffer_of_output_index.append(canonical_output_index_entry)
                 self._buffer_token_count += length
                 self._buffer_physical_token_count += physical_length
         else:
@@ -1204,10 +1388,6 @@ class DynamicBatchingSizeDataset(IterableDataset):
         assert self._buffer_physical_token_count == sum(
             item[2] if len(item) > 2 else item[1] for item in self._buffer
         ), "buffer_physical_token_count does not match the sum of physical lengths in buffer"
-        del state_dict["buffer"]
-
-        if "dynamic_batch_upstream_dataset_state" in state_dict:
-            self.dataset.load_state_dict(state_dict["dynamic_batch_upstream_dataset_state"])
 
         self._just_resumed = True
 
@@ -1323,6 +1503,7 @@ def build_interleave_dataset(
     namespace: Literal["train", "test"] = "train",
     transform: Optional[Callable] = None,
     seed: int = 42,
+    shuffle: bool = True,
     **kwargs,
 ):
     """
@@ -1333,6 +1514,7 @@ def build_interleave_dataset(
         namespace (Literal["train", "test"]): dataset namespace
         transform (Optional[Callable]): transform function
         seed (int): random seed
+        shuffle (bool): whether to shuffle each iterable source
     Returns:
         InterleavedIterableDataset: interleaved iterable dataset
         or
@@ -1344,6 +1526,10 @@ def build_interleave_dataset(
     sources = multisource_config["sources"]
     schedule = multisource_config["schedule"]
     source_names = multisource_config["names"]
+    source_ids = validate_source_ids(
+        multisource_config.get("source_ids", source_names),
+        expected_count=len(sources),
+    )
 
     if len(schedule) > 1 or schedule[0]["schedule_type"] != "const":
         logger.info_rank0("Interleaved dataset only supports const schedule type.")
@@ -1356,12 +1542,22 @@ def build_interleave_dataset(
 
         def add_ds_idx_to_iterable(dataset, ds_idx, source_name):
             def trans_example(example):
-                return {**example, "ds_idx": ds_idx, "source_name": source_name}
+                return {
+                    **example,
+                    "ds_idx": ds_idx,
+                    "source_name": source_name,
+                }
 
             return dataset.map(trans_example)
 
         for idx, source in enumerate(sources):
-            dataset = build_iterable_dataset(source, namespace=namespace, seed=seed, split_by_node=False)
+            dataset = build_iterable_dataset(
+                source,
+                namespace=namespace,
+                seed=seed,
+                split_by_node=False,
+                shuffle=shuffle,
+            )
             ds = dataset._data
             ds = add_ds_idx_to_iterable(ds, idx, source_names[idx])
             datasets.append(ds)
@@ -1374,6 +1570,7 @@ def build_interleave_dataset(
         interleave_dataset = InterleavedIterableDataset(
             interleave_dataset,
             transform=transform,
+            source_ids=source_ids,
         )
     elif datasets_type == "mapping":
         logger.info_rank0("Start building mapping multisource dataset")
@@ -1387,6 +1584,7 @@ def build_interleave_dataset(
         interleave_dataset = InterleavedMappingDataset(
             interleave_datasets(datasets=datasets, probabilities=weights, seed=seed),
             transform=transform,
+            source_ids=source_ids,
         )
     else:
         raise ValueError(f"Unsupported datasets_type: {datasets_type}")
@@ -1508,7 +1706,7 @@ def build_weighted_multisource_dataset(
     sources = multisource_config["sources"]
     source_names = multisource_config.get("names")
     source_ids = multisource_config.get(
-        "source_names", source_names
+        "source_ids", source_names
     )  # if source_ids is not provided, use source_names as source_ids
 
     level = multisource_config.get("level", "sample")

--- a/veomni/data/source_metadata.py
+++ b/veomni/data/source_metadata.py
@@ -1,0 +1,298 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Sequence
+from typing import Any, TypeAlias, cast
+
+
+SOURCE_METADATA_VERSION = 1
+SOURCE_METADATA_KEY = "_veomni_source_metadata"
+PACKED_SOURCE_METADATA_KEY = "_veomni_packed_source_metadata"
+PACKED_SOURCE_COORDINATE_SPACE = "packed_pre_sp"
+SOURCE_DIAGNOSTIC_FIELDS = ("row_id", "sample_id", "part_index")
+LEGACY_SOURCE_NAME_KEYS = ("channel_name", "source_name", "dataset_name", "data_name")
+INTERNAL_SOURCE_METADATA_KEYS = frozenset(
+    {
+        SOURCE_METADATA_KEY,
+        PACKED_SOURCE_METADATA_KEY,
+        "channel_id",
+        "ds_idx",
+        "dataset_id",
+        "source_id",
+        *LEGACY_SOURCE_NAME_KEYS,
+        "cur_token_num",
+        *SOURCE_DIAGNOSTIC_FIELDS,
+    }
+)
+SOURCE_METADATA_ENVELOPE_KEYS = frozenset(
+    {
+        SOURCE_METADATA_KEY,
+        PACKED_SOURCE_METADATA_KEY,
+    }
+)
+LEGACY_SOURCE_METADATA_KEYS = INTERNAL_SOURCE_METADATA_KEYS - SOURCE_METADATA_ENVELOPE_KEYS
+
+SourceId: TypeAlias = int | str
+
+
+def validate_source_id(source_id: object) -> SourceId:
+    """Return a source ID after enforcing its stable primitive representation."""
+    if type(source_id) not in (int, str):
+        raise ValueError("source_ids must contain only int or str values; bool is not supported")
+    return cast(SourceId, source_id)
+
+
+def validate_source_ids(source_ids: Sequence[object], *, expected_count: int) -> list[SourceId]:
+    """Validate source IDs as unique typed primitives aligned with the sources."""
+    if len(source_ids) != expected_count:
+        raise ValueError("source_ids length must match datasets length")
+    validated = [validate_source_id(source_id) for source_id in source_ids]
+    if len(set(validated)) != expected_count:
+        raise ValueError("source_ids must be unique")
+    return validated
+
+
+def _validate_diagnostic_field(name: str, value: object) -> int | str:
+    if name == "part_index":
+        if type(value) is not int:
+            raise ValueError("part_index must be an int")
+    elif type(value) not in (int, str):
+        raise ValueError(f"{name} must be an int or str")
+    return cast(int | str, value)
+
+
+def make_source_metadata(
+    source_id: SourceId,
+    source_name: str | None,
+    *,
+    row_id: int | str | None = None,
+    sample_id: int | str | None = None,
+    part_index: int | None = None,
+) -> dict[str, Any]:
+    """Build the versioned metadata envelope attached to a transformed sample."""
+    source_id = validate_source_id(source_id)
+    if source_name is not None and not isinstance(source_name, str):
+        raise ValueError("source_name must be a str or None")
+    metadata = {
+        "schema_version": SOURCE_METADATA_VERSION,
+        "source_id": source_id,
+    }
+    if source_name is not None:
+        metadata["source_name"] = source_name
+    diagnostics = {
+        "row_id": row_id,
+        "sample_id": sample_id,
+        "part_index": part_index,
+    }
+    for name, value in diagnostics.items():
+        if value is not None:
+            metadata[name] = _validate_diagnostic_field(name, value)
+    return metadata
+
+
+def normalize_source_metadata(metadata: object) -> dict[str, Any]:
+    """Validate a raw metadata envelope and copy only its public fields."""
+    if not isinstance(metadata, dict):
+        raise ValueError(f"{SOURCE_METADATA_KEY} must be a dict")
+    if metadata.get("schema_version") != SOURCE_METADATA_VERSION:
+        raise ValueError(f"{SOURCE_METADATA_KEY}.schema_version must be {SOURCE_METADATA_VERSION}")
+    if "source_id" not in metadata:
+        raise ValueError(f"{SOURCE_METADATA_KEY}.source_id is required")
+    source_name = metadata.get("source_name")
+    if source_name is not None and not isinstance(source_name, str):
+        raise ValueError(f"{SOURCE_METADATA_KEY}.source_name must be a str")
+    normalized = make_source_metadata(metadata["source_id"], source_name)
+    for name in SOURCE_DIAGNOSTIC_FIELDS:
+        if name in metadata:
+            normalized[name] = _validate_diagnostic_field(name, metadata[name])
+    return normalized
+
+
+def _normalize_packed_segment(
+    segment: object,
+    *,
+    expected_segment_index: int,
+    expected_token_start: int,
+) -> dict[str, Any]:
+    if not isinstance(segment, dict):
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.segments entries must be dicts")
+    source_id = validate_source_id(segment.get("source_id"))
+    source_name = segment.get("source_name")
+    if source_name is not None and not isinstance(source_name, str):
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.segments source_name must be a str")
+    coordinate_names = (
+        "segment_index",
+        "sample_index",
+        "subsegment_index",
+        "token_start",
+        "token_length",
+    )
+    raw_integer_fields = {name: segment.get(name) for name in coordinate_names}
+    if any(type(value) is not int for value in raw_integer_fields.values()):
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.segments coordinate fields must be ints")
+    integer_fields = cast(dict[str, int], raw_integer_fields)
+    if integer_fields["segment_index"] != expected_segment_index:
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.segments segment_index must be contiguous")
+    if integer_fields["sample_index"] < 0 or integer_fields["subsegment_index"] < 0:
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.segments sample indices must be non-negative")
+    if integer_fields["token_start"] != expected_token_start or integer_fields["token_length"] <= 0:
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.segments token coordinates must be contiguous and non-empty")
+
+    normalized: dict[str, Any] = {
+        "source_id": source_id,
+        **({"source_name": source_name} if source_name is not None else {}),
+    }
+    for name in SOURCE_DIAGNOSTIC_FIELDS:
+        if name in segment:
+            normalized[name] = _validate_diagnostic_field(name, segment[name])
+    normalized.update(integer_fields)
+    return normalized
+
+
+def make_packed_source_metadata(segments: list[dict], *, valid_token_count: int) -> dict[str, Any]:
+    """Build a packed, pre-sequence-parallel metadata envelope."""
+    if type(valid_token_count) is not int or valid_token_count < 0:
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.valid_token_count must be a non-negative int")
+    normalized_segments = []
+    expected_token_start = 0
+    current_sample_index = 0
+    next_subsegment_index = 0
+    for segment_index, segment in enumerate(segments):
+        normalized = _normalize_packed_segment(
+            segment,
+            expected_segment_index=segment_index,
+            expected_token_start=expected_token_start,
+        )
+        sample_index = normalized["sample_index"]
+        subsegment_index = normalized["subsegment_index"]
+        if segment_index == 0:
+            valid_sample_order = sample_index == 0 and subsegment_index == 0
+        elif sample_index == current_sample_index:
+            valid_sample_order = subsegment_index == next_subsegment_index
+        else:
+            valid_sample_order = sample_index == current_sample_index + 1 and subsegment_index == 0
+        if not valid_sample_order:
+            raise ValueError(
+                f"{PACKED_SOURCE_METADATA_KEY}.segments sample_index/subsegment_index must start at 0 "
+                "and advance contiguously"
+            )
+        if sample_index != current_sample_index:
+            current_sample_index = sample_index
+            next_subsegment_index = 0
+        next_subsegment_index += 1
+        normalized_segments.append(normalized)
+        expected_token_start += normalized["token_length"]
+    if expected_token_start != valid_token_count:
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.valid_token_count must equal the covered segment token count")
+    source_name_presence = {"source_name" in segment for segment in normalized_segments}
+    if len(source_name_presence) > 1:
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.segments source_name must be present on all segments or none")
+    source_names_by_typed_id: dict[tuple[type, SourceId], str] = {}
+    for segment in normalized_segments:
+        if "source_name" not in segment:
+            continue
+        typed_source_id = (type(segment["source_id"]), segment["source_id"])
+        source_name = segment["source_name"]
+        previous_name = source_names_by_typed_id.setdefault(typed_source_id, source_name)
+        if previous_name != source_name:
+            raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.segments with the same source_id must use one source_name")
+    return {
+        "schema_version": SOURCE_METADATA_VERSION,
+        "coordinate_space": PACKED_SOURCE_COORDINATE_SPACE,
+        "valid_token_count": valid_token_count,
+        "segments": normalized_segments,
+    }
+
+
+def normalize_packed_source_metadata(metadata: object) -> dict[str, Any]:
+    """Validate the packed envelope without accepting a legacy fallback."""
+    if not isinstance(metadata, dict):
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY} must be a dict")
+    if metadata.get("schema_version") != SOURCE_METADATA_VERSION:
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.schema_version must be {SOURCE_METADATA_VERSION}")
+    if metadata.get("coordinate_space") != PACKED_SOURCE_COORDINATE_SPACE:
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.coordinate_space must be {PACKED_SOURCE_COORDINATE_SPACE!r}")
+    segments = metadata.get("segments")
+    if not isinstance(segments, list):
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.segments must be a list")
+    valid_token_count = metadata.get("valid_token_count")
+    if type(valid_token_count) is not int:
+        raise ValueError(f"{PACKED_SOURCE_METADATA_KEY}.valid_token_count must be a non-negative int")
+    return make_packed_source_metadata(
+        segments,
+        valid_token_count=valid_token_count,
+    )
+
+
+def attach_source_metadata(
+    sample: Any,
+    *,
+    source_id: SourceId,
+    source_name: str | None,
+    ds_idx: int | None = None,
+) -> Any:
+    """Attach canonical and compatibility source fields after data transforms."""
+    source_id = validate_source_id(source_id)
+    if isinstance(sample, list):
+        for part_index, item in enumerate(sample):
+            if isinstance(item, dict):
+                existing_metadata = item.get(SOURCE_METADATA_KEY)
+                has_part_index = "part_index" in item or (
+                    isinstance(existing_metadata, dict) and "part_index" in existing_metadata
+                )
+                if not has_part_index:
+                    item["part_index"] = part_index
+            attach_source_metadata(
+                item,
+                source_id=source_id,
+                source_name=source_name,
+                ds_idx=ds_idx,
+            )
+        return sample
+    if not isinstance(sample, dict):
+        return sample
+
+    existing_metadata = sample.get(SOURCE_METADATA_KEY)
+    diagnostics = {}
+    if isinstance(existing_metadata, dict):
+        diagnostics.update(
+            {name: existing_metadata[name] for name in SOURCE_DIAGNOSTIC_FIELDS if name in existing_metadata}
+        )
+    diagnostics.update({name: sample[name] for name in SOURCE_DIAGNOSTIC_FIELDS if name in sample})
+
+    if ds_idx is not None:
+        sample["ds_idx"] = ds_idx
+    sample["source_id"] = source_id
+    for key in LEGACY_SOURCE_NAME_KEYS:
+        sample.pop(key, None)
+    if source_name is not None:
+        sample["source_name"] = source_name
+    sample[SOURCE_METADATA_KEY] = make_source_metadata(source_id, source_name, **diagnostics)
+    return sample
+
+
+def strip_source_metadata(model_inputs: dict[str, Any], *, strip_legacy: bool = False) -> None:
+    """Remove source-observation fields before invoking a model.
+
+    The namespaced canonical envelopes always belong to VeOmni. Generic keys
+    such as ``source_id`` and ``sample_id`` are removed only when an envelope
+    establishes ownership, or when the caller explicitly owns the legacy
+    multisource contract. This preserves unrelated custom-model inputs.
+    """
+    owns_legacy_fields = strip_legacy or any(key in model_inputs for key in SOURCE_METADATA_ENVELOPE_KEYS)
+    for key in SOURCE_METADATA_ENVELOPE_KEYS:
+        model_inputs.pop(key, None)
+    if owns_legacy_fields:
+        for key in LEGACY_SOURCE_METADATA_KEYS:
+            model_inputs.pop(key, None)

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -77,6 +77,7 @@ from ..utils.loss_utils import count_loss_token, mean_global_loss
 from ..utils.model_utils import pretty_print_trainable_parameters
 from .callbacks import (
     ChannelLossCallback,
+    ChannelLossDashboardCallback,
     CheckpointerCallback,
     EnvironMeterCallback,
     EvaluateCallback,
@@ -600,6 +601,8 @@ class BaseTrainer(Stateful, ABC):
         self.evaluate_callback = EvaluateCallback(self)
         self.moe_monitor_callback = MoERouterMonitorCallback(self)
         self.channel_loss_callback = ChannelLossCallback(self)
+        self._channel_loss_trace_step_id: Any = None
+        self.channel_loss_dashboard_callback = ChannelLossDashboardCallback(self)
         # Ordered dispatch list. Callbacks own their ParallelState explicitly:
         # each captured it at construction (``Callback.parallel_state``), and
         # ChannelLossComputer receives that same cached state. Shared objects
@@ -608,13 +611,15 @@ class BaseTrainer(Stateful, ABC):
         #
         # ``channel_loss_callback`` is ordered after the meter for
         # ``on_step_end`` (the meter resets ``step_*_metrics``) and before
-        # ``wandb`` (which logs them), so its per-source metrics survive into
-        # the logged payload. ``on_step_begin`` snapshots channel metadata first
-        # because multi-source accounting consumes it.
+        # ``channel_loss_dashboard_callback`` and ``wandb``, so both the compact
+        # dashboard and the native scalar payload observe the completed source
+        # metrics. ``on_step_begin`` snapshots channel metadata first because
+        # multi-source accounting consumes it.
         self._callbacks = [
             self.environ_meter_callback,
             self.tqdm_callback,
             self.channel_loss_callback,
+            self.channel_loss_dashboard_callback,
             self.wandb_callback,
             self.profile_callback,
             self.checkpointer_callback,
@@ -623,6 +628,18 @@ class BaseTrainer(Stateful, ABC):
             self.moe_monitor_callback,
         ]
         self.state = TrainerState()
+
+    def set_channel_loss_trace_step_id(self, trace_step_id: Any) -> None:
+        """Attach one opaque dataloader trace ID to the current optimizer step."""
+
+        self._channel_loss_trace_step_id = trace_step_id
+
+    def pop_channel_loss_trace_step_id(self) -> Any:
+        """Consume the current trace ID so it cannot leak into a later step."""
+
+        trace_step_id = self._channel_loss_trace_step_id
+        self._channel_loss_trace_step_id = None
+        return trace_step_id
 
     def on_train_begin(self):
         for callback in self._callbacks:

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -657,14 +657,19 @@ class BaseTrainer(Stateful, ABC):
         for callback in self._callbacks:
             callback.on_epoch_end(self.state)
 
-    def on_step_begin(self, micro_batches=None, **kwargs):
+    def on_step_begin(self, micro_batches=None, channel_loss_source_repeat: int = 1, **kwargs):
         # Multi-source accounting consumes ``ds_idx`` / ``source_name`` from the
         # micro-batches. Channel loss must snapshot that metadata first, while
         # keeping its on_step_end position after the meter so its metrics are not
         # overwritten by the meter's per-step reset.
         channel_loss_callback = getattr(self, "channel_loss_callback", None)
         if channel_loss_callback is not None:
-            channel_loss_callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
+            channel_loss_callback.on_step_begin(
+                self.state,
+                micro_batches=micro_batches,
+                source_repeat=channel_loss_source_repeat,
+                **kwargs,
+            )
         for callback in self._callbacks:
             if callback is channel_loss_callback:
                 continue

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -56,6 +56,7 @@ from ..data import (
 from ..data.chat_template import ChatTemplate
 from ..data.data_collator import DataCollator, MainCollator
 from ..data.data_transform import build_data_transform
+from ..data.source_metadata import strip_source_metadata
 from ..distributed.chunk_mbs import build_chunk_mbs_ranges, chunk_mbs_context
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
 from ..distributed.offloading import build_activation_offloading_context
@@ -679,7 +680,7 @@ class BaseTrainer(Stateful, ABC):
         for callback in self._callbacks:
             callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
 
-    def preforward(self, micro_batch: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def preforward(self, micro_batch: Dict[str, Any]) -> Dict[str, Any]:
         """Preprocess micro batches before forward pass.
 
         Tensors are moved to ``self.device`` non-blockingly. Nested dicts
@@ -697,6 +698,10 @@ class BaseTrainer(Stateful, ABC):
 
         chunk_mbs_config = getattr(self.args.train, "chunk_mbs_config", None)
         self._chunk_mbs_ranges = build_chunk_mbs_ranges(micro_batch, chunk_mbs_config)
+        strip_source_metadata(
+            micro_batch,
+            strip_legacy=bool(getattr(getattr(self.args, "data", None), "enable_multisource", False)),
+        )
         micro_batch = {k: _to_device(v) for k, v in micro_batch.items()}
         if getattr(self, "LOG_SAMPLE", True):
             helper.print_example(example=micro_batch, rank=self.args.train.local_rank)

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -606,9 +606,11 @@ class BaseTrainer(Stateful, ABC):
         # (EnvironMeter, DCP checkpointer) are handed the state directly, so
         # no ambient ``use_parallel_state`` scope is needed around hook dispatch.
         #
-        # ``channel_loss_callback`` is ordered after the meter (which resets
-        # ``step_*_metrics`` in ``on_step_end``) and before ``wandb`` (which
-        # logs them), so its per-source metrics survive into the logged payload.
+        # ``channel_loss_callback`` is ordered after the meter for
+        # ``on_step_end`` (the meter resets ``step_*_metrics``) and before
+        # ``wandb`` (which logs them), so its per-source metrics survive into
+        # the logged payload. ``on_step_begin`` snapshots channel metadata first
+        # because multi-source accounting consumes it.
         self._callbacks = [
             self.environ_meter_callback,
             self.tqdm_callback,
@@ -639,7 +641,16 @@ class BaseTrainer(Stateful, ABC):
             callback.on_epoch_end(self.state)
 
     def on_step_begin(self, micro_batches=None, **kwargs):
+        # Multi-source accounting consumes ``ds_idx`` / ``source_name`` from the
+        # micro-batches. Channel loss must snapshot that metadata first, while
+        # keeping its on_step_end position after the meter so its metrics are not
+        # overwritten by the meter's per-step reset.
+        channel_loss_callback = getattr(self, "channel_loss_callback", None)
+        if channel_loss_callback is not None:
+            channel_loss_callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
         for callback in self._callbacks:
+            if callback is channel_loss_callback:
+                continue
             callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
 
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):

--- a/veomni/trainer/callbacks/__init__.py
+++ b/veomni/trainer/callbacks/__init__.py
@@ -20,6 +20,7 @@ Provides callback system for customizing trainer behavior at various stages of t
 
 from .base import Callback, TrainerState
 from .channel_loss_callback import ChannelLossCallback, ChannelLossComputer
+from .channel_loss_dashboard import ChannelLossDashboardCallback, ChannelLossDashboardData
 from .checkpoint_callback import CheckpointerCallback, HFLoraCkptCallback, HuggingfaceCkptCallback
 from .evaluate_callback import EvaluateCallback
 from .trace_callback import (
@@ -36,6 +37,8 @@ __all__ = [
     "TrainerState",
     "ChannelLossCallback",
     "ChannelLossComputer",
+    "ChannelLossDashboardCallback",
+    "ChannelLossDashboardData",
     "CheckpointerCallback",
     "HuggingfaceCkptCallback",
     "HFLoraCkptCallback",

--- a/veomni/trainer/callbacks/channel_loss_callback.py
+++ b/veomni/trainer/callbacks/channel_loss_callback.py
@@ -103,6 +103,7 @@ class ChannelLossComputer:
         self._per_mb_attention_masks: list[torch.Tensor | None] = []
         self._micro_step = 0
         self.step_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor]] = {}
+        self.step_data_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         self.source_names: dict[ChannelKey, str] = {}
         self.strict = False
 
@@ -299,6 +300,7 @@ class ChannelLossComputer:
         self._per_mb_attention_masks = per_mb_attention_masks
         self._micro_step = 0
         self.step_totals = {}
+        self.step_data_totals = {}
 
     def before_micro_step(self) -> None:
         step = self._micro_step
@@ -318,11 +320,23 @@ class ChannelLossComputer:
                 source_id = item["source_id"]
                 loss_sum = item["loss_sum"].detach()
                 token_count = item["token_count"].detach()
+                sample_count = item["sample_count"].detach()
+                input_token_count = item["input_token_count"].detach()
                 previous = self.step_totals.get(source_id)
                 if previous is None:
                     self.step_totals[source_id] = (loss_sum, token_count)
                 else:
                     self.step_totals[source_id] = (previous[0] + loss_sum, previous[1] + token_count)
+
+                data_previous = self.step_data_totals.get(source_id)
+                if data_previous is None:
+                    self.step_data_totals[source_id] = (sample_count, input_token_count, token_count)
+                else:
+                    self.step_data_totals[source_id] = (
+                        data_previous[0] + sample_count,
+                        data_previous[1] + input_token_count,
+                        data_previous[2] + token_count,
+                    )
         self._source_ids = []
         self._position_ids = None
         self._attention_mask = None
@@ -436,6 +450,7 @@ class ChannelLossComputer:
             sp_enabled=sp_enabled,
             parallel_state=self.parallel_state,
             strict=self.strict,
+            include_data_stats=True,
         )
 
     def _per_token_ce(
@@ -511,6 +526,7 @@ class ChannelLossComputer:
         sp_enabled: bool = False,
         parallel_state: ParallelState | None = None,
         strict: bool = False,
+        include_data_stats: bool = False,
     ) -> list[dict[str, Any]]:
         if not source_ids:
             return []
@@ -542,6 +558,7 @@ class ChannelLossComputer:
                     ignore_index=ignore_index,
                     parallel_state=parallel_state,
                     strict=strict,
+                    include_data_stats=include_data_stats,
                 )
 
             row_width = pos_2d.size(1)
@@ -579,16 +596,24 @@ class ChannelLossComputer:
         for i, (_, start, end) in enumerate(segments):
             labels_slice = labels_flat[start : end + 1]
             loss_slice = per_token_loss[start : end + 1]
+            mask_slice = attention_mask_flat[start : end + 1] if attention_mask_flat is not None else None
             valid = labels_slice != ignore_index
             token_count = valid.sum()
             loss_sum = loss_slice[valid].sum()
-            channel_loss.append(
-                {
-                    "source_id": source_ids[i],
-                    "loss_sum": loss_sum,
-                    "token_count": token_count,
-                }
+            input_token_count = (
+                mask_slice.to(torch.bool).sum(dtype=torch.int64)
+                if mask_slice is not None
+                else torch.as_tensor(labels_slice.numel(), device=labels_slice.device, dtype=torch.int64)
             )
+            item = {
+                "source_id": source_ids[i],
+                "loss_sum": loss_sum,
+                "token_count": token_count,
+            }
+            if include_data_stats:
+                item["sample_count"] = torch.ones((), device=labels_slice.device, dtype=torch.int64)
+                item["input_token_count"] = input_token_count
+            channel_loss.append(item)
         return channel_loss
 
     @staticmethod
@@ -602,6 +627,7 @@ class ChannelLossComputer:
         ignore_index: int,
         parallel_state: ParallelState | None = None,
         strict: bool = False,
+        include_data_stats: bool = False,
     ) -> list[dict[str, Any]]:
         if parallel_state is None:
             raise ValueError("parallel_state is required for SP channel-loss aggregation.")
@@ -638,6 +664,11 @@ class ChannelLossComputer:
             valid = labels_slice != ignore_index
             token_count = valid.sum(dtype=torch.int64)
             loss_sum = loss_slice[valid].sum()
+            input_token_count = (
+                mask_slice.to(torch.bool).sum(dtype=torch.int64)
+                if mask_slice is not None
+                else torch.as_tensor(labels_slice.numel(), device=labels_slice.device, dtype=torch.int64)
+            )
             false_flag = torch.zeros((), dtype=torch.bool, device=labels_slice.device)
             has_explicit_padding_mask = (
                 ~mask_slice.to(torch.bool).any()
@@ -645,18 +676,20 @@ class ChannelLossComputer:
                 else false_flag
             )
             has_only_zero_positions = bool(pos_slice.eq(0).all().tolist()) if pos_slice.numel() > 0 else False
-            segments.append(
-                {
-                    "batch_idx": batch_idx,
-                    "sp_rank": sp_rank,
-                    "local_order": local_order,
-                    "is_start": is_start,
-                    "has_explicit_padding_mask": has_explicit_padding_mask,
-                    "has_only_zero_positions": has_only_zero_positions,
-                    "loss_sum": loss_sum,
-                    "token_count": token_count,
-                }
-            )
+            segment = {
+                "batch_idx": batch_idx,
+                "sp_rank": sp_rank,
+                "local_order": local_order,
+                "is_start": is_start,
+                "has_explicit_padding_mask": has_explicit_padding_mask,
+                "has_only_zero_positions": has_only_zero_positions,
+                "loss_sum": loss_sum,
+                "token_count": token_count,
+            }
+            if include_data_stats:
+                segment["sample_count"] = torch.as_tensor(int(is_start), device=labels_slice.device, dtype=torch.int64)
+                segment["input_token_count"] = input_token_count
+            segments.append(segment)
 
         for batch_idx, row_pos in enumerate(positions_cpu):
             row_len = min(local_width, max(seq_len - batch_idx * local_width, 0))
@@ -683,15 +716,24 @@ class ChannelLossComputer:
             device=per_token_loss.device,
             parallel_state=parallel_state,
             strict=strict,
+            include_data_stats=include_data_stats,
         )
-        return [
-            {
+        result = []
+        for item in reduced:
+            converted = {
                 "source_id": item["source_id"],
                 "loss_sum": torch.as_tensor(item["loss_sum"], device=per_token_loss.device, dtype=torch.float32),
                 "token_count": torch.as_tensor(item["token_count"], device=per_token_loss.device, dtype=torch.int64),
             }
-            for item in reduced
-        ]
+            if include_data_stats:
+                converted["sample_count"] = torch.as_tensor(
+                    item["sample_count"], device=per_token_loss.device, dtype=torch.int64
+                )
+                converted["input_token_count"] = torch.as_tensor(
+                    item["input_token_count"], device=per_token_loss.device, dtype=torch.int64
+                )
+            result.append(converted)
+        return result
 
     @staticmethod
     def _reduce_sp(
@@ -700,6 +742,7 @@ class ChannelLossComputer:
         device: torch.device,
         parallel_state: ParallelState | None = None,
         strict: bool = False,
+        include_data_stats: bool = False,
     ) -> list[dict[str, Any]]:
         if local_segments:
             local_zero_position_flags = torch.tensor(
@@ -747,12 +790,24 @@ class ChannelLossComputer:
                     local_zero_position_flags = torch.stack(
                         [segment["has_only_zero_positions"] for segment in local_segments]
                     ).to(device=device, dtype=torch.int64)
-                    local_integer_stats = torch.stack(
-                        [local_token_counts, local_explicit_padding_flags, local_zero_position_flags], dim=1
-                    )
+                    integer_columns = [local_token_counts]
+                    if include_data_stats:
+                        integer_columns.extend(
+                            [
+                                torch.stack([segment["sample_count"] for segment in local_segments]).to(
+                                    device=device, dtype=torch.int64
+                                ),
+                                torch.stack([segment["input_token_count"] for segment in local_segments]).to(
+                                    device=device, dtype=torch.int64
+                                ),
+                            ]
+                        )
+                    integer_columns.extend([local_explicit_padding_flags, local_zero_position_flags])
+                    local_integer_stats = torch.stack(integer_columns, dim=1)
                 else:
                     local_loss_sums = torch.empty(0, dtype=torch.float32, device=device)
-                    local_integer_stats = torch.empty((0, 3), dtype=torch.int64, device=device)
+                    integer_column_count = 5 if include_data_stats else 3
+                    local_integer_stats = torch.empty((0, integer_column_count), dtype=torch.int64, device=device)
 
                 loss_padding = local_loss_sums.new_zeros(max_segment_count - local_loss_sums.size(0))
                 integer_padding = local_integer_stats.new_zeros(
@@ -768,15 +823,18 @@ class ChannelLossComputer:
                 for rank_idx, rank_metadata in enumerate(gathered_metadata):
                     for segment_idx, metadata in enumerate(rank_metadata or []):
                         integer_stats = gathered_integer_stats[rank_idx][segment_idx]
-                        all_segments.append(
-                            {
-                                **metadata,
-                                "loss_sum": gathered_loss_sums[rank_idx][segment_idx],
-                                "token_count": integer_stats[0],
-                                "has_explicit_padding_mask": integer_stats[1].to(torch.bool),
-                                "has_only_zero_positions": integer_stats[2].to(torch.bool),
-                            }
-                        )
+                        stats_offset = 2 if include_data_stats else 0
+                        segment = {
+                            **metadata,
+                            "loss_sum": gathered_loss_sums[rank_idx][segment_idx],
+                            "token_count": integer_stats[0],
+                            "has_explicit_padding_mask": integer_stats[1 + stats_offset].to(torch.bool),
+                            "has_only_zero_positions": integer_stats[2 + stats_offset].to(torch.bool),
+                        }
+                        if include_data_stats:
+                            segment["sample_count"] = integer_stats[1]
+                            segment["input_token_count"] = integer_stats[2]
+                        all_segments.append(segment)
 
         all_segments.sort(
             key=lambda segment: (
@@ -808,13 +866,15 @@ class ChannelLossComputer:
         for segment in all_segments:
             batch_idx = int(segment.get("batch_idx", 0))
             if segment["is_start"]:
-                result.append(
-                    {
-                        "source_id": source_ids[doc_idx],
-                        "loss_sum": segment["loss_sum"],
-                        "token_count": segment["token_count"],
-                    }
-                )
+                item = {
+                    "source_id": source_ids[doc_idx],
+                    "loss_sum": segment["loss_sum"],
+                    "token_count": segment["token_count"],
+                }
+                if include_data_stats:
+                    item["sample_count"] = segment["sample_count"]
+                    item["input_token_count"] = segment["input_token_count"]
+                result.append(item)
                 last_result_idx_by_batch[batch_idx] = len(result) - 1
                 doc_idx += 1
                 continue
@@ -831,6 +891,9 @@ class ChannelLossComputer:
                 continue
             result[result_idx]["loss_sum"] += segment["loss_sum"]
             result[result_idx]["token_count"] += segment["token_count"]
+            if include_data_stats:
+                result[result_idx]["sample_count"] += segment["sample_count"]
+                result[result_idx]["input_token_count"] += segment["input_token_count"]
         return result
 
 
@@ -1027,6 +1090,8 @@ class ChannelLossCallback(Callback):
             return
 
         metrics = self._build_metrics(totals, source_names)
+        data_totals = self._reduce_step_data_totals(self.computer.step_data_totals, list(totals))
+        metrics.update(self._build_data_metrics(data_totals, source_names))
         if not metrics:
             return
 
@@ -1103,6 +1168,39 @@ class ChannelLossCallback(Callback):
         registered_names = self._register_sources(source_ids, synchronized_names)
         return totals, registered_names
 
+    def _reduce_step_data_totals(
+        self,
+        local_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+        source_ids: list[ChannelKey],
+    ) -> dict[ChannelKey, tuple[int, int, int]]:
+        if not source_ids:
+            return {}
+
+        device = self._data_totals_device(local_totals)
+        counts = torch.zeros((len(source_ids), 3), dtype=torch.int64, device=device)
+        source_indices = {source_id: index for index, source_id in enumerate(source_ids)}
+        for source_id, (sample_count, input_token_count, label_token_count) in local_totals.items():
+            index = source_indices.get(source_id)
+            if index is None:
+                continue
+            counts[index] = torch.stack(
+                [
+                    torch.as_tensor(sample_count, dtype=torch.int64, device=device),
+                    torch.as_tensor(input_token_count, dtype=torch.int64, device=device),
+                    torch.as_tensor(label_token_count, dtype=torch.int64, device=device),
+                ]
+            )
+
+        ps = self.parallel_state
+        if ps.dp_size > 1 and dist.is_available() and dist.is_initialized():
+            dist.all_reduce(counts, group=ps.dp_group)
+
+        values = counts.cpu().tolist()
+        return {
+            source_id: (int(values[index][0]), int(values[index][1]), int(values[index][2]))
+            for index, source_id in enumerate(source_ids)
+        }
+
     def _register_sources(
         self,
         source_ids: list[ChannelKey],
@@ -1157,6 +1255,16 @@ class ChannelLossCallback(Callback):
                 pass
         return torch.device("cpu")
 
+    def _data_totals_device(
+        self,
+        local_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+    ) -> torch.device:
+        for counts in local_totals.values():
+            for count in counts:
+                if isinstance(count, torch.Tensor):
+                    return count.device
+        return self._totals_device({})
+
     def _build_metrics(
         self,
         totals: dict[ChannelKey, tuple[float, int]],
@@ -1176,21 +1284,67 @@ class ChannelLossCallback(Callback):
                 metrics[f"{self.config.token_count_metric_prefix}/{name}"] = float(token_count)
         return metrics
 
+    def _build_data_metrics(
+        self,
+        totals: dict[ChannelKey, tuple[int, int, int]],
+        source_names: dict[ChannelKey, str] | None = None,
+    ) -> dict[str, float]:
+        metric_names = self._render_data_metric_names(totals, source_names)
+        metrics: dict[str, float] = {}
+        for source_id, (sample_count, input_token_count, label_token_count) in sorted(
+            totals.items(), key=lambda item: _channel_sort_key(item[0])
+        ):
+            if sample_count <= 0:
+                continue
+            name = metric_names[source_id]
+            metrics[f"samples/{name}"] = float(sample_count)
+            metrics[f"input_tokens/{name}"] = float(input_token_count)
+            metrics[f"label_tokens/{name}"] = float(label_token_count)
+            metrics[f"label_tokens_per_sample/{name}"] = label_token_count / sample_count
+        return metrics
+
+    def _render_data_metric_names(
+        self,
+        totals: dict[ChannelKey, tuple[int, int, int]],
+        source_names: dict[ChannelKey, str] | None,
+    ) -> dict[ChannelKey, str]:
+        base_names = self._render_base_metric_names(totals, source_names)
+        name_counts: dict[str, int] = defaultdict(int)
+        for name in base_names.values():
+            name_counts[name] += 1
+        return {
+            source_id: (
+                base_names[source_id]
+                if name_counts[base_names[source_id]] == 1
+                else f"{_stable_source_metric_fragment(source_id)}__{base_names[source_id]}"
+            )
+            for source_id in totals
+        }
+
     def _render_metric_names(
         self,
         totals: dict[ChannelKey, tuple[float, int]],
         source_names: dict[ChannelKey, str] | None,
     ) -> dict[ChannelKey, str]:
+        base_names = self._render_base_metric_names(totals, source_names)
+        return {
+            source_id: f"{_stable_source_metric_fragment(source_id)}__{base_names[source_id]}" for source_id in totals
+        }
+
+    def _render_base_metric_names(
+        self,
+        totals: dict[ChannelKey, tuple[Any, ...]],
+        source_names: dict[ChannelKey, str] | None,
+    ) -> dict[ChannelKey, str]:
         self._register_sources(list(totals), source_names)
         rendered: dict[ChannelKey, str] = {}
-        for source_id in totals:
+        for source_id in self._source_registry:
             source_name = self._source_registry[source_id]
-            display_name = (
+            rendered[source_id] = (
                 _sanitize_metric_fragment(source_name)
                 if source_name is not None
                 else self._resolve_source_name(source_id)
             )
-            rendered[source_id] = f"{_stable_source_metric_fragment(source_id)}__{display_name}"
         return rendered
 
     def _resolve_source_name(self, source_id: ChannelKey) -> str:

--- a/veomni/trainer/callbacks/channel_loss_callback.py
+++ b/veomni/trainer/callbacks/channel_loss_callback.py
@@ -1312,11 +1312,16 @@ class ChannelLossCallback(Callback):
         name_counts: dict[str, int] = defaultdict(int)
         for name in base_names.values():
             name_counts[name] += 1
+        qualified_names = {
+            source_id: f"{_stable_source_metric_fragment(source_id)}__{base_names[source_id]}"
+            for source_id in base_names
+        }
+        qualified_values = set(qualified_names.values())
         return {
             source_id: (
                 base_names[source_id]
-                if name_counts[base_names[source_id]] == 1
-                else f"{_stable_source_metric_fragment(source_id)}__{base_names[source_id]}"
+                if name_counts[base_names[source_id]] == 1 and base_names[source_id] not in qualified_values
+                else qualified_names[source_id]
             )
             for source_id in totals
         }

--- a/veomni/trainer/callbacks/channel_loss_callback.py
+++ b/veomni/trainer/callbacks/channel_loss_callback.py
@@ -37,6 +37,11 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 
+from ...data.source_metadata import (
+    PACKED_SOURCE_METADATA_KEY,
+    normalize_packed_source_metadata,
+    strip_source_metadata,
+)
 from ...distributed.parallel_state import get_parallel_state
 from ...utils.constants import IGNORE_INDEX
 from ...utils.device import empty_cache, synchronize
@@ -1724,12 +1729,21 @@ class ChannelLossCallback(Callback):
         self._collect_step = state.global_step % self.config.interval == 0
         if not self._collect_step:
             self.computer.begin_step([], [], [])
+            missing_source_micro_steps = []
+            for micro_step, micro_batch in enumerate(micro_batches or []):
+                source_ids, source_names, _, _, canonical_segments = self._extract_metadata(micro_batch)
+                if canonical_segments is not None:
+                    self._validate_canonical_legacy_metadata(
+                        micro_batch,
+                        source_ids,
+                        source_names,
+                        canonical_segments,
+                    )
+                else:
+                    self._raise_if_ambiguous_single_legacy_name(source_ids, source_names)
+                if self.config.strict and not source_ids:
+                    missing_source_micro_steps.append(micro_step)
             if self.config.strict:
-                missing_source_micro_steps = []
-                for micro_step, micro_batch in enumerate(micro_batches or []):
-                    source_ids, _, _, _ = self._extract_metadata(micro_batch)
-                    if not source_ids:
-                        missing_source_micro_steps.append(micro_step)
                 self._raise_if_missing_source_ids(missing_source_micro_steps)
             return
 
@@ -1738,10 +1752,21 @@ class ChannelLossCallback(Callback):
         per_mb_attention_masks: list[torch.Tensor | None] = []
         missing_source_micro_steps = []
         for micro_step, micro_batch in enumerate(micro_batches or []):
-            source_ids, source_names, position_ids, attention_mask = self._extract_metadata(micro_batch)
+            source_ids, source_names, position_ids, attention_mask, canonical_segments = self._extract_metadata(
+                micro_batch
+            )
             if self.config.strict and not source_ids:
                 missing_source_micro_steps.append(micro_step)
-            source_ids, source_names = self._repeat_source_metadata(source_ids, source_names, source_repeat)
+            if canonical_segments is not None:
+                source_names = self._validate_canonical_legacy_metadata(
+                    micro_batch,
+                    source_ids,
+                    source_names,
+                    canonical_segments,
+                )
+            else:
+                source_ids, source_names = self._repeat_source_metadata(source_ids, source_names, source_repeat)
+                self._raise_if_ambiguous_single_legacy_name(source_ids, source_names)
             self.computer.record_source_names(source_ids, source_names)
             per_mb_source_ids.append(source_ids)
             per_mb_position_ids.append(position_ids)
@@ -1765,6 +1790,65 @@ class ChannelLossCallback(Callback):
             source_names = [source_name for source_name in source_names for _ in range(repeat)]
         return repeated_ids, source_names
 
+    def _validate_canonical_legacy_metadata(
+        self,
+        micro_batch: dict[str, Any],
+        canonical_ids: list[ChannelKey],
+        canonical_names: list[str],
+        canonical_segments: list[dict[str, Any]],
+    ) -> list[str]:
+        legacy_ids = self._first_present_list(micro_batch, self.config.source_id_keys, _as_channel_key_list)
+        legacy_names = self._first_present_list(micro_batch, self.config.source_name_keys, _as_str_list)
+        sample_count = max(segment["sample_index"] for segment in canonical_segments) + 1 if canonical_segments else 0
+        if legacy_ids:
+            id_candidates = []
+            if len(legacy_ids) == sample_count:
+                id_candidates.append([legacy_ids[segment["sample_index"]] for segment in canonical_segments])
+            if len(legacy_ids) == len(canonical_segments):
+                id_candidates.append(legacy_ids)
+            canonical_signature = _source_id_signature(canonical_ids)
+            if not any(_source_id_signature(candidate_ids) == canonical_signature for candidate_ids in id_candidates):
+                raise ChannelLossMetadataError(
+                    "Channel loss: canonical source IDs conflict with legacy source metadata "
+                    f"(canonical={canonical_signature}, legacy={_source_id_signature(legacy_ids)}, "
+                    f"sample_count={sample_count})."
+                )
+
+        if not legacy_names:
+            return canonical_names
+        self._raise_if_ambiguous_single_legacy_name(canonical_ids, legacy_names)
+        name_candidates = []
+        if len(legacy_names) == sample_count:
+            name_candidates.append([legacy_names[segment["sample_index"]] for segment in canonical_segments])
+        if len(legacy_names) == len(canonical_segments):
+            name_candidates.append(legacy_names)
+        if len(legacy_names) == 1:
+            name_candidates.append(legacy_names * len(canonical_segments))
+        if canonical_names:
+            if any(candidate_names == canonical_names for candidate_names in name_candidates):
+                return canonical_names
+            raise ChannelLossMetadataError(
+                "Channel loss: canonical source names conflict with legacy source metadata "
+                f"(canonical={canonical_names!r}, legacy={legacy_names!r}, sample_count={sample_count})."
+            )
+        if not name_candidates:
+            raise ChannelLossMetadataError(
+                "Channel loss: canonical source names conflict with legacy source metadata "
+                f"(canonical_count=0, legacy_count={len(legacy_names)}, sample_count={sample_count})."
+            )
+        return name_candidates[0]
+
+    @staticmethod
+    def _raise_if_ambiguous_single_legacy_name(
+        source_ids: list[ChannelKey],
+        source_names: list[str],
+    ) -> None:
+        if len(source_names) == 1 and len(set(_source_id_signature(source_ids))) > 1:
+            raise ChannelLossMetadataError(
+                "Channel loss: a single legacy source name is ambiguous for multiple typed source IDs "
+                f"(source_ids={_source_id_signature(source_ids)}, legacy_name={source_names[0]!r})."
+            )
+
     def _raise_if_missing_source_ids(self, local_missing_micro_steps: list[int]) -> None:
         if not self._synchronize_strict_failure(bool(local_missing_micro_steps)):
             return
@@ -1785,7 +1869,10 @@ class ChannelLossCallback(Callback):
         self.computer.before_micro_step()
 
     def strip_model_inputs(self, micro_batch: dict[str, Any]) -> None:
-        if not self.enabled or not isinstance(micro_batch, dict):
+        if not isinstance(micro_batch, dict):
+            return
+        strip_source_metadata(micro_batch)
+        if not self.enabled:
             return
         for key in self._strip_keys:
             micro_batch.pop(key, None)
@@ -2175,17 +2262,41 @@ class ChannelLossCallback(Callback):
     def _extract_metadata(
         self,
         micro_batch: Any,
-    ) -> tuple[list[ChannelKey], list[str], torch.Tensor | None, torch.Tensor | None]:
+    ) -> tuple[list[ChannelKey], list[str], torch.Tensor | None, torch.Tensor | None, list[dict] | None]:
         if isinstance(micro_batch, dict):
-            source_ids = self._first_present_list(micro_batch, self.config.source_id_keys, _as_channel_key_list)
-            source_names = self._first_present_list(micro_batch, self.config.source_name_keys, _as_str_list)
+            if PACKED_SOURCE_METADATA_KEY in micro_batch:
+                try:
+                    packed_metadata = normalize_packed_source_metadata(micro_batch[PACKED_SOURCE_METADATA_KEY])
+                except ValueError as exc:
+                    raise ChannelLossMetadataError(f"Channel loss: invalid canonical source metadata: {exc}") from exc
+                self._validate_canonical_packing_boundaries(micro_batch, packed_metadata)
+                segments = packed_metadata["segments"]
+                canonical_source_ids = [segment["source_id"] for segment in segments]
+                canonical_source_names = (
+                    [segment["source_name"] for segment in segments]
+                    if all("source_name" in segment for segment in segments)
+                    else []
+                )
+                position_ids = micro_batch.get("position_ids")
+                attention_mask = micro_batch.get("attention_mask")
+                return (
+                    canonical_source_ids,
+                    canonical_source_names,
+                    position_ids if isinstance(position_ids, torch.Tensor) else None,
+                    attention_mask if isinstance(attention_mask, torch.Tensor) else None,
+                    segments,
+                )
+
+            legacy_source_ids = self._first_present_list(micro_batch, self.config.source_id_keys, _as_channel_key_list)
+            legacy_source_names = self._first_present_list(micro_batch, self.config.source_name_keys, _as_str_list)
             position_ids = micro_batch.get("position_ids")
             attention_mask = micro_batch.get("attention_mask")
             return (
-                source_ids,
-                source_names,
+                legacy_source_ids,
+                legacy_source_names,
                 position_ids if isinstance(position_ids, torch.Tensor) else None,
                 attention_mask if isinstance(attention_mask, torch.Tensor) else None,
+                None,
             )
 
         if isinstance(micro_batch, (list, tuple)):
@@ -2196,9 +2307,147 @@ class ChannelLossCallback(Callback):
                     continue
                 source_ids.extend(self._first_present_list(sample, self.config.source_id_keys, _as_channel_key_list))
                 source_names.extend(self._first_present_list(sample, self.config.source_name_keys, _as_str_list))
-            return source_ids, source_names, None, None
+            return source_ids, source_names, None, None, None
 
-        return [], [], None, None
+        return [], [], None, None, None
+
+    def _validate_canonical_packing_boundaries(
+        self,
+        micro_batch: dict[str, Any],
+        packed_metadata: dict[str, Any],
+    ) -> None:
+        canonical_boundaries = [0]
+        canonical_boundaries.extend(
+            segment["token_start"] + segment["token_length"] for segment in packed_metadata["segments"]
+        )
+        valid_token_count = packed_metadata["valid_token_count"]
+
+        cu_seq_lens_q = micro_batch.get("cu_seq_lens_q")
+        if isinstance(cu_seq_lens_q, torch.Tensor):
+            if cu_seq_lens_q.dim() != 1 or cu_seq_lens_q.numel() < 2:
+                raise ChannelLossMetadataError(
+                    "Channel loss: canonical boundary validation requires one-dimensional cu_seq_lens_q "
+                    "with at least two entries."
+                )
+            full_boundaries = cu_seq_lens_q.detach().cpu().tolist()
+            if (
+                full_boundaries[0] != 0
+                or any(type(boundary) is not int for boundary in full_boundaries)
+                or any(left >= right for left, right in zip(full_boundaries, full_boundaries[1:]))
+            ):
+                raise ChannelLossMetadataError(
+                    "Channel loss: canonical boundary validation requires strictly increasing cu_seq_lens_q "
+                    "starting at zero."
+                )
+
+            tail_padding_length = self._canonical_tail_padding_length(micro_batch.get("tail_padding_length"))
+            actual_valid_token_count = full_boundaries[-1] - tail_padding_length
+            if tail_padding_length > full_boundaries[-1] or actual_valid_token_count != valid_token_count:
+                raise ChannelLossMetadataError(
+                    "Channel loss: canonical valid_token_count conflicts with cu_seq_lens_q/tail_padding_length "
+                    f"(canonical={valid_token_count}, actual={actual_valid_token_count})."
+                )
+            actual_boundaries = [boundary for boundary in full_boundaries if boundary <= valid_token_count]
+            if not actual_boundaries or actual_boundaries[-1] != valid_token_count:
+                raise ChannelLossMetadataError(
+                    "Channel loss: canonical valid-token tail does not end on a cu_seq_lens_q boundary "
+                    f"(valid_token_count={valid_token_count}, cu_seq_lens_q={full_boundaries})."
+                )
+            if actual_boundaries != canonical_boundaries:
+                raise ChannelLossMetadataError(
+                    "Channel loss: canonical token boundaries conflict with full packed cu_seq_lens_q "
+                    f"(canonical={canonical_boundaries}, actual={actual_boundaries})."
+                )
+            position_ids = micro_batch.get("position_ids")
+            if not bool(self.parallel_state.sp_enabled):
+                if not isinstance(position_ids, torch.Tensor):
+                    raise ChannelLossMetadataError(
+                        "Channel loss: non-SP canonical boundary validation requires full position_ids."
+                    )
+                position_boundaries = self._canonical_boundaries_from_position_ids(
+                    position_ids,
+                    valid_token_count=valid_token_count,
+                    full_token_count=full_boundaries[-1],
+                    require_zero_tail=True,
+                )
+                if position_boundaries != canonical_boundaries:
+                    raise ChannelLossMetadataError(
+                        "Channel loss: canonical token boundaries conflict with full packed position_ids "
+                        f"(canonical={canonical_boundaries}, actual={position_boundaries})."
+                    )
+            return
+
+        position_ids = micro_batch.get("position_ids")
+        if bool(self.parallel_state.sp_enabled):
+            raise ChannelLossMetadataError(
+                "Channel loss: canonical boundary validation under sequence parallelism requires full pre-SP "
+                "cu_seq_lens_q."
+            )
+        if not isinstance(position_ids, torch.Tensor):
+            raise ChannelLossMetadataError(
+                "Channel loss: canonical boundary validation requires full position_ids when sequence "
+                "parallelism is disabled."
+            )
+        actual_boundaries = self._canonical_boundaries_from_position_ids(
+            position_ids,
+            valid_token_count=valid_token_count,
+            full_token_count=valid_token_count,
+            require_zero_tail=False,
+        )
+        if actual_boundaries != canonical_boundaries:
+            raise ChannelLossMetadataError(
+                "Channel loss: canonical token boundaries conflict with full packed position_ids "
+                f"(canonical={canonical_boundaries}, actual={actual_boundaries})."
+            )
+
+    @staticmethod
+    def _canonical_boundaries_from_position_ids(
+        position_ids: torch.Tensor,
+        *,
+        valid_token_count: int,
+        full_token_count: int,
+        require_zero_tail: bool,
+    ) -> list[int]:
+        if position_ids.dim() == 3:
+            position_ids = position_ids[:, 0, :]
+        flat_position_ids = position_ids.detach().reshape(-1)
+        if flat_position_ids.numel() != full_token_count:
+            raise ChannelLossMetadataError(
+                "Channel loss: canonical valid/full token counts conflict with full packed position_ids "
+                f"(canonical_valid={valid_token_count}, expected_full={full_token_count}, "
+                f"actual_full={flat_position_ids.numel()})."
+            )
+
+        padding_position_ids = flat_position_ids[valid_token_count:]
+        if (
+            require_zero_tail
+            and padding_position_ids.numel() > 0
+            and not bool(padding_position_ids.eq(0).all().cpu().item())
+        ):
+            raise ChannelLossMetadataError(
+                "Channel loss: canonical padding tail requires position_ids == 0 for every padded token."
+            )
+
+        valid_position_ids = flat_position_ids[:valid_token_count]
+        boundaries = torch.nonzero(valid_position_ids == 0, as_tuple=False).flatten().cpu().tolist()
+        boundaries.append(valid_token_count)
+        return boundaries
+
+    @staticmethod
+    def _canonical_tail_padding_length(value: Any) -> int:
+        if isinstance(value, torch.Tensor):
+            if value.numel() != 1:
+                raise ChannelLossMetadataError(
+                    "Channel loss: canonical boundary validation requires scalar tail_padding_length."
+                )
+            value = value.detach().cpu().item()
+        if value is None:
+            return 0
+        if type(value) is not int or value < 0:
+            raise ChannelLossMetadataError(
+                "Channel loss: canonical boundary validation requires non-negative integer tail_padding_length."
+            )
+        return value
 
     @staticmethod
     def _first_present_list(

--- a/veomni/trainer/callbacks/channel_loss_callback.py
+++ b/veomni/trainer/callbacks/channel_loss_callback.py
@@ -28,6 +28,7 @@ from collections import defaultdict
 from collections.abc import Hashable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 from numbers import Integral
 from typing import TYPE_CHECKING, Any, Callable
 from weakref import WeakSet
@@ -38,6 +39,7 @@ import torch.nn.functional as F
 
 from ...distributed.parallel_state import get_parallel_state
 from ...utils.constants import IGNORE_INDEX
+from ...utils.device import empty_cache, synchronize
 from ...utils.logging import get_logger
 from .base import Callback, TrainerState
 
@@ -80,6 +82,100 @@ class ChannelLossMetadataError(ValueError):
     """Raised when channel metadata cannot be aligned with packed segments."""
 
 
+class ChannelLossCollectiveError(RuntimeError):
+    """Raised when an observer collective fails and its process group is unsafe."""
+
+
+@dataclass(frozen=True, eq=False)
+class _SPCaptureDescriptor:
+    """Authoritative cached SP topology for one outer capture."""
+
+    enabled: bool
+    parallel_state: ParallelState | None
+    group: Any | None
+    world: int
+    rank: int
+    resolution_error: str | None = None
+
+
+@dataclass
+class _PendingSPObservation:
+    """Fully materialized SP payload prepared before forward-finally preflight."""
+
+    source_ids: list[ChannelKey]
+    device: torch.device
+    parallel_state: ParallelState
+    include_data_stats: bool
+    group: Any | None
+    world: int
+    capture_descriptor: _SPCaptureDescriptor
+    segment_count: int
+    loss_payload: torch.Tensor
+    integer_payload: torch.Tensor
+    gathered_segment_counts: list[int]
+    gathered_loss_payloads: list[torch.Tensor]
+    gathered_integer_payloads: list[torch.Tensor]
+
+
+def _sp_descriptor_from_parallel_state(parallel_state: ParallelState | None) -> _SPCaptureDescriptor:
+    if parallel_state is None or not bool(parallel_state.sp_enabled):
+        return _SPCaptureDescriptor(enabled=False, parallel_state=parallel_state, group=None, world=1, rank=0)
+    group = parallel_state.sp_group
+    rank = int(parallel_state.sp_rank)
+    if rank < 0:
+        rank = dist.get_rank(group) if group is not None else 0
+    return _SPCaptureDescriptor(
+        enabled=True,
+        parallel_state=parallel_state,
+        group=group,
+        world=int(parallel_state.sp_size),
+        rank=rank,
+    )
+
+
+def _sp_descriptors_match(left: _SPCaptureDescriptor, right: _SPCaptureDescriptor) -> bool:
+    return (
+        left.enabled == right.enabled
+        and left.parallel_state is right.parallel_state
+        and left.group is right.group
+        and left.world == right.world
+        and left.rank == right.rank
+        and left.resolution_error == right.resolution_error
+    )
+
+
+def _unresolved_sp_descriptor(
+    parallel_state: ParallelState | None,
+    message: str,
+) -> _SPCaptureDescriptor:
+    return _SPCaptureDescriptor(
+        enabled=False,
+        parallel_state=parallel_state,
+        group=None,
+        world=1,
+        rank=0,
+        resolution_error=message,
+    )
+
+
+def _resolve_cached_sp_capture_descriptor(parallel_state: ParallelState) -> _SPCaptureDescriptor:
+    try:
+        return _sp_descriptor_from_parallel_state(parallel_state)
+    except Exception as error:
+        return _unresolved_sp_descriptor(
+            parallel_state,
+            f"cached SP descriptor resolution failed: {type(error).__name__}: {error}",
+        )
+
+
+def _release_observer_cache(device: torch.device) -> None:
+    """Release detached CE workspaces before the training backward pass."""
+    if device.type == "cpu":
+        return
+    synchronize()
+    empty_cache()
+
+
 class ChannelLossComputer:
     """Computes detached per-source CE from model loss-function inputs."""
 
@@ -98,14 +194,24 @@ class ChannelLossComputer:
         self._position_ids: torch.Tensor | None = None
         self._attention_mask: torch.Tensor | None = None
         self._result: list[dict[str, Any]] | None = None
+        self._pending_observations: list[_PendingSPObservation | list[dict[str, Any]]] = []
+        self._observation_attempt_count = 0
+        self._capture_errors: list[tuple[str, str]] = []
+        self._observer_devices: list[torch.device] = []
+        self._capture_sp_descriptor: _SPCaptureDescriptor | None = None
         self._per_mb_source_ids: list[list[ChannelKey]] = []
         self._per_mb_position_ids: list[torch.Tensor | None] = []
         self._per_mb_attention_masks: list[torch.Tensor | None] = []
         self._micro_step = 0
+        self._micro_step_observation_count = 0
+        self._micro_step_failed = False
+        self.missing_observation_micro_steps: list[int] = []
+        self.strict_observation_errors: list[tuple[int, str]] = []
         self.step_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor]] = {}
         self.step_data_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         self.source_names: dict[ChannelKey, str] = {}
         self.strict = False
+        self.release_cache = False
 
     @staticmethod
     def _resolve_loss_fn_host(model: torch.nn.Module) -> torch.nn.Module | None:
@@ -261,11 +367,395 @@ class ChannelLossComputer:
 
     @contextmanager
     def capture(self) -> Iterator[None]:
+        nested = self.capture_active
+        if not nested:
+            self._reset_capture_state()
+            self._capture_sp_descriptor = _resolve_cached_sp_capture_descriptor(self.parallel_state)
         token = _ACTIVE_CHANNEL_LOSS_COMPUTER.set(self)
         try:
             yield
         finally:
             _ACTIVE_CHANNEL_LOSS_COMPUTER.reset(token)
+            if not nested:
+                self._finalize_capture()
+
+    def _reset_capture_state(self) -> None:
+        self._pending_observations = []
+        self._observation_attempt_count = 0
+        self._capture_errors = []
+        self._observer_devices = []
+
+    def _finalize_capture(self) -> None:
+        """Finalize detached observations before model backward can begin."""
+
+        observer_devices = list(self._observer_devices)
+        collective_failed = False
+        try:
+            descriptor = self._capture_sp_descriptor
+            descriptor_error = self._preflight_capture_descriptor(descriptor)
+            if descriptor_error is not None:
+                self._record_capture_failure(descriptor_error)
+            elif descriptor is not None and descriptor.enabled:
+                self._finalize_sp_capture(descriptor)
+            else:
+                self._finalize_local_capture()
+        except ChannelLossCollectiveError:
+            # A failed process-group operation cannot safely be converted into
+            # rank-local observer state or followed by another collective.
+            collective_failed = True
+            raise
+        except Exception as error:
+            # Local preparation/reconstruction failures must never escape a
+            # rank before strict world coordination at step end.
+            self._record_capture_failure(
+                f"channel-loss forward finalization failed with {type(error).__name__}: {error}"
+            )
+        finally:
+            if self.release_cache and not collective_failed:
+                released_devices: list[torch.device] = []
+                for device in observer_devices:
+                    if device in released_devices:
+                        continue
+                    released_devices.append(device)
+                    try:
+                        _release_observer_cache(device)
+                    except Exception:
+                        logger.warning_rank0(
+                            "Channel loss: failed to release detached CE allocator cache; continuing training.",
+                            exc_info=True,
+                        )
+            self._pending_observations = []
+            self._capture_errors = []
+            self._observer_devices = []
+            self._capture_sp_descriptor = None
+
+    @staticmethod
+    def _preflight_capture_descriptor(descriptor: _SPCaptureDescriptor | None) -> str | None:
+        """Reject rank-local SP topology divergence before any SP collective."""
+
+        if not dist.is_available() or not dist.is_initialized():
+            if descriptor is None:
+                return "Channel loss: capture has no authoritative SP descriptor."
+            if descriptor.resolution_error is not None:
+                return f"Channel loss: capture SP descriptor resolution failed: {descriptor.resolution_error}."
+            if descriptor.enabled and (
+                descriptor.world < 1
+                or descriptor.rank < 0
+                or descriptor.rank >= descriptor.world
+                or (descriptor.world > 1 and descriptor.group is None)
+            ):
+                return f"Channel loss: capture has an invalid SP descriptor: {descriptor}."
+            return None
+
+        try:
+            global_rank = dist.get_rank()
+            global_world = dist.get_world_size()
+        except Exception as error:
+            raise ChannelLossCollectiveError(
+                "Channel loss could not inspect the initialized default process group for descriptor preflight."
+            ) from error
+
+        errors: list[str] = []
+        group_ranks: tuple[int, ...] = ()
+        if descriptor is None:
+            errors.append("missing capture descriptor")
+            enabled = False
+            sp_world = -1
+            sp_rank = -1
+        else:
+            enabled = descriptor.enabled
+            sp_world = descriptor.world
+            sp_rank = descriptor.rank
+            if descriptor.resolution_error is not None:
+                errors.append(descriptor.resolution_error)
+            if enabled:
+                if descriptor.group is None:
+                    if sp_world == 1:
+                        group_ranks = (global_rank,)
+                    else:
+                        errors.append("enabled multi-rank SP descriptor has no process group")
+                else:
+                    try:
+                        get_process_group_ranks = getattr(dist, "get_process_group_ranks", None)
+                        if get_process_group_ranks is not None:
+                            group_ranks = tuple(int(rank) for rank in get_process_group_ranks(descriptor.group))
+                        else:
+                            group_ranks = tuple(
+                                int(dist.get_global_rank(descriptor.group, local_rank))
+                                for local_rank in range(sp_world)
+                            )
+                    except Exception as error:
+                        errors.append(f"failed to resolve SP group membership: {type(error).__name__}: {error}")
+
+        status = {
+            "global_rank": global_rank,
+            "global_world": global_world,
+            "enabled": enabled,
+            "sp_world": sp_world,
+            "sp_rank": sp_rank,
+            "group_ranks": group_ranks,
+            "errors": errors,
+        }
+        gathered_statuses: list[dict[str, Any] | None] = [None] * global_world
+        try:
+            dist.all_gather_object(gathered_statuses, status)
+        except Exception as error:
+            raise ChannelLossCollectiveError(
+                "Channel loss world descriptor preflight collective failed; the process group is unsafe."
+            ) from error
+        statuses = [item or {} for item in gathered_statuses]
+        return ChannelLossComputer._validate_capture_descriptor_preflight(statuses)
+
+    @staticmethod
+    def _validate_capture_descriptor_preflight(statuses: list[dict[str, Any]]) -> str | None:
+        if not statuses:
+            return "Channel loss: world SP descriptor preflight returned no statuses."
+
+        expected_ranks = list(range(len(statuses)))
+        global_ranks = [status.get("global_rank") for status in statuses]
+        global_worlds = [status.get("global_world") for status in statuses]
+        enabled_values = [status.get("enabled") for status in statuses]
+        errors = [status.get("errors") or [] for status in statuses]
+        valid = (
+            global_ranks == expected_ranks
+            and all(world == len(statuses) for world in global_worlds)
+            and all(isinstance(enabled, bool) for enabled in enabled_values)
+            and len(set(enabled_values)) == 1
+            and all(not rank_errors for rank_errors in errors)
+        )
+
+        if valid and bool(enabled_values[0]):
+            for status_idx, status in enumerate(statuses):
+                sp_world = status.get("sp_world")
+                sp_rank = status.get("sp_rank")
+                group_ranks = status.get("group_ranks")
+                if (
+                    not isinstance(sp_world, int)
+                    or not isinstance(sp_rank, int)
+                    or not isinstance(group_ranks, (list, tuple))
+                    or sp_world < 1
+                    or len(group_ranks) != sp_world
+                    or sp_rank < 0
+                    or sp_rank >= sp_world
+                    or any(
+                        not isinstance(member, int) or member < 0 or member >= len(statuses) for member in group_ranks
+                    )
+                    or len(set(group_ranks)) != sp_world
+                    or group_ranks[sp_rank] != status_idx
+                ):
+                    valid = False
+                    break
+                member_tuple = tuple(group_ranks)
+                if any(tuple(statuses[member].get("group_ranks") or ()) != member_tuple for member in member_tuple):
+                    valid = False
+                    break
+
+        if valid:
+            return None
+        return (
+            "Channel loss: world preflight rejected rank-local SP capture descriptor divergence before "
+            f"group-specific collectives (statuses={statuses})."
+        )
+
+    def _finalize_local_capture(self) -> None:
+        errors = list(self._capture_errors)
+        if self._source_ids and self._observation_attempt_count == 0:
+            errors.append(("metadata", "source metadata was present but no causal-LM loss hook was observed"))
+        if len(self._pending_observations) != self._observation_attempt_count:
+            errors.append(
+                (
+                    "metadata",
+                    "successful observation count does not match the number of observed causal-LM loss calls",
+                )
+            )
+        if any(isinstance(observation, _PendingSPObservation) for observation in self._pending_observations):
+            errors.append(("generic", "an SP payload was prepared while sequence parallelism was disabled"))
+        if errors:
+            self._record_capture_failure(_format_capture_errors(errors))
+            return
+
+        observations = [observation for observation in self._pending_observations if isinstance(observation, list)]
+        self._append_observations(observations)
+
+    def _finalize_sp_capture(self, descriptor: _SPCaptureDescriptor) -> None:
+        group = descriptor.group
+        world = descriptor.world
+        pending_sp = [
+            observation for observation in self._pending_observations if isinstance(observation, _PendingSPObservation)
+        ]
+        descriptor_errors: list[tuple[str, str]] = []
+        if not descriptor.enabled or descriptor.world < 1:
+            descriptor_errors.append(("generic", "capture has an invalid enabled SP descriptor"))
+        for observation_idx, observation in enumerate(pending_sp):
+            if not _sp_descriptors_match(observation.capture_descriptor, descriptor):
+                descriptor_errors.append(
+                    (
+                        "generic",
+                        f"observation {observation_idx} was prepared with a different SP capture descriptor",
+                    )
+                )
+            if (
+                observation.parallel_state is not descriptor.parallel_state
+                or observation.group is not descriptor.group
+                or observation.world != descriptor.world
+            ):
+                descriptor_errors.append(
+                    (
+                        "generic",
+                        f"observation {observation_idx} SP group/world does not match its capture descriptor",
+                    )
+                )
+        status = {
+            "has_source": bool(self._source_ids),
+            "observation_count": self._observation_attempt_count,
+            "successful_count": len(self._pending_observations),
+            "source_ids": _source_id_signature(self._source_ids),
+            "observation_source_ids": [_source_id_signature(observation.source_ids) for observation in pending_sp],
+            "sp_payload_count": len(pending_sp),
+            "payload_specs": [
+                (
+                    observation.loss_payload.numel(),
+                    observation.integer_payload.size(1),
+                    observation.include_data_stats,
+                )
+                for observation in pending_sp
+            ],
+            "segment_counts": [observation.segment_count for observation in pending_sp],
+            "descriptor_spec": (descriptor.enabled, descriptor.world, descriptor.group is not None),
+            "errors": [*self._capture_errors, *descriptor_errors],
+        }
+
+        if world > 1 and group is None:
+            status["errors"].append(("generic", "SP process group is unavailable"))
+
+        if world > 1 and group is not None and dist.is_available() and dist.is_initialized():
+            gathered_statuses: list[dict[str, Any] | None] = [None] * world
+            # This is the sole SP collective that decides whether any
+            # conditional observation payload collective may follow.
+            try:
+                dist.all_gather_object(gathered_statuses, status, group=group)
+            except Exception as error:
+                raise ChannelLossCollectiveError(
+                    "Channel loss SP payload preflight collective failed; the process group is unsafe."
+                ) from error
+            statuses = [item or {} for item in gathered_statuses]
+        else:
+            statuses = [status]
+
+        preflight_error = self._validate_sp_preflight(statuses)
+        if preflight_error is not None:
+            self._record_capture_failure(preflight_error)
+            return
+        for observation_idx, observation in enumerate(pending_sp):
+            observation.gathered_segment_counts = [
+                int(status["segment_counts"][observation_idx]) for status in statuses
+            ]
+
+        # No observer-owned tensor construction, conversion, or validation
+        # is permitted in this loop. All buffers were materialized before the
+        # preflight, so approved ranks execute an unconditional fixed sequence.
+        for observation in pending_sp:
+            self._gather_prepared_sp_payload(observation, descriptor)
+
+        reduced_observations: list[list[dict[str, Any]]] = []
+        reconstruction_errors: list[tuple[str, str]] = []
+        for observation_idx, observation in enumerate(pending_sp):
+            try:
+                reduced = self._reconstruct_prepared_sp_payload(observation, strict=True)
+                if not reduced:
+                    raise ChannelLossMetadataError("SP reduction produced no source-aligned CE payload")
+                reduced_observations.append(reduced)
+            except Exception as error:
+                reconstruction_errors.append(
+                    (
+                        "metadata" if isinstance(error, ChannelLossMetadataError) else "generic",
+                        f"observation {observation_idx}: {type(error).__name__}: {error}",
+                    )
+                )
+
+        if reconstruction_errors:
+            self._record_capture_failure(_format_capture_errors(reconstruction_errors))
+            return
+        self._append_observations(reduced_observations)
+
+    @staticmethod
+    def _validate_sp_preflight(statuses: list[dict[str, Any]]) -> str | None:
+        has_source = [bool(status.get("has_source")) for status in statuses]
+        observation_counts = [int(status.get("observation_count", -1)) for status in statuses]
+        successful_counts = [int(status.get("successful_count", -1)) for status in statuses]
+        payload_counts = [int(status.get("sp_payload_count", -1)) for status in statuses]
+        source_ids = [status.get("source_ids") for status in statuses]
+        errors = [status.get("errors") or [] for status in statuses]
+        observation_sources = [status.get("observation_source_ids") or [] for status in statuses]
+        payload_specs = [status.get("payload_specs") or [] for status in statuses]
+        segment_counts = [status.get("segment_counts") or [] for status in statuses]
+        descriptor_specs = [status.get("descriptor_spec") for status in statuses]
+        expected_observation_count = observation_counts[0] if observation_counts else -1
+        segment_count_contract_valid = True
+        for rank_specs, rank_counts in zip(payload_specs, segment_counts):
+            if len(rank_specs) != expected_observation_count or len(rank_counts) != expected_observation_count:
+                segment_count_contract_valid = False
+                break
+            for observation_idx, segment_count in enumerate(rank_counts):
+                if (
+                    not isinstance(segment_count, int)
+                    or segment_count < 0
+                    or segment_count > int(rank_specs[observation_idx][0])
+                ):
+                    segment_count_contract_valid = False
+                    break
+
+        valid = (
+            bool(statuses)
+            and all(has_source)
+            and len(set(observation_counts)) == 1
+            and expected_observation_count > 0
+            and successful_counts == observation_counts
+            and payload_counts == observation_counts
+            and all(source_id == source_ids[0] for source_id in source_ids)
+            and all(payload_spec == payload_specs[0] for payload_spec in payload_specs)
+            and all(descriptor_spec == descriptor_specs[0] for descriptor_spec in descriptor_specs)
+            and all(not rank_errors for rank_errors in errors)
+            and segment_count_contract_valid
+            and all(
+                len(rank_sources) == expected_observation_count
+                and all(observation_source == source_ids[rank_idx] for observation_source in rank_sources)
+                for rank_idx, rank_sources in enumerate(observation_sources)
+            )
+        )
+        if valid:
+            return None
+
+        return (
+            "Channel loss: SP preflight rejected observation payload before conditional collectives "
+            f"(has_source={has_source}, observation_counts={observation_counts}, "
+            f"successful_counts={successful_counts}, payload_counts={payload_counts}, "
+            f"source_ids={source_ids}, payload_specs={payload_specs}, "
+            f"segment_counts={segment_counts}, descriptor_specs={descriptor_specs}, errors={errors})."
+        )
+
+    def _append_observations(self, observations: list[list[dict[str, Any]]]) -> None:
+        if not observations or (self.strict and self._micro_step_failed):
+            return
+        if self._result is None:
+            self._result = []
+        for observation in observations:
+            self._result.extend(observation)
+        self._micro_step_observation_count += len(observations)
+
+    def _record_capture_failure(self, message: str) -> None:
+        if self.strict:
+            # A strict micro-step is atomic evidence: one failed observation
+            # invalidates successful observations from the same micro-step.
+            self._micro_step_failed = True
+            self._result = None
+            self._micro_step_observation_count = 0
+            self.strict_observation_errors.append((self._micro_step, message))
+            logger.warning_rank0(
+                f"Channel loss: deferring strict observation failure until globally synchronized step end: {message}"
+            )
+            return
+        logger.warning_rank0(f"Channel loss: {message} Skipping this model forward.")
 
     def _observe_opslot_call(
         self,
@@ -299,6 +789,10 @@ class ChannelLossComputer:
         self._per_mb_position_ids = per_mb_position_ids
         self._per_mb_attention_masks = per_mb_attention_masks
         self._micro_step = 0
+        self._micro_step_observation_count = 0
+        self._micro_step_failed = False
+        self.missing_observation_micro_steps = []
+        self.strict_observation_errors = []
         self.step_totals = {}
         self.step_data_totals = {}
 
@@ -313,8 +807,13 @@ class ChannelLossComputer:
             self._position_ids = None
             self._attention_mask = None
         self._result = None
+        self._micro_step_observation_count = 0
+        self._micro_step_failed = False
+        self._reset_capture_state()
 
     def after_micro_step(self) -> None:
+        if self.strict and self._source_ids and self._micro_step_observation_count == 0:
+            self.missing_observation_micro_steps.append(self._micro_step)
         if self._result:
             for item in self._result:
                 source_id = item["source_id"]
@@ -341,6 +840,7 @@ class ChannelLossComputer:
         self._position_ids = None
         self._attention_mask = None
         self._result = None
+        self._reset_capture_state()
         self._micro_step += 1
 
     def record_source_names(self, source_ids: list[ChannelKey], source_names: list[str]) -> None:
@@ -387,8 +887,19 @@ class ChannelLossComputer:
         shift_labels: torch.Tensor | None = None,
         ignore_index: int = IGNORE_INDEX,
     ) -> None:
+        observer_device = next(
+            (tensor.device for tensor in (logits, hidden_states, weights, labels) if isinstance(tensor, torch.Tensor)),
+            None,
+        )
+        standalone = not self.capture_active
+        if standalone:
+            self._reset_capture_state()
+            self._capture_sp_descriptor = _resolve_cached_sp_capture_descriptor(self.parallel_state)
+        self._observation_attempt_count += 1
+        if observer_device is not None:
+            self._observer_devices.append(observer_device)
         try:
-            self._result = self._compute_channel_loss(
+            result = self._compute_channel_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=vocab_size,
@@ -397,15 +908,21 @@ class ChannelLossComputer:
                 attention_mask=self._attention_mask,
                 shift_labels=shift_labels,
                 ignore_index=ignore_index,
+                defer_sp=True,
             )
-        except ChannelLossMetadataError:
-            if self.strict:
-                raise
-            logger.warning_rank0("Channel loss: metadata mismatch; skipping this micro-batch.", exc_info=True)
-            self._result = None
-        except Exception:
-            logger.warning_rank0("Channel loss: per-token CE failed; skipping this micro-batch.", exc_info=True)
-            self._result = None
+            if result:
+                self._pending_observations.append(result)
+            else:
+                self._capture_errors.append(
+                    ("metadata", "channel-loss observation produced no source-aligned CE payload")
+                )
+        except ChannelLossMetadataError as error:
+            self._capture_errors.append(("metadata", str(error)))
+        except Exception as error:
+            self._capture_errors.append(("generic", f"{type(error).__name__}: {error}"))
+        finally:
+            if standalone:
+                self._finalize_capture()
 
     @torch.no_grad()
     def _compute_channel_loss(
@@ -418,8 +935,12 @@ class ChannelLossComputer:
         attention_mask: torch.Tensor | None,
         shift_labels: torch.Tensor | None,
         ignore_index: int,
-    ) -> list[dict[str, Any]]:
-        sp_enabled = bool(self.parallel_state.sp_enabled)
+        defer_sp: bool = False,
+    ) -> list[dict[str, Any]] | _PendingSPObservation:
+        descriptor = self._capture_sp_descriptor
+        if descriptor is None:
+            descriptor = _resolve_cached_sp_capture_descriptor(self.parallel_state)
+        sp_enabled = descriptor.enabled
         if sp_enabled:
             effective_labels = labels
         elif shift_labels is not None:
@@ -448,9 +969,11 @@ class ChannelLossComputer:
             position_ids=self._position_ids,
             ignore_index=ignore_index,
             sp_enabled=sp_enabled,
-            parallel_state=self.parallel_state,
+            parallel_state=descriptor.parallel_state if sp_enabled else None,
+            capture_descriptor=descriptor,
             strict=self.strict,
             include_data_stats=True,
+            defer_sp=defer_sp,
         )
 
     def _per_token_ce(
@@ -525,9 +1048,11 @@ class ChannelLossComputer:
         ignore_index: int,
         sp_enabled: bool = False,
         parallel_state: ParallelState | None = None,
+        capture_descriptor: _SPCaptureDescriptor | None = None,
         strict: bool = False,
         include_data_stats: bool = False,
-    ) -> list[dict[str, Any]]:
+        defer_sp: bool = False,
+    ) -> list[dict[str, Any]] | _PendingSPObservation:
         if not source_ids:
             return []
 
@@ -557,8 +1082,10 @@ class ChannelLossComputer:
                     seq_len=seq_len,
                     ignore_index=ignore_index,
                     parallel_state=parallel_state,
+                    capture_descriptor=capture_descriptor,
                     strict=strict,
                     include_data_stats=include_data_stats,
+                    defer_reduce=defer_sp,
                 )
 
             row_width = pos_2d.size(1)
@@ -575,6 +1102,12 @@ class ChannelLossComputer:
                     (batch_idx, row_offset + int(start), row_offset + int(end) - 1)
                     for start, end in zip(row_starts.tolist(), row_ends.tolist())
                 )
+        elif sp_enabled:
+            msg = "Channel loss: sequence-parallel source alignment requires position_ids; skipping this micro-batch."
+            if strict:
+                raise ChannelLossMetadataError(msg)
+            logger.warning_rank0(msg)
+            return []
         else:
             segments = [(0, 0, seq_len - 1)]
 
@@ -626,13 +1159,20 @@ class ChannelLossComputer:
         seq_len: int,
         ignore_index: int,
         parallel_state: ParallelState | None = None,
+        capture_descriptor: _SPCaptureDescriptor | None = None,
         strict: bool = False,
         include_data_stats: bool = False,
-    ) -> list[dict[str, Any]]:
-        if parallel_state is None:
+        defer_reduce: bool = False,
+    ) -> list[dict[str, Any]] | _PendingSPObservation:
+        if capture_descriptor is not None:
+            sp_rank = capture_descriptor.rank
+        elif parallel_state is None:
             raise ValueError("parallel_state is required for SP channel-loss aggregation.")
-        sp_group = parallel_state.sp_group
-        sp_rank = dist.get_rank(sp_group) if sp_group is not None else 0
+        else:
+            sp_group = parallel_state.sp_group
+            sp_rank = int(parallel_state.sp_rank)
+            if sp_rank < 0:
+                sp_rank = dist.get_rank(sp_group) if sp_group is not None else 0
         segments: list[dict[str, Any]] = []
 
         if positions.dim() == 1:
@@ -710,6 +1250,17 @@ class ChannelLossComputer:
                 _partial(batch_idx, start, end, is_start=True, local_order=local_order)
                 local_order += 1
 
+        if defer_reduce:
+            return ChannelLossComputer._prepare_sp_observation_payload(
+                local_segments=segments,
+                source_ids=source_ids,
+                device=per_token_loss.device,
+                payload_capacity=max(seq_len, 1),
+                parallel_state=parallel_state,
+                capture_descriptor=capture_descriptor,
+                include_data_stats=include_data_stats,
+            )
+
         reduced = ChannelLossComputer._reduce_sp(
             segments,
             source_ids,
@@ -734,6 +1285,172 @@ class ChannelLossComputer:
                 )
             result.append(converted)
         return result
+
+    @staticmethod
+    def _prepare_sp_observation_payload(
+        local_segments: list[dict[str, Any]],
+        source_ids: list[ChannelKey],
+        device: torch.device,
+        payload_capacity: int,
+        parallel_state: ParallelState | None = None,
+        capture_descriptor: _SPCaptureDescriptor | None = None,
+        include_data_stats: bool = False,
+    ) -> _PendingSPObservation:
+        """Materialize every rank-local buffer before the SP preflight."""
+
+        if payload_capacity < len(local_segments):
+            raise ChannelLossMetadataError(
+                "Channel loss: local SP segment count exceeds its deterministic payload capacity "
+                f"({len(local_segments)} > {payload_capacity})."
+            )
+        if capture_descriptor is None:
+            if parallel_state is None:
+                raise ValueError("parallel_state is required to prepare an SP channel-loss observation.")
+            capture_descriptor = _sp_descriptor_from_parallel_state(parallel_state)
+        group = capture_descriptor.group
+        world = capture_descriptor.world
+
+        loss_values: list[torch.Tensor] = []
+        integer_rows: list[torch.Tensor] = []
+        integer_column_count = 9 if include_data_stats else 7
+        for segment in local_segments:
+            loss_values.append(
+                _as_scalar_tensor(segment["loss_sum"], device=device, dtype=torch.float32, name="loss_sum")
+            )
+            integer_values = [
+                _as_scalar_tensor(segment["batch_idx"], device=device, dtype=torch.int64, name="batch_idx"),
+                _as_scalar_tensor(segment["sp_rank"], device=device, dtype=torch.int64, name="sp_rank"),
+                _as_scalar_tensor(segment["local_order"], device=device, dtype=torch.int64, name="local_order"),
+                _as_scalar_tensor(segment["is_start"], device=device, dtype=torch.int64, name="is_start"),
+                _as_scalar_tensor(segment["token_count"], device=device, dtype=torch.int64, name="token_count"),
+            ]
+            if include_data_stats:
+                integer_values.extend(
+                    [
+                        _as_scalar_tensor(
+                            segment["sample_count"], device=device, dtype=torch.int64, name="sample_count"
+                        ),
+                        _as_scalar_tensor(
+                            segment["input_token_count"],
+                            device=device,
+                            dtype=torch.int64,
+                            name="input_token_count",
+                        ),
+                    ]
+                )
+            integer_values.extend(
+                [
+                    _as_scalar_tensor(
+                        segment["has_explicit_padding_mask"],
+                        device=device,
+                        dtype=torch.int64,
+                        name="has_explicit_padding_mask",
+                    ),
+                    _as_scalar_tensor(
+                        segment["has_only_zero_positions"],
+                        device=device,
+                        dtype=torch.int64,
+                        name="has_only_zero_positions",
+                    ),
+                ]
+            )
+            integer_rows.append(torch.stack(integer_values))
+
+        loss_payload = torch.zeros(payload_capacity, dtype=torch.float32, device=device)
+        integer_payload = torch.zeros((payload_capacity, integer_column_count), dtype=torch.int64, device=device)
+        if loss_values:
+            loss_payload[: len(loss_values)].copy_(torch.stack(loss_values))
+            integer_payload[: len(integer_rows)].copy_(torch.stack(integer_rows))
+
+        if world > 1:
+            gathered_loss_payloads = [torch.empty_like(loss_payload) for _ in range(world)]
+            gathered_integer_payloads = [torch.empty_like(integer_payload) for _ in range(world)]
+        else:
+            gathered_loss_payloads = [loss_payload]
+            gathered_integer_payloads = [integer_payload]
+
+        return _PendingSPObservation(
+            source_ids=list(source_ids),
+            device=device,
+            parallel_state=parallel_state,
+            include_data_stats=include_data_stats,
+            group=group,
+            world=world,
+            capture_descriptor=capture_descriptor,
+            segment_count=len(local_segments),
+            loss_payload=loss_payload,
+            integer_payload=integer_payload,
+            gathered_segment_counts=[len(local_segments)] if world <= 1 else [0] * world,
+            gathered_loss_payloads=gathered_loss_payloads,
+            gathered_integer_payloads=gathered_integer_payloads,
+        )
+
+    @staticmethod
+    def _gather_prepared_sp_payload(
+        observation: _PendingSPObservation,
+        descriptor: _SPCaptureDescriptor,
+    ) -> None:
+        if descriptor.group is None or descriptor.world <= 1:
+            return
+        try:
+            dist.all_gather(
+                observation.gathered_loss_payloads,
+                observation.loss_payload,
+                group=descriptor.group,
+            )
+            dist.all_gather(
+                observation.gathered_integer_payloads,
+                observation.integer_payload,
+                group=descriptor.group,
+            )
+        except Exception as error:
+            raise ChannelLossCollectiveError(
+                "Channel loss payload collective failed; the SP process group must not be reused by the observer."
+            ) from error
+
+    @staticmethod
+    def _reconstruct_prepared_sp_payload(
+        observation: _PendingSPObservation,
+        strict: bool,
+    ) -> list[dict[str, Any]]:
+        all_segments: list[dict[str, Any]] = []
+        for rank_idx, segment_count in enumerate(observation.gathered_segment_counts):
+            metadata_values = (
+                observation.gathered_integer_payloads[rank_idx][:segment_count, :4].to(device="cpu").tolist()
+            )
+            for segment_idx, (batch_idx, sp_rank, local_order, is_start) in enumerate(metadata_values):
+                if (
+                    int(batch_idx) < 0
+                    or int(sp_rank) != rank_idx
+                    or int(local_order) < 0
+                    or int(is_start) not in (0, 1)
+                ):
+                    raise ChannelLossMetadataError(
+                        "Channel loss: gathered SP segment metadata does not match its fixed payload rank/order."
+                    )
+                integer_stats = observation.gathered_integer_payloads[rank_idx][segment_idx]
+                stats_offset = 2 if observation.include_data_stats else 0
+                segment = {
+                    "batch_idx": int(batch_idx),
+                    "sp_rank": int(sp_rank),
+                    "local_order": int(local_order),
+                    "is_start": bool(is_start),
+                    "loss_sum": observation.gathered_loss_payloads[rank_idx][segment_idx],
+                    "token_count": integer_stats[4],
+                    "has_explicit_padding_mask": integer_stats[5 + stats_offset].to(torch.bool),
+                    "has_only_zero_positions": integer_stats[6 + stats_offset].to(torch.bool),
+                }
+                if observation.include_data_stats:
+                    segment["sample_count"] = integer_stats[5]
+                    segment["input_token_count"] = integer_stats[6]
+                all_segments.append(segment)
+
+        return ChannelLossComputer._merge_sp_segments(
+            all_segments,
+            observation.source_ids,
+            strict=strict,
+            include_data_stats=observation.include_data_stats,
+        )
 
     @staticmethod
     def _reduce_sp(
@@ -836,6 +1553,20 @@ class ChannelLossComputer:
                             segment["input_token_count"] = integer_stats[2]
                         all_segments.append(segment)
 
+        return ChannelLossComputer._merge_sp_segments(
+            all_segments,
+            source_ids,
+            strict=strict,
+            include_data_stats=include_data_stats,
+        )
+
+    @staticmethod
+    def _merge_sp_segments(
+        all_segments: list[dict[str, Any]],
+        source_ids: list[ChannelKey],
+        strict: bool,
+        include_data_stats: bool,
+    ) -> list[dict[str, Any]]:
         all_segments.sort(
             key=lambda segment: (
                 int(segment.get("batch_idx", 0)),
@@ -923,6 +1654,7 @@ class ChannelLossCallback(Callback):
         self._strip_keys.update(self.config.source_name_keys)
         self._strip_keys.update(self.config.extra_strip_keys)
         self.computer.strict = bool(self.config.strict)
+        self.computer.release_cache = bool(self.config.release_cache)
         self._collect_step = False
         self._source_registry: dict[ChannelKey, str | None] = {}
 
@@ -993,18 +1725,22 @@ class ChannelLossCallback(Callback):
         if not self._collect_step:
             self.computer.begin_step([], [], [])
             if self.config.strict:
-                for micro_batch in micro_batches or []:
+                missing_source_micro_steps = []
+                for micro_step, micro_batch in enumerate(micro_batches or []):
                     source_ids, _, _, _ = self._extract_metadata(micro_batch)
-                    self._require_source_ids(source_ids)
+                    if not source_ids:
+                        missing_source_micro_steps.append(micro_step)
+                self._raise_if_missing_source_ids(missing_source_micro_steps)
             return
 
         per_mb_source_ids: list[list[ChannelKey]] = []
         per_mb_position_ids: list[torch.Tensor | None] = []
         per_mb_attention_masks: list[torch.Tensor | None] = []
-        for micro_batch in micro_batches or []:
+        missing_source_micro_steps = []
+        for micro_step, micro_batch in enumerate(micro_batches or []):
             source_ids, source_names, position_ids, attention_mask = self._extract_metadata(micro_batch)
-            if self.config.strict:
-                self._require_source_ids(source_ids)
+            if self.config.strict and not source_ids:
+                missing_source_micro_steps.append(micro_step)
             source_ids, source_names = self._repeat_source_metadata(source_ids, source_names, source_repeat)
             self.computer.record_source_names(source_ids, source_names)
             per_mb_source_ids.append(source_ids)
@@ -1012,6 +1748,8 @@ class ChannelLossCallback(Callback):
             per_mb_attention_masks.append(attention_mask)
 
         self.computer.begin_step(per_mb_source_ids, per_mb_position_ids, per_mb_attention_masks)
+        if self.config.strict:
+            self._raise_if_missing_source_ids(missing_source_micro_steps)
 
     @staticmethod
     def _repeat_source_metadata(
@@ -1027,12 +1765,13 @@ class ChannelLossCallback(Callback):
             source_names = [source_name for source_name in source_names for _ in range(repeat)]
         return repeated_ids, source_names
 
-    def _require_source_ids(self, source_ids: list[ChannelKey]) -> None:
-        if source_ids:
+    def _raise_if_missing_source_ids(self, local_missing_micro_steps: list[int]) -> None:
+        if not self._synchronize_strict_failure(bool(local_missing_micro_steps)):
             return
         raise ValueError(
-            "train.channel_loss.enable=True but no configured source ID was found in a micro-batch. "
-            f"Checked keys: {self.config.source_id_keys}."
+            "train.channel_loss.enable=True but no configured source ID was found in a micro-batch on at least "
+            f"one rank. Checked keys: {self.config.source_id_keys}; "
+            f"local missing micro-batch indices: {local_missing_micro_steps}."
         )
 
     def on_micro_step_begin(
@@ -1085,12 +1824,34 @@ class ChannelLossCallback(Callback):
         if not self._collect_step:
             return
 
-        totals, source_names = self._reduce_step_totals(self.computer.step_totals)
+        if self.config.strict and self._synchronize_missing_observation():
+            raise ChannelLossMetadataError(
+                "Channel loss: sampled micro-step had source metadata but produced no causal-LM CE observation "
+                "or raised a channel-loss observation error "
+                f"(local missing micro-step indices: {self.computer.missing_observation_micro_steps}; "
+                f"local observation errors: {self.computer.strict_observation_errors})."
+            )
+
+        strict_reduction_errors: list[str] = []
+        totals, source_names = self._reduce_step_totals(
+            self.computer.step_totals,
+            strict_errors=strict_reduction_errors if self.config.strict else None,
+        )
         if not totals:
+            if self.config.strict and any(self.computer._per_mb_source_ids):
+                strict_reduction_errors.append(
+                    "Channel loss: sampled optimizer step had source metadata but produced no causal-LM CE totals. "
+                    "The model forward did not invoke an observed loss path."
+                )
+            if self.config.strict:
+                self._raise_if_strict_post_collective_failure(strict_reduction_errors)
             return
 
-        metrics = self._build_metrics(totals, source_names)
         data_totals = self._reduce_step_data_totals(self.computer.step_data_totals, list(totals))
+        if self.config.strict:
+            self._raise_if_strict_post_collective_failure(strict_reduction_errors)
+
+        metrics = self._build_metrics(totals, source_names)
         metrics.update(self._build_data_metrics(data_totals, source_names))
         if not metrics:
             return
@@ -1103,9 +1864,35 @@ class ChannelLossCallback(Callback):
         self.trainer.step_train_metrics.update(metrics)
         self.trainer.step_env_metrics.update(metrics)
 
+    def _synchronize_missing_observation(self) -> bool:
+        missing = bool(self.computer.missing_observation_micro_steps or self.computer.strict_observation_errors)
+        return self._synchronize_strict_failure(missing)
+
+    def _synchronize_strict_failure(self, failed: bool) -> bool:
+        if not dist.is_available() or not dist.is_initialized():
+            return failed
+
+        device = self._totals_device(self.computer.step_totals)
+        failure_count = torch.tensor(int(failed), dtype=torch.int64, device=device)
+        # This helper is called only at a common world boundary, before any
+        # group-specific collective or after every such collective completes.
+        dist.all_reduce(failure_count)
+        return bool(failure_count.cpu().item())
+
+    def _raise_if_strict_post_collective_failure(self, local_errors: list[str]) -> None:
+        if not self._synchronize_strict_failure(bool(local_errors)):
+            return
+        local_detail = " | ".join(local_errors) if local_errors else "none on this rank"
+        raise ChannelLossMetadataError(
+            "Channel loss: strict reduction/registry validation failed on at least one rank after all "
+            f"group-specific collectives completed (local errors: {local_detail})."
+        )
+
     def _reduce_step_totals(
         self,
         local_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor]],
+        *,
+        strict_errors: list[str] | None = None,
     ) -> tuple[dict[ChannelKey, tuple[float, int]], dict[ChannelKey, str]]:
         ps = self.parallel_state
         dp_size = ps.dp_size
@@ -1141,8 +1928,11 @@ class ChannelLossCallback(Callback):
             if len(candidates) > 1:
                 msg = f"Channel loss: source_id={source_id!r} has inconsistent names across DP ranks: {candidates}."
                 if self.config.strict:
-                    raise ChannelLossMetadataError(msg)
-                logger.warning_rank0(msg + " Using the lexicographically first name.")
+                    if strict_errors is None:
+                        raise ChannelLossMetadataError(msg)
+                    strict_errors.append(msg)
+                else:
+                    logger.warning_rank0(msg + " Using the lexicographically first name.")
             if candidates:
                 synchronized_names[source_id] = candidates[0]
 
@@ -1165,7 +1955,11 @@ class ChannelLossCallback(Callback):
             source_id: (float(loss_values[index]), int(token_values[index]))
             for index, source_id in enumerate(source_ids)
         }
-        registered_names = self._register_sources(source_ids, synchronized_names)
+        registered_names = self._register_sources(
+            source_ids,
+            synchronized_names,
+            strict_errors=strict_errors,
+        )
         return totals, registered_names
 
     def _reduce_step_data_totals(
@@ -1205,6 +1999,8 @@ class ChannelLossCallback(Callback):
         self,
         source_ids: list[ChannelKey],
         source_names: dict[ChannelKey, str] | None = None,
+        *,
+        strict_errors: list[str] | None = None,
     ) -> dict[ChannelKey, str]:
         source_names = source_names or {}
         for source_id in source_ids:
@@ -1223,8 +2019,11 @@ class ChannelLossCallback(Callback):
             candidates = sorted({registered_name, incoming_name})
             msg = f"Channel loss: source_id={source_id!r} has inconsistent names across sampled steps: {candidates}."
             if self.config.strict:
-                raise ChannelLossMetadataError(msg)
-            logger.warning_once(msg + " Using the lexicographically first name.")
+                if strict_errors is None:
+                    raise ChannelLossMetadataError(msg)
+                strict_errors.append(msg)
+            else:
+                logger.warning_once(msg + " Using the lexicographically first name.")
             self._source_registry[source_id] = candidates[0]
 
         registered_names = {
@@ -1657,6 +2456,31 @@ def _as_str_list(value: Any) -> list[str]:
         if text:
             result.append(text)
     return result
+
+
+def _as_scalar_tensor(
+    value: Any,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    name: str,
+) -> torch.Tensor:
+    tensor = torch.as_tensor(value, device=device, dtype=dtype)
+    if tensor.numel() != 1:
+        raise ChannelLossMetadataError(
+            f"Channel loss: local SP {name} must be scalar, got shape={tuple(tensor.shape)}."
+        )
+    return tensor.reshape(())
+
+
+def _source_id_signature(source_ids: list[ChannelKey]) -> tuple[tuple[str, str], ...]:
+    return tuple((type(source_id).__name__, repr(source_id)) for source_id in source_ids)
+
+
+def _format_capture_errors(errors: list[tuple[str, str]]) -> str:
+    return "Channel loss observation failed: " + " | ".join(
+        f"{error_type}: {message}" for error_type, message in errors
+    )
 
 
 def _sanitize_metric_fragment(value: Any) -> str:

--- a/veomni/trainer/callbacks/channel_loss_dashboard.py
+++ b/veomni/trainer/callbacks/channel_loss_dashboard.py
@@ -1,0 +1,473 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compact W&B dashboard for the channel-loss scalar contract.
+
+The dashboard combines the framework-owned scalar metrics into one stable,
+user-facing HTML panel. It deliberately has no dataloader, storage, or sample
+content dependency.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import math
+import os
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Mapping
+
+from ...utils.logging import get_logger
+from .base import Callback, TrainerState
+
+
+if TYPE_CHECKING:
+    from ..base import BaseTrainer
+
+
+logger = get_logger(__name__)
+
+_DASHBOARD_KEY = "channel_overview"
+_DEFAULT_MAX_RENDER_POINTS = 2000
+_MAX_RETAINED_POINTS = 10000
+_FOUNDATION_LOSS_KEY = "training/foundation_loss"
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logger.warning_once(f"Ignoring invalid {name}={raw_value!r}; expected a positive integer.")
+        return default
+    if value < 1:
+        logger.warning_once(f"Ignoring invalid {name}={raw_value!r}; expected a positive integer.")
+        return default
+    return value
+
+
+def _finite_float(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _stable_source_fragment(value: Any) -> str:
+    """Mirror the stable part of the public metric name without parsing labels."""
+
+    if isinstance(value, int):
+        return f"source-i-{value}"
+    encoded = str(value).encode("utf-8").hex()
+    return f"source-s-{encoded or 'empty'}"
+
+
+def _source_descriptors(trainer: BaseTrainer, metric_fragments: list[str]) -> dict[str, tuple[str, str]]:
+    """Resolve stable keys and labels while containing the compatibility shim.
+
+    The fallback uses the complete metric fragment for both fields.  This
+    function never splits on ``__`` because a valid source name may contain that
+    sequence.  When the core registry is available, the chart key is based only
+    on the stable source ID, so a display-name change cannot split one source
+    into multiple series.  If a future core version changes its registry
+    internals, collection keeps working with less-pretty labels.
+    """
+
+    descriptors = {fragment: (fragment, fragment) for fragment in metric_fragments}
+    callback = getattr(trainer, "channel_loss_callback", None)
+    registry = getattr(callback, "_source_registry", None)
+    if not isinstance(registry, Mapping):
+        return descriptors
+
+    for source_id, source_name in registry.items():
+        stable_key = _stable_source_fragment(source_id)
+        stable_prefix = f"{stable_key}__"
+        matches = [fragment for fragment in metric_fragments if fragment.startswith(stable_prefix)]
+        if len(matches) != 1:
+            continue
+        label = str(source_name) if source_name not in (None, "") else f"source {source_id}"
+        descriptors[matches[0]] = (stable_key, label)
+    return descriptors
+
+
+def _metric_values(metrics: Mapping[str, Any], prefix: str) -> dict[str, float]:
+    prefix_with_slash = f"{prefix}/"
+    result: dict[str, float] = {}
+    for name, raw_value in metrics.items():
+        if not name.startswith(prefix_with_slash):
+            continue
+        value = _finite_float(raw_value)
+        if value is not None:
+            result[name[len(prefix_with_slash) :]] = value
+    return result
+
+
+def _sanitized_metric_fragment(value: Any) -> str:
+    text = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value)).strip("_")
+    return text or "unknown"
+
+
+def _data_metric_suffixes(
+    available_suffixes: set[str],
+    fragments: list[str],
+    descriptors: Mapping[str, tuple[str, str]],
+) -> dict[str, str]:
+    """Resolve every source suffix jointly without coupling to core internals.
+
+    Data metrics use a short source label until two labels collide.  After a
+    collision they use the same stable-qualified suffix as channel loss.  The
+    adapter accepts both forms and never assigns one suffix to two sources.
+    Friendly suffixes are resolved for all sources before stable fallbacks so a
+    valid source label such as ``source-i-0__repoqa`` cannot steal another
+    source's values.
+    """
+
+    # New producers qualify every colliding/cross-colliding source.  If the
+    # complete channel-loss fragment set is present, that mapping is exact and
+    # globally injective; prefer it over the compatibility heuristics below.
+    if all(fragment in available_suffixes for fragment in fragments):
+        return {fragment: fragment for fragment in fragments}
+
+    friendly_candidates: dict[str, list[str]] = {}
+    candidate_owners: dict[str, set[str]] = {}
+    for fragment in fragments:
+        stable_key, label = descriptors[fragment]
+        stable_prefix = f"{stable_key}__"
+        display_fragment = fragment[len(stable_prefix) :] if fragment.startswith(stable_prefix) else ""
+        candidates = list(dict.fromkeys((display_fragment, _sanitized_metric_fragment(label))))
+        friendly_candidates[fragment] = [candidate for candidate in candidates if candidate]
+        for candidate in friendly_candidates[fragment]:
+            candidate_owners.setdefault(candidate, set()).add(fragment)
+
+    resolved: dict[str, str] = {}
+    used_suffixes: set[str] = set()
+    for fragment in fragments:
+        for candidate in friendly_candidates[fragment]:
+            if (
+                candidate in available_suffixes
+                and candidate not in used_suffixes
+                and len(candidate_owners[candidate]) == 1
+            ):
+                resolved[fragment] = candidate
+                used_suffixes.add(candidate)
+                break
+
+    for fragment in fragments:
+        if fragment not in resolved and fragment in available_suffixes and fragment not in used_suffixes:
+            resolved[fragment] = fragment
+            used_suffixes.add(fragment)
+    return resolved
+
+
+def _select_representative_points(points: list[dict[str, Any]], max_points: int) -> list[dict[str, Any]]:
+    if len(points) <= max_points:
+        return points
+    if max_points == 1:
+        return [points[-1]]
+
+    last_index = len(points) - 1
+    last_index_by_source = {}
+    for index, point in enumerate(points):
+        for source_key in point["values"]:
+            last_index_by_source[source_key] = index
+
+    mandatory_indices = {0, last_index, *last_index_by_source.values()}
+    if len(mandatory_indices) > max_points:
+        prioritized_indices = [last_index, *sorted(last_index_by_source.values(), reverse=True), 0]
+        mandatory_indices = set(list(dict.fromkeys(prioritized_indices))[:max_points])
+
+    indices = set(mandatory_indices)
+    for candidate_index in (round(index * last_index / (max_points - 1)) for index in range(max_points)):
+        if len(indices) >= max_points:
+            break
+        indices.add(candidate_index)
+    return [points[index] for index in sorted(indices)]
+
+
+@dataclass
+class ChannelLossDashboardData:
+    """Bounded-render, in-memory view of sampled channel-loss steps."""
+
+    points: list[dict[str, Any]] = field(default_factory=list)
+    labels: dict[str, str] = field(default_factory=dict)
+    sampled_points: int = 0
+
+    def record(
+        self,
+        trainer: BaseTrainer,
+        step: int,
+        metrics: Mapping[str, Any],
+        trace_step_id: Any = None,
+    ) -> bool:
+        callback = getattr(trainer, "channel_loss_callback", None)
+        config = getattr(callback, "config", None)
+        loss_prefix = getattr(config, "loss_metric_prefix", "channel_loss")
+        weighted_prefix = getattr(config, "weighted_loss_metric_prefix", "channel_loss_weighted")
+        token_prefix = getattr(config, "token_count_metric_prefix", "channel_tokens")
+
+        raw_values = _metric_values(metrics, loss_prefix)
+        if not raw_values:
+            return False
+
+        weighted_values = _metric_values(metrics, weighted_prefix)
+        token_values = _metric_values(metrics, token_prefix)
+        sample_values = _metric_values(metrics, "samples")
+        input_token_values = _metric_values(metrics, "input_tokens")
+        label_token_values = _metric_values(metrics, "label_tokens")
+        label_tokens_per_sample_values = _metric_values(metrics, "label_tokens_per_sample")
+        fragments = sorted(raw_values)
+        descriptors = _source_descriptors(trainer, fragments)
+        data_suffixes = _data_metric_suffixes(
+            set(sample_values)
+            | set(input_token_values)
+            | set(label_token_values)
+            | set(label_tokens_per_sample_values),
+            fragments,
+            descriptors,
+        )
+
+        if weighted_values and all(fragment in weighted_values for fragment in fragments):
+            overall_text_loss = sum(weighted_values[fragment] for fragment in fragments)
+        else:
+            overall_text_loss = _finite_float(metrics.get(_FOUNDATION_LOSS_KEY))
+
+        values = {}
+        for fragment in fragments:
+            stable_key, label = descriptors[fragment]
+            data_suffix = data_suffixes.get(fragment)
+            self.labels[stable_key] = label
+            values[stable_key] = {
+                "raw": raw_values[fragment],
+                "weighted": weighted_values.get(fragment),
+                "tokens": token_values.get(fragment),
+                "samples": sample_values.get(data_suffix) if data_suffix is not None else None,
+                "input_tokens": input_token_values.get(data_suffix) if data_suffix is not None else None,
+                "label_tokens": label_token_values.get(data_suffix) if data_suffix is not None else None,
+                "label_tokens_per_sample": (
+                    label_tokens_per_sample_values.get(data_suffix) if data_suffix is not None else None
+                ),
+            }
+        # Optional adapter contract: dataloaders with offline sample tracing may
+        # publish an opaque step identifier without exposing sample content to
+        # the framework dashboard.
+        point = {
+            "step": int(step),
+            "overall": overall_text_loss,
+            "trace_step_id": str(trace_step_id) if trace_step_id is not None else None,
+            "values": values,
+        }
+        if self.points and self.points[-1]["step"] == point["step"]:
+            self.points[-1] = point
+        else:
+            self.points.append(point)
+            self.sampled_points += 1
+        if len(self.points) > _MAX_RETAINED_POINTS:
+            self.points = _select_representative_points(self.points, (_MAX_RETAINED_POINTS + 1) // 2)
+            retained_sources = {
+                source_key for retained_point in self.points for source_key in retained_point["values"]
+            }
+            self.labels = {
+                source_key: label for source_key, label in self.labels.items() if source_key in retained_sources
+            }
+        return True
+
+    def _render_points(self, max_points: int) -> list[dict[str, Any]]:
+        return _select_representative_points(self.points, max_points)
+
+    def payload(self, max_points: int) -> dict[str, Any]:
+        points = self._render_points(max_points)
+        present_fragments = {fragment for point in points for fragment in point["values"]}
+        sources = [
+            {"key": fragment, "label": self.labels.get(fragment, fragment)} for fragment in sorted(present_fragments)
+        ]
+        return {
+            "points": points,
+            "sources": sources,
+            "sampled_points": self.sampled_points,
+            "retained_points": len(self.points),
+            "rendered_points": len(points),
+            "has_weighted": any(
+                source_values.get("weighted") is not None
+                for point in points
+                for source_values in point["values"].values()
+            ),
+            "has_tokens": any(
+                source_values.get("label_tokens") is not None or source_values.get("tokens") is not None
+                for point in points
+                for source_values in point["values"].values()
+            ),
+            "has_data_metrics": any(
+                source_values.get("samples") is not None
+                for point in points
+                for source_values in point["values"].values()
+            ),
+        }
+
+    def render_html(self, max_points: int = _DEFAULT_MAX_RENDER_POINTS) -> str:
+        payload = json.dumps(self.payload(max_points), ensure_ascii=False, separators=(",", ":"))
+        # Prevent source-controlled strings from terminating the data script.
+        payload = payload.replace("&", "\\u0026").replace("<", "\\u003c").replace(">", "\\u003e")
+        return _HTML_TEMPLATE.replace("__CHANNEL_LOSS_PAYLOAD__", payload)
+
+
+class ChannelLossDashboardCallback(Callback):
+    """Publish a compact, interactive dashboard without affecting training."""
+
+    def __init__(self, trainer: BaseTrainer) -> None:
+        super().__init__(trainer)
+        args = trainer.args
+        channel_config = getattr(args.train, "channel_loss", None)
+        self.enabled = bool(
+            getattr(channel_config, "enable", False) and args.train.global_rank == 0 and args.train.wandb.enable
+        )
+        self.data = ChannelLossDashboardData()
+        self.max_render_points = _positive_int_env("VEOMNI_CHANNEL_DASHBOARD_MAX_POINTS", _DEFAULT_MAX_RENDER_POINTS)
+        self._last_published_step: int | None = None
+        self._latest_completed_step: int | None = None
+        self._exit_hook_registered = False
+
+    def on_step_end(self, state: TrainerState, **kwargs: Any) -> None:
+        if not self.enabled:
+            return
+        self._latest_completed_step = int(state.global_step)
+        pop_trace_step_id = getattr(self.trainer, "pop_channel_loss_trace_step_id", None)
+        trace_step_id = pop_trace_step_id() if callable(pop_trace_step_id) else None
+        metrics = getattr(self.trainer, "step_env_metrics", None)
+        if not isinstance(metrics, Mapping):
+            return
+        try:
+            recorded = self.data.record(self.trainer, state.global_step, metrics, trace_step_id=trace_step_id)
+        except Exception as exc:  # observability must not take down training
+            logger.warning_once(f"Channel-loss dashboard collection failed and was skipped: {exc}")
+            return
+        if recorded and not self._exit_hook_registered:
+            # W&B initializes during on_train_begin. Registering here makes this
+            # hook run before W&B's earlier shutdown hook (atexit is LIFO).
+            atexit.register(self._publish_latest_at_exit)
+            self._exit_hook_registered = True
+        # Native scalars remain live in W&B.  Do not upload partial HTML
+        # snapshots: W&B may select the earliest media step by default, which
+        # made a long run look like it only contained step 1.
+        return
+
+    def on_train_end(self, state: TrainerState, **kwargs: Any) -> None:
+        if self.enabled and self.data.points:
+            self._publish(state.global_step)
+        if self._exit_hook_registered:
+            atexit.unregister(self._publish_latest_at_exit)
+            self._exit_hook_registered = False
+
+    def _publish_latest_at_exit(self) -> None:
+        """Best-effort flush for uncaught exceptions; SIGKILL remains unrecoverable."""
+
+        if (
+            self.enabled
+            and self.data.points
+            and self._latest_completed_step is not None
+            and self._last_published_step != self._latest_completed_step
+        ):
+            self._publish(self._latest_completed_step)
+
+    def _publish(self, step: int) -> None:
+        try:
+            import wandb
+
+            if wandb.run is None:
+                return
+            dashboard = wandb.Html(self.data.render_html(self.max_render_points), inject=False)
+            wandb.log({_DASHBOARD_KEY: dashboard}, step=step)
+            self._last_published_step = int(step)
+        except Exception as exc:  # observability must not take down training
+            logger.warning_once(f"Channel-loss dashboard upload failed and was skipped: {exc}")
+
+
+_HTML_TEMPLATE = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+:root{color-scheme:light;--ink:#172033;--muted:#6a7280;--grid:#e8ebf0;--border:#dfe3e8;--panel:#fff;--bg:#f6f7f9;--accent:#654ff0}
+*{box-sizing:border-box}html,body{max-width:100%}body{margin:0;background:var(--bg);color:var(--ink);font:13px/1.45 Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+.dashboard{width:100%;min-width:0;padding:14px}.topbar{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin:0 2px 12px}.title{font-size:18px;font-weight:720;letter-spacing:-.02em}.subtitle{color:var(--muted);margin-top:2px}.stats{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}.pill{background:#eef0f4;border-radius:999px;padding:5px 9px;color:#4b5360;white-space:nowrap}.panel{position:relative;min-width:0;background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:14px 14px 10px;box-shadow:0 1px 2px rgba(16,24,40,.035);margin-bottom:12px}.panel-head{display:flex;justify-content:space-between;align-items:flex-start;gap:12px;margin-bottom:5px}.panel-title{font-weight:680;font-size:14px}.panel-note{color:var(--muted);font-size:12px;margin-top:1px}.toggle{display:inline-flex;flex:none;border:1px solid var(--border);border-radius:8px;padding:2px;background:#f5f6f8}.toggle button{border:0;background:transparent;color:#5c6470;border-radius:6px;padding:5px 10px;cursor:pointer}.toggle button.active{background:#fff;color:var(--ink);box-shadow:0 1px 3px rgba(16,24,40,.14);font-weight:650}.toggle button:disabled{opacity:.4;cursor:not-allowed}.step-select{border:1px solid var(--border);border-radius:8px;background:#fff;color:var(--ink);padding:6px 28px 6px 9px;font:inherit}.chart{width:100%;min-height:285px;display:block;overflow:visible}.legend{display:flex;gap:7px 12px;flex-wrap:wrap;padding:3px 42px 0 58px;max-height:58px;overflow:auto}.legend button{display:inline-flex;align-items:center;gap:6px;border:0;background:transparent;color:#3f4752;padding:1px 0;cursor:pointer;font-size:12px}.legend button.off{opacity:.35;text-decoration:line-through}.swatch{width:9px;height:9px;border-radius:50%;flex:none}.foundation-swatch{width:14px;height:0;border-top:2px dashed #202631;border-radius:0}.tooltip{position:absolute;z-index:5;pointer-events:none;display:none;min-width:min(190px,calc(100% - 16px));max-width:min(310px,calc(100% - 16px));background:rgba(24,31,43,.96);color:#fff;border-radius:8px;padding:8px 10px;box-shadow:0 5px 18px rgba(0,0,0,.22);font-size:12px}.tooltip .step{font-weight:700;margin-bottom:4px}.tooltip .row{display:flex;justify-content:space-between;gap:16px}.tooltip .name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.tooltip .value{font-variant-numeric:tabular-nums}.table-wrap{overflow:auto;margin-top:9px;border:1px solid var(--border);border-radius:9px}.summary-table{width:100%;border-collapse:collapse;white-space:nowrap;font-variant-numeric:tabular-nums}.summary-table th,.summary-table td{padding:8px 10px;text-align:right;border-bottom:1px solid var(--grid)}.summary-table th{background:#f7f8fa;color:#5b6470;font-size:11px;font-weight:650}.summary-table th:first-child,.summary-table td:first-child{text-align:left}.summary-table tbody tr:last-child td{border-bottom:0}.summary-table .total td{font-weight:700;background:#fafbfc}.trace-note{color:var(--muted);font-size:11px;margin:8px 2px 1px;overflow-wrap:anywhere}.trace-note code{color:#4b5360}.footer{color:var(--muted);font-size:11px;padding:0 3px 2px}.empty{padding:80px 20px;text-align:center;color:var(--muted)}
+@media(max-width:520px){
+  body{font-size:11px}.dashboard{padding:7px}.topbar{display:block;margin:0 1px 7px}.title{font-size:14px}.subtitle,.stats,.panel-note,.footer{display:none}.panel{border-radius:8px;padding:8px 7px 6px;margin-bottom:7px}.panel-head{display:block;margin-bottom:1px}.panel-title{font-size:12px}.toggle{display:flex;width:100%;margin-top:5px}.toggle button{flex:1;min-width:0;padding:3px 4px;font-size:10px;white-space:nowrap}.step-select{width:100%;margin-top:5px;padding:4px 7px}.chart{height:132px;min-height:132px}.legend{gap:2px 8px;padding:1px 5px 0;max-height:32px}.legend button{font-size:10px;max-width:46%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.swatch{width:7px;height:7px}.foundation-swatch{width:10px}.tooltip{font-size:10px;min-width:min(150px,calc(100% - 16px));padding:6px 7px}.summary-table th,.summary-table td{padding:5px 7px}.trace-note{font-size:9px}
+}
+</style>
+</head>
+<body>
+<div class="dashboard">
+  <div class="topbar">
+    <div><div class="title">Channel loss · source overview</div><div class="subtitle">One shared axis per question; click a source label to isolate noise.</div></div>
+    <div class="stats" id="stats"></div>
+  </div>
+  <section class="panel" id="loss-panel">
+    <div class="panel-head">
+      <div><div class="panel-title">Source learning</div><div class="panel-note" id="loss-note">Average CE per supervised token; lower is better.</div></div>
+      <div class="toggle"><button id="raw-button" class="active">Raw CE</button><button id="weighted-button">Weighted contribution</button></div>
+    </div>
+    <svg class="chart" id="loss-chart" viewBox="0 0 960 300" preserveAspectRatio="none"></svg>
+    <div class="legend" id="loss-legend"></div><div class="tooltip" id="loss-tooltip"></div>
+  </section>
+  <section class="panel" id="mix-panel">
+    <div class="panel-head"><div><div class="panel-title">Actual data mix</div><div class="panel-note">Share of supervised label tokens observed by channel loss, stacked to 100%.</div></div></div>
+    <svg class="chart" id="mix-chart" viewBox="0 0 960 300" preserveAspectRatio="none"></svg>
+    <div class="legend" id="mix-legend"></div><div class="tooltip" id="mix-tooltip"></div>
+  </section>
+  <section class="panel" id="summary-panel">
+    <div class="panel-head">
+      <div><div class="panel-title">Step sample summary</div><div class="panel-note">Click either chart or choose a step. Counts are globally reduced by the channel-loss callback.</div></div>
+      <select class="step-select" id="summary-step" aria-label="Summary optimizer step"></select>
+    </div>
+    <div class="table-wrap"><table class="summary-table"><thead><tr><th>Source</th><th>Samples</th><th>Input tokens</th><th>Label tokens</th><th>Label / sample</th><th>Trace</th></tr></thead><tbody id="summary-body"></tbody></table></div>
+    <div class="trace-note" id="trace-note"></div>
+  </section>
+  <div class="footer">Native channel-loss scalars remain available for live W&amp;B comparison. Sample-level details remain in optional dataloader-owned trace artifacts; this dashboard renders aggregate metrics only.</div>
+</div>
+<script>
+const DATA=__CHANNEL_LOSS_PAYLOAD__;
+const NS="http://www.w3.org/2000/svg";
+const COLORS=["#654ff0","#10a37f","#ef7d32","#2d7ff9","#d84f8b","#00a6b2","#9b6b35","#7a63a8","#cf4b42","#5b8c3a","#64748b","#e2a400"];
+let mode="raw",summaryStep=DATA.points.at(-1)?.step??null;const hidden=new Set();
+const sourceMap=new Map(DATA.sources.map((s,i)=>[s.key,{...s,color:COLORS[i%COLORS.length]}]));
+const SHARES=DATA.points.map(p=>{let total=0;const values={};for(const src of DATA.sources){const item=p.values[src.key],value=item?.label_tokens??item?.tokens??0;values[src.key]=value;total+=value}return Object.fromEntries(DATA.sources.map(src=>[src.key,total>0?values[src.key]/total:0]))});
+const fmt=v=>v==null?"—":(Math.abs(v)>=1000?v.toLocaleString(undefined,{maximumFractionDigits:0}):v.toLocaleString(undefined,{maximumFractionDigits:4}));
+const pct=v=>v==null?"—":(100*v).toFixed(v<.01?2:1)+"%";
+const node=(name,attrs={},text=null)=>{const n=document.createElementNS(NS,name);for(const [k,v] of Object.entries(attrs))n.setAttribute(k,v);if(text!==null)n.textContent=text;return n};
+const visibleSources=()=>DATA.sources.filter(s=>!hidden.has(s.key));
+function scales(points,values,yFloor=0,yCeil=null){const W=960,H=300,m={l:58,r:18,t:14,b:38};let xmin=Infinity,xmax=-Infinity,lo=Infinity,hi=-Infinity;for(const p of points){xmin=Math.min(xmin,p.step);xmax=Math.max(xmax,p.step)}for(const v of values){if(Number.isFinite(v)){lo=Math.min(lo,v);hi=Math.max(hi,v)}}if(!Number.isFinite(lo)||!Number.isFinite(hi)){lo=0;hi=1}lo=Math.min(lo,yFloor);hi=yCeil??hi;if(hi<=lo)hi=lo+1;hi*=yCeil==null?1.06:1;const x=v=>m.l+(v-xmin)/Math.max(1,xmax-xmin)*(W-m.l-m.r);const y=v=>m.t+(hi-v)/(hi-lo)*(H-m.t-m.b);return{W,H,m,x,y,lo,hi,xmin,xmax}}
+function axes(svg,s,yTicks=5,percent=false){svg.append(node("line",{x1:s.m.l,y1:s.m.t,x2:s.m.l,y2:s.H-s.m.b,stroke:"#aeb5bf"}));svg.append(node("line",{x1:s.m.l,y1:s.H-s.m.b,x2:s.W-s.m.r,y2:s.H-s.m.b,stroke:"#aeb5bf"}));for(let i=0;i<=yTicks;i++){const v=s.lo+(s.hi-s.lo)*i/yTicks,y=s.y(v);svg.append(node("line",{x1:s.m.l,y1:y,x2:s.W-s.m.r,y2:y,stroke:"#e8ebf0"}));svg.append(node("text",{x:s.m.l-9,y:y+4,"text-anchor":"end",fill:"#737b88","font-size":"11"},percent?Math.round(v*100)+"%":fmt(v)))}const ticks=Math.min(6,DATA.points.length);for(let i=0;i<ticks;i++){const v=s.xmin+(s.xmax-s.xmin)*i/Math.max(1,ticks-1),x=s.x(v);svg.append(node("text",{x,y:s.H-13,"text-anchor":"middle",fill:"#737b88","font-size":"11"},fmt(Math.round(v))))}svg.append(node("text",{x:(s.m.l+s.W-s.m.r)/2,y:s.H-1,"text-anchor":"middle",fill:"#737b88","font-size":"11"},"optimizer step"))}
+function pathFor(points,s,getter){let d="",started=false;for(const p of points){const v=getter(p);if(v==null){started=false;continue}d+=(started?"L":"M")+s.x(p.step).toFixed(2)+","+s.y(v).toFixed(2);started=true}return d}
+function sampledMarkers(points,max=200){if(points.length<=max)return points;return Array.from({length:max},(_,i)=>points[Math.round(i*(points.length-1)/(max-1))])}
+function renderLegend(id){const el=document.getElementById(id);el.replaceChildren();for(const src of DATA.sources){const b=document.createElement("button");b.className=hidden.has(src.key)?"off":"";const sw=document.createElement("span");sw.className="swatch";sw.style.background=sourceMap.get(src.key).color;b.append(sw,document.createTextNode(src.label));b.onclick=()=>{hidden.has(src.key)?hidden.delete(src.key):hidden.add(src.key);renderAll()};el.append(b)}if(id==="loss-legend"){const b=document.createElement("button"),sw=document.createElement("span");sw.className="foundation-swatch";b.append(sw,document.createTextNode("overall text loss"));el.append(b)}}
+function installHover(svg,panel,tooltip,s,rowsFor){const line=node("line",{y1:s.m.t,y2:s.H-s.m.b,stroke:"#9299a5","stroke-dasharray":"3 3",display:"none"});svg.append(line);const overlay=node("rect",{x:s.m.l,y:s.m.t,width:s.W-s.m.l-s.m.r,height:s.H-s.m.t-s.m.b,fill:"transparent",cursor:"crosshair"});svg.append(overlay);const nearest=e=>{const r=svg.getBoundingClientRect(),vx=(e.clientX-r.left)/r.width*960,step=s.xmin+(vx-s.m.l)/(s.W-s.m.l-s.m.r)*(s.xmax-s.xmin);let pointIndex=0;for(let i=1;i<DATA.points.length;i++){if(Math.abs(DATA.points[i].step-step)<Math.abs(DATA.points[pointIndex].step-step))pointIndex=i}return[DATA.points[pointIndex],pointIndex]};overlay.addEventListener("mouseleave",()=>{line.setAttribute("display","none");tooltip.style.display="none"});overlay.addEventListener("click",e=>setSummaryStep(nearest(e)[0].step));overlay.addEventListener("mousemove",e=>{const [p,pointIndex]=nearest(e);line.setAttribute("x1",s.x(p.step));line.setAttribute("x2",s.x(p.step));line.setAttribute("display","block");const rows=rowsFor(p,pointIndex);tooltip.innerHTML="";const head=document.createElement("div");head.className="step";head.textContent="step "+p.step;tooltip.append(head);for(const [name,value] of rows){const row=document.createElement("div"),n=document.createElement("span"),v=document.createElement("span");row.className="row";n.className="name";v.className="value";n.textContent=name;v.textContent=value;row.append(n,v);tooltip.append(row)}tooltip.style.display="block";const pr=panel.getBoundingClientRect();let left=e.clientX-pr.left+12;if(left+tooltip.offsetWidth>pr.width-8)left=e.clientX-pr.left-tooltip.offsetWidth-12;left=Math.max(8,Math.min(left,Math.max(8,pr.width-tooltip.offsetWidth-8)));tooltip.style.left=left+"px";tooltip.style.top=(e.clientY-pr.top+10)+"px"})}
+function renderLoss(){const svg=document.getElementById("loss-chart");svg.replaceChildren();if(!DATA.points.length){svg.replaceWith(Object.assign(document.createElement("div"),{className:"empty",textContent:"No channel-loss samples yet."}));return}const vals=[];for(const p of DATA.points){if(p.overall!=null)vals.push(p.overall);for(const src of visibleSources()){const v=p.values[src.key]?.[mode];if(v!=null)vals.push(v)}}const s=scales(DATA.points,vals,0);axes(svg,s);for(const src of visibleSources()){const observations=DATA.points.filter(p=>p.values[src.key]?.[mode]!=null),color=sourceMap.get(src.key).color,d=pathFor(DATA.points,s,p=>p.values[src.key]?.[mode]??null);if(d)svg.append(node("path",{d,fill:"none",stroke:color,"stroke-width":"2.2","vector-effect":"non-scaling-stroke"}));for(const p of sampledMarkers(observations))svg.append(node("circle",{cx:s.x(p.step),cy:s.y(p.values[src.key][mode]),r:"2.5",fill:color,"vector-effect":"non-scaling-stroke"}))}const overallPoints=DATA.points.filter(p=>p.overall!=null),overallPath=pathFor(DATA.points,s,p=>p.overall);if(overallPath)svg.append(node("path",{d:overallPath,fill:"none",stroke:"#202631","stroke-width":"1.8","stroke-dasharray":"6 4","vector-effect":"non-scaling-stroke"}));for(const p of sampledMarkers(overallPoints))svg.append(node("circle",{cx:s.x(p.step),cy:s.y(p.overall),r:"2.1",fill:"#202631","vector-effect":"non-scaling-stroke"}));installHover(svg,document.getElementById("loss-panel"),document.getElementById("loss-tooltip"),s,p=>{const rows=visibleSources().map(src=>[src.label,fmt(p.values[src.key]?.[mode])]);rows.push(["overall text loss",fmt(p.overall)]);return rows});renderLegend("loss-legend")}
+function renderMix(){const svg=document.getElementById("mix-chart");svg.replaceChildren();if(!DATA.points.length)return;const s=scales(DATA.points,[0,1],0,1);s.hi=1;s.lo=0;s.y=v=>s.m.t+(1-v)*(s.H-s.m.t-s.m.b);axes(svg,s,4,true);if(DATA.points.length===1){let cumulative=0;for(const src of DATA.sources){const share=SHARES[0][src.key]??0,bottom=cumulative;cumulative+=share;if(hidden.has(src.key))continue;svg.append(node("rect",{x:s.m.l,y:s.y(cumulative),width:s.W-s.m.l-s.m.r,height:s.y(bottom)-s.y(cumulative),fill:sourceMap.get(src.key).color,"fill-opacity":".72",stroke:"#fff","stroke-width":".7"}))}}else{const cumulative=DATA.points.map(()=>0);for(const src of DATA.sources){if(hidden.has(src.key))continue;const top=[],bottom=[];DATA.points.forEach((p,i)=>{bottom.push(cumulative[i]);cumulative[i]+=SHARES[i][src.key]??0;top.push(cumulative[i])});const upper=DATA.points.map((p,i)=>s.x(p.step)+","+s.y(top[i])).join(" L");const lower=[...DATA.points].reverse().map((p,j)=>{const i=DATA.points.length-1-j;return s.x(p.step)+","+s.y(bottom[i])}).join(" L");svg.append(node("path",{d:"M"+upper+" L"+lower+" Z",fill:sourceMap.get(src.key).color,"fill-opacity":".72",stroke:"#fff","stroke-width":".7","vector-effect":"non-scaling-stroke"}))}}installHover(svg,document.getElementById("mix-panel"),document.getElementById("mix-tooltip"),s,(p,i)=>visibleSources().map(src=>[src.label,pct(SHARES[i][src.key])]));renderLegend("mix-legend")}
+function setSummaryStep(step){summaryStep=step;const select=document.getElementById("summary-step");if(select)select.value=String(step);renderSummary()}
+function addCell(row,value,className=""){const cell=document.createElement("td");cell.textContent=value;if(className)cell.className=className;row.append(cell)}
+function renderSummary(){const panel=document.getElementById("summary-panel");if(!DATA.has_data_metrics||!DATA.points.length){panel.hidden=true;return}panel.hidden=false;const select=document.getElementById("summary-step");if(!select.options.length){for(const point of DATA.points){const option=document.createElement("option");option.value=String(point.step);option.textContent="step "+point.step;select.append(option)}select.onchange=()=>setSummaryStep(Number(select.value))}if(summaryStep==null||!DATA.points.some(point=>point.step===summaryStep))summaryStep=DATA.points.at(-1).step;select.value=String(summaryStep);const point=DATA.points.find(item=>item.step===summaryStep),body=document.getElementById("summary-body");body.replaceChildren();const hasTrace=point.trace_step_id!=null;let totalSamples=0,totalInput=0,totalLabels=0;for(const src of DATA.sources){const values=point.values[src.key];if(!values||values.samples==null)continue;const row=document.createElement("tr");addCell(row,src.label);addCell(row,fmt(values.samples));addCell(row,fmt(values.input_tokens));addCell(row,fmt(values.label_tokens));addCell(row,fmt(values.label_tokens_per_sample));addCell(row,hasTrace?"linked":"aggregate only");body.append(row);totalSamples+=values.samples??0;totalInput+=values.input_tokens??0;totalLabels+=values.label_tokens??0}const total=document.createElement("tr");total.className="total";addCell(total,"TOTAL");addCell(total,fmt(totalSamples));addCell(total,fmt(totalInput));addCell(total,fmt(totalLabels));addCell(total,totalSamples?fmt(totalLabels/totalSamples):"—");addCell(total,hasTrace?"linked":"aggregate only");body.append(total);const note=document.getElementById("trace-note");note.replaceChildren();if(hasTrace){note.append(document.createTextNode("Trace step: "));const code=document.createElement("code");code.textContent=point.trace_step_id;note.append(code,document.createTextNode(" · Exact sample details stay in adapter-owned trace artifacts."))}else{note.textContent="Sample details are unavailable in this panel; enable a compatible dataloader trace adapter for offline drilldown."}}
+function renderStats(){const last=DATA.points.at(-1);const stats=document.getElementById("stats");stats.replaceChildren();const detail=DATA.retained_points<DATA.sampled_points?" · "+DATA.retained_points+" retained":DATA.rendered_points<DATA.retained_points?" · "+DATA.rendered_points+" shown":"";for(const text of [last?"latest step "+last.step:"no data",DATA.sources.length+" sources",DATA.sampled_points+" sampled points"+detail]){const p=document.createElement("span");p.className="pill";p.textContent=text;stats.append(p)}}
+function renderAll(){renderStats();renderLoss();if(DATA.has_tokens)renderMix();renderSummary()}
+document.getElementById("raw-button").onclick=()=>{mode="raw";document.getElementById("raw-button").classList.add("active");document.getElementById("weighted-button").classList.remove("active");document.getElementById("loss-note").textContent="Average CE per supervised token; lower is better.";renderLoss()};
+document.getElementById("weighted-button").onclick=()=>{if(!DATA.has_weighted)return;mode="weighted";document.getElementById("weighted-button").classList.add("active");document.getElementById("raw-button").classList.remove("active");document.getElementById("loss-note").textContent="Per-source contribution; contributions sum to the overall supervised text loss.";renderLoss()};
+if(!DATA.has_weighted){document.getElementById("weighted-button").disabled=true;document.getElementById("weighted-button").title="channel_loss.log_weighted_loss is disabled"}
+if(!DATA.has_tokens)document.getElementById("mix-panel").hidden=true;
+renderAll();
+</script>
+</body>
+</html>"""

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -28,6 +28,7 @@ from transformers.modeling_outputs import ModelOutput
 from ..arguments import DataArguments, ModelArguments, TrainingArguments, VeOmniArguments
 from ..data import build_data_transform, build_dataloader
 from ..data.data_collator import DataCollator
+from ..data.source_metadata import strip_source_metadata
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
 from ..distributed.parallel_state import get_parallel_state, use_parallel_state
 from ..models import build_foundation_model
@@ -433,6 +434,10 @@ class DiTTrainer:
                 return [_to_device(item) for item in v]
             return v
 
+        strip_source_metadata(
+            micro_batch,
+            strip_legacy=bool(getattr(getattr(self.base.args, "data", None), "enable_multisource", False)),
+        )
         micro_batch = {k: _to_device(v) for k, v in micro_batch.items()}
         if getattr(self.base, "LOG_SAMPLE", True):
             helper.print_example(example=micro_batch, rank=self.base.args.train.local_rank)

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -407,6 +407,11 @@ class TextDPOTrainer:
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
         self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
 
+    def set_channel_loss_trace_step_id(self, trace_step_id: Any) -> None:
+        """Forward the optional dataloader trace contract to the base trainer."""
+
+        self.base.set_channel_loss_trace_step_id(trace_step_id)
+
     def train_step(self, data_iterator: Any) -> Dict[str, float]:
         args: VeOmniDPOArguments = self.base.args
         self.base.state.global_step += 1

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -402,7 +402,7 @@ class TextDPOTrainer:
     def on_step_begin(self, micro_batches=None):
         # Each DPO preference pair is packed as two consecutive causal-LM
         # segments (chosen, rejected) but carries one source metadata entry.
-        self.base.on_step_begin(micro_batches=micro_batches, source_repeat=2)
+        self.base.on_step_begin(micro_batches=micro_batches, channel_loss_source_repeat=2)
 
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
         self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -108,6 +108,11 @@ class TextTrainer:
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
         self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
 
+    def set_channel_loss_trace_step_id(self, trace_step_id: Any) -> None:
+        """Forward the optional dataloader trace contract to the base trainer."""
+
+        self.base.set_channel_loss_trace_step_id(trace_step_id)
+
     def train_step(
         self,
         data_iterator: Any,

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -282,6 +282,11 @@ class VLMTrainer:
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
         self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
 
+    def set_channel_loss_trace_step_id(self, trace_step_id: Any) -> None:
+        """Forward the optional dataloader trace contract to the base trainer."""
+
+        self.base.set_channel_loss_trace_step_id(trace_step_id)
+
     def train_step(
         self,
         data_iterator: Any,

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -144,9 +144,7 @@ def _compute_wan_seqlens(micro_batch: Dict[str, "torch.Tensor"]) -> List[int]:
 
 
 def _get_multisource_ds_idx(micro_batch: Dict[str, "torch.Tensor"]) -> List[int]:
-    ds_idx = micro_batch.pop("ds_idx")
-    micro_batch.pop("source_name", None)
-    micro_batch.pop("cur_token_num", None)
+    ds_idx = micro_batch["ds_idx"]
     if isinstance(ds_idx, torch.Tensor):
         # packed micro batch
         return ds_idx.tolist()


### PR DESCRIPTION
### What does this PR do?

> Depends on #954 at `a73eab01`. This PR makes per-source attribution survive public/native loader transforms, packing, padding, DPO expansion, and sequence-parallel slicing without adding any private loader dependency.

- Adds a versioned raw-to-packed source metadata contract with typed stable IDs.
- Validates canonical segment coordinates against the actual packed attention and position boundaries on every canonical step, including unsampled non-strict steps.
- Migrates historical weighted-multisource checkpoints to stable IDs without silently redirecting dynamic-batching buffer entries.
- Removes observation-owned metadata before model forward while preserving unrelated custom-model inputs.

This PR contains no Byted loader, sample-content audit, HDFS, NPU/Mojo/GDR, activation-offload, or experiment code.

### Checklist Before Starting

- Related PR: #954
- PR title follows the enforced `[{modules}] {type}: {description}` format.

### Test

- `make quality`: passed.
- Focused loader/collator/channel-loss/checkpoint suite: `175 passed, 1 deselected`.
- `python -m compileall` on all changed product modules: passed.
- `git diff --check a73eab01..HEAD`: passed.
- Independent final blind review: approved with no P0/P1 findings.

The deselected test is the existing outer `torchrun` chain, which is blocked in this CPU development environment before the changed path by the default Triton/child-environment setup. No distributed-hardware, throughput, or loss-invariance result is claimed here; those require a follow-up hardware run of the combined PR stack.

### API and Usage Example

A custom public loader attaches one raw envelope after its transform and before `MainCollator`:

```python
sample["_veomni_source_metadata"] = {
    "schema_version": 1,
    "source_id": 7,              # int or str; type is preserved
    "source_name": "repoqa",     # optional
    "row_id": 42,                # optional diagnostic
    "sample_id": "sample-42",    # optional diagnostic
}
```

`MainCollator` consumes that envelope and emits one
`_veomni_packed_source_metadata` envelope in full pre-SP coordinates. Channel
loss uses the canonical envelope first and treats configured legacy keys as a
compatibility fallback.

### Design & Code Changes

- Public metadata schema:
  - validates typed `int | str` source IDs and source-ID/name consistency;
  - tracks ordered sample/subsegment token coordinates;
  - excludes fixed/SP tail padding from canonical valid-token coordinates.
- Public loaders:
  - preserve metadata after iterable, mapping, and weighted transforms;
  - honor configured stable IDs;
  - fail explicitly for fixed-batch one-to-many transforms instead of dropping parts.
- Resume:
  - versions weighted state and migrates the historical name-keyed builder state;
  - rewrites dynamic `save_by_idx` buffers only after upstream state restore;
  - rejects ambiguous, removed, or reused legacy aliases;
  - validates typed interleave source topology for new checkpoints while accepting legacy version-less states.
- Channel loss:
  - rejects canonical/legacy ID or name conflicts;
  - validates canonical boundaries against full `cu_seq_lens_q`, tail padding, and non-SP `position_ids`;
  - preserves the existing observation-only objective/gradient semantics.
- Trainer cleanup:
  - strips contract-owned fields in Base and DiT paths before logging/model use;
  - keeps generic fields when no canonical or multisource contract owns them.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied pre-commit quality checks.
- [x] Added/updated documentation.
- [x] Added focused tests for the new public contract and migration paths.
