### PR TITLE
[optim] feat: Support head group split on Muon

### DIFF
--- a/configs/text/deepseek_v4.yaml
+++ b/configs/text/deepseek_v4.yaml
@@ -60,6 +60,12 @@ train:
     # std | gram | gram_quack (default; needs gram-newton-schulz + quack on H100/B200/GB200)
     muon_ns_implementation: gram_quack
     muon_adjust_lr_fn: match_rms_adamw
+    # Head-split Muon (GLM-5 "Muon Split"). 0 = one polar factor per projection,
+    # 1 = per-head, g > 1 = g heads per block. The main win here is q_b_proj:
+    # V4-Flash stacks 64 heads x 512 into [32768, q_lora_rank], so full-matrix
+    # orthogonalization caps the update at rank=q_lora_rank and starves
+    # individual heads. Off by default because it changes the update math.
+    # muon_head_group_size: 1
     # MoE + EP: whole-expert Shard(0) when (num_experts/ep_size) % ep_fsdp_size == 0
     muon_expert_zero_comm: true
   init_device: meta

--- a/configs/text/deepseek_v4.yaml
+++ b/configs/text/deepseek_v4.yaml
@@ -60,12 +60,9 @@ train:
     # std | gram | gram_quack (default; needs gram-newton-schulz + quack on H100/B200/GB200)
     muon_ns_implementation: gram_quack
     muon_adjust_lr_fn: match_rms_adamw
-    # Head-split Muon (GLM-5 "Muon Split"). 0 = one polar factor per projection,
-    # 1 = per-head, g > 1 = g heads per block; >= 1 also requires the module list.
-    # The main win here is q_b_proj: V4-Flash stacks 64 heads x 512 into
-    # [32768, q_lora_rank], so full-matrix orthogonalization caps the update at
-    # rank=q_lora_rank and starves individual heads. Off by default because it
-    # changes the update math.
+    # Head-split Muon: heads per Newton-Schulz block (0 = full matrix), plus the
+    # projections to split. q_b_proj benefits most: its [num_heads * qk_head_dim,
+    # q_lora_rank] stack is rank-capped by q_lora_rank as a single matrix.
     # muon_head_group_size: 1
     # muon_head_split_modules: [q_b_proj]
     # MoE + EP: whole-expert Shard(0) when (num_experts/ep_size) % ep_fsdp_size == 0

--- a/configs/text/deepseek_v4.yaml
+++ b/configs/text/deepseek_v4.yaml
@@ -61,11 +61,13 @@ train:
     muon_ns_implementation: gram_quack
     muon_adjust_lr_fn: match_rms_adamw
     # Head-split Muon (GLM-5 "Muon Split"). 0 = one polar factor per projection,
-    # 1 = per-head, g > 1 = g heads per block. The main win here is q_b_proj:
-    # V4-Flash stacks 64 heads x 512 into [32768, q_lora_rank], so full-matrix
-    # orthogonalization caps the update at rank=q_lora_rank and starves
-    # individual heads. Off by default because it changes the update math.
+    # 1 = per-head, g > 1 = g heads per block; >= 1 also requires the module list.
+    # The main win here is q_b_proj: V4-Flash stacks 64 heads x 512 into
+    # [32768, q_lora_rank], so full-matrix orthogonalization caps the update at
+    # rank=q_lora_rank and starves individual heads. Off by default because it
+    # changes the update math.
     # muon_head_group_size: 1
+    # muon_head_split_modules: [q_b_proj]
     # MoE + EP: whole-expert Shard(0) when (num_experts/ep_size) % ep_fsdp_size == 0
     muon_expert_zero_comm: true
   init_device: meta

--- a/configs/text/qwen3_moe_muon.yaml
+++ b/configs/text/qwen3_moe_muon.yaml
@@ -49,10 +49,12 @@ train:
     # std | gram | gram_quack (default; quack CuTeDSL GEMM on H100/B200/GB200)
     muon_ns_implementation: gram_quack
     muon_adjust_lr_fn: match_rms_adamw
-    # Head-split Muon: heads per orthogonalization block (0 = full matrix).
-    # Qwen3's q_proj is only ~2x taller than wide and k/v_proj are wide, so
-    # expect little effect here; see docs/usage/basic_modules.md.
+    # Head-split Muon: heads per orthogonalization block (0 = full matrix), plus
+    # the projections to split (no default). Qwen3's q_proj is only ~2x taller
+    # than wide and k/v_proj are wide, so expect little effect here; see
+    # docs/usage/basic_modules.md.
     # muon_head_group_size: 2
+    # muon_head_split_modules: [q_proj, k_proj, v_proj]
     # Requires (num_experts / ep_size) % ep_fsdp_size == 0; otherwise falls back.
     muon_expert_zero_comm: true
   num_train_epochs: 1

--- a/configs/text/qwen3_moe_muon.yaml
+++ b/configs/text/qwen3_moe_muon.yaml
@@ -49,6 +49,10 @@ train:
     # std | gram | gram_quack (default; quack CuTeDSL GEMM on H100/B200/GB200)
     muon_ns_implementation: gram_quack
     muon_adjust_lr_fn: match_rms_adamw
+    # Head-split Muon: heads per orthogonalization block (0 = full matrix).
+    # Qwen3's q_proj is only ~2x taller than wide and k/v_proj are wide, so
+    # expect little effect here; see docs/usage/basic_modules.md.
+    # muon_head_group_size: 2
     # Requires (num_experts / ep_size) % ep_fsdp_size == 0; otherwise falls back.
     muon_expert_zero_comm: true
   num_train_epochs: 1

--- a/configs/text/qwen3_moe_muon.yaml
+++ b/configs/text/qwen3_moe_muon.yaml
@@ -49,10 +49,9 @@ train:
     # std | gram | gram_quack (default; quack CuTeDSL GEMM on H100/B200/GB200)
     muon_ns_implementation: gram_quack
     muon_adjust_lr_fn: match_rms_adamw
-    # Head-split Muon: heads per orthogonalization block (0 = full matrix), plus
-    # the projections to split (no default). Qwen3's q_proj is only ~2x taller
-    # than wide and k/v_proj are wide, so expect little effect here; see
-    # docs/usage/basic_modules.md.
+    # Head-split Muon: heads per Newton-Schulz block (0 = full matrix), plus the
+    # projections to split. Qwen3's q_proj is only ~2x taller than wide and
+    # k/v_proj are wide, so expect little effect; see docs/usage/basic_modules.md.
     # muon_head_group_size: 2
     # muon_head_split_modules: [q_proj, k_proj, v_proj]
     # Requires (num_experts / ep_size) % ep_fsdp_size == 0; otherwise falls back.

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -312,6 +312,8 @@ NPU validation runs at two times:
 | muon_ns_coefficients | `List[float]` | `[3.4445, -4.7750, 2.0315]` | Quintic Newton–Schulz polynomial coefficients. |
 | muon_eps | `float` | `1e-7` | Numerical-stability epsilon used in spectral-norm normalization. |
 | muon_adjust_lr_fn | `Literal["original", "match_rms_adamw"]` | `"match_rms_adamw"` | Per-matrix learning-rate adjustment strategy. |
+| muon_head_group_size | `int` | `0` | Attention heads per Newton–Schulz block ("Muon Split"). `0` orthogonalizes each projection as one matrix, `1` is per-head, `g>1` groups `g` heads. |
+| muon_head_split_modules | `List[str]` | `[]` | Leaf module names eligible for head splitting. Empty uses `q_proj`/`k_proj`/`v_proj` plus the MLA `q_b_proj`/`k_b_proj`/`v_b_proj` forms. |
 | muon_expert_zero_comm | `bool` | `False` | Use whole-expert `Shard(0)` when the FSDP+ExtraParallel topology permits zero-communication expert Muon updates. |
 | muon_ns_implementation | `Literal["std", "gram", "gram_quack"]` | `"gram_quack"` | Newton–Schulz backend: standard, pure-PyTorch Gram-NS, or Gram-NS with quack kernels (default; falls back to `gram` if unavailable). |
 | muon_gram_ns_reset_iterations | `List[int]` | `[2]` | Restart indices for Gram Newton–Schulz (ignored by `std`). |

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -312,8 +312,8 @@ NPU validation runs at two times:
 | muon_ns_coefficients | `List[float]` | `[3.4445, -4.7750, 2.0315]` | Quintic Newton–Schulz polynomial coefficients. |
 | muon_eps | `float` | `1e-7` | Numerical-stability epsilon used in spectral-norm normalization. |
 | muon_adjust_lr_fn | `Literal["original", "match_rms_adamw"]` | `"match_rms_adamw"` | Per-matrix learning-rate adjustment strategy. |
-| muon_head_group_size | `int` | `0` | Attention heads per Newton–Schulz block ("Muon Split"). `0` orthogonalizes each projection as one matrix, `1` is per-head, `g>1` groups `g` heads. |
-| muon_head_split_modules | `List[str]` | `[]` | Leaf module names eligible for head splitting. Empty uses `q_proj`/`k_proj`/`v_proj` plus the MLA `q_b_proj`/`k_b_proj`/`v_b_proj` forms. |
+| muon_head_group_size | `int` | `0` | Attention heads per Newton–Schulz block ("Muon Split"). `0` orthogonalizes each projection as one matrix, `1` is per-head, `g>1` groups `g` heads. Any value `>= 1` requires `muon_head_split_modules`. |
+| muon_head_split_modules | `List[str]` | `[]` | Leaf module names to head-split, e.g. `[q_b_proj]`. No default — required when `muon_head_group_size >= 1`. |
 | muon_expert_zero_comm | `bool` | `False` | Use whole-expert `Shard(0)` when the FSDP+ExtraParallel topology permits zero-communication expert Muon updates. |
 | muon_ns_implementation | `Literal["std", "gram", "gram_quack"]` | `"gram_quack"` | Newton–Schulz backend: standard, pure-PyTorch Gram-NS, or Gram-NS with quack kernels (default; falls back to `gram` if unavailable). |
 | muon_gram_ns_reset_iterations | `List[int]` | `[2]` | Restart indices for Gram Newton–Schulz (ignored by `std`). |

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -413,8 +413,8 @@ Muon-specific knobs (only consulted when `optimizer.type == "muon"`):
 | `muon_expert_zero_comm` | `false` | **MoE / FSDP+EP only.** When `true`, expert FSDP shards along dim-0 (whole experts per rank) instead of the default dim-1 (hidden split), letting Muon's batched Newton-Schulz run with **zero communication**. Requires `(num_experts / ep_size) % ep_fsdp_size == 0`; otherwise the trainer logs a warning and falls back to the dim-1 + all-to-all-gather path. |
 | `muon_ns_implementation` | `gram_quack` | Newton–Schulz backend: `std`, `gram` (pure PyTorch Gram-NS), or `gram_quack` (default; Dao-AILab + quack CuTeDSL GEMM; falls back to `gram` with a warning if unavailable). |
 | `muon_gram_ns_reset_iterations` | `[2]` | Restart indices for Gram-NS (`gram` / `gram_quack` only). |
-| `muon_head_group_size` | `0` | Attention heads per orthogonalization block ("Muon Split", see below). `0` keeps one polar factor per projection, `1` is fully per-head, `g>1` groups `g` heads per block. |
-| `muon_head_split_modules` | `[]` | Leaf module names eligible for head splitting, matched exactly against children of any module exposing `head_dim`. Empty uses `veomni.optim.muon.DEFAULT_HEAD_SPLIT_MODULES`. |
+| `muon_head_group_size` | `0` | Attention heads per orthogonalization block ("Muon Split", see below). `0` keeps one polar factor per projection, `1` is fully per-head, `g>1` groups `g` heads per block. Any value `>= 1` also requires `muon_head_split_modules`. |
+| `muon_head_split_modules` | `[]` | Leaf module names to head-split, matched exactly against the children of an attention module. **Required** when `muon_head_group_size >= 1`; there is no default list. |
 
 On build, VeOmni logs a one-line `[Muon]` summary (NS backend, resolved LRs, `expert_zero_comm`). Whether zero-comm sharding actually activated is logged separately as `[muon_expert_zero_comm]` during parallelize.
 
