### PR TITLE
[ckpt] fix: port DCP consolidation patch to torch 2.12

### DIFF
--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -144,7 +144,7 @@ Core files:
     - Calling checkpoint operations from only rank 0 causes deadlocks.
 
 18. **Distributed HF safetensors consolidation must support non-floating tensors**
-    - PyTorch 2.9–2.11 computes consolidated tensor byte sizes with `torch.finfo`, which crashes for valid integer and boolean buffers such as DeepSeek V4 `tid2eid`.
+    - PyTorch 2.9–2.12 computes consolidated tensor byte sizes with `torch.finfo`, which crashes for valid integer and boolean buffers such as DeepSeek V4 `tid2eid`.
     - `apply_dcp_consolidation_patch()` in `veomni/checkpoint/dcp_consolidation.py` replaces the metadata parser with `Tensor.element_size()` and verifies the upstream private-function source hash before patching.
     - Offline DCP-to-HF conversion may cast `save_dtype` only onto floating tensors; integer and boolean buffers must retain their original dtype, and shard-size planning must use their original element sizes.
     - Do not remove this patch during torch upgrades until the new upstream consolidator is verified with sharded integer-tensor save/load coverage.

--- a/docs/hardware_support/rocm/README.md
+++ b/docs/hardware_support/rocm/README.md
@@ -107,4 +107,4 @@ Validated on 8×MI308X / ROCm 7.14. End-to-end training (FSDP2 sharding, Ulysses
 
 - **CUDA-only kernels** (FA3/FA4/Quack/FlashMLA/DSA, e.g. `gpt_oss`) fall back to triton/eager on ROCm, or are skipped.
 - **GatedDeltaNet (qwen3_5 / qwen3_5_moe)**: the tilelang ROCm backend has a HIP wrapper/codegen defect; set `FLA_TILELANG=0` to use the Triton fallback (validated to train and align correctly).
-- **DCP → HF weight consolidation**: the version guard in `veomni/checkpoint/dcp_consolidation.py` only allows torch `2.9`/`2.11` and rejects the image's torch `2.12`. Relax the guard or use a 2.9/2.11 ROCm torch build; otherwise disable `save_hf_weights`.
+- **DCP → HF weight consolidation**: torch `2.12` is supported by the allow-listed patch in `veomni/checkpoint/dcp_consolidation.py`. Newer torch releases still need their `_process_output_file` hash added before `save_hf_weights` consolidation will succeed.

--- a/docs/usage/hdfs_fuse_patch.md
+++ b/docs/usage/hdfs_fuse_patch.md
@@ -52,7 +52,7 @@ No manual action is required. The patch is guarded by `_dcp_consolidation_patch_
 
 ## Requirements
 
-- **PyTorch Version**: Verified against PyTorch 2.9.1, 2.10.0, and the allow-listed 2.11.0 upstream/CI-wheel implementations. Other patch releases or builds fail the source-hash guard until explicitly verified and added.
+- **PyTorch Version**: Verified against PyTorch 2.9.1, 2.10.0, the allow-listed 2.11.0 upstream/CI-wheel implementations, and 2.12.x (handle-based `_read_tensor_data` API). Other patch releases or builds fail the source-hash guard until explicitly verified and added.
 - **Tensors must be sorted by offset** before writing (already ensured by the implementation)
 
 ## Implementation Details

--- a/tests/utils/test_save_safetensor_utils.py
+++ b/tests/utils/test_save_safetensor_utils.py
@@ -52,24 +52,27 @@ def _call_get_model_save_state(model, fqn_to_index_mapping, fake_state):
         return get_model_save_state(model, fqn_to_index_mapping)
 
 
-def _call_save_distributed(model, save_path, fqn_to_index_mapping, model_assets, fake_save_state):
+def _call_save_distributed(
+    model, save_path, fqn_to_index_mapping, model_assets, fake_save_state, use_native_consolidation=False
+):
     """
     Invoke _save_hf_safetensor_distributed with all deps mocked.
 
     Deferred imports are patched at their source modules;
     module-level imports are patched on save_safetensor_utils directly.
 
-    Returns (mock_get_state, mock_writer_cls, mock_dcp_save, mock_save_assets).
+    Returns (mock_get_state, mock_writer_cls, mock_dcp_save, mock_save_assets, mock_apply_patch).
     """
     mock_get_state = MagicMock(return_value=fake_save_state)
     mock_writer_cls = MagicMock()
     mock_dcp_save = MagicMock()
     mock_save_assets = MagicMock()
+    mock_apply_patch = MagicMock()
 
     with (
         # --- deferred imports: patch at source ---
         patch("torch.distributed.checkpoint.HuggingFaceStorageWriter", mock_writer_cls),
-        patch("veomni.checkpoint.dcp_consolidation.apply_dcp_consolidation_patch", MagicMock()),
+        patch("veomni.checkpoint.dcp_consolidation.apply_dcp_consolidation_patch", mock_apply_patch),
         # --- module-level imports: patch on consumer ---
         patch(f"{_MOD}.get_model_save_state", mock_get_state),
         patch(f"{_MOD}.dcp", MagicMock(save=mock_dcp_save)),
@@ -78,6 +81,7 @@ def _call_save_distributed(model, save_path, fqn_to_index_mapping, model_assets,
         patch(f"{_MOD}.helper", MagicMock()),
         patch(f"{_MOD}.gc", MagicMock()),
         patch(f"{_MOD}.synchronize", MagicMock()),
+        patch(f"{_MOD}.is_torch_version_greater_than", return_value=use_native_consolidation),
     ):
         from veomni.utils.save_safetensor_utils import _save_hf_safetensor_distributed
 
@@ -88,7 +92,7 @@ def _call_save_distributed(model, save_path, fqn_to_index_mapping, model_assets,
             model_assets=model_assets,
         )
 
-    return mock_get_state, mock_writer_cls, mock_dcp_save, mock_save_assets
+    return mock_get_state, mock_writer_cls, mock_dcp_save, mock_save_assets, mock_apply_patch
 
 
 # ===========================================================================
@@ -177,7 +181,7 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
             "mtp_head.proj.weight": 1,
             "mtp_head.proj.bias": 1,
         }
-        _, writer_cls, _, _ = _call_save_distributed(
+        _, writer_cls, _, _, _ = _call_save_distributed(
             self.model,
             "/tmp/test",
             mapping.copy(),
@@ -189,7 +193,7 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
 
     def test_none_mapping_passed_through(self):
         fake = {"w": torch.randn(4, 4, dtype=torch.bfloat16)}
-        _, writer_cls, _, _ = _call_save_distributed(
+        _, writer_cls, _, _, _ = _call_save_distributed(
             self.model,
             "/tmp/test",
             None,
@@ -201,7 +205,7 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
     def test_no_filtering_when_all_keys_match(self):
         fake = {"a": torch.randn(2, 2, dtype=torch.bfloat16), "b": torch.randn(2, 2, dtype=torch.bfloat16)}
         mapping = {"a": 0, "b": 0}
-        _, writer_cls, _, _ = _call_save_distributed(
+        _, writer_cls, _, _, _ = _call_save_distributed(
             self.model,
             "/tmp/test",
             mapping.copy(),
@@ -216,7 +220,7 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
             "int64_buffer": torch.randint(0, 8, (4, 4), dtype=torch.int64),
             "bool_buffer": torch.tensor([True, False]),
         }
-        _, _, dcp_save, _ = _call_save_distributed(
+        _, _, dcp_save, _, _ = _call_save_distributed(
             self.model,
             "/tmp/test",
             None,
@@ -227,6 +231,11 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
         saved_state = dcp_save.call_args.kwargs["state_dict"]
         self.assertEqual(set(saved_state), {"weight", "int64_buffer", "bool_buffer"})
         self.assertEqual(saved_state["int64_buffer"].dtype, torch.int64)
+
+        from veomni.utils.import_utils import is_torch_version_greater_than
+
+        if is_torch_version_greater_than("2.12"):
+            return
 
         import json
         import tempfile
@@ -289,7 +298,7 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
     def test_model_assets_saved(self):
         fake = {"w": torch.randn(2, 2, dtype=torch.bfloat16)}
         assets = [MagicMock()]
-        _, _, _, save_assets = _call_save_distributed(
+        _, _, _, save_assets, _ = _call_save_distributed(
             self.model,
             "/tmp/test",
             None,
@@ -297,6 +306,18 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
             fake,
         )
         save_assets.assert_called_once_with("/tmp/test", assets)
+
+    def test_compatibility_patch_applied_before_torch_2_12(self):
+        fake = {"w": torch.randn(2, 2, dtype=torch.bfloat16)}
+        *_, apply_patch = _call_save_distributed(self.model, "/tmp/test", None, None, fake)
+        apply_patch.assert_called_once_with()
+
+    def test_native_consolidation_used_from_torch_2_12(self):
+        fake = {"w": torch.randn(2, 2, dtype=torch.bfloat16)}
+        *_, apply_patch = _call_save_distributed(
+            self.model, "/tmp/test", None, None, fake, use_native_consolidation=True
+        )
+        apply_patch.assert_not_called()
 
 
 # ===========================================================================

--- a/tests/utils/test_save_safetensor_utils.py
+++ b/tests/utils/test_save_safetensor_utils.py
@@ -52,27 +52,24 @@ def _call_get_model_save_state(model, fqn_to_index_mapping, fake_state):
         return get_model_save_state(model, fqn_to_index_mapping)
 
 
-def _call_save_distributed(
-    model, save_path, fqn_to_index_mapping, model_assets, fake_save_state, use_native_consolidation=False
-):
+def _call_save_distributed(model, save_path, fqn_to_index_mapping, model_assets, fake_save_state):
     """
     Invoke _save_hf_safetensor_distributed with all deps mocked.
 
     Deferred imports are patched at their source modules;
     module-level imports are patched on save_safetensor_utils directly.
 
-    Returns (mock_get_state, mock_writer_cls, mock_dcp_save, mock_save_assets, mock_apply_patch).
+    Returns (mock_get_state, mock_writer_cls, mock_dcp_save, mock_save_assets).
     """
     mock_get_state = MagicMock(return_value=fake_save_state)
     mock_writer_cls = MagicMock()
     mock_dcp_save = MagicMock()
     mock_save_assets = MagicMock()
-    mock_apply_patch = MagicMock()
 
     with (
         # --- deferred imports: patch at source ---
         patch("torch.distributed.checkpoint.HuggingFaceStorageWriter", mock_writer_cls),
-        patch("veomni.checkpoint.dcp_consolidation.apply_dcp_consolidation_patch", mock_apply_patch),
+        patch("veomni.checkpoint.dcp_consolidation.apply_dcp_consolidation_patch", MagicMock()),
         # --- module-level imports: patch on consumer ---
         patch(f"{_MOD}.get_model_save_state", mock_get_state),
         patch(f"{_MOD}.dcp", MagicMock(save=mock_dcp_save)),
@@ -81,7 +78,6 @@ def _call_save_distributed(
         patch(f"{_MOD}.helper", MagicMock()),
         patch(f"{_MOD}.gc", MagicMock()),
         patch(f"{_MOD}.synchronize", MagicMock()),
-        patch(f"{_MOD}.is_torch_version_greater_than", return_value=use_native_consolidation),
     ):
         from veomni.utils.save_safetensor_utils import _save_hf_safetensor_distributed
 
@@ -92,7 +88,7 @@ def _call_save_distributed(
             model_assets=model_assets,
         )
 
-    return mock_get_state, mock_writer_cls, mock_dcp_save, mock_save_assets, mock_apply_patch
+    return mock_get_state, mock_writer_cls, mock_dcp_save, mock_save_assets
 
 
 # ===========================================================================
@@ -181,7 +177,7 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
             "mtp_head.proj.weight": 1,
             "mtp_head.proj.bias": 1,
         }
-        _, writer_cls, _, _, _ = _call_save_distributed(
+        _, writer_cls, _, _ = _call_save_distributed(
             self.model,
             "/tmp/test",
             mapping.copy(),
@@ -193,7 +189,7 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
 
     def test_none_mapping_passed_through(self):
         fake = {"w": torch.randn(4, 4, dtype=torch.bfloat16)}
-        _, writer_cls, _, _, _ = _call_save_distributed(
+        _, writer_cls, _, _ = _call_save_distributed(
             self.model,
             "/tmp/test",
             None,
@@ -205,7 +201,7 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
     def test_no_filtering_when_all_keys_match(self):
         fake = {"a": torch.randn(2, 2, dtype=torch.bfloat16), "b": torch.randn(2, 2, dtype=torch.bfloat16)}
         mapping = {"a": 0, "b": 0}
-        _, writer_cls, _, _, _ = _call_save_distributed(
+        _, writer_cls, _, _ = _call_save_distributed(
             self.model,
             "/tmp/test",
             mapping.copy(),
@@ -220,7 +216,7 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
             "int64_buffer": torch.randint(0, 8, (4, 4), dtype=torch.int64),
             "bool_buffer": torch.tensor([True, False]),
         }
-        _, _, dcp_save, _, _ = _call_save_distributed(
+        _, _, dcp_save, _ = _call_save_distributed(
             self.model,
             "/tmp/test",
             None,
@@ -231,11 +227,6 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
         saved_state = dcp_save.call_args.kwargs["state_dict"]
         self.assertEqual(set(saved_state), {"weight", "int64_buffer", "bool_buffer"})
         self.assertEqual(saved_state["int64_buffer"].dtype, torch.int64)
-
-        from veomni.utils.import_utils import is_torch_version_greater_than
-
-        if is_torch_version_greater_than("2.12"):
-            return
 
         import json
         import tempfile
@@ -298,7 +289,7 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
     def test_model_assets_saved(self):
         fake = {"w": torch.randn(2, 2, dtype=torch.bfloat16)}
         assets = [MagicMock()]
-        _, _, _, save_assets, _ = _call_save_distributed(
+        _, _, _, save_assets = _call_save_distributed(
             self.model,
             "/tmp/test",
             None,
@@ -306,18 +297,6 @@ class TestSaveHfSafetensorDistributed(unittest.TestCase):
             fake,
         )
         save_assets.assert_called_once_with("/tmp/test", assets)
-
-    def test_compatibility_patch_applied_before_torch_2_12(self):
-        fake = {"w": torch.randn(2, 2, dtype=torch.bfloat16)}
-        *_, apply_patch = _call_save_distributed(self.model, "/tmp/test", None, None, fake)
-        apply_patch.assert_called_once_with()
-
-    def test_native_consolidation_used_from_torch_2_12(self):
-        fake = {"w": torch.randn(2, 2, dtype=torch.bfloat16)}
-        *_, apply_patch = _call_save_distributed(
-            self.model, "/tmp/test", None, None, fake, use_native_consolidation=True
-        )
-        apply_patch.assert_not_called()
 
 
 # ===========================================================================

--- a/veomni/checkpoint/dcp_consolidation.py
+++ b/veomni/checkpoint/dcp_consolidation.py
@@ -15,7 +15,8 @@
 # ruff: noqa: F821
 # Reason: This module patches PyTorch internal functions using types.FunctionType
 # with __globals__ bound to the target module. Variables like DATA_OFFSETS_KEY,
-# _read_tensor_data_mmap, etc. are resolved at runtime from torch.distributed.checkpoint.
+# _read_tensor_data_mmap / _read_tensor_data, etc. are resolved at runtime from
+# torch.distributed.checkpoint.
 
 """Patches for PyTorch DCP (Distributed Checkpoint) safetensors consolidation.
 
@@ -34,7 +35,7 @@ import types
 _dcp_consolidation_patch_applied = False
 
 # Fixed torch versions for this patch - update when upgrading torch
-_SUPPORTED_TORCH_VERSION_PREFIXES = ("2.9", "2.10", "2.11")
+_SUPPORTED_TORCH_VERSION_PREFIXES = ("2.9", "2.10", "2.11", "2.12")
 _EXPECTED_PROCESS_OUTPUT_FILE_ARGS = ("output_file", "output_data", "input_files_data")
 _EXPECTED_PARSE_INPUT_METADATA_ARGS = ("input_files_data", "output_files_data")
 _SUPPORTED_PROCESS_OUTPUT_FILE_SHA256 = {
@@ -46,9 +47,11 @@ _SUPPORTED_PROCESS_OUTPUT_FILE_SHA256 = {
     "ff25a85cc52018707334f1206760fe186146771e5357388f0b4d6bc19bdf61c1",
     # torch 2.11.0+cu130 CI wheel
     "433c9d026092f48f5ba02631975294de1a8ae98e020d5cb6ffd0f5db760476fe",
+    # torch 2.12.0 / 2.12.1 (handle-based _read_tensor_data API)
+    "26f969037aed2bad375fa167bbe9d4e49ead5b900ea152afc353d40c11529af3",
 }
 _SUPPORTED_PARSE_INPUT_METADATA_SHA256 = {
-    # torch 2.9.1, 2.10.0, and 2.11.0 (upstream source and cu130 CI wheel)
+    # torch 2.9.1, 2.10.0, 2.11.0, and 2.12.x (unchanged)
     "f6c476c9467a32928c8b29c211988c78a14a934bc4cbc5763a3882a7fc3b11f0",
 }
 
@@ -76,8 +79,9 @@ def apply_dcp_consolidation_patch():
     is already ensured by sorting tensors before writing.
 
     The patch uses types.FunctionType to create a new function with __globals__
-    bound to the target module, enabling access to internal functions like
-    _read_tensor_data_mmap and _write_sub_tensor_to_file_optimized.
+    bound to the target module, enabling access to internal helpers such as
+    ``_read_tensor_data_mmap`` (torch <= 2.11) or ``_read_tensor_data``
+    (torch >= 2.12) and ``_write_sub_tensor_to_file_optimized``.
     """
     global _dcp_consolidation_patch_applied
 
@@ -143,11 +147,10 @@ def apply_dcp_consolidation_patch():
             "Please update the DCP consolidation patch."
         )
 
-    # Define the replacement function logic
-    # This is a modified version of torch.distributed.checkpoint._consolidate_hf_safetensors._process_output_file
-    # Original: https://github.com/pytorch/pytorch/blob/v2.9.1/torch/distributed/checkpoint/_consolidate_hf_safetensors.py
-    # Key change: Use append mode ("ab") instead of read-write mode ("r+b") for HDFS FUSE compatibility
-    def _process_output_file_impl(output_file, output_data, input_files_data):
+    # torch <= 2.11: mmap-based reader (_read_tensor_data_mmap)
+    # torch >= 2.12: handle-based reader (_read_tensor_data)
+    # Both upstream variants still open the output with r+b; keep "ab" for HDFS FUSE.
+    def _process_output_file_impl_mmap(output_file, output_data, input_files_data):
         sorted_tensors = sorted(output_data.fqn_data.items(), key=lambda x: x[1].offset_in_file)
 
         with open(output_file, "ab") as output_stream:  # Changed from "r+b"
@@ -187,6 +190,58 @@ def apply_dcp_consolidation_patch():
                     )
 
                 output_stream.write(full_tensor_mv)
+
+    def _process_output_file_impl_handle(output_file, output_data, input_files_data):
+        sorted_tensors = sorted(output_data.fqn_data.items(), key=lambda x: x[1].offset_in_file)
+
+        file_handles = {}
+        dcp_metadata = {}
+        for safetensors_file, file_data in input_files_data.items():
+            dcp_metadata[safetensors_file] = _get_dcp_custom_metadata(file_data.metadata)
+
+        try:
+            for safetensors_file in input_files_data:
+                file_handles[safetensors_file] = open(safetensors_file, "rb")  # noqa: SIM115
+
+            with open(output_file, "ab") as output_stream:  # Changed from "r+b"
+                for tensor_fqn, tensor_fqn_data in sorted_tensors:
+                    full_tensor_mv = memoryview(
+                        bytearray(math.prod(tensor_fqn_data.shape_in_file) * tensor_fqn_data.dtype_size)
+                    )
+
+                    for safetensors_file in input_files_data:
+                        file_metadata = input_files_data[safetensors_file].metadata
+                        input_metadata_size = input_files_data[safetensors_file].metadata_size
+
+                        if tensor_fqn not in file_metadata:
+                            continue
+
+                        metadata = file_metadata[tensor_fqn]
+                        data_offsets = metadata[DATA_OFFSETS_KEY]
+
+                        data_to_write = _read_tensor_data(
+                            file_handles[safetensors_file],
+                            data_offsets[0],
+                            data_offsets[1],
+                            input_metadata_size,
+                        )
+
+                        fqn_custom_metadata = dcp_metadata[safetensors_file][tensor_fqn]
+                        offsets_of_tensor_being_read = fqn_custom_metadata[SAVED_OFFSETS_KEY]
+
+                        _write_sub_tensor_to_file_optimized(
+                            full_tensor_mv,
+                            data_to_write,
+                            tensor_fqn_data.dtype_size,
+                            tensor_fqn_data.shape_in_file,
+                            offsets_of_tensor_being_read,
+                            metadata[SHAPE_KEY],
+                        )
+
+                    output_stream.write(full_tensor_mv)
+        finally:
+            for f in file_handles.values():
+                f.close()
 
     def _parse_input_metadata_impl(input_files_data, output_files_data):
         from safetensors.torch import _getdtype
@@ -228,14 +283,20 @@ def apply_dcp_consolidation_patch():
                         dtype_str=dtype_str,
                     )
 
+    process_impl = (
+        _process_output_file_impl_mmap
+        if hasattr(hf_module, "_read_tensor_data_mmap")
+        else _process_output_file_impl_handle
+    )
+
     # Create a new function with the target module's globals
-    # This ensures that internal functions like _read_tensor_data_mmap are resolved correctly
+    # This ensures that internal helpers are resolved correctly.
     patched_func = types.FunctionType(
-        _process_output_file_impl.__code__,
+        process_impl.__code__,
         hf_module.__dict__,  # Use target module's globals for symbol resolution
-        _process_output_file_impl.__name__,
-        _process_output_file_impl.__defaults__,
-        _process_output_file_impl.__closure__,
+        process_impl.__name__,
+        process_impl.__defaults__,
+        process_impl.__closure__,
     )
 
     patched_parse_input_metadata = types.FunctionType(

--- a/veomni/utils/save_safetensor_utils.py
+++ b/veomni/utils/save_safetensor_utils.py
@@ -94,13 +94,12 @@ def _save_hf_safetensor_distributed(
     """
     from torch.distributed.checkpoint import HuggingFaceStorageWriter
 
-    # PyTorch 2.12+ provides the native DCP -> HuggingFace safetensors path used
-    # here. Keep the compatibility patch only for older supported releases;
-    # applying it to 2.12+ rejects otherwise-compatible PyTorch internals.
-    if not is_torch_version_greater_than("2.12"):
-        from veomni.checkpoint.dcp_consolidation import apply_dcp_consolidation_patch
+    # Apply DCP consolidation patch just-in-time for HDFS FUSE compatibility
+    # and non-floating tensor dtypes. Torch 2.12 still needs this: upstream keeps
+    # r+b output opens and torch.finfo-based dtype sizing.
+    from veomni.checkpoint.dcp_consolidation import apply_dcp_consolidation_patch
 
-        apply_dcp_consolidation_patch()
+    apply_dcp_consolidation_patch()
 
     save_state = get_model_save_state(model, fqn_to_index_mapping, parallel_state=parallel_state)
 

--- a/veomni/utils/save_safetensor_utils.py
+++ b/veomni/utils/save_safetensor_utils.py
@@ -94,12 +94,13 @@ def _save_hf_safetensor_distributed(
     """
     from torch.distributed.checkpoint import HuggingFaceStorageWriter
 
-    # Apply DCP consolidation patch just-in-time for HDFS FUSE compatibility
-    # This patches torch.distributed.checkpoint._consolidate_hf_safetensors._process_output_file
-    # to use append mode instead of r+b mode, which is required for append-only file systems
-    from veomni.checkpoint.dcp_consolidation import apply_dcp_consolidation_patch
+    # PyTorch 2.12+ provides the native DCP -> HuggingFace safetensors path used
+    # here. Keep the compatibility patch only for older supported releases;
+    # applying it to 2.12+ rejects otherwise-compatible PyTorch internals.
+    if not is_torch_version_greater_than("2.12"):
+        from veomni.checkpoint.dcp_consolidation import apply_dcp_consolidation_patch
 
-    apply_dcp_consolidation_patch()
+        apply_dcp_consolidation_patch()
 
     save_state = get_model_save_state(model, fqn_to_index_mapping, parallel_state=parallel_state)
 


### PR DESCRIPTION
### What does this PR do?

PyTorch 2.12 changed the private DCP safetensors consolidation implementation from the mmap-based `_read_tensor_data_mmap` helper to a handle-based `_read_tensor_data` API. The existing VeOmni patch therefore raises `NameError` when its replacement `_process_output_file` runs on torch 2.12.

This PR ports the compatibility patch to torch 2.12 instead of disabling it. This is still required because upstream torch 2.12 continues to:

- use `torch.finfo` for tensor byte-size calculation, which fails for valid integer and boolean tensors; and
- open consolidated output files with `r+b`, which is incompatible with append-only filesystems such as HDFS FUSE.

### Checklist Before Starting

- Searched for related PRs/issues and reviewed the upstream torch 2.12 implementation.
- PR title follows the required `[{modules}] {type}: {description}` format.

### Test

The existing `test_save_state_passed_to_dcp_save` regression test exercises the complete torch 2.12 handle-based path:

1. Save a state dict containing `bfloat16`, `int64`, and `bool` tensors through `HuggingFaceStorageWriter` with consolidation enabled.
2. Consolidate the distributed checkpoint into a single safetensors file.
3. Reload the file and verify the integer and boolean tensors round-trip unchanged.
4. Verify consolidated `int64` metadata has the expected shape and byte size from `Tensor.element_size()`.

PR CI passed the GPU unit/E2E, Ascend, lint, documentation-path, and device API checks.

### API and Usage Example

No public API or user-facing usage changes. `save_hf_weights` continues to apply the compatibility patch automatically.

### Design & Code Changes

- Add torch 2.12 to the supported-version allowlist and allowlist its `_process_output_file` source hash.
- Keep the existing mmap-based implementation for torch 2.9–2.11.
- Add a torch 2.12 implementation that opens input shards once, reads tensor data through the new handle-based `_read_tensor_data` API, and closes all handles in a `finally` block.
- Select the implementation from the internal reader helper exposed by the installed torch version.
- Preserve the two original fixes: `Tensor.element_size()` for non-floating dtypes and append-mode (`ab`) output for HDFS FUSE.
- Update the compatibility documentation to include torch 2.12.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit/lint checks
- [x] Updated documentation
- [x] No `tasks/` scripts were moved or renamed
- [x] Existing DCP-to-HF regression coverage validates the changed path