### PR TITLE
[data, logging] fix: make packed-token accounting topology invariant

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -173,6 +173,7 @@ jobs:
         # TODO: run all tests under tests/utils/ once all util tests are verified
         run: |
           uv run --frozen pytest -s -x tests/utils/test_count_flops.py
+          uv run --frozen pytest -s -x tests/utils/test_token_accounting.py
       - name: Run Muon optimizer tests
         run: |
           uv run --frozen pytest -s -x tests/optim/test_muon_unit.py

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -190,6 +190,7 @@ jobs:
       - name: Run utils tests
         run: |
           uv run --frozen pytest -v -s -x tests/utils/test_count_flops.py
+          uv run --frozen pytest -v -s -x tests/utils/test_token_accounting.py
       - name: Run LoRA save/load test
         # peft ships under the `npu` extra, so the earlier
         # `uv sync --extra npu --group dev` step already installs it — no extra

--- a/docs/usage/trainer.md
+++ b/docs/usage/trainer.md
@@ -121,7 +121,10 @@ slicing and reduced only across data-parallel ranks:
 
 This distinction is important when a sequence-parallel attention backend uses
 rank-local `cu_seq_lens_q`; kernel-local boundaries are not a valid source-token
-throughput counter.
+throughput counter. When only rank-local `cu_seq_lens_q` is available under
+CP/Ulysses, the legacy FLOPs meter leaves those boundaries unchanged; it does
+not multiply each document by the SP degree. The collator counters above remain
+the authoritative global token totals.
 
 ### Custom Callbacks
 

--- a/docs/usage/trainer.md
+++ b/docs/usage/trainer.md
@@ -108,6 +108,21 @@ VeOmni includes several built-in callbacks:
 - **[HuggingfaceCkptCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/checkpoint_callback.py)**: Saves HuggingFace checkpoints.
 - **[EvaluateCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/evaluate_callback.py)**: Runs evaluation on the validation set.
 
+`EnvironMeterCallback` also reports topology-invariant packed-token metrics
+under `token_accounting/*`. The counters are captured before sequence-parallel
+slicing and reduced only across data-parallel ranks:
+
+- `physical_window_tokens`: padded window capacity.
+- `aligned_compute_tokens`: compute tokens after alignment, excluding known tail padding.
+- `source_input_tokens`: input document tokens before alignment and padding.
+- `loss_tokens`: labels that are not `IGNORE_INDEX`.
+- `source_fill`, `aligned_compute_fill`, and the corresponding
+  `*_tokens_per_second(M)` metrics.
+
+This distinction is important when a sequence-parallel attention backend uses
+rank-local `cu_seq_lens_q`; kernel-local boundaries are not a valid source-token
+throughput counter.
+
 ### Custom Callbacks
 
 You can create custom callbacks by inheriting from [`Callback`](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/base.py) and registering them with `trainer.add_callback`.

--- a/tests/utils/test_token_accounting.py
+++ b/tests/utils/test_token_accounting.py
@@ -88,6 +88,24 @@ def test_observability_validation_is_nonfatal():
     assert metrics == {}
 
 
+def test_collator_accounting_validation_is_nonfatal():
+    import veomni.data.data_collator as data_collator
+
+    batch = {"position_ids": torch.arange(8).unsqueeze(0)}
+    data_collator._finalize_token_accounting(
+        batch,
+        partial={
+            "source_input_tokens": 12,
+            "num_documents": 2,
+            "max_document_length": 7,
+            "sum_document_len_squared": 74,
+        },
+        loss_tokens=10,
+        tail_padding_length=0,
+    )
+
+    assert TOKEN_ACCOUNTING_KEY not in batch
+
 
 def test_metrics_distinguish_capacity_source_and_loss():
     totals = TokenAccounting(16, 12, 12, 10, 2, 7, 74)

