### PR TITLE
[perf] fix: use boost-clock peak FLOPS for Blackwell MFU

### DIFF
--- a/tests/utils/test_count_flops.py
+++ b/tests/utils/test_count_flops.py
@@ -42,6 +42,16 @@ def mock_device_flops():
         yield
 
 
+def test_b200_device_flops():
+    with patch("veomni.utils.count_flops.get_device_name", return_value="NVIDIA B200"):
+        assert get_device_flops() == 2382.0
+
+
+def test_gb200_device_flops():
+    with patch("veomni.utils.count_flops.get_device_name", return_value="NVIDIA GB200"):
+        assert get_device_flops() == 2565.0
+
+
 def test_b300_device_flops():
     with patch("veomni.utils.count_flops.get_device_name", return_value="NVIDIA B300"):
         assert get_device_flops() == 2250.0

--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -23,6 +23,16 @@ logger = logging.get_logger(__name__)
 
 
 def get_device_flops(unit="T"):
+    """Peak dense BF16 FLOPS of the current device.
+
+    All entries follow one convention: SM count x per-SM dense BF16 FLOPs per clock
+    (2048 Ampere, 4096 Hopper, 8192 Blackwell) x tensor-core boost clock. NVIDIA
+    publishes that boost clock up to Hopper, so the datasheet numbers already match;
+    for Blackwell it is the clock the deployed part actually runs at (`nvidia-smi
+    --query-gpu=clocks.max.sm`), which is higher than the clock behind the datasheet.
+    H20 and 910B are throughput-capped SKUs the formula does not describe.
+    """
+
     def unit_convert(number, level):
         units = ["B", "K", "M", "G", "T", "P"]
         if number <= 0:
@@ -47,8 +57,10 @@ def get_device_flops(unit="T"):
         flops = 148e12
     elif "910B" in device_name or "910_93" in device_name:
         flops = 354e12
+    elif "GB200" in device_name:
+        flops = 2565e12
     elif "B200" in device_name:
-        flops = 2250e12
+        flops = 2382e12
     elif "GB300" in device_name:
         flops = 2500e12
     elif "B300" in device_name:


### PR DESCRIPTION
GB200 had no entry in get_device_flops, so "NVIDIA GB200" matched the "B200" substring branch and MFU was computed against 2250 TFLOPS.

Peak FLOPS now follow one convention across the table: SM count x per-SM dense BF16 FLOPs per clock x tensor-core boost clock. Ampere/Hopper datasheet values already match it (NVIDIA publishes the tensor-core boost clock: A100 1410 MHz, H100 SXM5 1830 MHz); Blackwell datasheet values are quoted at a lower clock than the deployed part runs at, so they are recomputed from the boost clock:

  B200  148 SM x 8192 x 1.965 GHz = 2382 TFLOPS (was 2250)
  GB200 152 SM x 8192 x 2.062 GHz = 2565 TFLOPS (new)

Reported MFU drops 5.5% on B200 and 12.3% on GB200.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