@@ -423,6 +423,18 @@ On build, VeOmni logs a one-line `[Muon]` summary (NS backend, resolved LRs, `ex
 Attention computes scores per head, but Muon's natural unit is the whole matrix.
 Setting `muon_head_group_size` splits a head-stacked projection into row blocks
 and gives each block its own polar factor — GLM-5's "Muon Split".
+
+Both knobs are needed to turn it on; there is no built-in module list, because a
+default would quietly change the update math for every model whose attention uses
+the same names:
+
+```yaml
+train:
+  optimizer:
+    type: muon
+    muon_head_group_size: 1            # heads per block
+    muon_head_split_modules: [q_b_proj]  # which projections to split
+```
 
 Whether this helps depends on the shape of the stacked matrix:
 
@@ -447,11 +459,12 @@ Mechanics worth knowing when running an A/B:
   not the full matrix. Without that, a split `[32768, 1024]` param would take a
   `sqrt(32)`-times-larger step and the experiment would really be measuring a
   learning-rate change.
-- Splitting is applied by name, and `muon_head_split_modules` **replaces** the
-  default list rather than extending it. `o_proj` is head-structured along
-  *columns* and MLA `kv_b_proj` interleaves K and V inside each head, so neither
-  is eligible by default — nothing stops you from listing them, but row blocks
-  would not line up with heads.
+- Splitting is applied by name, so pick the list deliberately. Reasonable
+  starting points: `[q_b_proj]` for DeepSeek V3/V4 MLA up-projections,
+  `[q_proj, k_proj, v_proj]` for GQA attention, `[wq_b]` for a GLM MoE DSA
+  indexer. Nothing stops you from listing `o_proj` (head-structured along
+  *columns*) or MLA `kv_b_proj` (interleaves K and V inside each head), but row
+  blocks would not line up with heads there.
 - The head count is never guessed from the shape alone: a projection is split
   only when its row count equals a *declared* head count times a *declared*
   per-head dim (`num_heads`/`n_heads`/config equivalents against

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -413,8 +413,58 @@ Muon-specific knobs (only consulted when `optimizer.type == "muon"`):
 | `muon_expert_zero_comm` | `false` | **MoE / FSDP+EP only.** When `true`, expert FSDP shards along dim-0 (whole experts per rank) instead of the default dim-1 (hidden split), letting Muon's batched Newton-Schulz run with **zero communication**. Requires `(num_experts / ep_size) % ep_fsdp_size == 0`; otherwise the trainer logs a warning and falls back to the dim-1 + all-to-all-gather path. |
 | `muon_ns_implementation` | `gram_quack` | Newton–Schulz backend: `std`, `gram` (pure PyTorch Gram-NS), or `gram_quack` (default; Dao-AILab + quack CuTeDSL GEMM; falls back to `gram` with a warning if unavailable). |
 | `muon_gram_ns_reset_iterations` | `[2]` | Restart indices for Gram-NS (`gram` / `gram_quack` only). |
+| `muon_head_group_size` | `0` | Attention heads per orthogonalization block ("Muon Split", see below). `0` keeps one polar factor per projection, `1` is fully per-head, `g>1` groups `g` heads per block. |
+| `muon_head_split_modules` | `[]` | Leaf module names eligible for head splitting, matched exactly against children of any module exposing `head_dim`. Empty uses `veomni.optim.muon.DEFAULT_HEAD_SPLIT_MODULES`. |
 
 On build, VeOmni logs a one-line `[Muon]` summary (NS backend, resolved LRs, `expert_zero_comm`). Whether zero-comm sharding actually activated is logged separately as `[muon_expert_zero_comm]` during parallelize.
+
+### Head-split Muon (`muon_head_group_size`)
+
+Attention computes scores per head, but Muon's natural unit is the whole matrix.
+Setting `muon_head_group_size` splits a head-stacked projection into row blocks
+and gives each block its own polar factor — GLM-5's "Muon Split".
+
+Whether this helps depends on the shape of the stacked matrix:
+
+- **Wide or square** (`num_heads * head_dim <= in_features`, e.g. classic MHA
+  `q_proj`, GQA `k_proj`/`v_proj`): full-matrix orthogonalization already makes
+  every head block a partial isometry, so splitting only drops the cross-head
+  orthogonality constraint. Expect a wash; Tri Dao's Gram-NS report measured
+  *higher* loss when splitting near-square Llama attention weights by head.
+- **Much taller than wide** (`num_heads * head_dim >> in_features`, e.g. MLA /
+  low-rank up-projections such as DeepSeek V4's `q_b_proj` at `[32768, 1024]`):
+  the full matrix's polar factor is capped at `rank <= in_features`, so all heads
+  share one small update budget and weak-gradient heads are starved. Splitting
+  restores a full-scale whitened update per head. This is the case where GLM-5
+  reported MLA catching up to GQA-8, with stable attention logits and no QK-Clip.
+
+Intermediate group sizes often beat both extremes (the current modded-nanoGPT
+record orthogonalizes Q/K in head *pairs*), so `g` is a tunable, not a switch.
+
+Mechanics worth knowing when running an A/B:
+
+- The LR adjustment (`muon_adjust_lr_fn`) is computed from the **block** shape,
+  not the full matrix. Without that, a split `[32768, 1024]` param would take a
+  `sqrt(32)`-times-larger step and the experiment would really be measuring a
+  learning-rate change.
+- Splitting is applied by name, and `muon_head_split_modules` **replaces** the
+  default list rather than extending it. `o_proj` is head-structured along
+  *columns* and MLA `kv_b_proj` interleaves K and V inside each head, so neither
+  is eligible by default — nothing stops you from listing them, but row blocks
+  would not line up with heads.
+- The head count is never guessed from the shape alone: a projection is split
+  only when its row count equals a *declared* head count times a *declared*
+  per-head dim (`num_heads`/`n_heads`/config equivalents against
+  `head_dim`/`qk_head_dim`, module attributes before config). MLA sets
+  `config.head_dim` to the rope part only, so `rows // head_dim` would cut each
+  head into pieces. Anything that cannot be resolved is skipped with a warning.
+- Params are grouped by block count into separate Muon param groups. With the
+  option off, the optimizer state dict is unchanged, so existing checkpoints
+  resume as before. Turning it on adds one `head_blocks` entry per split param;
+  VeOmni's DCP loader tolerates its absence in an older checkpoint, and the
+  configured value always wins over a stored one.
+- Blocks are smaller matrices, so Newton–Schulz gets cheaper — the aspect ratio
+  seen by Gram-NS drops by roughly the number of blocks.
 
 For MoE training under FSDP2+EP, the Muon flow auto-classifies each parameter into one of four code paths in `DistributedMuon`:
 

--- a/tests/optim/test_muon_fsdp2_parity.py
+++ b/tests/optim/test_muon_fsdp2_parity.py
@@ -159,18 +159,38 @@ def _build_dense_model(
     return model
 
 
-def _dense_golden_state(full_shapes: dict, hidden: int, intermediate: int, mixed_dtype: bool) -> dict:
-    """Single-process reference for the dense FSDP2 path."""
-    device = torch.device("cpu")
-    model = _build_dense_model(device, hidden=hidden, intermediate=intermediate, mixed_dtype=mixed_dtype)
-    opt = DistributedMuon(
-        list(model.parameters()),
+def _dense_muon(model: nn.Module, head_blocks: int) -> DistributedMuon:
+    """Muon over every param, optionally splitting each matrix into row blocks.
+
+    ``up`` gets ``head_blocks`` blocks and ``down`` half as many, so splitting
+    produces *two* param groups: the all-to-all bucketing has to stay
+    rank-consistent across groups, not just within one.
+    """
+    if head_blocks <= 1:
+        grouped = list(model.parameters())
+    else:
+        by_blocks: dict = {}
+        for name, p in model.named_parameters():
+            blocks = head_blocks if name.endswith("up.weight") else head_blocks // 2
+            by_blocks.setdefault(blocks, []).append(p)
+        grouped = [{"params": params, "head_blocks": blocks} for blocks, params in sorted(by_blocks.items())]
+    return DistributedMuon(
+        grouped,
         lr=5e-3,
         weight_decay=0.0,
         momentum=0.9,
         nesterov=True,
         adjust_lr_fn="match_rms_adamw",
     )
+
+
+def _dense_golden_state(
+    full_shapes: dict, hidden: int, intermediate: int, mixed_dtype: bool, head_blocks: int = 1
+) -> dict:
+    """Single-process reference for the dense FSDP2 path."""
+    device = torch.device("cpu")
+    model = _build_dense_model(device, hidden=hidden, intermediate=intermediate, mixed_dtype=mixed_dtype)
+    opt = _dense_muon(model, head_blocks)
     for step in range(2):
         _make_grads(model, full_shapes, step, device)
         opt.step()
@@ -178,7 +198,7 @@ def _dense_golden_state(full_shapes: dict, hidden: int, intermediate: int, mixed
     return _full_state_dict(model)
 
 
-def _run_dense(hidden: int = 32, intermediate: int = 64, mixed_dtype: bool = False) -> None:
+def _run_dense(hidden: int = 32, intermediate: int = 64, mixed_dtype: bool = False, head_blocks: int = 1) -> None:
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
     device_type = get_device_type()
     get_torch_device().set_device(f"{device_type}:{local_rank}")
@@ -196,14 +216,7 @@ def _run_dense(hidden: int = 32, intermediate: int = 64, mixed_dtype: bool = Fal
     for name, p in model.named_parameters():
         assert isinstance(p, DTensor), f"expected DTensor for {name}, got {type(p)}"
 
-    opt = DistributedMuon(
-        list(model.parameters()),
-        lr=5e-3,
-        weight_decay=0.0,
-        momentum=0.9,
-        nesterov=True,
-        adjust_lr_fn="match_rms_adamw",
-    )
+    opt = _dense_muon(model, head_blocks)
     a2a_chunk_sizes = []
     original_ortho_fsdp_group_all2all = opt._ortho_fsdp_group_all2all
 
@@ -227,6 +240,7 @@ def _run_dense(hidden: int = 32, intermediate: int = 64, mixed_dtype: bool = Fal
             hidden=hidden,
             intermediate=intermediate,
             mixed_dtype=mixed_dtype,
+            head_blocks=head_blocks,
         )
         assert set(fsdp_state.keys()) == set(golden.keys())
         for k, v in golden.items():
@@ -498,6 +512,16 @@ def test_dense_mixed_dtype_4gpu():
 
 
 @pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
+def test_dense_head_split_4gpu():
+    """Head-block orthogonalization must survive the all-to-all owner path."""
+    cmd = _torchrun_cmd(nproc=4, port=_find_free_port(), mode="dense_head_split", use_zero_comm=False)
+    env = os.environ.copy()
+    env.setdefault("NCCL_DEBUG", "WARN")
+    result = subprocess.run(cmd, env=env, check=True)
+    assert result.returncode == 0
+
+
+@pytest.mark.skipif(not _has_devices(4), reason="device_count should be >= 4")
 def test_qwen3_moe_default_backend_4gpu():
     """Default backend: ``Shard(1)`` on experts + ep_fsdp all-gather in Muon."""
     cmd = _torchrun_cmd(nproc=4, port=_find_free_port(), mode="moe", use_zero_comm=False)
@@ -521,7 +545,11 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", choices=["dense", "dense_empty", "dense_mixed_dtype", "moe"], required=True)
+    parser.add_argument(
+        "--mode",
+        choices=["dense", "dense_empty", "dense_mixed_dtype", "dense_head_split", "moe"],
+        required=True,
+    )
     parser.add_argument("--zero-comm", type=int, default=0)
     args = parser.parse_args()
     if args.mode == "dense":
@@ -530,5 +558,8 @@ if __name__ == "__main__":
         _run_dense(hidden=2, intermediate=3)
     elif args.mode == "dense_mixed_dtype":
         _run_dense(mixed_dtype=True)
+    elif args.mode == "dense_head_split":
+        # up is [64, 32] and down is [32, 64], so 4 blocks divide both evenly.
+        _run_dense(head_blocks=4)
     else:
         _run_qwen3_moe(use_zero_comm=bool(args.zero_comm))

--- a/tests/optim/test_muon_unit.py
+++ b/tests/optim/test_muon_unit.py
@@ -63,16 +63,14 @@ def _sample_2d(M: int, K: int, dtype: torch.dtype = torch.float32, seed: int = 0
     return torch.randn(M, K, generator=g, dtype=dtype)
 
 
-# Head splitting has no built-in module list, so every call names its targets.
 _QKV_MODULES = ("q_proj", "k_proj", "v_proj")
 
 
 class _FakeAttention(nn.Module):
-    """GQA-shaped attention plus the look-alikes head splitting must not touch.
+    """GQA attention plus ``o_proj``/``q_a_proj``, which head splitting must not touch.
 
-    ``o_proj`` is head-structured along columns and ``q_a_proj`` is shared across
-    heads, yet both have a row count divisible by ``head_dim`` — so they only
-    stay out of the split by name, which is what the tests below pin down.
+    ``hidden == num_heads * head_dim`` is deliberate: ``o_proj`` then resolves to a
+    valid head layout, so it can only stay out of the split by name.
     """
 
     def __init__(self, hidden: int = 32, num_heads: int = 8, num_kv_heads: int = 2, head_dim: int = 4):
@@ -517,8 +515,7 @@ class TestHeadSplitInference:
     def test_only_listed_modules_are_eligible(self):
         blocks = infer_head_block_counts(_attention_model(), head_group_size=1, module_names=_QKV_MODULES)
 
-        # Equality (not membership) pins down that o_proj / q_a_proj stay out even
-        # though their row counts are multiples of head_dim.
+        # o_proj / q_a_proj stay out despite row counts that are multiples of head_dim.
         assert blocks == {
             "self_attn.q_proj.weight": 8,
             "self_attn.k_proj.weight": 2,
@@ -564,12 +561,7 @@ class TestHeadSplitInference:
         assert infer_head_block_counts(model, head_group_size=1, module_names=_QKV_MODULES) == {}
 
     def test_mla_row_stride_is_qk_head_dim_not_head_dim(self):
-        """MLA's ``head_dim`` is the rope part only; blocks must follow ``qk_head_dim``.
-
-        DeepSeek V3 / GLM-MoE-DSA stack ``num_heads * qk_head_dim`` rows while the
-        config reports ``head_dim == qk_rope_head_dim``, so deriving the count as
-        ``rows // head_dim`` would cut each head into three unrelated blocks.
-        """
+        """MLA's ``head_dim`` is the rope part only; blocks must follow ``qk_head_dim``."""
         num_heads, qk_nope, qk_rope = 8, 32, 16
         attn = nn.Module()
         attn.num_heads = num_heads
@@ -631,14 +623,9 @@ class TestHeadSplitUpdate:
 
     @pytest.mark.parametrize("adjust_lr_fn", ["original", "match_rms_adamw"])
     def test_lr_adjust_follows_the_block_shape(self, adjust_lr_fn):
-        """A tall stack must not inherit the full matrix's larger LR factor.
-
-        Both adjustment rules grow with the long dimension, so scoring a split
-        update against the unsplit ``[rows, cols]`` shape would silently inflate
-        the step by ``sqrt(head_blocks)``.
-        """
+        """A tall stack must not inherit the full matrix's larger LR factor."""
         head_blocks, block_rows, cols = 8, 16, 32
-        rows = head_blocks * block_rows  # 128 x 32: MLA-style tall head stack
+        rows = head_blocks * block_rows
         grad = _sample_2d(rows, cols, seed=5)
         p = nn.Parameter(torch.zeros_like(grad))
         p.grad = grad.clone()
@@ -680,7 +667,6 @@ class TestHeadSplitGuards:
             DistributedMuon([p], lr=1e-3, head_blocks=0)
 
     def test_add_param_group_is_validated_too(self):
-        """Otherwise a bad block count only surfaces mid-step, inside Newton-Schulz."""
         opt = DistributedMuon([nn.Parameter(torch.randn(4, 8))], lr=1e-3)
         with pytest.raises(ValueError, match="does not evenly divide"):
             opt.add_param_group({"params": [nn.Parameter(torch.randn(6, 8))], "head_blocks": 4})
@@ -732,7 +718,6 @@ class TestHeadSplitBuild:
             self._muon_groups_by_blocks(_attention_model(), head_group_size=-2)
 
     def test_group_size_without_module_list_raises(self):
-        """Opting in must be explicit on both knobs, never half-configured."""
         with pytest.raises(ValueError, match="requires muon_head_split_modules"):
             self._muon_groups_by_blocks(_attention_model(), head_group_size=1, head_split_modules=[])
 
@@ -744,12 +729,7 @@ class TestHeadSplitBuild:
         ],
     )
     def test_head_blocks_only_reaches_the_state_dict_when_splitting(self, head_group_size, expected):
-        """With the option off, the flattened DCP schema must match a pre-feature run.
-
-        ``head_blocks`` in the optimizer defaults would add a
-        ``param_groups.<fqn>.head_blocks`` entry for every param, which older
-        checkpoints do not carry.
-        """
+        """With the option off, the flattened DCP schema must match a pre-feature run."""
         from veomni.optim import build_optimizer
 
         model = _attention_model()

--- a/tests/optim/test_muon_unit.py
+++ b/tests/optim/test_muon_unit.py
@@ -30,6 +30,7 @@ from veomni.utils.device import IS_CUDA_AVAILABLE, get_device_type, get_gpu_comp
 
 muon_module = pytest.importorskip("torch.optim._muon")
 from torch.optim import Muon as UpstreamMuon  # noqa: E402
+from torch.optim._muon import _adjust_lr as upstream_adjust_lr  # noqa: E402
 from torch.optim._muon import _zeropower_via_newtonschulz as upstream_ns  # noqa: E402
 
 from veomni.optim.muon import (  # noqa: E402
@@ -40,6 +41,7 @@ from veomni.optim.muon import (  # noqa: E402
     _shard_row_sizes,
     batched_gram_newton_schulz,
     batched_newton_schulz,
+    infer_head_block_counts,
     run_newton_schulz,
     split_muon_adamw_params,
 )
@@ -59,6 +61,47 @@ def _toy_model() -> nn.Module:
 def _sample_2d(M: int, K: int, dtype: torch.dtype = torch.float32, seed: int = 0) -> torch.Tensor:
     g = torch.Generator(device="cpu").manual_seed(seed)
     return torch.randn(M, K, generator=g, dtype=dtype)
+
+
+class _FakeAttention(nn.Module):
+    """GQA-shaped attention plus the look-alikes head splitting must not touch.
+
+    ``o_proj`` is head-structured along columns and ``q_a_proj`` is shared across
+    heads, yet both have a row count divisible by ``head_dim`` — so they only
+    stay out of the split by name, which is what the tests below pin down.
+    """
+
+    def __init__(self, hidden: int = 32, num_heads: int = 8, num_kv_heads: int = 2, head_dim: int = 4):
+        super().__init__()
+        self.head_dim = head_dim
+        self.num_heads = num_heads
+        self.num_key_value_heads = num_kv_heads
+        self.q_proj = nn.Linear(hidden, num_heads * head_dim, bias=False)
+        self.k_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=False)
+        self.v_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=False)
+        self.o_proj = nn.Linear(num_heads * head_dim, hidden, bias=False)
+        self.q_a_proj = nn.Linear(hidden, 4 * head_dim, bias=False)
+
+
+def _attention_model(**kwargs) -> nn.Module:
+    torch.manual_seed(0)
+    model = nn.Module()
+    model.embed_tokens = nn.Embedding(8, 32)
+    model.self_attn = _FakeAttention(**kwargs)
+    return model
+
+
+def _head_split_muon(param: nn.Parameter, head_blocks: int, adjust_lr_fn=None, lr: float = 1.0) -> DistributedMuon:
+    """Muon over one param with momentum disabled, so update == orthogonalized grad."""
+    return DistributedMuon(
+        [{"params": [param], "head_blocks": head_blocks}],
+        lr=lr,
+        weight_decay=0.0,
+        momentum=0.0,
+        nesterov=False,
+        adjust_lr_fn=adjust_lr_fn,
+        ns_implementation="std",
+    )
 
 
 class TestSplit:
@@ -462,6 +505,279 @@ class TestMuonLrResolution:
         )
         muon_opt = opt.optimizers_dict["muon"]
         assert muon_opt.param_groups[0]["lr"] == pytest.approx(3e-3)
+
+
+class TestHeadSplitInference:
+    """``infer_head_block_counts`` must key off names, not just shapes."""
+
+    def test_only_row_stacked_projections_are_eligible(self):
+        blocks = infer_head_block_counts(_attention_model(), head_group_size=1)
+
+        # Equality (not membership) pins down that o_proj / q_a_proj stay out even
+        # though their row counts are multiples of head_dim.
+        assert blocks == {
+            "self_attn.q_proj.weight": 8,
+            "self_attn.k_proj.weight": 2,
+            "self_attn.v_proj.weight": 2,
+        }
+
+    @pytest.mark.parametrize(
+        "head_group_size, expected",
+        [
+            (2, {"self_attn.q_proj.weight": 4, "self_attn.k_proj.weight": 1, "self_attn.v_proj.weight": 1}),
+            (4, {"self_attn.q_proj.weight": 2}),  # 2 KV heads are not divisible by 4
+            (8, {}),  # one block per matrix is just full-matrix Muon
+        ],
+    )
+    def test_group_size_controls_block_count(self, head_group_size, expected):
+        blocks = infer_head_block_counts(_attention_model(), head_group_size=head_group_size)
+        assert blocks == {k: v for k, v in expected.items() if v > 1}
+
+    @pytest.mark.parametrize("head_group_size", [0, -1])
+    def test_non_positive_group_size_disables_splitting(self, head_group_size):
+        assert infer_head_block_counts(_attention_model(), head_group_size=head_group_size) == {}
+
+    def test_module_allowlist_is_the_only_gate(self):
+        blocks = infer_head_block_counts(_attention_model(), head_group_size=1, module_names=("o_proj",))
+        assert blocks == {"self_attn.o_proj.weight": 8}
+
+    def test_modules_without_head_dim_are_skipped(self):
+        model = _attention_model()
+        del model.self_attn.head_dim
+        assert infer_head_block_counts(model, head_group_size=1) == {}
+
+    def test_modules_without_head_count_are_skipped(self):
+        model = _attention_model()
+        del model.self_attn.num_heads
+        del model.self_attn.num_key_value_heads
+        assert infer_head_block_counts(model, head_group_size=1) == {}
+
+    def test_mla_row_stride_is_qk_head_dim_not_head_dim(self):
+        """MLA's ``head_dim`` is the rope part only; blocks must follow ``qk_head_dim``.
+
+        DeepSeek V3 / GLM-MoE-DSA stack ``num_heads * qk_head_dim`` rows while the
+        config reports ``head_dim == qk_rope_head_dim``, so deriving the count as
+        ``rows // head_dim`` would cut each head into three unrelated blocks.
+        """
+        num_heads, qk_nope, qk_rope = 8, 32, 16
+        attn = nn.Module()
+        attn.num_heads = num_heads
+        attn.qk_head_dim = qk_nope + qk_rope
+        attn.config = SimpleNamespace(num_attention_heads=num_heads, head_dim=qk_rope)
+        attn.q_b_proj = nn.Linear(64, num_heads * attn.qk_head_dim, bias=False)
+        model = nn.Module()
+        model.self_attn = attn
+
+        assert infer_head_block_counts(model, head_group_size=1) == {"self_attn.q_b_proj.weight": num_heads}
+
+    def test_unresolvable_row_count_is_skipped(self):
+        """A declared stride that does not tile the rows must not be guessed around."""
+        attn = nn.Module()
+        attn.num_heads = 8
+        attn.head_dim = 16
+        attn.q_proj = nn.Linear(64, 8 * 48, bias=False)  # stride is really 48, not head_dim
+        model = nn.Module()
+        model.self_attn = attn
+
+        assert infer_head_block_counts(model, head_group_size=1) == {}
+
+    def test_module_attrs_win_over_config_attrs(self):
+        """A DSA indexer's own smaller head layout must beat the shared config's."""
+        indexer = nn.Module()
+        indexer.n_heads = 4
+        indexer.head_dim = 32
+        # 4 * 32 and 8 * 16 both equal 128, so config-first resolution would pick 8.
+        indexer.config = SimpleNamespace(num_attention_heads=8, head_dim=16)
+        indexer.wq_b = nn.Linear(64, 128, bias=False)
+        model = nn.Module()
+        model.indexer = indexer
+
+        assert infer_head_block_counts(model, head_group_size=1) == {"indexer.wq_b.weight": 4}
+
+
+class TestHeadSplitUpdate:
+    """Row-block orthogonalization math and its learning-rate scaling."""
+
+    def _per_block_reference(self, grad: torch.Tensor, head_blocks: int) -> torch.Tensor:
+        rows = grad.shape[0] // head_blocks
+        return torch.cat(
+            [run_newton_schulz(grad[i * rows : (i + 1) * rows], ns_implementation="std") for i in range(head_blocks)],
+            dim=0,
+        )
+
+    def test_update_matches_per_block_newton_schulz(self):
+        head_blocks, rows, cols = 8, 16, 32
+        grad = _sample_2d(head_blocks * rows, cols, seed=11)
+        p = nn.Parameter(torch.zeros_like(grad))
+        p.grad = grad.clone()
+
+        _head_split_muon(p, head_blocks).step()
+
+        # rows <= cols keeps _adjust_lr at 1.0, so the update is the raw polar factor.
+        torch.testing.assert_close(-p.detach(), self._per_block_reference(grad, head_blocks))
+
+    @pytest.mark.parametrize("adjust_lr_fn", ["original", "match_rms_adamw"])
+    def test_lr_adjust_follows_the_block_shape(self, adjust_lr_fn):
+        """A tall stack must not inherit the full matrix's larger LR factor.
+
+        Both adjustment rules grow with the long dimension, so scoring a split
+        update against the unsplit ``[rows, cols]`` shape would silently inflate
+        the step by ``sqrt(head_blocks)``.
+        """
+        head_blocks, block_rows, cols = 8, 16, 32
+        rows = head_blocks * block_rows  # 128 x 32: MLA-style tall head stack
+        grad = _sample_2d(rows, cols, seed=5)
+        p = nn.Parameter(torch.zeros_like(grad))
+        p.grad = grad.clone()
+
+        _head_split_muon(p, head_blocks, adjust_lr_fn=adjust_lr_fn).step()
+
+        block_factor = upstream_adjust_lr(1.0, adjust_lr_fn, (block_rows, cols))
+        full_factor = upstream_adjust_lr(1.0, adjust_lr_fn, (rows, cols))
+        assert block_factor < full_factor
+        torch.testing.assert_close(-p.detach(), block_factor * self._per_block_reference(grad, head_blocks))
+
+    def test_split_and_full_updates_differ(self):
+        """Guard against the split silently degenerating into full-matrix Muon."""
+        head_blocks, block_rows, cols = 4, 8, 16
+        grad = _sample_2d(head_blocks * block_rows, cols, seed=3)
+        split, full = nn.Parameter(torch.zeros_like(grad)), nn.Parameter(torch.zeros_like(grad))
+        split.grad, full.grad = grad.clone(), grad.clone()
+
+        _head_split_muon(split, head_blocks).step()
+        _head_split_muon(full, 1).step()
+
+        assert not torch.allclose(-split.detach(), -full.detach(), atol=1e-3)
+
+
+class TestHeadSplitGuards:
+    def test_head_blocks_rejects_3d_params(self):
+        p = nn.Parameter(torch.randn(2, 4, 8))
+        with pytest.raises(ValueError, match="only applies to 2D"):
+            DistributedMuon([{"params": [p], "head_blocks": 2}], lr=1e-3)
+
+    def test_head_blocks_must_divide_rows(self):
+        p = nn.Parameter(torch.randn(6, 8))
+        with pytest.raises(ValueError, match="does not evenly divide"):
+            DistributedMuon([{"params": [p], "head_blocks": 4}], lr=1e-3)
+
+    def test_head_blocks_must_be_positive(self):
+        p = nn.Parameter(torch.randn(4, 8))
+        with pytest.raises(ValueError, match="head_blocks must be >= 1"):
+            DistributedMuon([p], lr=1e-3, head_blocks=0)
+
+    def test_add_param_group_is_validated_too(self):
+        """Otherwise a bad block count only surfaces mid-step, inside Newton-Schulz."""
+        opt = DistributedMuon([nn.Parameter(torch.randn(4, 8))], lr=1e-3)
+        with pytest.raises(ValueError, match="does not evenly divide"):
+            opt.add_param_group({"params": [nn.Parameter(torch.randn(6, 8))], "head_blocks": 4})
+
+    def test_configured_head_blocks_survives_resume(self):
+        """A checkpoint from a full-matrix run must not silently undo the split."""
+        p = nn.Parameter(torch.randn(16, 8))
+        opt = _head_split_muon(p, head_blocks=4)
+        p.grad = torch.randn_like(p)
+        opt.step()
+
+        stale = opt.state_dict()
+        stale["param_groups"][0]["head_blocks"] = 1
+        opt.load_state_dict(stale)
+
+        assert opt.param_groups[0]["head_blocks"] == 4
+
+
+class TestHeadSplitBuild:
+    def _muon_groups_by_blocks(self, model, **muon_kwargs):
+        from veomni.optim import build_optimizer
+
+        muon_kwargs.setdefault("lr", 1e-2)
+        muon_kwargs.setdefault("ns_implementation", "std")
+        opt = build_optimizer(model, lr=1e-4, optimizer_type="muon", muon_kwargs=muon_kwargs)
+        names = {id(p): n for n, p in model.named_parameters()}
+        return {
+            int(group.get("head_blocks", 1)): sorted(names[id(p)] for p in group["params"])
+            for group in opt.optimizers_dict["muon"].param_groups
+        }
+
+    def test_params_are_grouped_by_block_count(self):
+        model = _attention_model()
+        by_blocks = self._muon_groups_by_blocks(model, head_group_size=1)
+
+        assert by_blocks[8] == ["self_attn.q_proj.weight"]
+        assert by_blocks[2] == ["self_attn.k_proj.weight", "self_attn.v_proj.weight"]
+        # o_proj has the same shape as q_proj but is not head-stacked by row.
+        assert by_blocks[1] == ["self_attn.o_proj.weight", "self_attn.q_a_proj.weight"]
+
+    def test_default_config_keeps_one_full_matrix_group(self):
+        by_blocks = self._muon_groups_by_blocks(_attention_model())
+        assert list(by_blocks) == [1]
+
+    def test_negative_group_size_raises(self):
+        with pytest.raises(ValueError, match="muon_head_group_size must be >= 0"):
+            self._muon_groups_by_blocks(_attention_model(), head_group_size=-2)
+
+    @pytest.mark.parametrize(
+        "head_group_size, expected",
+        [
+            (0, []),
+            (1, ["self_attn.k_proj.weight", "self_attn.q_proj.weight", "self_attn.v_proj.weight"]),
+        ],
+    )
+    def test_head_blocks_only_reaches_the_state_dict_when_splitting(self, head_group_size, expected):
+        """With the option off, the flattened DCP schema must match a pre-feature run.
+
+        ``head_blocks`` in the optimizer defaults would add a
+        ``param_groups.<fqn>.head_blocks`` entry for every param, which older
+        checkpoints do not carry.
+        """
+        from veomni.optim import build_optimizer
+
+        model = _attention_model()
+        opt = build_optimizer(
+            model,
+            lr=1e-4,
+            optimizer_type="muon",
+            muon_kwargs={"lr": 1e-2, "ns_implementation": "std", "head_group_size": head_group_size},
+        )
+        for p in model.parameters():
+            if p.requires_grad:
+                p.grad = torch.randn_like(p)
+        opt.step()
+
+        tagged = sorted(k[len("param_groups.") : -len(".head_blocks")] for k in opt.state_dict() if "head_blocks" in k)
+        assert tagged == expected
+
+    def test_split_run_survives_a_state_dict_roundtrip(self):
+        """Multi-group Muon must save and reload through the MultiOptimizer path."""
+        from veomni.optim import build_optimizer
+
+        def _build(model):
+            return build_optimizer(
+                model,
+                lr=1e-4,
+                optimizer_type="muon",
+                muon_kwargs={"lr": 1e-2, "ns_implementation": "std", "head_group_size": 2},
+            )
+
+        model_a = _attention_model()
+        opt_a = _build(model_a)
+        for p in model_a.parameters():
+            if p.requires_grad:
+                p.grad = torch.randn_like(p)
+        opt_a.step()
+        saved = opt_a.state_dict()
+
+        model_b = _attention_model()
+        model_b.load_state_dict(model_a.state_dict())
+        opt_b = _build(model_b)
+        opt_b.load_state_dict(saved)
+
+        assert [g.get("head_blocks", 1) for g in opt_b.optimizers_dict["muon"].param_groups] == [1, 4]
+        reloaded = opt_b.state_dict()
+        assert set(saved) == set(reloaded)
+        for key, before in saved.items():
+            if isinstance(before, torch.Tensor):
+                torch.testing.assert_close(before, reloaded[key], atol=0.0, rtol=0.0, msg=f"mismatch at {key}")
 
 
 class TestGramQuackFallback:

--- a/tests/optim/test_muon_unit.py
+++ b/tests/optim/test_muon_unit.py
@@ -63,6 +63,10 @@ def _sample_2d(M: int, K: int, dtype: torch.dtype = torch.float32, seed: int = 0
     return torch.randn(M, K, generator=g, dtype=dtype)
 
 
+# Head splitting has no built-in module list, so every call names its targets.
+_QKV_MODULES = ("q_proj", "k_proj", "v_proj")
+
+
 class _FakeAttention(nn.Module):
     """GQA-shaped attention plus the look-alikes head splitting must not touch.
 
@@ -508,10 +512,10 @@ class TestMuonLrResolution:
 
 
 class TestHeadSplitInference:
-    """``infer_head_block_counts`` must key off names, not just shapes."""
+    """``infer_head_block_counts`` must key off declared head layouts, not shapes."""
 
-    def test_only_row_stacked_projections_are_eligible(self):
-        blocks = infer_head_block_counts(_attention_model(), head_group_size=1)
+    def test_only_listed_modules_are_eligible(self):
+        blocks = infer_head_block_counts(_attention_model(), head_group_size=1, module_names=_QKV_MODULES)
 
         # Equality (not membership) pins down that o_proj / q_a_proj stay out even
         # though their row counts are multiples of head_dim.
@@ -520,6 +524,10 @@ class TestHeadSplitInference:
             "self_attn.k_proj.weight": 2,
             "self_attn.v_proj.weight": 2,
         }
+
+    def test_module_list_is_required(self):
+        with pytest.raises(ValueError, match="explicit list of attention projection module names"):
+            infer_head_block_counts(_attention_model(), head_group_size=1, module_names=())
 
     @pytest.mark.parametrize(
         "head_group_size, expected",
@@ -530,27 +538,30 @@ class TestHeadSplitInference:
         ],
     )
     def test_group_size_controls_block_count(self, head_group_size, expected):
-        blocks = infer_head_block_counts(_attention_model(), head_group_size=head_group_size)
+        blocks = infer_head_block_counts(
+            _attention_model(), head_group_size=head_group_size, module_names=_QKV_MODULES
+        )
         assert blocks == {k: v for k, v in expected.items() if v > 1}
 
     @pytest.mark.parametrize("head_group_size", [0, -1])
     def test_non_positive_group_size_disables_splitting(self, head_group_size):
-        assert infer_head_block_counts(_attention_model(), head_group_size=head_group_size) == {}
+        assert infer_head_block_counts(_attention_model(), head_group_size, module_names=_QKV_MODULES) == {}
 
-    def test_module_allowlist_is_the_only_gate(self):
+    def test_listed_modules_are_trusted_even_when_column_stacked(self):
+        """No name is vetoed: ``o_proj`` splits by row if you ask for it."""
         blocks = infer_head_block_counts(_attention_model(), head_group_size=1, module_names=("o_proj",))
         assert blocks == {"self_attn.o_proj.weight": 8}
 
     def test_modules_without_head_dim_are_skipped(self):
         model = _attention_model()
         del model.self_attn.head_dim
-        assert infer_head_block_counts(model, head_group_size=1) == {}
+        assert infer_head_block_counts(model, head_group_size=1, module_names=_QKV_MODULES) == {}
 
     def test_modules_without_head_count_are_skipped(self):
         model = _attention_model()
         del model.self_attn.num_heads
         del model.self_attn.num_key_value_heads
-        assert infer_head_block_counts(model, head_group_size=1) == {}
+        assert infer_head_block_counts(model, head_group_size=1, module_names=_QKV_MODULES) == {}
 
     def test_mla_row_stride_is_qk_head_dim_not_head_dim(self):
         """MLA's ``head_dim`` is the rope part only; blocks must follow ``qk_head_dim``.
@@ -568,7 +579,8 @@ class TestHeadSplitInference:
         model = nn.Module()
         model.self_attn = attn
 
-        assert infer_head_block_counts(model, head_group_size=1) == {"self_attn.q_b_proj.weight": num_heads}
+        blocks = infer_head_block_counts(model, head_group_size=1, module_names=("q_b_proj",))
+        assert blocks == {"self_attn.q_b_proj.weight": num_heads}
 
     def test_unresolvable_row_count_is_skipped(self):
         """A declared stride that does not tile the rows must not be guessed around."""
@@ -579,7 +591,7 @@ class TestHeadSplitInference:
         model = nn.Module()
         model.self_attn = attn
 
-        assert infer_head_block_counts(model, head_group_size=1) == {}
+        assert infer_head_block_counts(model, head_group_size=1, module_names=_QKV_MODULES) == {}
 
     def test_module_attrs_win_over_config_attrs(self):
         """A DSA indexer's own smaller head layout must beat the shared config's."""
@@ -592,7 +604,8 @@ class TestHeadSplitInference:
         model = nn.Module()
         model.indexer = indexer
 
-        assert infer_head_block_counts(model, head_group_size=1) == {"indexer.wq_b.weight": 4}
+        blocks = infer_head_block_counts(model, head_group_size=1, module_names=("wq_b",))
+        assert blocks == {"indexer.wq_b.weight": 4}
 
 
 class TestHeadSplitUpdate:
@@ -692,6 +705,8 @@ class TestHeadSplitBuild:
 
         muon_kwargs.setdefault("lr", 1e-2)
         muon_kwargs.setdefault("ns_implementation", "std")
+        if muon_kwargs.get("head_group_size"):
+            muon_kwargs.setdefault("head_split_modules", _QKV_MODULES)
         opt = build_optimizer(model, lr=1e-4, optimizer_type="muon", muon_kwargs=muon_kwargs)
         names = {id(p): n for n, p in model.named_parameters()}
         return {
@@ -716,6 +731,11 @@ class TestHeadSplitBuild:
         with pytest.raises(ValueError, match="muon_head_group_size must be >= 0"):
             self._muon_groups_by_blocks(_attention_model(), head_group_size=-2)
 
+    def test_group_size_without_module_list_raises(self):
+        """Opting in must be explicit on both knobs, never half-configured."""
+        with pytest.raises(ValueError, match="requires muon_head_split_modules"):
+            self._muon_groups_by_blocks(_attention_model(), head_group_size=1, head_split_modules=[])
+
     @pytest.mark.parametrize(
         "head_group_size, expected",
         [
@@ -737,7 +757,12 @@ class TestHeadSplitBuild:
             model,
             lr=1e-4,
             optimizer_type="muon",
-            muon_kwargs={"lr": 1e-2, "ns_implementation": "std", "head_group_size": head_group_size},
+            muon_kwargs={
+                "lr": 1e-2,
+                "ns_implementation": "std",
+                "head_group_size": head_group_size,
+                "head_split_modules": _QKV_MODULES,
+            },
         )
         for p in model.parameters():
             if p.requires_grad:
@@ -756,7 +781,12 @@ class TestHeadSplitBuild:
                 model,
                 lr=1e-4,
                 optimizer_type="muon",
-                muon_kwargs={"lr": 1e-2, "ns_implementation": "std", "head_group_size": 2},
+                muon_kwargs={
+                    "lr": 1e-2,
+                    "ns_implementation": "std",
+                    "head_group_size": 2,
+                    "head_split_modules": _QKV_MODULES,
+                },
             )
 
         model_a = _attention_model()

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -147,12 +147,10 @@ class OptimizerConfig:
         default=0,
         metadata={
             "help": (
-                "Attention heads per Newton-Schulz block for head-split Muon (GLM-5 'Muon Split'). "
+                "Attention heads per Newton-Schulz block for head-split Muon. "
                 "0 (default) orthogonalizes each projection as a single matrix; 1 is fully per-head; "
                 "g > 1 puts g heads in each block. Any value >= 1 also requires "
-                "muon_head_split_modules. Expect gains when the head-stacked matrix is much taller "
-                "than its input dim (MLA/low-rank up-projections such as DeepSeek V4 q_b_proj) and "
-                "roughly no effect for square or wide GQA projections."
+                "muon_head_split_modules."
             )
         },
     )
@@ -161,12 +159,9 @@ class OptimizerConfig:
         metadata={
             "help": (
                 "Leaf module names to head-split, matched exactly against the children of an "
-                "attention module. Required (no default) whenever muon_head_group_size >= 1, since "
-                "which projections benefit depends on the architecture: e.g. ['q_b_proj'] for "
-                "DeepSeek V3/V4 MLA up-projections, ['q_proj', 'k_proj', 'v_proj'] for GQA, "
-                "['wq_b'] for a GLM MoE DSA indexer. o_proj is head-structured along columns and "
-                "MLA kv_b_proj interleaves K and V inside each head, so neither splits into "
-                "head-aligned rows."
+                "attention module, e.g. ['q_b_proj'] for DeepSeek V3/V4 MLA up-projections or "
+                "['q_proj', 'k_proj', 'v_proj'] for GQA. Required whenever "
+                "muon_head_group_size >= 1; see docs/usage/basic_modules.md."
             )
         },
     )

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -149,9 +149,10 @@ class OptimizerConfig:
             "help": (
                 "Attention heads per Newton-Schulz block for head-split Muon (GLM-5 'Muon Split'). "
                 "0 (default) orthogonalizes each projection as a single matrix; 1 is fully per-head; "
-                "g > 1 puts g heads in each block. Expect gains when the head-stacked matrix is much "
-                "taller than its input dim (MLA/low-rank up-projections such as DeepSeek V4 q_b_proj) "
-                "and roughly no effect for square or wide GQA projections."
+                "g > 1 puts g heads in each block. Any value >= 1 also requires "
+                "muon_head_split_modules. Expect gains when the head-stacked matrix is much taller "
+                "than its input dim (MLA/low-rank up-projections such as DeepSeek V4 q_b_proj) and "
+                "roughly no effect for square or wide GQA projections."
             )
         },
     )
