### PR TITLE
[optim, ci] feat: optimize Muon FSDP2 all-to-all

### DIFF
--- a/tests/optim/test_muon_fsdp2_parity.py
+++ b/tests/optim/test_muon_fsdp2_parity.py
@@ -79,14 +79,14 @@ def _make_grads(
             ep_factor = full.shape[0] // p.shape[0]
             local_full = _ep_local_slice(full, ep_factor, ep_rank) if ep_factor > 1 else full
             full_dt = DTensor.from_local(
-                local_full.to(device),
+                local_full.to(device=device, dtype=p.dtype),
                 device_mesh=p.device_mesh,
                 placements=[Replicate()] * p.device_mesh.ndim,
                 run_check=False,
             )
             p.grad = full_dt.redistribute(device_mesh=p.device_mesh, placements=p.placements)
         else:
-            p.grad = full.to(device)
+            p.grad = full.to(device=device, dtype=p.dtype)
 
 
 def _full_state_dict(model: nn.Module, ep_group=None) -> dict:
@@ -146,15 +146,23 @@ class _ToyDenseModel(nn.Module):
         return self.block1(self.block0(x)).sum()
 
 
-def _build_dense_model(device: torch.device, hidden: int = 32, intermediate: int = 64) -> nn.Module:
+def _build_dense_model(
+    device: torch.device,
+    hidden: int = 32,
+    intermediate: int = 64,
+    mixed_dtype: bool = False,
+) -> nn.Module:
     torch.manual_seed(SEED)
-    return _ToyDenseModel(hidden=hidden, intermediate=intermediate).to(device)
+    model = _ToyDenseModel(hidden=hidden, intermediate=intermediate).to(device)
+    if mixed_dtype:
+        model.block1.to(torch.bfloat16)
+    return model
 
 
-def _dense_golden_state(full_shapes: dict, hidden: int, intermediate: int) -> dict:
+def _dense_golden_state(full_shapes: dict, hidden: int, intermediate: int, mixed_dtype: bool) -> dict:
     """Single-process reference for the dense FSDP2 path."""
     device = torch.device("cpu")
-    model = _build_dense_model(device, hidden=hidden, intermediate=intermediate)
+    model = _build_dense_model(device, hidden=hidden, intermediate=intermediate, mixed_dtype=mixed_dtype)
     opt = DistributedMuon(
         list(model.parameters()),
         lr=5e-3,
@@ -170,7 +178,7 @@ def _dense_golden_state(full_shapes: dict, hidden: int, intermediate: int) -> di
     return _full_state_dict(model)
 
 
-def _run_dense(hidden: int = 32, intermediate: int = 64) -> None:
+def _run_dense(hidden: int = 32, intermediate: int = 64, mixed_dtype: bool = False) -> None:
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
     device_type = get_device_type()
     get_torch_device().set_device(f"{device_type}:{local_rank}")
@@ -179,7 +187,7 @@ def _run_dense(hidden: int = 32, intermediate: int = 64) -> None:
     world_size = dist.get_world_size()
     device = torch.device(f"{device_type}:{local_rank}")
 
-    model = _build_dense_model(device, hidden=hidden, intermediate=intermediate)
+    model = _build_dense_model(device, hidden=hidden, intermediate=intermediate, mixed_dtype=mixed_dtype)
     full_shapes = {fqn: tuple(p.shape) for fqn, p in model.named_parameters() if p.requires_grad}
     fully_shard(model.block0)
     fully_shard(model.block1)
@@ -202,14 +210,20 @@ def _run_dense(hidden: int = 32, intermediate: int = 64) -> None:
 
     fsdp_state = _full_state_dict(model)
     if rank == 0:
-        golden = _dense_golden_state(full_shapes, hidden=hidden, intermediate=intermediate)
+        golden = _dense_golden_state(
+            full_shapes,
+            hidden=hidden,
+            intermediate=intermediate,
+            mixed_dtype=mixed_dtype,
+        )
         assert set(fsdp_state.keys()) == set(golden.keys())
         for k, v in golden.items():
+            tol = 1e-2 if v.dtype == torch.bfloat16 else 1e-4
             torch.testing.assert_close(
                 fsdp_state[k],
                 v,
-                atol=1e-4,
-                rtol=1e-4,
+                atol=tol,
+                rtol=tol,
                 msg=f"FSDP2 Muon update for {k!r} diverges from single-device Muon (world_size={world_size}).",
             )
         print(f"[rank0] dense FSDP2 / single-device parity OK across {len(golden)} param(s)")
@@ -438,7 +452,7 @@ def _torchrun_cmd(nproc: int, port: int, mode: str, use_zero_comm: bool) -> list
 
 @pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
 def test_dense_4gpu():
-    cmd = _torchrun_cmd(nproc=4, port=29611, mode="dense", use_zero_comm=False)
+    cmd = _torchrun_cmd(nproc=4, port=find_free_port(), mode="dense", use_zero_comm=False)
     env = os.environ.copy()
     env.setdefault("NCCL_DEBUG", "WARN")
     result = subprocess.run(cmd, env=env, check=True)
@@ -455,9 +469,18 @@ def test_dense_empty_shards_4gpu():
 
 
 @pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
+def test_dense_mixed_dtype_4gpu():
+    cmd = _torchrun_cmd(nproc=4, port=find_free_port(), mode="dense_mixed_dtype", use_zero_comm=False)
+    env = os.environ.copy()
+    env.setdefault("NCCL_DEBUG", "WARN")
+    result = subprocess.run(cmd, env=env, check=True)
+    assert result.returncode == 0
+
+
+@pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
 def test_qwen3_moe_default_backend_4gpu():
     """Default backend: ``Shard(1)`` on experts + ep_fsdp all-gather in Muon."""
-    cmd = _torchrun_cmd(nproc=4, port=29612, mode="moe", use_zero_comm=False)
+    cmd = _torchrun_cmd(nproc=4, port=find_free_port(), mode="moe", use_zero_comm=False)
     env = os.environ.copy()
     env.setdefault("NCCL_DEBUG", "WARN")
     result = subprocess.run(cmd, env=env, check=True)
@@ -467,7 +490,7 @@ def test_qwen3_moe_default_backend_4gpu():
 @pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
 def test_qwen3_moe_zero_comm_backend_4gpu():
     """Zero-comm backend: ``Shard(0)`` on experts + local batched NS."""
-    cmd = _torchrun_cmd(nproc=4, port=29613, mode="moe", use_zero_comm=True)
+    cmd = _torchrun_cmd(nproc=4, port=find_free_port(), mode="moe", use_zero_comm=True)
     env = os.environ.copy()
     env.setdefault("NCCL_DEBUG", "WARN")
     result = subprocess.run(cmd, env=env, check=True)
@@ -478,12 +501,14 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", choices=["dense", "dense_empty", "moe"], required=True)
+    parser.add_argument("--mode", choices=["dense", "dense_empty", "dense_mixed_dtype", "moe"], required=True)
     parser.add_argument("--zero-comm", type=int, default=0)
     args = parser.parse_args()
     if args.mode == "dense":
         _run_dense()
     elif args.mode == "dense_empty":
         _run_dense(hidden=2, intermediate=3)
+    elif args.mode == "dense_mixed_dtype":
+        _run_dense(mixed_dtype=True)
     else:
         _run_qwen3_moe(use_zero_comm=bool(args.zero_comm))

--- a/tests/optim/test_muon_fsdp2_parity.py
+++ b/tests/optim/test_muon_fsdp2_parity.py
@@ -28,6 +28,7 @@ import torch.nn as nn
 from torch.distributed.fsdp import fully_shard
 from torch.distributed.tensor import DTensor, Replicate, Shard
 
+from tests.tools.launch_utils import find_free_port
 from veomni.distributed.parallel_state import init_parallel_state
 from veomni.optim.muon import DistributedMuon
 from veomni.utils.device import (
@@ -145,15 +146,15 @@ class _ToyDenseModel(nn.Module):
         return self.block1(self.block0(x)).sum()
 
 
-def _build_dense_model(device: torch.device) -> nn.Module:
+def _build_dense_model(device: torch.device, hidden: int = 32, intermediate: int = 64) -> nn.Module:
     torch.manual_seed(SEED)
-    return _ToyDenseModel().to(device)
+    return _ToyDenseModel(hidden=hidden, intermediate=intermediate).to(device)
 
 
-def _dense_golden_state(full_shapes: dict) -> dict:
+def _dense_golden_state(full_shapes: dict, hidden: int, intermediate: int) -> dict:
     """Single-process reference for the dense FSDP2 path."""
     device = torch.device("cpu")
-    model = _build_dense_model(device)
+    model = _build_dense_model(device, hidden=hidden, intermediate=intermediate)
     opt = DistributedMuon(
         list(model.parameters()),
         lr=5e-3,
@@ -169,7 +170,7 @@ def _dense_golden_state(full_shapes: dict) -> dict:
     return _full_state_dict(model)
 
 
-def _run_dense() -> None:
+def _run_dense(hidden: int = 32, intermediate: int = 64) -> None:
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
     device_type = get_device_type()
     get_torch_device().set_device(f"{device_type}:{local_rank}")
@@ -178,7 +179,7 @@ def _run_dense() -> None:
     world_size = dist.get_world_size()
     device = torch.device(f"{device_type}:{local_rank}")
 
-    model = _build_dense_model(device)
+    model = _build_dense_model(device, hidden=hidden, intermediate=intermediate)
     full_shapes = {fqn: tuple(p.shape) for fqn, p in model.named_parameters() if p.requires_grad}
     fully_shard(model.block0)
     fully_shard(model.block1)
@@ -201,7 +202,7 @@ def _run_dense() -> None:
 
     fsdp_state = _full_state_dict(model)
     if rank == 0:
-        golden = _dense_golden_state(full_shapes)
+        golden = _dense_golden_state(full_shapes, hidden=hidden, intermediate=intermediate)
         assert set(fsdp_state.keys()) == set(golden.keys())
         for k, v in golden.items():
             torch.testing.assert_close(
@@ -445,6 +446,15 @@ def test_dense_4gpu():
 
 
 @pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
+def test_dense_empty_shards_4gpu():
+    cmd = _torchrun_cmd(nproc=4, port=find_free_port(), mode="dense_empty", use_zero_comm=False)
+    env = os.environ.copy()
+    env.setdefault("NCCL_DEBUG", "WARN")
+    result = subprocess.run(cmd, env=env, check=True)
+    assert result.returncode == 0
+
+
+@pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
 def test_qwen3_moe_default_backend_4gpu():
     """Default backend: ``Shard(1)`` on experts + ep_fsdp all-gather in Muon."""
     cmd = _torchrun_cmd(nproc=4, port=29612, mode="moe", use_zero_comm=False)
@@ -468,10 +478,12 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", choices=["dense", "moe"], required=True)
+    parser.add_argument("--mode", choices=["dense", "dense_empty", "moe"], required=True)
     parser.add_argument("--zero-comm", type=int, default=0)
     args = parser.parse_args()
     if args.mode == "dense":
         _run_dense()
+    elif args.mode == "dense_empty":
+        _run_dense(hidden=2, intermediate=3)
     else:
         _run_qwen3_moe(use_zero_comm=bool(args.zero_comm))

--- a/tests/optim/test_muon_fsdp2_parity.py
+++ b/tests/optim/test_muon_fsdp2_parity.py
@@ -133,7 +133,7 @@ class _ToyDenseBlock(nn.Module):
 
 
 class _ToyDenseModel(nn.Module):
-    """Two stacked Linear blocks; every weight is 2D and Muon-eligible."""
+    """Three stacked Linear blocks; every weight is 2D and Muon-eligible."""
 
     _no_split_modules = ["_ToyDenseBlock"]
 
@@ -141,9 +141,10 @@ class _ToyDenseModel(nn.Module):
         super().__init__()
         self.block0 = _ToyDenseBlock(hidden, intermediate)
         self.block1 = _ToyDenseBlock(hidden, intermediate)
+        self.block2 = _ToyDenseBlock(hidden, intermediate)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.block1(self.block0(x)).sum()
+        return self.block2(self.block1(self.block0(x))).sum()
 
 
 def _build_dense_model(
@@ -191,6 +192,7 @@ def _run_dense(hidden: int = 32, intermediate: int = 64, mixed_dtype: bool = Fal
     full_shapes = {fqn: tuple(p.shape) for fqn, p in model.named_parameters() if p.requires_grad}
     fully_shard(model.block0)
     fully_shard(model.block1)
+    fully_shard(model.block2)
     fully_shard(model)
     for name, p in model.named_parameters():
         assert isinstance(p, DTensor), f"expected DTensor for {name}, got {type(p)}"
@@ -203,10 +205,21 @@ def _run_dense(hidden: int = 32, intermediate: int = 64, mixed_dtype: bool = Fal
         nesterov=True,
         adjust_lr_fn="match_rms_adamw",
     )
+    a2a_chunk_sizes = []
+    original_ortho_fsdp_group_all2all = opt._ortho_fsdp_group_all2all
+
+    def checked_ortho_fsdp_group_all2all(updates, mesh, ns_kwargs):
+        a2a_chunk_sizes.append(len(updates))
+        assert len(updates) <= world_size
+        return original_ortho_fsdp_group_all2all(updates, mesh, ns_kwargs)
+
+    opt._ortho_fsdp_group_all2all = checked_ortho_fsdp_group_all2all
     for step in range(2):
         _make_grads(model, full_shapes, step, device)
         opt.step()
         opt.zero_grad()
+    assert a2a_chunk_sizes
+    assert sum(a2a_chunk_sizes) == 2 * len(full_shapes)
 
     fsdp_state = _full_state_dict(model)
     if rank == 0:

--- a/tests/optim/test_muon_fsdp2_parity.py
+++ b/tests/optim/test_muon_fsdp2_parity.py
@@ -28,7 +28,6 @@ import torch.nn as nn
 from torch.distributed.fsdp import fully_shard
 from torch.distributed.tensor import DTensor, Replicate, Shard
 
-from tests.tools.launch_utils import find_free_port
 from veomni.distributed.parallel_state import init_parallel_state
 from veomni.optim.muon import DistributedMuon
 from veomni.utils.device import (
@@ -463,9 +462,17 @@ def _torchrun_cmd(nproc: int, port: int, mode: str, use_zero_comm: bool) -> list
     ]
 
 
+def _find_free_port() -> int:
+    # Torchrun executes this file directly, so imports from ``tests`` must stay
+    # on the pytest parent path.
+    from tests.tools.launch_utils import find_free_port
+
+    return find_free_port()
+
+
 @pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
 def test_dense_4gpu():
-    cmd = _torchrun_cmd(nproc=4, port=find_free_port(), mode="dense", use_zero_comm=False)
+    cmd = _torchrun_cmd(nproc=4, port=_find_free_port(), mode="dense", use_zero_comm=False)
     env = os.environ.copy()
     env.setdefault("NCCL_DEBUG", "WARN")
     result = subprocess.run(cmd, env=env, check=True)
@@ -474,7 +481,7 @@ def test_dense_4gpu():
 
 @pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
 def test_dense_empty_shards_4gpu():
-    cmd = _torchrun_cmd(nproc=4, port=find_free_port(), mode="dense_empty", use_zero_comm=False)
+    cmd = _torchrun_cmd(nproc=4, port=_find_free_port(), mode="dense_empty", use_zero_comm=False)
     env = os.environ.copy()
     env.setdefault("NCCL_DEBUG", "WARN")
     result = subprocess.run(cmd, env=env, check=True)
@@ -483,7 +490,7 @@ def test_dense_empty_shards_4gpu():
 
 @pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
 def test_dense_mixed_dtype_4gpu():
-    cmd = _torchrun_cmd(nproc=4, port=find_free_port(), mode="dense_mixed_dtype", use_zero_comm=False)
+    cmd = _torchrun_cmd(nproc=4, port=_find_free_port(), mode="dense_mixed_dtype", use_zero_comm=False)
     env = os.environ.copy()
     env.setdefault("NCCL_DEBUG", "WARN")
     result = subprocess.run(cmd, env=env, check=True)
@@ -493,7 +500,7 @@ def test_dense_mixed_dtype_4gpu():
 @pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
 def test_qwen3_moe_default_backend_4gpu():
     """Default backend: ``Shard(1)`` on experts + ep_fsdp all-gather in Muon."""
-    cmd = _torchrun_cmd(nproc=4, port=find_free_port(), mode="moe", use_zero_comm=False)
+    cmd = _torchrun_cmd(nproc=4, port=_find_free_port(), mode="moe", use_zero_comm=False)
     env = os.environ.copy()
     env.setdefault("NCCL_DEBUG", "WARN")
     result = subprocess.run(cmd, env=env, check=True)
@@ -503,7 +510,7 @@ def test_qwen3_moe_default_backend_4gpu():
 @pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
 def test_qwen3_moe_zero_comm_backend_4gpu():
     """Zero-comm backend: ``Shard(0)`` on experts + local batched NS."""
-    cmd = _torchrun_cmd(nproc=4, port=find_free_port(), mode="moe", use_zero_comm=True)
+    cmd = _torchrun_cmd(nproc=4, port=_find_free_port(), mode="moe", use_zero_comm=True)
     env = os.environ.copy()
     env.setdefault("NCCL_DEBUG", "WARN")
     result = subprocess.run(cmd, env=env, check=True)

--- a/tests/optim/test_muon_unit.py
+++ b/tests/optim/test_muon_unit.py
@@ -16,9 +16,12 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn as nn
+from torch.distributed.tensor import Shard
 
 from veomni.utils.device import IS_CUDA_AVAILABLE, get_device_type, get_gpu_compute_capability
 
@@ -31,6 +34,8 @@ from veomni.optim.muon import (  # noqa: E402
     DEFAULT_NS_COEFFICIENTS,
     DEFAULT_NS_STEPS,
     DistributedMuon,
+    _fsdp_all2all_fast_path_eligible,
+    _shard_row_sizes,
     batched_gram_newton_schulz,
     batched_newton_schulz,
     run_newton_schulz,
@@ -111,6 +116,19 @@ class TestParamShapeEligibility:
         else:
             with pytest.raises(ValueError, match="2D and 3D"):
                 DistributedMuon([p], lr=1e-3)
+
+
+class TestFsdpAllToAllEligibility:
+    def test_empty_rank_shards_remain_all_to_all_eligible(self):
+        world_size = 32
+        param = SimpleNamespace(
+            device_mesh=SimpleNamespace(ndim=1, size=lambda dim: world_size),
+            placements=(Shard(0),),
+            shape=(24, 16384),
+        )
+
+        assert _shard_row_sizes(param.shape[0], world_size) == [1] * 24 + [0] * 8
+        assert _fsdp_all2all_fast_path_eligible(param)
 
 
 class TestNumerics:

--- a/tests/optim/test_muon_unit.py
+++ b/tests/optim/test_muon_unit.py
@@ -23,6 +23,7 @@ import torch
 import torch.nn as nn
 from torch.distributed.tensor import Shard
 
+from veomni.optim import muon as muon_impl
 from veomni.utils.device import IS_CUDA_AVAILABLE, get_device_type, get_gpu_compute_capability
 
 
@@ -129,6 +130,14 @@ class TestFsdpAllToAllEligibility:
 
         assert _shard_row_sizes(param.shape[0], world_size) == [1] * 24 + [0] * 8
         assert _fsdp_all2all_fast_path_eligible(param)
+
+    def test_bucket_key_separates_local_dtypes(self):
+        mesh = object()
+        fp32 = SimpleNamespace(device_mesh=mesh, to_local=lambda: torch.empty(1, dtype=torch.float32))
+        bf16 = SimpleNamespace(device_mesh=mesh, to_local=lambda: torch.empty(1, dtype=torch.bfloat16))
+        bucket_key = getattr(muon_impl, "_fsdp_all2all_bucket_key", lambda update: update.device_mesh)
+
+        assert bucket_key(fp32) != bucket_key(bf16)
 
 
 class TestNumerics:

--- a/tests/optim/test_muon_unit.py
+++ b/tests/optim/test_muon_unit.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import weakref
 from types import SimpleNamespace
 
 import pytest
@@ -138,6 +139,40 @@ class TestFsdpAllToAllEligibility:
         bucket_key = getattr(muon_impl, "_fsdp_all2all_bucket_key", lambda update: update.device_mesh)
 
         assert bucket_key(fp32) != bucket_key(bf16)
+
+
+class TestIntermediateLifetime:
+    def test_non_all_to_all_orthos_are_released_per_parameter(self):
+        params = [nn.Parameter(torch.randn(4, 4)) for _ in range(8)]
+        opt = DistributedMuon(params, lr=1e-3, nesterov=False)
+        live = 0
+        peak = 0
+        calls = 0
+
+        def fake_compute_ortho(update, kind, **kwargs):
+            nonlocal calls, live, peak
+
+            ortho = torch.zeros_like(update)
+            calls += 1
+            live += 1
+            peak = max(peak, live)
+
+            def release():
+                nonlocal live
+                live -= 1
+
+            weakref.finalize(ortho, release)
+            return ortho
+
+        opt._compute_ortho = fake_compute_ortho
+        for p in params:
+            p.grad = torch.randn_like(p)
+
+        opt.step()
+
+        assert calls == len(params)
+        assert peak <= 2
+        assert live == 0
 
 
 class TestNumerics:

--- a/veomni/optim/muon.py
+++ b/veomni/optim/muon.py
@@ -23,6 +23,7 @@ params are gathered only when the NS iteration needs the full trailing
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from torch import Tensor
 from torch.distributed.tensor import DTensor, Replicate, Shard
@@ -487,6 +488,45 @@ def _wrap_full_as_dtensor_like(full: Tensor, ref: Tensor) -> Tensor:
     return replicated.redistribute(device_mesh=mesh, placements=ref.placements)
 
 
+def _fsdp_all2all_fast_path_eligible(p: DTensor) -> bool:
+    """True when ``p`` is an evenly-sharded 2D ``Shard(0)`` DTensor on a 1D mesh.
+
+    This is the dominant FSDP2 case. The owner-based all-to-all path assumes a
+    single shard dim (dim 0), a one-dimensional device mesh, and shard sizes
+    that ``torch.tensor_split`` can reconstruct exactly. Anything else (HSDP
+    multi-dim meshes, ``Shard(d>0)``, ragged shards) falls back to the generic
+    ``full_tensor()`` path, which stays byte-for-byte with the previous
+    behavior.
+    """
+    if p.device_mesh.ndim != 1:
+        return False
+    placements = p.placements
+    if len(placements) != 1 or not isinstance(placements[0], Shard):
+        return False
+    if placements[0].dim != 0:
+        return False
+    world = p.device_mesh.size(0)
+    if world <= 1:
+        return False
+    full_rows = int(p.shape[0])
+    # Only the last shard may be smaller; every earlier shard must be full.
+    # DTensor pads with size ``ceil(full_rows / world)`` per rank.
+    shard_rows = -(-full_rows // world)
+    return shard_rows * (world - 1) < full_rows
+
+
+def _shard_row_sizes(full_rows: int, world: int) -> List[int]:
+    """Per-rank row counts matching DTensor's ``Shard(0)`` even split."""
+    shard_rows = -(-full_rows // world)
+    sizes = []
+    remaining = full_rows
+    for _ in range(world):
+        take = min(shard_rows, max(remaining, 0))
+        sizes.append(take)
+        remaining -= take
+    return sizes
+
+
 class DistributedMuon(Optimizer):
     """Muon optimizer that handles dense and 3D-MoE FSDP2-sharded DTensors.
 
@@ -568,7 +608,21 @@ class DistributedMuon(Optimizer):
             adjust_lr_fn = group["adjust_lr_fn"]
             ns_implementation = str(group.get("ns_implementation", "gram_quack"))
             gram_ns_reset_iterations = tuple(group.get("gram_ns_reset_iterations", (2,)))
+            ns_kwargs = {
+                "ns_coefficients": ns_coefficients,
+                "ns_steps": ns_steps,
+                "eps": eps,
+                "ns_implementation": ns_implementation,
+                "gram_ns_reset_iterations": gram_ns_reset_iterations,
+            }
 
+            # Phase 1: local momentum update. Collect the orthogonalized update
+            # ``ortho`` per param. Evenly-sharded 2D ``Shard(0)`` params are
+            # deferred into per-mesh buckets so their Newton-Schulz runs once on
+            # a single owner rank (via all-to-all) instead of redundantly on
+            # every rank behind an all-gather + redistribute round-trip.
+            pending: List[Dict[str, Any]] = []
+            a2a_buckets: Dict[Any, List[int]] = {}
             for p in group["params"]:
                 if p.grad is None:
                     continue
@@ -587,15 +641,30 @@ class DistributedMuon(Optimizer):
                 update = grad.lerp(buf, momentum) if nesterov else buf
 
                 kind = _classify_param(p)
-                ortho = self._compute_ortho(
-                    update,
-                    kind,
-                    ns_coefficients,
-                    ns_steps,
-                    eps,
-                    ns_implementation=ns_implementation,
-                    gram_ns_reset_iterations=gram_ns_reset_iterations,
-                )
+                entry: Dict[str, Any] = {"p": p, "update": update, "kind": kind, "ortho": None}
+
+                if (
+                    kind == _KIND_FSDP_GATHER_2D
+                    and isinstance(update, DTensor)
+                    and _fsdp_all2all_fast_path_eligible(update)
+                ):
+                    a2a_buckets.setdefault(update.device_mesh, []).append(len(pending))
+                else:
+                    entry["ortho"] = self._compute_ortho(update, kind, **ns_kwargs)
+                pending.append(entry)
+
+            # Phase 2: owner-based all-to-all Newton-Schulz for bucketed params.
+            for mesh, idxs in a2a_buckets.items():
+                updates = [pending[i]["update"] for i in idxs]
+                local_orthos = self._ortho_fsdp_group_all2all(updates, mesh, ns_kwargs)
+                for i, local_ortho in zip(idxs, local_orthos):
+                    pending[i]["ortho"] = local_ortho
+                    pending[i]["ortho_is_local_shard"] = True
+
+            # Phase 3: apply the parameter update.
+            for entry in pending:
+                p = entry["p"]
+                ortho = entry["ortho"]
 
                 lr_shape = p.shape[-2:] if p.ndim >= 2 else p.shape
                 adjusted_lr = _adjust_lr(lr, adjust_lr_fn, lr_shape)
@@ -605,7 +674,14 @@ class DistributedMuon(Optimizer):
 
                 if isinstance(p, DTensor):
                     target_dtype = p.to_local().dtype
-                    if isinstance(ortho, DTensor):
+                    if entry.get("ortho_is_local_shard"):
+                        update_dt = DTensor.from_local(
+                            ortho.to(dtype=target_dtype),
+                            device_mesh=p.device_mesh,
+                            placements=p.placements,
+                            run_check=False,
+                        )
+                    elif isinstance(ortho, DTensor):
                         update_dt = ortho.to(dtype=target_dtype)
                     else:
                         update_dt = _wrap_full_as_dtensor_like(ortho.to(dtype=target_dtype), p)
@@ -615,6 +691,102 @@ class DistributedMuon(Optimizer):
                 p.add_(update_dt, alpha=-adjusted_lr)
 
         return loss
+
+    def _ortho_fsdp_group_all2all(
+        self,
+        updates: List["DTensor"],
+        mesh: Any,
+        ns_kwargs: Dict[str, Any],
+    ) -> List[Tensor]:
+        """Orthogonalize evenly-sharded 2D ``Shard(0)`` updates via all-to-all.
+
+        Instead of all-gathering every parameter to every rank and running
+        Newton-Schulz redundantly on all of them, params are processed in
+        chunks of ``world`` and each rank becomes the sole *owner* of one param
+        in the chunk. A single balanced ``all_to_all`` reassembles the owner's
+        full ``[M, K]`` matrix (each rank contributes its row shard); the owner
+        runs NS once; a reverse ``all_to_all`` scatters the row shards back.
+        This keeps the same math while cutting redundant compute by ``world``
+        and removing the redistribute round-trip.
+
+        Invariant: every rank must call this with the same ``updates`` list
+        length and ordering (guaranteed by the shared ``param_groups`` order and
+        the requirement that each Muon param has a gradient on all ranks). The
+        all-to-all pairing is position-based, so a rank-divergent bucket would
+        deadlock — the same constraint the previous all-gather path relied on.
+
+        Buffers are allocated per parameter (own ``dtype``/``K``), so a bucket
+        may safely mix dtypes and trailing shapes.
+
+        Returns one local-shard (``[m_local, K]``) tensor per input update, in
+        input order.
+        """
+        world = mesh.size(0)
+        my_idx = int(mesh.get_coordinate()[0])
+        group = mesh.get_group(0)
+        device = updates[0].to_local().device
+        pad_dtype = updates[0].to_local().dtype  # stable across ranks for empty padding slots
+
+        results: List[Optional[Tensor]] = [None] * len(updates)
+
+        for base in range(0, len(updates), world):
+            owned_pos = base + my_idx  # global index of the param this rank owns
+            owned_update = updates[owned_pos] if owned_pos < len(updates) else None
+
+            # Forward all_to_all: rank ``r`` sends its row shard of param
+            # ``base + j`` to owner rank ``j``; owner ``j`` gathers all ``world``
+            # row shards of its owned param ``base + j``.
+            send_list: List[Tensor] = []
+            recv_list: List[Tensor] = []
+            if owned_update is not None:
+                owned_k = int(owned_update.shape[1])
+                owned_dtype = owned_update.to_local().dtype
+                owned_rows = _shard_row_sizes(int(owned_update.shape[0]), world)
+            else:
+                owned_k = 0
+                owned_dtype = pad_dtype
+                owned_rows = [0] * world
+
+            for j in range(world):
+                pos = base + j
+                if pos < len(updates):
+                    send_list.append(updates[pos].to_local().contiguous())
+                else:
+                    send_list.append(torch.empty(0, 0, device=device, dtype=pad_dtype))
+                recv_list.append(torch.empty(owned_rows[j], owned_k, device=device, dtype=owned_dtype))
+
+            dist.all_to_all(recv_list, send_list, group=group)
+
+            if owned_update is not None:
+                full_grad = torch.cat(recv_list, dim=0)
+                full_ortho = self._compute_ortho(full_grad, _KIND_LOCAL, **ns_kwargs)
+                scatter_send = [c.contiguous() for c in torch.split(full_ortho, owned_rows, dim=0)]
+            else:
+                scatter_send = [torch.empty(0, 0, device=device, dtype=pad_dtype) for _ in range(world)]
+
+            # Reverse all_to_all: owner ``j`` returns each rank ``i`` its row
+            # shard of param ``base + j``.
+            back_recv: List[Tensor] = []
+            for j in range(world):
+                pos = base + j
+                if pos < len(updates):
+                    param = updates[pos]
+                    rows = _shard_row_sizes(int(param.shape[0]), world)[my_idx]
+                    back_recv.append(
+                        torch.empty(rows, int(param.shape[1]), device=device, dtype=param.to_local().dtype)
+                    )
+                else:
+                    back_recv.append(torch.empty(0, 0, device=device, dtype=pad_dtype))
+
+            dist.all_to_all(back_recv, scatter_send, group=group)
+
+            for j in range(world):
+                pos = base + j
+                if pos < len(updates):
+                    results[pos] = back_recv[j]
+
+        assert all(r is not None for r in results)
+        return results  # type: ignore[return-value]
 
     @staticmethod
     def _compute_ortho(

--- a/veomni/optim/muon.py
+++ b/veomni/optim/muon.py
@@ -489,14 +489,12 @@ def _wrap_full_as_dtensor_like(full: Tensor, ref: Tensor) -> Tensor:
 
 
 def _fsdp_all2all_fast_path_eligible(p: DTensor) -> bool:
-    """True when ``p`` is an evenly-sharded 2D ``Shard(0)`` DTensor on a 1D mesh.
+    """True when ``p`` is a 2D ``Shard(0)`` DTensor on a 1D mesh.
 
-    This is the dominant FSDP2 case. The owner-based all-to-all path assumes a
-    single shard dim (dim 0), a one-dimensional device mesh, and shard sizes
-    that ``torch.tensor_split`` can reconstruct exactly. Anything else (HSDP
-    multi-dim meshes, ``Shard(d>0)``, ragged shards) falls back to the generic
-    ``full_tensor()`` path, which stays byte-for-byte with the previous
-    behavior.
+    The owner-based all-to-all path supports empty tail-rank shards when the
+    first dimension is smaller than the mesh. Anything else (HSDP multi-dim
+    meshes, ``Shard(d>0)``, ragged shards) falls back to the generic
+    ``full_tensor()`` path.
     """
     if p.device_mesh.ndim != 1:
         return False
@@ -508,11 +506,7 @@ def _fsdp_all2all_fast_path_eligible(p: DTensor) -> bool:
     world = p.device_mesh.size(0)
     if world <= 1:
         return False
-    full_rows = int(p.shape[0])
-    # Only the last shard may be smaller; every earlier shard must be full.
-    # DTensor pads with size ``ceil(full_rows / world)`` per rank.
-    shard_rows = -(-full_rows // world)
-    return shard_rows * (world - 1) < full_rows
+    return True
 
 
 def _shard_row_sizes(full_rows: int, world: int) -> List[int]:
@@ -679,6 +673,8 @@ class DistributedMuon(Optimizer):
                             ortho.to(dtype=target_dtype),
                             device_mesh=p.device_mesh,
                             placements=p.placements,
+                            shape=p.shape,
+                            stride=p.stride(),
                             run_check=False,
                         )
                     elif isinstance(ortho, DTensor):

--- a/veomni/optim/muon.py
+++ b/veomni/optim/muon.py
@@ -509,6 +509,11 @@ def _fsdp_all2all_fast_path_eligible(p: DTensor) -> bool:
     return True
 
 
+def _fsdp_all2all_bucket_key(update: DTensor) -> Tuple[Any, torch.dtype]:
+    """Group all-to-all updates by mesh and local communication dtype."""
+    return update.device_mesh, update.to_local().dtype
+
+
 def _shard_row_sizes(full_rows: int, world: int) -> List[int]:
     """Per-rank row counts matching DTensor's ``Shard(0)`` even split."""
     shard_rows = -(-full_rows // world)
@@ -616,7 +621,7 @@ class DistributedMuon(Optimizer):
             # a single owner rank (via all-to-all) instead of redundantly on
             # every rank behind an all-gather + redistribute round-trip.
             pending: List[Dict[str, Any]] = []
-            a2a_buckets: Dict[Any, List[int]] = {}
+            a2a_buckets: Dict[Tuple[Any, torch.dtype], List[int]] = {}
             for p in group["params"]:
                 if p.grad is None:
                     continue
@@ -642,13 +647,13 @@ class DistributedMuon(Optimizer):
                     and isinstance(update, DTensor)
                     and _fsdp_all2all_fast_path_eligible(update)
                 ):
-                    a2a_buckets.setdefault(update.device_mesh, []).append(len(pending))
+                    a2a_buckets.setdefault(_fsdp_all2all_bucket_key(update), []).append(len(pending))
                 else:
                     entry["ortho"] = self._compute_ortho(update, kind, **ns_kwargs)
                 pending.append(entry)
 
             # Phase 2: owner-based all-to-all Newton-Schulz for bucketed params.
-            for mesh, idxs in a2a_buckets.items():
+            for (mesh, _local_dtype), idxs in a2a_buckets.items():
                 updates = [pending[i]["update"] for i in idxs]
                 local_orthos = self._ortho_fsdp_group_all2all(updates, mesh, ns_kwargs)
                 for i, local_ortho in zip(idxs, local_orthos):

--- a/veomni/optim/muon.py
+++ b/veomni/optim/muon.py
@@ -615,13 +615,11 @@ class DistributedMuon(Optimizer):
                 "gram_ns_reset_iterations": gram_ns_reset_iterations,
             }
 
-            # Phase 1: local momentum update. Collect the orthogonalized update
-            # ``ortho`` per param. Evenly-sharded 2D ``Shard(0)`` params are
-            # deferred into per-mesh buckets so their Newton-Schulz runs once on
-            # a single owner rank (via all-to-all) instead of redundantly on
-            # every rank behind an all-gather + redistribute round-trip.
-            pending: List[Dict[str, Any]] = []
-            a2a_buckets: Dict[Tuple[Any, torch.dtype], List[int]] = {}
+            # Keep at most one owner-assignment chunk live per mesh/dtype. This
+            # bounds temporary updates and orthogonalized shards by world size
+            # instead of retaining the entire optimizer group.
+            a2a_buckets: Dict[Tuple[Any, torch.dtype], List[Tuple[Tensor, Tensor]]] = {}
+
             for p in group["params"]:
                 if p.grad is None:
                     continue
@@ -640,58 +638,107 @@ class DistributedMuon(Optimizer):
                 update = grad.lerp(buf, momentum) if nesterov else buf
 
                 kind = _classify_param(p)
-                entry: Dict[str, Any] = {"p": p, "update": update, "kind": kind, "ortho": None}
-
                 if (
                     kind == _KIND_FSDP_GATHER_2D
                     and isinstance(update, DTensor)
                     and _fsdp_all2all_fast_path_eligible(update)
                 ):
-                    a2a_buckets.setdefault(_fsdp_all2all_bucket_key(update), []).append(len(pending))
-                else:
-                    entry["ortho"] = self._compute_ortho(update, kind, **ns_kwargs)
-                pending.append(entry)
-
-            # Phase 2: owner-based all-to-all Newton-Schulz for bucketed params.
-            for (mesh, _local_dtype), idxs in a2a_buckets.items():
-                updates = [pending[i]["update"] for i in idxs]
-                local_orthos = self._ortho_fsdp_group_all2all(updates, mesh, ns_kwargs)
-                for i, local_ortho in zip(idxs, local_orthos):
-                    pending[i]["ortho"] = local_ortho
-                    pending[i]["ortho_is_local_shard"] = True
-
-            # Phase 3: apply the parameter update.
-            for entry in pending:
-                p = entry["p"]
-                ortho = entry["ortho"]
-
-                lr_shape = p.shape[-2:] if p.ndim >= 2 else p.shape
-                adjusted_lr = _adjust_lr(lr, adjust_lr_fn, lr_shape)
-
-                if weight_decay != 0.0:
-                    p.mul_(1 - lr * weight_decay)
-
-                if isinstance(p, DTensor):
-                    target_dtype = p.to_local().dtype
-                    if entry.get("ortho_is_local_shard"):
-                        update_dt = DTensor.from_local(
-                            ortho.to(dtype=target_dtype),
-                            device_mesh=p.device_mesh,
-                            placements=p.placements,
-                            shape=p.shape,
-                            stride=p.stride(),
-                            run_check=False,
+                    key = _fsdp_all2all_bucket_key(update)
+                    entries = a2a_buckets.setdefault(key, [])
+                    entries.append((p, update))
+                    if len(entries) == update.device_mesh.size(0):
+                        self._flush_fsdp_all2all_chunk(
+                            entries,
+                            update.device_mesh,
+                            ns_kwargs,
+                            lr=lr,
+                            weight_decay=weight_decay,
+                            adjust_lr_fn=adjust_lr_fn,
                         )
-                    elif isinstance(ortho, DTensor):
-                        update_dt = ortho.to(dtype=target_dtype)
-                    else:
-                        update_dt = _wrap_full_as_dtensor_like(ortho.to(dtype=target_dtype), p)
                 else:
-                    update_dt = ortho.to(dtype=p.dtype)
+                    ortho = self._compute_ortho(update, kind, **ns_kwargs)
+                    self._apply_ortho(
+                        p,
+                        ortho,
+                        is_local_shard=False,
+                        lr=lr,
+                        weight_decay=weight_decay,
+                        adjust_lr_fn=adjust_lr_fn,
+                    )
 
-                p.add_(update_dt, alpha=-adjusted_lr)
+            for (mesh, _local_dtype), entries in a2a_buckets.items():
+                self._flush_fsdp_all2all_chunk(
+                    entries,
+                    mesh,
+                    ns_kwargs,
+                    lr=lr,
+                    weight_decay=weight_decay,
+                    adjust_lr_fn=adjust_lr_fn,
+                )
 
         return loss
+
+    def _flush_fsdp_all2all_chunk(
+        self,
+        entries: List[Tuple[Tensor, Tensor]],
+        mesh: Any,
+        ns_kwargs: Dict[str, Any],
+        *,
+        lr: float,
+        weight_decay: float,
+        adjust_lr_fn: Optional[str],
+    ) -> None:
+        if not entries:
+            return
+
+        updates = [update for _p, update in entries]
+        local_orthos = self._ortho_fsdp_group_all2all(updates, mesh, ns_kwargs)
+        for (p, _update), local_ortho in zip(entries, local_orthos):
+            self._apply_ortho(
+                p,
+                local_ortho,
+                is_local_shard=True,
+                lr=lr,
+                weight_decay=weight_decay,
+                adjust_lr_fn=adjust_lr_fn,
+            )
+        entries.clear()
+
+    @staticmethod
+    def _apply_ortho(
+        p: Tensor,
+        ortho: Tensor,
+        *,
+        is_local_shard: bool,
+        lr: float,
+        weight_decay: float,
+        adjust_lr_fn: Optional[str],
+    ) -> None:
+        lr_shape = p.shape[-2:] if p.ndim >= 2 else p.shape
+        adjusted_lr = _adjust_lr(lr, adjust_lr_fn, lr_shape)
+
+        if weight_decay != 0.0:
+            p.mul_(1 - lr * weight_decay)
+
+        if isinstance(p, DTensor):
+            target_dtype = p.to_local().dtype
+            if is_local_shard:
+                update_dt = DTensor.from_local(
+                    ortho.to(dtype=target_dtype),
+                    device_mesh=p.device_mesh,
+                    placements=p.placements,
+                    shape=p.shape,
+                    stride=p.stride(),
+                    run_check=False,
+                )
+            elif isinstance(ortho, DTensor):
+                update_dt = ortho.to(dtype=target_dtype)
+            else:
+                update_dt = _wrap_full_as_dtensor_like(ortho.to(dtype=target_dtype), p)
+        else:
+            update_dt = ortho.to(dtype=p.dtype)
+
+        p.add_(update_dt, alpha=-adjusted_lr)
 
     def _ortho_fsdp_group_all2all(
         self,
@@ -716,13 +763,16 @@ class DistributedMuon(Optimizer):
         all-to-all pairing is position-based, so a rank-divergent bucket would
         deadlock — the same constraint the previous all-gather path relied on.
 
-        Buffers are allocated per parameter (own ``dtype``/``K``), so a bucket
-        may safely mix dtypes and trailing shapes.
+        The caller must pass at most ``world`` updates with one common dtype.
+        Trailing shapes may differ.
 
         Returns one local-shard (``[m_local, K]``) tensor per input update, in
         input order.
         """
         world = mesh.size(0)
+        if len(updates) > world:
+            raise ValueError(f"Expected at most {world} all-to-all updates, got {len(updates)}")
+
         my_idx = int(mesh.get_coordinate()[0])
         group = mesh.get_group(0)
         device = updates[0].to_local().device


### PR DESCRIPTION
### What does this PR do?

> Replaces redundant per-parameter FSDP2 all-gathers and Newton-Schulz computation with owner-based all-to-all for 2D `Shard(0)` Muon parameters. Builds on #953.
>
> The optimized path supports uneven and empty tail-rank shards and separates communication buckets by local dtype.

### Checklist Before Starting

- Related PR: #953
- PR title follows `[{modules}] {type}: {description}` format.

### Test

> - `make quality`
> - `uv run pytest tests/optim/test_muon_unit.py -q` — 34 passed
> - `uv run pytest tests/optim/test_muon_fsdp2_parity.py -k 'dense_4gpu or dense_empty_shards_4gpu or dense_mixed_dtype_4gpu' -q` — 3 passed
> - The distributed tests require four accelerators and therefore remain hardware-gated.

### API and Usage Example

> N/A. Eligible FSDP2 Muon parameters automatically use the optimized path.

### Design & Code Changes

> - Group eligible 2D `Shard(0)` DTensor updates by device mesh and local dtype.
> - Process parameters in world-size chunks, assigning one full parameter to each owner rank.
> - Gather row shards and scatter orthogonalized updates with paired all-to-all collectives.
> - Preserve global DTensor shape/stride metadata for uneven and empty local shards.
> - Fall back to the existing full-tensor path for unsupported meshes and placements.
> - Add unit and four-GPU parity coverage for standard, empty-shard, and mixed-dtype cases.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Documentation is not required because there is no API or configuration change
- [x] Added tests; four-GPU parity coverage is hardware-gated
