### PR TITLE
[ops, dist, perf] fix: remove DeepSeek-V4 SP recompiles and device syncs

### DIFF
--- a/tests/ops/test_deepseek_v4_kernels.py
+++ b/tests/ops/test_deepseek_v4_kernels.py
@@ -256,13 +256,12 @@ def test_tilelang_sparse_attention_backward_shares_kernel_across_kv_lengths(monk
     from veomni.ops.kernels.deepseek_v4 import tilelang_sparse_mla_bwd as sparse_mla_bwd
 
     kv_block = sparse_mla_bwd.KV_BLOCK
-    compiled = []
+    requested_kv_lengths = []
     original_bwd = sparse_mla_bwd.bwd
 
-    def tracking_bwd(*args, **kwargs):
-        kernel = original_bwd(*args, **kwargs)
-        compiled.append(kernel)
-        return kernel
+    def tracking_bwd(B, S, S_kv, *args, **kwargs):
+        requested_kv_lengths.append(S_kv)
+        return original_bwd(B, S, S_kv, *args, **kwargs)
 
     monkeypatch.setattr(sparse_mla_bwd, "bwd", tracking_bwd)
 
@@ -288,7 +287,8 @@ def test_tilelang_sparse_attention_backward_shares_kernel_across_kv_lengths(monk
         for actual_grad, expected_grad in zip((q.grad, kv.grad, sinks.grad), expected_grads, strict=True):
             assert _cosine_similarity(actual_grad, expected_grad) > 0.95
 
-    assert len({id(kernel) for kernel in compiled}) == 1
+    # One specialization key for all three lengths, so TileLang compiles once.
+    assert set(requested_kv_lengths) == {kv_block}
 
 
 def test_deepseek_v4_generated_attention_dispatch_matches_eager():

--- a/tests/ops/test_deepseek_v4_kernels.py
+++ b/tests/ops/test_deepseek_v4_kernels.py
@@ -250,6 +250,47 @@ def test_tilelang_sparse_attention_forward_backward_with_invalid_indices():
         assert _cosine_similarity(actual_grad, expected_grad) > 0.95
 
 
+def test_tilelang_sparse_attention_backward_shares_kernel_across_kv_lengths(monkeypatch):
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4 import sparse_attn_tilelang
+    from veomni.ops.kernels.deepseek_v4 import tilelang_sparse_mla_bwd as sparse_mla_bwd
+
+    kv_block = sparse_mla_bwd.KV_BLOCK
+    compiled = []
+    original_bwd = sparse_mla_bwd.bwd
+
+    def tracking_bwd(*args, **kwargs):
+        kernel = original_bwd(*args, **kwargs)
+        compiled.append(kernel)
+        return kernel
+
+    monkeypatch.setattr(sparse_mla_bwd, "bwd", tracking_bwd)
+
+    batch, seqlen, heads, dim, topk = 1, 32, 8, 512, 64
+    scale = dim**-0.5
+    # All three round up to one KV block, so one compiled kernel must serve them all;
+    # the last one needs no padding at all.
+    for kv_len in (48, 129, kv_block):
+        torch.manual_seed(4)
+        q = torch.randn(batch, seqlen, heads, dim, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+        kv = torch.randn(batch, kv_len, dim, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+        sinks = torch.randn(heads, device=DEVICE, requires_grad=True)
+        indices = torch.randint(kv_len, (batch, seqlen, topk), device=DEVICE, dtype=torch.int32)
+        # Out of range for the real KV but inside the padded KV: must stay masked out.
+        indices[..., -2:] = kv_len
+
+        actual = sparse_attn_tilelang(q, kv, sinks, indices, scale)
+        expected = _sparse_attention_reference(q, kv, sinks, indices, scale)
+        grad = torch.randn_like(actual)
+        expected_grads = torch.autograd.grad((expected * grad.float()).sum(), (q, kv, sinks))
+        actual.backward(grad)
+        assert kv.grad.shape == kv.shape
+        for actual_grad, expected_grad in zip((q.grad, kv.grad, sinks.grad), expected_grads, strict=True):
+            assert _cosine_similarity(actual_grad, expected_grad) > 0.95
+
+    assert len({id(kernel) for kernel in compiled}) == 1
+
+
 def test_deepseek_v4_generated_attention_dispatch_matches_eager():
     _require_tilelang_cuda()
     from veomni.models.transformers.deepseek_v4.generated import patched_modeling_deepseek_v4_gpu as modeling

--- a/tests/parallel/ulysses/test_all_gather.py
+++ b/tests/parallel/ulysses/test_all_gather.py
@@ -16,6 +16,7 @@ from torch.testing._internal.common_utils import run_tests
 
 from veomni.distributed.sequence_parallel.data import gather_outputs, slice_input_tensor
 from veomni.distributed.sequence_parallel.loss import reduce_sequence_parallel_loss
+from veomni.distributed.sequence_parallel.ulysses import _all_gather
 from veomni.utils.helper import enable_high_precision_for_bf16, set_seed
 
 from .utils import (
@@ -60,6 +61,21 @@ class AllToAllCommTest(SequenceParallelTest):
         test_input_final = gather_outputs(test_input, gather_dim=1, group=group)
 
         torch.allclose(input_, test_input_final)
+
+    @pytest.mark.skipif(get_torch_device().device_count() < 2, reason="device_count should be >= 2")
+    def test_all_gather_shapes_stay_on_host(self):
+        group = self._get_process_group()
+        rank = dist.get_rank(group)
+        world_size = dist.get_world_size(group)
+        local = torch.full((rank + 1, 3), float(rank), device=get_device_type())
+
+        tensor_list, size_list = _all_gather(local, group=group)
+
+        # Plain ints, not device tensors: reading a shape back one dimension at a time
+        # syncs the device on every gather, and every layer gathers.
+        assert size_list == [[i + 1, 3] for i in range(world_size)]
+        for i, tensor in enumerate(tensor_list):
+            assert torch.equal(tensor, torch.full_like(tensor, float(i)))
 
     @staticmethod
     def _run_forward(x):

--- a/veomni/distributed/sequence_parallel/ulysses.py
+++ b/veomni/distributed/sequence_parallel/ulysses.py
@@ -35,14 +35,23 @@ def _all_gather(
     x: Tensor,
     group: dist.ProcessGroup,
 ):
-    device = x.device
-    dtype = x.dtype
+    """All-gather ``x`` over ``group``, returning the per-rank tensors and their shapes.
+
+    Shards may have different sizes, so the shapes are exchanged first. They are read
+    back to the host with a single ``tolist()``: materializing them as ``torch.Size``
+    from per-rank device tensors instead costs one device-to-host sync per dimension
+    per rank, and with a gather in every layer that drains the device queue thousands
+    of times per step. Shapes are returned as plain ints for the same reason.
+    """
     group = get_ulysses_sequence_parallel_group() if group is None else group
     sp_world_size = dist.get_world_size(group)
-    x_size = torch.tensor(x.size()).to(device)
-    size_list = [torch.zeros(x_size.size(), dtype=torch.int64, device=device) for i in range(sp_world_size)]
-    dist.all_gather(size_list, x_size, group=group)
-    tensor_list = [torch.zeros(torch.Size(size_list[i]), dtype=dtype, device=device) for i in range(sp_world_size)]
+    ndim = x.dim()
+    x_size = torch.tensor(x.size(), dtype=torch.int64, device=x.device)
+    all_sizes = torch.empty(sp_world_size * ndim, dtype=torch.int64, device=x.device)
+    dist.all_gather_into_tensor(all_sizes, x_size, group=group)
+    flat_sizes = all_sizes.tolist()
+    size_list = [flat_sizes[i * ndim : (i + 1) * ndim] for i in range(sp_world_size)]
+    tensor_list = [torch.empty(size, dtype=x.dtype, device=x.device) for size in size_list]
     dist.all_gather(tensor_list, x, group=group)
     return tensor_list, size_list
 
@@ -201,8 +210,7 @@ class _Gather(torch.autograd.Function):
         seq_world_size = dist.get_world_size(group)
         ctx.seq_world_size = seq_world_size
         output, size_list = _all_gather(local_input.contiguous(), group=ctx.group)
-        dim_size_list = [size_list[i][dim].item() for i in range(seq_world_size)]
-        ctx.dim_size_list = dim_size_list
+        ctx.dim_size_list = [size[dim] for size in size_list]
         return torch.cat(output, dim=dim)
 
     @staticmethod

--- a/veomni/distributed/sequence_parallel/ulysses.py
+++ b/veomni/distributed/sequence_parallel/ulysses.py
@@ -37,11 +37,12 @@ def _all_gather(
 ):
     """All-gather ``x`` over ``group``, returning the per-rank tensors and their shapes.
 
-    Shards may have different sizes, so the shapes are exchanged first. They are read
-    back to the host with a single ``tolist()``: materializing them as ``torch.Size``
-    from per-rank device tensors instead costs one device-to-host sync per dimension
-    per rank, and with a gather in every layer that drains the device queue thousands
-    of times per step. Shapes are returned as plain ints for the same reason.
+    Shards may differ in length, but every rank must pass the same number of
+    dimensions. Shapes are exchanged first and read back to the host with a single
+    ``tolist()``: materializing them as ``torch.Size`` from per-rank device tensors
+    instead costs one device-to-host sync per dimension per rank, and with a gather in
+    every layer that drains the device queue thousands of times per step. Shapes are
+    returned as plain ints for the same reason.
     """
     group = get_ulysses_sequence_parallel_group() if group is None else group
     sp_world_size = dist.get_world_size(group)

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py
@@ -26,6 +26,10 @@ import torch
 from tilelang import language as T
 
 
+# KV length granularity these kernels are specialized on; see sparse_mqa_bwd_interface.
+KV_BLOCK = 1024
+
+
 @tilelang.jit(out_idx=[-1])
 def preprocess(
     B,
@@ -277,7 +281,7 @@ def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale=N
     assert q.is_contiguous() and kv.is_contiguous()
     assert topk_idxs.is_contiguous() and lse.is_contiguous()
     B, S, H, D = q.shape
-    _, S_kv, _ = kv.shape
+    unpadded_S_kv = kv.shape[1]
     topk = topk_idxs.shape[-1]
 
     # Pad topk to next multiple of block_size (kernel requires divisibility)
@@ -297,6 +301,21 @@ def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale=N
         lse = torch.cat([lse, lse.new_zeros(B, S, head_pad)], dim=2).contiguous()
         attn_sink = torch.cat([attn_sink, attn_sink.new_zeros(head_pad)])
 
+    # Pad KV to a whole number of blocks. The compressor makes S_kv drift by a few
+    # tokens per step, and these kernels specialize on it, so the raw length would
+    # recompile them mid-training (seconds of stall per new length). Rounding up
+    # bounds the variant count while keeping S_kv a compile-time constant, which the
+    # indirect KV gather needs for static strides -- feeding the length in as a
+    # runtime value instead costs ~15% on the backward kernel.
+    #
+    # Widening S_kv also widens the kernel's in-range check, so indices at or past
+    # the real length are dropped here to keep them out of the pad rows.
+    kv_pad = -unpadded_S_kv % KV_BLOCK
+    if kv_pad:
+        topk_idxs = torch.where(topk_idxs < unpadded_S_kv, topk_idxs, -1)
+        kv = torch.cat([kv, kv.new_zeros(B, kv_pad, D)], dim=1).contiguous()
+    S_kv = unpadded_S_kv + kv_pad
+
     preprocess_kernel = preprocess(B, S, padded_H, D)
     bwd_kernel = bwd(B, S, S_kv, padded_H, D, topk, sm_scale)
     postprocess_kernel = postprocess(B, S_kv, D)
@@ -306,4 +325,4 @@ def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale=N
     d_attn_sink = torch.zeros_like(attn_sink)
     dq = bwd_kernel(q, kv, do, attn_sink, topk_idxs, lse, delta, dkv, d_attn_sink)
     dkv = postprocess_kernel(dkv)
-    return dq[:, :, :H].contiguous(), dkv, d_attn_sink[:H].contiguous()
+    return dq[:, :, :H].contiguous(), dkv[:, :unpadded_S_kv].contiguous(), d_attn_sink[:H].contiguous()

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py
@@ -310,6 +310,12 @@ def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale=N
     #
     # Widening S_kv also widens the kernel's in-range check, so indices at or past
     # the real length are dropped here to keep them out of the pad rows.
+    #
+    # topk is the other key these kernels specialize on. It stays pinned only while
+    # the compressor emits at least index_topk tokens, since the caller asks for
+    # sliding_window + min(compressed_len, index_topk) candidates. It is left
+    # unrounded on purpose: the main loop iterates over topk, so padding it would buy
+    # fewer recompiles at the price of proportionally more kernel time.
     kv_pad = -unpadded_S_kv % KV_BLOCK
     if kv_pad:
         topk_idxs = torch.where(topk_idxs < unpadded_S_kv, topk_idxs, -1)


### PR DESCRIPTION
### What does this PR do?

Two performance fixes found while profiling a 61-layer DeepSeek-V4 run with Ulysses
sequence parallelism. Neither shows up as kernel time, but together they cost seconds
per step: TileLang JIT recompiles in the sparse MLA backward, and blocking
device-to-host reads in the Ulysses all-gather.

### Checklist Before Starting

- Search for relative PRs/issues and link here: builds on #949 (DeepSeek-V4 Ulysses
  sequence parallel) and #971 (DeepSeek-V4 sparse indexing with SP)
- PR title follows `[{modules}] {type}: {description}` format

### Test

- `tests/ops/test_deepseek_v4_kernels.py::test_tilelang_sparse_attention_backward_shares_kernel_across_kv_lengths`
  — three KV lengths (48, 129, 1024) that all round up to a single block must request
  the same `S_kv` from the kernel builder, so TileLang compiles once. Gradients still
  match the reference at cosine similarity > 0.95, including indices deliberately
  placed at the real KV length to confirm they stay masked out of the pad rows.
- `tests/parallel/ulysses/test_all_gather.py::test_all_gather_shapes_stay_on_host`
  — uneven shards gather correctly and shapes come back as plain ints rather than
  device tensors.
- Backward kernel timing on GB200 at `B=1 S=4096 H=16 D=512 KV=4352 topk=640`:
  6.75 ms padded vs 6.71 ms unpadded. Passing `S_kv` in as a runtime value instead
  (making the indirect gather strides dynamic) costs 7.68 ms, so padding is the
  cheaper way to keep the length a compile-time constant.
- All-gather sync count at `world=2, ndim=3`: 8.0 `aten::item` calls per gather
  before, 0 after. For reference, the profiled 61-layer run measured 12786
  `aten::item` and 13418 `cudaStreamSynchronize` calls per step.

### API and Usage Example

> N/A — no public API or config changes.

### Design & Code Changes

- `veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py`: the backward kernels
  specialize on `S_kv`, and the compressor makes `S_kv` drift by a few tokens per
  step, so TileLang recompiled `sparse_mqa_bwd_kernel` and `postprocess_kernel`
  mid-training (over 10 s of JIT stalls inside a single profiled backward). `S_kv` is
  now rounded up to a 1024-token `KV_BLOCK` so the compile-time constant stops moving
  and the variant count stays bounded. Because the rounded length also widens the
  kernel's in-range index check, `topk_idxs` entries at or past the real KV length are
  invalidated before the call, and `dkv` is sliced back to the unpadded length on
  return. `topk` is left unrounded on purpose: the main loop iterates over it, so
  padding it would trade fewer recompiles for proportionally more kernel time.
- `veomni/distributed/sequence_parallel/ulysses.py`: `_all_gather` exchanged shard
  shapes as device tensors and then built `torch.Size` from them, reading one scalar
  back per dimension per rank; `_Gather.forward` read one more per rank for the split
  sizes. Shapes are now exchanged in a single `all_gather_into_tensor` and read back
  with one `tolist()`, then kept as plain ints so callers do not re-sync. Uneven
  shards still work. Output buffers switch from `zeros` to `empty` since
  `all_gather` overwrites them, and the docstring states the equal-rank precondition.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation — N/A, no API, config, or workflow surface changed
- If `tasks/` training scripts were moved or renamed: N/A
- Added tests to CI workflow — yes, one regression test per fix (listed above)