@@ -159,11 +160,13 @@ class OptimizerConfig:
         default_factory=list,
         metadata={
             "help": (
-                "Leaf module names eligible for head splitting, matched exactly against the children "
-                "of an attention module. Replaces (does not extend) the default list "
-                "veomni.optim.muon.DEFAULT_HEAD_SPLIT_MODULES, which covers q/k/v_proj, the MLA "
-                "q_b_proj/k_b_proj/v_b_proj forms and the DSA indexer's wq_b. Only consulted when "
-                "muon_head_group_size >= 1."
+                "Leaf module names to head-split, matched exactly against the children of an "
+                "attention module. Required (no default) whenever muon_head_group_size >= 1, since "
+                "which projections benefit depends on the architecture: e.g. ['q_b_proj'] for "
+                "DeepSeek V3/V4 MLA up-projections, ['q_proj', 'k_proj', 'v_proj'] for GQA, "
+                "['wq_b'] for a GLM MoE DSA indexer. o_proj is head-structured along columns and "
+                "MLA kv_b_proj interleaves K and V inside each head, so neither splits into "
+                "head-aligned rows."
             )
         },
     )

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -143,6 +143,30 @@ class OptimizerConfig:
             )
         },
     )
+    muon_head_group_size: int = field(
+        default=0,
+        metadata={
+            "help": (
+                "Attention heads per Newton-Schulz block for head-split Muon (GLM-5 'Muon Split'). "
+                "0 (default) orthogonalizes each projection as a single matrix; 1 is fully per-head; "
+                "g > 1 puts g heads in each block. Expect gains when the head-stacked matrix is much "
+                "taller than its input dim (MLA/low-rank up-projections such as DeepSeek V4 q_b_proj) "
+                "and roughly no effect for square or wide GQA projections."
+            )
+        },
+    )
+    muon_head_split_modules: List[str] = field(
+        default_factory=list,
+        metadata={
+            "help": (
+                "Leaf module names eligible for head splitting, matched exactly against the children "
+                "of an attention module. Replaces (does not extend) the default list "
+                "veomni.optim.muon.DEFAULT_HEAD_SPLIT_MODULES, which covers q/k/v_proj, the MLA "
+                "q_b_proj/k_b_proj/v_b_proj forms and the DSA indexer's wq_b. Only consulted when "
+                "muon_head_group_size >= 1."
+            )
+        },
+    )
     muon_expert_zero_comm: bool = field(
         default=False,
         metadata={

--- a/veomni/optim/muon.py
+++ b/veomni/optim/muon.py
@@ -20,9 +20,7 @@ params are gathered only when the NS iteration needs the full trailing
 ``[M, K]`` matrix.
 
 The per-group ``head_blocks`` option orthogonalizes a head-stacked attention
-projection in row blocks (one block per head group) instead of as one matrix,
-which is the "Muon Split" recipe from GLM-5. See
-``docs/usage/basic_modules.md`` for when this helps.
+projection in row blocks (one block per head group) instead of as one matrix.
 """
 
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
@@ -87,9 +85,8 @@ _DEFAULT_ADAMW_NAME_PATTERNS: Tuple[str, ...] = (
     "output_layer",
 )
 
-# Attribute names carrying a head count and a per-head row stride. Read from the
-# attention module first, then its config: MLA modules keep the true stride as
-# ``qk_head_dim`` while ``config.head_dim`` holds only the rope part.
+# Attribute names carrying a head count and a per-head row stride. MLA modules
+# keep the true stride as ``qk_head_dim``; ``head_dim`` is only the rope part.
 _HEAD_COUNT_ATTRS: Tuple[str, ...] = ("num_heads", "n_heads", "num_attention_heads", "num_key_value_heads")
 _HEAD_STRIDE_ATTRS: Tuple[str, ...] = ("head_dim", "qk_head_dim")
 
@@ -471,10 +468,10 @@ def _declared_ints(source: Any, attrs: Sequence[str]) -> List[int]:
 def _head_layout_tiers(module: "nn.Module") -> List[Tuple[List[int], List[int]]]:
     """``(head counts, per-head dims)`` to try, module attrs before config attrs.
 
-    The module's own attributes come first because a sub-module can disagree with
-    the shared config: a DSA indexer declares a smaller ``n_heads``/``head_dim``
-    pair while seeing the same config as the main attention, and mixing both
-    sources can make two different head counts fit the same row total.
+    A sub-module can disagree with the shared config -- a DSA indexer declares a
+    smaller ``n_heads``/``head_dim`` pair than the attention it sits in -- so its
+    own attributes are tried alone before the merged module+config tier, where
+    two different head counts can fit the same row total.
     """
     counts = _declared_ints(module, _HEAD_COUNT_ATTRS)
     strides = _declared_ints(module, _HEAD_STRIDE_ATTRS)
@@ -493,15 +490,10 @@ def _head_layout_tiers(module: "nn.Module") -> List[Tuple[List[int], List[int]]]
 def _stacked_head_counts(rows: int, tiers: Sequence[Tuple[Sequence[int], Sequence[int]]]) -> List[int]:
     """Head counts consistent with ``rows == heads * per_head_dim``.
 
-    Requiring a *declared* head count times a *declared* per-head dim is what
-    keeps row blocks on real head boundaries. Deriving the count as
-    ``rows // head_dim`` instead splits at arbitrary offsets whenever
-    ``head_dim`` is not the row stride: DeepSeek V3 sets ``config.head_dim`` to
-    the rope part only (16) while a head actually occupies ``qk_head_dim`` (48)
-    rows, so that shortcut would cut every head into three unrelated blocks.
-
-    Returns every match of the last tier tried, so the caller can refuse to
-    guess when a layout stays ambiguous.
+    Both factors must be *declared*, since ``rows // head_dim`` would split at
+    arbitrary offsets whenever ``head_dim`` is not the row stride (DeepSeek V3
+    reports the rope part only). Returns every match of the last tier tried, so
+    the caller can refuse to guess when a layout stays ambiguous.
     """
     matches: List[int] = []
     for counts, strides in tiers:
@@ -520,22 +512,11 @@ def infer_head_block_counts(
 
     A weight is eligible when it lives in a direct child module named in
     ``module_names`` of an attention module that declares both a head count and
-    a per-head dim (``num_heads``/``n_heads``/config equivalents and
-    ``head_dim``/``qk_head_dim``). GQA K/V projections resolve to
-    ``num_key_value_heads`` and MLA up-projections to ``qk_head_dim`` blocks
-    without any per-architecture special casing.
+    a per-head dim. ``head_group_size`` is the number of heads per block.
 
-    ``module_names`` is deliberately required and has no default: which
-    projections are worth splitting depends on the architecture's aspect ratios,
-    and a built-in list would quietly change the update math for every model
-    whose attention happens to use the same names.
-
-    ``head_group_size`` is the number of heads per orthogonalization block: 1 is
-    fully per-head, and values > 1 give the intermediate grouping that tends to
-    beat both extremes. Returns only params that end up with >1 block; anything
-    whose head layout cannot be pinned down, or whose head count is not
-    divisible by ``head_group_size``, is skipped (with a warning) and stays on
-    full-matrix Muon.
+    Returns only params that end up with >1 block; anything whose head layout
+    cannot be pinned down, or whose head count is not divisible by
+    ``head_group_size``, is skipped with a warning and stays on full-matrix Muon.
     """
     if head_group_size < 1:
         return {}
@@ -744,9 +725,9 @@ class DistributedMuon(Optimizer):
             "ns_implementation": ns_implementation,
             "gram_ns_reset_iterations": tuple(int(i) for i in gram_ns_reset_iterations),
         }
-        # Only carried when splitting is actually on: a default would add a
+        # Only carried when splitting is on: as a default it would add a
         # ``param_groups.<fqn>.head_blocks`` entry to every flattened optimizer
-        # state dict and break loading checkpoints written before this option.
+        # state dict, which checkpoints written before this option lack.
         if int(head_blocks) != 1:
             defaults["head_blocks"] = int(head_blocks)
         super().__init__(params, defaults)
@@ -791,9 +772,7 @@ class DistributedMuon(Optimizer):
         not resumable state. Torch restores every param-group option from the
         checkpoint, so without this a DCP resume (which rebuilds groups from the
         live optimizer and then delegates here) would silently drop back to
-        full-matrix updates for a run that turned ``muon_head_group_size`` on.
-        Toggling the option also changes the group count, which plain
-        ``torch.load`` resume rejects outright before reaching this override.
+        full-matrix updates.
         """
         # ``None`` where the group carries no ``head_blocks`` at all, so an unsplit
         # run does not gain the key (and its state dict keys) on resume.
@@ -831,8 +810,8 @@ class DistributedMuon(Optimizer):
             ns_implementation = str(group.get("ns_implementation", "gram_quack"))
             gram_ns_reset_iterations = tuple(group.get("gram_ns_reset_iterations", (2,)))
             head_blocks = int(group.get("head_blocks", 1))
-            # Orthogonalization-scope settings travel with the NS settings so the
-            # all-to-all owner path picks them up from one dict.
+            # Scope settings travel inside ns_kwargs so the all-to-all owner path
+            # reads them from one dict.
             ns_kwargs = {
                 "ns_coefficients": ns_coefficients,
                 "ns_steps": ns_steps,
@@ -946,8 +925,7 @@ class DistributedMuon(Optimizer):
     ) -> None:
         lr_shape = p.shape[-2:] if p.ndim >= 2 else p.shape
         if head_blocks > 1:
-            # The RMS/spectral scaling must follow the matrix NS actually saw, or
-            # a split param silently takes a ``sqrt(head_blocks)``-too-large step.
+            # Scale by the block shape NS actually saw, not the full matrix.
             lr_shape = (lr_shape[0] // head_blocks, lr_shape[1])
         adjusted_lr = _adjust_lr(lr, adjust_lr_fn, lr_shape)
 
@@ -1087,8 +1065,6 @@ class DistributedMuon(Optimizer):
         """Run Newton-Schulz on ``update`` according to its layout kind."""
 
         def _ns(x: Tensor) -> Tensor:
-            # ``head_blocks > 1`` reuses the batched NS path over row blocks, so
-            # each head group gets its own polar factor instead of sharing one.
             batched = _split_row_blocks(x, head_blocks) if head_blocks > 1 else x
             ortho = run_newton_schulz(
                 batched,

--- a/veomni/optim/muon.py
+++ b/veomni/optim/muon.py
@@ -18,6 +18,11 @@
 weights and adds batched Newton-Schulz for 3D MoE expert stacks. Sharded
 params are gathered only when the NS iteration needs the full trailing
 ``[M, K]`` matrix.
+
+The per-group ``head_blocks`` option orthogonalizes a head-stacked attention
+projection in row blocks (one block per head group) instead of as one matrix,
+which is the "Muon Split" recipe from GLM-5. See
+``docs/usage/basic_modules.md`` for when this helps.
 """
 
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
@@ -60,12 +65,14 @@ except ImportError:  # pragma: no cover - torch < 2.9 fallback
 
 
 __all__ = [
+    "DEFAULT_HEAD_SPLIT_MODULES",
     "DEFAULT_NS_COEFFICIENTS",
     "DEFAULT_NS_STEPS",
     "DistributedMuon",
     "batched_gram_newton_schulz",
     "NS_IMPLEMENTATIONS",
     "batched_newton_schulz",
+    "infer_head_block_counts",
     "run_newton_schulz",
     "split_muon_adamw_params",
 ]
@@ -80,6 +87,28 @@ _DEFAULT_ADAMW_NAME_PATTERNS: Tuple[str, ...] = (
     "lm_head",
     "output_layer",
 )
+
+# Leaf module names whose 2D weight stacks one row block per attention head, so
+# splitting rows by head is meaningful. Matched exactly (not as a substring)
+# against children of an attention module, which keeps look-alikes out:
+# ``o_proj`` is head-structured along *columns*, ``q_a_proj`` / ``kv_proj`` are
+# shared across heads, and MLA ``kv_b_proj`` interleaves K and V within each head
+# so uniform row blocks would fuse a head's K with its own V.
+DEFAULT_HEAD_SPLIT_MODULES: Tuple[str, ...] = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "q_b_proj",
+    "k_b_proj",
+    "v_b_proj",
+    "wq_b",  # GLM MoE DSA indexer's query up-projection
+)
+
+# Attribute names carrying a head count and a per-head row stride. Read from the
+# attention module first, then its config: MLA modules keep the true stride as
+# ``qk_head_dim`` while ``config.head_dim`` holds only the rope part.
+_HEAD_COUNT_ATTRS: Tuple[str, ...] = ("num_heads", "n_heads", "num_attention_heads", "num_key_value_heads")
+_HEAD_STRIDE_ATTRS: Tuple[str, ...] = ("head_dim", "qk_head_dim")
 
 
 def _as_coeff_schedule(
@@ -125,6 +154,16 @@ def _flatten_matrix_batch(grad: Tensor) -> Tuple[Tensor, torch.Size]:
     if grad.ndim == 3:
         return grad, original_shape
     return grad.reshape(-1, grad.shape[-2], grad.shape[-1]), original_shape
+
+
+def _split_row_blocks(update: Tensor, blocks: int) -> Tensor:
+    """View a 2D ``[M, K]`` update as ``[blocks, M // blocks, K]`` row blocks."""
+    if update.ndim != 2:
+        raise ValueError(f"Head-group splitting expects a 2D update, got shape {tuple(update.shape)}")
+    rows = int(update.shape[0])
+    if blocks < 1 or rows % blocks != 0:
+        raise ValueError(f"Cannot split {rows} rows into {blocks} equal head blocks")
+    return update.reshape(blocks, rows // blocks, update.shape[1])
 
 
 @torch.no_grad()
@@ -432,6 +471,138 @@ def split_muon_adamw_params(
     return muon_params, adamw_params, muon_names, adamw_names
 
 
+def _positive_int(value: Any) -> Optional[int]:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else None
+
+
+def _declared_ints(source: Any, attrs: Sequence[str]) -> List[int]:
+    """Collect distinct positive ints for ``attrs`` from ``source``."""
+    values: List[int] = []
+    for attr in attrs:
+        value = _positive_int(getattr(source, attr, None))
+        if value is not None and value not in values:
+            values.append(value)
+    return values
+
+
+def _head_layout_tiers(module: "nn.Module") -> List[Tuple[List[int], List[int]]]:
+    """``(head counts, per-head dims)`` to try, module attrs before config attrs.
+
+    The module's own attributes come first because a sub-module can disagree with
+    the shared config: a DSA indexer declares a smaller ``n_heads``/``head_dim``
+    pair while seeing the same config as the main attention, and mixing both
+    sources can make two different head counts fit the same row total.
+    """
+    counts = _declared_ints(module, _HEAD_COUNT_ATTRS)
+    strides = _declared_ints(module, _HEAD_STRIDE_ATTRS)
+    tiers = [(counts, strides)]
+    config = getattr(module, "config", None)
+    if config is not None:
+        tiers.append(
+            (
+                counts + [v for v in _declared_ints(config, _HEAD_COUNT_ATTRS) if v not in counts],
+                strides + [v for v in _declared_ints(config, _HEAD_STRIDE_ATTRS) if v not in strides],
+            )
+        )
+    return tiers
+
+
+def _stacked_head_counts(rows: int, tiers: Sequence[Tuple[Sequence[int], Sequence[int]]]) -> List[int]:
+    """Head counts consistent with ``rows == heads * per_head_dim``.
+
+    Requiring a *declared* head count times a *declared* per-head dim is what
+    keeps row blocks on real head boundaries. Deriving the count as
+    ``rows // head_dim`` instead splits at arbitrary offsets whenever
+    ``head_dim`` is not the row stride: DeepSeek V3 sets ``config.head_dim`` to
+    the rope part only (16) while a head actually occupies ``qk_head_dim`` (48)
+    rows, so that shortcut would cut every head into three unrelated blocks.
+
+    Returns every match of the last tier tried, so the caller can refuse to
+    guess when a layout stays ambiguous.
+    """
+    matches: List[int] = []
+    for counts, strides in tiers:
+        matches = sorted({heads for heads in counts for stride in strides if rows == heads * stride})
+        if len(matches) == 1:
+            break
+    return matches
+
+
+def infer_head_block_counts(
+    model: "nn.Module",
+    head_group_size: int,
+    module_names: Optional[Sequence[str]] = None,
+) -> Dict[str, int]:
+    """Map parameter FQN to the number of row blocks for head-split Muon.
+
+    A weight is eligible when it lives in a direct child module named in
+    ``module_names`` of an attention module that declares both a head count and
+    a per-head dim (``num_heads``/``n_heads``/config equivalents and
+    ``head_dim``/``qk_head_dim``). GQA K/V projections resolve to
+    ``num_key_value_heads`` and MLA up-projections to ``qk_head_dim`` blocks
+    without any per-architecture special casing.
+
+    ``head_group_size`` is the number of heads per orthogonalization block: 1 is
+    fully per-head, and values > 1 give the intermediate grouping that tends to
+    beat both extremes. Returns only params that end up with >1 block; anything
+    whose head layout cannot be pinned down, or whose head count is not
+    divisible by ``head_group_size``, is skipped (with a warning) and stays on
+    full-matrix Muon.
+    """
+    if head_group_size < 1:
+        return {}
+
+    allowed = set(DEFAULT_HEAD_SPLIT_MODULES if module_names is None else module_names)
+    blocks: Dict[str, int] = {}
+    warned: set = set()
+
+    def _warn_once(key: Tuple[Any, ...], message: str) -> None:
+        if key not in warned:
+            warned.add(key)
+            logger.warning_rank0(f"[Muon] {message}")
+
+    for module_name, module in model.named_modules():
+        tiers = _head_layout_tiers(module)
+        head_counts, strides = tiers[-1]
+        for child_name, child in module.named_children():
+            if child_name not in allowed:
+                continue
+            for param_name, param in child.named_parameters(recurse=False):
+                if param.ndim != 2 or not param.requires_grad:
+                    continue
+                fqn = ".".join(part for part in (module_name, child_name, param_name) if part)
+                if not head_counts or not strides:
+                    _warn_once(
+                        (module.__class__.__name__, child_name, "undeclared"),
+                        f"head split skipped for {fqn}: {module.__class__.__name__} declares no head "
+                        "count / per-head dim, so row blocks cannot be validated against head boundaries.",
+                    )
+                    continue
+                rows = int(param.shape[0])
+                matches = _stacked_head_counts(rows, tiers)
+                if len(matches) != 1:
+                    _warn_once(
+                        (child_name, rows, tuple(head_counts), tuple(strides)),
+                        f"head split skipped for {fqn}: {rows} rows do not match exactly one "
+                        f"(head count x per-head dim) product, with head counts {head_counts} and "
+                        f"per-head dims {strides}.",
+                    )
+                    continue
+                num_heads = matches[0]
+                if num_heads % head_group_size != 0:
+                    _warn_once(
+                        (child_name, num_heads, head_group_size, "group"),
+                        f"head split skipped for {fqn}: {num_heads} heads are not divisible by "
+                        f"head_group_size={head_group_size}.",
+                    )
+                    continue
+                num_blocks = num_heads // head_group_size
+                if num_blocks > 1:
+                    blocks[fqn] = num_blocks
+
+    return blocks
+
+
 _KIND_LOCAL = "local"
 _KIND_FSDP_GATHER_2D = "fsdp_gather_2d"
 _KIND_MOE_LOCAL_3D = "moe_local_3d"
@@ -547,6 +718,7 @@ class DistributedMuon(Optimizer):
         adjust_lr_fn: Optional[str] = None,
         ns_implementation: str = "gram_quack",
         gram_ns_reset_iterations: Sequence[int] = (2,),
+        head_blocks: int = 1,
     ) -> None:
         if not _MUON_AVAILABLE:
             raise RuntimeError(
@@ -564,6 +736,8 @@ class DistributedMuon(Optimizer):
             raise ValueError(f"Adjust learning rate function {adjust_lr_fn} is not supported")
         if ns_implementation not in NS_IMPLEMENTATIONS:
             raise ValueError(f"ns_implementation must be one of {NS_IMPLEMENTATIONS}, got {ns_implementation!r}")
+        if int(head_blocks) < 1:
+            raise ValueError(f"head_blocks must be >= 1 but is: {head_blocks}")
 
         defaults: Dict[str, Any] = {
             "lr": lr,
@@ -577,17 +751,73 @@ class DistributedMuon(Optimizer):
             "ns_implementation": ns_implementation,
             "gram_ns_reset_iterations": tuple(int(i) for i in gram_ns_reset_iterations),
         }
+        # Only carried when splitting is actually on: a default would add a
+        # ``param_groups.<fqn>.head_blocks`` entry to every flattened optimizer
+        # state dict and break loading checkpoints written before this option.
+        if int(head_blocks) != 1:
+            defaults["head_blocks"] = int(head_blocks)
         super().__init__(params, defaults)
 
         for group in self.param_groups:
-            for p in group["params"]:
-                if not _is_muon_eligible_ndim(p):
+            self._validate_group(group)
+
+    @staticmethod
+    def _validate_group(group: Dict[str, Any]) -> None:
+        """Reject param layouts Muon cannot orthogonalize, at build time."""
+        head_blocks = int(group.get("head_blocks", 1))
+        if head_blocks < 1:
+            raise ValueError(f"head_blocks must be >= 1 but is: {head_blocks}")
+        for p in group["params"]:
+            if not _is_muon_eligible_ndim(p):
+                raise ValueError(
+                    "DistributedMuon supports only 2D and 3D parameters; "
+                    f"got param with shape {tuple(p.size())}. Route 1D/4D+ "
+                    "params (biases, norms, conv weights) to AdamW via "
+                    "split_muon_adamw_params."
+                )
+            if head_blocks > 1:
+                if p.ndim != 2:
                     raise ValueError(
-                        "DistributedMuon supports only 2D and 3D parameters; "
-                        f"got param with shape {tuple(p.size())}. Route 1D/4D+ "
-                        "params (biases, norms, conv weights) to AdamW via "
-                        "split_muon_adamw_params."
+                        "head_blocks > 1 only applies to 2D head-stacked attention "
+                        f"projections; got a {p.ndim}D param with shape {tuple(p.size())}."
                     )
+                if p.shape[0] % head_blocks != 0:
+                    raise ValueError(
+                        f"head_blocks={head_blocks} does not evenly divide the "
+                        f"{p.shape[0]} rows of a param with shape {tuple(p.size())}."
+                    )
+
+    def add_param_group(self, param_group: Dict[str, Any]) -> None:  # type: ignore[override]
+        super().add_param_group(param_group)
+        self._validate_group(self.param_groups[-1])
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:  # type: ignore[override]
+        """Restore optimizer state while keeping this run's head-split scope.
+
+        ``head_blocks`` describes how a matrix is sliced for orthogonalization,
+        not resumable state. Torch restores every param-group option from the
+        checkpoint, so without this a DCP resume (which rebuilds groups from the
+        live optimizer and then delegates here) would silently drop back to
+        full-matrix updates for a run that turned ``muon_head_group_size`` on.
+        Toggling the option also changes the group count, which plain
+        ``torch.load`` resume rejects outright before reaching this override.
+        """
+        # ``None`` where the group carries no ``head_blocks`` at all, so an unsplit
+        # run does not gain the key (and its state dict keys) on resume.
+        configured = [group.get("head_blocks") for group in self.param_groups]
+        super().load_state_dict(state_dict)
+        restored = [group.get("head_blocks") for group in self.param_groups]
+        for group, blocks in zip(self.param_groups, configured):
+            if blocks is None:
+                group.pop("head_blocks", None)
+            else:
+                group["head_blocks"] = blocks
+        if restored != configured:
+            logger.warning_rank0(
+                f"[Muon] checkpoint head_blocks={[1 if b is None else b for b in restored]} disagrees "
+                f"with the configured {[1 if b is None else b for b in configured]}; "
+                "keeping the configured value."
+            )
 
     @torch.no_grad()
     def step(self, closure=None):  # type: ignore[override]
@@ -607,12 +837,16 @@ class DistributedMuon(Optimizer):
             adjust_lr_fn = group["adjust_lr_fn"]
             ns_implementation = str(group.get("ns_implementation", "gram_quack"))
             gram_ns_reset_iterations = tuple(group.get("gram_ns_reset_iterations", (2,)))
+            head_blocks = int(group.get("head_blocks", 1))
+            # Orthogonalization-scope settings travel with the NS settings so the
+            # all-to-all owner path picks them up from one dict.
             ns_kwargs = {
                 "ns_coefficients": ns_coefficients,
                 "ns_steps": ns_steps,
                 "eps": eps,
                 "ns_implementation": ns_implementation,
                 "gram_ns_reset_iterations": gram_ns_reset_iterations,
+                "head_blocks": head_blocks,
             }
 
             # Keep at most one owner-assignment chunk live per mesh/dtype. This
@@ -664,6 +898,7 @@ class DistributedMuon(Optimizer):
                         lr=lr,
                         weight_decay=weight_decay,
                         adjust_lr_fn=adjust_lr_fn,
+                        head_blocks=head_blocks,
                     )
 
             for (mesh, _local_dtype), entries in a2a_buckets.items():
@@ -701,6 +936,7 @@ class DistributedMuon(Optimizer):
                 lr=lr,
                 weight_decay=weight_decay,
                 adjust_lr_fn=adjust_lr_fn,
+                head_blocks=int(ns_kwargs.get("head_blocks", 1)),
             )
         entries.clear()
 
@@ -713,8 +949,13 @@ class DistributedMuon(Optimizer):
         lr: float,
         weight_decay: float,
         adjust_lr_fn: Optional[str],
+        head_blocks: int = 1,
     ) -> None:
         lr_shape = p.shape[-2:] if p.ndim >= 2 else p.shape