--- a/tests/utils/test_token_accounting.py
+++ b/tests/utils/test_token_accounting.py
@@ -1,0 +1,144 @@
+import types
+
+import pytest
+import torch
+
+from veomni.utils.constants import IGNORE_INDEX
+from veomni.utils.token_accounting import (
+    TOKEN_ACCOUNTING_KEY,
+    TokenAccounting,
+    build_token_accounting,
+    metrics_from_totals,
+    pop_token_accounting,
+)
+
+
+def _parallel_state(*, sp_size: int, sp_rank: int = 0):
+    return types.SimpleNamespace(
+        sp_enabled=sp_size > 1,
+        sp_size=sp_size,
+        sp_rank=sp_rank,
+        cp_enabled=False,
+    )
+
+
+def _documents():
+    return [
+        {
+            "input_ids": torch.arange(5),
+            "attention_mask": torch.ones(5, dtype=torch.long),
+            "labels": torch.arange(5),
+        },
+        {
+            "input_ids": torch.arange(7),
+            "attention_mask": torch.ones(7, dtype=torch.long),
+            "labels": torch.arange(7),
+        },
+    ]
+
+
+def _collate(monkeypatch, *, sp_size: int):
+    import veomni.data.data_collator as data_collator
+
+    monkeypatch.setattr(data_collator, "get_parallel_state", lambda: _parallel_state(sp_size=sp_size))
+    batch = data_collator.MainCollator(pad_to_length=16)(_documents())
+    assert TOKEN_ACCOUNTING_KEY in batch
+    return pop_token_accounting(batch)
+
+
+def test_token_accounting_validates_ordering():
+    stats = build_token_accounting(
+        physical_window_tokens=16,
+        aligned_compute_tokens=12,
+        source_input_tokens=12,
+        loss_tokens=10,
+        num_documents=2,
+        max_document_length=7,
+        sum_document_len_squared=74,
+    )
+    assert stats.source_input_tokens == 12
+
+    with pytest.raises(ValueError, match="ordering violated"):
+        build_token_accounting(
+            physical_window_tokens=10,
+            aligned_compute_tokens=12,
+            source_input_tokens=12,
+            loss_tokens=10,
+            num_documents=2,
+            max_document_length=7,
+        )
+
+
+def test_training_step_gate_rejects_schema_only_zero_counters():
+    with pytest.raises(ValueError, match="training-step gate violated"):
+        TokenAccounting(16, 12, 0, 0, 0, 0).validate_training_step()
+
+    TokenAccounting(16, 12, 12, 10, 2, 7, 74).validate_training_step()
+
+
+def test_metrics_distinguish_capacity_source_and_loss():
+    totals = TokenAccounting(16, 12, 12, 10, 2, 7, 74)
+    metrics = metrics_from_totals(totals, delta_time=2.0)
+
+    assert metrics["token_accounting/source_fill"] == pytest.approx(0.75)
+    assert metrics["token_accounting/loss_density"] == pytest.approx(10 / 12)
+    assert metrics["token_accounting/capacity_tokens_per_second(M)"] == pytest.approx(8e-6)
+    assert metrics["token_accounting/source_tokens_per_second(M)"] == pytest.approx(6e-6)
+
+
+def test_collator_accounting_is_sequence_parallel_invariant(monkeypatch):
+    without_sp = _collate(monkeypatch, sp_size=1)
+    with_sp = _collate(monkeypatch, sp_size=2)
+
+    assert without_sp == with_sp
+    assert with_sp.physical_window_tokens == 16
+    assert with_sp.aligned_compute_tokens == 12
+    assert with_sp.source_input_tokens == 12
+    assert with_sp.loss_tokens == 10
+    assert with_sp.num_documents == 2
+    assert with_sp.max_document_length == 7
+    assert with_sp.sum_document_len_squared == 74
+
+
+def test_compute_seqlens_prefers_global_linear_attention_boundaries(monkeypatch):
+    from veomni.utils import helper
+
+    state = types.SimpleNamespace(cp_enabled=True, sp_size=4)
+    monkeypatch.setattr(helper, "get_parallel_state", lambda: state)
+    micro_batch = {
+        "cu_seq_lens_q": torch.tensor([0, 3, 4], dtype=torch.int32),
+        "linear_attn_cu_seq_lens_q": torch.tensor([0, 12, 16], dtype=torch.int32),
+        "tail_padding_length": torch.tensor(1, dtype=torch.int32),
+    }
+
+    assert helper._compute_seqlens(micro_batch) == [12]
+
+
+def test_environ_meter_consumes_accounting_before_model_forward(monkeypatch):
+    from veomni.utils import helper
+
+    meter = object.__new__(helper.EnvironMeter)
+    meter.config = types.SimpleNamespace(condition_model_type=None)
+    meter.enable_multisource = False
+    meter.batch_token_accountings = []
+    meter.batch_accounting_expected = 0
+    meter.batch_accounting_observed = 0
+    meter.batch_seqlens = []
+    meter.images_seqlens = []
+    monkeypatch.setattr(helper, "_compute_seqlens", lambda _: [12])
+    monkeypatch.setattr(helper, "_compute_image_seqlens", lambda _: [])
+
+    batch = {TOKEN_ACCOUNTING_KEY: TokenAccounting(16, 12, 12, 10, 2, 7, 74).to_dict()}
+    meter.add(batch)
+
+    assert TOKEN_ACCOUNTING_KEY not in batch
+    assert meter.batch_accounting_expected == 1
+    assert meter.batch_accounting_observed == 1
+    assert meter.batch_token_accountings == [TokenAccounting(16, 12, 12, 10, 2, 7, 74)]
+
+
+def test_loss_count_excludes_padding_and_pack_boundaries(monkeypatch):
+    accounting = _collate(monkeypatch, sp_size=1)
+    assert accounting.loss_tokens < accounting.source_input_tokens
+    assert accounting.loss_tokens == 10
+    assert IGNORE_INDEX == -100

--- a/tests/utils/test_token_accounting.py
+++ b/tests/utils/test_token_accounting.py
@@ -76,6 +76,19 @@ def test_training_step_gate_rejects_schema_only_zero_counters():
     TokenAccounting(16, 12, 12, 10, 2, 7, 74).validate_training_step()
 
 
+def test_observability_validation_is_nonfatal():
+    from veomni.utils.helper import _safe_token_accounting_metrics
+
+    metrics, valid = _safe_token_accounting_metrics(
+        TokenAccounting(16, 12, 0, 0, 0, 0),
+        delta_time=1.0,
+    )
+
+    assert valid is False
+    assert metrics == {}
+
+
+
 def test_metrics_distinguish_capacity_source_and_loss():
     totals = TokenAccounting(16, 12, 12, 10, 2, 7, 74)
     metrics = metrics_from_totals(totals, delta_time=2.0)
