### PR TITLE
[dist, ops, data, model] feat: add Ring and Hybrid context parallel

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}"
           CHANGED=$(git diff --name-only "$BASE_SHA" HEAD -- || true)
-          if echo "$CHANGED" | grep -qE '(veomni/distributed/sequence_parallel/|veomni/models/transformers/qwen3_5/)'; then
+          if echo "$CHANGED" | grep -qE '(veomni/distributed/sequence_parallel/|veomni/distributed/context_parallel/|veomni/models/transformers/qwen3_5/)'; then
             echo "qwen3_5_ulysses=true" >> "$GITHUB_OUTPUT"
           else
             echo "qwen3_5_ulysses=false" >> "$GITHUB_OUTPUT"
@@ -128,6 +128,9 @@ jobs:
           uv run --frozen pytest -s -x tests/parallel/ulysses/test_slice_input_tensor.py
           uv run --frozen pytest -s -x tests/parallel/encoder_data_balance/test_balance_reverse.py
           uv run --frozen pytest -s -x tests/parallel/encoder_data_balance/test_balance_sorting_algo.py
+          uv run --frozen pytest -s -x tests/parallel/context_parallel/test_topology.py
+          uv run --frozen pytest -s -x tests/parallel/context_parallel/test_packed_sharding.py
+          uv run --frozen pytest -s -x tests/parallel/context_parallel/test_primitives.py
           uv run --frozen pytest -s -x tests/parallel/test_chunk_mbs.py
       - name: Run models tests
         run: |

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -88,7 +88,7 @@ init_parallel_state(
     dp_shard_size=args.train.accelerator.dp_shard_size, # data parallel shard degree
     tp_size=args.train.accelerator.tp_size, # tensor parallel size
     pp_size=args.train.accelerator.pp_size, # pipeline parallel size, not support now
-    cp_size=args.train.accelerator.cp_size, # context parallel size, not support now
+    cp_size=args.train.accelerator.cp_size, # context parallel size (Ring / Hybrid with ulysses_size)
     ulysses_size=args.train.accelerator.ulysses_size, # ulysses parallel size
     extra_parallel_sizes=args.train.accelerator.extra_parallel_sizes, # including expert parallel size
     extra_parallel_placement_innermost=args.train.accelerator.extra_parallel_placement_innermost,

--- a/tests/parallel/context_parallel/test_hybrid_groups.py
+++ b/tests/parallel/context_parallel/test_hybrid_groups.py
@@ -1,0 +1,68 @@
+import os
+import tempfile
+
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from veomni.distributed.context_parallel.topology import (
+    coords_from_sp_rank,
+    cp_global_ranks_for_ulysses_rank,
+    ulysses_global_ranks_for_cp_rank,
+)
+from veomni.distributed.sequence_parallel.comm import (
+    get_context_parallel_group,
+    get_ulysses_sequence_parallel_group,
+    get_unified_sequence_parallel_group,
+    init_sequence_parallel,
+)
+
+
+def _worker(rank: int, world_size: int, file_name: str, errors: mp.Queue):
+    try:
+        store = dist.FileStore(file_name, world_size)
+        dist.init_process_group("gloo", store=store, rank=rank, world_size=world_size)
+        cp_size, ulysses_size = 2, 4
+        init_sequence_parallel(ulysses_size=ulysses_size, sep_dp=True, cp_size=cp_size)
+
+        cp_rank, ulysses_rank = coords_from_sp_rank(rank % (cp_size * ulysses_size), cp_size, ulysses_size)
+        expected_cp = cp_global_ranks_for_ulysses_rank(
+            dp_index=0, ulysses_rank=ulysses_rank, cp_size=cp_size, ulysses_size=ulysses_size
+        )
+        expected_ulysses = ulysses_global_ranks_for_cp_rank(
+            dp_index=0, cp_rank=cp_rank, cp_size=cp_size, ulysses_size=ulysses_size
+        )
+
+        cp_group = get_context_parallel_group()
+        ulysses_group = get_ulysses_sequence_parallel_group()
+        sp_group = get_unified_sequence_parallel_group()
+
+        assert sorted(dist.get_process_group_ranks(cp_group)) == expected_cp
+        assert sorted(dist.get_process_group_ranks(ulysses_group)) == expected_ulysses
+        assert sorted(dist.get_process_group_ranks(sp_group)) == list(range(world_size))
+        assert dist.get_rank(cp_group) == expected_cp.index(rank)
+        assert dist.get_rank(ulysses_group) == expected_ulysses.index(rank)
+
+        dist.destroy_process_group()
+        errors.put(None)
+    except Exception as exc:  # noqa: BLE001
+        errors.put(repr(exc))
+
+
+def test_u4_cp2_init_sequence_parallel_groups():
+    world_size = 8
+    with tempfile.TemporaryDirectory() as tmp:
+        file_name = os.path.join(tmp, "pg")
+        ctx = mp.get_context("spawn")
+        errors = ctx.Queue()
+        processes = [
+            ctx.Process(target=_worker, args=(rank, world_size, file_name, errors))
+            for rank in range(world_size)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=180)
+            assert process.exitcode == 0, f"worker exited with {process.exitcode}"
+        for _ in range(world_size):
+            err = errors.get(timeout=5)
+            assert err is None, err

--- a/tests/parallel/context_parallel/test_packed_sharding.py
+++ b/tests/parallel/context_parallel/test_packed_sharding.py
@@ -1,0 +1,106 @@
+import pytest
+import torch
+
+from veomni.distributed.context_parallel.attention_backend import torch_packed_causal_attention
+from veomni.distributed.context_parallel.packed_sharding import (
+    apply_packed_cp_partition,
+    build_packed_cp_partition,
+)
+from veomni.distributed.context_parallel.ring_attention import (
+    dense_causal_attention,
+    simulate_packed_ring_causal_attention,
+)
+
+
+def test_packed_cp_partition_keeps_sample_boundaries_cp2():
+    # Two samples of length 16 each (divisible by 2*cp=4).
+    cu = torch.tensor([0, 16, 32], dtype=torch.int32)
+    seq = torch.arange(32)
+    p0 = build_packed_cp_partition(cu, cp_size=2, cp_rank=0)
+    p1 = build_packed_cp_partition(cu, cp_size=2, cp_rank=1)
+
+    torch.testing.assert_close(p0.local_cu_seqlens, torch.tensor([0, 8, 16], dtype=torch.int32))
+    torch.testing.assert_close(p1.local_cu_seqlens, torch.tensor([0, 8, 16], dtype=torch.int32))
+
+    # Rank0 per sample: early chunk0 + late chunk3 inside each sample.
+    expected0 = torch.cat(
+        (
+            torch.arange(0, 4),
+            torch.arange(12, 16),
+            torch.arange(16, 20),
+            torch.arange(28, 32),
+        )
+    )
+    torch.testing.assert_close(p0.token_indices, expected0)
+    torch.testing.assert_close(apply_packed_cp_partition(seq, p0, dim=0), expected0)
+
+
+def test_packed_partition_rejects_non_divisible_sample():
+    cu = torch.tensor([0, 15, 32], dtype=torch.int32)
+    with pytest.raises(ValueError, match="divisible"):
+        build_packed_cp_partition(cu, cp_size=2, cp_rank=0)
+
+
+def test_hybrid_packed_partition_u4_cp2():
+    cu = torch.tensor([0, 64], dtype=torch.int32)  # one sample, multiple=16
+    parts = [
+        build_packed_cp_partition(cu, cp_size=2, cp_rank=cp, ulysses_size=4, ulysses_rank=u)
+        for cp in range(2)
+        for u in range(4)
+    ]
+    assert all(p.token_indices.numel() == 8 for p in parts)
+    # All indices unique and cover full sequence.
+    covered = torch.cat([p.token_indices for p in parts]).sort().values
+    torch.testing.assert_close(covered, torch.arange(64))
+
+
+def test_simulate_packed_ring_matches_packed_dense_and_blocks_cross_sample():
+    torch.manual_seed(0)
+    cp_size = 2
+    batch, hq, hkv, head_dim = 1, 4, 2, 8
+    # Two samples length 32 each.
+    cu = torch.tensor([0, 32, 64], dtype=torch.int32)
+    query = torch.randn(batch, hq, 64, head_dim, dtype=torch.float32)
+    key = torch.randn(batch, hkv, 64, head_dim, dtype=torch.float32)
+    value = torch.randn(batch, hkv, 64, head_dim, dtype=torch.float32)
+    # Amplify sample-1 keys so cross-sample leakage would show up in sample-0 outputs.
+    key[:, :, 32:] = key[:, :, 32:] + 50.0
+
+    packed_dense = torch_packed_causal_attention(query, key, value, cu, softmax_scale=head_dim**-0.5)
+    ring = simulate_packed_ring_causal_attention(
+        query, key, value, cu, cp_size=cp_size, softmax_scale=head_dim**-0.5
+    )
+    torch.testing.assert_close(ring, packed_dense, atol=1e-4, rtol=1e-4)
+
+    # Sample-0 ring output must match dense attention on sample-0 alone.
+    s0 = dense_causal_attention(
+        query[:, :, :32], key[:, :, :32], value[:, :, :32], softmax_scale=head_dim**-0.5
+    )
+    torch.testing.assert_close(ring[:, :, :32], s0, atol=1e-4, rtol=1e-4)
+
+
+def test_ulysses_rank_major_reorder_roundtrip():
+    from veomni.distributed.context_parallel.packed_sharding import (
+        reorder_sample_major_to_ulysses_rank_major,
+        reorder_ulysses_rank_major_to_sample_major,
+        ulysses_local_cu_to_cp_local_cu,
+    )
+
+    # Two samples, ulysses-local lengths 4 and 4; U=2 → gathered seq 16.
+    local_cu = torch.tensor([0, 4, 8], dtype=torch.int32)
+    # Simulate post-gather rank-major: [u0_s0|u0_s1|u1_s0|u1_s1]
+    u0 = torch.arange(0, 8)
+    u1 = torch.arange(100, 108)
+    rank_major = torch.cat([u0, u1]).view(1, 16, 1, 1)
+    sample_major = reorder_ulysses_rank_major_to_sample_major(
+        rank_major, local_cu, ulysses_size=2, seq_dim=1
+    )
+    # Expected: [s0_u0|s0_u1|s1_u0|s1_u1] = [0..3|100..103|4..7|104..107]
+    expected = torch.tensor([0, 1, 2, 3, 100, 101, 102, 103, 4, 5, 6, 7, 104, 105, 106, 107])
+    torch.testing.assert_close(sample_major.view(-1), expected)
+    back = reorder_sample_major_to_ulysses_rank_major(
+        sample_major, local_cu, ulysses_size=2, seq_dim=1
+    )
+    torch.testing.assert_close(back, rank_major)
+    cp_cu = ulysses_local_cu_to_cp_local_cu(local_cu, 2)
+    torch.testing.assert_close(cp_cu, torch.tensor([0, 8, 16], dtype=torch.int32))

--- a/tests/parallel/context_parallel/test_primitives.py
+++ b/tests/parallel/context_parallel/test_primitives.py
@@ -1,0 +1,121 @@
+import pytest
+import torch
+
+from veomni.distributed.context_parallel.sharding import (
+    balanced_cp_restore,
+    balanced_cp_slice,
+    balanced_cp_to_rank_major,
+    hybrid_cp_slice,
+)
+from veomni.distributed.context_parallel.softmax_update import merge_attention_blocks
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_balanced_cp_slice_round_trip(cp_size: int):
+    sequence = torch.arange(64)
+    local_shards = [balanced_cp_slice(sequence, cp_size=cp_size, cp_rank=rank) for rank in range(cp_size)]
+
+    restored = balanced_cp_restore(torch.cat(local_shards), cp_size=cp_size)
+
+    torch.testing.assert_close(restored, sequence)
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_balanced_cp_to_rank_major_round_trip(cp_size: int):
+    sequence = torch.arange(64)
+    rank_major = balanced_cp_to_rank_major(sequence, cp_size=cp_size)
+    restored = balanced_cp_restore(rank_major, cp_size=cp_size)
+    torch.testing.assert_close(restored, sequence)
+    torch.testing.assert_close(
+        rank_major,
+        torch.cat([balanced_cp_slice(sequence, cp_size=cp_size, cp_rank=rank) for rank in range(cp_size)]),
+    )
+
+
+def test_hybrid_cp_slice_matches_ring_then_ulysses_partition():
+    sequence = torch.arange(64)
+    cp_size = 2
+    ulysses_size = 4
+
+    local_shards = [
+        hybrid_cp_slice(
+            sequence,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            ulysses_size=ulysses_size,
+            ulysses_rank=ulysses_rank,
+        )
+        for cp_rank in range(cp_size)
+        for ulysses_rank in range(ulysses_size)
+    ]
+
+    assert all(shard.numel() == 8 for shard in local_shards)
+    torch.testing.assert_close(local_shards[0], torch.arange(0, 8))
+    torch.testing.assert_close(local_shards[3], torch.arange(56, 64))
+    torch.testing.assert_close(local_shards[4], torch.arange(16, 24))
+    torch.testing.assert_close(local_shards[7], torch.arange(40, 48))
+
+
+def test_balanced_cp_slice_rejects_non_divisible_sequence():
+    with pytest.raises(ValueError, match="2 \\* cp_size"):
+        balanced_cp_slice(torch.arange(63), cp_size=2, cp_rank=0)
+
+
+def _block_attention(query: torch.Tensor, key: torch.Tensor, value: torch.Tensor):
+    scores = query @ key.transpose(-1, -2)
+    block_max = scores.max(dim=-1, keepdim=True).values
+    exp_scores = torch.exp(scores - block_max)
+    block_sum = exp_scores.sum(dim=-1, keepdim=True)
+    output = (exp_scores @ value) / block_sum
+    stats_shape = (*block_max.shape[:-1], 8)
+    return output, block_max.expand(stats_shape), block_sum.expand(stats_shape)
+
+
+def test_merge_attention_blocks_matches_full_softmax_and_gradients():
+    torch.manual_seed(0)
+    query = torch.randn(2, 3, 5, 4, dtype=torch.float64, requires_grad=True)
+    key_a = torch.randn(2, 3, 7, 4, dtype=torch.float64, requires_grad=True)
+    value_a = torch.randn(2, 3, 7, 6, dtype=torch.float64, requires_grad=True)
+    key_b = torch.randn(2, 3, 11, 4, dtype=torch.float64, requires_grad=True)
+    value_b = torch.randn(2, 3, 11, 6, dtype=torch.float64, requires_grad=True)
+
+    out_a, max_a, sum_a = _block_attention(query, key_a, value_a)
+    out_b, max_b, sum_b = _block_attention(query, key_b, value_b)
+    merged, _, _ = merge_attention_blocks(out_a, max_a, sum_a, out_b, max_b, sum_b)
+
+    full_scores = query @ torch.cat((key_a, key_b), dim=-2).transpose(-1, -2)
+    full_output = torch.softmax(full_scores, dim=-1) @ torch.cat((value_a, value_b), dim=-2)
+    torch.testing.assert_close(merged, full_output, atol=1e-10, rtol=1e-10)
+
+    merged.sum().backward()
+    merged_grads = [tensor.grad.detach().clone() for tensor in (query, key_a, value_a, key_b, value_b)]
+
+    for tensor in (query, key_a, value_a, key_b, value_b):
+        tensor.grad = None
+    full_output.sum().backward()
+    full_grads = [tensor.grad for tensor in (query, key_a, value_a, key_b, value_b)]
+
+    for actual, expected in zip(merged_grads, full_grads):
+        torch.testing.assert_close(actual, expected, atol=1e-10, rtol=1e-10)
+
+
+def test_merge_attention_blocks_handles_empty_previous_statistics():
+    current_output = torch.randn(1, 2, 3, 4)
+    current_max = torch.randn(1, 2, 3, 8)
+    current_sum = torch.rand(1, 2, 3, 8) + 0.1
+    previous_output = torch.zeros_like(current_output)
+    previous_max = torch.full_like(current_max, -torch.inf)
+    previous_sum = torch.zeros_like(current_sum)
+
+    merged, merged_max, merged_sum = merge_attention_blocks(
+        previous_output,
+        previous_max,
+        previous_sum,
+        current_output,
+        current_max,
+        current_sum,
+    )
+
+    torch.testing.assert_close(merged, current_output)
+    torch.testing.assert_close(merged_max, current_max)
+    torch.testing.assert_close(merged_sum, current_sum)

--- a/tests/parallel/context_parallel/test_ring_attention.py
+++ b/tests/parallel/context_parallel/test_ring_attention.py
@@ -1,0 +1,76 @@
+import pytest
+import torch
+
+from veomni.distributed.context_parallel.ring_attention import (
+    dense_causal_attention,
+    simulate_ring_causal_attention,
+)
+from veomni.distributed.context_parallel.sharding import balanced_cp_slice
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+@pytest.mark.parametrize(
+    "num_q_heads,num_kv_heads,head_dim,seq_len",
+    [
+        (4, 2, 8, 32),
+        (16, 2, 256, 64),  # Qwen3.6-35B-A3B exact head geometry, short seq
+    ],
+)
+def test_simulate_ring_matches_dense_causal_forward(
+    cp_size: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    seq_len: int,
+):
+    torch.manual_seed(0)
+    batch = 1
+    query = torch.randn(batch, num_q_heads, seq_len, head_dim, dtype=torch.float32)
+    key = torch.randn(batch, num_kv_heads, seq_len, head_dim, dtype=torch.float32)
+    value = torch.randn(batch, num_kv_heads, seq_len, head_dim, dtype=torch.float32)
+    scale = head_dim**-0.5
+
+    expected = dense_causal_attention(query, key, value, softmax_scale=scale)
+    actual = simulate_ring_causal_attention(
+        query, key, value, cp_size=cp_size, softmax_scale=scale, backend="torch"
+    )
+
+    torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+
+def test_simulate_ring_matches_dense_causal_gradients_gqa():
+    torch.manual_seed(1)
+    cp_size = 2
+    batch, hq, hkv, seq_len, head_dim = 1, 16, 2, 64, 256
+    scale = head_dim**-0.5
+
+    query = torch.randn(batch, hq, seq_len, head_dim, dtype=torch.float64, requires_grad=True)
+    key = torch.randn(batch, hkv, seq_len, head_dim, dtype=torch.float64, requires_grad=True)
+    value = torch.randn(batch, hkv, seq_len, head_dim, dtype=torch.float64, requires_grad=True)
+
+    ring_out = simulate_ring_causal_attention(
+        query, key, value, cp_size=cp_size, softmax_scale=scale, backend="torch"
+    )
+    ring_out.sum().backward()
+    ring_grads = [query.grad.detach().clone(), key.grad.detach().clone(), value.grad.detach().clone()]
+
+    for tensor in (query, key, value):
+        tensor.grad = None
+
+    dense_out = dense_causal_attention(query, key, value, softmax_scale=scale)
+    dense_out.sum().backward()
+    dense_grads = [query.grad, key.grad, value.grad]
+
+    torch.testing.assert_close(ring_out.detach(), dense_out.detach(), atol=1e-5, rtol=1e-5)
+    for actual, expected in zip(ring_grads, dense_grads):
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_balanced_local_shards_cover_full_sequence_without_overlap():
+    seq = torch.arange(64).view(1, 1, 64, 1)
+    shards = [balanced_cp_slice(seq, cp_size=2, cp_rank=rank, dim=2) for rank in range(2)]
+    assert shards[0].shape[2] == 32
+    assert shards[1].shape[2] == 32
+    # Rank0 = c0||c3, Rank1 = c1||c2
+    torch.testing.assert_close(shards[0][0, 0, :, 0], torch.cat((torch.arange(0, 16), torch.arange(48, 64))))
+    torch.testing.assert_close(shards[1][0, 0, :, 0], torch.cat((torch.arange(16, 32), torch.arange(32, 48))))

--- a/tests/parallel/context_parallel/test_ring_p2p_distributed.py
+++ b/tests/parallel/context_parallel/test_ring_p2p_distributed.py
@@ -1,0 +1,140 @@
+import os
+import tempfile
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from veomni.distributed.context_parallel.ring_attention import (
+    dense_causal_attention,
+    ringattn_context_parallel,
+)
+from veomni.distributed.context_parallel.ring_p2p import RingP2P
+from veomni.distributed.context_parallel.sharding import balanced_cp_restore, balanced_cp_slice
+
+
+def _init_gloo(rank: int, world_size: int, file_name: str):
+    store = dist.FileStore(file_name, world_size)
+    dist.init_process_group("gloo", store=store, rank=rank, world_size=world_size)
+    return dist.distributed_c10d._get_default_group()
+
+
+def _ring_p2p_worker(rank: int, world_size: int, file_name: str, errors: mp.Queue):
+    try:
+        group = _init_gloo(rank, world_size, file_name)
+        ranks = list(range(world_size))
+        ring = RingP2P(ranks, group)
+        send = torch.full((4,), float(rank + 1))
+        recv = torch.zeros_like(send)
+        ring.async_send_recv(send, recv)
+        ring.wait()
+        expected = float((rank - 1 + world_size) % world_size + 1)
+        torch.testing.assert_close(recv, torch.full_like(recv, expected))
+        dist.destroy_process_group()
+        errors.put(None)
+    except Exception as exc:  # noqa: BLE001 - surface worker failures to parent
+        errors.put(repr(exc))
+
+
+def _attention_worker(rank: int, world_size: int, file_name: str, errors: mp.Queue):
+    try:
+        group = _init_gloo(rank, world_size, file_name)
+        ranks = list(range(world_size))
+        torch.manual_seed(0)
+        batch, hq, hkv, seq_len, head_dim = 1, 16, 2, 64, 256
+        scale = head_dim**-0.5
+
+        query = torch.empty(batch, hq, seq_len, head_dim, dtype=torch.float32)
+        key = torch.empty(batch, hkv, seq_len, head_dim, dtype=torch.float32)
+        value = torch.empty(batch, hkv, seq_len, head_dim, dtype=torch.float32)
+        if rank == 0:
+            torch.manual_seed(0)
+            query = torch.randn_like(query)
+            key = torch.randn_like(key)
+            value = torch.randn_like(value)
+        dist.broadcast(query, src=0)
+        dist.broadcast(key, src=0)
+        dist.broadcast(value, src=0)
+
+        local_q = balanced_cp_slice(query, cp_size=2, cp_rank=rank, dim=2).detach().requires_grad_(True)
+        local_k = balanced_cp_slice(key, cp_size=2, cp_rank=rank, dim=2).detach().requires_grad_(True)
+        local_v = balanced_cp_slice(value, cp_size=2, cp_rank=rank, dim=2).detach().requires_grad_(True)
+
+        local_out = ringattn_context_parallel(
+            local_q,
+            local_k,
+            local_v,
+            hq,
+            group,
+            ranks,
+            softmax_scale=scale,
+            backend="torch",
+        )
+        loss = local_out.sum()
+        loss.backward()
+
+        gathered = [torch.empty_like(local_out) for _ in range(world_size)]
+        dist.all_gather(gathered, local_out.detach())
+        if rank == 0:
+            ring_full = balanced_cp_restore(torch.cat(gathered, dim=2), cp_size=2, dim=2)
+            dense = dense_causal_attention(query, key, value, softmax_scale=scale)
+            torch.testing.assert_close(ring_full, dense, atol=2e-4, rtol=2e-4)
+
+            # Gradient parity on local shards vs dense sliced grads.
+            query_r = query.detach().requires_grad_(True)
+            key_r = key.detach().requires_grad_(True)
+            value_r = value.detach().requires_grad_(True)
+            dense_out = dense_causal_attention(query_r, key_r, value_r, softmax_scale=scale)
+            dense_out.sum().backward()
+            torch.testing.assert_close(
+                local_q.grad,
+                balanced_cp_slice(query_r.grad, cp_size=2, cp_rank=0, dim=2),
+                atol=2e-4,
+                rtol=2e-4,
+            )
+            torch.testing.assert_close(
+                local_k.grad,
+                balanced_cp_slice(key_r.grad, cp_size=2, cp_rank=0, dim=2),
+                atol=2e-4,
+                rtol=2e-4,
+            )
+            torch.testing.assert_close(
+                local_v.grad,
+                balanced_cp_slice(value_r.grad, cp_size=2, cp_rank=0, dim=2),
+                atol=2e-4,
+                rtol=2e-4,
+            )
+
+        dist.barrier()
+        dist.destroy_process_group()
+        errors.put(None)
+    except Exception as exc:  # noqa: BLE001
+        errors.put(repr(exc))
+
+
+def _run_mp(worker, world_size: int = 2):
+    with tempfile.TemporaryDirectory() as tmp:
+        file_name = os.path.join(tmp, "pg")
+        ctx = mp.get_context("spawn")
+        errors = ctx.Queue()
+        processes = [
+            ctx.Process(target=worker, args=(rank, world_size, file_name, errors))
+            for rank in range(world_size)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=120)
+            assert process.exitcode == 0, f"worker exited with {process.exitcode}"
+        for _ in range(world_size):
+            err = errors.get(timeout=5)
+            assert err is None, err
+
+
+def test_ring_p2p_exchanges_tensor_gloo():
+    _run_mp(_ring_p2p_worker)
+
+
+def test_attention_with_cp_matches_dense_gloo():
+    _run_mp(_attention_worker)

--- a/tests/parallel/context_parallel/test_topology.py
+++ b/tests/parallel/context_parallel/test_topology.py
@@ -1,0 +1,55 @@
+import torch
+
+from veomni.distributed.context_parallel.sharding import hybrid_cp_slice
+from veomni.distributed.context_parallel.topology import (
+    coords_from_sp_rank,
+    cp_global_ranks_for_ulysses_rank,
+    sp_rank_from_coords,
+    ulysses_global_ranks_for_cp_rank,
+)
+
+
+def test_sp_rank_coords_round_trip_u4_cp2():
+    cp_size, ulysses_size = 2, 4
+    for sp_rank in range(cp_size * ulysses_size):
+        cp_rank, ulysses_rank = coords_from_sp_rank(sp_rank, cp_size, ulysses_size)
+        assert sp_rank_from_coords(cp_rank, ulysses_rank, ulysses_size) == sp_rank
+
+
+def test_group_ranks_match_init_sequence_parallel_layout():
+    cp_size, ulysses_size = 2, 4
+    # DP0 Ulysses groups for each CP slot.
+    assert ulysses_global_ranks_for_cp_rank(
+        dp_index=0, cp_rank=0, cp_size=cp_size, ulysses_size=ulysses_size
+    ) == [0, 1, 2, 3]
+    assert ulysses_global_ranks_for_cp_rank(
+        dp_index=0, cp_rank=1, cp_size=cp_size, ulysses_size=ulysses_size
+    ) == [4, 5, 6, 7]
+    # DP0 CP rings for each Ulysses slot.
+    assert cp_global_ranks_for_ulysses_rank(
+        dp_index=0, ulysses_rank=0, cp_size=cp_size, ulysses_size=ulysses_size
+    ) == [0, 4]
+    assert cp_global_ranks_for_ulysses_rank(
+        dp_index=0, ulysses_rank=3, cp_size=cp_size, ulysses_size=ulysses_size
+    ) == [3, 7]
+
+
+def test_hybrid_slice_for_all_u4_cp2_ranks():
+    sequence = torch.arange(64)
+    cp_size, ulysses_size = 2, 4
+    shards = []
+    for sp_rank in range(cp_size * ulysses_size):
+        cp_rank, ulysses_rank = coords_from_sp_rank(sp_rank, cp_size, ulysses_size)
+        shards.append(
+            hybrid_cp_slice(
+                sequence,
+                cp_size=cp_size,
+                cp_rank=cp_rank,
+                ulysses_size=ulysses_size,
+                ulysses_rank=ulysses_rank,
+            )
+        )
+    assert all(shard.numel() == 8 for shard in shards)
+    # Contiguous SP would give [24:32] for rank3; hybrid CP0/U3 is the late half of rank0.
+    torch.testing.assert_close(shards[3], torch.arange(56, 64))
+    torch.testing.assert_close(shards[4], torch.arange(16, 24))

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -64,14 +64,13 @@ def add_flash_attention_kwargs_from_position_ids(
         batch: The batch dictionary containing position_ids. Will be modified in-place to add
                cu_seq_lens_q, cu_seq_lens_k, max_length_q, max_length_k, and
                linear_attn_cu_seq_lens_q. When ``linear_attn_tail_padding_length > 0``,
-               also stores ``tail_padding_length`` (0-d ``torch.int32`` tensor) so
-               downstream valid-seqlens helpers can strip the coalesced pad segment and
-               distributed/PP stages preserve the metadata.
+               also stores ``tail_padding_length`` so downstream valid-seqlens helpers can
+               strip the coalesced pad segment.
         linear_attn_tail_padding_length: Number of known padding tokens appended at the tail by
                collators (``pad_to_length`` / SP pad). ``position_ids == 0`` encodes each pad
                token as its own 1-token boundary; both FlashAttention and linear-attention
-               cu-seqlens coalesce that tail into one segment. Ascend NPU
-               ``npu_fusion_attention`` SIGSEGVs on the uncoalesced per-token form.
+               cu-seqlens coalesce that tail into one segment. NPU ``npu_fusion_attention``
+               SIGSEGVs on the uncoalesced per-token form.
 
     Returns:
         Tuple of (cu_seq_lens_q, cu_seq_lens_k, max_length_q, max_length_k) for additional use.
@@ -87,12 +86,7 @@ def add_flash_attention_kwargs_from_position_ids(
         seqlens = cu_seq_lens_q[1:] - cu_seq_lens_q[:-1]
         max_length_q = int(seqlens.max().item()) if seqlens.numel() else 0
         max_length_k = max_length_q
-        # Keep as a 0-d tensor so PP / distributed stages preserve the metadata.
-        batch["tail_padding_length"] = torch.tensor(
-            linear_attn_tail_padding_length,
-            dtype=torch.int32,
-            device=cu_seq_lens_q.device,
-        )
+        batch["tail_padding_length"] = int(linear_attn_tail_padding_length)
 
     batch["cu_seq_lens_q"] = cu_seq_lens_q
     batch["cu_seq_lens_k"] = cu_seq_lens_k
@@ -139,7 +133,7 @@ DEFAULT_DATA_COLLATE_INFO: Dict[str, DataCollateInfo] = {
     "input_ids": DataCollateInfo(-1, True, 0, 1),
     "labels": DataCollateInfo(-1, True, IGNORE_INDEX, 1),
     "attention_mask": DataCollateInfo(-1, False, 1, 1),
-    "position_ids": DataCollateInfo(-1, False, 0, 1),
+    "position_ids": DataCollateInfo(-1, True, 0, 1),  # CP/Ulysses must shard RoPE positions with tokens
     "pixel_values": DataCollateInfo(0, True, 0, 4),
     "pixel_values_videos": DataCollateInfo(0, True, 0, 4),
     "image_mask": DataCollateInfo(-1, False, 0, 1),
@@ -324,10 +318,42 @@ class SequenceParallelCollator(DataCollator):
     metadata_collate_func: Optional[MetadataCollateFunc] = None
 
     def __post_init__(self):
-        self.sp_size = get_parallel_state().sp_size
-        self.sp_rank = get_parallel_state().sp_rank
+        parallel_state = get_parallel_state()
+        self.sp_size = parallel_state.sp_size
+        self.sp_rank = parallel_state.sp_rank
+        self.cp_size = parallel_state.cp_size
+        self.ulysses_size = parallel_state.ulysses_size
+        self.cp_rank = parallel_state.cp_rank if parallel_state.cp_enabled else 0
+        self.ulysses_rank = parallel_state.ulysses_rank if parallel_state.ulysses_enabled else 0
+        # Balanced causal CP needs 2 * cp chunks before Ulysses split.
+        self.sp_pad_multiple = 2 if parallel_state.cp_enabled else 1
 
     def sp_slice(self, key: str, feature: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        if self.cp_size > 1:
+            from ..distributed.context_parallel.sharding import hybrid_cp_slice
+
+            if isinstance(feature, list):
+                assert dim == 0, f"Only support dim=0 for {key} as it is a List"
+                tensor = torch.arange(len(feature))
+                # Hybrid slice index list via tensor path then reselect.
+                index = hybrid_cp_slice(
+                    tensor,
+                    cp_size=self.cp_size,
+                    cp_rank=self.cp_rank,
+                    ulysses_size=self.ulysses_size,
+                    ulysses_rank=self.ulysses_rank,
+                    dim=0,
+                )
+                return [feature[i] for i in index.tolist()]
+            return hybrid_cp_slice(
+                feature,
+                cp_size=self.cp_size,
+                cp_rank=self.cp_rank,
+                ulysses_size=self.ulysses_size,
+                ulysses_rank=self.ulysses_rank,
+                dim=dim,
+            )
+
         if isinstance(feature, list):
             assert dim == 0, f"Only support dim=0 for {key} as it is a List"
             seq_length = len(feature)
@@ -352,7 +378,7 @@ class SequenceParallelCollator(DataCollator):
         else:
             seq_length = feature.size(dim)
 
-        scale_sp_size = self.sp_size * pad_scale
+        scale_sp_size = self.sp_size * pad_scale * self.sp_pad_multiple
         sp_chunk_size = (seq_length + scale_sp_size - 1) // scale_sp_size
         pad_size = sp_chunk_size * scale_sp_size - seq_length
         if pad_size == 0:
@@ -407,15 +433,86 @@ class SequenceParallelCollator(DataCollator):
                 if key == "position_ids":
                     linear_attn_tail_padding_length += post_pad_len - pre_pad_len
 
-            if sp_slice and key != "position_ids":  # position_ids should be sp sliced after precompute fa kwargs
-                # sp slice
+            # Defer slicing until FA kwargs exist when CP is enabled (need global cu_seqlens).
+            if self.cp_size <= 1 and sp_slice and key != "position_ids":
                 batch[key] = self.sp_slice(key, batch[key], dim=pack_dim)
 
         add_flash_attention_kwargs_from_position_ids(batch, linear_attn_tail_padding_length)
 
-        batch["position_ids"] = self.sp_slice(
-            "position_ids", batch["position_ids"], dim=self.collate_infos["position_ids"].pack_dim
-        )
+        if self.cp_size > 1:
+            from ..distributed.context_parallel.packed_sharding import (
+                apply_packed_cp_partition,
+                build_packed_cp_partition,
+                pad_packed_tensor_to_sample_multiple,
+            )
+
+            if "cu_seq_lens_q" not in batch:
+                raise RuntimeError("CP>1 requires cu_seq_lens_q from packed position_ids.")
+            sample_multiple = 2 * self.cp_size * max(self.ulysses_size, 1)
+            # Per-sample pad so zigzag CP is well-defined on packed boundaries.
+            # All sequence tensors must share the same original cu_seqlens plan.
+            cu_src = batch["cu_seq_lens_q"]
+            cu_dst = None
+            for key in list(batch.keys()):
+                collate_info: DataCollateInfo = self.collate_infos.get(key, None)
+                if collate_info is None or not isinstance(batch[key], torch.Tensor):
+                    continue
+                pad_value = 0 if collate_info.sp_pad_value is None else collate_info.sp_pad_value
+                batch[key], cu_new = pad_packed_tensor_to_sample_multiple(
+                    batch[key],
+                    cu_src,
+                    multiple=sample_multiple,
+                    dim=collate_info.pack_dim,
+                    pad_value=pad_value,
+                )
+                cu_dst = cu_new
+            if cu_dst is None:
+                raise RuntimeError("CP>1 packing pad found no sequence tensors to align.")
+            batch["cu_seq_lens_q"] = cu_dst
+            batch["cu_seq_lens_k"] = cu_dst.clone()
+            diffs = (cu_dst[1:] - cu_dst[:-1]).tolist()
+            batch["max_length_q"] = int(max(diffs) if diffs else 0)
+            batch["max_length_k"] = batch["max_length_q"]
+
+            # GDN gathers to full sequence under unified SP; keep global cu_seqlens for it.
+            # Ring FA keeps local cu_seq_lens_q after partition below.
+            batch["linear_attn_cu_seq_lens_q"] = batch["cu_seq_lens_q"].clone()
+            partition = build_packed_cp_partition(
+                batch["cu_seq_lens_q"],
+                cp_size=self.cp_size,
+                cp_rank=self.cp_rank,
+                ulysses_size=max(self.ulysses_size, 1),
+                ulysses_rank=self.ulysses_rank if self.ulysses_size > 1 else 0,
+            )
+            for key in list(batch.keys()):
+                collate_info: DataCollateInfo = self.collate_infos.get(key, None)
+                if collate_info is None or not collate_info.sp_slice:
+                    continue
+                if isinstance(batch[key], list):
+                    index = partition.token_indices
+                    batch[key] = [batch[key][i] for i in index.tolist()]
+                else:
+                    batch[key] = apply_packed_cp_partition(
+                        batch[key], partition, dim=collate_info.pack_dim
+                    )
+            # RoPE cos/sin follow position_ids; must match local token shard under CP.
+            if "position_ids" in batch and isinstance(batch["position_ids"], torch.Tensor):
+                pos_dim = self.collate_infos["position_ids"].pack_dim
+                # Avoid double-slice if already partitioned via sp_slice=True above.
+                if batch["position_ids"].size(pos_dim) != partition.token_indices.numel():
+                    batch["position_ids"] = apply_packed_cp_partition(
+                        batch["position_ids"], partition, dim=pos_dim
+                    )
+            local_cu = partition.local_cu_seqlens
+            batch["cu_seq_lens_q"] = local_cu
+            batch["cu_seq_lens_k"] = local_cu.clone()
+            batch["max_length_q"] = partition.local_max_seqlen
+            batch["max_length_k"] = partition.local_max_seqlen
+            # linear_attn_cu_seq_lens_q stays global for GDN post-gather kernels.
+        else:
+            batch["position_ids"] = self.sp_slice(
+                "position_ids", batch["position_ids"], dim=self.collate_infos["position_ids"].pack_dim
+            )
 
         # Hand the SP-padded batch + per-modality sp-pad patch counts to the
         # model-provided hook, which derives ``multimodal_metadata`` (cu_seqlens,
@@ -538,10 +635,9 @@ class PostCollator(DataCollator):
 @dataclass
 class SeqlensComputePostCollator(DataCollator):
     def __call__(self, micro_batch: Dict[str, torch.Tensor]):
-        tail_padding_length = micro_batch.get("tail_padding_length")
         seq_lens = valid_seqlens_from_cu_seqlens(
             micro_batch["cu_seq_lens_q"],
-            tail_padding_length=int(tail_padding_length) if tail_padding_length is not None else None,
+            int(micro_batch.get("tail_padding_length", 0) or 0),
         ).tolist()
         return seq_lens
 

--- a/veomni/distributed/context_parallel/__init__.py
+++ b/veomni/distributed/context_parallel/__init__.py
@@ -1,0 +1,43 @@
+from .attention_backend import has_npu_fusion_attention, torch_attention_forward, torch_packed_causal_attention
+from .packed_sharding import PackedCPPartition, apply_packed_cp_partition, build_packed_cp_partition
+from .ring_attention import (
+    AttentionWithCp,
+    dense_causal_attention,
+    ringattn_context_parallel,
+    simulate_packed_ring_causal_attention,
+    simulate_ring_causal_attention,
+)
+from .ring_p2p import RingP2P
+from .sharding import balanced_cp_restore, balanced_cp_slice, balanced_cp_to_rank_major, hybrid_cp_slice
+from .softmax_update import merge_attention_blocks
+from .topology import (
+    coords_from_sp_rank,
+    cp_global_ranks_for_ulysses_rank,
+    sp_rank_from_coords,
+    ulysses_global_ranks_for_cp_rank,
+)
+
+
+__all__ = [
+    "AttentionWithCp",
+    "PackedCPPartition",
+    "RingP2P",
+    "apply_packed_cp_partition",
+    "balanced_cp_restore",
+    "balanced_cp_slice",
+    "balanced_cp_to_rank_major",
+    "build_packed_cp_partition",
+    "coords_from_sp_rank",
+    "cp_global_ranks_for_ulysses_rank",
+    "dense_causal_attention",
+    "has_npu_fusion_attention",
+    "hybrid_cp_slice",
+    "merge_attention_blocks",
+    "ringattn_context_parallel",
+    "simulate_packed_ring_causal_attention",
+    "simulate_ring_causal_attention",
+    "sp_rank_from_coords",
+    "torch_attention_forward",
+    "torch_packed_causal_attention",
+    "ulysses_global_ranks_for_cp_rank",
+]

--- a/veomni/distributed/context_parallel/attention_backend.py
+++ b/veomni/distributed/context_parallel/attention_backend.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026 ByteDance AI4SE. MindSpeed-compatible Torch FA backend for Ring CP tests.
+"""Attention backends used by Ring context parallel.
+
+Torch backend is the Day-1 correctness path (CPU/NPU). NPU fusion attention is
+optional and used when ``torch_npu.npu_fusion_attention`` is available.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+
+def _repeat_kv(hidden_states: Tensor, n_rep: int) -> Tensor:
+    if n_rep == 1:
+        return hidden_states
+    batch, num_kv_heads, seq_len, head_dim = hidden_states.shape
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_kv_heads, n_rep, seq_len, head_dim)
+    return hidden_states.reshape(batch, num_kv_heads * n_rep, seq_len, head_dim)
+
+
+def _expand_softmax_stats(stat: Tensor) -> Tensor:
+    """Broadcast trailing singleton softmax stats to NPU-style width-8."""
+    if stat.size(-1) == 8:
+        return stat
+    if stat.size(-1) != 1:
+        raise ValueError(f"Expected softmax stats trailing dim 1 or 8, got {stat.shape}.")
+    return stat.expand(*stat.shape[:-1], 8).contiguous()
+
+
+def torch_attention_forward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    softmax_scale: float,
+    causal: bool,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Eager BNSD attention that also returns online-softmax statistics.
+
+    Args:
+        query/key/value: [B, H, S, D] (GQA allowed: H_q may exceed H_kv)
+        softmax_scale: attention scale
+        causal: whether to apply a lower-triangular mask on equal-length Q/K
+
+    Returns:
+        output [B, Hq, Sq, D], softmax_max/sum [B, Hq, Sq, 8]
+    """
+    batch, num_q_heads, q_len, head_dim = query.shape
+    num_kv_heads = key.shape[1]
+    if num_q_heads % num_kv_heads != 0:
+        raise ValueError(f"GQA requires Hq % Hkv == 0, got {num_q_heads} and {num_kv_heads}.")
+    n_rep = num_q_heads // num_kv_heads
+    key_exp = _repeat_kv(key, n_rep)
+    value_exp = _repeat_kv(value, n_rep)
+
+    # FP32 scores for stable online-softmax stats.
+    scores = torch.matmul(query.float(), key_exp.float().transpose(-1, -2)) * float(softmax_scale)
+    if causal:
+        if q_len != key_exp.size(2):
+            raise ValueError(
+                f"Causal torch attention requires equal Q/K lengths, got {q_len} and {key_exp.size(2)}."
+            )
+        causal_mask = torch.ones(q_len, q_len, dtype=torch.bool, device=query.device).triu(diagonal=1)
+        scores = scores.masked_fill(causal_mask, torch.finfo(scores.dtype).min)
+
+    block_max = scores.amax(dim=-1, keepdim=True)
+    exp_scores = torch.exp(scores - block_max)
+    block_sum = exp_scores.sum(dim=-1, keepdim=True)
+    probs = exp_scores / block_sum.clamp_min(torch.finfo(exp_scores.dtype).tiny)
+    output = torch.matmul(probs.to(value_exp.dtype), value_exp)
+
+    # Tokens that attended an empty/fully-masked row get -inf max / 0 sum.
+    if causal:
+        fully_masked = ~torch.isfinite(block_max)
+        block_max = torch.where(fully_masked, torch.full_like(block_max, -torch.inf), block_max)
+        block_sum = torch.where(fully_masked, torch.zeros_like(block_sum), block_sum)
+
+    softmax_max = _expand_softmax_stats(block_max.to(query.dtype))
+    softmax_sum = _expand_softmax_stats(block_sum.to(query.dtype))
+    return output, softmax_max, softmax_sum
+
+
+def torch_attention_backward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    dout: Tensor,
+    attn_out: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    *,
+    softmax_scale: float,
+    causal: bool,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Block-wise attention backward using global merged online-softmax stats."""
+    batch, num_q_heads, q_len, head_dim = query.shape
+    num_kv_heads = key.shape[1]
+    n_rep = num_q_heads // num_kv_heads
+    key_exp = _repeat_kv(key, n_rep)
+    value_exp = _repeat_kv(value, n_rep)
+    k_len = key_exp.size(2)
+
+    scores = torch.matmul(query.float(), key_exp.float().transpose(-1, -2)) * float(softmax_scale)
+    if causal:
+        causal_mask = torch.ones(q_len, k_len, dtype=torch.bool, device=query.device).triu(diagonal=1)
+        scores = scores.masked_fill(causal_mask, torch.finfo(scores.dtype).min)
+
+    # Reconstruct P from global LSE pieces: P = exp(S - max) / sum.
+    global_max = softmax_max[..., :1].float()
+    global_sum = softmax_sum[..., :1].float().clamp_min(torch.finfo(torch.float32).tiny)
+    probs = torch.exp(scores - global_max) / global_sum
+    if causal:
+        probs = probs.masked_fill(causal_mask, 0.0)
+
+    dout_f = dout.float()
+    out_f = attn_out.float()
+    delta = (dout_f * out_f).sum(dim=-1, keepdim=True)
+
+    dv_exp = torch.matmul(probs.transpose(-1, -2), dout_f)
+    dp = torch.matmul(dout_f, value_exp.float().transpose(-1, -2))
+    ds = probs * (dp - delta)
+    dq = torch.matmul(ds, key_exp.float()) * float(softmax_scale)
+    dk_exp = torch.matmul(ds.transpose(-1, -2), query.float()) * float(softmax_scale)
+
+    if n_rep == 1:
+        dk, dv = dk_exp, dv_exp
+    else:
+        dk = dk_exp.view(batch, num_kv_heads, n_rep, k_len, head_dim).sum(dim=2)
+        dv = dv_exp.view(batch, num_kv_heads, n_rep, k_len, head_dim).sum(dim=2)
+
+    return dq.to(query.dtype), dk.to(key.dtype), dv.to(value.dtype)
+
+
+def npu_attention_forward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    num_heads: int,
+    softmax_scale: float,
+    causal: bool,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """NPU fusion attention forward (BNSD). Falls back is not available here."""
+    import torch_npu
+
+    atten_mask = None
+    sparse_mode = 0
+    pre_tokens = key.size(2)
+    next_tokens = pre_tokens
+    if causal:
+        atten_mask = torch.ones((2048, 2048), dtype=torch.bool, device=query.device)
+        atten_mask = torch.triu(atten_mask, diagonal=1)
+        next_tokens = 0
+        sparse_mode = 3
+
+    outs = torch_npu.npu_fusion_attention(
+        query,
+        key,
+        value,
+        num_heads,
+        "BNSD",
+        pse=None,
+        padding_mask=None,
+        atten_mask=atten_mask,
+        scale=softmax_scale,
+        pre_tockens=pre_tokens,
+        next_tockens=next_tokens,
+        keep_prob=1.0,
+        sparse_mode=sparse_mode,
+    )
+    return outs[0], outs[1], outs[2]
+
+
+def npu_attention_backward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    dout: Tensor,
+    attn_out: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    *,
+    num_heads: int,
+    softmax_scale: float,
+    causal: bool,
+) -> tuple[Tensor, Tensor, Tensor]:
+    import torch_npu
+
+    atten_mask = None
+    sparse_mode = 0
+    pre_tokens = key.size(2)
+    next_tokens = pre_tokens
+    if causal:
+        atten_mask = torch.ones((2048, 2048), dtype=torch.bool, device=query.device)
+        atten_mask = torch.triu(atten_mask, diagonal=1)
+        next_tokens = 0
+        sparse_mode = 3
+
+    grads = torch_npu.npu_fusion_attention_grad(
+        query,
+        key,
+        value,
+        dout,
+        num_heads,
+        "BNSD",
+        pse=None,
+        padding_mask=None,
+        atten_mask=atten_mask,
+        softmax_max=softmax_max,
+        softmax_sum=softmax_sum,
+        attention_in=attn_out,
+        scale_value=softmax_scale,
+        pre_tockens=pre_tokens,
+        next_tockens=next_tokens,
+        sparse_mode=sparse_mode,
+        keep_prob=1.0,
+    )
+    return grads[0], grads[1], grads[2]
+
+
+def has_npu_fusion_attention() -> bool:
+    try:
+        import torch_npu
+
+        return hasattr(torch_npu, "npu_fusion_attention") and hasattr(torch_npu, "npu_fusion_attention_grad")
+    except Exception:
+        return False
+
+
+def torch_packed_causal_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    cu_seqlens: Tensor,
+    *,
+    softmax_scale: Optional[float] = None,
+) -> Tensor:
+    """Dense packed causal attention with no cross-sample visibility.
+
+    Inputs are BNSD with batch=1: [1, H, T, D]. ``cu_seqlens`` is int32 [N+1].
+    """
+    if query.size(0) != 1:
+        raise ValueError(f"torch_packed_causal_attention expects batch=1, got {query.shape}.")
+    if softmax_scale is None:
+        softmax_scale = query.shape[-1] ** -0.5
+    cu = cu_seqlens.detach().cpu().tolist()
+    outs = []
+    for start, end in zip(cu[:-1], cu[1:]):
+        start, end = int(start), int(end)
+        outs.append(
+            torch_attention_forward(
+                query[:, :, start:end],
+                key[:, :, start:end],
+                value[:, :, start:end],
+                softmax_scale=float(softmax_scale),
+                causal=True,
+            )[0]
+        )
+    return torch.cat(outs, dim=2)

--- a/veomni/distributed/context_parallel/causal_schedule.py
+++ b/veomni/distributed/context_parallel/causal_schedule.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2024, Huawei Technologies Co., Ltd.  All rights reserved.
+# Ported/adapted from MindSpeed ring_context_parallel causal helpers (BSD-3-Clause).
+"""Causal zigzag block schedule for Ring context parallel (BNSD layout)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from torch import Tensor
+
+from .softmax_update import merge_attention_blocks
+
+
+def as_balanced_halves(tensor: Tensor) -> Tensor:
+    """View local CP shard [B, H, 2S, ...] as [B, H, 2, S, ...]."""
+    if tensor.size(2) % 2 != 0:
+        raise ValueError(f"Sequence dim must be even for balanced CP, got {tensor.size(2)}.")
+    return tensor.view(tensor.size(0), tensor.size(1), 2, tensor.size(2) // 2, *tensor.shape[3:])
+
+
+def flatten_balanced_halves(tensor: Tensor) -> Tensor:
+    """Flatten [B, H, 2, S, ...] back to [B, H, 2S, ...]."""
+    return tensor.reshape(tensor.size(0), tensor.size(1), -1, *tensor.shape[4:])
+
+
+def causal_forward_fetch(
+    q_block_id: int,
+    kv_block_id: int,
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    attn_mask: Optional[Tensor] = None,
+) -> tuple[Tensor, Tensor, Tensor, Optional[Tensor]]:
+    """Select Q/K/V slices for one causal ring step.
+
+    Inputs are balanced-halved BNSD: [B, H, 2, S, D].
+    """
+    if q_block_id == kv_block_id:
+        return (
+            flatten_balanced_halves(query),
+            flatten_balanced_halves(key),
+            flatten_balanced_halves(value),
+            attn_mask,
+        )
+    if kv_block_id <= q_block_id:
+        return (
+            flatten_balanced_halves(query),
+            key[:, :, 0],
+            value[:, :, 0],
+            None,
+        )
+    return (
+        query[:, :, 1],
+        flatten_balanced_halves(key),
+        flatten_balanced_halves(value),
+        None,
+    )
+
+
+def causal_backward_fetch(
+    q_block_id: int,
+    kv_block_id: int,
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    attn_out: Tensor,
+    dout: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    attn_mask: Optional[Tensor] = None,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Optional[Tensor]]:
+    """Select backward operands for one causal ring step (balanced-halved BNSD)."""
+    if q_block_id >= kv_block_id:
+        cur_softmax_max = flatten_balanced_halves(softmax_max)
+        cur_softmax_sum = flatten_balanced_halves(softmax_sum)
+        cur_q = flatten_balanced_halves(query)
+        cur_attn_out = flatten_balanced_halves(attn_out)
+        cur_dout = flatten_balanced_halves(dout)
+        if q_block_id == kv_block_id:
+            return (
+                cur_q,
+                flatten_balanced_halves(key),
+                flatten_balanced_halves(value),
+                cur_attn_out,
+                cur_dout,
+                cur_softmax_max,
+                cur_softmax_sum,
+                attn_mask,
+            )
+        return (
+            cur_q,
+            key[:, :, 0],
+            value[:, :, 0],
+            cur_attn_out,
+            cur_dout,
+            cur_softmax_max,
+            cur_softmax_sum,
+            None,
+        )
+
+    return (
+        query[:, :, 1],
+        flatten_balanced_halves(key),
+        flatten_balanced_halves(value),
+        attn_out[:, :, 1],
+        dout[:, :, 1],
+        softmax_max[:, :, 1],
+        softmax_sum[:, :, 1],
+        None,
+    )
+
+
+def causal_out_update(
+    q_block_id: int,
+    kv_block_id: int,
+    cur_attn_out: Tensor,
+    cur_softmax_max: Tensor,
+    cur_softmax_sum: Tensor,
+    attn_out: Optional[Tensor],
+    softmax_max: Optional[Tensor],
+    softmax_sum: Optional[Tensor],
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Merge one causal ring step into the running online-softmax state."""
+    if q_block_id == kv_block_id or attn_out is None:
+        return cur_attn_out, cur_softmax_max, cur_softmax_sum
+
+    if kv_block_id <= q_block_id:
+        return merge_attention_blocks(
+            attn_out,
+            softmax_max,
+            softmax_sum,
+            cur_attn_out,
+            cur_softmax_max,
+            cur_softmax_sum,
+        )
+
+    # Future relative block: only the late query half observes this KV.
+    out_view = as_balanced_halves(attn_out)
+    max_view = as_balanced_halves(softmax_max)
+    sum_view = as_balanced_halves(softmax_sum)
+    updated_out, updated_max, updated_sum = merge_attention_blocks(
+        out_view[:, :, 1],
+        max_view[:, :, 1],
+        sum_view[:, :, 1],
+        cur_attn_out,
+        cur_softmax_max,
+        cur_softmax_sum,
+    )
+    out_view = out_view.clone()
+    max_view = max_view.clone()
+    sum_view = sum_view.clone()
+    out_view[:, :, 1].copy_(updated_out)
+    max_view[:, :, 1].copy_(updated_max)
+    sum_view[:, :, 1].copy_(updated_sum)
+    return (
+        flatten_balanced_halves(out_view),
+        flatten_balanced_halves(max_view),
+        flatten_balanced_halves(sum_view),
+    )
+
+
+def causal_grad_update(
+    q_block_id: int,
+    kv_block_id: int,
+    cur_dq: Tensor,
+    cur_dk: Tensor,
+    cur_dv: Tensor,
+    dq: Tensor,
+    dk: Tensor,
+    dv: Tensor,
+) -> None:
+    """Accumulate step gradients into balanced-halved dQ/dK/dV buffers."""
+    if q_block_id == kv_block_id:
+        dq.add_(as_balanced_halves(cur_dq))
+        dk.add_(as_balanced_halves(cur_dk))
+        dv.add_(as_balanced_halves(cur_dv))
+        return
+
+    if q_block_id > kv_block_id:
+        dq.add_(as_balanced_halves(cur_dq))
+        dk[:, :, 0].add_(cur_dk)
+        dv[:, :, 0].add_(cur_dv)
+        return
+
+    dq[:, :, 1].add_(cur_dq)
+    dk.add_(as_balanced_halves(cur_dk))
+    dv.add_(as_balanced_halves(cur_dv))

--- a/veomni/distributed/context_parallel/gdn_sp.py
+++ b/veomni/distributed/context_parallel/gdn_sp.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2025 VeOmni Authors.
+# Load-balancing helpers adapted from MindSpeed-LLM gdn_context_parallel (BSD-3-Clause).
+"""GDN sequence-parallel helpers for hybrid Ring-CP layouts."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch.distributed as dist
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+from ..parallel_state import get_parallel_state
+from .sharding import balanced_cp_restore, balanced_cp_to_rank_major
+
+
+def resolve_gdn_sp_group() -> tuple[Optional[ProcessGroup], int, int, bool]:
+    """Return (group, sp_size, head_rank, need_zigzag_restore) for GDN A2A.
+
+    - Ulysses-only: use ulysses group (no zigzag restore).
+    - CP enabled (with or without Ulysses): use unified SP group and restore
+      canonical order after gather / re-apply zigzag before scatter.
+    """
+    state = get_parallel_state()
+    if state.cp_enabled:
+        group = state.sp_group
+        if group is None and not state.ulysses_enabled:
+            group = state.cp_group
+        if group is None:
+            raise RuntimeError("CP-enabled GDN requires unified sequence-parallel group.")
+        sp_rank = state.sp_rank if state.sp_rank >= 0 else (state.cp_rank if state.cp_rank >= 0 else 0)
+        return group, state.sp_size, sp_rank, True
+    if state.ulysses_enabled:
+        return state.ulysses_group, state.ulysses_size, state.ulysses_rank, False
+    return None, 1, 0, False
+
+
+def maybe_restore_canonical(tensor: Tensor, *, enabled: bool, cp_size: int, dim: int = 1) -> Tensor:
+    if not enabled or cp_size <= 1:
+        return tensor
+    return balanced_cp_restore(tensor, cp_size=cp_size, dim=dim)
+
+
+def maybe_to_rank_major(tensor: Tensor, *, enabled: bool, cp_size: int, dim: int = 1) -> Tensor:
+    if not enabled or cp_size <= 1:
+        return tensor
+    return balanced_cp_to_rank_major(tensor, cp_size=cp_size, dim=dim)
+
+
+def gdn_sp_world_size(group: Optional[ProcessGroup]) -> int:
+    if group is None:
+        return 1
+    return dist.get_world_size(group)

--- a/veomni/distributed/context_parallel/packed_sharding.py
+++ b/veomni/distributed/context_parallel/packed_sharding.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026 ByteDance AI4SE.
+# Sample-aware zigzag sharding adapted from MindSpeed get_index (BSD-3-Clause).
+"""Per-sample balanced CP / hybrid sharding for packed sequences."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+
+from .sharding import _validate_parallel_coordinate
+
+
+@dataclass(frozen=True)
+class PackedCPPartition:
+    """Gather indices and CP-local packed metadata for one rank."""
+
+    token_indices: Tensor  # int64 [T_local]
+    local_cu_seqlens: Tensor  # int32 [num_samples + 1]
+    local_max_seqlen: int
+    sample_multiple: int
+
+
+def _sample_lengths(cu_seqlens: Tensor) -> list[int]:
+    cu = cu_seqlens.detach().cpu().tolist()
+    if not cu or cu[0] != 0:
+        raise ValueError(f"cu_seqlens must start at 0, got {cu[:3]}...")
+    return [int(cu[i + 1] - cu[i]) for i in range(len(cu) - 1)]
+
+
+def build_packed_cp_partition(
+    cu_seqlens: Tensor,
+    *,
+    cp_size: int,
+    cp_rank: int,
+    ulysses_size: int = 1,
+    ulysses_rank: int = 0,
+) -> PackedCPPartition:
+    """Build sample-aware hybrid CP×Ulysses gather indices from global cu_seqlens."""
+    _validate_parallel_coordinate(cp_size, cp_rank, "cp")
+    _validate_parallel_coordinate(ulysses_size, ulysses_rank, "ulysses")
+    multiple = 2 * cp_size * ulysses_size
+    lengths = _sample_lengths(cu_seqlens)
+    for idx, length in enumerate(lengths):
+        if length % multiple != 0:
+            raise ValueError(
+                f"Packed sample {idx} length {length} must be divisible by "
+                f"2 * cp_size * ulysses_size ({multiple}) for Ring CP."
+            )
+
+    points = cu_seqlens.detach().cpu().tolist()
+    index_chunks: list[Tensor] = []
+    local_lengths: list[int] = []
+    for start, end in zip(points[:-1], points[1:]):
+        start, end = int(start), int(end)
+        # Per-sample zigzag CP, then contiguous Ulysses on the CP-local shard.
+        size = (end - start) // (2 * cp_size)
+        part1 = torch.arange(start + cp_rank * size, start + (cp_rank + 1) * size)
+        part2 = torch.arange(end - (cp_rank + 1) * size, end - cp_rank * size)
+        cp_local = torch.cat((part1, part2))
+        if ulysses_size > 1:
+            ulysses_chunk = cp_local.numel() // ulysses_size
+            begin = ulysses_rank * ulysses_chunk
+            cp_local = cp_local[begin : begin + ulysses_chunk]
+        index_chunks.append(cp_local)
+        local_lengths.append(int(cp_local.numel()))
+
+    token_indices = torch.cat(index_chunks) if index_chunks else torch.zeros(0, dtype=torch.long)
+    local_cu = torch.tensor([0] + local_lengths, dtype=torch.int32).cumsum(0).to(dtype=torch.int32)
+    local_max = max(local_lengths) if local_lengths else 0
+    return PackedCPPartition(
+        token_indices=token_indices,
+        local_cu_seqlens=local_cu,
+        local_max_seqlen=local_max,
+        sample_multiple=multiple,
+    )
+
+
+def apply_packed_cp_partition(tensor: Tensor, partition: PackedCPPartition, *, dim: int = -1) -> Tensor:
+    """Gather ``tensor`` along ``dim`` using packed CP indices."""
+    dim = dim % tensor.ndim
+    index = partition.token_indices.to(device=tensor.device)
+    if index.numel() == 0:
+        sizes = list(tensor.shape)
+        sizes[dim] = 0
+        return tensor.new_empty(sizes)
+    return tensor.index_select(dim, index).contiguous()
+
+
+def pad_sample_lengths_to_multiple(lengths: list[int], multiple: int) -> list[int]:
+    """Return padded lengths (each >= original, divisible by multiple)."""
+    if multiple < 1:
+        raise ValueError(f"multiple must be positive, got {multiple}.")
+    padded = []
+    for length in lengths:
+        rem = length % multiple
+        padded.append(length if rem == 0 else length + (multiple - rem))
+    return padded
+
+
+def pad_packed_tensor_to_sample_multiple(
+    tensor: Tensor,
+    cu_seqlens: Tensor,
+    *,
+    multiple: int,
+    dim: int = -1,
+    pad_value: int | float = 0,
+) -> tuple[Tensor, Tensor]:
+    """Pad each packed sample so its length is divisible by ``multiple``.
+
+    Returns ``(padded_tensor, new_cu_seqlens)``.
+    """
+    dim = dim % tensor.ndim
+    lengths = _sample_lengths(cu_seqlens)
+    padded_lengths = pad_sample_lengths_to_multiple(lengths, multiple)
+    if padded_lengths == lengths:
+        return tensor, cu_seqlens.to(dtype=torch.int32)
+
+    pieces = []
+    points = cu_seqlens.detach().cpu().tolist()
+    for (start, end), new_len, old_len in zip(zip(points[:-1], points[1:]), padded_lengths, lengths):
+        start, end = int(start), int(end)
+        piece = tensor.narrow(dim, start, end - start)
+        pad_n = new_len - old_len
+        if pad_n:
+            pad_shape = list(piece.shape)
+            pad_shape[dim] = pad_n
+            piece = torch.cat(
+                (piece, piece.new_full(pad_shape, fill_value=pad_value)),
+                dim=dim,
+            )
+        pieces.append(piece)
+    padded = torch.cat(pieces, dim=dim)
+    new_cu = torch.tensor([0] + padded_lengths, dtype=torch.int32).cumsum(0).to(dtype=torch.int32)
+    return padded.contiguous(), new_cu
+
+def ulysses_local_cu_to_cp_local_cu(local_cu_seqlens: Tensor, ulysses_size: int) -> Tensor:
+    """Scale Ulysses-local cu_seqlens to CP-local lengths after gather_seq."""
+    if ulysses_size <= 1:
+        return local_cu_seqlens.to(dtype=torch.int32)
+    lengths = local_cu_seqlens.diff() * int(ulysses_size)
+    out = torch.empty(local_cu_seqlens.numel(), dtype=torch.int32, device=local_cu_seqlens.device)
+    out[0] = 0
+    out[1:] = lengths.to(dtype=torch.int32).cumsum(0)
+    return out
+
+
+def reorder_ulysses_rank_major_to_sample_major(
+    tensor: Tensor,
+    ulysses_local_cu_seqlens: Tensor,
+    *,
+    ulysses_size: int,
+    seq_dim: int,
+) -> Tensor:
+    """Map post-Ulysses gather layout ``[u0_packed|u1_packed|...]`` to CP-local
+    sample-major ``[s0_u0|s0_u1|...|s1_u0|s1_u1|...]`` for Ring CP.
+    """
+    if ulysses_size <= 1:
+        return tensor
+    seq_dim = seq_dim % tensor.ndim
+    lengths = _sample_lengths(ulysses_local_cu_seqlens)
+    if not lengths:
+        return tensor
+    rank_span = sum(lengths)
+    expected = rank_span * ulysses_size
+    actual = int(tensor.size(seq_dim))
+    if actual != expected:
+        raise RuntimeError(
+            f"Ulysses gather seq length {actual} != sum(local_cu)*ulysses_size ({expected})"
+        )
+    rank_blocks = tensor.split(rank_span, dim=seq_dim)
+    per_sample: list[list[Tensor]] = [[] for _ in lengths]
+    for block in rank_blocks:
+        for i, chunk in enumerate(block.split(lengths, dim=seq_dim)):
+            per_sample[i].append(chunk)
+    samples = [torch.cat(chunks, dim=seq_dim) for chunks in per_sample]
+    return torch.cat(samples, dim=seq_dim).contiguous()
+
+
+def reorder_sample_major_to_ulysses_rank_major(
+    tensor: Tensor,
+    ulysses_local_cu_seqlens: Tensor,
+    *,
+    ulysses_size: int,
+    seq_dim: int,
+) -> Tensor:
+    """Inverse of :func:`reorder_ulysses_rank_major_to_sample_major` before Ulysses scatter."""
+    if ulysses_size <= 1:
+        return tensor
+    seq_dim = seq_dim % tensor.ndim
+    lengths = _sample_lengths(ulysses_local_cu_seqlens)
+    if not lengths:
+        return tensor
+    cp_lengths = [length * ulysses_size for length in lengths]
+    expected = sum(cp_lengths)
+    actual = int(tensor.size(seq_dim))
+    if actual != expected:
+        raise RuntimeError(
+            f"CP-local seq length {actual} != sum(local_cu)*ulysses_size ({expected})"
+        )
+    samples = tensor.split(cp_lengths, dim=seq_dim)
+    by_rank: list[list[Tensor]] = [[] for _ in range(ulysses_size)]
+    for sample, ulen in zip(samples, lengths):
+        for rank, chunk in enumerate(sample.split(ulen, dim=seq_dim)):
+            by_rank[rank].append(chunk)
+    ranks = [torch.cat(chunks, dim=seq_dim) for chunks in by_rank]
+    return torch.cat(ranks, dim=seq_dim).contiguous()

--- a/veomni/distributed/context_parallel/ring_attention.py
+++ b/veomni/distributed/context_parallel/ring_attention.py
@@ -1,0 +1,440 @@
+# Copyright (c) 2024, Huawei Technologies Co., Ltd.  All rights reserved.
+# Ported/adapted from MindSpeed AttentionWithCp (BSD-3-Clause) for Open-VeOmni.
+"""Minimal causal Ring context-parallel attention (CP>=2, BNSD, dropout=0)."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+import torch.distributed as dist
+from torch import Tensor
+
+from .attention_backend import (
+    has_npu_fusion_attention,
+    npu_attention_backward,
+    npu_attention_forward,
+    torch_attention_backward,
+    torch_attention_forward,
+)
+from .causal_schedule import (
+    as_balanced_halves,
+    causal_backward_fetch,
+    causal_forward_fetch,
+    causal_grad_update,
+    causal_out_update,
+    flatten_balanced_halves,
+)
+from .ring_p2p import RingP2P
+from .sharding import balanced_cp_restore, balanced_cp_slice
+
+
+def _attention_forward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    num_heads: int,
+    softmax_scale: float,
+    causal: bool,
+    backend: str,
+) -> tuple[Tensor, Tensor, Tensor]:
+    if backend == "npu":
+        return npu_attention_forward(
+            query,
+            key,
+            value,
+            num_heads=num_heads,
+            softmax_scale=softmax_scale,
+            causal=causal,
+        )
+    return torch_attention_forward(query, key, value, softmax_scale=softmax_scale, causal=causal)
+
+
+def _attention_backward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    dout: Tensor,
+    attn_out: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    *,
+    num_heads: int,
+    softmax_scale: float,
+    causal: bool,
+    backend: str,
+) -> tuple[Tensor, Tensor, Tensor]:
+    if backend == "npu":
+        return npu_attention_backward(
+            query,
+            key,
+            value,
+            dout,
+            attn_out,
+            softmax_max,
+            softmax_sum,
+            num_heads=num_heads,
+            softmax_scale=softmax_scale,
+            causal=causal,
+        )
+    return torch_attention_backward(
+        query,
+        key,
+        value,
+        dout,
+        attn_out,
+        softmax_max,
+        softmax_sum,
+        softmax_scale=softmax_scale,
+        causal=causal,
+    )
+
+
+def _default_backend(requested: Optional[str]) -> str:
+    if requested is not None:
+        return requested
+    return "npu" if has_npu_fusion_attention() else "torch"
+
+
+def simulate_ring_causal_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    cp_size: int,
+    softmax_scale: Optional[float] = None,
+    backend: str = "torch",
+) -> Tensor:
+    """Single-process causal Ring CP simulation with full KV visibility.
+
+    Used for Day-1 schedule/online-softmax correctness against dense attention.
+    Inputs are global BNSD tensors; output restores canonical sequence order.
+    """
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be positive, got {cp_size}.")
+    if softmax_scale is None:
+        softmax_scale = query.shape[-1] ** -0.5
+
+    num_heads = query.shape[1]
+    local_outputs = []
+    for cp_rank in range(cp_size):
+        local_q = as_balanced_halves(balanced_cp_slice(query, cp_size, cp_rank, dim=2))
+        local_k = as_balanced_halves(balanced_cp_slice(key, cp_size, cp_rank, dim=2))
+        local_v = as_balanced_halves(balanced_cp_slice(value, cp_size, cp_rank, dim=2))
+
+        # Collect every rank's balanced KV shard so we can emulate the ring.
+        kv_shards = [
+            (
+                as_balanced_halves(balanced_cp_slice(key, cp_size, rank, dim=2)),
+                as_balanced_halves(balanced_cp_slice(value, cp_size, rank, dim=2)),
+            )
+            for rank in range(cp_size)
+        ]
+
+        attn_out = softmax_max = softmax_sum = None
+        kv_block_id = cp_rank
+        for _ in range(cp_size):
+            cur_k, cur_v = kv_shards[kv_block_id]
+            cur_q, cur_k, cur_v, cur_mask = causal_forward_fetch(
+                cp_rank, kv_block_id, local_q, cur_k, cur_v, attn_mask=True
+            )
+            step_out, step_max, step_sum = _attention_forward(
+                cur_q,
+                cur_k,
+                cur_v,
+                num_heads=num_heads,
+                softmax_scale=softmax_scale,
+                causal=cur_mask is not None,
+                backend=backend,
+            )
+            attn_out, softmax_max, softmax_sum = causal_out_update(
+                cp_rank,
+                kv_block_id,
+                step_out,
+                step_max,
+                step_sum,
+                attn_out,
+                softmax_max,
+                softmax_sum,
+            )
+            kv_block_id = (kv_block_id - 1) % cp_size
+
+        local_outputs.append(attn_out)
+
+    return balanced_cp_restore(torch.cat(local_outputs, dim=2), cp_size=cp_size, dim=2)
+
+
+class AttentionWithCp(torch.autograd.Function):
+    """Causal Ring attention with context parallelism (single ring, full KV cache)."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        num_heads: int,
+        cp_group: dist.ProcessGroup,
+        cp_global_ranks: Sequence[int],
+        softmax_scale: Optional[float] = None,
+        backend: Optional[str] = None,
+        overlap_group: Optional[dist.ProcessGroup] = None,
+    ) -> Tensor:
+        backend = _default_backend(backend)
+        if softmax_scale is None:
+            softmax_scale = query.shape[-1] ** -0.5
+
+        cp_size = dist.get_world_size(cp_group)
+        rank = dist.get_rank(cp_group)
+        if cp_size < 2:
+            raise ValueError("AttentionWithCp requires cp_size >= 2.")
+
+        # Local shard is already balanced CP-sliced by the caller: [B,H,2S,D]
+        q = as_balanced_halves(query)
+        k = as_balanced_halves(key)
+        v = as_balanced_halves(value)
+
+        ring = RingP2P(cp_global_ranks, cp_group, overlap_group)
+        cur_kv = torch.cat((k.unsqueeze(0), v.unsqueeze(0)), dim=0)
+        next_kv = torch.empty_like(cur_kv)
+
+        attn_out = softmax_max = softmax_sum = None
+        kv_block_id = rank
+        cached_k = []
+        cached_v = []
+
+        for step in range(cp_size):
+            if step < cp_size - 1:
+                ring.async_send_recv(cur_kv, next_kv)
+
+            cur_k, cur_v = cur_kv[0], cur_kv[1]
+            cached_k.append(cur_k.clone())
+            cached_v.append(cur_v.clone())
+
+            cur_q, step_k, step_v, cur_mask = causal_forward_fetch(
+                rank, kv_block_id, q, cur_k, cur_v, attn_mask=True
+            )
+            step_out, step_max, step_sum = _attention_forward(
+                cur_q,
+                step_k,
+                step_v,
+                num_heads=num_heads,
+                softmax_scale=softmax_scale,
+                causal=cur_mask is not None,
+                backend=backend,
+            )
+            attn_out, softmax_max, softmax_sum = causal_out_update(
+                rank,
+                kv_block_id,
+                step_out,
+                step_max,
+                step_sum,
+                attn_out,
+                softmax_max,
+                softmax_sum,
+            )
+
+            if ring.wait():
+                cur_kv, next_kv = next_kv, cur_kv
+            kv_block_id = (kv_block_id - 1) % cp_size
+
+        # Save KV in reverse visitation order for backward replay:
+        # forward visits rank, rank-1, ..., so cache[0]=local, cache[-1]=last received.
+        # Backward visits in reverse: start from last received KV.
+        k_stack = torch.stack(cached_k[::-1], dim=0)
+        v_stack = torch.stack(cached_v[::-1], dim=0)
+        ctx.save_for_backward(q, k_stack, v_stack, attn_out, softmax_max, softmax_sum)
+        ctx.num_heads = num_heads
+        ctx.softmax_scale = float(softmax_scale)
+        ctx.backend = backend
+        ctx.cp_size = cp_size
+        ctx.rank = rank
+        ctx.cp_global_ranks = list(cp_global_ranks)
+        ctx.cp_group = cp_group
+        ctx.overlap_group = overlap_group
+        # Final kv_block_id after forward loop points at the next (unused) block;
+        # last computed block was (rank - (cp_size-1)) % cp_size.
+        ctx.final_kv_block_id = (rank - (cp_size - 1)) % cp_size
+        return attn_out
+
+    @staticmethod
+    def backward(ctx, dout: Tensor):
+        q, k_stack, v_stack, attn_out, softmax_max, softmax_sum = ctx.saved_tensors
+        cp_size = ctx.cp_size
+        rank = ctx.rank
+        backend = ctx.backend
+        softmax_scale = ctx.softmax_scale
+        num_heads = ctx.num_heads
+
+        dout_h = as_balanced_halves(dout)
+        attn_out_h = as_balanced_halves(attn_out)
+        softmax_max_h = as_balanced_halves(softmax_max)
+        softmax_sum_h = as_balanced_halves(softmax_sum)
+
+        # Full-cache replay: KV comes from forward saves; only dKV travels the ring.
+        dkv_ring = RingP2P(ctx.cp_global_ranks, ctx.cp_group, ctx.overlap_group, is_backward=True)
+        cur_dkv = torch.zeros((2, *k_stack[0].shape), dtype=k_stack[0].dtype, device=k_stack[0].device)
+        next_dkv = torch.zeros_like(cur_dkv)
+
+        dq = torch.zeros_like(q)
+        kv_block_id = ctx.final_kv_block_id
+
+        for step in range(cp_size):
+            cur_k = k_stack[step]
+            cur_v = v_stack[step]
+            step_q, step_k, step_v, step_out, step_dout, step_max, step_sum, step_mask = causal_backward_fetch(
+                rank,
+                kv_block_id,
+                q,
+                cur_k,
+                cur_v,
+                attn_out_h,
+                dout_h,
+                softmax_max_h,
+                softmax_sum_h,
+                attn_mask=True,
+            )
+            dq_step, dk_step, dv_step = _attention_backward(
+                step_q,
+                step_k,
+                step_v,
+                step_dout,
+                step_out,
+                step_max,
+                step_sum,
+                num_heads=num_heads,
+                softmax_scale=softmax_scale,
+                causal=step_mask is not None,
+                backend=backend,
+            )
+
+            if step > 0:
+                dkv_ring.wait()
+                cur_dkv, next_dkv = next_dkv, cur_dkv
+
+            dk, dv = cur_dkv[0], cur_dkv[1]
+            causal_grad_update(rank, kv_block_id, dq_step, dk_step, dv_step, dq, dk, dv)
+
+            if step < cp_size - 1:
+                dkv_ring.async_send_recv(cur_dkv, next_dkv)
+
+            kv_block_id = (kv_block_id + 1) % cp_size
+
+        if dkv_ring.wait():
+            cur_dkv, next_dkv = next_dkv, cur_dkv
+
+        dk, dv = cur_dkv[0], cur_dkv[1]
+        return (
+            flatten_balanced_halves(dq),
+            flatten_balanced_halves(dk),
+            flatten_balanced_halves(dv),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def ringattn_context_parallel(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    num_heads: int,
+    cp_group: dist.ProcessGroup,
+    cp_global_ranks: Sequence[int],
+    softmax_scale: Optional[float] = None,
+    backend: Optional[str] = None,
+    overlap_group: Optional[dist.ProcessGroup] = None,
+    cu_seqlens: Optional[Tensor] = None,
+) -> Tensor:
+    """Public entry for causal Ring CP attention over already-sliced local Q/K/V.
+
+    When ``cu_seqlens`` is provided, runs per-sample Ring (no cross-sample attention).
+    Local sample lengths must already match the packed CP partition.
+    """
+    if cu_seqlens is None:
+        return AttentionWithCp.apply(
+            query,
+            key,
+            value,
+            num_heads,
+            cp_group,
+            list(cp_global_ranks),
+            softmax_scale,
+            backend,
+            overlap_group,
+        )
+
+    cu = cu_seqlens.detach().to(device="cpu").tolist()
+    if query.size(0) != 1:
+        raise ValueError(f"Packed Ring CP currently supports batch=1, got {query.shape}.")
+    outs = []
+    for start, end in zip(cu[:-1], cu[1:]):
+        start, end = int(start), int(end)
+        if end <= start:
+            continue
+        outs.append(
+            AttentionWithCp.apply(
+                query[:, :, start:end],
+                key[:, :, start:end],
+                value[:, :, start:end],
+                num_heads,
+                cp_group,
+                list(cp_global_ranks),
+                softmax_scale,
+                backend,
+                overlap_group,
+            )
+        )
+    if not outs:
+        return query.new_empty(query.shape)
+    return torch.cat(outs, dim=2)
+
+
+def simulate_packed_ring_causal_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    cu_seqlens: Tensor,
+    *,
+    cp_size: int,
+    softmax_scale: Optional[float] = None,
+    backend: str = "torch",
+) -> Tensor:
+    """Per-sample Ring CP simulation (no cross-sample leakage)."""
+    from .attention_backend import torch_packed_causal_attention  # noqa: F401 — kept for API symmetry
+
+    if softmax_scale is None:
+        softmax_scale = query.shape[-1] ** -0.5
+    cu = cu_seqlens.detach().cpu().tolist()
+    outs = []
+    for start, end in zip(cu[:-1], cu[1:]):
+        start, end = int(start), int(end)
+        outs.append(
+            simulate_ring_causal_attention(
+                query[:, :, start:end],
+                key[:, :, start:end],
+                value[:, :, start:end],
+                cp_size=cp_size,
+                softmax_scale=softmax_scale,
+                backend=backend,
+            )
+        )
+    return torch.cat(outs, dim=2)
+
+
+def dense_causal_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    softmax_scale: Optional[float] = None,
+) -> Tensor:
+    """Reference dense causal attention (BNSD, GQA-aware)."""
+    if softmax_scale is None:
+        softmax_scale = query.shape[-1] ** -0.5
+    out, _, _ = torch_attention_forward(query, key, value, softmax_scale=softmax_scale, causal=True)
+    return out

--- a/veomni/distributed/context_parallel/ring_p2p.py
+++ b/veomni/distributed/context_parallel/ring_p2p.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2024, Huawei Technologies Co., Ltd.  All rights reserved.
+# Ported from MindSpeed RingP2P (BSD-3-Clause) for Open-VeOmni context parallel.
+"""Ring isend/irecv helpers for context-parallel KV exchange."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Union
+
+import torch
+import torch.distributed as dist
+from torch import Tensor
+
+
+TensorOrPair = Union[Tensor, List[Tensor]]
+
+
+class RingP2P:
+    """Even/odd ordered P2P send/recv on a ring of global ranks."""
+
+    def __init__(
+        self,
+        ring_global_ranks: Sequence[int],
+        group: dist.ProcessGroup,
+        group_for_send_recv_overlap: Optional[dist.ProcessGroup] = None,
+        is_backward: bool = False,
+    ) -> None:
+        self.group = group
+        self.group_for_send_recv_overlap = (
+            group if group_for_send_recv_overlap is None else group_for_send_recv_overlap
+        )
+
+        global_rank = dist.get_rank()
+        ring_rank = list(ring_global_ranks).index(global_rank)
+        ring_size = len(ring_global_ranks)
+        self.next = ring_global_ranks[(ring_rank + 1) % ring_size]
+        self.prev = ring_global_ranks[(ring_rank + ring_size - 1) % ring_size]
+        self.ring_rank = ring_rank
+        if is_backward:
+            self.next, self.prev = self.prev, self.next
+
+        self.send_recv_ops: list[dist.Work] = []
+        self._packed_recv = None
+
+    def async_send_recv(self, send_tensor: TensorOrPair, recv_tensor: TensorOrPair) -> None:
+        """Launch even/odd isend/irecv. Supports a single tensor or a mutable [K, V] list."""
+        self._packed_recv = None
+        packed = isinstance(send_tensor, list)
+        if packed:
+            if not isinstance(recv_tensor, list) or len(send_tensor) != 2 or len(recv_tensor) != 2:
+                raise ValueError("Packed RingP2P tensors must be length-2 mutable lists [K, V].")
+            k_send, v_send = send_tensor
+            k_recv, v_recv = recv_tensor
+            if k_send.shape != k_recv.shape or v_send.shape != v_recv.shape:
+                raise ValueError(
+                    "Shape mismatch in KV tensors:\n"
+                    f"  k_send: {k_send.shape} vs k_recv: {k_recv.shape}\n"
+                    f"  v_send: {v_send.shape} vs v_recv: {v_recv.shape}"
+                )
+            k_shape, v_shape = k_send.shape, v_send.shape
+            k_numel = k_send.numel()
+            send_payload = torch.cat((k_send.reshape(-1), v_send.reshape(-1)), dim=0).contiguous()
+            recv_payload = torch.empty_like(send_payload)
+        else:
+            send_payload = send_tensor.contiguous()
+            recv_payload = recv_tensor
+            k_numel = k_shape = v_shape = None
+
+        if self.ring_rank % 2 == 0:
+            send_op = dist.isend(send_payload, self.next, self.group)
+            recv_op = dist.irecv(recv_payload, self.prev, self.group_for_send_recv_overlap)
+            self.send_recv_ops.extend((send_op, recv_op))
+        else:
+            recv_op = dist.irecv(recv_payload, self.prev, self.group)
+            send_op = dist.isend(send_payload, self.next, self.group_for_send_recv_overlap)
+            self.send_recv_ops.extend((recv_op, send_op))
+
+        if packed:
+            self._packed_recv = (recv_tensor, recv_payload, k_numel, k_shape, v_shape)
+
+    def wait(self) -> int:
+        """Wait for outstanding P2P ops. Returns 1 if work completed, else 0."""
+        if not self.send_recv_ops:
+            return 0
+        for op in self.send_recv_ops:
+            op.wait()
+        self.send_recv_ops = []
+        if self._packed_recv is not None:
+            recv_tensor, recv_payload, k_numel, k_shape, v_shape = self._packed_recv
+            recv_tensor[0] = recv_payload[:k_numel].view(k_shape)
+            recv_tensor[1] = recv_payload[k_numel:].view(v_shape)
+            self._packed_recv = None
+        return 1

--- a/veomni/distributed/context_parallel/sharding.py
+++ b/veomni/distributed/context_parallel/sharding.py
@@ -1,0 +1,83 @@
+import torch
+from torch import Tensor
+
+
+def _validate_parallel_coordinate(size: int, rank: int, name: str) -> None:
+    if size < 1:
+        raise ValueError(f"{name}_size must be positive, got {size}.")
+    if not 0 <= rank < size:
+        raise ValueError(f"{name}_rank must be in [0, {size}), got {rank}.")
+
+
+def balanced_cp_slice(tensor: Tensor, cp_size: int, cp_rank: int, dim: int = 0) -> Tensor:
+    """Select the mirrored two-chunk causal partition for one CP rank."""
+    _validate_parallel_coordinate(cp_size, cp_rank, "cp")
+    dim = dim % tensor.ndim
+    sequence_length = tensor.size(dim)
+    num_chunks = 2 * cp_size
+    if sequence_length % num_chunks != 0:
+        raise ValueError(
+            f"Sequence length ({sequence_length}) must be divisible by 2 * cp_size ({num_chunks}) "
+            "for balanced causal CP sharding."
+        )
+
+    chunks = tensor.chunk(num_chunks, dim=dim)
+    return torch.cat((chunks[cp_rank], chunks[num_chunks - cp_rank - 1]), dim=dim).contiguous()
+
+
+def balanced_cp_restore(tensor: Tensor, cp_size: int, dim: int = 0) -> Tensor:
+    """Restore canonical sequence order from rank-major balanced CP shards."""
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be positive, got {cp_size}.")
+    dim = dim % tensor.ndim
+    num_chunks = 2 * cp_size
+    if tensor.size(dim) % num_chunks != 0:
+        raise ValueError(
+            f"Gathered sequence length ({tensor.size(dim)}) must be divisible by 2 * cp_size ({num_chunks})."
+        )
+
+    rank_major_chunks = tensor.chunk(num_chunks, dim=dim)
+    canonical_chunks = [None] * num_chunks
+    for cp_rank in range(cp_size):
+        canonical_chunks[cp_rank] = rank_major_chunks[2 * cp_rank]
+        canonical_chunks[num_chunks - cp_rank - 1] = rank_major_chunks[2 * cp_rank + 1]
+    return torch.cat(canonical_chunks, dim=dim).contiguous()
+
+
+def balanced_cp_to_rank_major(tensor: Tensor, cp_size: int, dim: int = 0) -> Tensor:
+    """Convert canonical sequence order to rank-major balanced CP layout."""
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be positive, got {cp_size}.")
+    dim = dim % tensor.ndim
+    num_chunks = 2 * cp_size
+    if tensor.size(dim) % num_chunks != 0:
+        raise ValueError(
+            f"Sequence length ({tensor.size(dim)}) must be divisible by 2 * cp_size ({num_chunks})."
+        )
+
+    canonical_chunks = tensor.chunk(num_chunks, dim=dim)
+    rank_major_chunks = []
+    for cp_rank in range(cp_size):
+        rank_major_chunks.append(canonical_chunks[cp_rank])
+        rank_major_chunks.append(canonical_chunks[num_chunks - cp_rank - 1])
+    return torch.cat(rank_major_chunks, dim=dim).contiguous()
+
+
+def hybrid_cp_slice(
+    tensor: Tensor,
+    cp_size: int,
+    cp_rank: int,
+    ulysses_size: int,
+    ulysses_rank: int,
+    dim: int = 0,
+) -> Tensor:
+    """Apply balanced Ring-CP sharding followed by contiguous Ulysses sharding."""
+    _validate_parallel_coordinate(ulysses_size, ulysses_rank, "ulysses")
+    cp_shard = balanced_cp_slice(tensor, cp_size=cp_size, cp_rank=cp_rank, dim=dim)
+    dim = dim % cp_shard.ndim
+    if cp_shard.size(dim) % ulysses_size != 0:
+        raise ValueError(
+            f"CP-local sequence length ({cp_shard.size(dim)}) must be divisible by "
+            f"ulysses_size ({ulysses_size})."
+        )
+    return cp_shard.chunk(ulysses_size, dim=dim)[ulysses_rank].contiguous()

--- a/veomni/distributed/context_parallel/softmax_update.py
+++ b/veomni/distributed/context_parallel/softmax_update.py
@@ -1,0 +1,78 @@
+import torch
+from torch import Tensor
+
+
+def _output_scale(statistic: Tensor, output: Tensor) -> Tensor:
+    scale = statistic[..., :1]
+    if scale.ndim != output.ndim:
+        raise ValueError(
+            f"Softmax statistic rank ({scale.ndim}) must match attention output rank ({output.ndim})."
+        )
+    if scale.shape[:-1] != output.shape[:-1]:
+        raise ValueError(
+            f"Softmax statistic prefix {scale.shape[:-1]} must match attention output prefix {output.shape[:-1]}."
+        )
+    return scale
+
+
+def merge_attention_blocks(
+    previous_output: Tensor,
+    previous_softmax_max: Tensor,
+    previous_softmax_sum: Tensor,
+    current_output: Tensor,
+    current_softmax_max: Tensor,
+    current_softmax_sum: Tensor,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Merge independently normalized attention blocks with online softmax."""
+    if previous_output.shape != current_output.shape:
+        raise ValueError(
+            f"Attention output shapes must match, got {previous_output.shape} and {current_output.shape}."
+        )
+    if previous_softmax_max.shape != current_softmax_max.shape:
+        raise ValueError(
+            "Softmax max shapes must match, got "
+            f"{previous_softmax_max.shape} and {current_softmax_max.shape}."
+        )
+    if previous_softmax_sum.shape != current_softmax_sum.shape:
+        raise ValueError(
+            "Softmax sum shapes must match, got "
+            f"{previous_softmax_sum.shape} and {current_softmax_sum.shape}."
+        )
+
+    accumulator_dtype = torch.promote_types(previous_output.dtype, current_output.dtype)
+    if accumulator_dtype in (torch.float16, torch.bfloat16):
+        accumulator_dtype = torch.float32
+    previous_max = previous_softmax_max.to(accumulator_dtype)
+    current_max = current_softmax_max.to(accumulator_dtype)
+    merged_max = torch.maximum(previous_max, current_max)
+
+    previous_finite = torch.isfinite(previous_max)
+    current_finite = torch.isfinite(current_max)
+    previous_scale = torch.where(
+        previous_finite,
+        torch.exp(previous_max - torch.where(previous_finite, merged_max, previous_max)),
+        torch.zeros_like(previous_max),
+    )
+    current_scale = torch.where(
+        current_finite,
+        torch.exp(current_max - torch.where(current_finite, merged_max, current_max)),
+        torch.zeros_like(current_max),
+    )
+
+    previous_sum_scaled = previous_softmax_sum.to(accumulator_dtype) * previous_scale
+    current_sum_scaled = current_softmax_sum.to(accumulator_dtype) * current_scale
+    merged_sum = previous_sum_scaled + current_sum_scaled
+    nonzero_sum = merged_sum > 0
+    previous_weight = torch.where(nonzero_sum, previous_sum_scaled / merged_sum, torch.zeros_like(merged_sum))
+    current_weight = torch.where(nonzero_sum, current_sum_scaled / merged_sum, torch.zeros_like(merged_sum))
+
+    previous_output_weight = _output_scale(previous_weight, previous_output)
+    current_output_weight = _output_scale(current_weight, current_output)
+    output = previous_output.to(accumulator_dtype) * previous_output_weight
+    output = output + current_output.to(accumulator_dtype) * current_output_weight
+
+    return (
+        output.to(previous_output.dtype),
+        merged_max.to(previous_softmax_max.dtype),
+        merged_sum.to(previous_softmax_sum.dtype),
+    )

--- a/veomni/distributed/context_parallel/topology.py
+++ b/veomni/distributed/context_parallel/topology.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 ByteDance AI4SE.
+"""Hybrid CP × Ulysses rank topology helpers.
+
+Canonical layout (matches ``init_sequence_parallel``):
+    sp_rank = cp_rank * ulysses_size + ulysses_rank
+
+DeviceMesh dim order must therefore be ``cp`` then ``ulysses`` (CP outer,
+Ulysses inner) so flattened ``sp`` ranks agree with legacy group construction.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def validate_hybrid_sizes(cp_size: int, ulysses_size: int) -> None:
+    if cp_size < 1 or ulysses_size < 1:
+        raise ValueError(f"cp_size and ulysses_size must be >= 1, got {cp_size}, {ulysses_size}.")
+
+
+def sp_rank_from_coords(cp_rank: int, ulysses_rank: int, ulysses_size: int) -> int:
+    validate_hybrid_sizes(1, ulysses_size)
+    return cp_rank * ulysses_size + ulysses_rank
+
+
+def coords_from_sp_rank(sp_rank: int, cp_size: int, ulysses_size: int) -> tuple[int, int]:
+    validate_hybrid_sizes(cp_size, ulysses_size)
+    if not 0 <= sp_rank < cp_size * ulysses_size:
+        raise ValueError(f"sp_rank {sp_rank} out of range for CP{cp_size}×U{ulysses_size}.")
+    cp_rank = sp_rank // ulysses_size
+    ulysses_rank = sp_rank % ulysses_size
+    return cp_rank, ulysses_rank
+
+
+def cp_global_ranks_for_ulysses_rank(
+    *,
+    dp_index: int,
+    ulysses_rank: int,
+    cp_size: int,
+    ulysses_size: int,
+) -> list[int]:
+    """Global ranks that form one CP ring (fixed DP + Ulysses coordinate)."""
+    validate_hybrid_sizes(cp_size, ulysses_size)
+    unified = cp_size * ulysses_size
+    start = dp_index * unified + ulysses_rank
+    return list(range(start, (dp_index + 1) * unified, ulysses_size))
+
+
+def ulysses_global_ranks_for_cp_rank(
+    *,
+    dp_index: int,
+    cp_rank: int,
+    cp_size: int,
+    ulysses_size: int,
+) -> list[int]:
+    """Global ranks that form one Ulysses group (fixed DP + CP coordinate)."""
+    validate_hybrid_sizes(cp_size, ulysses_size)
+    unified = cp_size * ulysses_size
+    start = dp_index * unified + cp_rank * ulysses_size
+    return list(range(start, start + ulysses_size))
+
+
+def ordered_cp_global_ranks(group_ranks: Sequence[int]) -> list[int]:
+    """Return CP ring ranks sorted by CP rank (ascending)."""
+    return sorted(group_ranks)

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -69,6 +69,9 @@ class ParallelState:
     device_type: str = get_device_type()
     include_sp_in_fsdp: bool = True
     device_mesh: Optional["DeviceMesh"] = None
+    # Ascend torch_npu may leave DeviceMesh._flatten_mapping empty; keep the
+    # 1D mesh returned by _flatten(mesh_dim_name="sp") for get_group/get_local_rank.
+    _sp_mesh: Optional["DeviceMesh"] = field(default=None, repr=False, compare=False)
     extra_parallel_names: Tuple[str] = ("ep",)
     extra_parallel_sizes: Dict[str, int] = field(default_factory=lambda: {"ep": 1})
     extra_parallel_fsdp_device_mesh: Dict[str, Optional["DeviceMesh"]] = field(default_factory=lambda: {"ep": None})
@@ -79,7 +82,11 @@ class ParallelState:
             raise NotImplementedError("Decoupled sequence parallel has not been implemented.")
 
         if self.cp_size > 1:
-            raise NotImplementedError("Ring attention is not supported yet.")
+            # Ring CP kernel lives in veomni.distributed.context_parallel.
+            logger.info_rank0(
+                f"Context parallel enabled: cp_size={self.cp_size}, "
+                f"ulysses_size={self.ulysses_size}, sp_size={self.sp_size}."
+            )
 
         if self.pp_size * self.dp_size * self.cp_size * self.ulysses_size * self.tp_size != self.world_size:
             raise ValueError("The product of parallel sizes should be equal to the world size.")
@@ -362,16 +369,43 @@ class ParallelState:
     # ------------------------------ SP ------------------------------ #
     @property
     def sp_group(self) -> Optional["ProcessGroup"]:
-        if self.device_mesh is not None and self.sp_enabled:
+        if self.device_mesh is None or not self.sp_enabled:
+            return None
+        # Prefer explicit flattened SP mesh (required on Ascend where root
+        # get_group("sp") KeyErrors despite init-time _flatten).
+        if self._sp_mesh is not None:
+            return self._sp_mesh.get_group()
+        try:
             return self.device_mesh.get_group("sp")
-
+        except Exception:
+            pass
+        if self.cp_enabled and not self.ulysses_enabled:
+            return self.device_mesh.get_group("cp")
+        if self.ulysses_enabled and not self.cp_enabled:
+            return self.device_mesh.get_group("ulysses")
+        if self.cp_enabled and self.ulysses_enabled:
+            # Last resort: flatten now and cache.
+            flat = self.device_mesh[("cp", "ulysses")]._flatten(mesh_dim_name="sp")
+            object.__setattr__(self, "_sp_mesh", flat)
+            return flat.get_group()
         return None
 
     @property
     def sp_rank(self) -> int:
-        if self.device_mesh is not None and self.sp_enabled:
+        if self.device_mesh is None or not self.sp_enabled:
+            return -1
+        if self._sp_mesh is not None:
+            return self._sp_mesh.get_local_rank()
+        try:
             return self.device_mesh.get_local_rank("sp")
-
+        except Exception:
+            pass
+        if self.cp_enabled and not self.ulysses_enabled:
+            return self.device_mesh.get_local_rank("cp")
+        if self.ulysses_enabled and not self.cp_enabled:
+            return self.device_mesh.get_local_rank("ulysses")
+        if self.cp_enabled and self.ulysses_enabled and self.sp_group is not None:
+            return dist.get_rank(self.sp_group)
         return -1
 
     @property
@@ -544,9 +578,11 @@ def init_parallel_state(
 
     mesh_shape = []
     mesh_dim_names = []
+    # CP outer / Ulysses inner: matches init_sequence_parallel layout
+    # sp_rank = cp_rank * ulysses_size + ulysses_rank.
     for d, dim_name in zip(
-        [pp_size, dp_replicate_size, dp_shard_size, ulysses_size, cp_size, tp_size],
-        ["pp", "dp_replicate", "dp_shard", "ulysses", "cp", "tp"],
+        [pp_size, dp_replicate_size, dp_shard_size, cp_size, ulysses_size, tp_size],
+        ["pp", "dp_replicate", "dp_shard", "cp", "ulysses", "tp"],
     ):
         if d > 1 or dim_name in ["dp_shard"]:
             mesh_shape.append(d)
@@ -574,14 +610,15 @@ def init_parallel_state(
         dp_mesh_dim_names.append("dp_shard")
         dp_shard_sp_mesh_dim_names.append("dp_shard")
         dp_sp_mesh_dim_names.append("dp_shard")
-    if ulysses_size > 1:
-        dp_shard_sp_mesh_dim_names.append("ulysses")
-        sp_mesh_dim_names.append("ulysses")
-        dp_sp_mesh_dim_names.append("ulysses")
+    # Flatten order must keep CP before Ulysses so sp_rank matches legacy groups.
     if cp_size > 1:
         dp_shard_sp_mesh_dim_names.append("cp")
         sp_mesh_dim_names.append("cp")
         dp_sp_mesh_dim_names.append("cp")
+    if ulysses_size > 1:
+        dp_shard_sp_mesh_dim_names.append("ulysses")
+        sp_mesh_dim_names.append("ulysses")
+        dp_sp_mesh_dim_names.append("ulysses")
 
     if dp_mesh_dim_names != []:
         device_mesh[tuple(dp_mesh_dim_names)]._flatten(mesh_dim_name="dp")
@@ -592,8 +629,9 @@ def init_parallel_state(
     if dp_sp_mesh_dim_names != []:
         device_mesh[tuple(dp_sp_mesh_dim_names)]._flatten(mesh_dim_name="dp_sp")
 
+    sp_mesh = None
     if sp_mesh_dim_names != []:
-        device_mesh[tuple(sp_mesh_dim_names)]._flatten(mesh_dim_name="sp")
+        sp_mesh = device_mesh[tuple(sp_mesh_dim_names)]._flatten(mesh_dim_name="sp")
 
     for para_size, para_outside, para_name in zip(
         extra_parallel_sizes, extra_parallel_placement_innermost, extra_parallel_names
@@ -642,6 +680,7 @@ def init_parallel_state(
         device_type=device_type,
         include_sp_in_fsdp=include_sp_in_fsdp,
         device_mesh=device_mesh,
+        _sp_mesh=sp_mesh,
         extra_parallel_names=extra_parallel_names,
         extra_parallel_sizes=dict(zip(extra_parallel_names, extra_parallel_sizes)),
         extra_parallel_fsdp_device_mesh=extra_parallel_fsdp_device_mesh,

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -662,19 +662,25 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
-        # Modification: Ulysses SP all-to-all for linear attention heads.
-        ulysses_enabled = get_parallel_state().ulysses_enabled
-        if ulysses_enabled:
-            ulysses_group = get_parallel_state().ulysses_group
-            ulysses_size = get_parallel_state().ulysses_size
-            ulysses_rank = get_parallel_state().ulysses_rank
-            assert self.num_k_heads % ulysses_size == 0 and self.num_v_heads % ulysses_size == 0, (
-                f"SP size ({ulysses_size}) must divide num_k_heads ({self.num_k_heads}) "
+        # Modification: Ulysses / unified-SP all-to-all for linear attention heads.
+        # CP>1 uses unified SP + zigzag restore (not Ring). Ulysses-only unchanged.
+        from veomni.distributed.context_parallel.gdn_sp import (
+            maybe_restore_canonical,
+            maybe_to_rank_major,
+            resolve_gdn_sp_group,
+        )
+
+        gdn_sp_group, gdn_sp_size, gdn_head_rank, gdn_need_zigzag = resolve_gdn_sp_group()
+        gdn_sp_enabled = gdn_sp_group is not None
+        cp_size_for_gdn = get_parallel_state().cp_size if gdn_need_zigzag else 1
+        if gdn_sp_enabled:
+            assert self.num_k_heads % gdn_sp_size == 0 and self.num_v_heads % gdn_sp_size == 0, (
+                f"SP size ({gdn_sp_size}) must divide num_k_heads ({self.num_k_heads}) "
                 f"and num_v_heads ({self.num_v_heads}) for gated deltanet LASP"
             )
 
-            local_num_k_heads = self.num_k_heads // ulysses_size
-            local_num_v_heads = self.num_v_heads // ulysses_size
+            local_num_k_heads = self.num_k_heads // gdn_sp_size
+            local_num_v_heads = self.num_v_heads // gdn_sp_size
             local_key_dim = self.head_k_dim * local_num_k_heads
             local_value_dim = self.head_v_dim * local_num_v_heads
 
@@ -685,14 +691,20 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             v_proj = v_proj.reshape(batch_size, seq_len, self.num_v_heads, self.head_v_dim)
 
             # All-to-all: gather full sequence, scatter heads -> [B, S_full, local_heads, head_dim]
-            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=ulysses_group)
-            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=ulysses_group)
-            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=ulysses_group)
+            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
 
             b = b.reshape(batch_size, seq_len, self.num_v_heads)
             a = a.reshape(batch_size, seq_len, self.num_v_heads)
-            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=ulysses_group)
-            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=ulysses_group)
+            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=gdn_sp_group)
+
+            q_proj = maybe_restore_canonical(q_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            k_proj = maybe_restore_canonical(k_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            v_proj = maybe_restore_canonical(v_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            b = maybe_restore_canonical(b, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            a = maybe_restore_canonical(a, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
 
             # Flatten heads back to channels and concat for conv1d: [B, S_full, local_dim]
             q_proj = q_proj.reshape(q_proj.shape[0], q_proj.shape[1], -1)
@@ -704,6 +716,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             local_num_v_heads = self.num_v_heads
             local_key_dim = self.key_dim
             local_value_dim = self.value_dim
+            gdn_head_rank = 0
 
         if use_precomputed_states:
             # Modification: keep this disabled until FLA causal_conv1d_update decode path is validated.
@@ -714,10 +727,10 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                 conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
                 cache_params.conv_states[self.layer_idx] = conv_state
             if self.causal_conv1d_fn is not None:
-                # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
-                if ulysses_enabled:
+                # Modification: shard conv1d weights per SP rank to match head-sharded channels.
+                if gdn_sp_enabled:
                     conv_weight = self._get_local_conv1d_weight(
-                        ulysses_rank=ulysses_rank,
+                        ulysses_rank=gdn_head_rank,
                         local_key_dim=local_key_dim,
                         local_value_dim=local_value_dim,
                     )
@@ -767,9 +780,9 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
         beta = b.sigmoid()
         # If the model is loaded in fp16, without the .float() here, A might be -inf
-        # Modification: slice A_log/dt_bias for local V-heads under Ulysses SP.
-        if ulysses_enabled:
-            v_head_offset = ulysses_rank * local_num_v_heads
+        # Modification: slice A_log/dt_bias for local V-heads under SP.
+        if gdn_sp_enabled:
+            v_head_offset = gdn_head_rank * local_num_v_heads
             v_head_slice = slice(v_head_offset, v_head_offset + local_num_v_heads)
             g = -self.A_log[v_head_slice].float().exp() * F.softplus(a.float() + self.dt_bias[v_head_slice])
         else:
@@ -821,9 +834,12 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
 
         # Modification: gather attention output back to sequence-sharded layout before gated norm.
-        if ulysses_enabled:
+        if gdn_sp_enabled:
+            core_attn_out = maybe_to_rank_major(
+                core_attn_out, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1
+            )
             core_attn_out = gather_heads_scatter_seq(
-                core_attn_out, head_dim=2, seq_dim=1, group=get_parallel_state().ulysses_group
+                core_attn_out, head_dim=2, seq_dim=1, group=gdn_sp_group
             )
 
         # reshape input data into 2D tensor

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -661,19 +661,25 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
-        # Modification: Ulysses SP all-to-all for linear attention heads.
-        ulysses_enabled = get_parallel_state().ulysses_enabled
-        if ulysses_enabled:
-            ulysses_group = get_parallel_state().ulysses_group
-            ulysses_size = get_parallel_state().ulysses_size
-            ulysses_rank = get_parallel_state().ulysses_rank
-            assert self.num_k_heads % ulysses_size == 0 and self.num_v_heads % ulysses_size == 0, (
-                f"SP size ({ulysses_size}) must divide num_k_heads ({self.num_k_heads}) "
+        # Modification: Ulysses / unified-SP all-to-all for linear attention heads.
+        # CP>1 uses unified SP + zigzag restore (not Ring). Ulysses-only unchanged.
+        from veomni.distributed.context_parallel.gdn_sp import (
+            maybe_restore_canonical,
+            maybe_to_rank_major,
+            resolve_gdn_sp_group,
+        )
+
+        gdn_sp_group, gdn_sp_size, gdn_head_rank, gdn_need_zigzag = resolve_gdn_sp_group()
+        gdn_sp_enabled = gdn_sp_group is not None
+        cp_size_for_gdn = get_parallel_state().cp_size if gdn_need_zigzag else 1
+        if gdn_sp_enabled:
+            assert self.num_k_heads % gdn_sp_size == 0 and self.num_v_heads % gdn_sp_size == 0, (
+                f"SP size ({gdn_sp_size}) must divide num_k_heads ({self.num_k_heads}) "
                 f"and num_v_heads ({self.num_v_heads}) for gated deltanet LASP"
             )
 
-            local_num_k_heads = self.num_k_heads // ulysses_size
-            local_num_v_heads = self.num_v_heads // ulysses_size
+            local_num_k_heads = self.num_k_heads // gdn_sp_size
+            local_num_v_heads = self.num_v_heads // gdn_sp_size
             local_key_dim = self.head_k_dim * local_num_k_heads
             local_value_dim = self.head_v_dim * local_num_v_heads
 
@@ -684,14 +690,20 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             v_proj = v_proj.reshape(batch_size, seq_len, self.num_v_heads, self.head_v_dim)
 
             # All-to-all: gather full sequence, scatter heads -> [B, S_full, local_heads, head_dim]
-            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=ulysses_group)
-            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=ulysses_group)
-            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=ulysses_group)
+            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
 
             b = b.reshape(batch_size, seq_len, self.num_v_heads)
             a = a.reshape(batch_size, seq_len, self.num_v_heads)
-            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=ulysses_group)
-            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=ulysses_group)
+            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=gdn_sp_group)
+
+            q_proj = maybe_restore_canonical(q_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            k_proj = maybe_restore_canonical(k_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            v_proj = maybe_restore_canonical(v_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            b = maybe_restore_canonical(b, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            a = maybe_restore_canonical(a, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
 
             # Flatten heads back to channels and concat for conv1d: [B, S_full, local_dim]
             q_proj = q_proj.reshape(q_proj.shape[0], q_proj.shape[1], -1)
@@ -703,6 +715,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             local_num_v_heads = self.num_v_heads
             local_key_dim = self.key_dim
             local_value_dim = self.value_dim
+            gdn_head_rank = 0
 
         if use_precomputed_states:
             # Modification: keep this disabled until FLA causal_conv1d_update decode path is validated.
@@ -713,10 +726,10 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                 conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
                 cache_params.conv_states[self.layer_idx] = conv_state
             if self.causal_conv1d_fn is not None:
-                # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
-                if ulysses_enabled:
+                # Modification: shard conv1d weights per SP rank to match head-sharded channels.
+                if gdn_sp_enabled:
                     conv_weight = self._get_local_conv1d_weight(
-                        ulysses_rank=ulysses_rank,
+                        ulysses_rank=gdn_head_rank,
                         local_key_dim=local_key_dim,
                         local_value_dim=local_value_dim,
                     )
@@ -751,9 +764,9 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
         beta = b.sigmoid()
         # If the model is loaded in fp16, without the .float() here, A might be -inf
-        # Modification: slice A_log/dt_bias for local V-heads under Ulysses SP.
-        if ulysses_enabled:
-            v_head_offset = ulysses_rank * local_num_v_heads
+        # Modification: slice A_log/dt_bias for local V-heads under SP.
+        if gdn_sp_enabled:
+            v_head_offset = gdn_head_rank * local_num_v_heads
             v_head_slice = slice(v_head_offset, v_head_offset + local_num_v_heads)
             g = -self.A_log[v_head_slice].float().exp() * F.softplus(a.float() + self.dt_bias[v_head_slice])
         else:
@@ -802,9 +815,12 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
 
         # Modification: gather attention output back to sequence-sharded layout before gated norm.
-        if ulysses_enabled:
+        if gdn_sp_enabled:
+            core_attn_out = maybe_to_rank_major(
+                core_attn_out, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1
+            )
             core_attn_out = gather_heads_scatter_seq(
-                core_attn_out, head_dim=2, seq_dim=1, group=get_parallel_state().ulysses_group
+                core_attn_out, head_dim=2, seq_dim=1, group=gdn_sp_group
             )
 
         # reshape input data into 2D tensor

--- a/veomni/ops/kernels/attention/__init__.py
+++ b/veomni/ops/kernels/attention/__init__.py
@@ -280,50 +280,153 @@ def flash_attention_forward(
 
         # Only after all_to_all we got the full seq_len
         seq_len = query.shape[1]
-        s_aux = kwargs.get("s_aux")
-        if s_aux is not None and s_aux.ndim == 1 and s_aux.numel() == q_head_num:
-            local_q_head_num = query.shape[2]
-            head_start = dist.get_rank(ulysses_group) * local_q_head_num
-            kwargs["s_aux"] = s_aux.narrow(0, head_start, local_q_head_num).contiguous()
 
-    # Resolve the token that will be passed to Transformers' lazy_import_flash_attention.
-    #
-    # FA2 and FA3 have dedicated branches in transformers' _lazy_imports, so we
-    # use the plain transformers names and they are resolved without hitting the
-    # hub-kernel path.
-    #
-    # FA4 has no such branch; unrecognised names fall through to the hub-kernel
-    # loader. By keeping the VeOmni name here, our monkey-patch of
-    # ``load_and_register_attn_kernel`` intercepts it and loads
-    # ``flash_attn.cute`` locally.
-    if module.config._attn_implementation == "veomni_flash_attention_2_with_sp":
-        fa_kernel_implementation = "flash_attention_2"
-    elif module.config._attn_implementation == "veomni_flash_attention_3_with_sp":
-        fa_kernel_implementation = "flash_attention_3"
-    elif module.config._attn_implementation == "veomni_flash_attention_4_with_sp":
-        fa_kernel_implementation = "veomni_flash_attention_4_with_sp"  # intercepted by VeOmni hub-kernel patch
-    else:
-        raise ValueError(
-            f"unknown attn_implementation for veomni flash_attention with SP support: {module.config._attn_implementation}"
+    # Ring context-parallel attention (after optional Ulysses gather).
+    # Local sequence layout must already be balanced zigzag from the collator.
+    cp_enabled = get_parallel_state().cp_enabled and not skip_ulysses
+    # Hybrid: Ulysses gather concatenates rank-major packed shards; Ring needs
+    # sample-major CP-local order + scaled cu_seqlens (see packed_sharding).
+    _hybrid_ulysses_local_cu = None
+    if ulysses_enabled and cp_enabled and not skip_ulysses:
+        from ....distributed.context_parallel.packed_sharding import (
+            reorder_ulysses_rank_major_to_sample_major,
+            ulysses_local_cu_to_cp_local_cu,
         )
 
-    attn_output = _flash_attention_forward(
-        query,
-        key,
-        value,
-        attention_mask,
-        query_length=seq_len,
-        is_causal=is_causal,
-        dropout=dropout,
-        softmax_scale=scaling,
-        sliding_window=sliding_window,
-        softcap=softcap,
-        use_top_left_mask=False,
-        target_dtype=target_dtype,
-        attn_implementation=fa_kernel_implementation,
-        layer_idx=module.layer_idx if hasattr(module, "layer_idx") else None,
-        **kwargs,
-    )
+        _hybrid_ulysses_local_cu = kwargs.get("cu_seq_lens_q")
+        if _hybrid_ulysses_local_cu is None:
+            _hybrid_ulysses_local_cu = kwargs.get("cu_seqlens_q")
+        if _hybrid_ulysses_local_cu is not None:
+            seq_dim = 1 if query.ndim == 4 else 0
+            actual = int(query.size(seq_dim))
+            local_sum = int(_hybrid_ulysses_local_cu.diff().sum().item())
+            expected = local_sum * int(ulysses_size)
+            if actual != expected:
+                # ViT passes global cu_seqlens while Q is only Ulysses-gathered
+                # (CP-local). Skip LM hybrid reorder; drop cu to avoid packed-ring OOB.
+                _hybrid_ulysses_local_cu = None
+                kwargs = dict(kwargs)
+                for _k in (
+                    "cu_seq_lens_q",
+                    "cu_seq_lens_k",
+                    "cu_seqlens_q",
+                    "cu_seqlens_k",
+                ):
+                    kwargs.pop(_k, None)
+            else:
+                query = reorder_ulysses_rank_major_to_sample_major(
+                    query, _hybrid_ulysses_local_cu, ulysses_size=ulysses_size, seq_dim=seq_dim
+                )
+                key = reorder_ulysses_rank_major_to_sample_major(
+                    key, _hybrid_ulysses_local_cu, ulysses_size=ulysses_size, seq_dim=seq_dim
+                )
+                value = reorder_ulysses_rank_major_to_sample_major(
+                    value, _hybrid_ulysses_local_cu, ulysses_size=ulysses_size, seq_dim=seq_dim
+                )
+                cp_cu = ulysses_local_cu_to_cp_local_cu(_hybrid_ulysses_local_cu, ulysses_size)
+                kwargs = dict(kwargs)
+                kwargs["cu_seq_lens_q"] = cp_cu
+                kwargs["cu_seq_lens_k"] = cp_cu
+                kwargs["cu_seqlens_q"] = cp_cu
+                kwargs["cu_seqlens_k"] = cp_cu
+                if "max_length_q" in kwargs or "max_seqlen_q" in kwargs:
+                    max_cp = int(cp_cu.diff().max().item()) if cp_cu.numel() > 1 else 0
+                    kwargs["max_length_q"] = max_cp
+                    kwargs["max_length_k"] = max_cp
+                    kwargs["max_seqlen_q"] = max_cp
+                    kwargs["max_seqlen_k"] = max_cp
+                seq_len = query.shape[1] if query.ndim == 4 else query.shape[0]
+
+    if cp_enabled:
+        from ....distributed.context_parallel.attention_backend import has_npu_fusion_attention
+        from ....distributed.context_parallel.ring_attention import ringattn_context_parallel
+
+        cu_seqlens = kwargs.get("cu_seq_lens_q")
+        if cu_seqlens is None:
+            cu_seqlens = kwargs.get("cu_seqlens_q")
+        # HF packed/varlen SFT often passes is_causal=False; Ring path is causal-only for now.
+        # Proceed with causal Ring regardless of the flag (non-causal CP is out of cut).
+        if sliding_window is not None or softcap is not None:
+            raise NotImplementedError("Ring CP does not support sliding_window/softcap yet.")
+        if dropout not in (0, 0.0):
+            raise NotImplementedError("Ring CP does not support attention dropout yet.")
+
+        query_bnsd = query.transpose(1, 2).contiguous()
+        key_bnsd = key.transpose(1, 2).contiguous()
+        value_bnsd = value.transpose(1, 2).contiguous()
+        cp_group = get_parallel_state().cp_group
+        cp_global_ranks = dist.get_process_group_ranks(cp_group)
+        backend = "npu" if has_npu_fusion_attention() and query.device.type == "npu" else "torch"
+        attn_output_bnsd = ringattn_context_parallel(
+            query_bnsd,
+            key_bnsd,
+            value_bnsd,
+            query_bnsd.shape[1],
+            cp_group,
+            cp_global_ranks,
+            softmax_scale=scaling,
+            backend=backend,
+            cu_seqlens=cu_seqlens,
+        )
+        attn_output = attn_output_bnsd.transpose(1, 2).contiguous()
+    else:
+        # Resolve the token that will be passed to Transformers' lazy_import_flash_attention.
+        #
+        # FA2 and FA3 have dedicated branches in transformers' _lazy_imports, so we
+        # use the plain transformers names and they are resolved without hitting the
+        # hub-kernel path.
+        #
+        # FA4 has no such branch; unrecognised names fall through to the hub-kernel
+        # loader. By keeping the VeOmni name here, our monkey-patch of
+        # ``load_and_register_attn_kernel`` intercepts it and loads
+        # ``flash_attn.cute`` locally.
+        if module.config._attn_implementation == "veomni_flash_attention_2_with_sp":
+            fa_kernel_implementation = "flash_attention_2"
+        elif module.config._attn_implementation == "veomni_flash_attention_3_with_sp":
+            fa_kernel_implementation = "flash_attention_3"
+        elif module.config._attn_implementation == "veomni_flash_attention_4_with_sp":
+            fa_kernel_implementation = "veomni_flash_attention_4_with_sp"  # intercepted by VeOmni hub-kernel patch
+        else:
+            raise ValueError(
+                f"unknown attn_implementation for veomni flash_attention with SP support: {module.config._attn_implementation}"
+            )
+
+        attn_output = _flash_attention_forward(
+            query,
+            key,
+            value,
+            attention_mask,
+            query_length=seq_len,
+            is_causal=is_causal,
+            dropout=dropout,
+            softmax_scale=scaling,
+            sliding_window=sliding_window,
+            softcap=softcap,
+            use_top_left_mask=False,
+            target_dtype=target_dtype,
+            attn_implementation=fa_kernel_implementation,
+            layer_idx=module.layer_idx if hasattr(module, "layer_idx") else None,
+            **kwargs,
+        )
+
+    # Hybrid inverse reorder before Ulysses scatter (rank-major packed shards).
+    if (
+        ulysses_enabled
+        and cp_enabled
+        and not skip_ulysses
+        and _hybrid_ulysses_local_cu is not None
+    ):
+        from ....distributed.context_parallel.packed_sharding import (
+            reorder_sample_major_to_ulysses_rank_major,
+        )
+
+        seq_dim = 1 if attn_output.ndim == 4 else 0
+        attn_output = reorder_sample_major_to_ulysses_rank_major(
+            attn_output,
+            _hybrid_ulysses_local_cu,
+            ulysses_size=get_parallel_state().ulysses_size,
+            seq_dim=seq_dim,
+        )
 
     # Ulysses patch
     if ulysses_enabled and not skip_ulysses:


### PR DESCRIPTION
### What does this PR do?

Adds MindSpeed-style **Ring context parallel** and **Hybrid Ulysses×Ring CP** for packed causal attention in VeOmni.

- New `veomni.distributed.context_parallel` package: zigzag sharding, Ring P2P, causal schedule, softmax merge, packed CP partition helpers, and GDN SP zigzag restore.
- `ParallelState` enables `cp_size>1` (pure Ring or Hybrid with `ulysses_size`), keeping a unified SP mesh for flatten/`sp_group` (including Ascend DeviceMesh).
- Flash-attention path runs Ring after optional Ulysses gather; Hybrid reorders rank-major packed shards to sample-major CP-local layout and scales `cu_seqlens`.
- Data collator partitions packed sequences for CP (LM local cu vs GDN global cu).
- Qwen3.5 MoE GatedDeltaNet (GPU + NPU patches) uses unified SP + zigzag restore when CP is enabled.

Validated on 16×Ascend 910B2 Qwen3.6-35B-A3B SFT @ 128k: CP shows modest comm overlap gains vs pure Ulysses; Hybrid U2×CP4 slightly faster than pure CP8 in that setting. 128k / 16-card is not the best CP battlefield; this lands the complete implementation for broader geometries and follow-on EP overlap work.

### Checklist Before Starting

- Search for relative PRs/issues and link here: n/a (new capability; replaces prior `NotImplementedError` for Ring CP)
- PR title follows `[{modules}] {type}: {description}` format

### Test

- Unit: `tests/parallel/context_parallel/` (topology, packed sharding, primitives; wired into GPU unit-test workflow)
- End-to-end (internal 16×910B2, retained SMA job):
  - Pure Ring U1×CP8×EP8: healthy training; ~286 s/step vs Ulysses SP8 ~268.5 (~+7%)
  - Prefetch true/false A/B: ~1% delta (negligible)
  - Hybrid U2×CP4×EP8: DONE `rc=0`; steady ~272.9 s/step (~4.5% better than CP8 prefetch)
  - Profile: Ring send/recv active; EP `alltoallv` still dominant at this scale

### API and Usage Example

```python
init_parallel_state(
    ...,
    cp_size=4,          # Ring CP
    ulysses_size=2,     # Hybrid: CP-outer × Ulysses-inner
    extra_parallel_sizes=[8],  # e.g. EP
    ...
)
```

Packed collator automatically applies zigzag CP partitions when `cp_size>1`. Attention dispatch selects Ring after Ulysses gather when both are enabled.

### Design & Code Changes

1. **Topology**: SP rank = `cp_rank * ulysses_size + ulysses_rank` (CP outer).
2. **Ring attention**: KV rotate via P2P; causal half-schedule; online softmax merge; NPU fusion attention backend when available.
3. **Hybrid correctness**: after Ulysses gather, reorder packed shards + scale cu before Ring; inverse before Ulysses scatter; ViT global-cu guard.
4. **GDN**: CP uses unified SP group + zigzag restore/reapply around linear-attn A2A (not Ring).

### Checklist Before Submitting

- Read the Contribute Guide
- Applied pre-commit checks (py_compile + diff --check locally)
- Added/updated documentation (`docs/usage/basic_modules.md` cp_size note)
- Added tests to CI workflow