+        if head_blocks > 1:
+            # The RMS/spectral scaling must follow the matrix NS actually saw, or
+            # a split param silently takes a ``sqrt(head_blocks)``-too-large step.
+            lr_shape = (lr_shape[0] // head_blocks, lr_shape[1])
         adjusted_lr = _adjust_lr(lr, adjust_lr_fn, lr_shape)
 
         if weight_decay != 0.0:
@@ -848,18 +1089,23 @@ class DistributedMuon(Optimizer):
         eps: float,
         ns_implementation: str = "gram_quack",
         gram_ns_reset_iterations: Sequence[int] = (2,),
+        head_blocks: int = 1,
     ) -> Tensor:
         """Run Newton-Schulz on ``update`` according to its layout kind."""
 
         def _ns(x: Tensor) -> Tensor:
-            return run_newton_schulz(
-                x,
+            # ``head_blocks > 1`` reuses the batched NS path over row blocks, so
+            # each head group gets its own polar factor instead of sharing one.
+            batched = _split_row_blocks(x, head_blocks) if head_blocks > 1 else x
+            ortho = run_newton_schulz(
+                batched,
                 ns_coefficients=ns_coefficients,
                 ns_steps=ns_steps,
                 eps=eps,
                 ns_implementation=ns_implementation,
                 gram_ns_reset_iterations=gram_ns_reset_iterations,
             )
+            return ortho.reshape(x.shape) if head_blocks > 1 else ortho
 
         if kind == _KIND_LOCAL:
             return _ns(update)

--- a/veomni/optim/muon.py
+++ b/veomni/optim/muon.py
@@ -65,7 +65,6 @@ except ImportError:  # pragma: no cover - torch < 2.9 fallback
 
 
 __all__ = [
-    "DEFAULT_HEAD_SPLIT_MODULES",
     "DEFAULT_NS_COEFFICIENTS",
     "DEFAULT_NS_STEPS",
     "DistributedMuon",
@@ -86,22 +85,6 @@ _DEFAULT_ADAMW_NAME_PATTERNS: Tuple[str, ...] = (
     "embedding",
     "lm_head",
     "output_layer",
-)
-
-# Leaf module names whose 2D weight stacks one row block per attention head, so
-# splitting rows by head is meaningful. Matched exactly (not as a substring)
-# against children of an attention module, which keeps look-alikes out:
-# ``o_proj`` is head-structured along *columns*, ``q_a_proj`` / ``kv_proj`` are
-# shared across heads, and MLA ``kv_b_proj`` interleaves K and V within each head
-# so uniform row blocks would fuse a head's K with its own V.
-DEFAULT_HEAD_SPLIT_MODULES: Tuple[str, ...] = (
-    "q_proj",
-    "k_proj",
-    "v_proj",
-    "q_b_proj",
-    "k_b_proj",
-    "v_b_proj",
-    "wq_b",  # GLM MoE DSA indexer's query up-projection
 )
 
 # Attribute names carrying a head count and a per-head row stride. Read from the
@@ -531,7 +514,7 @@ def _stacked_head_counts(rows: int, tiers: Sequence[Tuple[Sequence[int], Sequenc
 def infer_head_block_counts(
     model: "nn.Module",
     head_group_size: int,
-    module_names: Optional[Sequence[str]] = None,
+    module_names: Sequence[str],
 ) -> Dict[str, int]:
     """Map parameter FQN to the number of row blocks for head-split Muon.
 
@@ -542,6 +525,11 @@ def infer_head_block_counts(
     ``num_key_value_heads`` and MLA up-projections to ``qk_head_dim`` blocks
     without any per-architecture special casing.
 
+    ``module_names`` is deliberately required and has no default: which
+    projections are worth splitting depends on the architecture's aspect ratios,
+    and a built-in list would quietly change the update math for every model
+    whose attention happens to use the same names.
+
     ``head_group_size`` is the number of heads per orthogonalization block: 1 is
     fully per-head, and values > 1 give the intermediate grouping that tends to
     beat both extremes. Returns only params that end up with >1 block; anything
@@ -551,8 +539,13 @@ def infer_head_block_counts(
     """
     if head_group_size < 1:
         return {}
+    if not module_names:
+        raise ValueError(
+            "Head-split Muon needs an explicit list of attention projection module names "
+            "(head_group_size >= 1 with an empty module_names)."
+        )
 
-    allowed = set(DEFAULT_HEAD_SPLIT_MODULES if module_names is None else module_names)
+    allowed = set(module_names)
     blocks: Dict[str, int] = {}
     warned: set = set()
 

--- a/veomni/optim/optimizer.py
+++ b/veomni/optim/optimizer.py
@@ -497,10 +497,9 @@ def _muon_param_groups(
 ) -> Union[List[torch.nn.Parameter], List[Dict[str, Any]]]:
     """Split ``params`` into one Muon param group per head-block count.
 
-    Muon carries the orthogonalization scope as the per-group ``head_blocks``
-    option, so params that disagree must sit in different groups. Groups are
-    emitted in ascending block order so every rank iterates them in the same
-    order — the all-to-all pairing in ``DistributedMuon`` is position-based.
+    Groups are emitted in ascending block order so every rank iterates them in
+    the same order: the all-to-all pairing in ``DistributedMuon`` is
+    position-based.
     """
     if not head_blocks_by_param:
         return list(params)
@@ -508,8 +507,8 @@ def _muon_param_groups(
     by_blocks: Dict[int, List[torch.nn.Parameter]] = {}
     for p in params:
         by_blocks.setdefault(head_blocks_by_param.get(id(p), 1), []).append(p)
-    # The unsplit group stays free of ``head_blocks`` so its flattened DCP state
-    # dict keys match a run with head splitting disabled.
+    # The unsplit group stays free of ``head_blocks`` so its DCP state dict keys
+    # match a run with head splitting disabled.
     return [
         {"params": group_params} if blocks == 1 else {"params": group_params, "head_blocks": blocks}
         for blocks, group_params in sorted(by_blocks.items())
@@ -536,8 +535,6 @@ def _build_muon_with_adamw(
     # Summary-only keys collected by the trainer; not DistributedMuon ctor args.
     expert_zero_comm = bool(muon_kwargs.pop("expert_zero_comm", False))
     adamw_lr = float(muon_kwargs.pop("adamw_lr", lr))
-    # Head-split scope is resolved from the model here, then handed to Muon as
-    # per-param-group ``head_blocks``.
     head_group_size = int(muon_kwargs.pop("head_group_size", 0) or 0)
     head_split_modules = tuple(muon_kwargs.pop("head_split_modules", None) or ())
     if head_group_size < 0:
@@ -547,9 +544,7 @@ def _build_muon_with_adamw(
             f"muon_head_group_size={head_group_size} requires muon_head_split_modules: there is no "
             "default list, because which attention projections benefit from head splitting depends "
             "on the architecture. List the leaf module names to split, e.g. ['q_b_proj'] for "
-            "DeepSeek V4/V3 MLA up-projections or ['q_proj', 'k_proj', 'v_proj'] for GQA attention. "
-            "Note that o_proj is head-structured along columns and MLA kv_b_proj interleaves K and V "
-            "inside each head, so neither splits into head-aligned rows."
+            "DeepSeek V4/V3 MLA up-projections or ['q_proj', 'k_proj', 'v_proj'] for GQA attention."
         )
     muon_lr_explicit = bool(
         muon_kwargs.pop("muon_lr_explicit", "lr" in muon_kwargs and muon_kwargs.get("lr") is not None)
@@ -576,9 +571,7 @@ def _build_muon_with_adamw(
         muon_name_set = set(muon_names)
         param_by_name = dict(model.named_parameters())
         for fqn, blocks in sorted(blocks_by_fqn.items()):
-            if fqn not in muon_name_set:
-                # Routed to AdamW (e.g. via no_decay_modules), so there is no
-                # orthogonalization to scope.
+            if fqn not in muon_name_set:  # routed to AdamW, nothing to scope
                 continue
             head_blocks_by_param[id(param_by_name[fqn])] = blocks
             head_split_names.append(fqn)

--- a/veomni/optim/optimizer.py
+++ b/veomni/optim/optimizer.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -31,7 +31,7 @@ from torch.optim.optimizer import Optimizer
 
 from ..distributed.parallel_state import get_parallel_state
 from ..utils import logging
-from .muon import DistributedMuon, split_muon_adamw_params
+from .muon import DistributedMuon, infer_head_block_counts, split_muon_adamw_params
 
 
 def _collect_ep_replicated_lora_param_ids(model: "nn.Module") -> set[int]:
@@ -491,6 +491,31 @@ def _is_extra_parallel_param(p: torch.nn.Parameter, extra_parallel_names: Sequen
     return None
 
 
+def _muon_param_groups(
+    params: List[torch.nn.Parameter],
+    head_blocks_by_param: Dict[int, int],
+) -> Union[List[torch.nn.Parameter], List[Dict[str, Any]]]:
+    """Split ``params`` into one Muon param group per head-block count.
+
+    Muon carries the orthogonalization scope as the per-group ``head_blocks``
+    option, so params that disagree must sit in different groups. Groups are
+    emitted in ascending block order so every rank iterates them in the same
+    order — the all-to-all pairing in ``DistributedMuon`` is position-based.
+    """
+    if not head_blocks_by_param:
+        return list(params)
+
+    by_blocks: Dict[int, List[torch.nn.Parameter]] = {}
+    for p in params:
+        by_blocks.setdefault(head_blocks_by_param.get(id(p), 1), []).append(p)
+    # The unsplit group stays free of ``head_blocks`` so its flattened DCP state
+    # dict keys match a run with head splitting disabled.
+    return [
+        {"params": group_params} if blocks == 1 else {"params": group_params, "head_blocks": blocks}
+        for blocks, group_params in sorted(by_blocks.items())
+    ]
+
+
 def _build_muon_with_adamw(
     model: "nn.Module",
     lr: float,
@@ -511,6 +536,12 @@ def _build_muon_with_adamw(
     # Summary-only keys collected by the trainer; not DistributedMuon ctor args.
     expert_zero_comm = bool(muon_kwargs.pop("expert_zero_comm", False))
     adamw_lr = float(muon_kwargs.pop("adamw_lr", lr))
+    # Head-split scope is resolved from the model here, then handed to Muon as
+    # per-param-group ``head_blocks``.
+    head_group_size = int(muon_kwargs.pop("head_group_size", 0) or 0)
+    head_split_modules = muon_kwargs.pop("head_split_modules", None) or None
+    if head_group_size < 0:
+        raise ValueError(f"muon_head_group_size must be >= 0 (0 disables head splitting), got {head_group_size}")
     muon_lr_explicit = bool(
         muon_kwargs.pop("muon_lr_explicit", "lr" in muon_kwargs and muon_kwargs.get("lr") is not None)
     )
@@ -528,6 +559,26 @@ def _build_muon_with_adamw(
             "Muon optimizer was selected but the model has no eligible 2D/3D parameters. "
             "Falling back to AdamW would be silent so we raise instead."
         )
+
+    head_blocks_by_param: Dict[int, int] = {}
+    head_split_names: List[str] = []
+    if head_group_size >= 1:
+        blocks_by_fqn = infer_head_block_counts(model, head_group_size, head_split_modules)
+        muon_name_set = set(muon_names)
+        param_by_name = dict(model.named_parameters())
+        for fqn, blocks in sorted(blocks_by_fqn.items()):
+            if fqn not in muon_name_set:
+                # Routed to AdamW (e.g. via no_decay_modules), so there is no
+                # orthogonalization to scope.
+                continue
+            head_blocks_by_param[id(param_by_name[fqn])] = blocks
+            head_split_names.append(fqn)
+        if not head_split_names:
+            logger.warning_rank0(
+                f"[Muon] muon_head_group_size={head_group_size} matched no attention projection; "
+                "every param stays on full-matrix Muon. Check muon_head_split_modules against "
+                "this architecture's attention module names."
+            )
 
     extra_parallel_aware = _should_build_extra_parallel_aware(model)
     parallel_state = get_parallel_state() if extra_parallel_aware else None
@@ -580,6 +631,15 @@ def _build_muon_with_adamw(
         f"expert_zero_comm={expert_zero_comm} "
         "(applied at FSDP parallelize; see [muon_expert_zero_comm] logs)."
     )
+    if head_split_names:
+        blocks_hist: Dict[int, int] = {}
+        for blocks in head_blocks_by_param.values():
+            blocks_hist[blocks] = blocks_hist.get(blocks, 0) + 1
+        logger.info_rank0(
+            f"[Muon] head split: {len(head_split_names)} param(s) orthogonalized in blocks of "
+            f"{head_group_size} head(s); {{blocks: params}}={dict(sorted(blocks_hist.items()))}; "
+            f"first few: {head_split_names[:3]}."
+        )
     if extra_parallel_aware:
         for para in extra_parallel_names:
             logger.info_rank0(
@@ -590,7 +650,7 @@ def _build_muon_with_adamw(
 
     def _make_muon(params: List[torch.nn.Parameter]) -> DistributedMuon:
         return DistributedMuon(
-            params,
+            _muon_param_groups(params, head_blocks_by_param),
             lr=muon_kwargs.get("lr", 2e-2),
             weight_decay=muon_kwargs.get("weight_decay", 0.0),
             momentum=muon_kwargs.get("momentum", 0.95),

--- a/veomni/optim/optimizer.py
+++ b/veomni/optim/optimizer.py
@@ -539,9 +539,18 @@ def _build_muon_with_adamw(
     # Head-split scope is resolved from the model here, then handed to Muon as
     # per-param-group ``head_blocks``.
     head_group_size = int(muon_kwargs.pop("head_group_size", 0) or 0)
-    head_split_modules = muon_kwargs.pop("head_split_modules", None) or None
+    head_split_modules = tuple(muon_kwargs.pop("head_split_modules", None) or ())
     if head_group_size < 0:
         raise ValueError(f"muon_head_group_size must be >= 0 (0 disables head splitting), got {head_group_size}")
+    if head_group_size >= 1 and not head_split_modules:
+        raise ValueError(
+            f"muon_head_group_size={head_group_size} requires muon_head_split_modules: there is no "
+            "default list, because which attention projections benefit from head splitting depends "
+            "on the architecture. List the leaf module names to split, e.g. ['q_b_proj'] for "
+            "DeepSeek V4/V3 MLA up-projections or ['q_proj', 'k_proj', 'v_proj'] for GQA attention. "
+            "Note that o_proj is head-structured along columns and MLA kv_b_proj interleaves K and V "
+            "inside each head, so neither splits into head-aligned rows."
+        )
     muon_lr_explicit = bool(
         muon_kwargs.pop("muon_lr_explicit", "lr" in muon_kwargs and muon_kwargs.get("lr") is not None)
     )
@@ -576,8 +585,8 @@ def _build_muon_with_adamw(
         if not head_split_names:
             logger.warning_rank0(
                 f"[Muon] muon_head_group_size={head_group_size} matched no attention projection; "
-                "every param stays on full-matrix Muon. Check muon_head_split_modules against "
-                "this architecture's attention module names."
+                f"every param stays on full-matrix Muon. Check muon_head_split_modules="
+                f"{list(head_split_modules)} against this architecture's attention module names."
             )
 
     extra_parallel_aware = _should_build_extra_parallel_aware(model)

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -223,6 +223,9 @@ def _collect_muon_kwargs(optimizer_cfg) -> Dict[str, Any]:
         "adjust_lr_fn": optimizer_cfg.muon_adjust_lr_fn,
         "ns_implementation": optimizer_cfg.muon_ns_implementation,
         "gram_ns_reset_iterations": tuple(optimizer_cfg.muon_gram_ns_reset_iterations),
+        # Resolved against the model in _build_muon_with_adamw, not ctor kwargs.
+        "head_group_size": int(optimizer_cfg.muon_head_group_size),
+        "head_split_modules": tuple(optimizer_cfg.muon_head_split_modules),
         # Surface for startup summary only; not a DistributedMuon ctor kwarg.
         "expert_zero_comm": bool(optimizer_cfg.muon_expert_zero_comm),
         "adamw_lr": float(optimizer_cfg.lr),


### PR DESCRIPTION
### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
