### PR TITLE
[logging, lora] feat: Extend count_flops to allow Lora config for Qwen 2/3/3.5 models

### DIFF
--- a/docs/key_features/lora.md
+++ b/docs/key_features/lora.md
@@ -137,6 +137,46 @@ else:
     self.hf_ckpt_callback = HuggingfaceCkptCallback(self)
 ```
 
+### 2.1 LoRA MFU and FLOPs accounting
+
+`EnvironMeterCallback` passes the effective `VeOmniLoraConfig` from the wrapped model to
+`VeomniFlopsCounter`, so the reported FLOPs and MFU reflect the work performed by LoRA
+training instead of using the full-fine-tuning estimate. Full-fine-tuning accounting is
+unchanged when no LoRA config is present.
+
+LoRA FLOPs estimation currently supports only the Qwen-family model types registered in
+`LORA_MODULES_BY_MODEL_TYPE`. An unsupported model or LoRA target emits a warning and
+reports zero achieved FLOPs and zero MFU rather than interrupting training or reporting a
+misleading value. `scripts/profile/compare_lora_flops.py` exercises this path against real
+Hugging Face Qwen configs and compares full fine-tuning with several LoRA target sets and
+ranks.
+
+> `VLMTrainer` does not currently initialize LoRA. The vision accounting described below
+> is included for a future VLM LoRA capability and is not an indication that VLM LoRA
+> training is available today.
+
+For Qwen VLM configurations, vision-tower accounting uses the vision-token sequence lengths
+collected from the current batch and follows this logic:
+
+1. If the batch has no vision tokens, ViT FLOPs are zero.
+2. If the batch has vision tokens but none of `target_modules` matches a supported ViT
+   module, the ViT is treated as frozen and only its forward-pass FLOPs are counted.
+3. If at least one target matches a supported ViT module, the ViT is treated as participating
+   in LoRA training: base forward/input-gradient work and the matched LoRA forward/backward
+   work are counted.
+
+The native LoRA implementation currently adapts two kinds of weights:
+
+- `nn.Linear` modules selected through `target_modules`.
+- Fused routed-MoE expert weights, represented as 3-D `nn.Parameter`s and selected through
+  `target_parameters`.
+
+The MoE experts are not `nn.Embedding` layers. The FLOPs estimator counts adapter work for
+both supported categories above. Within the ViT, only matched linear layers receive LoRA
+FLOPs; non-linear projections such as Qwen's `Conv3d` patch embedding do not. If native LoRA
+later supports another module type such as `Conv3d`, `VeomniFlopsCounter` and its module-shape
+tables must be updated at the same time or MFU will be underestimated.
+
 ---
 
 ## 3. Weight Loading with LoRA

--- a/scripts/profile/compare_lora_flops.py
+++ b/scripts/profile/compare_lora_flops.py
@@ -16,7 +16,12 @@ from unittest.mock import patch
 
 from transformers import AutoConfig
 
-from veomni.lora.config import FUSED_MOE_LORA_MODULES, LORA_MODULES_BY_MODEL_TYPE, VeOmniLoraConfig
+from veomni.lora.config import (
+    FUSED_MOE_LORA_MODULES,
+    LORA_MODULES_BY_MODEL_TYPE,
+    VIT_LORA_MODULES_BY_MODEL_TYPE,
+    VeOmniLoraConfig,
+)
 from veomni.utils.count_flops import VeomniFlopsCounter
 
 
@@ -46,8 +51,11 @@ ROUTED_EXPERT_TARGETS = ["*.mlp.experts.gate_up_proj", "*.mlp.experts.down_proj"
 
 def get_lora_configs(model_type: str, rank: int) -> dict[str, VeOmniLoraConfig]:
     supported_modules = LORA_MODULES_BY_MODEL_TYPE[model_type]
+    vision_modules = VIT_LORA_MODULES_BY_MODEL_TYPE.get(model_type, ())
     mlp_modules = [module for module in supported_modules if module in FUSED_MOE_LORA_MODULES]
-    attention_modules = [module for module in supported_modules if module not in FUSED_MOE_LORA_MODULES]
+    attention_modules = [
+        module for module in supported_modules if module not in FUSED_MOE_LORA_MODULES and module not in vision_modules
+    ]
     target_parameters = ROUTED_EXPERT_TARGETS if model_type in ROUTED_MOE_TYPES else None
     shared_mlp_modules = mlp_modules if model_type in SHARED_EXPERT_TYPES or target_parameters is None else None
 
@@ -60,11 +68,17 @@ def get_lora_configs(model_type: str, rank: int) -> dict[str, VeOmniLoraConfig]:
             moe_mode="independent" if routed_targets else None,
         )
 
-    return {
-        "LoRA all": make_config([*attention_modules, *(shared_mlp_modules or [])], target_parameters),
+    configs = {
+        "LoRA all": make_config(
+            list(dict.fromkeys([*attention_modules, *(shared_mlp_modules or []), *vision_modules])),
+            target_parameters,
+        ),
         "LoRA attention": make_config(attention_modules),
         "LoRA MLP": make_config(shared_mlp_modules, target_parameters),
     }
+    if vision_modules:
+        configs["LoRA vision"] = make_config(list(vision_modules))
+    return configs
 
 
 def compare_model(model_name: str, model_id: str, model_type: str, architecture: str) -> None:

--- a/scripts/profile/compare_lora_flops.py
+++ b/scripts/profile/compare_lora_flops.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from transformers import AutoConfig
+
+from veomni.lora.config import FUSED_MOE_LORA_MODULES, LORA_MODULES_BY_MODEL_TYPE
+from veomni.utils.count_flops import VeomniFlopsCounter
+
+
+BATCH_SEQLENS = [2048, 2048, 2048, 2048]
+IMAGES_SEQLENS = [256, 256, 256, 256]
+DELTA_TIME = 1.0
+LORA_RANKS = [8, 64, 256, 1024, 4096]
+
+MODELS = [
+    ("Qwen2 0.5B", "Qwen/Qwen2-0.5B", "qwen2", "dense GQA"),
+    ("Qwen2 72B", "Qwen/Qwen2-72B", "qwen2", "dense GQA"),
+    ("Qwen3 0.6B", "Qwen/Qwen3-0.6B", "qwen3", "dense GQA + QK norm"),
+    ("Qwen3 32B", "Qwen/Qwen3-32B", "qwen3", "dense GQA + QK norm"),
+    ("Qwen3 30B-A3B", "Qwen/Qwen3-30B-A3B", "qwen3_moe", "MoE; 3B active"),
+    ("Qwen2.5-VL 3B", "Qwen/Qwen2.5-VL-3B-Instruct", "qwen2_5_vl", "dense VLM"),
+    ("Qwen3-VL 2B", "Qwen/Qwen3-VL-2B-Instruct", "qwen3_vl", "dense VLM"),
+    ("Qwen3.5 9B", "Qwen/Qwen3.5-9B", "qwen3_5", "hybrid dense VLM"),
+    ("Qwen3.5 27B", "Qwen/Qwen3.5-27B", "qwen3_5", "hybrid dense VLM"),
+    ("Qwen3.5 35B-A3B", "Qwen/Qwen3.5-35B-A3B", "qwen3_5_moe", "hybrid MoE VLM; 3B active"),
+]
+
+
+def get_module_groups(model_type: str) -> dict[str, list[str]]:
+    supported_modules = LORA_MODULES_BY_MODEL_TYPE[model_type]
+    mlp_modules = [module for module in supported_modules if module in FUSED_MOE_LORA_MODULES]
+    attention_modules = [module for module in supported_modules if module not in FUSED_MOE_LORA_MODULES]
+    return {
+        "LoRA all": list(supported_modules),
+        "LoRA attention": attention_modules,
+        "LoRA MLP": mlp_modules,
+    }
+
+
+def compare_model(model_name: str, model_id: str, model_type: str, architecture: str) -> None:
+    # AutoConfig downloads only the small config metadata, never model weights.
+    counter = VeomniFlopsCounter(AutoConfig.from_pretrained(model_id))
+    input_kwargs = {"images_seqlens": IMAGES_SEQLENS} if getattr(counter.config, "vision_config", None) else {}
+    module_groups = get_module_groups(model_type)
+
+    full_flops, _ = counter.estimate_flops(BATCH_SEQLENS, DELTA_TIME, **input_kwargs)
+
+    print(f"\n{model_name} ({model_id}; {architecture})")
+    print("=" * 78)
+    print(f"{'Mode':<24} {'Rank':>6} {'TFLOPs/step':>16} {'vs full':>12}")
+    print("-" * 78)
+    print(f"{'Full fine-tuning':<24} {'-':>6} {full_flops:>16.6f} {100:>11.2f}%")
+
+    for rank in LORA_RANKS:
+        for label, modules in module_groups.items():
+            flops, _ = counter.estimate_flops(
+                BATCH_SEQLENS,
+                DELTA_TIME,
+                lora_rank=rank,
+                lora_modules=modules,
+                **input_kwargs,
+            )
+            print(f"{label:<24} {rank:>6} {flops:>16.6f} {flops / full_flops * 100:>11.2f}%")
+
+
+def main() -> None:
+    # Only achieved FLOPs are compared, so no physical accelerator is required.
+    with patch("veomni.utils.count_flops.get_device_flops", return_value=1.0):
+        for model in MODELS:
+            compare_model(*model)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile/compare_lora_flops.py
+++ b/scripts/profile/compare_lora_flops.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from unittest.mock import patch
-
-from transformers import AutoConfig
 
 from veomni.lora.config import (
     FUSED_MOE_LORA_MODULES,
@@ -22,6 +21,7 @@ from veomni.lora.config import (
     VIT_LORA_MODULES_BY_MODEL_TYPE,
     VeOmniLoraConfig,
 )
+from veomni.models.auto import build_config
 from veomni.utils.count_flops import VeomniFlopsCounter
 
 
@@ -47,6 +47,15 @@ MODELS = [
 ROUTED_MOE_TYPES = {"qwen3_moe", "qwen3_vl_moe", "qwen3_next", "qwen3_5_moe", "qwen3_5_moe_text"}
 SHARED_EXPERT_TYPES = {"qwen3_next", "qwen3_5_moe", "qwen3_5_moe_text"}
 ROUTED_EXPERT_TARGETS = ["*.mlp.experts.gate_up_proj", "*.mlp.experts.down_proj"]
+
+
+def require_positive_finite_flops(value: float, *, model_name: str, mode: str, rank: int | None = None) -> None:
+    if not math.isfinite(value) or value <= 0:
+        rank_context = "" if rank is None else f", rank={rank}"
+        raise RuntimeError(
+            f"Invalid FLOPs for {model_name}: mode={mode}{rank_context}, value={value!r}. "
+            "The model config or LoRA targets are not supported by the FLOP estimator."
+        )
 
 
 def get_lora_configs(model_type: str, rank: int) -> dict[str, VeOmniLoraConfig]:
@@ -82,10 +91,19 @@ def get_lora_configs(model_type: str, rank: int) -> dict[str, VeOmniLoraConfig]:
 
 
 def compare_model(model_name: str, model_id: str, model_type: str, architecture: str) -> None:
-    # AutoConfig downloads only the small config metadata, never model weights.
-    counter = VeomniFlopsCounter(AutoConfig.from_pretrained(model_id))
+    # Exercise VeOmni's production config registry/replacement path while still
+    # downloading only the small config metadata, never model weights.
+    config = build_config(model_id)
+    if config.model_type != model_type:
+        raise RuntimeError(
+            f"Unexpected model type for {model_name} ({model_id}): "
+            f"loaded {config.model_type!r}, expected {model_type!r}."
+        )
+
+    counter = VeomniFlopsCounter(config)
     input_kwargs = {"images_seqlens": IMAGES_SEQLENS} if getattr(counter.config, "vision_config", None) else {}
     full_flops, _ = counter.estimate_flops(BATCH_SEQLENS, DELTA_TIME, **input_kwargs)
+    require_positive_finite_flops(full_flops, model_name=model_name, mode="Full fine-tuning")
 
     print(f"\n{model_name} ({model_id}; {architecture})")
     print("=" * 78)
@@ -101,6 +119,7 @@ def compare_model(model_name: str, model_id: str, model_type: str, architecture:
                 lora_config=lora_config,
                 **input_kwargs,
             )
+            require_positive_finite_flops(flops, model_name=model_name, mode=label, rank=rank)
             print(f"{label:<24} {rank:>6} {flops:>16.6f} {flops / full_flops * 100:>11.2f}%")
 
 

--- a/scripts/profile/compare_lora_flops.py
+++ b/scripts/profile/compare_lora_flops.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 
 from transformers import AutoConfig
 
-from veomni.lora.config import FUSED_MOE_LORA_MODULES, LORA_MODULES_BY_MODEL_TYPE
+from veomni.lora.config import FUSED_MOE_LORA_MODULES, LORA_MODULES_BY_MODEL_TYPE, VeOmniLoraConfig
 from veomni.utils.count_flops import VeomniFlopsCounter
 
 
@@ -31,6 +31,7 @@ MODELS = [
     ("Qwen3 0.6B", "Qwen/Qwen3-0.6B", "qwen3", "dense GQA + QK norm"),
     ("Qwen3 32B", "Qwen/Qwen3-32B", "qwen3", "dense GQA + QK norm"),
     ("Qwen3 30B-A3B", "Qwen/Qwen3-30B-A3B", "qwen3_moe", "MoE; 3B active"),
+    ("Qwen3-Next 80B-A3B", "Qwen/Qwen3-Next-80B-A3B-Instruct", "qwen3_next", "hybrid MoE; 3B active"),
     ("Qwen2.5-VL 3B", "Qwen/Qwen2.5-VL-3B-Instruct", "qwen2_5_vl", "dense VLM"),
     ("Qwen3-VL 2B", "Qwen/Qwen3-VL-2B-Instruct", "qwen3_vl", "dense VLM"),
     ("Qwen3.5 9B", "Qwen/Qwen3.5-9B", "qwen3_5", "hybrid dense VLM"),
@@ -38,15 +39,31 @@ MODELS = [
     ("Qwen3.5 35B-A3B", "Qwen/Qwen3.5-35B-A3B", "qwen3_5_moe", "hybrid MoE VLM; 3B active"),
 ]
 
+ROUTED_MOE_TYPES = {"qwen3_moe", "qwen3_vl_moe", "qwen3_next", "qwen3_5_moe", "qwen3_5_moe_text"}
+SHARED_EXPERT_TYPES = {"qwen3_next", "qwen3_5_moe", "qwen3_5_moe_text"}
+ROUTED_EXPERT_TARGETS = ["*.mlp.experts.gate_up_proj", "*.mlp.experts.down_proj"]
 
-def get_module_groups(model_type: str) -> dict[str, list[str]]:
+
+def get_lora_configs(model_type: str, rank: int) -> dict[str, VeOmniLoraConfig]:
     supported_modules = LORA_MODULES_BY_MODEL_TYPE[model_type]
     mlp_modules = [module for module in supported_modules if module in FUSED_MOE_LORA_MODULES]
     attention_modules = [module for module in supported_modules if module not in FUSED_MOE_LORA_MODULES]
+    target_parameters = ROUTED_EXPERT_TARGETS if model_type in ROUTED_MOE_TYPES else None
+    shared_mlp_modules = mlp_modules if model_type in SHARED_EXPERT_TYPES or target_parameters is None else None
+
+    def make_config(target_modules, routed_targets=None):
+        return VeOmniLoraConfig(
+            r=rank,
+            lora_alpha=rank,
+            target_modules=target_modules,
+            target_parameters=routed_targets,
+            moe_mode="independent" if routed_targets else None,
+        )
+
     return {
-        "LoRA all": list(supported_modules),
-        "LoRA attention": attention_modules,
-        "LoRA MLP": mlp_modules,
+        "LoRA all": make_config([*attention_modules, *(shared_mlp_modules or [])], target_parameters),
+        "LoRA attention": make_config(attention_modules),
+        "LoRA MLP": make_config(shared_mlp_modules, target_parameters),
     }
 
 
@@ -54,8 +71,6 @@ def compare_model(model_name: str, model_id: str, model_type: str, architecture:
     # AutoConfig downloads only the small config metadata, never model weights.
     counter = VeomniFlopsCounter(AutoConfig.from_pretrained(model_id))
     input_kwargs = {"images_seqlens": IMAGES_SEQLENS} if getattr(counter.config, "vision_config", None) else {}
-    module_groups = get_module_groups(model_type)
-
     full_flops, _ = counter.estimate_flops(BATCH_SEQLENS, DELTA_TIME, **input_kwargs)
 
     print(f"\n{model_name} ({model_id}; {architecture})")
@@ -65,12 +80,11 @@ def compare_model(model_name: str, model_id: str, model_type: str, architecture:
     print(f"{'Full fine-tuning':<24} {'-':>6} {full_flops:>16.6f} {100:>11.2f}%")
 
     for rank in LORA_RANKS:
-        for label, modules in module_groups.items():
+        for label, lora_config in get_lora_configs(model_type, rank).items():
             flops, _ = counter.estimate_flops(
                 BATCH_SEQLENS,
                 DELTA_TIME,
-                lora_rank=rank,
-                lora_modules=modules,
+                lora_config=lora_config,
                 **input_kwargs,
             )
             print(f"{label:<24} {rank:>6} {flops:>16.6f} {flops / full_flops * 100:>11.2f}%")

--- a/tests/utils/test_count_flops.py
+++ b/tests/utils/test_count_flops.py
@@ -205,16 +205,22 @@ class TestQwen35LoraFlops:
         )
         return (linear_flops + attention_flops + gdn_flops) / delta_time / 1e12
 
-    @pytest.mark.parametrize(
-        "lora_modules",
-        [
-            ["q_proj", "k_proj", "v_proj", "o_proj"],
-            ["in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a", "out_proj"],
-            ["gate_proj", "up_proj", "down_proj"],
-        ],
-    )
-    def test_selected_lora_modules(self, qwen3_5_counter, lora_modules):
+    def test_dense_hybrid_lora_arithmetic(self, qwen3_5_counter):
         batch_seqlens = [12, 5]
+        lora_modules = [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "in_proj_qkv",
+            "in_proj_z",
+            "in_proj_b",
+            "in_proj_a",
+            "out_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ]
         flops, _ = qwen3_5_counter.estimate_flops(
             batch_seqlens,
             delta_time=2.0,
@@ -222,20 +228,6 @@ class TestQwen35LoraFlops:
         )
 
         expected = self._expected_flops(qwen3_5_counter.config, batch_seqlens, 2.0, 8, lora_modules)
-        assert flops == pytest.approx(expected, rel=1e-9)
-
-    def test_standalone_text_model_type(self, qwen3_5_counter):
-        text_config = deepcopy(qwen3_5_counter.config.text_config)
-        counter = VeomniFlopsCounter(text_config)
-        lora_modules = ["q_proj", "in_proj_qkv", "gate_proj"]
-
-        flops, _ = counter.estimate_flops(
-            [12, 5],
-            delta_time=2.0,
-            lora_config=_lora_config(8, lora_modules),
-        )
-
-        expected = self._expected_flops(text_config, [12, 5], 2.0, 8, lora_modules)
         assert flops == pytest.approx(expected, rel=1e-9)
 
     def test_vision_flops_follow_input_and_lora_targets(self, qwen3_5_counter):
@@ -359,173 +351,54 @@ class TestQwen3Flops:
         flops, _ = qwen3_counter.estimate_flops(batch_seqlens, delta_time=1.0)
         assert flops == pytest.approx(expected_flops / 1e12, rel=1e-9)
 
-    def test_standalone_moe_text_model_type(self, qwen3_5_moe_counter):
-        text_config = deepcopy(qwen3_5_moe_counter.config.text_config)
-        counter = VeomniFlopsCounter(text_config)
-
-        flops, _ = counter.estimate_flops(
-            [12, 5],
-            delta_time=1.0,
-            lora_config=_default_lora_config(text_config),
-        )
-
-        assert flops > 0
-
-    def test_routed_expert_lora_scales_with_topk(self, qwen3_5_moe_counter):
-        def rank_delta(config):
-            counter = VeomniFlopsCounter(config)
-            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(4))
-            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(8))
-            return rank8 - rank4
-
-        topk1_config = deepcopy(qwen3_5_moe_counter.config)
-        topk1_config.text_config.num_experts_per_tok = 1
-
-        actual_delta = rank_delta(qwen3_5_moe_counter.config)
-        text_config = qwen3_5_moe_counter.config.text_config
-        params_per_rank = (
-            3
-            * (text_config.hidden_size + text_config.moe_intermediate_size)
-            * text_config.num_hidden_layers
-            * text_config.num_experts_per_tok
-        )
-        expected_delta = 6 * (8 - 4) * params_per_rank * (12 + 5) / 1e12
-
-        assert actual_delta == pytest.approx(
-            text_config.num_experts_per_tok * rank_delta(topk1_config),
-            rel=1e-9,
-        )
-        assert actual_delta == pytest.approx(expected_delta, rel=1e-9)
-
 
 class TestAllQwenLoraFlops:
     pytestmark = pytest.mark.usefixtures("mock_device_flops")
 
-    def test_single_fused_moe_mlp_target_installs_all_adapters(self, qwen3_5_moe_counter):
-        qwen3_moe = _load_toy_config("tests/toy_config/qwen3_moe_toy")
-        qwen3_5_moe = qwen3_5_moe_counter.config
-        qwen3_next = deepcopy(qwen3_5_moe.text_config)
+    def test_supported_qwen_family_dispatch(self, qwen3_5_moe_counter):
+        configs = [
+            _load_toy_config(f"tests/toy_config/{config_dir}")
+            for config_dir in ("qwen2vl_toy", "qwen25vl_toy", "qwen3vl_toy", "qwen3_moe_toy", "qwen3vlmoe_toy")
+        ]
+        qwen3_next = deepcopy(qwen3_5_moe_counter.config.text_config)
         qwen3_next.model_type = "qwen3_next"
+        configs.extend((qwen3_5_moe_counter.config, qwen3_5_moe_counter.config.text_config, qwen3_next))
 
-        for config in (qwen3_moe, qwen3_5_moe, qwen3_next):
+        routed_moe_types = {"qwen3_moe", "qwen3_vl_moe", "qwen3_next", "qwen3_5_moe", "qwen3_5_moe_text"}
+        for config in configs:
             counter = VeomniFlopsCounter(config)
-            all_mlp_flops, _ = counter.estimate_flops(
-                [12, 5],
-                1.0,
-                lora_config=_routed_lora_config(8),
-            )
-            for target_parameter in ROUTED_EXPERT_TARGETS:
-                single_target_flops, _ = counter.estimate_flops(
-                    [12, 5],
-                    1.0,
-                    lora_config=_lora_config(8, target_parameters=[target_parameter], moe_mode="independent"),
-                )
-                assert single_target_flops == pytest.approx(all_mlp_flops, rel=1e-9)
+            kwargs = {"images_seqlens": [16]} if hasattr(config, "vision_config") else {}
+            modules = list(LORA_MODULES_BY_MODEL_TYPE[config.model_type])
+            make_config = _routed_lora_config if config.model_type in routed_moe_types else _lora_config
 
-    @pytest.mark.parametrize(
-        "config_dir",
-        [
-            "qwen2vl_toy",
-            "qwen25vl_toy",
-            "qwen3vl_toy",
-            "qwen3_moe_toy",
-            "qwen3vlmoe_toy",
-        ],
-    )
-    def test_new_qwen_family_support(self, config_dir):
-        config = _load_toy_config(f"tests/toy_config/{config_dir}")
-        counter = VeomniFlopsCounter(config)
-        kwargs = {"images_seqlens": [16]} if hasattr(config, "vision_config") else {}
+            full_flops, _ = counter.estimate_flops([12, 5], 1.0, **kwargs)
+            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_config=make_config(4, modules), **kwargs)
+            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_config=make_config(8, modules), **kwargs)
 
-        full_flops, _ = counter.estimate_flops([12, 5], delta_time=1.0, **kwargs)
-        lora_flops, _ = counter.estimate_flops(
-            [12, 5],
-            delta_time=1.0,
-            lora_config=_default_lora_config(config),
-            **kwargs,
-        )
+            assert 0 < rank4 < rank8 < full_flops, config.model_type
 
-        assert 0 < lora_flops < full_flops
-
-    def test_qwen3_next_projection_names(self, qwen3_5_moe_counter):
-        config = deepcopy(qwen3_5_moe_counter.config.text_config)
-        config.model_type = "qwen3_next"
-        counter = VeomniFlopsCounter(config)
-        modules = ["q_proj", "in_proj_qkvz", "in_proj_ba", "out_proj", "gate_proj"]
-
-        rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_lora_config(4, modules))
-        rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_lora_config(8, modules))
-
-        full_layers = sum(layer_type == "full_attention" for layer_type in config.layer_types)
-        linear_layers = sum(layer_type == "linear_attention" for layer_type in config.layer_types)
-        q_size = config.num_attention_heads * config.head_dim
-        linear_k_size = config.linear_num_key_heads * config.linear_key_head_dim
-        linear_v_size = config.linear_num_value_heads * config.linear_value_head_dim
-        params_per_rank = (
-            (config.hidden_size + 2 * q_size) * full_layers
-            + (config.hidden_size + 2 * linear_k_size + 2 * linear_v_size) * linear_layers
-            + (config.hidden_size + 2 * config.linear_num_value_heads) * linear_layers
-            + (linear_v_size + config.hidden_size) * linear_layers
-            + (config.hidden_size + config.shared_expert_intermediate_size) * config.num_hidden_layers
-        )
-        expected_delta = 6 * (8 - 4) * params_per_rank * (12 + 5) / 1e12
-
-        assert rank8 - rank4 == pytest.approx(expected_delta, rel=1e-9)
-
-    def test_qwen3_next_lora_uses_correct_gated_q_proj_base(self, qwen3_5_moe_counter):
-        config = deepcopy(qwen3_5_moe_counter.config.text_config)
-        config.model_type = "qwen3_next"
-        counter = VeomniFlopsCounter(config)
-        batch_seqlens = [12, 5]
-        tokens_sum = sum(batch_seqlens)
-        rank = 8
-
-        attn_linear_N, full_layers, linear_layers, head_dim, num_heads = counter._compute_hybrid_attn_params(config)
-        moe_N = (
-            config.hidden_size * config.num_experts
-            + config.hidden_size * config.moe_intermediate_size * config.num_experts_per_tok * 3
-            + config.hidden_size * config.shared_expert_intermediate_size * 3
-            + config.hidden_size
-        ) * config.num_hidden_layers
-        base_N = moe_N + attn_linear_N + config.hidden_size * config.vocab_size
-        q_size = config.num_attention_heads * head_dim
-        lora_N = rank * (config.hidden_size + 2 * q_size) * full_layers
-        linear_flops = (4 * base_N + 6 * lora_N) * tokens_sum
-        attention_flops = 12 * sum(seqlen * seqlen for seqlen in batch_seqlens) * head_dim * num_heads * full_layers
-        recurrence_flops = counter._compute_gdn_recurrence_flops(config, tokens_sum, linear_layers)
-        expected = (linear_flops + attention_flops + recurrence_flops) / 1e12
-
-        actual, _ = counter.estimate_flops(
-            batch_seqlens,
-            1.0,
-            lora_config=_lora_config(rank, ["q_proj"]),
-        )
-
-        assert actual == pytest.approx(expected, rel=1e-9)
-
-    def test_shared_moe_mode_reuses_gate_and_up_adapters(self, qwen3_5_moe_counter):
+    def test_routed_moe_lora_modes_and_topk(self, qwen3_5_moe_counter):
         config = qwen3_5_moe_counter.config
         text_config = config.text_config
         batch_seqlens = [12, 5]
 
-        rank4, _ = VeomniFlopsCounter(config).estimate_flops(
-            batch_seqlens,
-            1.0,
-            lora_config=_routed_lora_config(4, moe_mode="shared"),
-        )
-        rank8, _ = VeomniFlopsCounter(config).estimate_flops(
-            batch_seqlens,
-            1.0,
-            lora_config=_routed_lora_config(8, moe_mode="shared"),
-        )
-
-        params_per_rank = (
-            (text_config.hidden_size + text_config.moe_intermediate_size)
-            * text_config.num_hidden_layers
-            * (2 + text_config.num_experts_per_tok)
-        )
-        expected_delta = 6 * (8 - 4) * params_per_rank * sum(batch_seqlens) / 1e12
-        assert rank8 - rank4 == pytest.approx(expected_delta, rel=1e-9)
+        for mode, adapter_uses in (
+            ("independent", 3 * text_config.num_experts_per_tok),
+            ("shared", 2 + text_config.num_experts_per_tok),
+        ):
+            rank4, _ = VeomniFlopsCounter(config).estimate_flops(
+                batch_seqlens, 1.0, lora_config=_routed_lora_config(4, moe_mode=mode)
+            )
+            rank8, _ = VeomniFlopsCounter(config).estimate_flops(
+                batch_seqlens, 1.0, lora_config=_routed_lora_config(8, moe_mode=mode)
+            )
+            params_per_rank = (
+                (text_config.hidden_size + text_config.moe_intermediate_size)
+                * text_config.num_hidden_layers
+                * adapter_uses
+            )
+            expected_delta = 6 * (8 - 4) * params_per_rank * sum(batch_seqlens) / 1e12
+            assert rank8 - rank4 == pytest.approx(expected_delta, rel=1e-9), mode
 
     def test_shared_and_routed_expert_adapters_are_additive(self, qwen3_5_moe_counter):
         counter = qwen3_5_moe_counter
@@ -556,304 +429,49 @@ class TestAllQwenLoraFlops:
 
         assert combined - attention == pytest.approx((shared - attention) + (routed - attention), rel=1e-9)
 
-    def test_qwen25_vl_matching_vision_mlp_modules(self):
-        config = _load_toy_config("tests/toy_config/qwen25vl_toy")
-        counter = VeomniFlopsCounter(config)
-        batch_seqlens = [12, 5]
-        images_seqlens = [16]
-        modules = ["gate_proj", "up_proj", "down_proj"]
-        rank = 8
 
-        text_flops, _ = counter.estimate_flops(
-            batch_seqlens,
-            1.0,
-            lora_config=_lora_config(rank, modules),
-        )
-        vl_flops, _ = counter.estimate_flops(
-            batch_seqlens,
-            1.0,
-            lora_config=_lora_config(rank, modules),
-            images_seqlens=images_seqlens,
-        )
-
-        vision = config.vision_config
-        tokens_sum = sum(images_seqlens)
-        dim = vision.hidden_size
-        intermediate_size = vision.intermediate_size
-        mlp_params = dim * intermediate_size * 3
-        attention_params = dim * dim * 4
-        merger_params = (vision.out_hidden_size + dim * vision.spatial_merge_size**2) * (
-            dim * vision.spatial_merge_size**2
-        )
-        base_params = (mlp_params + attention_params) * vision.depth + merger_params
-        lora_params = rank * (dim + intermediate_size) * 3 * vision.depth
-        linear_flops = (4 * base_params + 6 * lora_params) * tokens_sum
-        attention_flops = (
-            12
-            * sum(seqlen * seqlen for seqlen in images_seqlens)
-            * (dim // vision.num_heads)
-            * vision.num_heads
-            * len(vision.fullatt_block_indexes)
-        )
-        expected_vision_flops = (linear_flops + attention_flops) / 1e12
-
-        assert vl_flops - text_flops == pytest.approx(expected_vision_flops, rel=1e-9)
-
-    def test_qwen3_vl_deepstack_merger_lora(self):
-        config = _load_toy_config("tests/toy_config/qwen3vl_toy")
-        counter = VeomniFlopsCounter(config)
-        batch_seqlens = [12, 5]
-        images_seqlens = [16]
-
-        rank4_flops, _ = counter.estimate_flops(
-            batch_seqlens,
-            1.0,
-            lora_config=_lora_config(4, ["linear_fc1"]),
-            images_seqlens=images_seqlens,
-        )
-        rank8_flops, _ = counter.estimate_flops(
-            batch_seqlens,
-            1.0,
-            lora_config=_lora_config(8, ["linear_fc1"]),
-            images_seqlens=images_seqlens,
-        )
-
-        vision = config.vision_config
-        merger_hidden_size = vision.hidden_size * vision.spatial_merge_size**2
-        params_per_rank = (vision.hidden_size + vision.intermediate_size) * vision.depth + 2 * merger_hidden_size * (
-            1 + len(vision.deepstack_visual_indexes)
-        )
-        expected_delta = 6 * (8 - 4) * params_per_rank * sum(images_seqlens) / 1e12
-
-        assert rank8_flops - rank4_flops == pytest.approx(expected_delta, rel=1e-9)
-
-
-class TestQwen2LoraFlops:
+class TestLoraValidationFlops:
     pytestmark = pytest.mark.usefixtures("mock_device_flops")
 
-    @staticmethod
-    def _expected_flops(config, batch_seqlens, delta_time, lora_rank, lora_modules):
-        tokens_sum = sum(batch_seqlens)
-        hidden_size = config.hidden_size
-        intermediate_size = config.intermediate_size
-        head_dim = getattr(config, "head_dim", hidden_size // config.num_attention_heads)
-        q_size = config.num_attention_heads * head_dim
-        kv_size = config.num_key_value_heads * head_dim
+    def test_lora_validation_and_failure_behavior(self, qwen3_config, gpt_oss_config):
+        invalid_cases = [
+            (qwen3_config, _lora_config(8, ["q_proj", "q_proj"]), "must not contain duplicates"),
+            (qwen3_config, _lora_config(8, ["unknown_proj"]), "Unsupported qwen3"),
+            (qwen3_config, _lora_config(8, "q_proj"), "does not support regex-string"),
+            (qwen3_config, {"r": 8}, "VeOmniLoraConfig"),
+            (qwen3_config, _routed_lora_config(8), "not supported for non-MoE"),
+            (
+                _load_toy_config("tests/toy_config/qwen3_moe_toy"),
+                _lora_config(8, target_parameters=["*.mlp.experts.router_weight"]),
+                "fused routed-expert",
+            ),
+            (gpt_oss_config, _lora_config(8, ["q_proj"]), "supports Qwen model types"),
+        ]
+        for config, lora_config, error_match in invalid_cases:
+            counter = VeomniFlopsCounter(config)
+            with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
+                flops, promised_flops = counter.estimate_flops([12, 5], 2.0, lora_config=lora_config)
+            assert (flops, promised_flops) == (0, 1000.0), error_match
+            assert error_match in warning.call_args.args[1]
 
-        module_shapes = {
-            "q_proj": (hidden_size, q_size),
-            "k_proj": (hidden_size, kv_size),
-            "v_proj": (hidden_size, kv_size),
-            "o_proj": (q_size, hidden_size),
-            "gate_proj": (hidden_size, intermediate_size),
-            "up_proj": (hidden_size, intermediate_size),
-            "down_proj": (intermediate_size, hidden_size),
-        }
-        mlp_params = hidden_size * intermediate_size * 3
-        attn_linear_params = hidden_size * (q_size + 2 * kv_size + q_size)
-        lm_head_params = hidden_size * config.vocab_size
-        base_linear_params = (mlp_params + attn_linear_params) * config.num_hidden_layers + lm_head_params
-        lora_params = sum(lora_rank * sum(module_shapes[name]) for name in lora_modules)
-        lora_params *= config.num_hidden_layers
-        linear_flops = (4 * base_linear_params + 6 * lora_params) * tokens_sum
-
-        seqlen_square_sum = sum(seqlen * seqlen for seqlen in batch_seqlens)
-        attention_flops = 12 * seqlen_square_sum * head_dim * config.num_attention_heads * config.num_hidden_layers
-        return (linear_flops + attention_flops) / delta_time / 1e12
-
-    def test_full_finetuning_unchanged(self, qwen3_counter, qwen3_config):
-        batch_seqlens = [12, 5]
-        flops, promised_flops = qwen3_counter.estimate_flops(batch_seqlens, delta_time=2.0)
-
-        tokens_sum = sum(batch_seqlens)
-        head_dim = getattr(
-            qwen3_config,
-            "head_dim",
-            qwen3_config.hidden_size // qwen3_config.num_attention_heads,
-        )
-        q_size = qwen3_config.num_attention_heads * head_dim
-        kv_size = qwen3_config.num_key_value_heads * head_dim
-        linear_params = (
-            qwen3_config.hidden_size
-            * (3 * qwen3_config.intermediate_size + 2 * q_size + 2 * kv_size)
-            * qwen3_config.num_hidden_layers
-            + qwen3_config.hidden_size * qwen3_config.vocab_size
-        )
-        attention_flops = (
-            12
-            * sum(seqlen * seqlen for seqlen in batch_seqlens)
-            * head_dim
-            * qwen3_config.num_attention_heads
-            * qwen3_config.num_hidden_layers
-        )
-        expected = (6 * linear_params * tokens_sum + attention_flops) / 2.0 / 1e12
-
-        assert flops == pytest.approx(expected, rel=1e-9)
-        assert promised_flops == 1000.0
-
-    @pytest.mark.parametrize(
-        "lora_modules",
-        [
-            ["q_proj", "k_proj", "v_proj", "o_proj"],
-            ["gate_proj", "up_proj", "down_proj"],
-        ],
-    )
-    def test_selected_lora_modules(self, qwen3_counter, qwen3_config, lora_modules):
-        batch_seqlens = [12, 5]
-        flops, _ = qwen3_counter.estimate_flops(
-            batch_seqlens,
-            delta_time=2.0,
-            lora_config=_lora_config(8, lora_modules),
-        )
-
-        expected = self._expected_flops(qwen3_config, batch_seqlens, 2.0, 8, lora_modules)
-        assert flops == pytest.approx(expected, rel=1e-9)
-
-    def test_frozen_lm_head_keeps_input_gradient_cost(self, qwen3_config):
-        batch_seqlens = [12, 5]
-        tokens_sum = sum(batch_seqlens)
-        larger_vocab_config = deepcopy(qwen3_config)
-        larger_vocab_config.vocab_size += 1
-
-        full_flops, _ = VeomniFlopsCounter(qwen3_config).estimate_flops(batch_seqlens, delta_time=1.0)
-        larger_full_flops, _ = VeomniFlopsCounter(larger_vocab_config).estimate_flops(
-            batch_seqlens,
-            delta_time=1.0,
-        )
-        lora_flops, _ = VeomniFlopsCounter(qwen3_config).estimate_flops(
-            batch_seqlens,
-            delta_time=1.0,
-            lora_config=_default_lora_config(qwen3_config),
-        )
-        larger_lora_flops, _ = VeomniFlopsCounter(larger_vocab_config).estimate_flops(
-            batch_seqlens,
-            delta_time=1.0,
-            lora_config=_default_lora_config(larger_vocab_config),
-        )
-
-        # A larger vocabulary adds one lm_head row. FFT computes forward, dX,
-        # and dW; LoRA freezes the head but still computes forward and dX.
-        one_head_row_flops = qwen3_config.hidden_size * tokens_sum / 1e12
-        assert larger_full_flops - full_flops == pytest.approx(6 * one_head_row_flops, rel=1e-9)
-        assert larger_lora_flops - lora_flops == pytest.approx(4 * one_head_row_flops, rel=1e-9)
-
-    def test_qwen2_model_type(self, qwen3_config):
-        qwen2_config = deepcopy(qwen3_config)
-        qwen2_config.model_type = "qwen2"
-        counter = VeomniFlopsCounter(qwen2_config)
-
-        flops, _ = counter.estimate_flops(
-            [12, 5],
-            delta_time=2.0,
-            lora_config=_default_lora_config(qwen2_config),
-        )
-        assert flops > 0
-
-    def test_qwen3_explicit_head_dim_for_full_and_lora(self, qwen3_config):
-        config = deepcopy(qwen3_config)
-        config.head_dim = config.hidden_size // config.num_attention_heads * 2
-        counter = VeomniFlopsCounter(config)
-        batch_seqlens = [12, 5]
-        lora_modules = ["q_proj", "k_proj", "v_proj", "o_proj"]
-
-        full_flops, _ = counter.estimate_flops(batch_seqlens, delta_time=2.0)
-        lora_flops, _ = counter.estimate_flops(
-            batch_seqlens,
-            delta_time=2.0,
-            lora_config=_lora_config(8, lora_modules),
-        )
-
-        tokens_sum = sum(batch_seqlens)
-        q_size = config.num_attention_heads * config.head_dim
-        kv_size = config.num_key_value_heads * config.head_dim
-        linear_params = (
-            config.hidden_size * (3 * config.intermediate_size + 2 * q_size + 2 * kv_size) * config.num_hidden_layers
-            + config.hidden_size * config.vocab_size
-        )
-        attention_flops = (
-            12
-            * sum(seqlen * seqlen for seqlen in batch_seqlens)
-            * config.head_dim
-            * config.num_attention_heads
-            * config.num_hidden_layers
-        )
-        expected_full = (6 * linear_params * tokens_sum + attention_flops) / 2.0 / 1e12
-        expected_lora = self._expected_flops(config, batch_seqlens, 2.0, 8, lora_modules)
-
-        assert full_flops == pytest.approx(expected_full, rel=1e-9)
-        assert lora_flops == pytest.approx(expected_lora, rel=1e-9)
-
-    @pytest.mark.parametrize(
-        ("lora_config", "error_match"),
-        [
-            (_lora_config(8, ["q_proj", "q_proj"]), "must not contain duplicates"),
-            (_lora_config(8, ["q_proj", "unknown_proj"]), "Unsupported qwen3"),
-            (_lora_config(8, "q_proj"), "does not support regex-string"),
-        ],
-    )
-    def test_invalid_lora_config_returns_zero(self, qwen3_counter, lora_config, error_match):
+        counter = VeomniFlopsCounter(qwen3_config)
+        duplicate_warning = _lora_config(8, ["warning_once_unknown_proj"])
         with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
-            flops, promised_flops = qwen3_counter.estimate_flops(
-                [12, 5],
-                delta_time=2.0,
-                lora_config=lora_config,
-            )
+            counter.estimate_flops([12, 5], 2.0, lora_config=duplicate_warning)
+            counter.estimate_flops([12, 5], 2.0, lora_config=duplicate_warning)
+        warning.assert_called_once()
 
-        assert flops == 0
-        assert promised_flops == 1000.0
-        assert error_match in warning.call_args.args[1]
-
-    def test_invalid_lora_config_type_returns_zero(self, qwen3_counter):
-        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
-            flops, promised_flops = qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_config={"r": 8})
-
-        assert flops == 0
-        assert promised_flops == 1000.0
-        assert "VeOmniLoraConfig" in warning.call_args.args[1]
-
-    def test_loose_lora_arguments_are_not_part_of_api(self, qwen3_counter):
         with pytest.raises(TypeError, match="unexpected keyword argument"):
-            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_rank=8)
+            counter.estimate_flops([12, 5], 2.0, lora_rank=8)
 
-    def test_non_moe_target_parameters_return_zero(self, qwen3_counter):
-        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
-            flops, promised_flops = qwen3_counter.estimate_flops(
-                [12, 5],
-                delta_time=2.0,
-                lora_config=_routed_lora_config(8),
-            )
-
-        assert flops == 0
-        assert promised_flops == 1000.0
-        assert "not supported for non-MoE" in warning.call_args.args[1]
-
-    def test_unsupported_target_parameter_returns_zero(self):
-        counter = VeomniFlopsCounter(_load_toy_config("tests/toy_config/qwen3_moe_toy"))
-        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
-            flops, promised_flops = counter.estimate_flops(
-                [12, 5],
-                delta_time=2.0,
-                lora_config=_lora_config(8, target_parameters=["*.mlp.experts.router_weight"]),
-            )
-
-        assert flops == 0
-        assert promised_flops == 1000.0
-        assert "fused routed-expert" in warning.call_args.args[1]
-
-    def test_non_flop_lora_fields_are_ignored(self, qwen3_counter):
-        target_modules = ["q_proj"]
-        baseline, _ = qwen3_counter.estimate_flops(
+        baseline, _ = counter.estimate_flops([12, 5], 2.0, lora_config=_lora_config(8, ["q_proj"]))
+        ignored_fields, _ = counter.estimate_flops(
             [12, 5],
-            delta_time=2.0,
-            lora_config=_lora_config(8, target_modules),
-        )
-        ignored_fields, _ = qwen3_counter.estimate_flops(
-            [12, 5],
-            delta_time=2.0,
+            2.0,
             lora_config=VeOmniLoraConfig(
                 r=8,
                 lora_alpha=256,
-                target_modules=target_modules,
+                target_modules=["q_proj"],
                 exclude_modules=["q_proj"],
                 lora_dropout=0.5,
                 bias="all",
@@ -863,42 +481,14 @@ class TestQwen2LoraFlops:
                 alpha_pattern={".*q_proj": 512},
             ),
         )
-
         assert ignored_fields == baseline
 
-    def test_lora_unsupported_model_type_returns_zero(self, gpt_oss_counter):
-        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
-            flops, promised_flops = gpt_oss_counter.estimate_flops(
-                [12, 5],
-                delta_time=2.0,
-                lora_config=_lora_config(8, ["q_proj"]),
-            )
-
-        assert flops == 0
-        assert promised_flops == 1000.0
-        assert "supports Qwen model types" in warning.call_args.args[1]
-
-    def test_lora_validation_warning_is_emitted_once(self, qwen3_counter):
-        lora_config = _lora_config(8, ["warning_once_unknown_proj"])
-
-        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
-            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_config=lora_config)
-            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_config=lora_config)
-
-        warning.assert_called_once()
-
-    def test_valid_lora_does_not_hide_estimator_errors(self, qwen3_counter):
         def fail_estimation(*args, **kwargs):
             raise RuntimeError("estimator failure")
 
-        qwen3_counter.estimate_func["qwen3"] = fail_estimation
-
+        counter.estimate_func["qwen3"] = fail_estimation
         with pytest.raises(RuntimeError, match="estimator failure"):
-            qwen3_counter.estimate_flops(
-                [12, 5],
-                delta_time=2.0,
-                lora_config=_lora_config(8, ["q_proj"]),
-            )
+            counter.estimate_flops([12, 5], 2.0, lora_config=_lora_config(8, ["q_proj"]))
 
 
 class TestGptOssFlops:

--- a/tests/utils/test_count_flops.py
+++ b/tests/utils/test_count_flops.py
@@ -267,8 +267,8 @@ class TestQwen35LoraFlops:
             images_seqlens=images_seqlens,
         )
 
-        # The language-only LoRA API freezes the vision tower: forward-only
-        # ViT work is one third of the full forward-plus-backward estimate.
+        # Qwen3.5's supported LoRA targets do not match the vision tower, so its
+        # inputs and parameters require no gradients and it executes forward-only.
         assert lora_vl - lora_text == pytest.approx((full_vl - full_text) / 3, rel=1e-9)
 
 
@@ -673,6 +673,34 @@ class TestQwen2LoraFlops:
         ]
         expected = self._expected_flops(qwen3_config, batch_seqlens, 2.0, 8, default_modules)
         assert flops == pytest.approx(expected, rel=1e-9)
+
+    def test_frozen_lm_head_keeps_input_gradient_cost(self, qwen3_config):
+        batch_seqlens = [12, 5]
+        tokens_sum = sum(batch_seqlens)
+        larger_vocab_config = deepcopy(qwen3_config)
+        larger_vocab_config.vocab_size += 1
+
+        full_flops, _ = VeomniFlopsCounter(qwen3_config).estimate_flops(batch_seqlens, delta_time=1.0)
+        larger_full_flops, _ = VeomniFlopsCounter(larger_vocab_config).estimate_flops(
+            batch_seqlens,
+            delta_time=1.0,
+        )
+        lora_flops, _ = VeomniFlopsCounter(qwen3_config).estimate_flops(
+            batch_seqlens,
+            delta_time=1.0,
+            lora_rank=8,
+        )
+        larger_lora_flops, _ = VeomniFlopsCounter(larger_vocab_config).estimate_flops(
+            batch_seqlens,
+            delta_time=1.0,
+            lora_rank=8,
+        )
+
+        # A larger vocabulary adds one lm_head row. FFT computes forward, dX,
+        # and dW; LoRA freezes the head but still computes forward and dX.
+        one_head_row_flops = qwen3_config.hidden_size * tokens_sum / 1e12
+        assert larger_full_flops - full_flops == pytest.approx(6 * one_head_row_flops, rel=1e-9)
+        assert larger_lora_flops - lora_flops == pytest.approx(4 * one_head_row_flops, rel=1e-9)
 
     def test_qwen2_model_type(self, qwen3_config):
         qwen2_config = deepcopy(qwen3_config)

--- a/tests/utils/test_count_flops.py
+++ b/tests/utils/test_count_flops.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
+from veomni.lora.config import LORA_MODULES_BY_MODEL_TYPE, VeOmniLoraConfig
 from veomni.utils.count_flops import VeomniFlopsCounter, get_device_flops
 
 
@@ -34,6 +35,27 @@ def _to_namespace(value):
 def _load_toy_config(config_dir):
     with Path(config_dir, "config.json").open(encoding="utf-8") as fp:
         return _to_namespace(json.load(fp))
+
+
+def _lora_config(rank, target_modules=None, target_parameters=None, moe_mode=None):
+    return VeOmniLoraConfig(
+        r=rank,
+        lora_alpha=rank,
+        target_modules=target_modules,
+        target_parameters=target_parameters,
+        moe_mode=moe_mode,
+    )
+
+
+def _default_lora_config(config, rank=8):
+    return _lora_config(rank, list(LORA_MODULES_BY_MODEL_TYPE[config.model_type]))
+
+
+ROUTED_EXPERT_TARGETS = ["*.mlp.experts.gate_up_proj", "*.mlp.experts.down_proj"]
+
+
+def _routed_lora_config(rank, target_modules=None, moe_mode="independent"):
+    return _lora_config(rank, target_modules, ROUTED_EXPERT_TARGETS, moe_mode)
 
 
 @pytest.fixture
@@ -207,8 +229,7 @@ class TestQwen35LoraFlops:
         flops, _ = qwen3_5_counter.estimate_flops(
             batch_seqlens,
             delta_time=2.0,
-            lora_rank=8,
-            lora_modules=lora_modules,
+            lora_config=_lora_config(8, lora_modules),
         )
 
         expected = self._expected_flops(qwen3_5_counter.config, batch_seqlens, 2.0, 8, lora_modules)
@@ -216,7 +237,11 @@ class TestQwen35LoraFlops:
 
     def test_default_lora_modules(self, qwen3_5_counter):
         batch_seqlens = [12, 5]
-        flops, _ = qwen3_5_counter.estimate_flops(batch_seqlens, delta_time=2.0, lora_rank=8)
+        flops, _ = qwen3_5_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=2.0,
+            lora_config=_default_lora_config(qwen3_5_counter.config),
+        )
 
         default_modules = [
             "q_proj",
@@ -243,8 +268,7 @@ class TestQwen35LoraFlops:
         flops, _ = counter.estimate_flops(
             [12, 5],
             delta_time=2.0,
-            lora_rank=8,
-            lora_modules=lora_modules,
+            lora_config=_lora_config(8, lora_modules),
         )
 
         expected = self._expected_flops(text_config, [12, 5], 2.0, 8, lora_modules)
@@ -259,11 +283,16 @@ class TestQwen35LoraFlops:
             delta_time=2.0,
             images_seqlens=images_seqlens,
         )
-        lora_text, _ = qwen3_5_counter.estimate_flops(batch_seqlens, delta_time=2.0, lora_rank=8)
+        lora_config = _default_lora_config(qwen3_5_counter.config)
+        lora_text, _ = qwen3_5_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=2.0,
+            lora_config=lora_config,
+        )
         lora_vl, _ = qwen3_5_counter.estimate_flops(
             batch_seqlens,
             delta_time=2.0,
-            lora_rank=8,
+            lora_config=lora_config,
             images_seqlens=images_seqlens,
         )
 
@@ -289,14 +318,22 @@ class TestQwen35MoeFlops:
     def test_numerical(self, qwen3_5_moe_counter):
         batch_seqlens = [1024, 1024, 1024, 1024]
         flops, _ = qwen3_5_moe_counter.estimate_flops(batch_seqlens, delta_time=1.0)
-        # Embedding lookup is not a matmul; only lm_head contributes vocab_size * hidden_size.
-        assert flops == pytest.approx(16.888079843328, rel=1e-9)
+        text_config = qwen3_5_moe_counter.config.text_config
+        shared_expert_gate_flops = (
+            6 * text_config.hidden_size * text_config.num_hidden_layers * sum(batch_seqlens) / 1e12
+        )
+        # The embedding lookup is excluded. The shared-expert scalar gate is
+        # an ordinary trainable linear and follows the FFT factor-six convention.
+        assert flops == pytest.approx(16.888079843328 + shared_expert_gate_flops, rel=1e-9)
 
     def test_numerical_with_vit(self, qwen3_5_moe_counter):
         batch_seqlens = [1024, 1024, 1024, 1024]
         flops, _ = qwen3_5_moe_counter.estimate_flops(batch_seqlens, delta_time=1.0, images_seqlens=[256, 512])
-        # Embedding lookup is not a matmul; only lm_head contributes vocab_size * hidden_size.
-        assert flops == pytest.approx(19.05408344064, rel=1e-9)
+        text_config = qwen3_5_moe_counter.config.text_config
+        shared_expert_gate_flops = (
+            6 * text_config.hidden_size * text_config.num_hidden_layers * sum(batch_seqlens) / 1e12
+        )
+        assert flops == pytest.approx(19.05408344064 + shared_expert_gate_flops, rel=1e-9)
 
 
 class TestQwen3Flops:
@@ -338,8 +375,7 @@ class TestQwen3Flops:
         lora_flops, _ = qwen3_5_moe_counter.estimate_flops(
             batch_seqlens,
             delta_time=1.0,
-            lora_rank=8,
-            lora_modules=lora_modules,
+            lora_config=_lora_config(8, lora_modules),
         )
 
         assert 0 < lora_flops < full_flops
@@ -348,17 +384,19 @@ class TestQwen3Flops:
         text_config = deepcopy(qwen3_5_moe_counter.config.text_config)
         counter = VeomniFlopsCounter(text_config)
 
-        flops, _ = counter.estimate_flops([12, 5], delta_time=1.0, lora_rank=8)
+        flops, _ = counter.estimate_flops(
+            [12, 5],
+            delta_time=1.0,
+            lora_config=_default_lora_config(text_config),
+        )
 
         assert flops > 0
 
     def test_routed_expert_lora_scales_with_topk(self, qwen3_5_moe_counter):
-        modules = ["gate_proj", "up_proj", "down_proj"]
-
         def rank_delta(config):
             counter = VeomniFlopsCounter(config)
-            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=4, lora_modules=modules)
-            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=8, lora_modules=modules)
+            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(4))
+            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(8))
             return rank8 - rank4
 
         topk1_config = deepcopy(qwen3_5_moe_counter.config)
@@ -395,15 +433,13 @@ class TestAllQwenLoraFlops:
             all_mlp_flops, _ = counter.estimate_flops(
                 [12, 5],
                 1.0,
-                lora_rank=8,
-                lora_modules=["gate_proj", "up_proj", "down_proj"],
+                lora_config=_routed_lora_config(8),
             )
-            for module in ("gate_proj", "up_proj", "down_proj"):
+            for target_parameter in ROUTED_EXPERT_TARGETS:
                 single_target_flops, _ = counter.estimate_flops(
                     [12, 5],
                     1.0,
-                    lora_rank=8,
-                    lora_modules=[module],
+                    lora_config=_lora_config(8, target_parameters=[target_parameter], moe_mode="independent"),
                 )
                 assert single_target_flops == pytest.approx(all_mlp_flops, rel=1e-9)
 
@@ -423,18 +459,22 @@ class TestAllQwenLoraFlops:
         kwargs = {"images_seqlens": [16]} if hasattr(config, "vision_config") else {}
 
         full_flops, _ = counter.estimate_flops([12, 5], delta_time=1.0, **kwargs)
-        lora_flops, _ = counter.estimate_flops([12, 5], delta_time=1.0, lora_rank=8, **kwargs)
+        lora_flops, _ = counter.estimate_flops(
+            [12, 5],
+            delta_time=1.0,
+            lora_config=_default_lora_config(config),
+            **kwargs,
+        )
 
         assert 0 < lora_flops < full_flops
 
     def test_qwen3_moe_adapter_work_scales_with_topk(self):
         config = _load_toy_config("tests/toy_config/qwen3_moe_toy")
-        modules = ["gate_proj", "up_proj", "down_proj"]
 
         def rank_delta(current_config):
             counter = VeomniFlopsCounter(current_config)
-            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=4, lora_modules=modules)
-            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=8, lora_modules=modules)
+            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(4))
+            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(8))
             return rank8 - rank4
 
         topk1_config = deepcopy(config)
@@ -458,8 +498,8 @@ class TestAllQwenLoraFlops:
         counter = VeomniFlopsCounter(config)
         modules = ["q_proj", "in_proj_qkvz", "in_proj_ba", "out_proj", "gate_proj"]
 
-        rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=4, lora_modules=modules)
-        rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=8, lora_modules=modules)
+        rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_lora_config(4, modules))
+        rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_lora_config(8, modules))
 
         full_layers = sum(layer_type == "full_attention" for layer_type in config.layer_types)
         linear_layers = sum(layer_type == "linear_attention" for layer_type in config.layer_types)
@@ -471,10 +511,7 @@ class TestAllQwenLoraFlops:
             + (config.hidden_size + 2 * linear_k_size + 2 * linear_v_size) * linear_layers
             + (config.hidden_size + 2 * config.linear_num_value_heads) * linear_layers
             + (linear_v_size + config.hidden_size) * linear_layers
-            + 3
-            * (config.hidden_size + config.moe_intermediate_size)
-            * config.num_hidden_layers
-            * config.num_experts_per_tok
+            + (config.hidden_size + config.shared_expert_intermediate_size) * config.num_hidden_layers
         )
         expected_delta = 6 * (8 - 4) * params_per_rank * (12 + 5) / 1e12
 
@@ -493,6 +530,7 @@ class TestAllQwenLoraFlops:
             config.hidden_size * config.num_experts
             + config.hidden_size * config.moe_intermediate_size * config.num_experts_per_tok * 3
             + config.hidden_size * config.shared_expert_intermediate_size * 3
+            + config.hidden_size
         ) * config.num_hidden_layers
         base_N = moe_N + attn_linear_N + config.hidden_size * config.vocab_size
         q_size = config.num_attention_heads * head_dim
@@ -505,8 +543,7 @@ class TestAllQwenLoraFlops:
         actual, _ = counter.estimate_flops(
             batch_seqlens,
             1.0,
-            lora_rank=rank,
-            lora_modules=["q_proj"],
+            lora_config=_lora_config(rank, ["q_proj"]),
         )
 
         assert actual == pytest.approx(expected, rel=1e-9)
@@ -514,12 +551,11 @@ class TestAllQwenLoraFlops:
     def test_qwen3_next_mlp_targets_routed_experts(self, qwen3_5_moe_counter):
         config = deepcopy(qwen3_5_moe_counter.config.text_config)
         config.model_type = "qwen3_next"
-        modules = ["gate_proj", "up_proj", "down_proj"]
 
         def rank_delta(current_config):
             counter = VeomniFlopsCounter(current_config)
-            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=4, lora_modules=modules)
-            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=8, lora_modules=modules)
+            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(4))
+            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(8))
             return rank8 - rank4
 
         topk1_config = deepcopy(config)
@@ -529,6 +565,59 @@ class TestAllQwenLoraFlops:
             config.num_experts_per_tok * rank_delta(topk1_config),
             rel=1e-9,
         )
+
+    def test_shared_moe_mode_reuses_gate_and_up_adapters(self, qwen3_5_moe_counter):
+        config = qwen3_5_moe_counter.config
+        text_config = config.text_config
+        batch_seqlens = [12, 5]
+
+        rank4, _ = VeomniFlopsCounter(config).estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_config=_routed_lora_config(4, moe_mode="shared"),
+        )
+        rank8, _ = VeomniFlopsCounter(config).estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_config=_routed_lora_config(8, moe_mode="shared"),
+        )
+
+        params_per_rank = (
+            (text_config.hidden_size + text_config.moe_intermediate_size)
+            * text_config.num_hidden_layers
+            * (2 + text_config.num_experts_per_tok)
+        )
+        expected_delta = 6 * (8 - 4) * params_per_rank * sum(batch_seqlens) / 1e12
+        assert rank8 - rank4 == pytest.approx(expected_delta, rel=1e-9)
+
+    def test_shared_and_routed_expert_adapters_are_additive(self, qwen3_5_moe_counter):
+        counter = qwen3_5_moe_counter
+        batch_seqlens = [12, 5]
+        attention_modules = ["q_proj"]
+        shared_modules = ["q_proj", "gate_proj", "up_proj", "down_proj"]
+
+        attention, _ = counter.estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_config=_lora_config(8, attention_modules),
+        )
+        shared, _ = counter.estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_config=_lora_config(8, shared_modules),
+        )
+        routed, _ = counter.estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_config=_routed_lora_config(8, attention_modules),
+        )
+        combined, _ = counter.estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_config=_routed_lora_config(8, shared_modules),
+        )
+
+        assert combined - attention == pytest.approx((shared - attention) + (routed - attention), rel=1e-9)
 
     def test_qwen25_vl_matching_vision_mlp_modules(self):
         config = _load_toy_config("tests/toy_config/qwen25vl_toy")
@@ -541,14 +630,12 @@ class TestAllQwenLoraFlops:
         text_flops, _ = counter.estimate_flops(
             batch_seqlens,
             1.0,
-            lora_rank=rank,
-            lora_modules=modules,
+            lora_config=_lora_config(rank, modules),
         )
         vl_flops, _ = counter.estimate_flops(
             batch_seqlens,
             1.0,
-            lora_rank=rank,
-            lora_modules=modules,
+            lora_config=_lora_config(rank, modules),
             images_seqlens=images_seqlens,
         )
 
@@ -651,8 +738,7 @@ class TestQwen2LoraFlops:
         flops, _ = qwen3_counter.estimate_flops(
             batch_seqlens,
             delta_time=2.0,
-            lora_rank=8,
-            lora_modules=lora_modules,
+            lora_config=_lora_config(8, lora_modules),
         )
 
         expected = self._expected_flops(qwen3_config, batch_seqlens, 2.0, 8, lora_modules)
@@ -660,8 +746,6 @@ class TestQwen2LoraFlops:
 
     def test_default_lora_modules(self, qwen3_counter, qwen3_config):
         batch_seqlens = [12, 5]
-        flops, _ = qwen3_counter.estimate_flops(batch_seqlens, delta_time=2.0, lora_rank=8)
-
         default_modules = [
             "q_proj",
             "k_proj",
@@ -671,6 +755,11 @@ class TestQwen2LoraFlops:
             "up_proj",
             "down_proj",
         ]
+        flops, _ = qwen3_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=2.0,
+            lora_config=_lora_config(8, default_modules),
+        )
         expected = self._expected_flops(qwen3_config, batch_seqlens, 2.0, 8, default_modules)
         assert flops == pytest.approx(expected, rel=1e-9)
 
@@ -688,12 +777,12 @@ class TestQwen2LoraFlops:
         lora_flops, _ = VeomniFlopsCounter(qwen3_config).estimate_flops(
             batch_seqlens,
             delta_time=1.0,
-            lora_rank=8,
+            lora_config=_default_lora_config(qwen3_config),
         )
         larger_lora_flops, _ = VeomniFlopsCounter(larger_vocab_config).estimate_flops(
             batch_seqlens,
             delta_time=1.0,
-            lora_rank=8,
+            lora_config=_default_lora_config(larger_vocab_config),
         )
 
         # A larger vocabulary adds one lm_head row. FFT computes forward, dX,
@@ -707,7 +796,11 @@ class TestQwen2LoraFlops:
         qwen2_config.model_type = "qwen2"
         counter = VeomniFlopsCounter(qwen2_config)
 
-        flops, _ = counter.estimate_flops([12, 5], delta_time=2.0, lora_rank=8)
+        flops, _ = counter.estimate_flops(
+            [12, 5],
+            delta_time=2.0,
+            lora_config=_default_lora_config(qwen2_config),
+        )
         assert flops > 0
 
     def test_qwen3_explicit_head_dim_for_full_and_lora(self, qwen3_config):
@@ -721,8 +814,7 @@ class TestQwen2LoraFlops:
         lora_flops, _ = counter.estimate_flops(
             batch_seqlens,
             delta_time=2.0,
-            lora_rank=8,
-            lora_modules=lora_modules,
+            lora_config=_lora_config(8, lora_modules),
         )
 
         tokens_sum = sum(batch_seqlens)
@@ -745,36 +837,80 @@ class TestQwen2LoraFlops:
         assert full_flops == pytest.approx(expected_full, rel=1e-9)
         assert lora_flops == pytest.approx(expected_lora, rel=1e-9)
 
-    @pytest.mark.parametrize("lora_rank", [0, -1, 1.5, True])
-    def test_invalid_lora_rank(self, qwen3_counter, lora_rank):
-        with pytest.raises(ValueError, match="positive integer"):
-            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_rank=lora_rank)
-
     @pytest.mark.parametrize(
-        ("lora_modules", "error_match"),
+        ("lora_config", "error_match"),
         [
-            ([], "must not be empty"),
-            (["q_proj", "q_proj"], "must not contain duplicates"),
-            (["q_proj", "unknown_proj"], "Unsupported qwen3"),
-            ("q_proj", "must be a list"),
+            (_lora_config(8, ["q_proj", "q_proj"]), "must not contain duplicates"),
+            (_lora_config(8, ["q_proj", "unknown_proj"]), "Unsupported qwen3"),
+            (_lora_config(8, "q_proj"), "does not support regex-string"),
         ],
     )
-    def test_invalid_lora_modules(self, qwen3_counter, lora_modules, error_match):
+    def test_invalid_lora_config(self, qwen3_counter, lora_config, error_match):
         with pytest.raises(ValueError, match=error_match):
             qwen3_counter.estimate_flops(
                 [12, 5],
                 delta_time=2.0,
-                lora_rank=8,
-                lora_modules=lora_modules,
+                lora_config=lora_config,
             )
 
-    def test_lora_modules_require_rank(self, qwen3_counter):
-        with pytest.raises(ValueError, match="requires a positive"):
-            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_modules=["q_proj"])
+    def test_lora_config_requires_config_type(self, qwen3_counter):
+        with pytest.raises(TypeError, match="VeOmniLoraConfig"):
+            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_config={"r": 8})
+
+    def test_loose_lora_arguments_are_not_part_of_api(self, qwen3_counter):
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_rank=8)
+
+    def test_non_moe_model_rejects_target_parameters(self, qwen3_counter):
+        with pytest.raises(ValueError, match="not supported for non-MoE"):
+            qwen3_counter.estimate_flops(
+                [12, 5],
+                delta_time=2.0,
+                lora_config=_routed_lora_config(8),
+            )
+
+    def test_unsupported_target_parameter_is_rejected(self):
+        counter = VeomniFlopsCounter(_load_toy_config("tests/toy_config/qwen3_moe_toy"))
+        with pytest.raises(ValueError, match="fused routed-expert"):
+            counter.estimate_flops(
+                [12, 5],
+                delta_time=2.0,
+                lora_config=_lora_config(8, target_parameters=["*.mlp.experts.router_weight"]),
+            )
+
+    def test_non_flop_lora_fields_are_ignored(self, qwen3_counter):
+        target_modules = ["q_proj"]
+        baseline, _ = qwen3_counter.estimate_flops(
+            [12, 5],
+            delta_time=2.0,
+            lora_config=_lora_config(8, target_modules),
+        )
+        ignored_fields, _ = qwen3_counter.estimate_flops(
+            [12, 5],
+            delta_time=2.0,
+            lora_config=VeOmniLoraConfig(
+                r=8,
+                lora_alpha=256,
+                target_modules=target_modules,
+                exclude_modules=["q_proj"],
+                lora_dropout=0.5,
+                bias="all",
+                use_rslora=True,
+                init_lora_weights=False,
+                rank_pattern={".*q_proj": 64},
+                alpha_pattern={".*q_proj": 512},
+            ),
+        )
+
+        assert ignored_fields == baseline
 
     def test_lora_rejects_unsupported_model_type(self, gpt_oss_counter):
         with pytest.raises(ValueError, match="supports Qwen model types"):
-            gpt_oss_counter.estimate_flops([12, 5], delta_time=2.0, lora_rank=8)
+            gpt_oss_counter.estimate_flops(
+                [12, 5],
+                delta_time=2.0,
+                lora_config=_lora_config(8, ["q_proj"]),
+            )
 
 
 class TestGptOssFlops:

--- a/tests/utils/test_count_flops.py
+++ b/tests/utils/test_count_flops.py
@@ -59,9 +59,13 @@ def qwen3_5_counter():
 
 
 @pytest.fixture
-def qwen3_counter():
-    config = _load_toy_config("tests/toy_config/qwen3_toy")
-    return VeomniFlopsCounter(config)
+def qwen3_config():
+    return _load_toy_config("tests/toy_config/qwen3_toy")
+
+
+@pytest.fixture
+def qwen3_counter(qwen3_config):
+    return VeomniFlopsCounter(qwen3_config)
 
 
 @pytest.fixture
@@ -125,6 +129,149 @@ class TestQwen35Flops:
         assert flops == pytest.approx(109.196454395904, rel=1e-9)
 
 
+class TestQwen35LoraFlops:
+    pytestmark = pytest.mark.usefixtures("mock_device_flops")
+
+    @staticmethod
+    def _expected_flops(config, batch_seqlens, delta_time, lora_rank, lora_modules):
+        text_config = config.text_config if hasattr(config, "text_config") else config
+        tokens_sum = sum(batch_seqlens)
+        hidden_size = text_config.hidden_size
+        head_dim = getattr(
+            text_config,
+            "head_dim",
+            hidden_size // text_config.num_attention_heads,
+        )
+        q_size = text_config.num_attention_heads * head_dim
+        kv_size = text_config.num_key_value_heads * head_dim
+        linear_k_size = text_config.linear_num_key_heads * text_config.linear_key_head_dim
+        linear_v_size = text_config.linear_num_value_heads * text_config.linear_value_head_dim
+        num_full_layers = sum(layer_type == "full_attention" for layer_type in text_config.layer_types)
+        num_linear_layers = sum(layer_type == "linear_attention" for layer_type in text_config.layer_types)
+
+        module_shapes_and_counts = {
+            "q_proj": ((hidden_size, 2 * q_size), num_full_layers),
+            "k_proj": ((hidden_size, kv_size), num_full_layers),
+            "v_proj": ((hidden_size, kv_size), num_full_layers),
+            "o_proj": ((q_size, hidden_size), num_full_layers),
+            "in_proj_qkv": ((hidden_size, 2 * linear_k_size + linear_v_size), num_linear_layers),
+            "in_proj_z": ((hidden_size, linear_v_size), num_linear_layers),
+            "in_proj_b": ((hidden_size, text_config.linear_num_value_heads), num_linear_layers),
+            "in_proj_a": ((hidden_size, text_config.linear_num_value_heads), num_linear_layers),
+            "out_proj": ((linear_v_size, hidden_size), num_linear_layers),
+            "gate_proj": ((hidden_size, text_config.intermediate_size), text_config.num_hidden_layers),
+            "up_proj": ((hidden_size, text_config.intermediate_size), text_config.num_hidden_layers),
+            "down_proj": ((text_config.intermediate_size, hidden_size), text_config.num_hidden_layers),
+        }
+
+        full_attn_params = hidden_size * (2 * q_size + 2 * kv_size) + q_size * hidden_size
+        gdn_params = hidden_size * (2 * linear_k_size + 3 * linear_v_size + 2 * text_config.linear_num_value_heads)
+        gdn_params += text_config.linear_conv_kernel_dim * (2 * linear_k_size + linear_v_size)
+        mlp_params = hidden_size * text_config.intermediate_size * 3 * text_config.num_hidden_layers
+        lm_head_params = hidden_size * text_config.vocab_size
+        base_params = full_attn_params * num_full_layers + gdn_params * num_linear_layers + mlp_params + lm_head_params
+
+        lora_params = 0
+        for module_name in lora_modules:
+            (in_features, out_features), layer_count = module_shapes_and_counts[module_name]
+            lora_params += lora_rank * (in_features + out_features) * layer_count
+        linear_flops = (4 * base_params + 6 * lora_params) * tokens_sum
+
+        attention_flops = (
+            12
+            * sum(seqlen * seqlen for seqlen in batch_seqlens)
+            * head_dim
+            * text_config.num_attention_heads
+            * num_full_layers
+        )
+        gdn_flops = (
+            15
+            * text_config.linear_key_head_dim
+            * text_config.linear_value_head_dim
+            * text_config.linear_num_value_heads
+            * tokens_sum
+            * num_linear_layers
+        )
+        return (linear_flops + attention_flops + gdn_flops) / delta_time / 1e12
+
+    @pytest.mark.parametrize(
+        "lora_modules",
+        [
+            ["q_proj", "k_proj", "v_proj", "o_proj"],
+            ["in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a", "out_proj"],
+            ["gate_proj", "up_proj", "down_proj"],
+        ],
+    )
+    def test_selected_lora_modules(self, qwen3_5_counter, lora_modules):
+        batch_seqlens = [12, 5]
+        flops, _ = qwen3_5_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=2.0,
+            lora_rank=8,
+            lora_modules=lora_modules,
+        )
+
+        expected = self._expected_flops(qwen3_5_counter.config, batch_seqlens, 2.0, 8, lora_modules)
+        assert flops == pytest.approx(expected, rel=1e-9)
+
+    def test_default_lora_modules(self, qwen3_5_counter):
+        batch_seqlens = [12, 5]
+        flops, _ = qwen3_5_counter.estimate_flops(batch_seqlens, delta_time=2.0, lora_rank=8)
+
+        default_modules = [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "in_proj_qkv",
+            "in_proj_z",
+            "in_proj_b",
+            "in_proj_a",
+            "out_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ]
+        expected = self._expected_flops(qwen3_5_counter.config, batch_seqlens, 2.0, 8, default_modules)
+        assert flops == pytest.approx(expected, rel=1e-9)
+
+    def test_standalone_text_model_type(self, qwen3_5_counter):
+        text_config = deepcopy(qwen3_5_counter.config.text_config)
+        counter = VeomniFlopsCounter(text_config)
+        lora_modules = ["q_proj", "in_proj_qkv", "gate_proj"]
+
+        flops, _ = counter.estimate_flops(
+            [12, 5],
+            delta_time=2.0,
+            lora_rank=8,
+            lora_modules=lora_modules,
+        )
+
+        expected = self._expected_flops(text_config, [12, 5], 2.0, 8, lora_modules)
+        assert flops == pytest.approx(expected, rel=1e-9)
+
+    def test_vision_inputs_use_frozen_vit_cost(self, qwen3_5_counter):
+        batch_seqlens = [12, 5]
+        images_seqlens = [16]
+        full_text, _ = qwen3_5_counter.estimate_flops(batch_seqlens, delta_time=2.0)
+        full_vl, _ = qwen3_5_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=2.0,
+            images_seqlens=images_seqlens,
+        )
+        lora_text, _ = qwen3_5_counter.estimate_flops(batch_seqlens, delta_time=2.0, lora_rank=8)
+        lora_vl, _ = qwen3_5_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=2.0,
+            lora_rank=8,
+            images_seqlens=images_seqlens,
+        )
+
+        # The language-only LoRA API freezes the vision tower: forward-only
+        # ViT work is one third of the full forward-plus-backward estimate.
+        assert lora_vl - lora_text == pytest.approx((full_vl - full_text) / 3, rel=1e-9)
+
+
 class TestQwen35MoeFlops:
     pytestmark = pytest.mark.usefixtures("mock_device_flops")
 
@@ -177,6 +324,429 @@ class TestQwen3Flops:
 
         flops, _ = qwen3_counter.estimate_flops(batch_seqlens, delta_time=1.0)
         assert flops == pytest.approx(expected_flops / 1e12, rel=1e-9)
+
+    @pytest.mark.parametrize(
+        "lora_modules",
+        [
+            ["q_proj", "in_proj_qkv", "out_proj"],
+            ["gate_proj", "up_proj", "down_proj"],
+        ],
+    )
+    def test_lora_modules(self, qwen3_5_moe_counter, lora_modules):
+        batch_seqlens = [12, 5]
+        full_flops, _ = qwen3_5_moe_counter.estimate_flops(batch_seqlens, delta_time=1.0)
+        lora_flops, _ = qwen3_5_moe_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=1.0,
+            lora_rank=8,
+            lora_modules=lora_modules,
+        )
+
+        assert 0 < lora_flops < full_flops
+
+    def test_standalone_moe_text_model_type(self, qwen3_5_moe_counter):
+        text_config = deepcopy(qwen3_5_moe_counter.config.text_config)
+        counter = VeomniFlopsCounter(text_config)
+
+        flops, _ = counter.estimate_flops([12, 5], delta_time=1.0, lora_rank=8)
+
+        assert flops > 0
+
+    def test_routed_expert_lora_scales_with_topk(self, qwen3_5_moe_counter):
+        modules = ["gate_proj", "up_proj", "down_proj"]
+
+        def rank_delta(config):
+            counter = VeomniFlopsCounter(config)
+            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=4, lora_modules=modules)
+            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=8, lora_modules=modules)
+            return rank8 - rank4
+
+        topk1_config = deepcopy(qwen3_5_moe_counter.config)
+        topk1_config.text_config.num_experts_per_tok = 1
+
+        actual_delta = rank_delta(qwen3_5_moe_counter.config)
+        text_config = qwen3_5_moe_counter.config.text_config
+        params_per_rank = (
+            3
+            * (text_config.hidden_size + text_config.moe_intermediate_size)
+            * text_config.num_hidden_layers
+            * text_config.num_experts_per_tok
+        )
+        expected_delta = 6 * (8 - 4) * params_per_rank * (12 + 5) / 1e12
+
+        assert actual_delta == pytest.approx(
+            text_config.num_experts_per_tok * rank_delta(topk1_config),
+            rel=1e-9,
+        )
+        assert actual_delta == pytest.approx(expected_delta, rel=1e-9)
+
+
+class TestAllQwenLoraFlops:
+    pytestmark = pytest.mark.usefixtures("mock_device_flops")
+
+    def test_single_fused_moe_mlp_target_installs_all_adapters(self, qwen3_5_moe_counter):
+        qwen3_moe = _load_toy_config("tests/toy_config/qwen3_moe_toy")
+        qwen3_5_moe = qwen3_5_moe_counter.config
+        qwen3_next = deepcopy(qwen3_5_moe.text_config)
+        qwen3_next.model_type = "qwen3_next"
+
+        for config in (qwen3_moe, qwen3_5_moe, qwen3_next):
+            counter = VeomniFlopsCounter(config)
+            all_mlp_flops, _ = counter.estimate_flops(
+                [12, 5],
+                1.0,
+                lora_rank=8,
+                lora_modules=["gate_proj", "up_proj", "down_proj"],
+            )
+            for module in ("gate_proj", "up_proj", "down_proj"):
+                single_target_flops, _ = counter.estimate_flops(
+                    [12, 5],
+                    1.0,
+                    lora_rank=8,
+                    lora_modules=[module],
+                )
+                assert single_target_flops == pytest.approx(all_mlp_flops, rel=1e-9)
+
+    @pytest.mark.parametrize(
+        "config_dir",
+        [
+            "qwen2vl_toy",
+            "qwen25vl_toy",
+            "qwen3vl_toy",
+            "qwen3_moe_toy",
+            "qwen3vlmoe_toy",
+        ],
+    )
+    def test_new_qwen_family_support(self, config_dir):
+        config = _load_toy_config(f"tests/toy_config/{config_dir}")
+        counter = VeomniFlopsCounter(config)
+        kwargs = {"images_seqlens": [16]} if hasattr(config, "vision_config") else {}
+
+        full_flops, _ = counter.estimate_flops([12, 5], delta_time=1.0, **kwargs)
+        lora_flops, _ = counter.estimate_flops([12, 5], delta_time=1.0, lora_rank=8, **kwargs)
+
+        assert 0 < lora_flops < full_flops
+
+    def test_qwen3_moe_adapter_work_scales_with_topk(self):
+        config = _load_toy_config("tests/toy_config/qwen3_moe_toy")
+        modules = ["gate_proj", "up_proj", "down_proj"]
+
+        def rank_delta(current_config):
+            counter = VeomniFlopsCounter(current_config)
+            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=4, lora_modules=modules)
+            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=8, lora_modules=modules)
+            return rank8 - rank4
+
+        topk1_config = deepcopy(config)
+        topk1_config.num_experts_per_tok = 1
+
+        actual_delta = rank_delta(config)
+        params_per_rank = (
+            3
+            * (config.hidden_size + config.moe_intermediate_size)
+            * config.num_hidden_layers
+            * config.num_experts_per_tok
+        )
+        expected_delta = 6 * (8 - 4) * params_per_rank * (12 + 5) / 1e12
+
+        assert actual_delta == pytest.approx(2 * rank_delta(topk1_config), rel=1e-9)
+        assert actual_delta == pytest.approx(expected_delta, rel=1e-9)
+
+    def test_qwen3_next_projection_names(self, qwen3_5_moe_counter):
+        config = deepcopy(qwen3_5_moe_counter.config.text_config)
+        config.model_type = "qwen3_next"
+        counter = VeomniFlopsCounter(config)
+        modules = ["q_proj", "in_proj_qkvz", "in_proj_ba", "out_proj", "gate_proj"]
+
+        rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=4, lora_modules=modules)
+        rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=8, lora_modules=modules)
+
+        full_layers = sum(layer_type == "full_attention" for layer_type in config.layer_types)
+        linear_layers = sum(layer_type == "linear_attention" for layer_type in config.layer_types)
+        q_size = config.num_attention_heads * config.head_dim
+        linear_k_size = config.linear_num_key_heads * config.linear_key_head_dim
+        linear_v_size = config.linear_num_value_heads * config.linear_value_head_dim
+        params_per_rank = (
+            (config.hidden_size + 2 * q_size) * full_layers
+            + (config.hidden_size + 2 * linear_k_size + 2 * linear_v_size) * linear_layers
+            + (config.hidden_size + 2 * config.linear_num_value_heads) * linear_layers
+            + (linear_v_size + config.hidden_size) * linear_layers
+            + 3
+            * (config.hidden_size + config.moe_intermediate_size)
+            * config.num_hidden_layers
+            * config.num_experts_per_tok
+        )
+        expected_delta = 6 * (8 - 4) * params_per_rank * (12 + 5) / 1e12
+
+        assert rank8 - rank4 == pytest.approx(expected_delta, rel=1e-9)
+
+    def test_qwen3_next_lora_uses_correct_gated_q_proj_base(self, qwen3_5_moe_counter):
+        config = deepcopy(qwen3_5_moe_counter.config.text_config)
+        config.model_type = "qwen3_next"
+        counter = VeomniFlopsCounter(config)
+        batch_seqlens = [12, 5]
+        tokens_sum = sum(batch_seqlens)
+        rank = 8
+
+        attn_linear_N, full_layers, linear_layers, head_dim, num_heads = counter._compute_hybrid_attn_params(config)
+        moe_N = (
+            config.hidden_size * config.num_experts
+            + config.hidden_size * config.moe_intermediate_size * config.num_experts_per_tok * 3
+            + config.hidden_size * config.shared_expert_intermediate_size * 3
+        ) * config.num_hidden_layers
+        base_N = moe_N + attn_linear_N + config.hidden_size * config.vocab_size
+        q_size = config.num_attention_heads * head_dim
+        lora_N = rank * (config.hidden_size + 2 * q_size) * full_layers
+        linear_flops = (4 * base_N + 6 * lora_N) * tokens_sum
+        attention_flops = 12 * sum(seqlen * seqlen for seqlen in batch_seqlens) * head_dim * num_heads * full_layers
+        recurrence_flops = counter._compute_gdn_recurrence_flops(config, tokens_sum, linear_layers)
+        expected = (linear_flops + attention_flops + recurrence_flops) / 1e12
+
+        actual, _ = counter.estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_rank=rank,
+            lora_modules=["q_proj"],
+        )
+
+        assert actual == pytest.approx(expected, rel=1e-9)
+
+    def test_qwen3_next_mlp_targets_routed_experts(self, qwen3_5_moe_counter):
+        config = deepcopy(qwen3_5_moe_counter.config.text_config)
+        config.model_type = "qwen3_next"
+        modules = ["gate_proj", "up_proj", "down_proj"]
+
+        def rank_delta(current_config):
+            counter = VeomniFlopsCounter(current_config)
+            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=4, lora_modules=modules)
+            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_rank=8, lora_modules=modules)
+            return rank8 - rank4
+
+        topk1_config = deepcopy(config)
+        topk1_config.num_experts_per_tok = 1
+
+        assert rank_delta(config) == pytest.approx(
+            config.num_experts_per_tok * rank_delta(topk1_config),
+            rel=1e-9,
+        )
+
+    def test_qwen25_vl_matching_vision_mlp_modules(self):
+        config = _load_toy_config("tests/toy_config/qwen25vl_toy")
+        counter = VeomniFlopsCounter(config)
+        batch_seqlens = [12, 5]
+        images_seqlens = [16]
+        modules = ["gate_proj", "up_proj", "down_proj"]
+        rank = 8
+
+        text_flops, _ = counter.estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_rank=rank,
+            lora_modules=modules,
+        )
+        vl_flops, _ = counter.estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_rank=rank,
+            lora_modules=modules,
+            images_seqlens=images_seqlens,
+        )
+
+        vision = config.vision_config
+        tokens_sum = sum(images_seqlens)
+        dim = vision.hidden_size
+        intermediate_size = vision.intermediate_size
+        mlp_params = dim * intermediate_size * 3
+        attention_params = dim * dim * 4
+        merger_params = (vision.out_hidden_size + dim * vision.spatial_merge_size**2) * (
+            dim * vision.spatial_merge_size**2
+        )
+        base_params = (mlp_params + attention_params) * vision.depth + merger_params
+        lora_params = rank * (dim + intermediate_size) * 3 * vision.depth
+        linear_flops = (4 * base_params + 6 * lora_params) * tokens_sum
+        attention_flops = (
+            12
+            * sum(seqlen * seqlen for seqlen in images_seqlens)
+            * (dim // vision.num_heads)
+            * vision.num_heads
+            * len(vision.fullatt_block_indexes)
+        )
+        expected_vision_flops = (linear_flops + attention_flops) / 1e12
+
+        assert vl_flops - text_flops == pytest.approx(expected_vision_flops, rel=1e-9)
+
+
+class TestQwen2LoraFlops:
+    pytestmark = pytest.mark.usefixtures("mock_device_flops")
+
+    @staticmethod
+    def _expected_flops(config, batch_seqlens, delta_time, lora_rank, lora_modules):
+        tokens_sum = sum(batch_seqlens)
+        hidden_size = config.hidden_size
+        intermediate_size = config.intermediate_size
+        head_dim = getattr(config, "head_dim", hidden_size // config.num_attention_heads)
+        q_size = config.num_attention_heads * head_dim
+        kv_size = config.num_key_value_heads * head_dim
+
+        module_shapes = {
+            "q_proj": (hidden_size, q_size),
+            "k_proj": (hidden_size, kv_size),
+            "v_proj": (hidden_size, kv_size),
+            "o_proj": (q_size, hidden_size),
+            "gate_proj": (hidden_size, intermediate_size),
+            "up_proj": (hidden_size, intermediate_size),
+            "down_proj": (intermediate_size, hidden_size),
+        }
+        mlp_params = hidden_size * intermediate_size * 3
+        attn_linear_params = hidden_size * (q_size + 2 * kv_size + q_size)
+        lm_head_params = hidden_size * config.vocab_size
+        base_linear_params = (mlp_params + attn_linear_params) * config.num_hidden_layers + lm_head_params
+        lora_params = sum(lora_rank * sum(module_shapes[name]) for name in lora_modules)
+        lora_params *= config.num_hidden_layers
+        linear_flops = (4 * base_linear_params + 6 * lora_params) * tokens_sum
+
+        seqlen_square_sum = sum(seqlen * seqlen for seqlen in batch_seqlens)
+        attention_flops = 12 * seqlen_square_sum * head_dim * config.num_attention_heads * config.num_hidden_layers
+        return (linear_flops + attention_flops) / delta_time / 1e12
+
+    def test_full_finetuning_unchanged(self, qwen3_counter, qwen3_config):
+        batch_seqlens = [12, 5]
+        flops, promised_flops = qwen3_counter.estimate_flops(batch_seqlens, delta_time=2.0)
+
+        tokens_sum = sum(batch_seqlens)
+        head_dim = getattr(
+            qwen3_config,
+            "head_dim",
+            qwen3_config.hidden_size // qwen3_config.num_attention_heads,
+        )
+        q_size = qwen3_config.num_attention_heads * head_dim
+        kv_size = qwen3_config.num_key_value_heads * head_dim
+        linear_params = (
+            qwen3_config.hidden_size
+            * (3 * qwen3_config.intermediate_size + 2 * q_size + 2 * kv_size)
+            * qwen3_config.num_hidden_layers
+            + qwen3_config.hidden_size * qwen3_config.vocab_size
+        )
+        attention_flops = (
+            12
+            * sum(seqlen * seqlen for seqlen in batch_seqlens)
+            * head_dim
+            * qwen3_config.num_attention_heads
+            * qwen3_config.num_hidden_layers
+        )
+        expected = (6 * linear_params * tokens_sum + attention_flops) / 2.0 / 1e12
+
+        assert flops == pytest.approx(expected, rel=1e-9)
+        assert promised_flops == 1000.0
+
+    @pytest.mark.parametrize(
+        "lora_modules",
+        [
+            ["q_proj", "k_proj", "v_proj", "o_proj"],
+            ["gate_proj", "up_proj", "down_proj"],
+        ],
+    )
+    def test_selected_lora_modules(self, qwen3_counter, qwen3_config, lora_modules):
+        batch_seqlens = [12, 5]
+        flops, _ = qwen3_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=2.0,
+            lora_rank=8,
+            lora_modules=lora_modules,
+        )
+
+        expected = self._expected_flops(qwen3_config, batch_seqlens, 2.0, 8, lora_modules)
+        assert flops == pytest.approx(expected, rel=1e-9)
+
+    def test_default_lora_modules(self, qwen3_counter, qwen3_config):
+        batch_seqlens = [12, 5]
+        flops, _ = qwen3_counter.estimate_flops(batch_seqlens, delta_time=2.0, lora_rank=8)
+
+        default_modules = [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ]
+        expected = self._expected_flops(qwen3_config, batch_seqlens, 2.0, 8, default_modules)
+        assert flops == pytest.approx(expected, rel=1e-9)
+
+    def test_qwen2_model_type(self, qwen3_config):
+        qwen2_config = deepcopy(qwen3_config)
+        qwen2_config.model_type = "qwen2"
+        counter = VeomniFlopsCounter(qwen2_config)
+
+        flops, _ = counter.estimate_flops([12, 5], delta_time=2.0, lora_rank=8)
+        assert flops > 0
+
+    def test_qwen3_explicit_head_dim_for_full_and_lora(self, qwen3_config):
+        config = deepcopy(qwen3_config)
+        config.head_dim = config.hidden_size // config.num_attention_heads * 2
+        counter = VeomniFlopsCounter(config)
+        batch_seqlens = [12, 5]
+        lora_modules = ["q_proj", "k_proj", "v_proj", "o_proj"]
+
+        full_flops, _ = counter.estimate_flops(batch_seqlens, delta_time=2.0)
+        lora_flops, _ = counter.estimate_flops(
+            batch_seqlens,
+            delta_time=2.0,
+            lora_rank=8,
+            lora_modules=lora_modules,
+        )
+
+        tokens_sum = sum(batch_seqlens)
+        q_size = config.num_attention_heads * config.head_dim
+        kv_size = config.num_key_value_heads * config.head_dim
+        linear_params = (
+            config.hidden_size * (3 * config.intermediate_size + 2 * q_size + 2 * kv_size) * config.num_hidden_layers
+            + config.hidden_size * config.vocab_size
+        )
+        attention_flops = (
+            12
+            * sum(seqlen * seqlen for seqlen in batch_seqlens)
+            * config.head_dim
+            * config.num_attention_heads
+            * config.num_hidden_layers
+        )
+        expected_full = (6 * linear_params * tokens_sum + attention_flops) / 2.0 / 1e12
+        expected_lora = self._expected_flops(config, batch_seqlens, 2.0, 8, lora_modules)
+
+        assert full_flops == pytest.approx(expected_full, rel=1e-9)
+        assert lora_flops == pytest.approx(expected_lora, rel=1e-9)
+
+    @pytest.mark.parametrize("lora_rank", [0, -1, 1.5, True])
+    def test_invalid_lora_rank(self, qwen3_counter, lora_rank):
+        with pytest.raises(ValueError, match="positive integer"):
+            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_rank=lora_rank)
+
+    @pytest.mark.parametrize(
+        ("lora_modules", "error_match"),
+        [
+            ([], "must not be empty"),
+            (["q_proj", "q_proj"], "must not contain duplicates"),
+            (["q_proj", "unknown_proj"], "Unsupported qwen3"),
+            ("q_proj", "must be a list"),
+        ],
+    )
+    def test_invalid_lora_modules(self, qwen3_counter, lora_modules, error_match):
+        with pytest.raises(ValueError, match=error_match):
+            qwen3_counter.estimate_flops(
+                [12, 5],
+                delta_time=2.0,
+                lora_rank=8,
+                lora_modules=lora_modules,
+            )
+
+    def test_lora_modules_require_rank(self, qwen3_counter):
+        with pytest.raises(ValueError, match="requires a positive"):
+            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_modules=["q_proj"])
+
+    def test_lora_rejects_unsupported_model_type(self, gpt_oss_counter):
+        with pytest.raises(ValueError, match="supports Qwen model types"):
+            gpt_oss_counter.estimate_flops([12, 5], delta_time=2.0, lora_rank=8)
 
 
 class TestGptOssFlops:

--- a/tests/utils/test_count_flops.py
+++ b/tests/utils/test_count_flops.py
@@ -127,17 +127,6 @@ def deepseek_v4_counter(deepseek_v4_config):
 class TestQwen35Flops:
     pytestmark = pytest.mark.usefixtures("mock_device_flops")
 
-    def test_text_only(self, qwen3_5_counter):
-        batch_seqlens = [1024, 1024, 1024, 1024]
-        flops, _ = qwen3_5_counter.estimate_flops(batch_seqlens, delta_time=1.0)
-        assert flops > 0
-
-    def test_with_vit(self, qwen3_5_counter):
-        batch_seqlens = [1024, 1024, 1024, 1024]
-        text_flops, _ = qwen3_5_counter.estimate_flops(batch_seqlens, delta_time=1.0)
-        vit_flops, _ = qwen3_5_counter.estimate_flops(batch_seqlens, delta_time=1.0, images_seqlens=[256, 512])
-        assert vit_flops > text_flops
-
     def test_numerical(self, qwen3_5_counter):
         batch_seqlens = [1024, 1024, 1024, 1024]
         flops, _ = qwen3_5_counter.estimate_flops(batch_seqlens, delta_time=1.0)
@@ -235,31 +224,6 @@ class TestQwen35LoraFlops:
         expected = self._expected_flops(qwen3_5_counter.config, batch_seqlens, 2.0, 8, lora_modules)
         assert flops == pytest.approx(expected, rel=1e-9)
 
-    def test_default_lora_modules(self, qwen3_5_counter):
-        batch_seqlens = [12, 5]
-        flops, _ = qwen3_5_counter.estimate_flops(
-            batch_seqlens,
-            delta_time=2.0,
-            lora_config=_default_lora_config(qwen3_5_counter.config),
-        )
-
-        default_modules = [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-            "o_proj",
-            "in_proj_qkv",
-            "in_proj_z",
-            "in_proj_b",
-            "in_proj_a",
-            "out_proj",
-            "gate_proj",
-            "up_proj",
-            "down_proj",
-        ]
-        expected = self._expected_flops(qwen3_5_counter.config, batch_seqlens, 2.0, 8, default_modules)
-        assert flops == pytest.approx(expected, rel=1e-9)
-
     def test_standalone_text_model_type(self, qwen3_5_counter):
         text_config = deepcopy(qwen3_5_counter.config.text_config)
         counter = VeomniFlopsCounter(text_config)
@@ -274,43 +238,50 @@ class TestQwen35LoraFlops:
         expected = self._expected_flops(text_config, [12, 5], 2.0, 8, lora_modules)
         assert flops == pytest.approx(expected, rel=1e-9)
 
-    def test_vision_inputs_use_frozen_vit_cost(self, qwen3_5_counter):
+    def test_vision_flops_follow_input_and_lora_targets(self, qwen3_5_counter):
         batch_seqlens = [12, 5]
         images_seqlens = [16]
+        rank = 8
+
         full_text, _ = qwen3_5_counter.estimate_flops(batch_seqlens, delta_time=2.0)
         full_vl, _ = qwen3_5_counter.estimate_flops(
             batch_seqlens,
             delta_time=2.0,
             images_seqlens=images_seqlens,
         )
-        lora_config = _lora_config(8, ["q_proj", "in_proj_qkv", "gate_proj"])
+        decoder_lora_config = _lora_config(rank, ["q_proj", "in_proj_qkv", "gate_proj"])
         lora_text, _ = qwen3_5_counter.estimate_flops(
             batch_seqlens,
             delta_time=2.0,
-            lora_config=lora_config,
+            lora_config=decoder_lora_config,
+        )
+        empty_image_flops, _ = qwen3_5_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=2.0,
+            lora_config=decoder_lora_config,
+            images_seqlens=[],
         )
         lora_vl, _ = qwen3_5_counter.estimate_flops(
             batch_seqlens,
             delta_time=2.0,
-            lora_config=lora_config,
+            lora_config=decoder_lora_config,
             images_seqlens=images_seqlens,
         )
 
+        # No vision tokens skip the ViT. Decoder-only targets leave it frozen
+        # and detached, so only one forward pass (one third of FFT) remains.
+        assert empty_image_flops == lora_text
         # Decoder-only targets leave the vision tower frozen and detached.
         assert lora_vl - lora_text == pytest.approx((full_vl - full_text) / 3, rel=1e-9)
 
-    def test_vision_target_counts_backward_and_adapter_flops(self, qwen3_5_counter):
-        batch_seqlens = [12, 5]
-        images_seqlens = [16]
-        rank = 8
         text_flops, _ = qwen3_5_counter.estimate_flops(
             batch_seqlens,
-            delta_time=1.0,
+            delta_time=2.0,
             lora_config=_lora_config(rank, ["qkv"]),
         )
         vl_flops, _ = qwen3_5_counter.estimate_flops(
             batch_seqlens,
-            delta_time=1.0,
+            delta_time=2.0,
             lora_config=_lora_config(rank, ["qkv"]),
             images_seqlens=images_seqlens,
         )
@@ -335,34 +306,11 @@ class TestQwen35LoraFlops:
             * vision.depth
         )
 
-        assert vl_flops - text_flops == pytest.approx((linear_flops + attention_flops) / 1e12, rel=1e-9)
-
-    def test_empty_image_sequences_skip_vision(self, qwen3_5_counter):
-        lora_config = _lora_config(8, ["linear_fc1"])
-        text_flops, _ = qwen3_5_counter.estimate_flops([12, 5], 1.0, lora_config=lora_config)
-        empty_image_flops, _ = qwen3_5_counter.estimate_flops(
-            [12, 5],
-            1.0,
-            lora_config=lora_config,
-            images_seqlens=[],
-        )
-
-        assert empty_image_flops == text_flops
+        assert vl_flops - text_flops == pytest.approx((linear_flops + attention_flops) / 2.0 / 1e12, rel=1e-9)
 
 
 class TestQwen35MoeFlops:
     pytestmark = pytest.mark.usefixtures("mock_device_flops")
-
-    def test_text_only(self, qwen3_5_moe_counter):
-        batch_seqlens = [1024, 1024, 1024, 1024]
-        flops, _ = qwen3_5_moe_counter.estimate_flops(batch_seqlens, delta_time=1.0)
-        assert flops > 0
-
-    def test_with_vit(self, qwen3_5_moe_counter):
-        batch_seqlens = [1024, 1024, 1024, 1024]
-        text_flops, _ = qwen3_5_moe_counter.estimate_flops(batch_seqlens, delta_time=1.0)
-        vit_flops, _ = qwen3_5_moe_counter.estimate_flops(batch_seqlens, delta_time=1.0, images_seqlens=[256, 512])
-        assert vit_flops > text_flops
 
     def test_numerical(self, qwen3_5_moe_counter):
         batch_seqlens = [1024, 1024, 1024, 1024]
@@ -410,24 +358,6 @@ class TestQwen3Flops:
 
         flops, _ = qwen3_counter.estimate_flops(batch_seqlens, delta_time=1.0)
         assert flops == pytest.approx(expected_flops / 1e12, rel=1e-9)
-
-    @pytest.mark.parametrize(
-        "lora_modules",
-        [
-            ["q_proj", "in_proj_qkv", "out_proj"],
-            ["gate_proj", "up_proj", "down_proj"],
-        ],
-    )
-    def test_lora_modules(self, qwen3_5_moe_counter, lora_modules):
-        batch_seqlens = [12, 5]
-        full_flops, _ = qwen3_5_moe_counter.estimate_flops(batch_seqlens, delta_time=1.0)
-        lora_flops, _ = qwen3_5_moe_counter.estimate_flops(
-            batch_seqlens,
-            delta_time=1.0,
-            lora_config=_lora_config(8, lora_modules),
-        )
-
-        assert 0 < lora_flops < full_flops
 
     def test_standalone_moe_text_model_type(self, qwen3_5_moe_counter):
         text_config = deepcopy(qwen3_5_moe_counter.config.text_config)
@@ -517,30 +447,6 @@ class TestAllQwenLoraFlops:
 
         assert 0 < lora_flops < full_flops
 
-    def test_qwen3_moe_adapter_work_scales_with_topk(self):
-        config = _load_toy_config("tests/toy_config/qwen3_moe_toy")
-
-        def rank_delta(current_config):
-            counter = VeomniFlopsCounter(current_config)
-            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(4))
-            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(8))
-            return rank8 - rank4
-
-        topk1_config = deepcopy(config)
-        topk1_config.num_experts_per_tok = 1
-
-        actual_delta = rank_delta(config)
-        params_per_rank = (
-            3
-            * (config.hidden_size + config.moe_intermediate_size)
-            * config.num_hidden_layers
-            * config.num_experts_per_tok
-        )
-        expected_delta = 6 * (8 - 4) * params_per_rank * (12 + 5) / 1e12
-
-        assert actual_delta == pytest.approx(2 * rank_delta(topk1_config), rel=1e-9)
-        assert actual_delta == pytest.approx(expected_delta, rel=1e-9)
-
     def test_qwen3_next_projection_names(self, qwen3_5_moe_counter):
         config = deepcopy(qwen3_5_moe_counter.config.text_config)
         config.model_type = "qwen3_next"
@@ -596,24 +502,6 @@ class TestAllQwenLoraFlops:
         )
 
         assert actual == pytest.approx(expected, rel=1e-9)
-
-    def test_qwen3_next_mlp_targets_routed_experts(self, qwen3_5_moe_counter):
-        config = deepcopy(qwen3_5_moe_counter.config.text_config)
-        config.model_type = "qwen3_next"
-
-        def rank_delta(current_config):
-            counter = VeomniFlopsCounter(current_config)
-            rank4, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(4))
-            rank8, _ = counter.estimate_flops([12, 5], 1.0, lora_config=_routed_lora_config(8))
-            return rank8 - rank4
-
-        topk1_config = deepcopy(config)
-        topk1_config.num_experts_per_tok = 1
-
-        assert rank_delta(config) == pytest.approx(
-            config.num_experts_per_tok * rank_delta(topk1_config),
-            rel=1e-9,
-        )
 
     def test_shared_moe_mode_reuses_gate_and_up_adapters(self, qwen3_5_moe_counter):
         config = qwen3_5_moe_counter.config
@@ -819,25 +707,6 @@ class TestQwen2LoraFlops:
         )
 
         expected = self._expected_flops(qwen3_config, batch_seqlens, 2.0, 8, lora_modules)
-        assert flops == pytest.approx(expected, rel=1e-9)
-
-    def test_default_lora_modules(self, qwen3_counter, qwen3_config):
-        batch_seqlens = [12, 5]
-        default_modules = [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-            "o_proj",
-            "gate_proj",
-            "up_proj",
-            "down_proj",
-        ]
-        flops, _ = qwen3_counter.estimate_flops(
-            batch_seqlens,
-            delta_time=2.0,
-            lora_config=_lora_config(8, default_modules),
-        )
-        expected = self._expected_flops(qwen3_config, batch_seqlens, 2.0, 8, default_modules)
         assert flops == pytest.approx(expected, rel=1e-9)
 
     def test_frozen_lm_head_keeps_input_gradient_cost(self, qwen3_config):

--- a/tests/utils/test_count_flops.py
+++ b/tests/utils/test_count_flops.py
@@ -283,7 +283,7 @@ class TestQwen35LoraFlops:
             delta_time=2.0,
             images_seqlens=images_seqlens,
         )
-        lora_config = _default_lora_config(qwen3_5_counter.config)
+        lora_config = _lora_config(8, ["q_proj", "in_proj_qkv", "gate_proj"])
         lora_text, _ = qwen3_5_counter.estimate_flops(
             batch_seqlens,
             delta_time=2.0,
@@ -296,9 +296,58 @@ class TestQwen35LoraFlops:
             images_seqlens=images_seqlens,
         )
 
-        # Qwen3.5's supported LoRA targets do not match the vision tower, so its
-        # inputs and parameters require no gradients and it executes forward-only.
+        # Decoder-only targets leave the vision tower frozen and detached.
         assert lora_vl - lora_text == pytest.approx((full_vl - full_text) / 3, rel=1e-9)
+
+    def test_vision_target_counts_backward_and_adapter_flops(self, qwen3_5_counter):
+        batch_seqlens = [12, 5]
+        images_seqlens = [16]
+        rank = 8
+        text_flops, _ = qwen3_5_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=1.0,
+            lora_config=_lora_config(rank, ["qkv"]),
+        )
+        vl_flops, _ = qwen3_5_counter.estimate_flops(
+            batch_seqlens,
+            delta_time=1.0,
+            lora_config=_lora_config(rank, ["qkv"]),
+            images_seqlens=images_seqlens,
+        )
+
+        vision = qwen3_5_counter.config.vision_config
+        tokens_sum = sum(images_seqlens)
+        dim = vision.hidden_size
+        merger_hidden_size = dim * vision.spatial_merge_size**2
+        patch_embed_params = (
+            dim * vision.in_channels * vision.temporal_patch_size * vision.patch_size * vision.patch_size
+        )
+        block_params = dim * (2 * vision.intermediate_size + 4 * dim) * vision.depth
+        merger_params = merger_hidden_size * (merger_hidden_size + vision.out_hidden_size)
+        adaptable_base_params = block_params + merger_params
+        lora_params = rank * (dim + 3 * dim) * vision.depth
+        linear_flops = (2 * patch_embed_params + 4 * adaptable_base_params + 6 * lora_params) * tokens_sum
+        attention_flops = (
+            12
+            * sum(seqlen * seqlen for seqlen in images_seqlens)
+            * (dim // vision.num_heads)
+            * vision.num_heads
+            * vision.depth
+        )
+
+        assert vl_flops - text_flops == pytest.approx((linear_flops + attention_flops) / 1e12, rel=1e-9)
+
+    def test_empty_image_sequences_skip_vision(self, qwen3_5_counter):
+        lora_config = _lora_config(8, ["linear_fc1"])
+        text_flops, _ = qwen3_5_counter.estimate_flops([12, 5], 1.0, lora_config=lora_config)
+        empty_image_flops, _ = qwen3_5_counter.estimate_flops(
+            [12, 5],
+            1.0,
+            lora_config=lora_config,
+            images_seqlens=[],
+        )
+
+        assert empty_image_flops == text_flops
 
 
 class TestQwen35MoeFlops:
@@ -661,6 +710,34 @@ class TestAllQwenLoraFlops:
         expected_vision_flops = (linear_flops + attention_flops) / 1e12
 
         assert vl_flops - text_flops == pytest.approx(expected_vision_flops, rel=1e-9)
+
+    def test_qwen3_vl_deepstack_merger_lora(self):
+        config = _load_toy_config("tests/toy_config/qwen3vl_toy")
+        counter = VeomniFlopsCounter(config)
+        batch_seqlens = [12, 5]
+        images_seqlens = [16]
+
+        rank4_flops, _ = counter.estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_config=_lora_config(4, ["linear_fc1"]),
+            images_seqlens=images_seqlens,
+        )
+        rank8_flops, _ = counter.estimate_flops(
+            batch_seqlens,
+            1.0,
+            lora_config=_lora_config(8, ["linear_fc1"]),
+            images_seqlens=images_seqlens,
+        )
+
+        vision = config.vision_config
+        merger_hidden_size = vision.hidden_size * vision.spatial_merge_size**2
+        params_per_rank = (vision.hidden_size + vision.intermediate_size) * vision.depth + 2 * merger_hidden_size * (
+            1 + len(vision.deepstack_visual_indexes)
+        )
+        expected_delta = 6 * (8 - 4) * params_per_rank * sum(images_seqlens) / 1e12
+
+        assert rank8_flops - rank4_flops == pytest.approx(expected_delta, rel=1e-9)
 
 
 class TestQwen2LoraFlops:

--- a/tests/utils/test_count_flops.py
+++ b/tests/utils/test_count_flops.py
@@ -922,38 +922,54 @@ class TestQwen2LoraFlops:
             (_lora_config(8, "q_proj"), "does not support regex-string"),
         ],
     )
-    def test_invalid_lora_config(self, qwen3_counter, lora_config, error_match):
-        with pytest.raises(ValueError, match=error_match):
-            qwen3_counter.estimate_flops(
+    def test_invalid_lora_config_returns_zero(self, qwen3_counter, lora_config, error_match):
+        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
+            flops, promised_flops = qwen3_counter.estimate_flops(
                 [12, 5],
                 delta_time=2.0,
                 lora_config=lora_config,
             )
 
-    def test_lora_config_requires_config_type(self, qwen3_counter):
-        with pytest.raises(TypeError, match="VeOmniLoraConfig"):
-            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_config={"r": 8})
+        assert flops == 0
+        assert promised_flops == 1000.0
+        assert error_match in warning.call_args.args[1]
+
+    def test_invalid_lora_config_type_returns_zero(self, qwen3_counter):
+        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
+            flops, promised_flops = qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_config={"r": 8})
+
+        assert flops == 0
+        assert promised_flops == 1000.0
+        assert "VeOmniLoraConfig" in warning.call_args.args[1]
 
     def test_loose_lora_arguments_are_not_part_of_api(self, qwen3_counter):
         with pytest.raises(TypeError, match="unexpected keyword argument"):
             qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_rank=8)
 
-    def test_non_moe_model_rejects_target_parameters(self, qwen3_counter):
-        with pytest.raises(ValueError, match="not supported for non-MoE"):
-            qwen3_counter.estimate_flops(
+    def test_non_moe_target_parameters_return_zero(self, qwen3_counter):
+        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
+            flops, promised_flops = qwen3_counter.estimate_flops(
                 [12, 5],
                 delta_time=2.0,
                 lora_config=_routed_lora_config(8),
             )
 
-    def test_unsupported_target_parameter_is_rejected(self):
+        assert flops == 0
+        assert promised_flops == 1000.0
+        assert "not supported for non-MoE" in warning.call_args.args[1]
+
+    def test_unsupported_target_parameter_returns_zero(self):
         counter = VeomniFlopsCounter(_load_toy_config("tests/toy_config/qwen3_moe_toy"))
-        with pytest.raises(ValueError, match="fused routed-expert"):
-            counter.estimate_flops(
+        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
+            flops, promised_flops = counter.estimate_flops(
                 [12, 5],
                 delta_time=2.0,
                 lora_config=_lora_config(8, target_parameters=["*.mlp.experts.router_weight"]),
             )
+
+        assert flops == 0
+        assert promised_flops == 1000.0
+        assert "fused routed-expert" in warning.call_args.args[1]
 
     def test_non_flop_lora_fields_are_ignored(self, qwen3_counter):
         target_modules = ["q_proj"]
@@ -981,9 +997,35 @@ class TestQwen2LoraFlops:
 
         assert ignored_fields == baseline
 
-    def test_lora_rejects_unsupported_model_type(self, gpt_oss_counter):
-        with pytest.raises(ValueError, match="supports Qwen model types"):
-            gpt_oss_counter.estimate_flops(
+    def test_lora_unsupported_model_type_returns_zero(self, gpt_oss_counter):
+        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
+            flops, promised_flops = gpt_oss_counter.estimate_flops(
+                [12, 5],
+                delta_time=2.0,
+                lora_config=_lora_config(8, ["q_proj"]),
+            )
+
+        assert flops == 0
+        assert promised_flops == 1000.0
+        assert "supports Qwen model types" in warning.call_args.args[1]
+
+    def test_lora_validation_warning_is_emitted_once(self, qwen3_counter):
+        lora_config = _lora_config(8, ["warning_once_unknown_proj"])
+
+        with patch("veomni.utils.count_flops.logger.warning_rank0") as warning:
+            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_config=lora_config)
+            qwen3_counter.estimate_flops([12, 5], delta_time=2.0, lora_config=lora_config)
+
+        warning.assert_called_once()
+
+    def test_valid_lora_does_not_hide_estimator_errors(self, qwen3_counter):
+        def fail_estimation(*args, **kwargs):
+            raise RuntimeError("estimator failure")
+
+        qwen3_counter.estimate_func["qwen3"] = fail_estimation
+
+        with pytest.raises(RuntimeError, match="estimator failure"):
+            qwen3_counter.estimate_flops(
                 [12, 5],
                 delta_time=2.0,
                 lora_config=_lora_config(8, ["q_proj"]),

--- a/tests/utils/test_helper.py
+++ b/tests/utils/test_helper.py
@@ -2,6 +2,8 @@ import os
 import random
 import subprocess
 from dataclasses import dataclass, field
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
@@ -9,11 +11,66 @@ from transformers import Qwen2Config
 
 from veomni.arguments import DataArguments, ModelArguments, TrainingArguments, VeOmniArguments, parse_args
 from veomni.distributed.parallel_state import init_parallel_state
+from veomni.lora import VeOmniLoraConfig
 from veomni.utils import helper
 from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
 
 
 logger = helper.create_logger(__name__)
+
+
+def test_environ_meter_passes_supported_lora_config(monkeypatch):
+    calls = []
+
+    class FakeFlopsCounter:
+        supports_lora = True
+
+        def __init__(self, config):
+            self.config = config
+
+        def estimate_flops(self, batch_seqlens, delta_time, **kwargs):
+            calls.append((batch_seqlens, delta_time, kwargs))
+            return 1.0, 2.0
+
+    fake_device = SimpleNamespace(
+        max_memory_allocated=lambda: 0,
+        max_memory_reserved=lambda: 0,
+        memory_stats=lambda: {"num_alloc_retries": 0},
+    )
+    fake_memory = SimpleNamespace(used=0, available=0, percent=0)
+    monkeypatch.setattr(helper, "VeomniFlopsCounter", FakeFlopsCounter)
+    monkeypatch.setattr(helper.dist, "get_world_size", lambda: 1)
+    monkeypatch.setattr(helper, "all_reduce", lambda values, **kwargs: values)
+    monkeypatch.setattr(helper, "get_torch_device", lambda: fake_device)
+    monkeypatch.setattr(helper.psutil, "virtual_memory", lambda: fake_memory)
+
+    meter = helper.EnvironMeter(
+        config=SimpleNamespace(model_type="qwen3"),
+        global_batch_size=1,
+        empty_cache_steps=0,
+        parallel_state=SimpleNamespace(dp_group=None),
+    )
+    meter.batch_seqlens = [12, 5]
+    meter.images_seqlens = [16]
+    lora_config = VeOmniLoraConfig(r=8, target_modules=["q_proj"])
+
+    meter.step(delta_time=0.5, global_step=1, lora_config=lora_config)
+
+    assert calls == [([12, 5], 0.5, {"images_seqlens": [16], "lora_config": lora_config})]
+
+    calls.clear()
+    meter.supports_lora_flops = False
+    meter.batch_seqlens = [7]
+    with patch("veomni.utils.helper.logger.warning_rank0") as warning:
+        metrics = meter.step(delta_time=0.25, global_step=2, lora_config=lora_config)
+
+        meter.batch_seqlens = [8]
+        meter.step(delta_time=0.25, global_step=3, lora_config=lora_config)
+
+    assert calls == [([7], 0.25, {}), ([8], 0.25, {})]
+    assert metrics["flops_achieved(T)"] == 0
+    assert metrics["mfu"] == 0
+    warning.assert_called_once()
 
 
 @dataclass

--- a/veomni/lora/config.py
+++ b/veomni/lora/config.py
@@ -73,20 +73,39 @@ QWEN3_5_LORA_MODULES = (
     "up_proj",
     "down_proj",
 )
+QWEN2_VIT_LORA_MODULES = ("qkv", "proj", "fc1", "fc2", "mlp.0", "mlp.2")
+QWEN2_5_VIT_LORA_MODULES = ("qkv", "proj", "gate_proj", "up_proj", "down_proj", "mlp.0", "mlp.2")
+QWEN3_VIT_LORA_MODULES = ("qkv", "proj", "linear_fc1", "linear_fc2")
+VIT_LORA_MODULES_BY_MODEL_TYPE = MappingProxyType(
+    {
+        "qwen2_vl": QWEN2_VIT_LORA_MODULES,
+        "qwen2_5_vl": QWEN2_5_VIT_LORA_MODULES,
+        "qwen3_vl": QWEN3_VIT_LORA_MODULES,
+        "qwen3_vl_moe": QWEN3_VIT_LORA_MODULES,
+        "qwen3_5": QWEN3_VIT_LORA_MODULES,
+        "qwen3_5_moe": QWEN3_VIT_LORA_MODULES,
+    }
+)
 FUSED_MOE_LORA_MODULES = ("gate_proj", "up_proj", "down_proj")
+
+
+def _merge_module_names(*module_groups: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(module for group in module_groups for module in group))
+
+
 LORA_MODULES_BY_MODEL_TYPE = MappingProxyType(
     {
         "qwen2": QWEN2_LORA_MODULES,
-        "qwen2_vl": QWEN2_LORA_MODULES,
-        "qwen2_5_vl": QWEN2_LORA_MODULES,
+        "qwen2_vl": _merge_module_names(QWEN2_LORA_MODULES, QWEN2_VIT_LORA_MODULES),
+        "qwen2_5_vl": _merge_module_names(QWEN2_LORA_MODULES, QWEN2_5_VIT_LORA_MODULES),
         "qwen3": QWEN2_LORA_MODULES,
         "qwen3_moe": QWEN2_LORA_MODULES,
-        "qwen3_vl": QWEN2_LORA_MODULES,
-        "qwen3_vl_moe": QWEN2_LORA_MODULES,
+        "qwen3_vl": _merge_module_names(QWEN2_LORA_MODULES, QWEN3_VIT_LORA_MODULES),
+        "qwen3_vl_moe": _merge_module_names(QWEN2_LORA_MODULES, QWEN3_VIT_LORA_MODULES),
         "qwen3_next": QWEN3_NEXT_LORA_MODULES,
-        "qwen3_5": QWEN3_5_LORA_MODULES,
+        "qwen3_5": _merge_module_names(QWEN3_5_LORA_MODULES, QWEN3_VIT_LORA_MODULES),
         "qwen3_5_text": QWEN3_5_LORA_MODULES,
-        "qwen3_5_moe": QWEN3_5_LORA_MODULES,
+        "qwen3_5_moe": _merge_module_names(QWEN3_5_LORA_MODULES, QWEN3_VIT_LORA_MODULES),
         "qwen3_5_moe_text": QWEN3_5_LORA_MODULES,
     }
 )

--- a/veomni/lora/config.py
+++ b/veomni/lora/config.py
@@ -28,6 +28,7 @@ import dataclasses
 import json
 import os
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any, Literal
 
 from ..utils import logging
@@ -36,6 +37,59 @@ from ..utils import logging
 logger = logging.get_logger(__name__)
 
 ADAPTER_CONFIG_NAME = "adapter_config.json"
+
+QWEN2_LORA_MODULES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+QWEN3_NEXT_LORA_MODULES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "in_proj_qkvz",
+    "in_proj_ba",
+    "out_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+QWEN3_5_LORA_MODULES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "in_proj_qkv",
+    "in_proj_z",
+    "in_proj_b",
+    "in_proj_a",
+    "out_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+FUSED_MOE_LORA_MODULES = ("gate_proj", "up_proj", "down_proj")
+LORA_MODULES_BY_MODEL_TYPE = MappingProxyType(
+    {
+        "qwen2": QWEN2_LORA_MODULES,
+        "qwen2_vl": QWEN2_LORA_MODULES,
+        "qwen2_5_vl": QWEN2_LORA_MODULES,
+        "qwen3": QWEN2_LORA_MODULES,
+        "qwen3_moe": QWEN2_LORA_MODULES,
+        "qwen3_vl": QWEN2_LORA_MODULES,
+        "qwen3_vl_moe": QWEN2_LORA_MODULES,
+        "qwen3_next": QWEN3_NEXT_LORA_MODULES,
+        "qwen3_5": QWEN3_5_LORA_MODULES,
+        "qwen3_5_text": QWEN3_5_LORA_MODULES,
+        "qwen3_5_moe": QWEN3_5_LORA_MODULES,
+        "qwen3_5_moe_text": QWEN3_5_LORA_MODULES,
+    }
+)
 
 # Namespaced block inside adapter_config.json for VeOmni-only settings. PEFT's
 # ``LoraConfig.from_pretrained`` drops unknown top-level keys, so anything the

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -188,6 +188,7 @@ class EnvironMeterCallback(Callback):
         super().__init__(trainer)
 
         args: "VeOmniArguments" = self.trainer.args
+        self.lora_config = trainer.model.get_lora_config() if hasattr(trainer.model, "get_lora_config") else None
         self.trainer.environ_meter = helper.EnvironMeter(
             config=trainer.model_config,
             global_batch_size=args.train.global_batch_size,
@@ -208,7 +209,11 @@ class EnvironMeterCallback(Callback):
         self, state: TrainerState, loss: float, loss_dict: Dict[str, float], grad_norm: float, **kwargs
     ) -> None:
         delta_time = time.time() - self.start_time
-        step_env_metrics = self.trainer.environ_meter.step(delta_time, global_step=state.global_step)
+        step_env_metrics = self.trainer.environ_meter.step(
+            delta_time,
+            global_step=state.global_step,
+            lora_config=self.lora_config,
+        )
 
         step_train_metrics = {
             "total_loss": loss,

--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -97,6 +97,7 @@ class VeomniFlopsCounter:
         }
 
         self.config = config
+        self._warned_lora_validation_errors = set()
 
     def _estimate_unknown_flops(self, tokens_sum, batch_seqlens, delta_time, **kwargs):
         return 0
@@ -141,30 +142,30 @@ class VeomniFlopsCounter:
         return (base_factor * base_params + 6 * lora_params) * tokens
 
     @staticmethod
-    def _validate_lora_config(model_type, lora_config):
+    def _get_lora_validation_error(model_type, lora_config):
         if lora_config is None:
             return None
         if not isinstance(lora_config, VeOmniLoraConfig):
-            raise TypeError(f"`lora_config` must be a VeOmniLoraConfig or None, got {type(lora_config).__name__}.")
+            return f"`lora_config` must be a VeOmniLoraConfig or None, got {type(lora_config).__name__}."
 
         supported_modules = LORA_MODULES_BY_MODEL_TYPE.get(model_type)
         if supported_modules is None:
-            raise ValueError(
+            return (
                 f"LoRA FLOPs estimation supports Qwen model types {sorted(LORA_MODULES_BY_MODEL_TYPE)}, "
                 f"got {model_type!r}."
             )
 
         target_modules = lora_config.target_modules or []
         if isinstance(target_modules, str):
-            raise ValueError("LoRA FLOPs estimation does not support regex-string `target_modules`.")
+            return "LoRA FLOPs estimation does not support regex-string `target_modules`."
         if not isinstance(target_modules, list) or not all(isinstance(module, str) for module in target_modules):
-            raise ValueError("`lora_config.target_modules` must be a list of projection names or None.")
+            return "`lora_config.target_modules` must be a list of projection names or None."
         if len(target_modules) != len(set(target_modules)):
-            raise ValueError(f"`lora_config.target_modules` must not contain duplicates, got {target_modules!r}.")
+            return f"`lora_config.target_modules` must not contain duplicates, got {target_modules!r}."
 
         unsupported_modules = set(target_modules) - set(supported_modules)
         if unsupported_modules:
-            raise ValueError(
+            return (
                 f"Unsupported {model_type} LoRA modules: {sorted(unsupported_modules)}. "
                 f"Supported modules: {list(supported_modules)}."
             )
@@ -173,21 +174,21 @@ class VeomniFlopsCounter:
         if not isinstance(target_parameters, list) or not all(
             isinstance(pattern, str) for pattern in target_parameters
         ):
-            raise ValueError("`lora_config.target_parameters` must be a list of parameter patterns or None.")
+            return "`lora_config.target_parameters` must be a list of parameter patterns or None."
         if target_parameters:
             supported_moe_types = {"qwen3_moe", "qwen3_vl_moe", "qwen3_next", "qwen3_5_moe", "qwen3_5_moe_text"}
             if model_type not in supported_moe_types:
-                raise ValueError(f"`target_parameters` is not supported for non-MoE model type {model_type!r}.")
+                return f"`target_parameters` is not supported for non-MoE model type {model_type!r}."
             supported_suffixes = ("gate_up_proj", "down_proj")
             unsupported_patterns = [
                 pattern for pattern in target_parameters if not pattern.endswith(supported_suffixes)
             ]
             if unsupported_patterns:
-                raise ValueError(
+                return (
                     "LoRA FLOPs estimation only supports fused routed-expert target parameters ending in "
                     f"{supported_suffixes}, got {unsupported_patterns!r}."
                 )
-        return lora_config
+        return None
 
     @staticmethod
     def _compute_routed_moe_lora_flops(config, tokens, lora_config):
@@ -1249,7 +1250,8 @@ class VeomniFlopsCounter:
                 Qwen models. FLOPs estimation reads only ``r``, ``target_modules``,
                 ``target_parameters``, and ``moe_mode``. Other fields and their arithmetic effects
                 are intentionally ignored. A vision tower without a matching target is counted as
-                frozen, forward-only work.
+                frozen, forward-only work. Unsupported LoRA configurations emit a warning and
+                return zero achieved FLOPs instead of interrupting training.
             images_seqlens (List[int], optional): Vision-token sequence lengths for multimodal
                 models.
 
@@ -1257,7 +1259,16 @@ class VeomniFlopsCounter:
             estimated_flops (float): The estimated FLOPS based on the input tokens and time.
             promised_flops (float): The expected FLOPS of the current device.
         """
-        lora_config = self._validate_lora_config(self.config.model_type, lora_config)
+        lora_validation_error = self._get_lora_validation_error(self.config.model_type, lora_config)
+        if lora_validation_error is not None:
+            if lora_validation_error not in self._warned_lora_validation_errors:
+                logger.warning_rank0(
+                    "LoRA FLOPs are unavailable: %s Returning zero FLOPs so training can continue.",
+                    lora_validation_error,
+                )
+                self._warned_lora_validation_errors.add(lora_validation_error)
+            return 0, get_device_flops()
+
         kwargs = {}
         if lora_config is not None:
             kwargs["lora_config"] = lora_config

--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -15,63 +15,12 @@
 
 from transformers import PretrainedConfig
 
+from ..lora.config import FUSED_MOE_LORA_MODULES, LORA_MODULES_BY_MODEL_TYPE
 from . import logging
 from .device import get_device_name
 
 
 logger = logging.get_logger(__name__)
-
-
-_DENSE_QWEN_LORA_MODULES = (
-    "q_proj",
-    "k_proj",
-    "v_proj",
-    "o_proj",
-    "gate_proj",
-    "up_proj",
-    "down_proj",
-)
-_QWEN3_NEXT_LORA_MODULES = (
-    "q_proj",
-    "k_proj",
-    "v_proj",
-    "o_proj",
-    "in_proj_qkvz",
-    "in_proj_ba",
-    "out_proj",
-    "gate_proj",
-    "up_proj",
-    "down_proj",
-)
-_QWEN3_5_LORA_MODULES = (
-    "q_proj",
-    "k_proj",
-    "v_proj",
-    "o_proj",
-    "in_proj_qkv",
-    "in_proj_z",
-    "in_proj_b",
-    "in_proj_a",
-    "out_proj",
-    "gate_proj",
-    "up_proj",
-    "down_proj",
-)
-_FUSED_MOE_LORA_MODULES = ("gate_proj", "up_proj", "down_proj")
-_LORA_MODULES_BY_MODEL_TYPE = {
-    "qwen2": _DENSE_QWEN_LORA_MODULES,
-    "qwen2_vl": _DENSE_QWEN_LORA_MODULES,
-    "qwen2_5_vl": _DENSE_QWEN_LORA_MODULES,
-    "qwen3": _DENSE_QWEN_LORA_MODULES,
-    "qwen3_moe": _DENSE_QWEN_LORA_MODULES,
-    "qwen3_vl": _DENSE_QWEN_LORA_MODULES,
-    "qwen3_vl_moe": _DENSE_QWEN_LORA_MODULES,
-    "qwen3_next": _QWEN3_NEXT_LORA_MODULES,
-    "qwen3_5": _QWEN3_5_LORA_MODULES,
-    "qwen3_5_text": _QWEN3_5_LORA_MODULES,
-    "qwen3_5_moe": _QWEN3_5_LORA_MODULES,
-    "qwen3_5_moe_text": _QWEN3_5_LORA_MODULES,
-}
 
 
 def get_device_flops(unit="T"):
@@ -164,9 +113,16 @@ class VeomniFlopsCounter:
         lora_rank=None,
         lora_modules=None,
         module_shapes=None,
-        frozen_without_targets=False,
+        detached_without_targets=False,
     ):
-        """Count linear-layer work for full fine-tuning or LoRA."""
+        """Count linear-layer work for full fine-tuning or LoRA.
+
+        Full fine-tuning performs forward, input-gradient, and weight-gradient
+        matmuls (factor 6). A frozen LoRA base still needs its input gradient to
+        reach earlier adapters (factor 4). A fully frozen component whose inputs
+        need no gradients, such as an unadapted vision tower, is forward-only
+        (factor 2).
+        """
         if lora_rank is None:
             return 6 * base_params * tokens
 
@@ -176,7 +132,7 @@ class VeomniFlopsCounter:
             lora_rank * (module_shapes[module][0] + module_shapes[module][1]) * module_shapes[module][2]
             for module in matched_modules
         )
-        base_factor = 2 if frozen_without_targets and not matched_modules else 4
+        base_factor = 2 if detached_without_targets and not matched_modules else 4
         return (base_factor * base_params + 6 * lora_params) * tokens
 
     @staticmethod
@@ -188,10 +144,10 @@ class VeomniFlopsCounter:
         if isinstance(lora_rank, bool) or not isinstance(lora_rank, int) or lora_rank <= 0:
             raise ValueError(f"`lora_rank` must be a positive integer or None, got {lora_rank!r}.")
 
-        supported_modules = _LORA_MODULES_BY_MODEL_TYPE.get(model_type)
+        supported_modules = LORA_MODULES_BY_MODEL_TYPE.get(model_type)
         if supported_modules is None:
             raise ValueError(
-                f"LoRA FLOPs estimation supports Qwen model types {sorted(_LORA_MODULES_BY_MODEL_TYPE)}, "
+                f"LoRA FLOPs estimation supports Qwen model types {sorted(LORA_MODULES_BY_MODEL_TYPE)}, "
                 f"got {model_type!r}."
             )
         if lora_modules is None:
@@ -214,10 +170,10 @@ class VeomniFlopsCounter:
     @staticmethod
     def _expand_fused_moe_lora_modules(lora_modules):
         """A matched fused experts module always installs all three MLP adapters."""
-        if not lora_modules or not any(module in _FUSED_MOE_LORA_MODULES for module in lora_modules):
+        if not lora_modules or not any(module in FUSED_MOE_LORA_MODULES for module in lora_modules):
             return lora_modules
-        non_mlp_modules = [module for module in lora_modules if module not in _FUSED_MOE_LORA_MODULES]
-        return [*non_mlp_modules, *_FUSED_MOE_LORA_MODULES]
+        non_mlp_modules = [module for module in lora_modules if module not in FUSED_MOE_LORA_MODULES]
+        return [*non_mlp_modules, *FUSED_MOE_LORA_MODULES]
 
     def _compute_qwen_dense_text_flops(
         self,
@@ -711,7 +667,7 @@ class VeomniFlopsCounter:
             vit_flops = self._estimate_qwen3_vit_flop(
                 images_seqlens,
                 self.config.vision_config,
-                frozen=lora_rank is not None,
+                forward_only=lora_rank is not None,
             )
         else:
             vit_flops = 0
@@ -743,7 +699,7 @@ class VeomniFlopsCounter:
             vit_flops = self._estimate_qwen3_vit_flop(
                 images_seqlens,
                 self.config.vision_config,
-                frozen=lora_rank is not None,
+                forward_only=lora_rank is not None,
             )
         else:
             vit_flops = 0
@@ -752,7 +708,7 @@ class VeomniFlopsCounter:
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
-    def _estimate_qwen3_vit_flop(self, images_seqlens, config, frozen=False):
+    def _estimate_qwen3_vit_flop(self, images_seqlens, config, forward_only=False):
         """
         Estimate the FLOPS of the vision encoder for Qwen2 and Qwen2.5
         """
@@ -785,7 +741,7 @@ class VeomniFlopsCounter:
         dense_N = patch_embed_N + (mlp_N + attn_linear_N) * depth + deepstack_merger_N + merger_N
 
         # non-attn all_layer & all_token fwd & bwd flops
-        dense_N_flops = (2 if frozen else 6) * dense_N * tokens_sum
+        dense_N_flops = (2 if forward_only else 6) * dense_N * tokens_sum
 
         # In Qwen3 VL, full attention is used in all vision layers.
         full_attn_layer_num = depth
@@ -794,7 +750,7 @@ class VeomniFlopsCounter:
         seqlen_square_sum = 0
         for seqlen in images_seqlens:
             seqlen_square_sum += seqlen * seqlen
-        attention_factor = 4 if frozen else 12
+        attention_factor = 4 if forward_only else 12
         attn_qkv_flops = attention_factor * seqlen_square_sum * head_dim * num_heads * full_attn_layer_num
 
         vit_flops = dense_N_flops + attn_qkv_flops
@@ -854,7 +810,7 @@ class VeomniFlopsCounter:
             lora_rank=lora_rank,
             lora_modules=lora_modules,
             module_shapes=vision_module_shapes,
-            frozen_without_targets=True,
+            detached_without_targets=True,
         )
         vision_has_lora = any(module in vision_module_shapes for module in lora_modules or ())
         attention_factor = 12 if lora_rank is None or vision_has_lora else 4
@@ -1212,7 +1168,7 @@ class VeomniFlopsCounter:
             vit_flops = self._estimate_qwen3_vit_flop(
                 images_seqlens,
                 getattr(self.config, "vision_config", None),
-                frozen=lora_rank is not None,
+                forward_only=lora_rank is not None,
             )
         else:
             vit_flops = 0

--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -128,10 +128,15 @@ class VeomniFlopsCounter:
         module_shapes = module_shapes or {}
         target_modules = lora_config.target_modules or []
         matched_modules = [module for module in target_modules if module in module_shapes]
-        lora_params = sum(
-            lora_config.r * (module_shapes[module][0] + module_shapes[module][1]) * module_shapes[module][2]
-            for module in matched_modules
-        )
+        lora_params = 0
+        for module in matched_modules:
+            shape_groups = module_shapes[module]
+            if isinstance(shape_groups, tuple):
+                shape_groups = (shape_groups,)
+            lora_params += sum(
+                lora_config.r * (in_features + out_features) * count
+                for in_features, out_features, count in shape_groups
+            )
         base_factor = 2 if detached_without_targets and not matched_modules else 4
         return (base_factor * base_params + 6 * lora_params) * tokens
 
@@ -641,7 +646,7 @@ class VeomniFlopsCounter:
 
         # vit flops
         images_seqlens = kargs.get("images_seqlens", None)
-        if images_seqlens is not None:
+        if images_seqlens:
             vit_flops = self._estimate_qwen_vit_flop(
                 images_seqlens,
                 self.config.vision_config,
@@ -672,11 +677,11 @@ class VeomniFlopsCounter:
 
         # vit flops
         images_seqlens = kargs.get("images_seqlens", None)
-        if images_seqlens is not None:
+        if images_seqlens:
             vit_flops = self._estimate_qwen3_vit_flop(
                 images_seqlens,
                 self.config.vision_config,
-                forward_only=lora_config is not None,
+                lora_config=lora_config,
             )
         else:
             vit_flops = 0
@@ -702,11 +707,11 @@ class VeomniFlopsCounter:
         )
         # vit flops
         images_seqlens = kargs.get("images_seqlens", None)
-        if images_seqlens is not None:
+        if images_seqlens:
             vit_flops = self._estimate_qwen3_vit_flop(
                 images_seqlens,
                 self.config.vision_config,
-                forward_only=lora_config is not None,
+                lora_config=lora_config,
             )
         else:
             vit_flops = 0
@@ -715,9 +720,9 @@ class VeomniFlopsCounter:
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
-    def _estimate_qwen3_vit_flop(self, images_seqlens, config, forward_only=False):
+    def _estimate_qwen3_vit_flop(self, images_seqlens, config, lora_config=None):
         """
-        Estimate the FLOPS of the vision encoder for Qwen2 and Qwen2.5
+        Estimate the FLOPs of the Qwen3-family vision encoder.
         """
 
         if config is None:
@@ -743,12 +748,40 @@ class VeomniFlopsCounter:
         merger_N = (out_hidden_size + (dim * (spatial_merge_size**2))) * (dim * (spatial_merge_size**2))
 
         # Qwen3 VL uses deep stack, one merger for every deepstack layer
-        deepstack_merger_N = merger_N * len(config.deepstack_visual_indexes)
+        merger_count = 1 + len(getattr(config, "deepstack_visual_indexes", ()))
+        deepstack_merger_N = merger_N * (merger_count - 1)
         # non-attn all_layer parm
         dense_N = patch_embed_N + (mlp_N + attn_linear_N) * depth + deepstack_merger_N + merger_N
 
-        # non-attn all_layer & all_token fwd & bwd flops
-        dense_N_flops = (2 if forward_only else 6) * dense_N * tokens_sum
+        vision_module_shapes = {
+            "qkv": (dim, 3 * dim, depth),
+            "proj": (dim, dim, depth),
+            "linear_fc1": [
+                (dim, mlp_hidden_dim, depth),
+                (dim * spatial_merge_size**2, dim * spatial_merge_size**2, merger_count),
+            ],
+            "linear_fc2": [
+                (mlp_hidden_dim, dim, depth),
+                (dim * spatial_merge_size**2, out_hidden_size, merger_count),
+            ],
+        }
+        target_modules = lora_config.target_modules if lora_config is not None else ()
+        vision_has_lora = any(module in vision_module_shapes for module in target_modules or ())
+
+        if lora_config is None:
+            dense_N_flops = 6 * dense_N * tokens_sum
+        elif not vision_has_lora:
+            dense_N_flops = 2 * dense_N * tokens_sum
+        else:
+            # Patch embedding is Conv3d and is not adapted by VeOmni's linear LoRA.
+            adaptable_base_N = dense_N - patch_embed_N
+            dense_N_flops = 2 * patch_embed_N * tokens_sum
+            dense_N_flops += self._compute_linear_flops(
+                adaptable_base_N,
+                tokens_sum,
+                lora_config=lora_config,
+                module_shapes=vision_module_shapes,
+            )
 
         # In Qwen3 VL, full attention is used in all vision layers.
         full_attn_layer_num = depth
@@ -757,7 +790,7 @@ class VeomniFlopsCounter:
         seqlen_square_sum = 0
         for seqlen in images_seqlens:
             seqlen_square_sum += seqlen * seqlen
-        attention_factor = 4 if forward_only else 12
+        attention_factor = 12 if lora_config is None or vision_has_lora else 4
         attn_qkv_flops = attention_factor * seqlen_square_sum * head_dim * num_heads * full_attn_layer_num
 
         vit_flops = dense_N_flops + attn_qkv_flops
@@ -804,13 +837,28 @@ class VeomniFlopsCounter:
         # non-attn all_layer parm
         dense_N = (mlp_N + attn_linear_N) * depth + patch_embed_and_merger_N
 
-        vision_module_shapes = {}
-        if not is_qwen2_vl:
-            vision_module_shapes = {
-                "gate_proj": (dim, mlp_hidden_dim, depth),
-                "up_proj": (dim, mlp_hidden_dim, depth),
-                "down_proj": (mlp_hidden_dim, dim, depth),
-            }
+        merger_hidden_size = dim * spatial_merge_size**2
+        vision_module_shapes = {
+            "qkv": (dim, 3 * dim, depth),
+            "proj": (dim, dim, depth),
+            "mlp.0": (merger_hidden_size, merger_hidden_size, 1),
+            "mlp.2": (merger_hidden_size, out_hidden_size, 1),
+        }
+        if is_qwen2_vl:
+            vision_module_shapes.update(
+                {
+                    "fc1": (dim, mlp_hidden_dim, depth),
+                    "fc2": (mlp_hidden_dim, dim, depth),
+                }
+            )
+        else:
+            vision_module_shapes.update(
+                {
+                    "gate_proj": (dim, mlp_hidden_dim, depth),
+                    "up_proj": (dim, mlp_hidden_dim, depth),
+                    "down_proj": (mlp_hidden_dim, dim, depth),
+                }
+            )
         dense_N_flops = self._compute_linear_flops(
             dense_N,
             tokens_sum,
@@ -1170,11 +1218,11 @@ class VeomniFlopsCounter:
 
         # vit flops (Qwen3-VL ViT)
         images_seqlens = kargs.get("images_seqlens", None)
-        if images_seqlens is not None:
+        if images_seqlens:
             vit_flops = self._estimate_qwen3_vit_flop(
                 images_seqlens,
                 getattr(self.config, "vision_config", None),
-                forward_only=lora_config is not None,
+                lora_config=lora_config,
             )
         else:
             vit_flops = 0

--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -15,7 +15,7 @@
 
 from transformers import PretrainedConfig
 
-from ..lora.config import FUSED_MOE_LORA_MODULES, LORA_MODULES_BY_MODEL_TYPE
+from ..lora.config import LORA_MODULES_BY_MODEL_TYPE, VeOmniLoraConfig
 from . import logging
 from .device import get_device_name
 
@@ -110,8 +110,7 @@ class VeomniFlopsCounter:
     def _compute_linear_flops(
         base_params,
         tokens,
-        lora_rank=None,
-        lora_modules=None,
+        lora_config=None,
         module_shapes=None,
         detached_without_targets=False,
     ):
@@ -123,26 +122,25 @@ class VeomniFlopsCounter:
         need no gradients, such as an unadapted vision tower, is forward-only
         (factor 2).
         """
-        if lora_rank is None:
+        if lora_config is None:
             return 6 * base_params * tokens
 
         module_shapes = module_shapes or {}
-        matched_modules = [module for module in lora_modules if module in module_shapes]
+        target_modules = lora_config.target_modules or []
+        matched_modules = [module for module in target_modules if module in module_shapes]
         lora_params = sum(
-            lora_rank * (module_shapes[module][0] + module_shapes[module][1]) * module_shapes[module][2]
+            lora_config.r * (module_shapes[module][0] + module_shapes[module][1]) * module_shapes[module][2]
             for module in matched_modules
         )
         base_factor = 2 if detached_without_targets and not matched_modules else 4
         return (base_factor * base_params + 6 * lora_params) * tokens
 
     @staticmethod
-    def _validate_lora_args(model_type, lora_rank, lora_modules):
-        if lora_rank is None:
-            if lora_modules is not None:
-                raise ValueError("`lora_modules` requires a positive `lora_rank`.")
-            return None, None
-        if isinstance(lora_rank, bool) or not isinstance(lora_rank, int) or lora_rank <= 0:
-            raise ValueError(f"`lora_rank` must be a positive integer or None, got {lora_rank!r}.")
+    def _validate_lora_config(model_type, lora_config):
+        if lora_config is None:
+            return None
+        if not isinstance(lora_config, VeOmniLoraConfig):
+            raise TypeError(f"`lora_config` must be a VeOmniLoraConfig or None, got {type(lora_config).__name__}.")
 
         supported_modules = LORA_MODULES_BY_MODEL_TYPE.get(model_type)
         if supported_modules is None:
@@ -150,38 +148,66 @@ class VeomniFlopsCounter:
                 f"LoRA FLOPs estimation supports Qwen model types {sorted(LORA_MODULES_BY_MODEL_TYPE)}, "
                 f"got {model_type!r}."
             )
-        if lora_modules is None:
-            return lora_rank, list(supported_modules)
-        if not isinstance(lora_modules, list) or not all(isinstance(module, str) for module in lora_modules):
-            raise ValueError("`lora_modules` must be a list of projection names.")
-        if not lora_modules:
-            raise ValueError("`lora_modules` must not be empty when `lora_rank` is set.")
-        if len(lora_modules) != len(set(lora_modules)):
-            raise ValueError(f"`lora_modules` must not contain duplicates, got {lora_modules!r}.")
 
-        unsupported_modules = set(lora_modules) - set(supported_modules)
+        target_modules = lora_config.target_modules or []
+        if isinstance(target_modules, str):
+            raise ValueError("LoRA FLOPs estimation does not support regex-string `target_modules`.")
+        if not isinstance(target_modules, list) or not all(isinstance(module, str) for module in target_modules):
+            raise ValueError("`lora_config.target_modules` must be a list of projection names or None.")
+        if len(target_modules) != len(set(target_modules)):
+            raise ValueError(f"`lora_config.target_modules` must not contain duplicates, got {target_modules!r}.")
+
+        unsupported_modules = set(target_modules) - set(supported_modules)
         if unsupported_modules:
             raise ValueError(
                 f"Unsupported {model_type} LoRA modules: {sorted(unsupported_modules)}. "
                 f"Supported modules: {list(supported_modules)}."
             )
-        return lora_rank, lora_modules
+
+        target_parameters = lora_config.target_parameters or []
+        if not isinstance(target_parameters, list) or not all(
+            isinstance(pattern, str) for pattern in target_parameters
+        ):
+            raise ValueError("`lora_config.target_parameters` must be a list of parameter patterns or None.")
+        if target_parameters:
+            supported_moe_types = {"qwen3_moe", "qwen3_vl_moe", "qwen3_next", "qwen3_5_moe", "qwen3_5_moe_text"}
+            if model_type not in supported_moe_types:
+                raise ValueError(f"`target_parameters` is not supported for non-MoE model type {model_type!r}.")
+            supported_suffixes = ("gate_up_proj", "down_proj")
+            unsupported_patterns = [
+                pattern for pattern in target_parameters if not pattern.endswith(supported_suffixes)
+            ]
+            if unsupported_patterns:
+                raise ValueError(
+                    "LoRA FLOPs estimation only supports fused routed-expert target parameters ending in "
+                    f"{supported_suffixes}, got {unsupported_patterns!r}."
+                )
+        return lora_config
 
     @staticmethod
-    def _expand_fused_moe_lora_modules(lora_modules):
-        """A matched fused experts module always installs all three MLP adapters."""
-        if not lora_modules or not any(module in FUSED_MOE_LORA_MODULES for module in lora_modules):
-            return lora_modules
-        non_mlp_modules = [module for module in lora_modules if module not in FUSED_MOE_LORA_MODULES]
-        return [*non_mlp_modules, *FUSED_MOE_LORA_MODULES]
+    def _compute_routed_moe_lora_flops(config, tokens, lora_config):
+        """Count fused routed-expert adapters selected through ``target_parameters``."""
+        if lora_config is None or not lora_config.target_parameters:
+            return 0
+
+        hidden_size = config.hidden_size
+        intermediate_size = config.moe_intermediate_size
+        experts_per_token = config.num_experts_per_tok
+        num_hidden_layers = config.num_hidden_layers
+        if (lora_config.moe_mode or "independent") == "shared":
+            adapter_uses_per_layer = 2 + experts_per_token  # gate/up once, down per routed expert
+        else:
+            adapter_uses_per_layer = 3 * experts_per_token
+
+        lora_params = lora_config.r * (hidden_size + intermediate_size) * adapter_uses_per_layer * num_hidden_layers
+        return 6 * lora_params * tokens
 
     def _compute_qwen_dense_text_flops(
         self,
         config,
         tokens_sum,
         batch_seqlens,
-        lora_rank=None,
-        lora_modules=None,
+        lora_config=None,
     ):
         """Compute raw text FLOPs shared by dense Qwen text and VL models."""
         hidden_size = config.hidden_size
@@ -207,8 +233,7 @@ class VeomniFlopsCounter:
         linear_flops = self._compute_linear_flops(
             base_N,
             tokens_sum,
-            lora_rank=lora_rank,
-            lora_modules=lora_modules,
+            lora_config=lora_config,
             module_shapes=module_shapes,
         )
 
@@ -221,8 +246,7 @@ class VeomniFlopsCounter:
         config,
         tokens_sum,
         batch_seqlens,
-        lora_rank=None,
-        lora_modules=None,
+        lora_config=None,
     ):
         """Compute raw text FLOPs shared by Qwen3 MoE text and VL models."""
         hidden_size = config.hidden_size
@@ -232,30 +256,24 @@ class VeomniFlopsCounter:
         q_size = num_attention_heads * head_dim
         kv_size = config.num_key_value_heads * head_dim
 
-        lora_modules = self._expand_fused_moe_lora_modules(lora_modules)
-
         router_N = hidden_size * config.num_experts
         active_expert_N = hidden_size * config.moe_intermediate_size * config.num_experts_per_tok * 3
         attn_linear_N = hidden_size * (2 * q_size + 2 * kv_size)
         lm_head_N = self._compute_lm_head_params(hidden_size, config.vocab_size)
         base_N = (router_N + active_expert_N + attn_linear_N) * num_hidden_layers + lm_head_N
-        active_expert_count = num_hidden_layers * config.num_experts_per_tok
         module_shapes = {
             "q_proj": (hidden_size, q_size, num_hidden_layers),
             "k_proj": (hidden_size, kv_size, num_hidden_layers),
             "v_proj": (hidden_size, kv_size, num_hidden_layers),
             "o_proj": (q_size, hidden_size, num_hidden_layers),
-            "gate_proj": (hidden_size, config.moe_intermediate_size, active_expert_count),
-            "up_proj": (hidden_size, config.moe_intermediate_size, active_expert_count),
-            "down_proj": (config.moe_intermediate_size, hidden_size, active_expert_count),
         }
         linear_flops = self._compute_linear_flops(
             base_N,
             tokens_sum,
-            lora_rank=lora_rank,
-            lora_modules=lora_modules,
+            lora_config=lora_config,
             module_shapes=module_shapes,
         )
+        linear_flops += self._compute_routed_moe_lora_flops(config, tokens_sum, lora_config)
 
         seqlen_square_sum = sum(seqlen * seqlen for seqlen in batch_seqlens)
         attention_core_flops = 12 * seqlen_square_sum * head_dim * num_attention_heads * num_hidden_layers
@@ -468,15 +486,13 @@ class VeomniFlopsCounter:
         tokens_sum,
         batch_seqlens,
         delta_time,
-        lora_rank=None,
-        lora_modules=None,
+        lora_config=None,
     ):
         flops_all_token = self._compute_qwen3_moe_text_flops(
             self.config,
             tokens_sum,
             batch_seqlens,
-            lora_rank,
-            lora_modules,
+            lora_config,
         )
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
@@ -562,15 +578,13 @@ class VeomniFlopsCounter:
         tokens_sum,
         batch_seqlens,
         delta_time,
-        lora_rank=None,
-        lora_modules=None,
+        lora_config=None,
     ):
         flops_all_token = self._compute_qwen_dense_text_flops(
             self.config,
             tokens_sum,
             batch_seqlens,
-            lora_rank,
-            lora_modules,
+            lora_config,
         )
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
@@ -614,8 +628,7 @@ class VeomniFlopsCounter:
         tokens_sum,
         batch_seqlens,
         delta_time,
-        lora_rank=None,
-        lora_modules=None,
+        lora_config=None,
         **kargs,
     ):
         text_config = self.config.text_config if hasattr(self.config, "text_config") else self.config
@@ -623,8 +636,7 @@ class VeomniFlopsCounter:
             text_config,
             tokens_sum,
             batch_seqlens,
-            lora_rank,
-            lora_modules,
+            lora_config,
         )
 
         # vit flops
@@ -633,8 +645,7 @@ class VeomniFlopsCounter:
             vit_flops = self._estimate_qwen_vit_flop(
                 images_seqlens,
                 self.config.vision_config,
-                lora_rank=lora_rank,
-                lora_modules=lora_modules,
+                lora_config=lora_config,
             )
         else:
             vit_flops = 0
@@ -649,16 +660,14 @@ class VeomniFlopsCounter:
         tokens_sum,
         batch_seqlens,
         delta_time,
-        lora_rank=None,
-        lora_modules=None,
+        lora_config=None,
         **kargs,
     ):
         text_flops = self._compute_qwen_dense_text_flops(
             self.config.text_config,
             tokens_sum,
             batch_seqlens,
-            lora_rank,
-            lora_modules,
+            lora_config,
         )
 
         # vit flops
@@ -667,7 +676,7 @@ class VeomniFlopsCounter:
             vit_flops = self._estimate_qwen3_vit_flop(
                 images_seqlens,
                 self.config.vision_config,
-                forward_only=lora_rank is not None,
+                forward_only=lora_config is not None,
             )
         else:
             vit_flops = 0
@@ -682,16 +691,14 @@ class VeomniFlopsCounter:
         tokens_sum,
         batch_seqlens,
         delta_time,
-        lora_rank=None,
-        lora_modules=None,
+        lora_config=None,
         **kargs,
     ):
         text_flops = self._compute_qwen3_moe_text_flops(
             self.config.text_config,
             tokens_sum,
             batch_seqlens,
-            lora_rank,
-            lora_modules,
+            lora_config,
         )
         # vit flops
         images_seqlens = kargs.get("images_seqlens", None)
@@ -699,7 +706,7 @@ class VeomniFlopsCounter:
             vit_flops = self._estimate_qwen3_vit_flop(
                 images_seqlens,
                 self.config.vision_config,
-                forward_only=lora_rank is not None,
+                forward_only=lora_config is not None,
             )
         else:
             vit_flops = 0
@@ -757,7 +764,7 @@ class VeomniFlopsCounter:
 
         return vit_flops
 
-    def _estimate_qwen_vit_flop(self, images_seqlens, config, lora_rank=None, lora_modules=None):
+    def _estimate_qwen_vit_flop(self, images_seqlens, config, lora_config=None):
         """
         Estimate the FLOPS of the vision encoder for Qwen2 and Qwen2.5
         """
@@ -807,13 +814,13 @@ class VeomniFlopsCounter:
         dense_N_flops = self._compute_linear_flops(
             dense_N,
             tokens_sum,
-            lora_rank=lora_rank,
-            lora_modules=lora_modules,
+            lora_config=lora_config,
             module_shapes=vision_module_shapes,
             detached_without_targets=True,
         )
-        vision_has_lora = any(module in vision_module_shapes for module in lora_modules or ())
-        attention_factor = 12 if lora_rank is None or vision_has_lora else 4
+        target_modules = lora_config.target_modules if lora_config is not None else ()
+        vision_has_lora = any(module in vision_module_shapes for module in target_modules or ())
+        attention_factor = 12 if lora_config is None or vision_has_lora else 4
 
         # In Qwen2.5 VL, windowed attention is used in some layers.
         full_attn_layer_num = config.depth if is_qwen2_vl else len(config.fullatt_block_indexes)
@@ -969,14 +976,11 @@ class VeomniFlopsCounter:
         tokens_sum,
         batch_seqlens,
         delta_time,
-        lora_rank=None,
-        lora_modules=None,
+        lora_config=None,
     ):
         """
         Estimate the FLOPS of the Qwen3 Next model.
         """
-        lora_modules = self._expand_fused_moe_lora_modules(lora_modules)
-
         hidden_size = self.config.hidden_size
         vocab_size = self.config.vocab_size
         num_hidden_layers = self.config.num_hidden_layers
@@ -986,12 +990,13 @@ class VeomniFlopsCounter:
             self._compute_hybrid_attn_params(self.config)
         )
 
-        # moe per layer parm
-        # TopkGate layer and gate_proj, up_proj and down_proj using SwiGLU in ExpertMlp layer & shared experts
+        # MoE per-layer parameters: top-k router, routed/shared SwiGLU experts,
+        # and the scalar sigmoid gate applied to the shared expert output.
         moe_gata_N = hidden_size * self.config.num_experts
         moe_sharedexpertmlp_N = hidden_size * self.config.shared_expert_intermediate_size * 3
+        moe_sharedexpert_gate_N = hidden_size
         moe_expertmlp_N = hidden_size * self.config.moe_intermediate_size * self.config.num_experts_per_tok * 3
-        moe_N = (moe_gata_N + moe_expertmlp_N + moe_sharedexpertmlp_N) * num_hidden_layers
+        moe_N = (moe_gata_N + moe_expertmlp_N + moe_sharedexpertmlp_N + moe_sharedexpert_gate_N) * num_hidden_layers
 
         # lm head param
         lm_head_N = self._compute_lm_head_params(hidden_size, vocab_size)
@@ -1000,7 +1005,6 @@ class VeomniFlopsCounter:
         kv_size = self.config.num_key_value_heads * head_dim
         linear_k_size = self.config.linear_num_key_heads * self.config.linear_key_head_dim
         linear_v_size = self.config.linear_num_value_heads * self.config.linear_value_head_dim
-        active_expert_count = num_hidden_layers * self.config.num_experts_per_tok
         module_shapes = {
             "q_proj": (hidden_size, 2 * q_size, num_full_attn_layers),
             "k_proj": (hidden_size, kv_size, num_full_attn_layers),
@@ -1017,17 +1021,17 @@ class VeomniFlopsCounter:
                 num_linear_attn_layers,
             ),
             "out_proj": (linear_v_size, hidden_size, num_linear_attn_layers),
-            "gate_proj": (hidden_size, self.config.moe_intermediate_size, active_expert_count),
-            "up_proj": (hidden_size, self.config.moe_intermediate_size, active_expert_count),
-            "down_proj": (self.config.moe_intermediate_size, hidden_size, active_expert_count),
+            "gate_proj": (hidden_size, self.config.shared_expert_intermediate_size, num_hidden_layers),
+            "up_proj": (hidden_size, self.config.shared_expert_intermediate_size, num_hidden_layers),
+            "down_proj": (self.config.shared_expert_intermediate_size, hidden_size, num_hidden_layers),
         }
         dense_N_flops = self._compute_linear_flops(
             moe_N + attn_linear_N + lm_head_N,
             tokens_sum,
-            lora_rank=lora_rank,
-            lora_modules=lora_modules,
+            lora_config=lora_config,
             module_shapes=module_shapes,
         )
+        dense_N_flops += self._compute_routed_moe_lora_flops(self.config, tokens_sum, lora_config)
         # attn all_layer & all_token fwd & bwd flops, only count full attention layers
         seqlen_square_sum = 0
         for seqlen in batch_seqlens:
@@ -1047,8 +1051,7 @@ class VeomniFlopsCounter:
         tokens_sum,
         batch_seqlens,
         delta_time,
-        lora_rank=None,
-        lora_modules=None,
+        lora_config=None,
         **kargs,
     ):
         """
@@ -1074,6 +1077,8 @@ class VeomniFlopsCounter:
                     gate_proj:  hidden_size -> shared_expert_intermediate_size
                     up_proj:    hidden_size -> shared_expert_intermediate_size
                     down_proj:  shared_expert_intermediate_size -> hidden_size
+                Shared expert gate:
+                    shared_expert_gate: hidden_size -> 1
 
             Hybrid attention: see _compute_hybrid_attn_params docstring.
 
@@ -1100,12 +1105,15 @@ class VeomniFlopsCounter:
         # MLP params: MoE or dense depending on config
         is_moe = hasattr(text_config, "num_experts")
         if is_moe:
-            lora_modules = self._expand_fused_moe_lora_modules(lora_modules)
-            # MoE per layer: router gate + routed expert MLPs (top-k) + shared expert MLP
+            # MoE per layer: router, routed expert MLPs (top-k), shared expert
+            # MLP, and the scalar sigmoid gate on the shared expert output.
             moe_gata_N = hidden_size * text_config.num_experts
             moe_expertmlp_N = hidden_size * text_config.moe_intermediate_size * text_config.num_experts_per_tok * 3
             moe_sharedexpertmlp_N = hidden_size * text_config.shared_expert_intermediate_size * 3
-            mlp_N = (moe_gata_N + moe_expertmlp_N + moe_sharedexpertmlp_N) * num_hidden_layers
+            moe_sharedexpert_gate_N = hidden_size
+            mlp_N = (
+                moe_gata_N + moe_expertmlp_N + moe_sharedexpertmlp_N + moe_sharedexpert_gate_N
+            ) * num_hidden_layers
         else:
             # dense MLP per layer: gate_proj + up_proj + down_proj (SwiGLU)
             mlp_N = hidden_size * text_config.intermediate_size * 3 * num_hidden_layers
@@ -1132,26 +1140,24 @@ class VeomniFlopsCounter:
             "out_proj": (linear_v_size, hidden_size, num_linear_attn_layers),
         }
         if is_moe:
-            active_expert_count = num_hidden_layers * text_config.num_experts_per_tok
-            mlp_size = text_config.moe_intermediate_size
-            mlp_count = active_expert_count
+            mlp_size = text_config.shared_expert_intermediate_size
         else:
             mlp_size = text_config.intermediate_size
-            mlp_count = num_hidden_layers
         module_shapes.update(
             {
-                "gate_proj": (hidden_size, mlp_size, mlp_count),
-                "up_proj": (hidden_size, mlp_size, mlp_count),
-                "down_proj": (mlp_size, hidden_size, mlp_count),
+                "gate_proj": (hidden_size, mlp_size, num_hidden_layers),
+                "up_proj": (hidden_size, mlp_size, num_hidden_layers),
+                "down_proj": (mlp_size, hidden_size, num_hidden_layers),
             }
         )
         dense_N_flops = self._compute_linear_flops(
             mlp_N + attn_linear_N + lm_head_N,
             tokens_sum,
-            lora_rank=lora_rank,
-            lora_modules=lora_modules,
+            lora_config=lora_config,
             module_shapes=module_shapes,
         )
+        if is_moe:
+            dense_N_flops += self._compute_routed_moe_lora_flops(text_config, tokens_sum, lora_config)
 
         # quadratic attention flops (Q@K and attn@V), only for full attention layers
         seqlen_square_sum = 0
@@ -1168,7 +1174,7 @@ class VeomniFlopsCounter:
             vit_flops = self._estimate_qwen3_vit_flop(
                 images_seqlens,
                 getattr(self.config, "vision_config", None),
-                forward_only=lora_rank is not None,
+                forward_only=lora_config is not None,
             )
         else:
             vit_flops = 0
@@ -1182,9 +1188,8 @@ class VeomniFlopsCounter:
         self,
         batch_seqlens,
         delta_time,
-        lora_rank: int | None = None,
-        lora_modules: list[str] | None = None,
-        **kwargs,
+        lora_config: VeOmniLoraConfig | None = None,
+        images_seqlens=None,
     ):
         """
         Estimate the FLOPS based on the number of valid tokens in the current batch and the time taken.
@@ -1192,24 +1197,24 @@ class VeomniFlopsCounter:
         Args:
             batch_seqlens (List[int]): A list where each element represents the number of valid tokens in the current batch.
             delta_time (float): The time taken to process the batch, in seconds.
-            lora_rank (int, optional): LoRA rank for supported Qwen models. ``None`` keeps the full
-                fine-tuning estimate. For MoE models, MLP targets represent independent adapters on
-                the active top-k routed experts.
-            lora_modules (List[str], optional): Semantic projection names adapted with LoRA. Defaults
-                to all supported projections for the model family when ``lora_rank`` is set. A vision
-                tower without a matching target is counted as frozen, forward-only work.
+            lora_config (VeOmniLoraConfig, optional): Effective LoRA configuration for supported
+                Qwen models. FLOPs estimation reads only ``r``, ``target_modules``,
+                ``target_parameters``, and ``moe_mode``. Other fields and their arithmetic effects
+                are intentionally ignored. A vision tower without a matching target is counted as
+                frozen, forward-only work.
+            images_seqlens (List[int], optional): Vision-token sequence lengths for multimodal
+                models.
 
         Returns:
             estimated_flops (float): The estimated FLOPS based on the input tokens and time.
             promised_flops (float): The expected FLOPS of the current device.
         """
-        lora_rank, lora_modules = self._validate_lora_args(
-            self.config.model_type,
-            lora_rank,
-            lora_modules,
-        )
-        if lora_rank is not None:
-            kwargs.update(lora_rank=lora_rank, lora_modules=lora_modules)
+        lora_config = self._validate_lora_config(self.config.model_type, lora_config)
+        kwargs = {}
+        if lora_config is not None:
+            kwargs["lora_config"] = lora_config
+        if images_seqlens is not None:
+            kwargs["images_seqlens"] = images_seqlens
 
         tokens_sum = sum(batch_seqlens)
         func = self.estimate_func.get(self.config.model_type, self._estimate_unknown_flops)

--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -22,6 +22,58 @@ from .device import get_device_name
 logger = logging.get_logger(__name__)
 
 
+_DENSE_QWEN_LORA_MODULES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+_QWEN3_NEXT_LORA_MODULES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "in_proj_qkvz",
+    "in_proj_ba",
+    "out_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+_QWEN3_5_LORA_MODULES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "in_proj_qkv",
+    "in_proj_z",
+    "in_proj_b",
+    "in_proj_a",
+    "out_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+_FUSED_MOE_LORA_MODULES = ("gate_proj", "up_proj", "down_proj")
+_LORA_MODULES_BY_MODEL_TYPE = {
+    "qwen2": _DENSE_QWEN_LORA_MODULES,
+    "qwen2_vl": _DENSE_QWEN_LORA_MODULES,
+    "qwen2_5_vl": _DENSE_QWEN_LORA_MODULES,
+    "qwen3": _DENSE_QWEN_LORA_MODULES,
+    "qwen3_moe": _DENSE_QWEN_LORA_MODULES,
+    "qwen3_vl": _DENSE_QWEN_LORA_MODULES,
+    "qwen3_vl_moe": _DENSE_QWEN_LORA_MODULES,
+    "qwen3_next": _QWEN3_NEXT_LORA_MODULES,
+    "qwen3_5": _QWEN3_5_LORA_MODULES,
+    "qwen3_5_text": _QWEN3_5_LORA_MODULES,
+    "qwen3_5_moe": _QWEN3_5_LORA_MODULES,
+    "qwen3_5_moe_text": _QWEN3_5_LORA_MODULES,
+}
+
+
 def get_device_flops(unit="T"):
     def unit_convert(number, level):
         units = ["B", "K", "M", "G", "T", "P"]
@@ -89,6 +141,7 @@ class VeomniFlopsCounter:
             "qwen3": self._estimate_qwen2_flops,
             "seed_oss": self._estimate_seed_flops,
             "qwen3_5": self._estimate_qwen3_5_family_flops,
+            "qwen3_5_text": self._estimate_qwen3_5_family_flops,
             "qwen3_5_moe": self._estimate_qwen3_5_family_flops,
             "qwen3_5_moe_text": self._estimate_qwen3_5_family_flops,
             "gpt_oss": self._estimate_gpt_oss_flops,
@@ -104,7 +157,76 @@ class VeomniFlopsCounter:
         # nn.Embedding is a table lookup, so only the lm_head matmul contributes FLOPs.
         return vocab_size * hidden_size
 
-    def _compute_qwen_dense_text_flops(self, config, tokens_sum, batch_seqlens):
+    @staticmethod
+    def _compute_linear_flops(
+        base_params,
+        tokens,
+        lora_rank=None,
+        lora_modules=None,
+        module_shapes=None,
+        frozen_without_targets=False,
+    ):
+        """Count linear-layer work for full fine-tuning or LoRA."""
+        if lora_rank is None:
+            return 6 * base_params * tokens
+
+        module_shapes = module_shapes or {}
+        matched_modules = [module for module in lora_modules if module in module_shapes]
+        lora_params = sum(
+            lora_rank * (module_shapes[module][0] + module_shapes[module][1]) * module_shapes[module][2]
+            for module in matched_modules
+        )
+        base_factor = 2 if frozen_without_targets and not matched_modules else 4
+        return (base_factor * base_params + 6 * lora_params) * tokens
+
+    @staticmethod
+    def _validate_lora_args(model_type, lora_rank, lora_modules):
+        if lora_rank is None:
+            if lora_modules is not None:
+                raise ValueError("`lora_modules` requires a positive `lora_rank`.")
+            return None, None
+        if isinstance(lora_rank, bool) or not isinstance(lora_rank, int) or lora_rank <= 0:
+            raise ValueError(f"`lora_rank` must be a positive integer or None, got {lora_rank!r}.")
+
+        supported_modules = _LORA_MODULES_BY_MODEL_TYPE.get(model_type)
+        if supported_modules is None:
+            raise ValueError(
+                f"LoRA FLOPs estimation supports Qwen model types {sorted(_LORA_MODULES_BY_MODEL_TYPE)}, "
+                f"got {model_type!r}."
+            )
+        if lora_modules is None:
+            return lora_rank, list(supported_modules)
+        if not isinstance(lora_modules, list) or not all(isinstance(module, str) for module in lora_modules):
+            raise ValueError("`lora_modules` must be a list of projection names.")
+        if not lora_modules:
+            raise ValueError("`lora_modules` must not be empty when `lora_rank` is set.")
+        if len(lora_modules) != len(set(lora_modules)):
+            raise ValueError(f"`lora_modules` must not contain duplicates, got {lora_modules!r}.")
+
+        unsupported_modules = set(lora_modules) - set(supported_modules)
+        if unsupported_modules:
+            raise ValueError(
+                f"Unsupported {model_type} LoRA modules: {sorted(unsupported_modules)}. "
+                f"Supported modules: {list(supported_modules)}."
+            )
+        return lora_rank, lora_modules
+
+    @staticmethod
+    def _expand_fused_moe_lora_modules(lora_modules):
+        """A matched fused experts module always installs all three MLP adapters."""
+        if not lora_modules or not any(module in _FUSED_MOE_LORA_MODULES for module in lora_modules):
+            return lora_modules
+        non_mlp_modules = [module for module in lora_modules if module not in _FUSED_MOE_LORA_MODULES]
+        return [*non_mlp_modules, *_FUSED_MOE_LORA_MODULES]
+
+    def _compute_qwen_dense_text_flops(
+        self,
+        config,
+        tokens_sum,
+        batch_seqlens,
+        lora_rank=None,
+        lora_modules=None,
+    ):
         """Compute raw text FLOPs shared by dense Qwen text and VL models."""
         hidden_size = config.hidden_size
         num_attention_heads = config.num_attention_heads
@@ -116,14 +238,36 @@ class VeomniFlopsCounter:
         mlp_N = hidden_size * config.intermediate_size * 3
         attn_linear_N = hidden_size * (2 * q_size + 2 * kv_size)
         lm_head_N = self._compute_lm_head_params(hidden_size, config.vocab_size)
-        dense_N = (mlp_N + attn_linear_N) * num_hidden_layers + lm_head_N
-        dense_N_flops = 6 * dense_N * tokens_sum
+        base_N = (mlp_N + attn_linear_N) * num_hidden_layers + lm_head_N
+        module_shapes = {
+            "q_proj": (hidden_size, q_size, num_hidden_layers),
+            "k_proj": (hidden_size, kv_size, num_hidden_layers),
+            "v_proj": (hidden_size, kv_size, num_hidden_layers),
+            "o_proj": (q_size, hidden_size, num_hidden_layers),
+            "gate_proj": (hidden_size, config.intermediate_size, num_hidden_layers),
+            "up_proj": (hidden_size, config.intermediate_size, num_hidden_layers),
+            "down_proj": (config.intermediate_size, hidden_size, num_hidden_layers),
+        }
+        linear_flops = self._compute_linear_flops(
+            base_N,
+            tokens_sum,
+            lora_rank=lora_rank,
+            lora_modules=lora_modules,
+            module_shapes=module_shapes,
+        )
 
         seqlen_square_sum = sum(seqlen * seqlen for seqlen in batch_seqlens)
-        attn_qkv_flops = 12 * seqlen_square_sum * head_dim * num_attention_heads * num_hidden_layers
-        return dense_N_flops + attn_qkv_flops
+        attention_core_flops = 12 * seqlen_square_sum * head_dim * num_attention_heads * num_hidden_layers
+        return linear_flops + attention_core_flops
 
-    def _compute_qwen3_moe_text_flops(self, config, tokens_sum, batch_seqlens):
+    def _compute_qwen3_moe_text_flops(
+        self,
+        config,
+        tokens_sum,
+        batch_seqlens,
+        lora_rank=None,
+        lora_modules=None,
+    ):
         """Compute raw text FLOPs shared by Qwen3 MoE text and VL models."""
         hidden_size = config.hidden_size
         num_attention_heads = config.num_attention_heads
@@ -132,16 +276,34 @@ class VeomniFlopsCounter:
         q_size = num_attention_heads * head_dim
         kv_size = config.num_key_value_heads * head_dim
 
-        moe_gata_N = hidden_size * config.num_experts
-        moe_expertmlp_N = hidden_size * config.moe_intermediate_size * config.num_experts_per_tok * 3
+        lora_modules = self._expand_fused_moe_lora_modules(lora_modules)
+
+        router_N = hidden_size * config.num_experts
+        active_expert_N = hidden_size * config.moe_intermediate_size * config.num_experts_per_tok * 3
         attn_linear_N = hidden_size * (2 * q_size + 2 * kv_size)
         lm_head_N = self._compute_lm_head_params(hidden_size, config.vocab_size)
-        moe_N = (moe_gata_N + moe_expertmlp_N + attn_linear_N) * num_hidden_layers + lm_head_N
-        dense_N_flops = 6 * moe_N * tokens_sum
+        base_N = (router_N + active_expert_N + attn_linear_N) * num_hidden_layers + lm_head_N
+        active_expert_count = num_hidden_layers * config.num_experts_per_tok
+        module_shapes = {
+            "q_proj": (hidden_size, q_size, num_hidden_layers),
+            "k_proj": (hidden_size, kv_size, num_hidden_layers),
+            "v_proj": (hidden_size, kv_size, num_hidden_layers),
+            "o_proj": (q_size, hidden_size, num_hidden_layers),
+            "gate_proj": (hidden_size, config.moe_intermediate_size, active_expert_count),
+            "up_proj": (hidden_size, config.moe_intermediate_size, active_expert_count),
+            "down_proj": (config.moe_intermediate_size, hidden_size, active_expert_count),
+        }
+        linear_flops = self._compute_linear_flops(
+            base_N,
+            tokens_sum,
+            lora_rank=lora_rank,
+            lora_modules=lora_modules,
+            module_shapes=module_shapes,
+        )
 
         seqlen_square_sum = sum(seqlen * seqlen for seqlen in batch_seqlens)
-        attn_qkv_flops = 12 * seqlen_square_sum * head_dim * num_attention_heads * num_hidden_layers
-        return dense_N_flops + attn_qkv_flops
+        attention_core_flops = 12 * seqlen_square_sum * head_dim * num_attention_heads * num_hidden_layers
+        return linear_flops + attention_core_flops
 
     def _estimate_seed_flops(self, tokens_sum, batch_seqlens, delta_time):
         hidden_size = self.config.hidden_size
@@ -345,8 +507,21 @@ class VeomniFlopsCounter:
         flops_all_token = linear_flops + mhc_residual_flops + attention_flops + indexer_flops
         return flops_all_token * (1.0 / delta_time) / 1e12
 
-    def _estimate_qwen3_moe_flops(self, tokens_sum, batch_seqlens, delta_time):
-        flops_all_token = self._compute_qwen3_moe_text_flops(self.config, tokens_sum, batch_seqlens)
+    def _estimate_qwen3_moe_flops(
+        self,
+        tokens_sum,
+        batch_seqlens,
+        delta_time,
+        lora_rank=None,
+        lora_modules=None,
+    ):
+        flops_all_token = self._compute_qwen3_moe_text_flops(
+            self.config,
+            tokens_sum,
+            batch_seqlens,
+            lora_rank,
+            lora_modules,
+        )
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
@@ -426,8 +601,21 @@ class VeomniFlopsCounter:
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
-    def _estimate_qwen2_flops(self, tokens_sum, batch_seqlens, delta_time):
-        flops_all_token = self._compute_qwen_dense_text_flops(self.config, tokens_sum, batch_seqlens)
+    def _estimate_qwen2_flops(
+        self,
+        tokens_sum,
+        batch_seqlens,
+        delta_time,
+        lora_rank=None,
+        lora_modules=None,
+    ):
+        flops_all_token = self._compute_qwen_dense_text_flops(
+            self.config,
+            tokens_sum,
+            batch_seqlens,
+            lora_rank,
+            lora_modules,
+        )
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
@@ -465,14 +653,33 @@ class VeomniFlopsCounter:
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
-    def _estimate_qwen2_vl_flops(self, tokens_sum, batch_seqlens, delta_time, **kargs):
+    def _estimate_qwen2_vl_flops(
+        self,
+        tokens_sum,
+        batch_seqlens,
+        delta_time,
+        lora_rank=None,
+        lora_modules=None,
+        **kargs,
+    ):
         text_config = self.config.text_config if hasattr(self.config, "text_config") else self.config
-        text_flops = self._compute_qwen_dense_text_flops(text_config, tokens_sum, batch_seqlens)
+        text_flops = self._compute_qwen_dense_text_flops(
+            text_config,
+            tokens_sum,
+            batch_seqlens,
+            lora_rank,
+            lora_modules,
+        )
 
         # vit flops
         images_seqlens = kargs.get("images_seqlens", None)
         if images_seqlens is not None:
-            vit_flops = self._estimate_qwen_vit_flop(images_seqlens, self.config.vision_config)
+            vit_flops = self._estimate_qwen_vit_flop(
+                images_seqlens,
+                self.config.vision_config,
+                lora_rank=lora_rank,
+                lora_modules=lora_modules,
+            )
         else:
             vit_flops = 0
 
@@ -481,13 +688,31 @@ class VeomniFlopsCounter:
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
-    def _estimate_qwen3_vl_flops(self, tokens_sum, batch_seqlens, delta_time, **kargs):
-        text_flops = self._compute_qwen_dense_text_flops(self.config.text_config, tokens_sum, batch_seqlens)
+    def _estimate_qwen3_vl_flops(
+        self,
+        tokens_sum,
+        batch_seqlens,
+        delta_time,
+        lora_rank=None,
+        lora_modules=None,
+        **kargs,
+    ):
+        text_flops = self._compute_qwen_dense_text_flops(
+            self.config.text_config,
+            tokens_sum,
+            batch_seqlens,
+            lora_rank,
+            lora_modules,
+        )
 
         # vit flops
         images_seqlens = kargs.get("images_seqlens", None)
         if images_seqlens is not None:
-            vit_flops = self._estimate_qwen3_vit_flop(images_seqlens, self.config.vision_config)
+            vit_flops = self._estimate_qwen3_vit_flop(
+                images_seqlens,
+                self.config.vision_config,
+                frozen=lora_rank is not None,
+            )
         else:
             vit_flops = 0
 
@@ -496,12 +721,30 @@ class VeomniFlopsCounter:
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
-    def _estimate_qwen3_vl_moe_flops(self, tokens_sum, batch_seqlens, delta_time, **kargs):
-        text_flops = self._compute_qwen3_moe_text_flops(self.config.text_config, tokens_sum, batch_seqlens)
+    def _estimate_qwen3_vl_moe_flops(
+        self,
+        tokens_sum,
+        batch_seqlens,
+        delta_time,
+        lora_rank=None,
+        lora_modules=None,
+        **kargs,
+    ):
+        text_flops = self._compute_qwen3_moe_text_flops(
+            self.config.text_config,
+            tokens_sum,
+            batch_seqlens,
+            lora_rank,
+            lora_modules,
+        )
         # vit flops
         images_seqlens = kargs.get("images_seqlens", None)
         if images_seqlens is not None:
-            vit_flops = self._estimate_qwen3_vit_flop(images_seqlens, self.config.vision_config)
+            vit_flops = self._estimate_qwen3_vit_flop(
+                images_seqlens,
+                self.config.vision_config,
+                frozen=lora_rank is not None,
+            )
         else:
             vit_flops = 0
         # all_layer & all_token fwd & bwd flops
@@ -509,7 +752,7 @@ class VeomniFlopsCounter:
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
-    def _estimate_qwen3_vit_flop(self, images_seqlens, config):
+    def _estimate_qwen3_vit_flop(self, images_seqlens, config, frozen=False):
         """
         Estimate the FLOPS of the vision encoder for Qwen2 and Qwen2.5
         """
@@ -542,7 +785,7 @@ class VeomniFlopsCounter:
         dense_N = patch_embed_N + (mlp_N + attn_linear_N) * depth + deepstack_merger_N + merger_N
 
         # non-attn all_layer & all_token fwd & bwd flops
-        dense_N_flops = 6 * dense_N * tokens_sum
+        dense_N_flops = (2 if frozen else 6) * dense_N * tokens_sum
 
         # In Qwen3 VL, full attention is used in all vision layers.
         full_attn_layer_num = depth
@@ -551,13 +794,14 @@ class VeomniFlopsCounter:
         seqlen_square_sum = 0
         for seqlen in images_seqlens:
             seqlen_square_sum += seqlen * seqlen
-        attn_qkv_flops = 12 * seqlen_square_sum * head_dim * num_heads * full_attn_layer_num
+        attention_factor = 4 if frozen else 12
+        attn_qkv_flops = attention_factor * seqlen_square_sum * head_dim * num_heads * full_attn_layer_num
 
         vit_flops = dense_N_flops + attn_qkv_flops
 
         return vit_flops
 
-    def _estimate_qwen_vit_flop(self, images_seqlens, config):
+    def _estimate_qwen_vit_flop(self, images_seqlens, config, lora_rank=None, lora_modules=None):
         """
         Estimate the FLOPS of the vision encoder for Qwen2 and Qwen2.5
         """
@@ -597,8 +841,23 @@ class VeomniFlopsCounter:
         # non-attn all_layer parm
         dense_N = (mlp_N + attn_linear_N) * depth + patch_embed_and_merger_N
 
-        # non-attn all_layer & all_token fwd & bwd flops
-        dense_N_flops = 6 * dense_N * tokens_sum
+        vision_module_shapes = {}
+        if not is_qwen2_vl:
+            vision_module_shapes = {
+                "gate_proj": (dim, mlp_hidden_dim, depth),
+                "up_proj": (dim, mlp_hidden_dim, depth),
+                "down_proj": (mlp_hidden_dim, dim, depth),
+            }
+        dense_N_flops = self._compute_linear_flops(
+            dense_N,
+            tokens_sum,
+            lora_rank=lora_rank,
+            lora_modules=lora_modules,
+            module_shapes=vision_module_shapes,
+            frozen_without_targets=True,
+        )
+        vision_has_lora = any(module in vision_module_shapes for module in lora_modules or ())
+        attention_factor = 12 if lora_rank is None or vision_has_lora else 4
 
         # In Qwen2.5 VL, windowed attention is used in some layers.
         full_attn_layer_num = config.depth if is_qwen2_vl else len(config.fullatt_block_indexes)
@@ -608,11 +867,11 @@ class VeomniFlopsCounter:
         seqlen_square_sum = 0
         for seqlen in images_seqlens:
             seqlen_square_sum += seqlen * seqlen
-        attn_qkv_flops = 12 * seqlen_square_sum * head_dim * num_heads * full_attn_layer_num
+        attn_qkv_flops = attention_factor * seqlen_square_sum * head_dim * num_heads * full_attn_layer_num
 
         # If window attention is used, add the window attention flops
         if window_attn_layer_num > 0:
-            window_attn_compute_flops = 12 * tokens_sum * (config.window_size**2) * head_dim * num_heads
+            window_attn_compute_flops = attention_factor * tokens_sum * (config.window_size**2) * head_dim * num_heads
             attn_qkv_flops += window_attn_compute_flops * window_attn_layer_num
 
         vit_flops = dense_N_flops + attn_qkv_flops
@@ -749,10 +1008,19 @@ class VeomniFlopsCounter:
             * num_gdn_layers
         )
 
-    def _estimate_qwen3_next_flops(self, tokens_sum, batch_seqlens, delta_time):
+    def _estimate_qwen3_next_flops(
+        self,
+        tokens_sum,
+        batch_seqlens,
+        delta_time,
+        lora_rank=None,
+        lora_modules=None,
+    ):
         """
         Estimate the FLOPS of the Qwen3 Next model.
         """
+        lora_modules = self._expand_fused_moe_lora_modules(lora_modules)
+
         hidden_size = self.config.hidden_size
         vocab_size = self.config.vocab_size
         num_hidden_layers = self.config.num_hidden_layers
@@ -771,8 +1039,39 @@ class VeomniFlopsCounter:
 
         # lm head param
         lm_head_N = self._compute_lm_head_params(hidden_size, vocab_size)
-        # non-attn all_layer & all_token fwd & bwd flops
-        dense_N_flops = 6 * (moe_N + attn_linear_N + lm_head_N) * tokens_sum
+        head_dim = getattr(self.config, "head_dim", hidden_size // self.config.num_attention_heads)
+        q_size = self.config.num_attention_heads * head_dim
+        kv_size = self.config.num_key_value_heads * head_dim
+        linear_k_size = self.config.linear_num_key_heads * self.config.linear_key_head_dim
+        linear_v_size = self.config.linear_num_value_heads * self.config.linear_value_head_dim
+        active_expert_count = num_hidden_layers * self.config.num_experts_per_tok
+        module_shapes = {
+            "q_proj": (hidden_size, 2 * q_size, num_full_attn_layers),
+            "k_proj": (hidden_size, kv_size, num_full_attn_layers),
+            "v_proj": (hidden_size, kv_size, num_full_attn_layers),
+            "o_proj": (q_size, hidden_size, num_full_attn_layers),
+            "in_proj_qkvz": (
+                hidden_size,
+                2 * linear_k_size + 2 * linear_v_size,
+                num_linear_attn_layers,
+            ),
+            "in_proj_ba": (
+                hidden_size,
+                2 * self.config.linear_num_value_heads,
+                num_linear_attn_layers,
+            ),
+            "out_proj": (linear_v_size, hidden_size, num_linear_attn_layers),
+            "gate_proj": (hidden_size, self.config.moe_intermediate_size, active_expert_count),
+            "up_proj": (hidden_size, self.config.moe_intermediate_size, active_expert_count),
+            "down_proj": (self.config.moe_intermediate_size, hidden_size, active_expert_count),
+        }
+        dense_N_flops = self._compute_linear_flops(
+            moe_N + attn_linear_N + lm_head_N,
+            tokens_sum,
+            lora_rank=lora_rank,
+            lora_modules=lora_modules,
+            module_shapes=module_shapes,
+        )
         # attn all_layer & all_token fwd & bwd flops, only count full attention layers
         seqlen_square_sum = 0
         for seqlen in batch_seqlens:
@@ -787,7 +1086,15 @@ class VeomniFlopsCounter:
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
-    def _estimate_qwen3_5_family_flops(self, tokens_sum, batch_seqlens, delta_time, **kargs):
+    def _estimate_qwen3_5_family_flops(
+        self,
+        tokens_sum,
+        batch_seqlens,
+        delta_time,
+        lora_rank=None,
+        lora_modules=None,
+        **kargs,
+    ):
         """
         Estimate the FLOPS of the Qwen3.5 model family (dense/MoE MLP + hybrid attention + ViT).
 
@@ -837,6 +1144,7 @@ class VeomniFlopsCounter:
         # MLP params: MoE or dense depending on config
         is_moe = hasattr(text_config, "num_experts")
         if is_moe:
+            lora_modules = self._expand_fused_moe_lora_modules(lora_modules)
             # MoE per layer: router gate + routed expert MLPs (top-k) + shared expert MLP
             moe_gata_N = hidden_size * text_config.num_experts
             moe_expertmlp_N = hidden_size * text_config.moe_intermediate_size * text_config.num_experts_per_tok * 3
@@ -848,8 +1156,46 @@ class VeomniFlopsCounter:
 
         # lm_head only; embed_tokens is a table lookup.
         lm_head_N = self._compute_lm_head_params(hidden_size, vocab_size)
-        # linear projection flops: 6 (fwd + bwd) * params * tokens
-        dense_N_flops = 6 * (mlp_N + attn_linear_N + lm_head_N) * tokens_sum
+        q_size = text_config.num_attention_heads * head_dim
+        kv_size = text_config.num_key_value_heads * head_dim
+        linear_k_size = text_config.linear_num_key_heads * text_config.linear_key_head_dim
+        linear_v_size = text_config.linear_num_value_heads * text_config.linear_value_head_dim
+        module_shapes = {
+            "q_proj": (hidden_size, 2 * q_size, num_full_attn_layers),
+            "k_proj": (hidden_size, kv_size, num_full_attn_layers),
+            "v_proj": (hidden_size, kv_size, num_full_attn_layers),
+            "o_proj": (q_size, hidden_size, num_full_attn_layers),
+            "in_proj_qkv": (
+                hidden_size,
+                2 * linear_k_size + linear_v_size,
+                num_linear_attn_layers,
+            ),
+            "in_proj_z": (hidden_size, linear_v_size, num_linear_attn_layers),
+            "in_proj_b": (hidden_size, text_config.linear_num_value_heads, num_linear_attn_layers),
+            "in_proj_a": (hidden_size, text_config.linear_num_value_heads, num_linear_attn_layers),
+            "out_proj": (linear_v_size, hidden_size, num_linear_attn_layers),
+        }
+        if is_moe:
+            active_expert_count = num_hidden_layers * text_config.num_experts_per_tok
+            mlp_size = text_config.moe_intermediate_size
+            mlp_count = active_expert_count
+        else:
+            mlp_size = text_config.intermediate_size
+            mlp_count = num_hidden_layers
+        module_shapes.update(
+            {
+                "gate_proj": (hidden_size, mlp_size, mlp_count),
+                "up_proj": (hidden_size, mlp_size, mlp_count),
+                "down_proj": (mlp_size, hidden_size, mlp_count),
+            }
+        )
+        dense_N_flops = self._compute_linear_flops(
+            mlp_N + attn_linear_N + lm_head_N,
+            tokens_sum,
+            lora_rank=lora_rank,
+            lora_modules=lora_modules,
+            module_shapes=module_shapes,
+        )
 
         # quadratic attention flops (Q@K and attn@V), only for full attention layers
         seqlen_square_sum = 0
@@ -863,7 +1209,11 @@ class VeomniFlopsCounter:
         # vit flops (Qwen3-VL ViT)
         images_seqlens = kargs.get("images_seqlens", None)
         if images_seqlens is not None:
-            vit_flops = self._estimate_qwen3_vit_flop(images_seqlens, self.config.vision_config)
+            vit_flops = self._estimate_qwen3_vit_flop(
+                images_seqlens,
+                getattr(self.config, "vision_config", None),
+                frozen=lora_rank is not None,
+            )
         else:
             vit_flops = 0
 
@@ -872,18 +1222,39 @@ class VeomniFlopsCounter:
         flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
         return flops_achieved
 
-    def estimate_flops(self, batch_seqlens, delta_time, **kwargs):
+    def estimate_flops(
+        self,
+        batch_seqlens,
+        delta_time,
+        lora_rank: int | None = None,
+        lora_modules: list[str] | None = None,
+        **kwargs,
+    ):
         """
         Estimate the FLOPS based on the number of valid tokens in the current batch and the time taken.
 
         Args:
             batch_seqlens (List[int]): A list where each element represents the number of valid tokens in the current batch.
             delta_time (float): The time taken to process the batch, in seconds.
+            lora_rank (int, optional): LoRA rank for supported Qwen models. ``None`` keeps the full
+                fine-tuning estimate. For MoE models, MLP targets represent independent adapters on
+                the active top-k routed experts.
+            lora_modules (List[str], optional): Semantic projection names adapted with LoRA. Defaults
+                to all supported projections for the model family when ``lora_rank`` is set. A vision
+                tower without a matching target is counted as frozen, forward-only work.
 
         Returns:
             estimated_flops (float): The estimated FLOPS based on the input tokens and time.
             promised_flops (float): The expected FLOPS of the current device.
         """
+        lora_rank, lora_modules = self._validate_lora_args(
+            self.config.model_type,
+            lora_rank,
+            lora_modules,
+        )
+        if lora_rank is not None:
+            kwargs.update(lora_rank=lora_rank, lora_modules=lora_modules)
+
         tokens_sum = sum(batch_seqlens)
         func = self.estimate_func.get(self.config.model_type, self._estimate_unknown_flops)
         estimated_flops = func(tokens_sum, batch_seqlens, delta_time, **kwargs)

--- a/veomni/utils/helper.py
+++ b/veomni/utils/helper.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
     from transformers import PretrainedConfig
 
     from ..distributed.parallel_state import ParallelState
+    from ..lora import VeOmniLoraConfig
 
 
 logger = logging.get_logger(__name__)
@@ -206,8 +207,12 @@ class EnvironMeter:
         # for internal use
         if VALID_CONFIG_TYPE is not None and isinstance(config, VALID_CONFIG_TYPE):
             self.estimate_flops = FlopsCounter(config).estimate_flops
+            self.supports_lora_flops = False
         else:
-            self.estimate_flops = VeomniFlopsCounter(config).estimate_flops
+            flops_counter = VeomniFlopsCounter(config)
+            self.estimate_flops = flops_counter.estimate_flops
+            self.supports_lora_flops = True
+        self._warned_unsupported_lora_flops = False
 
         if self.gc_steps > 0:
             gc.disable()
@@ -241,13 +246,32 @@ class EnvironMeter:
         else:  # dit diffusers model
             self.batch_seqlens.extend(_compute_wan_seqlens(micro_batch))
 
-    def step(self, delta_time: float, global_step: int) -> Dict[str, Any]:
-        if len(self.images_seqlens) > 0:
-            flops_achieved, flops_promised = self.estimate_flops(
-                self.batch_seqlens, delta_time, images_seqlens=self.images_seqlens
-            )
-        else:
-            flops_achieved, flops_promised = self.estimate_flops(self.batch_seqlens, delta_time)
+    def step(
+        self,
+        delta_time: float,
+        global_step: int,
+        lora_config: Optional["VeOmniLoraConfig"] = None,
+    ) -> Dict[str, Any]:
+        flops_kwargs = {}
+        if self.images_seqlens:
+            flops_kwargs["images_seqlens"] = self.images_seqlens
+        lora_flops_unavailable = lora_config is not None and not self.supports_lora_flops
+        if lora_config is not None:
+            if self.supports_lora_flops:
+                flops_kwargs["lora_config"] = lora_config
+            elif not self._warned_unsupported_lora_flops:
+                logger.warning_rank0(
+                    "LoRA FLOPs are unavailable because the configured FLOP counter does not accept "
+                    "VeOmniLoraConfig. Returning zero FLOPs so training can continue."
+                )
+                self._warned_unsupported_lora_flops = True
+        flops_achieved, flops_promised = self.estimate_flops(
+            self.batch_seqlens,
+            delta_time,
+            **flops_kwargs,
+        )
+        if lora_flops_unavailable:
+            flops_achieved = 0
         flops_achieved, batch_tokens, real_global_batch_size = all_reduce(
             (flops_achieved, sum(self.batch_seqlens), len(self.batch_seqlens)),
             op="sum",


### PR DESCRIPTION
### What does this PR do?

Extend count_flops to allow Lora config for Qwen 2/3/3.5 models

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

FFT flops count unchanged for:
- 336 different Qwen models, each with 11 batch/sequence settings.
- Run a quick sanity check fo 0.6B qwen model + lora, and mfu is reported
- Added scripts/profile/compare_lora_flops.py, a script that uses Veomni's config loader to load config, and pass it to the flops counter. Tested 10 different Text / Image / MOE models, all output are similar to the following:
<img width="557" height="357" alt="image" src="https://github.com/user-attachments/assets/42ca707e-b9ad-41ce-81d1-d9e3c5cd1684" />


### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