@@ -108,10 +121,25 @@ def test_compute_seqlens_prefers_global_linear_attention_boundaries(monkeypatch)
     micro_batch = {
         "cu_seq_lens_q": torch.tensor([0, 3, 4], dtype=torch.int32),
         "linear_attn_cu_seq_lens_q": torch.tensor([0, 12, 16], dtype=torch.int32),
-        "tail_padding_length": torch.tensor(1, dtype=torch.int32),
+        "tail_padding_length": torch.tensor(4, dtype=torch.int32),
     }
 
     assert helper._compute_seqlens(micro_batch) == [12]
+
+
+def test_compute_seqlens_does_not_scale_rank_local_documents_under_cp(monkeypatch):
+    from veomni.utils import helper
+
+    monkeypatch.setattr(
+        helper,
+        "get_parallel_state",
+        lambda: types.SimpleNamespace(cp_enabled=True, sp_size=4),
+    )
+    micro_batch = {"cu_seq_lens_q": torch.tensor([0, 3, 7], dtype=torch.int32)}
+
+    # CP boundaries are rank-local fragments. Multiplying each fragment would
+    # inflate the quadratic attention term used by the FLOPs estimator.
+    assert helper._compute_seqlens(micro_batch) == [3, 4]
 
 
 def test_environ_meter_consumes_accounting_before_model_forward(monkeypatch):

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -356,15 +356,19 @@ def _finalize_token_accounting(
         aligned = int(batch["linear_attn_cu_seq_lens_q"][-1].item()) - int(tail_padding_length)
     else:
         aligned = physical - int(tail_padding_length)
-    stats = build_token_accounting(
-        physical_window_tokens=physical,
-        aligned_compute_tokens=aligned,
-        source_input_tokens=int(partial["source_input_tokens"]),
-        loss_tokens=loss_tokens,
-        num_documents=int(partial["num_documents"]),
-        max_document_length=int(partial["max_document_length"]),
-        sum_document_len_squared=int(partial["sum_document_len_squared"]),
-    )
+    try:
+        stats = build_token_accounting(
+            physical_window_tokens=physical,
+            aligned_compute_tokens=aligned,
+            source_input_tokens=int(partial["source_input_tokens"]),
+            loss_tokens=loss_tokens,
+            num_documents=int(partial["num_documents"]),
+            max_document_length=int(partial["max_document_length"]),
+            sum_document_len_squared=int(partial["sum_document_len_squared"]),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning_rank0("Skipping invalid token-accounting metadata: %s", exc)
+        return
     attach_token_accounting(batch, stats)
 
 

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -31,6 +31,13 @@ from ..utils.seqlen_pos_transform_utils import (
     prepare_fa_kwargs_from_position_ids,
     valid_seqlens_from_cu_seqlens,
 )
+from ..utils.token_accounting import (
+    attach_token_accounting,
+    build_token_accounting,
+    count_loss_tokens,
+    document_lengths_from_position_ids,
+    summarize_document_lengths,
+)
 
 
 # A model-provided hook that derives ``multimodal_metadata`` from a packed +
@@ -45,6 +52,7 @@ MetadataCollateFunc = Callable[[Dict[str, Any], Dict[str, int]], None]
 logger = logging.get_logger(__name__)
 
 _LINEAR_ATTN_TAIL_PADDING_LENGTH = "_linear_attn_tail_padding_length"
+_TOKEN_ACCOUNTING_PARTIAL = "_token_accounting_partial"
 
 
 def add_flash_attention_kwargs_from_position_ids(
@@ -293,6 +301,13 @@ class PackingCollator(DataCollator):
                 if pack_dim == -1:
                     batch[key] = batch[key].unsqueeze(0)
 
+        if "position_ids" in batch:
+            document_stats = summarize_document_lengths(document_lengths_from_position_ids(batch["position_ids"]))
+        else:
+            sequence_length = int(batch["input_ids"].shape[-1]) if "input_ids" in batch else 0
+            document_stats = summarize_document_lengths([sequence_length] if sequence_length else [])
+        batch[_TOKEN_ACCOUNTING_PARTIAL] = document_stats
+
         linear_attn_tail_padding_length = 0
         if self.pad_to_length:
             input_ids_len_before = batch["input_ids"].shape[-1]
@@ -308,9 +323,47 @@ class PackingCollator(DataCollator):
             # the hook sees the SP-padded batch + per-modality pad counts.
             if self.metadata_collate_func is not None:
                 self.metadata_collate_func(batch, {"pixel_values": 0, "pixel_values_videos": 0})
+            if not self.seq_classification and "labels" in batch:
+                shifted_labels = F.pad(batch["labels"][..., 1:].contiguous(), (0, 1), "constant", IGNORE_INDEX)
+                loss_tokens = count_loss_tokens(shifted_labels)
+            else:
+                loss_tokens = count_loss_tokens(batch["labels"]) if "labels" in batch else 0
+            _finalize_token_accounting(
+                batch,
+                partial=batch.pop(_TOKEN_ACCOUNTING_PARTIAL),
+                loss_tokens=loss_tokens,
+                tail_padding_length=linear_attn_tail_padding_length,
+            )
         elif linear_attn_tail_padding_length:
             batch[_LINEAR_ATTN_TAIL_PADDING_LENGTH] = linear_attn_tail_padding_length
         return batch
+
+
+def _finalize_token_accounting(
+    batch: Dict[str, Any],
+    *,
+    partial: Dict[str, int],
+    loss_tokens: int,
+    tail_padding_length: int,
+) -> None:
+    """Attach global token counters before sequence-parallel slicing."""
+    if "position_ids" not in batch:
+        return
+    physical = int(batch["position_ids"].shape[0] * batch["position_ids"].shape[-1])
+    if "linear_attn_cu_seq_lens_q" in batch:
+        aligned = int(batch["linear_attn_cu_seq_lens_q"][-1].item()) - int(tail_padding_length)
+    else:
+        aligned = physical - int(tail_padding_length)
+    stats = build_token_accounting(
+        physical_window_tokens=physical,
+        aligned_compute_tokens=aligned,
+        source_input_tokens=int(partial["source_input_tokens"]),
+        loss_tokens=loss_tokens,
+        num_documents=int(partial["num_documents"]),
+        max_document_length=int(partial["max_document_length"]),
+        sum_document_len_squared=int(partial["sum_document_len_squared"]),
+    )
+    attach_token_accounting(batch, stats)
 
 
 @dataclass
@@ -369,11 +422,15 @@ class SequenceParallelCollator(DataCollator):
             return torch.cat((feature, pad), dim=dim)
 
     def __call__(self, batch: Dict[str, Union[torch.Tensor, List[torch.Tensor]]]) -> Dict[str, torch.Tensor]:
+        partial_accounting = batch.pop(_TOKEN_ACCOUNTING_PARTIAL)
         if not self.seq_classification:
             # shift labels
             labels = batch["labels"][..., 1:].contiguous()
             labels = F.pad(labels, (0, 1), "constant", IGNORE_INDEX)
             batch["labels"] = labels
+            loss_tokens = count_loss_tokens(labels)
+        else:
+            loss_tokens = count_loss_tokens(batch["labels"]) if "labels" in batch else 0
 
         linear_attn_tail_padding_length = int(batch.pop(_LINEAR_ATTN_TAIL_PADDING_LENGTH, 0))
 
@@ -412,6 +469,12 @@ class SequenceParallelCollator(DataCollator):
                 batch[key] = self.sp_slice(key, batch[key], dim=pack_dim)
 
         add_flash_attention_kwargs_from_position_ids(batch, linear_attn_tail_padding_length)
+        _finalize_token_accounting(
+            batch,
+            partial=partial_accounting,
+            loss_tokens=loss_tokens,
+            tail_padding_length=linear_attn_tail_padding_length,
+        )
 
         batch["position_ids"] = self.sp_slice(
             "position_ids", batch["position_ids"], dim=self.collate_infos["position_ids"].pack_dim

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -328,12 +328,14 @@ class PackingCollator(DataCollator):
                 loss_tokens = count_loss_tokens(shifted_labels)
             else:
                 loss_tokens = count_loss_tokens(batch["labels"]) if "labels" in batch else 0
-            _finalize_token_accounting(
-                batch,
-                partial=batch.pop(_TOKEN_ACCOUNTING_PARTIAL),
-                loss_tokens=loss_tokens,
-                tail_padding_length=linear_attn_tail_padding_length,
-            )
+            partial_accounting = batch.pop(_TOKEN_ACCOUNTING_PARTIAL, None)
+            if partial_accounting is not None:
+                _finalize_token_accounting(
+                    batch,
+                    partial=partial_accounting,
+                    loss_tokens=loss_tokens,
+                    tail_padding_length=linear_attn_tail_padding_length,
+                )
         elif linear_attn_tail_padding_length:
             batch[_LINEAR_ATTN_TAIL_PADDING_LENGTH] = linear_attn_tail_padding_length
         return batch
@@ -422,7 +424,7 @@ class SequenceParallelCollator(DataCollator):
             return torch.cat((feature, pad), dim=dim)
 
     def __call__(self, batch: Dict[str, Union[torch.Tensor, List[torch.Tensor]]]) -> Dict[str, torch.Tensor]:
-        partial_accounting = batch.pop(_TOKEN_ACCOUNTING_PARTIAL)
+        partial_accounting = batch.pop(_TOKEN_ACCOUNTING_PARTIAL, None)
         if not self.seq_classification:
             # shift labels
             labels = batch["labels"][..., 1:].contiguous()
@@ -469,12 +471,13 @@ class SequenceParallelCollator(DataCollator):
                 batch[key] = self.sp_slice(key, batch[key], dim=pack_dim)
 
         add_flash_attention_kwargs_from_position_ids(batch, linear_attn_tail_padding_length)
-        _finalize_token_accounting(
-            batch,
-            partial=partial_accounting,
-            loss_tokens=loss_tokens,
-            tail_padding_length=linear_attn_tail_padding_length,
-        )
+        if partial_accounting is not None:
+            _finalize_token_accounting(
+                batch,
+                partial=partial_accounting,
+                loss_tokens=loss_tokens,
+                tail_padding_length=linear_attn_tail_padding_length,
+            )
 
         batch["position_ids"] = self.sp_slice(
             "position_ids", batch["position_ids"], dim=self.collate_infos["position_ids"].pack_dim

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -95,10 +95,7 @@ def _compute_seqlens(micro_batch: Dict[str, "torch.Tensor"]) -> List[int]:
     if "linear_attn_cu_seq_lens_q" in micro_batch:
         # This metadata remains global when an attention backend replaces
         # cu_seq_lens_q with sequence-parallel local boundaries.
-        parallel_state = get_parallel_state()
         tail_padding_length = int(micro_batch.get("tail_padding_length", 0) or 0)
-        if getattr(parallel_state, "cp_enabled", False):
-            tail_padding_length *= int(parallel_state.sp_size)
         seqlens = valid_seqlens_from_cu_seqlens(
             micro_batch["linear_attn_cu_seq_lens_q"],
             tail_padding_length=tail_padding_length,
@@ -106,15 +103,14 @@ def _compute_seqlens(micro_batch: Dict[str, "torch.Tensor"]) -> List[int]:
         return seqlens.tolist()
 
     if "cu_seq_lens_q" in micro_batch:
-        # packed micro batch
-        parallel_state = get_parallel_state()
+        # Packed micro batch. Under CP/Ulysses this may be rank-local. Do not
+        # multiply each document fragment by sp_size: boundaries need not
+        # align across ranks, and the FLOPs estimator squares these lengths.
         tail_padding_length = micro_batch.get("tail_padding_length")
         seqlens = valid_seqlens_from_cu_seqlens(
             micro_batch["cu_seq_lens_q"],
             tail_padding_length=int(tail_padding_length) if tail_padding_length is not None else None,
         )
-        if getattr(parallel_state, "cp_enabled", False):
-            seqlens = seqlens * int(parallel_state.sp_size)
         return seqlens.tolist()
 
     elif "attention_mask" in micro_batch:
@@ -175,6 +171,23 @@ def _get_multisource_ds_idx(micro_batch: Dict[str, "torch.Tensor"]) -> List[int]
     else:
         # unpacked sample
         return [ds_idx]
+
+
+def _safe_token_accounting_metrics(
+    totals: TokenAccounting,
+    *,
+    delta_time: float,
+) -> tuple[Dict[str, float], bool]:
+    """Validate observability counters without making training fail closed."""
+    try:
+        totals.validate_training_step()
+    except ValueError as exc:
+        logger.warning_rank0(
+            "Token accounting validation failed; keeping the training step alive and suppressing derived metrics: %s",
+            exc,
+        )
+        return {}, False
+    return metrics_from_totals(totals, delta_time=delta_time), True
 
 
 class EnvironMeter:
@@ -264,6 +277,9 @@ class EnvironMeter:
                 if self.enable_multisource:
                     self.batch_ds_idx.extend(_get_multisource_ds_idx(sample))
         else:  # dit diffusers model
+            samples = micro_batch if isinstance(micro_batch, List) else [micro_batch]
+            for sample in samples:
+                pop_token_accounting(sample)
             self.batch_seqlens.extend(_compute_wan_seqlens(micro_batch))
 
     def step(self, delta_time: float, global_step: int) -> Dict[str, Any]:
@@ -361,9 +377,12 @@ class EnvironMeter:
                 max_document_length=int(max_document_length),
                 sum_document_len_squared=int(sum_document_len_squared),
             )
-            totals.validate_training_step()
-            metrics.update(metrics_from_totals(totals, delta_time=delta_time))
-            metrics["token_accounting/collator_accounting_hook"] = 1.0
+            token_metrics, accounting_valid = _safe_token_accounting_metrics(totals, delta_time=delta_time)
+            if accounting_valid:
+                metrics.update(token_metrics)
+                metrics["token_accounting/collator_accounting_hook"] = 1.0
+            else:
+                metrics["token_accounting/collator_accounting_hook"] = 0.0
         else:
             metrics["token_accounting/collator_accounting_hook"] = 0.0
 

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -48,6 +48,12 @@ from .device import (
 from .dist_utils import all_reduce
 from .multisource_utils import parse_multisource_config
 from .seqlen_pos_transform_utils import valid_seqlens_from_cu_seqlens
+from .token_accounting import (
+    TokenAccounting,
+    metrics_from_totals,
+    pop_token_accounting,
+    sum_accountings,
+)
 
 
 try:
@@ -86,14 +92,30 @@ CACHE_DIR = os.path.expanduser(os.getenv("CACHE_DIR", os.path.join("~/.cache", "
 
 
 def _compute_seqlens(micro_batch: Dict[str, "torch.Tensor"]) -> List[int]:
+    if "linear_attn_cu_seq_lens_q" in micro_batch:
+        # This metadata remains global when an attention backend replaces
+        # cu_seq_lens_q with sequence-parallel local boundaries.
+        parallel_state = get_parallel_state()
+        tail_padding_length = int(micro_batch.get("tail_padding_length", 0) or 0)
+        if getattr(parallel_state, "cp_enabled", False):
+            tail_padding_length *= int(parallel_state.sp_size)
+        seqlens = valid_seqlens_from_cu_seqlens(
+            micro_batch["linear_attn_cu_seq_lens_q"],
+            tail_padding_length=tail_padding_length,
+        )
+        return seqlens.tolist()
+
     if "cu_seq_lens_q" in micro_batch:
         # packed micro batch
+        parallel_state = get_parallel_state()
         tail_padding_length = micro_batch.get("tail_padding_length")
         seqlens = valid_seqlens_from_cu_seqlens(
             micro_batch["cu_seq_lens_q"],
             tail_padding_length=int(tail_padding_length) if tail_padding_length is not None else None,
-        ).tolist()
-        return seqlens
+        )
+        if getattr(parallel_state, "cp_enabled", False):
+            seqlens = seqlens * int(parallel_state.sp_size)
+        return seqlens.tolist()
 
     elif "attention_mask" in micro_batch:
         # unpacked sample
@@ -192,6 +214,9 @@ class EnvironMeter:
         self.batch_seqlens = []
         self.batch_ds_idx = []
         self.images_seqlens = []
+        self.batch_token_accountings: List[TokenAccounting] = []
+        self.batch_accounting_expected = 0
+        self.batch_accounting_observed = 0
 
         if self.enable_multisource:
             if dataloader is None or data_path is None:
@@ -227,17 +252,17 @@ class EnvironMeter:
 
     def add(self, micro_batch: Union[Dict[str, "torch.Tensor"], List[Dict[str, "torch.Tensor"]]]) -> None:
         if getattr(self.config, "condition_model_type", None) is None:  # hf model
-            if isinstance(micro_batch, List):
-                for sample in micro_batch:
-                    self.batch_seqlens.extend(_compute_seqlens(sample))
-                    self.images_seqlens.extend(_compute_image_seqlens(sample))
-                    if self.enable_multisource:
-                        self.batch_ds_idx.extend(_get_multisource_ds_idx(sample))
-            else:
-                self.batch_seqlens.extend(_compute_seqlens(micro_batch))
-                self.images_seqlens.extend(_compute_image_seqlens(micro_batch))
+            samples = micro_batch if isinstance(micro_batch, List) else [micro_batch]
+            for sample in samples:
+                self.batch_accounting_expected += 1
+                accounting = pop_token_accounting(sample)
+                if accounting is not None:
+                    self.batch_token_accountings.append(accounting)
+                    self.batch_accounting_observed += 1
+                self.batch_seqlens.extend(_compute_seqlens(sample))
+                self.images_seqlens.extend(_compute_image_seqlens(sample))
                 if self.enable_multisource:
-                    self.batch_ds_idx.extend(_get_multisource_ds_idx(micro_batch))
+                    self.batch_ds_idx.extend(_get_multisource_ds_idx(sample))
         else:  # dit diffusers model
             self.batch_seqlens.extend(_compute_wan_seqlens(micro_batch))
 
@@ -262,6 +287,39 @@ class EnvironMeter:
         tokens_per_second = batch_tokens / delta_time
         self.consume_tokens += batch_tokens
         self.consume_chunks += real_global_batch_size
+
+        local_hook = int(
+            self.batch_accounting_expected > 0 and self.batch_accounting_observed == self.batch_accounting_expected
+        )
+        local_accounting = sum_accountings(self.batch_token_accountings)
+        accounting_values = torch.tensor(
+            (
+                local_accounting.physical_window_tokens,
+                local_accounting.aligned_compute_tokens,
+                local_accounting.source_input_tokens,
+                local_accounting.loss_tokens,
+                local_accounting.num_documents,
+                local_accounting.sum_document_len_squared,
+                local_hook,
+            ),
+            dtype=torch.int64,
+            device=get_device_type(),
+        )
+        (
+            physical_window_tokens,
+            aligned_compute_tokens,
+            source_input_tokens,
+            loss_tokens,
+            num_documents,
+            sum_document_len_squared,
+            hook_ranks,
+        ) = all_reduce(accounting_values, op="sum", group=self.parallel_state.dp_group)
+        max_document_length = all_reduce(
+            torch.tensor(local_accounting.max_document_length, dtype=torch.int64, device=get_device_type()),
+            op="max",
+            group=self.parallel_state.dp_group,
+        )
+        expected_hook_ranks = dist.get_world_size(group=self.parallel_state.dp_group)
 
         # cuda memory
         allocated_memory = get_torch_device().max_memory_allocated()
@@ -290,7 +348,24 @@ class EnvironMeter:
             "cpu_available_memory(GB)": cpu_memory_info.available / (1024**3),
             "cpu_memory_usage(%)": cpu_memory_info.percent,
             "num_alloc_retries": num_alloc_retries,
+            "token_accounting/collator_hook_ranks": float(hook_ranks),
+            "token_accounting/expected_dp_ranks": float(expected_hook_ranks),
         }
+        if int(hook_ranks) == expected_hook_ranks and expected_hook_ranks > 0:
+            totals = TokenAccounting(
+                physical_window_tokens=int(physical_window_tokens),
+                aligned_compute_tokens=int(aligned_compute_tokens),
+                source_input_tokens=int(source_input_tokens),
+                loss_tokens=int(loss_tokens),
+                num_documents=int(num_documents),
+                max_document_length=int(max_document_length),
+                sum_document_len_squared=int(sum_document_len_squared),
+            )
+            totals.validate_training_step()
+            metrics.update(metrics_from_totals(totals, delta_time=delta_time))
+            metrics["token_accounting/collator_accounting_hook"] = 1.0
+        else:
+            metrics["token_accounting/collator_accounting_hook"] = 0.0
 
         if self.enable_multisource:
             metrics.update(self.multisource_tracker.step(self.batch_ds_idx, self.batch_seqlens))
@@ -304,6 +379,9 @@ class EnvironMeter:
         self.batch_seqlens = []
         self.batch_ds_idx = []
         self.images_seqlens = []
+        self.batch_token_accountings = []
+        self.batch_accounting_expected = 0
+        self.batch_accounting_observed = 0
 
         return metrics
 

--- a/veomni/utils/token_accounting.py
+++ b/veomni/utils/token_accounting.py
@@ -1,0 +1,204 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Topology-invariant token accounting for packed training batches.
+
+Kernel sequence metadata may describe only the local sequence-parallel shard.
+Business metrics instead need global counters captured before SP/CP slicing.
+"""
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Union
+
+import torch
+
+from .constants import IGNORE_INDEX
+from .seqlen_pos_transform_utils import prepare_fa_kwargs_from_position_ids
+
+
+TOKEN_ACCOUNTING_KEY = "_token_accounting"
+METRIC_PREFIX = "token_accounting"
+
+
+@dataclass(frozen=True)
+class TokenAccounting:
+    """Global token counters for one pre-shard micro-batch."""
+
+    physical_window_tokens: int
+    aligned_compute_tokens: int
+    source_input_tokens: int
+    loss_tokens: int
+    num_documents: int
+    max_document_length: int
+    sum_document_len_squared: int = 0
+
+    def validate_ordering(self) -> None:
+        if not (
+            0
+            <= self.loss_tokens
+            <= self.source_input_tokens
+            <= self.aligned_compute_tokens
+            <= self.physical_window_tokens
+        ):
+            raise ValueError(
+                "token accounting ordering violated: "
+                f"loss={self.loss_tokens} source={self.source_input_tokens} "
+                f"aligned={self.aligned_compute_tokens} physical={self.physical_window_tokens}"
+            )
+        if self.num_documents < 0:
+            raise ValueError(f"num_documents must be non-negative, got {self.num_documents}")
+
+    def validate_training_step(self) -> None:
+        """Fail closed when a step has schema-only or empty business counters."""
+        self.validate_ordering()
+        if self.loss_tokens <= 0 or self.num_documents <= 0:
+            raise ValueError(
+                "token accounting training-step gate violated: "
+                f"loss={self.loss_tokens} source={self.source_input_tokens} "
+                f"aligned={self.aligned_compute_tokens} physical={self.physical_window_tokens} "
+                f"num_documents={self.num_documents}"
+            )
+
+    def to_dict(self) -> Dict[str, int]:
+        return {key: int(value) for key, value in asdict(self).items()}
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "TokenAccounting":
+        return cls(
+            physical_window_tokens=int(data["physical_window_tokens"]),
+            aligned_compute_tokens=int(data["aligned_compute_tokens"]),
+            source_input_tokens=int(data["source_input_tokens"]),
+            loss_tokens=int(data["loss_tokens"]),
+            num_documents=int(data["num_documents"]),
+            max_document_length=int(data["max_document_length"]),
+            sum_document_len_squared=int(data.get("sum_document_len_squared", 0)),
+        )
+
+
+def document_lengths_from_position_ids(position_ids: torch.Tensor) -> List[int]:
+    """Return packed document lengths from global, pre-shard position IDs."""
+    if position_ids.dim() == 3:
+        position_ids = position_ids[:, 0, :]
+    (cu_seq_lens, _), _ = prepare_fa_kwargs_from_position_ids(position_ids)
+    return [int(length) for length in (cu_seq_lens[1:] - cu_seq_lens[:-1]).tolist()]
+
+
+def summarize_document_lengths(lengths: Sequence[int]) -> Dict[str, int]:
+    lengths = [int(length) for length in lengths]
+    return {
+        "source_input_tokens": int(sum(lengths)),
+        "num_documents": len(lengths),
+        "max_document_length": int(max(lengths, default=0)),
+        "sum_document_len_squared": int(sum(length * length for length in lengths)),
+    }
+
+
+def count_loss_tokens(labels: torch.Tensor) -> int:
+    """Count labels that participate in the loss denominator."""
+    return int((labels != IGNORE_INDEX).sum().item())
+
+
+def build_token_accounting(
+    *,
+    physical_window_tokens: int,
+    aligned_compute_tokens: int,
+    source_input_tokens: int,
+    loss_tokens: int,
+    num_documents: int,
+    max_document_length: int,
+    sum_document_len_squared: int = 0,
+) -> TokenAccounting:
+    stats = TokenAccounting(
+        physical_window_tokens=int(physical_window_tokens),
+        aligned_compute_tokens=int(aligned_compute_tokens),
+        source_input_tokens=int(source_input_tokens),
+        loss_tokens=int(loss_tokens),
+        num_documents=int(num_documents),
+        max_document_length=int(max_document_length),
+        sum_document_len_squared=int(sum_document_len_squared),
+    )
+    stats.validate_ordering()
+    return stats
+
+
+def attach_token_accounting(
+    batch: MutableMapping[str, Any],
+    stats: Union[TokenAccounting, Mapping[str, Any]],
+) -> None:
+    batch[TOKEN_ACCOUNTING_KEY] = (
+        stats.to_dict() if isinstance(stats, TokenAccounting) else {key: int(value) for key, value in stats.items()}
+    )
+
+
+def pop_token_accounting(batch: MutableMapping[str, Any]) -> Optional[TokenAccounting]:
+    raw = batch.pop(TOKEN_ACCOUNTING_KEY, None)
+    if raw is None:
+        return None
+    return raw if isinstance(raw, TokenAccounting) else TokenAccounting.from_mapping(raw)
+
+
+def sum_accountings(items: Iterable[TokenAccounting]) -> TokenAccounting:
+    physical = aligned = source = loss = documents = max_document = sum_squared = 0
+    for item in items:
+        physical += item.physical_window_tokens
+        aligned += item.aligned_compute_tokens
+        source += item.source_input_tokens
+        loss += item.loss_tokens
+        documents += item.num_documents
+        max_document = max(max_document, item.max_document_length)
+        sum_squared += item.sum_document_len_squared
+    return TokenAccounting(
+        physical_window_tokens=physical,
+        aligned_compute_tokens=aligned,
+        source_input_tokens=source,
+        loss_tokens=loss,
+        num_documents=documents,
+        max_document_length=max_document,
+        sum_document_len_squared=sum_squared,
+    )
+
+
+def metrics_from_totals(
+    totals: TokenAccounting,
+    *,
+    delta_time: float,
+    prefix: str = METRIC_PREFIX,
+) -> Dict[str, float]:
+    """Build W&B metrics from DP-reduced token totals for one step."""
+    physical = float(totals.physical_window_tokens)
+    aligned = float(totals.aligned_compute_tokens)
+    source = float(totals.source_input_tokens)
+    loss = float(totals.loss_tokens)
+    seconds = float(delta_time)
+
+    def tokens_per_second(tokens: float) -> float:
+        return tokens / seconds / 1e6 if seconds > 0 else 0.0
+
+    return {
+        f"{prefix}/physical_window_tokens": physical,
+        f"{prefix}/aligned_compute_tokens": aligned,
+        f"{prefix}/source_input_tokens": source,
+        f"{prefix}/loss_tokens": loss,
+        f"{prefix}/num_documents": float(totals.num_documents),
+        f"{prefix}/max_document_length": float(totals.max_document_length),
+        f"{prefix}/sum_document_len_squared": float(totals.sum_document_len_squared),
+        f"{prefix}/source_fill": source / physical if physical else 0.0,
+        f"{prefix}/aligned_compute_fill": aligned / physical if physical else 0.0,
+        f"{prefix}/loss_density": loss / source if source else 0.0,
+        f"{prefix}/loss_fill": loss / physical if physical else 0.0,
+        f"{prefix}/capacity_tokens_per_second(M)": tokens_per_second(physical),
+        f"{prefix}/aligned_compute_tokens_per_second(M)": tokens_per_second(aligned),
+        f"{prefix}/source_tokens_per_second(M)": tokens_per_second(source),
+        f"{prefix}/loss_tokens_per_second(M)": tokens_per_second(loss),
+    }


### PR DESCRIPTION
### What does this PR do?

Adds topology-invariant packed-token accounting to `EnvironMeterCallback`.
Business token counters are captured in the collator before Ulysses/CP slicing,
then reduced only over the data-parallel group. This prevents rank-local
`cu_seq_lens_q` from shrinking W&B throughput and fill metrics by the sequence
parallel factor.

Related work: #969 introduces a context-parallel backend whose kernel-local
sequence boundaries motivated this fix.

### Checklist Before Starting

- Searched related PRs/issues; linked #969 above.
- PR title follows `[{modules}] {type}: {description}`.

### Test

- `17 passed`: `tests/utils/test_token_accounting.py`,
  `tests/data/test_collators.py`, and
  `tests/data/test_dpo_data_processor.py`.
- `ruff check tasks tests veomni docs`
- `ruff format --check tasks tests veomni docs` (618 files)
- Live 32-device validation with SP=8/32:

| topology | source fill | capacity tok/s | source tok/s |
| --- | ---: | ---: | ---: |
| 128K, SP8, MBS1 | 97.92% | 30.97K | 30.32K |
| 128K, SP8, MBS2 | 98.51% | 32.22K | 31.74K |
| 512K, SP32, MBS1 | 99.03% | 22.66K | 22.44K |

All live steps satisfied `0 < loss <= source <= aligned <= physical`,
`num_documents > 0`, and full DP-rank hook coverage.

### API and Usage Example

No configuration change is required. `EnvironMeterCallback` now emits:

- `token_accounting/physical_window_tokens`
- `token_accounting/aligned_compute_tokens`
- `token_accounting/source_input_tokens`
- `token_accounting/loss_tokens`
- `token_accounting/source_fill`
- `token_accounting/aligned_compute_fill`
- capacity/aligned/source/loss `*_tokens_per_second(M)`
- document statistics and DP hook-readiness fields

### Design & Code Changes

- Capture document, source, loss, aligned-compute, and physical-window counters
  before sequence-parallel slicing.
- Remove the private accounting payload in `EnvironMeter.add()` before model
  forward.
- Sum counters with int64 collectives over `dp_group`; require every DP rank and
  every local micro-batch to carry the accounting payload.
- Fail closed for schema-only/zero business counters.
- Prefer global `linear_attn_cu_seq_lens_q` for legacy sequence/FLOPs metrics,
  with a CP-aware fallback for local `cu_seq_lens_q`.
- Document the distinction between capacity, aligned-compute, source, and loss
  token throughput.

This PR does not implement state-only GDN context parallelism and does not
change the replicated-GDN FLOPs/MFU estimator.

### Checklist Before Submitting

- Read the Contribute Guide.
- Applied formatting and lint checks.
- Added documentation.
- Added focused unit and collator regression tests.

