### PR TITLE
P1: GDN KCP context parallel (lossy, comm S-independent) — stacked on #985

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}"
           CHANGED=$(git diff --name-only "$BASE_SHA" HEAD -- || true)
-          if echo "$CHANGED" | grep -qE '(veomni/distributed/sequence_parallel/|veomni/models/transformers/qwen3_5/)'; then
+          if echo "$CHANGED" | grep -qE '(veomni/distributed/sequence_parallel/|veomni/distributed/context_parallel/|veomni/models/transformers/qwen3_5/)'; then
             echo "qwen3_5_ulysses=true" >> "$GITHUB_OUTPUT"
           else
             echo "qwen3_5_ulysses=false" >> "$GITHUB_OUTPUT"
@@ -128,6 +128,9 @@ jobs:
           uv run --frozen pytest -s -x tests/parallel/ulysses/test_slice_input_tensor.py
           uv run --frozen pytest -s -x tests/parallel/encoder_data_balance/test_balance_reverse.py
           uv run --frozen pytest -s -x tests/parallel/encoder_data_balance/test_balance_sorting_algo.py
+          uv run --frozen pytest -s -x tests/parallel/context_parallel/test_topology.py
+          uv run --frozen pytest -s -x tests/parallel/context_parallel/test_packed_sharding.py
+          uv run --frozen pytest -s -x tests/parallel/context_parallel/test_primitives.py
           uv run --frozen pytest -s -x tests/parallel/test_chunk_mbs.py
       - name: Run models tests
         run: |

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -88,7 +88,7 @@ init_parallel_state(
     dp_shard_size=args.train.accelerator.dp_shard_size, # data parallel shard degree
     tp_size=args.train.accelerator.tp_size, # tensor parallel size
     pp_size=args.train.accelerator.pp_size, # pipeline parallel size, not support now
-    cp_size=args.train.accelerator.cp_size, # context parallel size, not support now
+    cp_size=args.train.accelerator.cp_size, # context parallel size (Ring / Hybrid with ulysses_size)
     ulysses_size=args.train.accelerator.ulysses_size, # ulysses parallel size
     extra_parallel_sizes=args.train.accelerator.extra_parallel_sizes, # including expert parallel size
     extra_parallel_placement_innermost=args.train.accelerator.extra_parallel_placement_innermost,

--- a/tests/parallel/context_parallel/_run_gdn_kcp_prefix_smoke.py
+++ b/tests/parallel/context_parallel/_run_gdn_kcp_prefix_smoke.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Host smoke for KCP affine + prefix-merge (avoids full veomni import)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+CP = ROOT / "veomni" / "distributed" / "context_parallel"
+
+
+def _load(name: str, path: Path, package: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = package
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+for name, path in [
+    ("veomni", ROOT / "veomni"),
+    ("veomni.distributed", ROOT / "veomni" / "distributed"),
+    ("veomni.distributed.context_parallel", CP),
+]:
+    m = types.ModuleType(name)
+    m.__path__ = [str(path)]
+    sys.modules[name] = m
+
+_load(
+    "veomni.distributed.context_parallel.sharding",
+    CP / "sharding.py",
+    "veomni.distributed.context_parallel",
+)
+scan = _load(
+    "veomni.distributed.context_parallel.gdn_scan_cp",
+    CP / "gdn_scan_cp.py",
+    "veomni.distributed.context_parallel",
+)
+kcp = _load(
+    "veomni.distributed.context_parallel.gdn_kcp",
+    CP / "gdn_kcp.py",
+    "veomni.distributed.context_parallel",
+)
+
+
+def _naive_final_state(key, value, g, beta, *, initial_state=None, use_qk_l2norm=True):
+    if use_qk_l2norm:
+        key = key * torch.rsqrt(key.pow(2).sum(dim=-1, keepdim=True) + 1e-6)
+    k, v, gg, bb = key.float(), value.float(), g.float(), beta.float()
+    _b, t, h, kd = k.shape
+    vd = v.shape[-1]
+    s = (
+        initial_state.float()[0]
+        if initial_state is not None
+        else torch.zeros(h, kd, vd, dtype=torch.float32)
+    )
+    for i in range(t):
+        eg = gg[0, i].exp()
+        kt, vt, bt = k[0, i], v[0, i], bb[0, i]
+        s = s * eg[:, None, None]
+        bv = bt[:, None] * (vt - (s * kt[..., None]).sum(-2))
+        s = s + kt.unsqueeze(-1) * bv.unsqueeze(-2)
+    return s
+
+
+def main() -> None:
+    assert scan.normalize_gdn_cp_impl("kcp") == "kcp"
+    assert scan.gdn_replication_factor_for_impl("kcp", cp_size=8) == 1
+
+    torch.manual_seed(0)
+    b, t, h, kd, vd = 1, 48, 2, 8, 4
+    key = torch.randn(b, t, h, kd)
+    value = torch.randn(b, t, h, vd)
+    g = torch.randn(b, t, h) * 0.1
+    beta = torch.sigmoid(torch.randn(b, t, h))
+    hm = kcp.local_affine_summary_recurrent(key, value, g, beta, use_qk_l2norm=True)
+    he, M = kcp.unpack_affine_hm(hm[0], v_dim=vd)
+    s_ref = _naive_final_state(key, value, g, beta, use_qk_l2norm=True)
+    torch.testing.assert_close(he, s_ref, atol=1e-4, rtol=1e-4)
+    s0 = torch.randn_like(s_ref)
+    s_lin = torch.einsum("hki,hiv->hkv", M, s0) + he
+    s_ref2 = _naive_final_state(
+        key, value, g, beta, initial_state=s0.unsqueeze(0), use_qk_l2norm=True
+    )
+    torch.testing.assert_close(s_lin, s_ref2, atol=1e-4, rtol=1e-4)
+    print("PASS affine_identity")
+
+    torch.manual_seed(1)
+    t = 64
+    key = torch.randn(b, t, h, kd)
+    value = torch.randn(b, t, h, vd)
+    g = torch.randn(b, t, h) * 0.05
+    beta = torch.sigmoid(torch.randn(b, t, h))
+    mid = t // 2
+    hm0 = kcp.local_affine_summary_recurrent(
+        key[:, :mid], value[:, :mid], g[:, :mid], beta[:, :mid], use_qk_l2norm=True
+    )
+    hm1 = kcp.local_affine_summary_recurrent(
+        key[:, mid:], value[:, mid:], g[:, mid:], beta[:, mid:], use_qk_l2norm=True
+    )
+    ag = torch.stack([hm0[0], hm1[0]], dim=0).unsqueeze(1)
+    s1 = kcp.prefix_merge_initial_state(ag, cp_rank=1, v_dim=vd)[0]
+    he0, _ = kcp.unpack_affine_hm(hm0[0], v_dim=vd)
+    torch.testing.assert_close(s1, he0, atol=1e-5, rtol=1e-5)
+    he1, M1 = kcp.unpack_affine_hm(hm1[0], v_dim=vd)
+    s_final = torch.einsum("hki,hiv->hkv", M1, s1) + he1
+    s_ref = _naive_final_state(key, value, g, beta, use_qk_l2norm=True)
+    torch.testing.assert_close(s_final, s_ref, atol=1e-4, rtol=1e-4)
+    print("PASS prefix_merge_vs_serial")
+
+    b64 = kcp.assert_kcp_comm_bytes_independent_of_seq(
+        cp_size=4, num_heads=8, k_dim=128, v_dim=128, num_seqs=1
+    )
+    assert b64 == 4 * 1 * 8 * 128 * (128 + 128) * 4
+    print("PASS comm_bytes")
+    print("ALL_KCP_HOST_SMOKE_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parallel/context_parallel/_run_gdn_scan_repartition_smoke.py
+++ b/tests/parallel/context_parallel/_run_gdn_scan_repartition_smoke.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Host smoke for CP-A repartition without importing full veomni (hf-hub pin)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+CP = ROOT / "veomni" / "distributed" / "context_parallel"
+
+
+def _load(name: str, path: Path, package: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = package
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main() -> None:
+    # Minimal package stubs so relative imports in sharding/gdn_scan_cp work.
+    for name, path in [
+        ("veomni", ROOT / "veomni"),
+        ("veomni.distributed", ROOT / "veomni" / "distributed"),
+        ("veomni.distributed.context_parallel", CP),
+    ]:
+        m = types.ModuleType(name)
+        m.__path__ = [str(path)]
+        sys.modules[name] = m
+
+    sharding = _load(
+        "veomni.distributed.context_parallel.sharding",
+        CP / "sharding.py",
+        "veomni.distributed.context_parallel",
+    )
+    scan = _load(
+        "veomni.distributed.context_parallel.gdn_scan_cp",
+        CP / "gdn_scan_cp.py",
+        "veomni.distributed.context_parallel",
+    )
+    # gdn_scan_cp imports .sharding — already loaded under that name.
+
+    n_ok = 0
+    for cp_size in (2, 4, 8):
+        for seq_len in (64, 128, 256):
+            full = torch.arange(seq_len, dtype=torch.int64).view(1, seq_len, 1)
+            zigzag = [
+                sharding.balanced_cp_slice(full, cp_size=cp_size, cp_rank=r, dim=1)
+                for r in range(cp_size)
+            ]
+            blocks = scan.simulate_zigzag_to_block(zigzag, cp_size=cp_size, seq_dim=1)
+            local = seq_len // cp_size
+            for r, block in enumerate(blocks):
+                expected = full[:, r * local : (r + 1) * local, :]
+                assert torch.equal(block, expected), (cp_size, r)
+            back = scan.simulate_block_to_zigzag(blocks, cp_size=cp_size, seq_dim=1)
+            for r in range(cp_size):
+                assert torch.equal(back[r], zigzag[r]), (cp_size, r)
+            n_ok += 1
+
+    assert scan.gdn_replication_factor_for_impl("state_passing_serial", cp_size=4) == 1
+    assert scan.gdn_replication_factor_for_impl("gather_full", cp_size=4) == 4
+    print(f"CP_A_REPARTITION_SMOKE_OK cases={n_ok}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parallel/context_parallel/_run_gdn_scan_serial_smoke.py
+++ b/tests/parallel/context_parallel/_run_gdn_scan_serial_smoke.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Host CP-B smoke: serial state-passing vs dense full scan (no NPU/FLA)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+ROOT = Path(__file__).resolve().parents[3]
+CP = ROOT / "veomni" / "distributed" / "context_parallel"
+
+
+def _load(name: str, path: Path, package: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = package
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _l2norm(x: torch.Tensor, dim: int = -1, eps: float = 1e-6) -> torch.Tensor:
+    return x * torch.rsqrt(x.pow(2).sum(dim=dim, keepdim=True) + eps)
+
+
+def torch_chunk_gated_delta_rule(
+    query,
+    key,
+    value,
+    g,
+    beta,
+    chunk_size=64,
+    initial_state=None,
+    output_final_state=False,
+    use_qk_l2norm_in_kernel=False,
+    **kwargs,
+):
+    """Local copy of the modeling reference (dense, no cu_seqlens)."""
+    initial_dtype = query.dtype
+    if use_qk_l2norm_in_kernel:
+        query = _l2norm(query, dim=-1, eps=1e-6)
+        key = _l2norm(key, dim=-1, eps=1e-6)
+    query, key, value, beta, g = [
+        x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
+    ]
+
+    batch_size, num_heads, sequence_length, k_head_dim = key.shape
+    v_head_dim = value.shape[-1]
+    pad_size = (chunk_size - sequence_length % chunk_size) % chunk_size
+    query = F.pad(query, (0, 0, 0, pad_size))
+    key = F.pad(key, (0, 0, 0, pad_size))
+    value = F.pad(value, (0, 0, 0, pad_size))
+    beta = F.pad(beta, (0, pad_size))
+    g = F.pad(g, (0, pad_size))
+    total_sequence_length = sequence_length + pad_size
+    scale = 1 / (query.shape[-1] ** 0.5)
+    query = query * scale
+
+    v_beta = value * beta.unsqueeze(-1)
+    k_beta = key * beta.unsqueeze(-1)
+    query, key, value, k_beta, v_beta = [
+        x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1])
+        for x in (query, key, value, k_beta, v_beta)
+    ]
+    g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
+    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0)
+
+    g = g.cumsum(dim=-1)
+    decay_mask = ((g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float()).tril()
+    attn = -((k_beta @ key.transpose(-1, -2)) * decay_mask).masked_fill(mask, 0)
+    for i in range(1, chunk_size):
+        row = attn[..., i, :i].clone()
+        sub = attn[..., :i, :i].clone()
+        attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
+    attn = attn + torch.eye(chunk_size, dtype=attn.dtype, device=attn.device)
+    value = attn @ v_beta
+    k_cumdecay = attn @ (k_beta * g.exp().unsqueeze(-1))
+    last_recurrent_state = (
+        torch.zeros(batch_size, num_heads, k_head_dim, v_head_dim, dtype=value.dtype, device=value.device)
+        if initial_state is None
+        else initial_state.to(value)
+    )
+    core_attn_out = torch.zeros_like(value)
+    for i in range(0, total_sequence_length // chunk_size):
+        q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
+        attn_i = q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]
+        v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state
+        v_new = v_i - v_prime
+        attn_inter = (q_i * g[:, :, i, :, None].exp()) @ last_recurrent_state
+        core_attn_out[:, :, i] = attn_inter + attn_i @ v_new
+        last_recurrent_state = (
+            last_recurrent_state * g[:, :, i, -1, None, None].exp()
+            + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(-1, -2) @ v_new
+        )
+
+    if not output_final_state:
+        last_recurrent_state = None
+    core_attn_out = core_attn_out.reshape(
+        core_attn_out.shape[0], core_attn_out.shape[1], -1, core_attn_out.shape[-1]
+    )
+    core_attn_out = core_attn_out[:, :, :sequence_length]
+    core_attn_out = core_attn_out.transpose(1, 2).contiguous().to(initial_dtype)
+    return core_attn_out, last_recurrent_state
+
+
+def _run_serial_vs_dense(cp_size: int, seq_len: int, *, atol: float = 2e-3) -> float:
+    torch.manual_seed(0)
+    b, h, dk, dv = 1, 2, 8, 16
+    assert seq_len % cp_size == 0
+    local = seq_len // cp_size
+    q = torch.randn(b, seq_len, h, dk)
+    k = torch.randn(b, seq_len, h, dk)
+    v = torch.randn(b, seq_len, h, dv)
+    beta = torch.rand(b, seq_len, h)
+    g = -torch.rand(b, seq_len, h)
+
+    dense_out, _ = torch_chunk_gated_delta_rule(
+        q, k, v, g=g, beta=beta, initial_state=None, output_final_state=False
+    )
+
+    parts = []
+    s = None
+    for r in range(cp_size):
+        sl = slice(r * local, (r + 1) * local)
+        if s is None:
+            s = q.new_zeros(b, h, dk, dv)
+        out_r, s = torch_chunk_gated_delta_rule(
+            q[:, sl],
+            k[:, sl],
+            v[:, sl],
+            g=g[:, sl],
+            beta=beta[:, sl],
+            initial_state=s,
+            output_final_state=True,
+        )
+        parts.append(out_r)
+    serial_out = torch.cat(parts, dim=1)
+    err = (serial_out - dense_out).abs().max().item()
+    if err > atol:
+        raise AssertionError(f"cp={cp_size} seq={seq_len} max_abs_err={err} > {atol}")
+    return err
+
+
+def _run_repartition_plus_serial_layout(scan, sharding, cp_size: int, seq_len: int) -> None:
+    """Zigzag shards → contiguous blocks → serial scan layout equals dense order."""
+    full = torch.arange(seq_len, dtype=torch.float32).view(1, seq_len, 1)
+    zigzag = [
+        sharding.balanced_cp_slice(full, cp_size=cp_size, cp_rank=r, dim=1) for r in range(cp_size)
+    ]
+    blocks = scan.simulate_zigzag_to_block(zigzag, cp_size=cp_size, seq_dim=1)
+    local = seq_len // cp_size
+    for r, block in enumerate(blocks):
+        expected = full[:, r * local : (r + 1) * local, :]
+        assert torch.equal(block, expected)
+
+
+def main() -> None:
+    for name, path in [
+        ("veomni", ROOT / "veomni"),
+        ("veomni.distributed", ROOT / "veomni" / "distributed"),
+        ("veomni.distributed.context_parallel", CP),
+    ]:
+        m = types.ModuleType(name)
+        m.__path__ = [str(path)]
+        sys.modules[name] = m
+
+    sharding = _load(
+        "veomni.distributed.context_parallel.sharding",
+        CP / "sharding.py",
+        "veomni.distributed.context_parallel",
+    )
+    scan = _load(
+        "veomni.distributed.context_parallel.gdn_scan_cp",
+        CP / "gdn_scan_cp.py",
+        "veomni.distributed.context_parallel",
+    )
+
+    assert scan.gdn_replication_factor_for_impl("state_passing_serial", cp_size=4) == 1
+    assert scan.normalize_gdn_cp_impl("serial") == scan.GDN_CP_IMPL_STATE_PASSING_SERIAL
+
+    errs = []
+    n_ok = 0
+    for cp_size in (2, 4):
+        for seq_len in (128, 256):
+            _run_repartition_plus_serial_layout(scan, sharding, cp_size, seq_len)
+            errs.append(_run_serial_vs_dense(cp_size, seq_len))
+            n_ok += 1
+
+    # Grad: serial state kept in-graph matches dense cumsum.
+    torch.manual_seed(1)
+    x = torch.randn(1, 64, 4, requires_grad=True)
+    x.cumsum(dim=1).sum().backward()
+    g_dense = x.grad.detach().clone()
+    cp = 4
+    local = 64 // cp
+    x2 = x.detach().clone().requires_grad_(True)
+    s = torch.zeros(1, 1, 4)
+    outs = []
+    for r in range(cp):
+        chunk = x2[:, r * local : (r + 1) * local]
+        y_r = s + chunk.cumsum(dim=1)
+        outs.append(y_r)
+        s = y_r[:, -1:, :]
+    torch.cat(outs, dim=1).sum().backward()
+    if not torch.allclose(x2.grad, g_dense, atol=1e-5):
+        raise AssertionError("serial cumsum autograd mismatch vs dense")
+
+    print(
+        f"CP_B_SERIAL_SMOKE_OK cases={n_ok} "
+        f"max_abs_err={max(errs):.3e} mean_abs_err={sum(errs)/len(errs):.3e}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parallel/context_parallel/test_gdn_kcp_prefix.py
+++ b/tests/parallel/context_parallel/test_gdn_kcp_prefix.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2025 VeOmni Authors.
+"""Host tests for GDN KCP local-affine + prefix-merge (P1)."""
+from __future__ import annotations
+
+import torch
+
+from veomni.distributed.context_parallel.gdn_kcp import (
+    assert_kcp_comm_bytes_independent_of_seq,
+    local_affine_summary_recurrent,
+    pack_affine_hm,
+    prefix_merge_initial_state,
+    unpack_affine_hm,
+)
+from veomni.distributed.context_parallel.gdn_scan_cp import (
+    gdn_replication_factor_for_impl,
+    normalize_gdn_cp_impl,
+)
+
+
+def _naive_final_state(key, value, g, beta, *, initial_state=None, use_qk_l2norm=True):
+    """Token-loop GDN state (matches local_affine_summary_recurrent)."""
+    if use_qk_l2norm:
+        key = key * torch.rsqrt(key.pow(2).sum(dim=-1, keepdim=True) + 1e-6)
+    k, v, gg, bb = key.float(), value.float(), g.float(), beta.float()
+    bsz, t, h, kd = k.shape
+    vd = v.shape[-1]
+    assert bsz == 1
+    s = (
+        initial_state.float()
+        if initial_state is not None
+        else torch.zeros(1, h, kd, vd, dtype=torch.float32)
+    )
+    s = s[0]
+    for i in range(t):
+        eg = gg[0, i].exp()
+        kt, vt, bt = k[0, i], v[0, i], bb[0, i]
+        s = s * eg[:, None, None]
+        bv = bt[:, None] * (vt - (s * kt[..., None]).sum(-2))
+        s = s + kt.unsqueeze(-1) * bv.unsqueeze(-2)
+    return s.unsqueeze(0)
+
+
+def test_kcp_impl_identity():
+    assert normalize_gdn_cp_impl("kcp") == "kcp"
+    assert gdn_replication_factor_for_impl("kcp", cp_size=8) == 1
+
+
+def test_affine_summary_matches_zero_init_final_state():
+    torch.manual_seed(0)
+    b, t, h, kd, vd = 1, 48, 2, 8, 4
+    key = torch.randn(b, t, h, kd)
+    value = torch.randn(b, t, h, vd)
+    g = torch.randn(b, t, h) * 0.1
+    beta = torch.sigmoid(torch.randn(b, t, h))
+    hm = local_affine_summary_recurrent(key, value, g, beta, use_qk_l2norm=True)
+    he, M = unpack_affine_hm(hm[0], v_dim=vd)
+    # From zero init: S_final = he
+    s_ref = _naive_final_state(key, value, g, beta, use_qk_l2norm=True)[0]
+    torch.testing.assert_close(he, s_ref, atol=1e-4, rtol=1e-4)
+    # M @ 0 + he == he; also check M applied to random S0
+    s0 = torch.randn_like(s_ref)
+    s_lin = torch.einsum("hki,hiv->hkv", M, s0) + he
+    s_ref2 = _naive_final_state(
+        key, value, g, beta, initial_state=s0.unsqueeze(0), use_qk_l2norm=True
+    )[0]
+    torch.testing.assert_close(s_lin, s_ref2, atol=1e-4, rtol=1e-4)
+
+
+def test_prefix_merge_equals_serial_chain():
+    """CP2: merge(hm0) then apply hm1 ≡ full-sequence final state."""
+    torch.manual_seed(1)
+    b, t, h, kd, vd = 1, 64, 2, 8, 4
+    key = torch.randn(b, t, h, kd)
+    value = torch.randn(b, t, h, vd)
+    g = torch.randn(b, t, h) * 0.05
+    beta = torch.sigmoid(torch.randn(b, t, h))
+    mid = t // 2
+    hm0 = local_affine_summary_recurrent(
+        key[:, :mid], value[:, :mid], g[:, :mid], beta[:, :mid], use_qk_l2norm=True
+    )
+    hm1 = local_affine_summary_recurrent(
+        key[:, mid:], value[:, mid:], g[:, mid:], beta[:, mid:], use_qk_l2norm=True
+    )
+    ag = torch.stack([hm0[0], hm1[0]], dim=0).unsqueeze(1)  # [CP=2,N=1,...]
+    # rank1 S_init = prefix merge of rank0 only
+    s1 = prefix_merge_initial_state(ag, cp_rank=1, v_dim=vd)[0]
+    he0, _ = unpack_affine_hm(hm0[0], v_dim=vd)
+    torch.testing.assert_close(s1, he0, atol=1e-5, rtol=1e-5)
+    # final via affine on rank1 block
+    he1, M1 = unpack_affine_hm(hm1[0], v_dim=vd)
+    s_final = torch.einsum("hki,hiv->hkv", M1, s1) + he1
+    s_ref = _naive_final_state(key, value, g, beta, use_qk_l2norm=True)[0]
+    torch.testing.assert_close(s_final, s_ref, atol=1e-4, rtol=1e-4)
+
+
+def test_comm_bytes_independent_of_seq():
+    b64 = assert_kcp_comm_bytes_independent_of_seq(
+        cp_size=4, num_heads=8, k_dim=128, v_dim=128, num_seqs=1
+    )
+    b256 = assert_kcp_comm_bytes_independent_of_seq(
+        cp_size=4, num_heads=8, k_dim=128, v_dim=128, num_seqs=1
+    )
+    assert b64 == b256
+    # formula: CP * N * H * K * (K+V) * 4
+    assert b64 == 4 * 1 * 8 * 128 * (128 + 128) * 4
+
+
+def test_pack_roundtrip_fp32_only():
+    he = torch.randn(2, 4, 3, dtype=torch.float32)
+    M = torch.randn(2, 4, 4, dtype=torch.float32)
+    hm = pack_affine_hm(he, M)
+    he2, M2 = unpack_affine_hm(hm, v_dim=3)
+    torch.testing.assert_close(he2, he)
+    torch.testing.assert_close(M2, M)

--- a/tests/parallel/context_parallel/test_gdn_scan_repartition.py
+++ b/tests/parallel/context_parallel/test_gdn_scan_repartition.py
@@ -1,0 +1,71 @@
+"""CP-A gate: zigzag↔contiguous repartition round-trip (bit-exact).
+
+Must pass before wiring GDN kernels (implementation contract).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from veomni.distributed.context_parallel.gdn_scan_cp import (
+    contiguous_block_chunk_indices,
+    gdn_replication_factor_for_impl,
+    normalize_gdn_cp_impl,
+    simulate_block_to_zigzag,
+    simulate_zigzag_to_block,
+    zigzag_half_destination,
+    zigzag_owner_of_chunk,
+)
+from veomni.distributed.context_parallel.sharding import balanced_cp_slice
+
+
+@pytest.mark.parametrize("cp_size", [2, 4, 8])
+@pytest.mark.parametrize("seq_len", [64, 128, 256])
+def test_simulate_repartition_round_trip_bit_exact(cp_size: int, seq_len: int):
+    assert seq_len % (2 * cp_size) == 0
+    # Distinct token ids so permutation errors cannot cancel.
+    full = torch.arange(seq_len, dtype=torch.int64).view(1, seq_len, 1)
+    zigzag = [balanced_cp_slice(full, cp_size=cp_size, cp_rank=r, dim=1) for r in range(cp_size)]
+    blocks = simulate_zigzag_to_block(zigzag, cp_size=cp_size, seq_dim=1)
+
+    local = seq_len // cp_size
+    for r, block in enumerate(blocks):
+        assert block.shape[1] == local
+        expected = full[:, r * local : (r + 1) * local, :]
+        assert torch.equal(block, expected), f"cp={cp_size} rank={r} contig mismatch"
+
+    zigzag_back = simulate_block_to_zigzag(blocks, cp_size=cp_size, seq_dim=1)
+    for r in range(cp_size):
+        assert torch.equal(zigzag_back[r], zigzag[r]), f"cp={cp_size} rank={r} zigzag mismatch"
+
+
+@pytest.mark.parametrize("cp_size", [2, 4, 8])
+def test_chunk_routing_consistency(cp_size: int):
+    for chunk_idx in range(2 * cp_size):
+        z_rank, half = zigzag_owner_of_chunk(chunk_idx, cp_size)
+        dst = zigzag_half_destination(z_rank, half, cp_size)
+        assert dst == chunk_idx // 2
+    for c_rank in range(cp_size):
+        i0, i1 = contiguous_block_chunk_indices(c_rank, cp_size)
+        assert i0 == 2 * c_rank and i1 == 2 * c_rank + 1
+
+
+def test_impl_normalize_and_replication_factor():
+    assert normalize_gdn_cp_impl("serial") == "state_passing_serial"
+    assert normalize_gdn_cp_impl("gather_full") == "gather_full_replicated"
+    assert gdn_replication_factor_for_impl("gather_full_replicated", cp_size=4) == 4
+    assert gdn_replication_factor_for_impl("state_passing_serial", cp_size=4) == 1
+    assert gdn_replication_factor_for_impl("kcp", cp_size=4) == 1
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_repartition_preserves_numel_and_never_s_full(cp_size: int):
+    seq_len = 128
+    full = torch.arange(seq_len).view(2, seq_len, 3, 5)
+    zigzag = [balanced_cp_slice(full, cp_size=cp_size, cp_rank=r, dim=1) for r in range(cp_size)]
+    blocks = simulate_zigzag_to_block(zigzag, cp_size=cp_size, seq_dim=1)
+    for block in blocks:
+        assert block.shape[1] == seq_len // cp_size
+        assert block.shape[1] * cp_size == seq_len
+        assert block.numel() == zigzag[0].numel()

--- a/tests/parallel/context_parallel/test_gdn_sp_2d.py
+++ b/tests/parallel/context_parallel/test_gdn_sp_2d.py
@@ -1,0 +1,678 @@
+"""Correctness tests for two-dimensional GDN sequence parallelism."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+from veomni.distributed.context_parallel.gdn_sp import (
+    cp_gather_sequence,
+    cp_scatter_sequence,
+    derive_gdn_local_cu_seqlens,
+    resolve_gdn_parallel_plan,
+    scale_cp_repeated_parameter_grad,
+)
+from veomni.distributed.context_parallel.packed_sharding import build_packed_cp_partition
+from veomni.distributed.context_parallel.sharding import balanced_cp_restore, balanced_cp_slice
+
+
+@dataclass
+class _FakeParallelState:
+    ulysses_size: int
+    cp_size: int
+    ulysses_group: object
+    cp_group: object
+    ulysses_rank: int = 0
+    cp_rank: int = 0
+
+    @property
+    def ulysses_enabled(self) -> bool:
+        return self.ulysses_size > 1
+
+    @property
+    def cp_enabled(self) -> bool:
+        return self.cp_size > 1
+
+
+def test_gdn_plan_keeps_ulysses_heads_and_cp_sequence_separate():
+    state = _FakeParallelState(
+        ulysses_size=8,
+        cp_size=4,
+        ulysses_group=object(),
+        cp_group=object(),
+    )
+    with patch("veomni.distributed.context_parallel.gdn_sp.get_parallel_state", return_value=state):
+        plan = resolve_gdn_parallel_plan()
+
+    assert plan.ulysses_size == 8
+    assert plan.cp_size == 4
+    assert plan.head_parallel_enabled
+    assert plan.cp_sequence_enabled
+    assert plan.cp_seq_enabled == plan.cp_sequence_enabled
+
+
+def _toy_forward(
+    local_input: torch.Tensor,
+    *,
+    pre_weight: torch.Tensor,
+    core_weight: torch.Tensor,
+    z_weight: torch.Tensor,
+    norm_weight: torch.Tensor,
+    out_weight: torch.Tensor,
+    cp_group,
+    cp_size: int,
+    cp_rank: int,
+) -> torch.Tensor:
+    projected = local_input @ pre_weight
+    z = torch.sigmoid(local_input @ z_weight)
+
+    full_projected = cp_gather_sequence(
+        projected,
+        cp_group=cp_group,
+        cp_size=cp_size,
+        seq_dim=1,
+    )
+    repeated_core_weight = scale_cp_repeated_parameter_grad(core_weight, cp_size=cp_size)
+    full_core = torch.cumsum(full_projected, dim=1) @ repeated_core_weight
+    local_core = cp_scatter_sequence(
+        full_core,
+        cp_group=cp_group,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        seq_dim=1,
+    )
+
+    # These operations consume only this rank's output shard. Their parameters
+    # are not part of the repeated full-sequence core and must not be scaled.
+    normalized = local_core * norm_weight
+    return (normalized * z) @ out_weight
+
+
+def _dense_toy_forward(
+    full_input: torch.Tensor,
+    *,
+    pre_weight: torch.Tensor,
+    core_weight: torch.Tensor,
+    z_weight: torch.Tensor,
+    norm_weight: torch.Tensor,
+    out_weight: torch.Tensor,
+) -> torch.Tensor:
+    projected = full_input @ pre_weight
+    core = torch.cumsum(projected, dim=1) @ core_weight
+    z = torch.sigmoid(full_input @ z_weight)
+    return (core * norm_weight * z) @ out_weight
+
+
+def _gdn_dense_parity_worker(rank: int, world_size: int, file_name: str, errors: mp.Queue) -> None:
+    try:
+        store = dist.FileStore(file_name, world_size)
+        dist.init_process_group("gloo", store=store, rank=rank, world_size=world_size)
+        group = dist.distributed_c10d._get_default_group()
+
+        torch.manual_seed(1234)
+        full_input = torch.randn(1, 8, 3, dtype=torch.float64)
+        target = torch.randn(1, 8, 2, dtype=torch.float64)
+        initial_parameters = {
+            "pre_weight": torch.randn(3, 4, dtype=torch.float64),
+            "core_weight": torch.randn(4, 4, dtype=torch.float64),
+            "z_weight": torch.randn(3, 4, dtype=torch.float64),
+            "norm_weight": torch.randn(4, dtype=torch.float64),
+            "out_weight": torch.randn(4, 2, dtype=torch.float64),
+        }
+
+        reference_input = full_input.detach().clone().requires_grad_(True)
+        reference_parameters = {
+            name: value.detach().clone().requires_grad_(True) for name, value in initial_parameters.items()
+        }
+        reference_output = _dense_toy_forward(reference_input, **reference_parameters)
+        (reference_output * target).sum().backward()
+
+        local_input = (
+            balanced_cp_slice(full_input, cp_size=world_size, cp_rank=rank, dim=1).detach().requires_grad_(True)
+        )
+        local_target = balanced_cp_slice(target, cp_size=world_size, cp_rank=rank, dim=1)
+        local_parameters = {
+            name: value.detach().clone().requires_grad_(True) for name, value in initial_parameters.items()
+        }
+        local_output = _toy_forward(
+            local_input,
+            **local_parameters,
+            cp_group=group,
+            cp_size=world_size,
+            cp_rank=rank,
+        )
+        (local_output * local_target).sum().backward()
+
+        expected_local_output = balanced_cp_slice(
+            reference_output.detach(),
+            cp_size=world_size,
+            cp_rank=rank,
+            dim=1,
+        )
+        torch.testing.assert_close(local_output, expected_local_output, atol=1e-10, rtol=1e-10)
+        expected_local_input_grad = balanced_cp_slice(
+            reference_input.grad,
+            cp_size=world_size,
+            cp_rank=rank,
+            dim=1,
+        )
+        torch.testing.assert_close(local_input.grad, expected_local_input_grad, atol=1e-10, rtol=1e-10)
+
+        gathered_outputs = [torch.empty_like(local_output) for _ in range(world_size)]
+        dist.all_gather(gathered_outputs, local_output.detach(), group=group)
+        restored_output = balanced_cp_restore(torch.cat(gathered_outputs, dim=1), cp_size=world_size, dim=1)
+        torch.testing.assert_close(restored_output, reference_output.detach(), atol=1e-10, rtol=1e-10)
+
+        for name, parameter in local_parameters.items():
+            dist.all_reduce(parameter.grad, op=dist.ReduceOp.SUM, group=group)
+            torch.testing.assert_close(
+                parameter.grad,
+                reference_parameters[name].grad,
+                atol=1e-10,
+                rtol=1e-10,
+                msg=lambda message, parameter_name=name: (
+                    f"{message}\ncollective parameter-gradient mismatch for {parameter_name}"
+                ),
+            )
+
+        dist.destroy_process_group()
+        errors.put(None)
+    except Exception as exc:  # noqa: BLE001
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        errors.put(repr(exc))
+
+
+def test_cp_repeated_gdn_matches_dense_output_input_and_parameter_grads():
+    world_size = 2
+    with tempfile.TemporaryDirectory() as tmp:
+        file_name = os.path.join(tmp, "gdn-cp-pg")
+        ctx = mp.get_context("spawn")
+        errors = ctx.Queue()
+        processes = [
+            ctx.Process(
+                target=_gdn_dense_parity_worker,
+                args=(rank, world_size, file_name, errors),
+            )
+            for rank in range(world_size)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=120)
+            assert process.exitcode == 0, f"worker exited with {process.exitcode}"
+        for _ in range(world_size):
+            error = errors.get(timeout=5)
+            assert error is None, error
+
+
+def _packed_cumsum(tensor: torch.Tensor, cu_seqlens: torch.Tensor) -> torch.Tensor:
+    points = cu_seqlens.tolist()
+    return torch.cat(
+        [tensor.narrow(1, int(start), int(end - start)).cumsum(dim=1) for start, end in zip(points[:-1], points[1:])],
+        dim=1,
+    )
+
+
+def _gloo_all_to_all_tensor(
+    tensor: torch.Tensor,
+    scatter_dim: int,
+    gather_dim: int,
+    group,
+    async_op: bool = False,
+) -> torch.Tensor:
+    """Reference all-to-all for CPU tests because Gloo lacks ``all_to_all``."""
+    if async_op:
+        raise NotImplementedError("The test-only Gloo all-to-all does not support async collectives.")
+    world_size = dist.get_world_size(group)
+    destination_rank = dist.get_rank(group)
+    gathered = [torch.empty_like(tensor) for _ in range(world_size)]
+    dist.all_gather(gathered, tensor.contiguous(), group=group)
+    destination_chunks = [
+        torch.tensor_split(source, world_size, dim=scatter_dim)[destination_rank].contiguous() for source in gathered
+    ]
+    return torch.cat(destination_chunks, dim=gather_dim).contiguous()
+
+
+def _packed_cp_parity_worker(rank: int, world_size: int, file_name: str, errors: mp.Queue) -> None:
+    try:
+        store = dist.FileStore(file_name, world_size)
+        dist.init_process_group("gloo", store=store, rank=rank, world_size=world_size)
+        group = dist.distributed_c10d._get_default_group()
+
+        torch.manual_seed(4321)
+        global_cu = torch.tensor([0, 8, 20], dtype=torch.int32)
+        full_input = torch.randn(1, 20, 3, dtype=torch.float64)
+        target = torch.randn(1, 20, 2, dtype=torch.float64)
+        initial_weight = torch.randn(3, 2, dtype=torch.float64)
+
+        reference_input = full_input.detach().clone().requires_grad_(True)
+        reference_weight = initial_weight.detach().clone().requires_grad_(True)
+        reference_output = _packed_cumsum(reference_input, global_cu) @ reference_weight
+        (reference_output * target).sum().backward()
+
+        partition = build_packed_cp_partition(
+            global_cu,
+            cp_size=world_size,
+            cp_rank=rank,
+        )
+        local_input = full_input.index_select(1, partition.token_indices).detach().requires_grad_(True)
+        local_target = target.index_select(1, partition.token_indices)
+        local_weight = initial_weight.detach().clone().requires_grad_(True)
+        _, cp_local_cu = derive_gdn_local_cu_seqlens(
+            global_cu,
+            ulysses_size=1,
+            cp_size=world_size,
+        )
+
+        full_gathered = cp_gather_sequence(
+            local_input,
+            cp_group=group,
+            cp_size=world_size,
+            seq_dim=1,
+            cp_local_cu_seqlens=cp_local_cu,
+        )
+        repeated_weight = scale_cp_repeated_parameter_grad(local_weight, cp_size=world_size)
+        full_output = _packed_cumsum(full_gathered, global_cu) @ repeated_weight
+        local_output = cp_scatter_sequence(
+            full_output,
+            cp_group=group,
+            cp_size=world_size,
+            cp_rank=rank,
+            seq_dim=1,
+            cp_local_cu_seqlens=cp_local_cu,
+        )
+        (local_output * local_target).sum().backward()
+
+        torch.testing.assert_close(
+            local_input.grad,
+            reference_input.grad.index_select(1, partition.token_indices),
+            atol=1e-10,
+            rtol=1e-10,
+        )
+
+        gathered_outputs = [torch.empty_like(local_output) for _ in range(world_size)]
+        dist.all_gather(gathered_outputs, local_output.detach(), group=group)
+        restored_output = torch.empty_like(reference_output)
+        for cp_rank, output_shard in enumerate(gathered_outputs):
+            cp_partition = build_packed_cp_partition(
+                global_cu,
+                cp_size=world_size,
+                cp_rank=cp_rank,
+            )
+            restored_output.index_copy_(1, cp_partition.token_indices, output_shard)
+        torch.testing.assert_close(restored_output, reference_output.detach(), atol=1e-10, rtol=1e-10)
+
+        dist.all_reduce(local_weight.grad, op=dist.ReduceOp.SUM, group=group)
+        torch.testing.assert_close(local_weight.grad, reference_weight.grad, atol=1e-10, rtol=1e-10)
+
+        dist.destroy_process_group()
+        errors.put(None)
+    except Exception as exc:  # noqa: BLE001
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        errors.put(repr(exc))
+
+
+def test_cp_packed_multisegment_output_input_and_parameter_grad_parity():
+    world_size = 2
+    with tempfile.TemporaryDirectory() as tmp:
+        file_name = os.path.join(tmp, "gdn-packed-cp-pg")
+        ctx = mp.get_context("spawn")
+        errors = ctx.Queue()
+        processes = [
+            ctx.Process(
+                target=_packed_cp_parity_worker,
+                args=(rank, world_size, file_name, errors),
+            )
+            for rank in range(world_size)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=120)
+            assert process.exitcode == 0, f"worker exited with {process.exitcode}"
+        for _ in range(world_size):
+            error = errors.get(timeout=5)
+            assert error is None, error
+
+
+def _fake_causal_conv1d(
+    *,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    activation: str,
+    cu_seqlens: torch.Tensor | None = None,
+    **_kwargs,
+) -> tuple[torch.Tensor]:
+    kernel_size = weight.shape[-1]
+    if cu_seqlens is None:
+        segments = (x,)
+    else:
+        points = cu_seqlens.tolist()
+        segments = tuple(x.narrow(1, int(start), int(end - start)) for start, end in zip(points[:-1], points[1:]))
+    outputs = [
+        F.conv1d(
+            F.pad(segment.transpose(1, 2), (kernel_size - 1, 0)),
+            weight[:, None, :],
+            bias=bias,
+            groups=x.shape[-1],
+        ).transpose(1, 2)
+        for segment in segments
+    ]
+    output = torch.cat(outputs, dim=1)
+    if activation == "silu":
+        output = F.silu(output)
+    return (output,)
+
+
+def _fake_gated_delta_rule(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+    **_kwargs,
+) -> tuple[torch.Tensor, None]:
+    recurrent_input = value + 0.1 * query + 0.2 * key + g.unsqueeze(-1) + beta.unsqueeze(-1)
+    if cu_seqlens is None:
+        return torch.cumsum(recurrent_input, dim=1), None
+    return _packed_cumsum(recurrent_input, cu_seqlens), None
+
+
+def _model_integration_worker(rank: int, world_size: int, file_name: str, errors: mp.Queue) -> None:
+    try:
+        from types import SimpleNamespace
+
+        from veomni.models.transformers.qwen3_5_moe.generated.patched_modeling_qwen3_5_moe_gpu import (
+            Qwen3_5MoeGatedDeltaNet,
+        )
+
+        store = dist.FileStore(file_name, world_size)
+        dist.init_process_group("gloo", store=store, rank=rank, world_size=world_size)
+        group = dist.distributed_c10d._get_default_group()
+
+        torch.manual_seed(2026)
+        config = SimpleNamespace(
+            hidden_size=4,
+            linear_num_value_heads=2,
+            linear_num_key_heads=2,
+            linear_key_head_dim=2,
+            linear_value_head_dim=2,
+            linear_conv_kernel_dim=3,
+            hidden_act="silu",
+            rms_norm_eps=1e-6,
+            dtype=torch.float64,
+        )
+        layer = Qwen3_5MoeGatedDeltaNet(config, layer_idx=0).double()
+        layer.causal_conv1d_fn = _fake_causal_conv1d
+        layer.chunk_gated_delta_rule = _fake_gated_delta_rule
+
+        full_input = torch.randn(1, 8, config.hidden_size, dtype=torch.float64)
+        target = torch.randn_like(full_input)
+        global_cu_seqlens = torch.tensor([0, full_input.shape[1]], dtype=torch.int32)
+
+        reference_input = full_input.detach().clone().requires_grad_(True)
+        no_sp_state = SimpleNamespace(ulysses_enabled=False, cp_enabled=False)
+        with patch("veomni.distributed.context_parallel.gdn_sp.get_parallel_state", return_value=no_sp_state):
+            reference_output = layer(
+                reference_input,
+                attention_mask=None,
+                cu_seq_lens_q=global_cu_seqlens,
+            )
+            (reference_output * target).sum().backward()
+        reference_parameter_grads = {
+            name: parameter.grad.detach().clone()
+            for name, parameter in layer.named_parameters()
+            if parameter.grad is not None
+        }
+        layer.zero_grad(set_to_none=True)
+
+        local_input = (
+            balanced_cp_slice(full_input, cp_size=world_size, cp_rank=rank, dim=1).detach().requires_grad_(True)
+        )
+        local_target = balanced_cp_slice(target, cp_size=world_size, cp_rank=rank, dim=1)
+        cp_state = SimpleNamespace(
+            ulysses_enabled=False,
+            cp_enabled=True,
+            cp_group=group,
+            cp_size=world_size,
+            cp_rank=rank,
+        )
+        with patch("veomni.distributed.context_parallel.gdn_sp.get_parallel_state", return_value=cp_state):
+            local_output = layer(
+                local_input,
+                attention_mask=None,
+                cu_seq_lens_q=global_cu_seqlens,
+            )
+            (local_output * local_target).sum().backward()
+
+        expected_local_input_grad = balanced_cp_slice(
+            reference_input.grad,
+            cp_size=world_size,
+            cp_rank=rank,
+            dim=1,
+        )
+        torch.testing.assert_close(local_input.grad, expected_local_input_grad, atol=1e-8, rtol=1e-7)
+
+        gathered_outputs = [torch.empty_like(local_output) for _ in range(world_size)]
+        dist.all_gather(gathered_outputs, local_output.detach(), group=group)
+        restored_output = balanced_cp_restore(torch.cat(gathered_outputs, dim=1), cp_size=world_size, dim=1)
+        torch.testing.assert_close(restored_output, reference_output.detach(), atol=1e-8, rtol=1e-7)
+
+        for name, parameter in layer.named_parameters():
+            if parameter.grad is None:
+                continue
+            dist.all_reduce(parameter.grad, op=dist.ReduceOp.SUM, group=group)
+            torch.testing.assert_close(
+                parameter.grad,
+                reference_parameter_grads[name],
+                atol=1e-7,
+                rtol=1e-5,
+                msg=lambda message, parameter_name=name: (
+                    f"{message}\nQwen3.5-MoE GDN parameter-gradient mismatch for {parameter_name}"
+                ),
+            )
+
+        dist.destroy_process_group()
+        errors.put(None)
+    except Exception as exc:  # noqa: BLE001
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        errors.put(repr(exc))
+
+
+def test_qwen3_5_moe_gdn_cp_path_matches_dense_output_input_and_parameter_grads():
+    world_size = 2
+    with tempfile.TemporaryDirectory() as tmp:
+        file_name = os.path.join(tmp, "qwen-gdn-cp-pg")
+        ctx = mp.get_context("spawn")
+        errors = ctx.Queue()
+        processes = [
+            ctx.Process(
+                target=_model_integration_worker,
+                args=(rank, world_size, file_name, errors),
+            )
+            for rank in range(world_size)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=120)
+            assert process.exitcode == 0, f"worker exited with {process.exitcode}"
+        for _ in range(world_size):
+            error = errors.get(timeout=5)
+            assert error is None, error
+
+
+def _model_u2cp2_packed_worker(rank: int, world_size: int, file_name: str, errors: mp.Queue) -> None:
+    try:
+        from types import SimpleNamespace
+
+        from veomni.models.transformers.qwen3_5_moe.generated.patched_modeling_qwen3_5_moe_gpu import (
+            Qwen3_5MoeGatedDeltaNet,
+        )
+
+        store = dist.FileStore(file_name, world_size)
+        dist.init_process_group("gloo", store=store, rank=rank, world_size=world_size)
+
+        ulysses_groups = (
+            dist.new_group(ranks=[0, 1]),
+            dist.new_group(ranks=[2, 3]),
+        )
+        cp_groups = (
+            dist.new_group(ranks=[0, 2]),
+            dist.new_group(ranks=[1, 3]),
+        )
+        ulysses_size = 2
+        cp_size = 2
+        cp_rank = rank // ulysses_size
+        ulysses_rank = rank % ulysses_size
+        ulysses_group = ulysses_groups[cp_rank]
+        cp_group = cp_groups[ulysses_rank]
+
+        torch.manual_seed(2027)
+        config = SimpleNamespace(
+            hidden_size=4,
+            linear_num_value_heads=2,
+            linear_num_key_heads=2,
+            linear_key_head_dim=2,
+            linear_value_head_dim=2,
+            linear_conv_kernel_dim=3,
+            hidden_act="silu",
+            rms_norm_eps=1e-6,
+            dtype=torch.float64,
+        )
+        layer = Qwen3_5MoeGatedDeltaNet(config, layer_idx=0).double()
+        layer.causal_conv1d_fn = _fake_causal_conv1d
+        layer.chunk_gated_delta_rule = _fake_gated_delta_rule
+
+        global_cu_seqlens = torch.tensor([0, 16, 40], dtype=torch.int32)
+        full_input = torch.randn(1, 40, config.hidden_size, dtype=torch.float64)
+        target = torch.randn_like(full_input)
+
+        reference_input = full_input.detach().clone().requires_grad_(True)
+        no_sp_state = SimpleNamespace(ulysses_enabled=False, cp_enabled=False)
+        with patch("veomni.distributed.context_parallel.gdn_sp.get_parallel_state", return_value=no_sp_state):
+            reference_output = layer(
+                reference_input,
+                attention_mask=None,
+                cu_seq_lens_q=global_cu_seqlens,
+            )
+            (reference_output * target).sum().backward()
+        reference_parameter_grads = {
+            name: parameter.grad.detach().clone()
+            for name, parameter in layer.named_parameters()
+            if parameter.grad is not None
+        }
+        layer.zero_grad(set_to_none=True)
+
+        partition = build_packed_cp_partition(
+            global_cu_seqlens,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            ulysses_size=ulysses_size,
+            ulysses_rank=ulysses_rank,
+        )
+        local_input = full_input.index_select(1, partition.token_indices).detach().requires_grad_(True)
+        local_target = target.index_select(1, partition.token_indices)
+        hybrid_state = SimpleNamespace(
+            ulysses_enabled=True,
+            cp_enabled=True,
+            ulysses_group=ulysses_group,
+            ulysses_size=ulysses_size,
+            ulysses_rank=ulysses_rank,
+            cp_group=cp_group,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+        )
+        with (
+            patch("veomni.distributed.context_parallel.gdn_sp.get_parallel_state", return_value=hybrid_state),
+            patch(
+                "veomni.distributed.sequence_parallel.ulysses.all_to_all_tensor",
+                new=_gloo_all_to_all_tensor,
+            ),
+        ):
+            local_output = layer(
+                local_input,
+                attention_mask=None,
+                cu_seq_lens_q=global_cu_seqlens,
+            )
+            (local_output * local_target).sum().backward()
+
+        torch.testing.assert_close(
+            local_input.grad,
+            reference_input.grad.index_select(1, partition.token_indices),
+            atol=1e-8,
+            rtol=1e-7,
+        )
+
+        gathered_outputs = [torch.empty_like(local_output) for _ in range(world_size)]
+        dist.all_gather(gathered_outputs, local_output.detach())
+        restored_output = torch.empty_like(reference_output)
+        for peer_rank, output_shard in enumerate(gathered_outputs):
+            peer_cp_rank = peer_rank // ulysses_size
+            peer_ulysses_rank = peer_rank % ulysses_size
+            peer_partition = build_packed_cp_partition(
+                global_cu_seqlens,
+                cp_size=cp_size,
+                cp_rank=peer_cp_rank,
+                ulysses_size=ulysses_size,
+                ulysses_rank=peer_ulysses_rank,
+            )
+            restored_output.index_copy_(1, peer_partition.token_indices, output_shard)
+        torch.testing.assert_close(restored_output, reference_output.detach(), atol=1e-8, rtol=1e-7)
+
+        for name, parameter in layer.named_parameters():
+            if parameter.grad is None:
+                continue
+            dist.all_reduce(parameter.grad, op=dist.ReduceOp.SUM)
+            torch.testing.assert_close(
+                parameter.grad,
+                reference_parameter_grads[name],
+                atol=1e-7,
+                rtol=1e-5,
+                msg=lambda message, parameter_name=name: (
+                    f"{message}\nU2CP2 packed Qwen3.5-MoE GDN parameter-gradient mismatch for {parameter_name}"
+                ),
+            )
+
+        dist.destroy_process_group()
+        errors.put(None)
+    except Exception as exc:  # noqa: BLE001
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        errors.put(repr(exc))
+
+
+def test_qwen3_5_moe_gdn_u2cp2_packed_matches_dense_output_input_and_parameter_grads():
+    world_size = 4
+    with tempfile.TemporaryDirectory() as tmp:
+        file_name = os.path.join(tmp, "qwen-gdn-u2cp2-packed-pg")
+        ctx = mp.get_context("spawn")
+        errors = ctx.Queue()
+        processes = [
+            ctx.Process(
+                target=_model_u2cp2_packed_worker,
+                args=(rank, world_size, file_name, errors),
+            )
+            for rank in range(world_size)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=180)
+            assert process.exitcode == 0, f"worker exited with {process.exitcode}"
+        for _ in range(world_size):
+            error = errors.get(timeout=5)
+            assert error is None, error

--- a/tests/parallel/context_parallel/test_hybrid_groups.py
+++ b/tests/parallel/context_parallel/test_hybrid_groups.py
@@ -1,0 +1,68 @@
+import os
+import tempfile
+
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from veomni.distributed.context_parallel.topology import (
+    coords_from_sp_rank,
+    cp_global_ranks_for_ulysses_rank,
+    ulysses_global_ranks_for_cp_rank,
+)
+from veomni.distributed.sequence_parallel.comm import (
+    get_context_parallel_group,
+    get_ulysses_sequence_parallel_group,
+    get_unified_sequence_parallel_group,
+    init_sequence_parallel,
+)
+
+
+def _worker(rank: int, world_size: int, file_name: str, errors: mp.Queue):
+    try:
+        store = dist.FileStore(file_name, world_size)
+        dist.init_process_group("gloo", store=store, rank=rank, world_size=world_size)
+        cp_size, ulysses_size = 2, 4
+        init_sequence_parallel(ulysses_size=ulysses_size, sep_dp=True, cp_size=cp_size)
+
+        cp_rank, ulysses_rank = coords_from_sp_rank(rank % (cp_size * ulysses_size), cp_size, ulysses_size)
+        expected_cp = cp_global_ranks_for_ulysses_rank(
+            dp_index=0, ulysses_rank=ulysses_rank, cp_size=cp_size, ulysses_size=ulysses_size
+        )
+        expected_ulysses = ulysses_global_ranks_for_cp_rank(
+            dp_index=0, cp_rank=cp_rank, cp_size=cp_size, ulysses_size=ulysses_size
+        )
+
+        cp_group = get_context_parallel_group()
+        ulysses_group = get_ulysses_sequence_parallel_group()
+        sp_group = get_unified_sequence_parallel_group()
+
+        assert sorted(dist.get_process_group_ranks(cp_group)) == expected_cp
+        assert sorted(dist.get_process_group_ranks(ulysses_group)) == expected_ulysses
+        assert sorted(dist.get_process_group_ranks(sp_group)) == list(range(world_size))
+        assert dist.get_rank(cp_group) == expected_cp.index(rank)
+        assert dist.get_rank(ulysses_group) == expected_ulysses.index(rank)
+
+        dist.destroy_process_group()
+        errors.put(None)
+    except Exception as exc:  # noqa: BLE001
+        errors.put(repr(exc))
+
+
+def test_u4_cp2_init_sequence_parallel_groups():
+    world_size = 8
+    with tempfile.TemporaryDirectory() as tmp:
+        file_name = os.path.join(tmp, "pg")
+        ctx = mp.get_context("spawn")
+        errors = ctx.Queue()
+        processes = [
+            ctx.Process(target=_worker, args=(rank, world_size, file_name, errors))
+            for rank in range(world_size)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=180)
+            assert process.exitcode == 0, f"worker exited with {process.exitcode}"
+        for _ in range(world_size):
+            err = errors.get(timeout=5)
+            assert err is None, err

--- a/tests/parallel/context_parallel/test_packed_sharding.py
+++ b/tests/parallel/context_parallel/test_packed_sharding.py
@@ -1,0 +1,106 @@
+import pytest
+import torch
+
+from veomni.distributed.context_parallel.attention_backend import torch_packed_causal_attention
+from veomni.distributed.context_parallel.packed_sharding import (
+    apply_packed_cp_partition,
+    build_packed_cp_partition,
+)
+from veomni.distributed.context_parallel.ring_attention import (
+    dense_causal_attention,
+    simulate_packed_ring_causal_attention,
+)
+
+
+def test_packed_cp_partition_keeps_sample_boundaries_cp2():
+    # Two samples of length 16 each (divisible by 2*cp=4).
+    cu = torch.tensor([0, 16, 32], dtype=torch.int32)
+    seq = torch.arange(32)
+    p0 = build_packed_cp_partition(cu, cp_size=2, cp_rank=0)
+    p1 = build_packed_cp_partition(cu, cp_size=2, cp_rank=1)
+
+    torch.testing.assert_close(p0.local_cu_seqlens, torch.tensor([0, 8, 16], dtype=torch.int32))
+    torch.testing.assert_close(p1.local_cu_seqlens, torch.tensor([0, 8, 16], dtype=torch.int32))
+
+    # Rank0 per sample: early chunk0 + late chunk3 inside each sample.
+    expected0 = torch.cat(
+        (
+            torch.arange(0, 4),
+            torch.arange(12, 16),
+            torch.arange(16, 20),
+            torch.arange(28, 32),
+        )
+    )
+    torch.testing.assert_close(p0.token_indices, expected0)
+    torch.testing.assert_close(apply_packed_cp_partition(seq, p0, dim=0), expected0)
+
+
+def test_packed_partition_rejects_non_divisible_sample():
+    cu = torch.tensor([0, 15, 32], dtype=torch.int32)
+    with pytest.raises(ValueError, match="divisible"):
+        build_packed_cp_partition(cu, cp_size=2, cp_rank=0)
+
+
+def test_hybrid_packed_partition_u4_cp2():
+    cu = torch.tensor([0, 64], dtype=torch.int32)  # one sample, multiple=16
+    parts = [
+        build_packed_cp_partition(cu, cp_size=2, cp_rank=cp, ulysses_size=4, ulysses_rank=u)
+        for cp in range(2)
+        for u in range(4)
+    ]
+    assert all(p.token_indices.numel() == 8 for p in parts)
+    # All indices unique and cover full sequence.
+    covered = torch.cat([p.token_indices for p in parts]).sort().values
+    torch.testing.assert_close(covered, torch.arange(64))
+
+
+def test_simulate_packed_ring_matches_packed_dense_and_blocks_cross_sample():
+    torch.manual_seed(0)
+    cp_size = 2
+    batch, hq, hkv, head_dim = 1, 4, 2, 8
+    # Two samples length 32 each.
+    cu = torch.tensor([0, 32, 64], dtype=torch.int32)
+    query = torch.randn(batch, hq, 64, head_dim, dtype=torch.float32)
+    key = torch.randn(batch, hkv, 64, head_dim, dtype=torch.float32)
+    value = torch.randn(batch, hkv, 64, head_dim, dtype=torch.float32)
+    # Amplify sample-1 keys so cross-sample leakage would show up in sample-0 outputs.
+    key[:, :, 32:] = key[:, :, 32:] + 50.0
+
+    packed_dense = torch_packed_causal_attention(query, key, value, cu, softmax_scale=head_dim**-0.5)
+    ring = simulate_packed_ring_causal_attention(
+        query, key, value, cu, cp_size=cp_size, softmax_scale=head_dim**-0.5
+    )
+    torch.testing.assert_close(ring, packed_dense, atol=1e-4, rtol=1e-4)
+
+    # Sample-0 ring output must match dense attention on sample-0 alone.
+    s0 = dense_causal_attention(
+        query[:, :, :32], key[:, :, :32], value[:, :, :32], softmax_scale=head_dim**-0.5
+    )
+    torch.testing.assert_close(ring[:, :, :32], s0, atol=1e-4, rtol=1e-4)
+
+
+def test_ulysses_rank_major_reorder_roundtrip():
+    from veomni.distributed.context_parallel.packed_sharding import (
+        reorder_sample_major_to_ulysses_rank_major,
+        reorder_ulysses_rank_major_to_sample_major,
+        ulysses_local_cu_to_cp_local_cu,
+    )
+
+    # Two samples, ulysses-local lengths 4 and 4; U=2 → gathered seq 16.
+    local_cu = torch.tensor([0, 4, 8], dtype=torch.int32)
+    # Simulate post-gather rank-major: [u0_s0|u0_s1|u1_s0|u1_s1]
+    u0 = torch.arange(0, 8)
+    u1 = torch.arange(100, 108)
+    rank_major = torch.cat([u0, u1]).view(1, 16, 1, 1)
+    sample_major = reorder_ulysses_rank_major_to_sample_major(
+        rank_major, local_cu, ulysses_size=2, seq_dim=1
+    )
+    # Expected: [s0_u0|s0_u1|s1_u0|s1_u1] = [0..3|100..103|4..7|104..107]
+    expected = torch.tensor([0, 1, 2, 3, 100, 101, 102, 103, 4, 5, 6, 7, 104, 105, 106, 107])
+    torch.testing.assert_close(sample_major.view(-1), expected)
+    back = reorder_sample_major_to_ulysses_rank_major(
+        sample_major, local_cu, ulysses_size=2, seq_dim=1
+    )
+    torch.testing.assert_close(back, rank_major)
+    cp_cu = ulysses_local_cu_to_cp_local_cu(local_cu, 2)
+    torch.testing.assert_close(cp_cu, torch.tensor([0, 8, 16], dtype=torch.int32))

--- a/tests/parallel/context_parallel/test_primitives.py
+++ b/tests/parallel/context_parallel/test_primitives.py
@@ -1,0 +1,121 @@
+import pytest
+import torch
+
+from veomni.distributed.context_parallel.sharding import (
+    balanced_cp_restore,
+    balanced_cp_slice,
+    balanced_cp_to_rank_major,
+    hybrid_cp_slice,
+)
+from veomni.distributed.context_parallel.softmax_update import merge_attention_blocks
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_balanced_cp_slice_round_trip(cp_size: int):
+    sequence = torch.arange(64)
+    local_shards = [balanced_cp_slice(sequence, cp_size=cp_size, cp_rank=rank) for rank in range(cp_size)]
+
+    restored = balanced_cp_restore(torch.cat(local_shards), cp_size=cp_size)
+
+    torch.testing.assert_close(restored, sequence)
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_balanced_cp_to_rank_major_round_trip(cp_size: int):
+    sequence = torch.arange(64)
+    rank_major = balanced_cp_to_rank_major(sequence, cp_size=cp_size)
+    restored = balanced_cp_restore(rank_major, cp_size=cp_size)
+    torch.testing.assert_close(restored, sequence)
+    torch.testing.assert_close(
+        rank_major,
+        torch.cat([balanced_cp_slice(sequence, cp_size=cp_size, cp_rank=rank) for rank in range(cp_size)]),
+    )
+
+
+def test_hybrid_cp_slice_matches_ring_then_ulysses_partition():
+    sequence = torch.arange(64)
+    cp_size = 2
+    ulysses_size = 4
+
+    local_shards = [
+        hybrid_cp_slice(
+            sequence,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            ulysses_size=ulysses_size,
+            ulysses_rank=ulysses_rank,
+        )
+        for cp_rank in range(cp_size)
+        for ulysses_rank in range(ulysses_size)
+    ]
+
+    assert all(shard.numel() == 8 for shard in local_shards)
+    torch.testing.assert_close(local_shards[0], torch.arange(0, 8))
+    torch.testing.assert_close(local_shards[3], torch.arange(56, 64))
+    torch.testing.assert_close(local_shards[4], torch.arange(16, 24))
+    torch.testing.assert_close(local_shards[7], torch.arange(40, 48))
+
+
+def test_balanced_cp_slice_rejects_non_divisible_sequence():
+    with pytest.raises(ValueError, match="2 \\* cp_size"):
+        balanced_cp_slice(torch.arange(63), cp_size=2, cp_rank=0)
+
+
+def _block_attention(query: torch.Tensor, key: torch.Tensor, value: torch.Tensor):
+    scores = query @ key.transpose(-1, -2)
+    block_max = scores.max(dim=-1, keepdim=True).values
+    exp_scores = torch.exp(scores - block_max)
+    block_sum = exp_scores.sum(dim=-1, keepdim=True)
+    output = (exp_scores @ value) / block_sum
+    stats_shape = (*block_max.shape[:-1], 8)
+    return output, block_max.expand(stats_shape), block_sum.expand(stats_shape)
+
+
+def test_merge_attention_blocks_matches_full_softmax_and_gradients():
+    torch.manual_seed(0)
+    query = torch.randn(2, 3, 5, 4, dtype=torch.float64, requires_grad=True)
+    key_a = torch.randn(2, 3, 7, 4, dtype=torch.float64, requires_grad=True)
+    value_a = torch.randn(2, 3, 7, 6, dtype=torch.float64, requires_grad=True)
+    key_b = torch.randn(2, 3, 11, 4, dtype=torch.float64, requires_grad=True)
+    value_b = torch.randn(2, 3, 11, 6, dtype=torch.float64, requires_grad=True)
+
+    out_a, max_a, sum_a = _block_attention(query, key_a, value_a)
+    out_b, max_b, sum_b = _block_attention(query, key_b, value_b)
+    merged, _, _ = merge_attention_blocks(out_a, max_a, sum_a, out_b, max_b, sum_b)
+
+    full_scores = query @ torch.cat((key_a, key_b), dim=-2).transpose(-1, -2)
+    full_output = torch.softmax(full_scores, dim=-1) @ torch.cat((value_a, value_b), dim=-2)
+    torch.testing.assert_close(merged, full_output, atol=1e-10, rtol=1e-10)
+
+    merged.sum().backward()
+    merged_grads = [tensor.grad.detach().clone() for tensor in (query, key_a, value_a, key_b, value_b)]
+
+    for tensor in (query, key_a, value_a, key_b, value_b):
+        tensor.grad = None
+    full_output.sum().backward()
+    full_grads = [tensor.grad for tensor in (query, key_a, value_a, key_b, value_b)]
+
+    for actual, expected in zip(merged_grads, full_grads):
+        torch.testing.assert_close(actual, expected, atol=1e-10, rtol=1e-10)
+
+
+def test_merge_attention_blocks_handles_empty_previous_statistics():
+    current_output = torch.randn(1, 2, 3, 4)
+    current_max = torch.randn(1, 2, 3, 8)
+    current_sum = torch.rand(1, 2, 3, 8) + 0.1
+    previous_output = torch.zeros_like(current_output)
+    previous_max = torch.full_like(current_max, -torch.inf)
+    previous_sum = torch.zeros_like(current_sum)
+
+    merged, merged_max, merged_sum = merge_attention_blocks(
+        previous_output,
+        previous_max,
+        previous_sum,
+        current_output,
+        current_max,
+        current_sum,
+    )
+
+    torch.testing.assert_close(merged, current_output)
+    torch.testing.assert_close(merged_max, current_max)
+    torch.testing.assert_close(merged_sum, current_sum)

--- a/tests/parallel/context_parallel/test_ring_attention.py
+++ b/tests/parallel/context_parallel/test_ring_attention.py
@@ -1,0 +1,76 @@
+import pytest
+import torch
+
+from veomni.distributed.context_parallel.ring_attention import (
+    dense_causal_attention,
+    simulate_ring_causal_attention,
+)
+from veomni.distributed.context_parallel.sharding import balanced_cp_slice
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+@pytest.mark.parametrize(
+    "num_q_heads,num_kv_heads,head_dim,seq_len",
+    [
+        (4, 2, 8, 32),
+        (16, 2, 256, 64),  # Qwen3.6-35B-A3B exact head geometry, short seq
+    ],
+)
+def test_simulate_ring_matches_dense_causal_forward(
+    cp_size: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    seq_len: int,
+):
+    torch.manual_seed(0)
+    batch = 1
+    query = torch.randn(batch, num_q_heads, seq_len, head_dim, dtype=torch.float32)
+    key = torch.randn(batch, num_kv_heads, seq_len, head_dim, dtype=torch.float32)
+    value = torch.randn(batch, num_kv_heads, seq_len, head_dim, dtype=torch.float32)
+    scale = head_dim**-0.5
+
+    expected = dense_causal_attention(query, key, value, softmax_scale=scale)
+    actual = simulate_ring_causal_attention(
+        query, key, value, cp_size=cp_size, softmax_scale=scale, backend="torch"
+    )
+
+    torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+
+def test_simulate_ring_matches_dense_causal_gradients_gqa():
+    torch.manual_seed(1)
+    cp_size = 2
+    batch, hq, hkv, seq_len, head_dim = 1, 16, 2, 64, 256
+    scale = head_dim**-0.5
+
+    query = torch.randn(batch, hq, seq_len, head_dim, dtype=torch.float64, requires_grad=True)
+    key = torch.randn(batch, hkv, seq_len, head_dim, dtype=torch.float64, requires_grad=True)
+    value = torch.randn(batch, hkv, seq_len, head_dim, dtype=torch.float64, requires_grad=True)
+
+    ring_out = simulate_ring_causal_attention(
+        query, key, value, cp_size=cp_size, softmax_scale=scale, backend="torch"
+    )
+    ring_out.sum().backward()
+    ring_grads = [query.grad.detach().clone(), key.grad.detach().clone(), value.grad.detach().clone()]
+
+    for tensor in (query, key, value):
+        tensor.grad = None
+
+    dense_out = dense_causal_attention(query, key, value, softmax_scale=scale)
+    dense_out.sum().backward()
+    dense_grads = [query.grad, key.grad, value.grad]
+
+    torch.testing.assert_close(ring_out.detach(), dense_out.detach(), atol=1e-5, rtol=1e-5)
+    for actual, expected in zip(ring_grads, dense_grads):
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_balanced_local_shards_cover_full_sequence_without_overlap():
+    seq = torch.arange(64).view(1, 1, 64, 1)
+    shards = [balanced_cp_slice(seq, cp_size=2, cp_rank=rank, dim=2) for rank in range(2)]
+    assert shards[0].shape[2] == 32
+    assert shards[1].shape[2] == 32
+    # Rank0 = c0||c3, Rank1 = c1||c2
+    torch.testing.assert_close(shards[0][0, 0, :, 0], torch.cat((torch.arange(0, 16), torch.arange(48, 64))))
+    torch.testing.assert_close(shards[1][0, 0, :, 0], torch.cat((torch.arange(16, 32), torch.arange(32, 48))))

--- a/tests/parallel/context_parallel/test_ring_p2p_distributed.py
+++ b/tests/parallel/context_parallel/test_ring_p2p_distributed.py
@@ -1,0 +1,140 @@
+import os
+import tempfile
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from veomni.distributed.context_parallel.ring_attention import (
+    dense_causal_attention,
+    ringattn_context_parallel,
+)
+from veomni.distributed.context_parallel.ring_p2p import RingP2P
+from veomni.distributed.context_parallel.sharding import balanced_cp_restore, balanced_cp_slice
+
+
+def _init_gloo(rank: int, world_size: int, file_name: str):
+    store = dist.FileStore(file_name, world_size)
+    dist.init_process_group("gloo", store=store, rank=rank, world_size=world_size)
+    return dist.distributed_c10d._get_default_group()
+
+
+def _ring_p2p_worker(rank: int, world_size: int, file_name: str, errors: mp.Queue):
+    try:
+        group = _init_gloo(rank, world_size, file_name)
+        ranks = list(range(world_size))
+        ring = RingP2P(ranks, group)
+        send = torch.full((4,), float(rank + 1))
+        recv = torch.zeros_like(send)
+        ring.async_send_recv(send, recv)
+        ring.wait()
+        expected = float((rank - 1 + world_size) % world_size + 1)
+        torch.testing.assert_close(recv, torch.full_like(recv, expected))
+        dist.destroy_process_group()
+        errors.put(None)
+    except Exception as exc:  # noqa: BLE001 - surface worker failures to parent
+        errors.put(repr(exc))
+
+
+def _attention_worker(rank: int, world_size: int, file_name: str, errors: mp.Queue):
+    try:
+        group = _init_gloo(rank, world_size, file_name)
+        ranks = list(range(world_size))
+        torch.manual_seed(0)
+        batch, hq, hkv, seq_len, head_dim = 1, 16, 2, 64, 256
+        scale = head_dim**-0.5
+
+        query = torch.empty(batch, hq, seq_len, head_dim, dtype=torch.float32)
+        key = torch.empty(batch, hkv, seq_len, head_dim, dtype=torch.float32)
+        value = torch.empty(batch, hkv, seq_len, head_dim, dtype=torch.float32)
+        if rank == 0:
+            torch.manual_seed(0)
+            query = torch.randn_like(query)
+            key = torch.randn_like(key)
+            value = torch.randn_like(value)
+        dist.broadcast(query, src=0)
+        dist.broadcast(key, src=0)
+        dist.broadcast(value, src=0)
+
+        local_q = balanced_cp_slice(query, cp_size=2, cp_rank=rank, dim=2).detach().requires_grad_(True)
+        local_k = balanced_cp_slice(key, cp_size=2, cp_rank=rank, dim=2).detach().requires_grad_(True)
+        local_v = balanced_cp_slice(value, cp_size=2, cp_rank=rank, dim=2).detach().requires_grad_(True)
+
+        local_out = ringattn_context_parallel(
+            local_q,
+            local_k,
+            local_v,
+            hq,
+            group,
+            ranks,
+            softmax_scale=scale,
+            backend="torch",
+        )
+        loss = local_out.sum()
+        loss.backward()
+
+        gathered = [torch.empty_like(local_out) for _ in range(world_size)]
+        dist.all_gather(gathered, local_out.detach())
+        if rank == 0:
+            ring_full = balanced_cp_restore(torch.cat(gathered, dim=2), cp_size=2, dim=2)
+            dense = dense_causal_attention(query, key, value, softmax_scale=scale)
+            torch.testing.assert_close(ring_full, dense, atol=2e-4, rtol=2e-4)
+
+            # Gradient parity on local shards vs dense sliced grads.
+            query_r = query.detach().requires_grad_(True)
+            key_r = key.detach().requires_grad_(True)
+            value_r = value.detach().requires_grad_(True)
+            dense_out = dense_causal_attention(query_r, key_r, value_r, softmax_scale=scale)
+            dense_out.sum().backward()
+            torch.testing.assert_close(
+                local_q.grad,
+                balanced_cp_slice(query_r.grad, cp_size=2, cp_rank=0, dim=2),
+                atol=2e-4,
+                rtol=2e-4,
+            )
+            torch.testing.assert_close(
+                local_k.grad,
+                balanced_cp_slice(key_r.grad, cp_size=2, cp_rank=0, dim=2),
+                atol=2e-4,
+                rtol=2e-4,
+            )
+            torch.testing.assert_close(
+                local_v.grad,
+                balanced_cp_slice(value_r.grad, cp_size=2, cp_rank=0, dim=2),
+                atol=2e-4,
+                rtol=2e-4,
+            )
+
+        dist.barrier()
+        dist.destroy_process_group()
+        errors.put(None)
+    except Exception as exc:  # noqa: BLE001
+        errors.put(repr(exc))
+
+
+def _run_mp(worker, world_size: int = 2):
+    with tempfile.TemporaryDirectory() as tmp:
+        file_name = os.path.join(tmp, "pg")
+        ctx = mp.get_context("spawn")
+        errors = ctx.Queue()
+        processes = [
+            ctx.Process(target=worker, args=(rank, world_size, file_name, errors))
+            for rank in range(world_size)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=120)
+            assert process.exitcode == 0, f"worker exited with {process.exitcode}"
+        for _ in range(world_size):
+            err = errors.get(timeout=5)
+            assert err is None, err
+
+
+def test_ring_p2p_exchanges_tensor_gloo():
+    _run_mp(_ring_p2p_worker)
+
+
+def test_attention_with_cp_matches_dense_gloo():
+    _run_mp(_attention_worker)

--- a/tests/parallel/context_parallel/test_topology.py
+++ b/tests/parallel/context_parallel/test_topology.py
@@ -1,0 +1,55 @@
+import torch
+
+from veomni.distributed.context_parallel.sharding import hybrid_cp_slice
+from veomni.distributed.context_parallel.topology import (
+    coords_from_sp_rank,
+    cp_global_ranks_for_ulysses_rank,
+    sp_rank_from_coords,
+    ulysses_global_ranks_for_cp_rank,
+)
+
+
+def test_sp_rank_coords_round_trip_u4_cp2():
+    cp_size, ulysses_size = 2, 4
+    for sp_rank in range(cp_size * ulysses_size):
+        cp_rank, ulysses_rank = coords_from_sp_rank(sp_rank, cp_size, ulysses_size)
+        assert sp_rank_from_coords(cp_rank, ulysses_rank, ulysses_size) == sp_rank
+
+
+def test_group_ranks_match_init_sequence_parallel_layout():
+    cp_size, ulysses_size = 2, 4
+    # DP0 Ulysses groups for each CP slot.
+    assert ulysses_global_ranks_for_cp_rank(
+        dp_index=0, cp_rank=0, cp_size=cp_size, ulysses_size=ulysses_size
+    ) == [0, 1, 2, 3]
+    assert ulysses_global_ranks_for_cp_rank(
+        dp_index=0, cp_rank=1, cp_size=cp_size, ulysses_size=ulysses_size
+    ) == [4, 5, 6, 7]
+    # DP0 CP rings for each Ulysses slot.
+    assert cp_global_ranks_for_ulysses_rank(
+        dp_index=0, ulysses_rank=0, cp_size=cp_size, ulysses_size=ulysses_size
+    ) == [0, 4]
+    assert cp_global_ranks_for_ulysses_rank(
+        dp_index=0, ulysses_rank=3, cp_size=cp_size, ulysses_size=ulysses_size
+    ) == [3, 7]
+
+
+def test_hybrid_slice_for_all_u4_cp2_ranks():
+    sequence = torch.arange(64)
+    cp_size, ulysses_size = 2, 4
+    shards = []
+    for sp_rank in range(cp_size * ulysses_size):
+        cp_rank, ulysses_rank = coords_from_sp_rank(sp_rank, cp_size, ulysses_size)
+        shards.append(
+            hybrid_cp_slice(
+                sequence,
+                cp_size=cp_size,
+                cp_rank=cp_rank,
+                ulysses_size=ulysses_size,
+                ulysses_rank=ulysses_rank,
+            )
+        )
+    assert all(shard.numel() == 8 for shard in shards)
+    # Contiguous SP would give [24:32] for rank3; hybrid CP0/U3 is the late half of rank0.
+    torch.testing.assert_close(shards[3], torch.arange(56, 64))
+    torch.testing.assert_close(shards[4], torch.arange(16, 24))

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -64,14 +64,13 @@ def add_flash_attention_kwargs_from_position_ids(
         batch: The batch dictionary containing position_ids. Will be modified in-place to add
                cu_seq_lens_q, cu_seq_lens_k, max_length_q, max_length_k, and
                linear_attn_cu_seq_lens_q. When ``linear_attn_tail_padding_length > 0``,
-               also stores ``tail_padding_length`` (0-d ``torch.int32`` tensor) so
-               downstream valid-seqlens helpers can strip the coalesced pad segment and
-               distributed/PP stages preserve the metadata.
+               also stores ``tail_padding_length`` so downstream valid-seqlens helpers can
+               strip the coalesced pad segment.
         linear_attn_tail_padding_length: Number of known padding tokens appended at the tail by
                collators (``pad_to_length`` / SP pad). ``position_ids == 0`` encodes each pad
                token as its own 1-token boundary; both FlashAttention and linear-attention
-               cu-seqlens coalesce that tail into one segment. Ascend NPU
-               ``npu_fusion_attention`` SIGSEGVs on the uncoalesced per-token form.
+               cu-seqlens coalesce that tail into one segment. NPU ``npu_fusion_attention``
+               SIGSEGVs on the uncoalesced per-token form.
 
     Returns:
         Tuple of (cu_seq_lens_q, cu_seq_lens_k, max_length_q, max_length_k) for additional use.
@@ -87,12 +86,7 @@ def add_flash_attention_kwargs_from_position_ids(
         seqlens = cu_seq_lens_q[1:] - cu_seq_lens_q[:-1]
         max_length_q = int(seqlens.max().item()) if seqlens.numel() else 0
         max_length_k = max_length_q
-        # Keep as a 0-d tensor so PP / distributed stages preserve the metadata.
-        batch["tail_padding_length"] = torch.tensor(
-            linear_attn_tail_padding_length,
-            dtype=torch.int32,
-            device=cu_seq_lens_q.device,
-        )
+        batch["tail_padding_length"] = int(linear_attn_tail_padding_length)
 
     batch["cu_seq_lens_q"] = cu_seq_lens_q
     batch["cu_seq_lens_k"] = cu_seq_lens_k
@@ -139,7 +133,7 @@ DEFAULT_DATA_COLLATE_INFO: Dict[str, DataCollateInfo] = {
     "input_ids": DataCollateInfo(-1, True, 0, 1),
     "labels": DataCollateInfo(-1, True, IGNORE_INDEX, 1),
     "attention_mask": DataCollateInfo(-1, False, 1, 1),
-    "position_ids": DataCollateInfo(-1, False, 0, 1),
+    "position_ids": DataCollateInfo(-1, True, 0, 1),  # CP/Ulysses must shard RoPE positions with tokens
     "pixel_values": DataCollateInfo(0, True, 0, 4),
     "pixel_values_videos": DataCollateInfo(0, True, 0, 4),
     "image_mask": DataCollateInfo(-1, False, 0, 1),
@@ -324,10 +318,42 @@ class SequenceParallelCollator(DataCollator):
     metadata_collate_func: Optional[MetadataCollateFunc] = None
 
     def __post_init__(self):
-        self.sp_size = get_parallel_state().sp_size
-        self.sp_rank = get_parallel_state().sp_rank
+        parallel_state = get_parallel_state()
+        self.sp_size = parallel_state.sp_size
+        self.sp_rank = parallel_state.sp_rank
+        self.cp_size = parallel_state.cp_size
+        self.ulysses_size = parallel_state.ulysses_size
+        self.cp_rank = parallel_state.cp_rank if parallel_state.cp_enabled else 0
+        self.ulysses_rank = parallel_state.ulysses_rank if parallel_state.ulysses_enabled else 0
+        # Balanced causal CP needs 2 * cp chunks before Ulysses split.
+        self.sp_pad_multiple = 2 if parallel_state.cp_enabled else 1
 
     def sp_slice(self, key: str, feature: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        if self.cp_size > 1:
+            from ..distributed.context_parallel.sharding import hybrid_cp_slice
+
+            if isinstance(feature, list):
+                assert dim == 0, f"Only support dim=0 for {key} as it is a List"
+                tensor = torch.arange(len(feature))
+                # Hybrid slice index list via tensor path then reselect.
+                index = hybrid_cp_slice(
+                    tensor,
+                    cp_size=self.cp_size,
+                    cp_rank=self.cp_rank,
+                    ulysses_size=self.ulysses_size,
+                    ulysses_rank=self.ulysses_rank,
+                    dim=0,
+                )
+                return [feature[i] for i in index.tolist()]
+            return hybrid_cp_slice(
+                feature,
+                cp_size=self.cp_size,
+                cp_rank=self.cp_rank,
+                ulysses_size=self.ulysses_size,
+                ulysses_rank=self.ulysses_rank,
+                dim=dim,
+            )
+
         if isinstance(feature, list):
             assert dim == 0, f"Only support dim=0 for {key} as it is a List"
             seq_length = len(feature)
@@ -352,7 +378,7 @@ class SequenceParallelCollator(DataCollator):
         else:
             seq_length = feature.size(dim)
 
-        scale_sp_size = self.sp_size * pad_scale
+        scale_sp_size = self.sp_size * pad_scale * self.sp_pad_multiple
         sp_chunk_size = (seq_length + scale_sp_size - 1) // scale_sp_size
         pad_size = sp_chunk_size * scale_sp_size - seq_length
         if pad_size == 0:
@@ -407,15 +433,86 @@ class SequenceParallelCollator(DataCollator):
                 if key == "position_ids":
                     linear_attn_tail_padding_length += post_pad_len - pre_pad_len
 
-            if sp_slice and key != "position_ids":  # position_ids should be sp sliced after precompute fa kwargs
-                # sp slice
+            # Defer slicing until FA kwargs exist when CP is enabled (need global cu_seqlens).
+            if self.cp_size <= 1 and sp_slice and key != "position_ids":
                 batch[key] = self.sp_slice(key, batch[key], dim=pack_dim)
 
         add_flash_attention_kwargs_from_position_ids(batch, linear_attn_tail_padding_length)
 
-        batch["position_ids"] = self.sp_slice(
-            "position_ids", batch["position_ids"], dim=self.collate_infos["position_ids"].pack_dim
-        )
+        if self.cp_size > 1:
+            from ..distributed.context_parallel.packed_sharding import (
+                apply_packed_cp_partition,
+                build_packed_cp_partition,
+                pad_packed_tensor_to_sample_multiple,
+            )
+
+            if "cu_seq_lens_q" not in batch:
+                raise RuntimeError("CP>1 requires cu_seq_lens_q from packed position_ids.")
+            sample_multiple = 2 * self.cp_size * max(self.ulysses_size, 1)
+            # Per-sample pad so zigzag CP is well-defined on packed boundaries.
+            # All sequence tensors must share the same original cu_seqlens plan.
+            cu_src = batch["cu_seq_lens_q"]
+            cu_dst = None
+            for key in list(batch.keys()):
+                collate_info: DataCollateInfo = self.collate_infos.get(key, None)
+                if collate_info is None or not isinstance(batch[key], torch.Tensor):
+                    continue
+                pad_value = 0 if collate_info.sp_pad_value is None else collate_info.sp_pad_value
+                batch[key], cu_new = pad_packed_tensor_to_sample_multiple(
+                    batch[key],
+                    cu_src,
+                    multiple=sample_multiple,
+                    dim=collate_info.pack_dim,
+                    pad_value=pad_value,
+                )
+                cu_dst = cu_new
+            if cu_dst is None:
+                raise RuntimeError("CP>1 packing pad found no sequence tensors to align.")
+            batch["cu_seq_lens_q"] = cu_dst
+            batch["cu_seq_lens_k"] = cu_dst.clone()
+            diffs = (cu_dst[1:] - cu_dst[:-1]).tolist()
+            batch["max_length_q"] = int(max(diffs) if diffs else 0)
+            batch["max_length_k"] = batch["max_length_q"]
+
+            # GDN gathers to full sequence under unified SP; keep global cu_seqlens for it.
+            # Ring FA keeps local cu_seq_lens_q after partition below.
+            batch["linear_attn_cu_seq_lens_q"] = batch["cu_seq_lens_q"].clone()
+            partition = build_packed_cp_partition(
+                batch["cu_seq_lens_q"],
+                cp_size=self.cp_size,
+                cp_rank=self.cp_rank,
+                ulysses_size=max(self.ulysses_size, 1),
+                ulysses_rank=self.ulysses_rank if self.ulysses_size > 1 else 0,
+            )
+            for key in list(batch.keys()):
+                collate_info: DataCollateInfo = self.collate_infos.get(key, None)
+                if collate_info is None or not collate_info.sp_slice:
+                    continue
+                if isinstance(batch[key], list):
+                    index = partition.token_indices
+                    batch[key] = [batch[key][i] for i in index.tolist()]
+                else:
+                    batch[key] = apply_packed_cp_partition(
+                        batch[key], partition, dim=collate_info.pack_dim
+                    )
+            # RoPE cos/sin follow position_ids; must match local token shard under CP.
+            if "position_ids" in batch and isinstance(batch["position_ids"], torch.Tensor):
+                pos_dim = self.collate_infos["position_ids"].pack_dim
+                # Avoid double-slice if already partitioned via sp_slice=True above.
+                if batch["position_ids"].size(pos_dim) != partition.token_indices.numel():
+                    batch["position_ids"] = apply_packed_cp_partition(
+                        batch["position_ids"], partition, dim=pos_dim
+                    )
+            local_cu = partition.local_cu_seqlens
+            batch["cu_seq_lens_q"] = local_cu
+            batch["cu_seq_lens_k"] = local_cu.clone()
+            batch["max_length_q"] = partition.local_max_seqlen
+            batch["max_length_k"] = partition.local_max_seqlen
+            # linear_attn_cu_seq_lens_q stays global for GDN post-gather kernels.
+        else:
+            batch["position_ids"] = self.sp_slice(
+                "position_ids", batch["position_ids"], dim=self.collate_infos["position_ids"].pack_dim
+            )
 
         # Hand the SP-padded batch + per-modality sp-pad patch counts to the
         # model-provided hook, which derives ``multimodal_metadata`` (cu_seqlens,
@@ -538,10 +635,9 @@ class PostCollator(DataCollator):
 @dataclass
 class SeqlensComputePostCollator(DataCollator):
     def __call__(self, micro_batch: Dict[str, torch.Tensor]):
-        tail_padding_length = micro_batch.get("tail_padding_length")
         seq_lens = valid_seqlens_from_cu_seqlens(
             micro_batch["cu_seq_lens_q"],
-            tail_padding_length=int(tail_padding_length) if tail_padding_length is not None else None,
+            int(micro_batch.get("tail_padding_length", 0) or 0),
         ).tolist()
         return seq_lens
 

--- a/veomni/distributed/context_parallel/__init__.py
+++ b/veomni/distributed/context_parallel/__init__.py
@@ -1,0 +1,43 @@
+from .attention_backend import has_npu_fusion_attention, torch_attention_forward, torch_packed_causal_attention
+from .packed_sharding import PackedCPPartition, apply_packed_cp_partition, build_packed_cp_partition
+from .ring_attention import (
+    AttentionWithCp,
+    dense_causal_attention,
+    ringattn_context_parallel,
+    simulate_packed_ring_causal_attention,
+    simulate_ring_causal_attention,
+)
+from .ring_p2p import RingP2P
+from .sharding import balanced_cp_restore, balanced_cp_slice, balanced_cp_to_rank_major, hybrid_cp_slice
+from .softmax_update import merge_attention_blocks
+from .topology import (
+    coords_from_sp_rank,
+    cp_global_ranks_for_ulysses_rank,
+    sp_rank_from_coords,
+    ulysses_global_ranks_for_cp_rank,
+)
+
+
+__all__ = [
+    "AttentionWithCp",
+    "PackedCPPartition",
+    "RingP2P",
+    "apply_packed_cp_partition",
+    "balanced_cp_restore",
+    "balanced_cp_slice",
+    "balanced_cp_to_rank_major",
+    "build_packed_cp_partition",
+    "coords_from_sp_rank",
+    "cp_global_ranks_for_ulysses_rank",
+    "dense_causal_attention",
+    "has_npu_fusion_attention",
+    "hybrid_cp_slice",
+    "merge_attention_blocks",
+    "ringattn_context_parallel",
+    "simulate_packed_ring_causal_attention",
+    "simulate_ring_causal_attention",
+    "sp_rank_from_coords",
+    "torch_attention_forward",
+    "torch_packed_causal_attention",
+    "ulysses_global_ranks_for_cp_rank",
+]

--- a/veomni/distributed/context_parallel/attention_backend.py
+++ b/veomni/distributed/context_parallel/attention_backend.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026 ByteDance AI4SE. MindSpeed-compatible Torch FA backend for Ring CP tests.
+"""Attention backends used by Ring context parallel.
+
+Torch backend is the Day-1 correctness path (CPU/NPU). NPU fusion attention is
+optional and used when ``torch_npu.npu_fusion_attention`` is available.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+
+def _repeat_kv(hidden_states: Tensor, n_rep: int) -> Tensor:
+    if n_rep == 1:
+        return hidden_states
+    batch, num_kv_heads, seq_len, head_dim = hidden_states.shape
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_kv_heads, n_rep, seq_len, head_dim)
+    return hidden_states.reshape(batch, num_kv_heads * n_rep, seq_len, head_dim)
+
+
+def _expand_softmax_stats(stat: Tensor) -> Tensor:
+    """Broadcast trailing singleton softmax stats to NPU-style width-8."""
+    if stat.size(-1) == 8:
+        return stat
+    if stat.size(-1) != 1:
+        raise ValueError(f"Expected softmax stats trailing dim 1 or 8, got {stat.shape}.")
+    return stat.expand(*stat.shape[:-1], 8).contiguous()
+
+
+def torch_attention_forward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    softmax_scale: float,
+    causal: bool,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Eager BNSD attention that also returns online-softmax statistics.
+
+    Args:
+        query/key/value: [B, H, S, D] (GQA allowed: H_q may exceed H_kv)
+        softmax_scale: attention scale
+        causal: whether to apply a lower-triangular mask on equal-length Q/K
+
+    Returns:
+        output [B, Hq, Sq, D], softmax_max/sum [B, Hq, Sq, 8]
+    """
+    batch, num_q_heads, q_len, head_dim = query.shape
+    num_kv_heads = key.shape[1]
+    if num_q_heads % num_kv_heads != 0:
+        raise ValueError(f"GQA requires Hq % Hkv == 0, got {num_q_heads} and {num_kv_heads}.")
+    n_rep = num_q_heads // num_kv_heads
+    key_exp = _repeat_kv(key, n_rep)
+    value_exp = _repeat_kv(value, n_rep)
+
+    # FP32 scores for stable online-softmax stats.
+    scores = torch.matmul(query.float(), key_exp.float().transpose(-1, -2)) * float(softmax_scale)
+    if causal:
+        if q_len != key_exp.size(2):
+            raise ValueError(
+                f"Causal torch attention requires equal Q/K lengths, got {q_len} and {key_exp.size(2)}."
+            )
+        causal_mask = torch.ones(q_len, q_len, dtype=torch.bool, device=query.device).triu(diagonal=1)
+        scores = scores.masked_fill(causal_mask, torch.finfo(scores.dtype).min)
+
+    block_max = scores.amax(dim=-1, keepdim=True)
+    exp_scores = torch.exp(scores - block_max)
+    block_sum = exp_scores.sum(dim=-1, keepdim=True)
+    probs = exp_scores / block_sum.clamp_min(torch.finfo(exp_scores.dtype).tiny)
+    output = torch.matmul(probs.to(value_exp.dtype), value_exp)
+
+    # Tokens that attended an empty/fully-masked row get -inf max / 0 sum.
+    if causal:
+        fully_masked = ~torch.isfinite(block_max)
+        block_max = torch.where(fully_masked, torch.full_like(block_max, -torch.inf), block_max)
+        block_sum = torch.where(fully_masked, torch.zeros_like(block_sum), block_sum)
+
+    softmax_max = _expand_softmax_stats(block_max.to(query.dtype))
+    softmax_sum = _expand_softmax_stats(block_sum.to(query.dtype))
+    return output, softmax_max, softmax_sum
+
+
+def torch_attention_backward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    dout: Tensor,
+    attn_out: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    *,
+    softmax_scale: float,
+    causal: bool,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Block-wise attention backward using global merged online-softmax stats."""
+    batch, num_q_heads, q_len, head_dim = query.shape
+    num_kv_heads = key.shape[1]
+    n_rep = num_q_heads // num_kv_heads
+    key_exp = _repeat_kv(key, n_rep)
+    value_exp = _repeat_kv(value, n_rep)
+    k_len = key_exp.size(2)
+
+    scores = torch.matmul(query.float(), key_exp.float().transpose(-1, -2)) * float(softmax_scale)
+    if causal:
+        causal_mask = torch.ones(q_len, k_len, dtype=torch.bool, device=query.device).triu(diagonal=1)
+        scores = scores.masked_fill(causal_mask, torch.finfo(scores.dtype).min)
+
+    # Reconstruct P from global LSE pieces: P = exp(S - max) / sum.
+    global_max = softmax_max[..., :1].float()
+    global_sum = softmax_sum[..., :1].float().clamp_min(torch.finfo(torch.float32).tiny)
+    probs = torch.exp(scores - global_max) / global_sum
+    if causal:
+        probs = probs.masked_fill(causal_mask, 0.0)
+
+    dout_f = dout.float()
+    out_f = attn_out.float()
+    delta = (dout_f * out_f).sum(dim=-1, keepdim=True)
+
+    dv_exp = torch.matmul(probs.transpose(-1, -2), dout_f)
+    dp = torch.matmul(dout_f, value_exp.float().transpose(-1, -2))
+    ds = probs * (dp - delta)
+    dq = torch.matmul(ds, key_exp.float()) * float(softmax_scale)
+    dk_exp = torch.matmul(ds.transpose(-1, -2), query.float()) * float(softmax_scale)
+
+    if n_rep == 1:
+        dk, dv = dk_exp, dv_exp
+    else:
+        dk = dk_exp.view(batch, num_kv_heads, n_rep, k_len, head_dim).sum(dim=2)
+        dv = dv_exp.view(batch, num_kv_heads, n_rep, k_len, head_dim).sum(dim=2)
+
+    return dq.to(query.dtype), dk.to(key.dtype), dv.to(value.dtype)
+
+
+def npu_attention_forward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    num_heads: int,
+    softmax_scale: float,
+    causal: bool,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """NPU fusion attention forward (BNSD). Falls back is not available here."""
+    import torch_npu
+
+    atten_mask = None
+    sparse_mode = 0
+    pre_tokens = key.size(2)
+    next_tokens = pre_tokens
+    if causal:
+        atten_mask = torch.ones((2048, 2048), dtype=torch.bool, device=query.device)
+        atten_mask = torch.triu(atten_mask, diagonal=1)
+        next_tokens = 0
+        sparse_mode = 3
+
+    outs = torch_npu.npu_fusion_attention(
+        query,
+        key,
+        value,
+        num_heads,
+        "BNSD",
+        pse=None,
+        padding_mask=None,
+        atten_mask=atten_mask,
+        scale=softmax_scale,
+        pre_tockens=pre_tokens,
+        next_tockens=next_tokens,
+        keep_prob=1.0,
+        sparse_mode=sparse_mode,
+    )
+    return outs[0], outs[1], outs[2]
+
+
+def npu_attention_backward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    dout: Tensor,
+    attn_out: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    *,
+    num_heads: int,
+    softmax_scale: float,
+    causal: bool,
+) -> tuple[Tensor, Tensor, Tensor]:
+    import torch_npu
+
+    atten_mask = None
+    sparse_mode = 0
+    pre_tokens = key.size(2)
+    next_tokens = pre_tokens
+    if causal:
+        atten_mask = torch.ones((2048, 2048), dtype=torch.bool, device=query.device)
+        atten_mask = torch.triu(atten_mask, diagonal=1)
+        next_tokens = 0
+        sparse_mode = 3
+
+    grads = torch_npu.npu_fusion_attention_grad(
+        query,
+        key,
+        value,
+        dout,
+        num_heads,
+        "BNSD",
+        pse=None,
+        padding_mask=None,
+        atten_mask=atten_mask,
+        softmax_max=softmax_max,
+        softmax_sum=softmax_sum,
+        attention_in=attn_out,
+        scale_value=softmax_scale,
+        pre_tockens=pre_tokens,
+        next_tockens=next_tokens,
+        sparse_mode=sparse_mode,
+        keep_prob=1.0,
+    )
+    return grads[0], grads[1], grads[2]
+
+
+def has_npu_fusion_attention() -> bool:
+    try:
+        import torch_npu
+
+        return hasattr(torch_npu, "npu_fusion_attention") and hasattr(torch_npu, "npu_fusion_attention_grad")
+    except Exception:
+        return False
+
+
+def torch_packed_causal_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    cu_seqlens: Tensor,
+    *,
+    softmax_scale: Optional[float] = None,
+) -> Tensor:
+    """Dense packed causal attention with no cross-sample visibility.
+
+    Inputs are BNSD with batch=1: [1, H, T, D]. ``cu_seqlens`` is int32 [N+1].
+    """
+    if query.size(0) != 1:
+        raise ValueError(f"torch_packed_causal_attention expects batch=1, got {query.shape}.")
+    if softmax_scale is None:
+        softmax_scale = query.shape[-1] ** -0.5
+    cu = cu_seqlens.detach().cpu().tolist()
+    outs = []
+    for start, end in zip(cu[:-1], cu[1:]):
+        start, end = int(start), int(end)
+        outs.append(
+            torch_attention_forward(
+                query[:, :, start:end],
+                key[:, :, start:end],
+                value[:, :, start:end],
+                softmax_scale=float(softmax_scale),
+                causal=True,
+            )[0]
+        )
+    return torch.cat(outs, dim=2)

--- a/veomni/distributed/context_parallel/causal_schedule.py
+++ b/veomni/distributed/context_parallel/causal_schedule.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2024, Huawei Technologies Co., Ltd.  All rights reserved.
+# Ported/adapted from MindSpeed ring_context_parallel causal helpers (BSD-3-Clause).
+"""Causal zigzag block schedule for Ring context parallel (BNSD layout)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from torch import Tensor
+
+from .softmax_update import merge_attention_blocks
+
+
+def as_balanced_halves(tensor: Tensor) -> Tensor:
+    """View local CP shard [B, H, 2S, ...] as [B, H, 2, S, ...]."""
+    if tensor.size(2) % 2 != 0:
+        raise ValueError(f"Sequence dim must be even for balanced CP, got {tensor.size(2)}.")
+    return tensor.view(tensor.size(0), tensor.size(1), 2, tensor.size(2) // 2, *tensor.shape[3:])
+
+
+def flatten_balanced_halves(tensor: Tensor) -> Tensor:
+    """Flatten [B, H, 2, S, ...] back to [B, H, 2S, ...]."""
+    return tensor.reshape(tensor.size(0), tensor.size(1), -1, *tensor.shape[4:])
+
+
+def causal_forward_fetch(
+    q_block_id: int,
+    kv_block_id: int,
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    attn_mask: Optional[Tensor] = None,
+) -> tuple[Tensor, Tensor, Tensor, Optional[Tensor]]:
+    """Select Q/K/V slices for one causal ring step.
+
+    Inputs are balanced-halved BNSD: [B, H, 2, S, D].
+    """
+    if q_block_id == kv_block_id:
+        return (
+            flatten_balanced_halves(query),
+            flatten_balanced_halves(key),
+            flatten_balanced_halves(value),
+            attn_mask,
+        )
+    if kv_block_id <= q_block_id:
+        return (
+            flatten_balanced_halves(query),
+            key[:, :, 0],
+            value[:, :, 0],
+            None,
+        )
+    return (
+        query[:, :, 1],
+        flatten_balanced_halves(key),
+        flatten_balanced_halves(value),
+        None,
+    )
+
+
+def causal_backward_fetch(
+    q_block_id: int,
+    kv_block_id: int,
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    attn_out: Tensor,
+    dout: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    attn_mask: Optional[Tensor] = None,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Optional[Tensor]]:
+    """Select backward operands for one causal ring step (balanced-halved BNSD)."""
+    if q_block_id >= kv_block_id:
+        cur_softmax_max = flatten_balanced_halves(softmax_max)
+        cur_softmax_sum = flatten_balanced_halves(softmax_sum)
+        cur_q = flatten_balanced_halves(query)
+        cur_attn_out = flatten_balanced_halves(attn_out)
+        cur_dout = flatten_balanced_halves(dout)
+        if q_block_id == kv_block_id:
+            return (
+                cur_q,
+                flatten_balanced_halves(key),
+                flatten_balanced_halves(value),
+                cur_attn_out,
+                cur_dout,
+                cur_softmax_max,
+                cur_softmax_sum,
+                attn_mask,
+            )
+        return (
+            cur_q,
+            key[:, :, 0],
+            value[:, :, 0],
+            cur_attn_out,
+            cur_dout,
+            cur_softmax_max,
+            cur_softmax_sum,
+            None,
+        )
+
+    return (
+        query[:, :, 1],
+        flatten_balanced_halves(key),
+        flatten_balanced_halves(value),
+        attn_out[:, :, 1],
+        dout[:, :, 1],
+        softmax_max[:, :, 1],
+        softmax_sum[:, :, 1],
+        None,
+    )
+
+
+def causal_out_update(
+    q_block_id: int,
+    kv_block_id: int,
+    cur_attn_out: Tensor,
+    cur_softmax_max: Tensor,
+    cur_softmax_sum: Tensor,
+    attn_out: Optional[Tensor],
+    softmax_max: Optional[Tensor],
+    softmax_sum: Optional[Tensor],
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Merge one causal ring step into the running online-softmax state."""
+    if q_block_id == kv_block_id or attn_out is None:
+        return cur_attn_out, cur_softmax_max, cur_softmax_sum
+
+    if kv_block_id <= q_block_id:
+        return merge_attention_blocks(
+            attn_out,
+            softmax_max,
+            softmax_sum,
+            cur_attn_out,
+            cur_softmax_max,
+            cur_softmax_sum,
+        )
+
+    # Future relative block: only the late query half observes this KV.
+    out_view = as_balanced_halves(attn_out)
+    max_view = as_balanced_halves(softmax_max)
+    sum_view = as_balanced_halves(softmax_sum)
+    updated_out, updated_max, updated_sum = merge_attention_blocks(
+        out_view[:, :, 1],
+        max_view[:, :, 1],
+        sum_view[:, :, 1],
+        cur_attn_out,
+        cur_softmax_max,
+        cur_softmax_sum,
+    )
+    out_view = out_view.clone()
+    max_view = max_view.clone()
+    sum_view = sum_view.clone()
+    out_view[:, :, 1].copy_(updated_out)
+    max_view[:, :, 1].copy_(updated_max)
+    sum_view[:, :, 1].copy_(updated_sum)
+    return (
+        flatten_balanced_halves(out_view),
+        flatten_balanced_halves(max_view),
+        flatten_balanced_halves(sum_view),
+    )
+
+
+def causal_grad_update(
+    q_block_id: int,
+    kv_block_id: int,
+    cur_dq: Tensor,
+    cur_dk: Tensor,
+    cur_dv: Tensor,
+    dq: Tensor,
+    dk: Tensor,
+    dv: Tensor,
+) -> None:
+    """Accumulate step gradients into balanced-halved dQ/dK/dV buffers."""
+    if q_block_id == kv_block_id:
+        dq.add_(as_balanced_halves(cur_dq))
+        dk.add_(as_balanced_halves(cur_dk))
+        dv.add_(as_balanced_halves(cur_dv))
+        return
+
+    if q_block_id > kv_block_id:
+        dq.add_(as_balanced_halves(cur_dq))
+        dk[:, :, 0].add_(cur_dk)
+        dv[:, :, 0].add_(cur_dv)
+        return
+
+    dq[:, :, 1].add_(cur_dq)
+    dk.add_(as_balanced_halves(cur_dk))
+    dv.add_(as_balanced_halves(cur_dv))

--- a/veomni/distributed/context_parallel/gdn_kcp.py
+++ b/veomni/distributed/context_parallel/gdn_kcp.py
@@ -25,6 +25,7 @@ validate P1 vs P0 with an independent tol (CP-C). Default ``gdn_cp_impl`` stays
 
 from __future__ import annotations
 
+import os
 from typing import Any, List, Optional, Sequence, Tuple
 
 import torch
@@ -167,6 +168,23 @@ class _KcpAllGatherHm(torch.autograd.Function):
         ctx.cp_rank = int(cp_rank)
         if int(cp_size) <= 1:
             return local_hm.unsqueeze(0)
+        try:
+            from .gdn_mem_probe import emit_comm_layer, mem_probe_enabled
+
+            if mem_probe_enabled():
+                local_bytes = int(local_hm.numel()) * int(local_hm.element_size())
+                emit_comm_layer(
+                    impl="kcp",
+                    op="all_gather_hm",
+                    payload_bytes_local=local_bytes,
+                    payload_bytes_total=local_bytes * int(cp_size),
+                    shape=list(local_hm.shape),
+                    seq_len_local=None,  # hm has no S axis — INV-2
+                    depends_on_s=False,
+                    extra={"dtype": str(local_hm.dtype).replace("torch.", "")},
+                )
+        except Exception:
+            pass
         gathered = [torch.empty_like(local_hm) for _ in range(int(cp_size))]
         dist.all_gather(gathered, local_hm.contiguous(), group=group)
         return torch.stack(gathered, dim=0)
@@ -221,21 +239,20 @@ def resolve_kcp_initial_state(
             dtype=torch.float32,
         )
 
-    if int(cp_rank) < int(cp_size) - 1:
-        local_hm = local_affine_summary_recurrent(
-            key,
-            value,
-            g,
-            beta,
-            cu_seqlens=cu_seqlens,
-            use_qk_l2norm=use_qk_l2norm,
-        )
+    # Opt-in probe only (VEOMNI_GDN_KCP_AFFINE_STUB=1, default off): skip O(S)
+    # eager token loop; keep correct hm shape so AG payload bytes still measure
+    # INV-2. Not for numerical gates / production (Mojo will replace the scan).
+    affine_stub = os.environ.get("VEOMNI_GDN_KCP_AFFINE_STUB", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+    if cu_seqlens is None:
+        n = int(key.shape[0])
     else:
-        # Shape probe without scan work.
-        if cu_seqlens is None:
-            n = int(key.shape[0])
-        else:
-            n = int(cu_seqlens.numel() - 1)
+        n = int(cu_seqlens.numel() - 1)
+    if affine_stub or int(cp_rank) >= int(cp_size) - 1:
         local_hm = torch.zeros(
             n,
             int(key.shape[2]),
@@ -243,6 +260,15 @@ def resolve_kcp_initial_state(
             v_dim + int(key.shape[3]),
             device=key.device,
             dtype=torch.float32,
+        )
+    else:
+        local_hm = local_affine_summary_recurrent(
+            key,
+            value,
+            g,
+            beta,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm=use_qk_l2norm,
         )
 
     ag_hm = all_gather_affine_hm(

--- a/veomni/distributed/context_parallel/gdn_kcp.py
+++ b/veomni/distributed/context_parallel/gdn_kcp.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2025 VeOmni Authors.
+"""GDN KCP (P1): local affine summary + all-gather{he,M} + prefix-merge.
+
+Contract: [[GDN State-Passing CP Implementation Contract 20260727]]
+
+Replaces serial P2P state passing at runtime (serial code retained as golden).
+Communication volume ∝ ``CP × H × K × (K+V)`` — independent of sequence length S.
+
+Algorithm (FLA ``fla/ops/cp`` semantics, eager portable implementation):
+1. Non-last ranks: local gated-delta scan from zero → affine ``S_final = M @ S_init + he``
+   packed as ``hm = [he | M]`` in **float32** (INV-7).
+2. ``all_gather`` ``hm`` on ``cp_group`` — buffer **must** stay fp32.
+3. Non-first ranks: prefix-merge preceding ranks' ``(he, M)`` → ``S_init`` (fp32).
+4. Run local ``chunk_gated_delta_rule(..., initial_state=S_init)`` on ``S/cp`` tokens.
+   Do **not** chain serial send/recv.
+
+INV-7 (dtype lock): all-gather / ``hm`` / ``S_init`` buffers are explicit **float32**,
+aligned with Mojo GDR ``final_state`` and serial P0. Do **not** change to bf16 —
+serial v6 hit bf16 template × fp32 state byte-misalignment → NaN (same class of bug).
+
+Lossy vs serial: accepted; keep ``state_passing_serial`` as the lossless golden and
+validate P1 vs P0 with an independent tol (CP-C). Default ``gdn_cp_impl`` stays
+``gather_full_replicated`` — kcp is opt-in (lossy + eager pre-scan cost).
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Sequence, Tuple
+
+import torch
+import torch.distributed as dist
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+
+def pack_affine_hm(he: Tensor, M: Tensor) -> Tensor:
+    """Pack ``hm[..., :V]=he``, ``hm[..., V:]=M``. Shapes ``[*, H, K, V]`` / ``[*, H, K, K]``."""
+    if he.shape[:-1] != M.shape[:-1] or he.shape[-2] != M.shape[-2]:
+        raise ValueError(f"he/M shape mismatch: he={tuple(he.shape)} M={tuple(M.shape)}")
+    if he.dtype != torch.float32 or M.dtype != torch.float32:
+        raise ValueError("INV-7: he/M must be float32 before pack")
+    return torch.cat([he, M], dim=-1)
+
+
+def unpack_affine_hm(hm: Tensor, *, v_dim: int) -> Tuple[Tensor, Tensor]:
+    if hm.dtype != torch.float32:
+        raise ValueError("INV-7: hm must be float32")
+    he = hm[..., :v_dim]
+    M = hm[..., v_dim:]
+    k_dim = int(he.shape[-2])
+    if int(M.shape[-1]) != k_dim:
+        raise ValueError(f"M last dim {M.shape[-1]} != K {k_dim}")
+    return he, M
+
+
+def _eye_m(num_heads: int, k_dim: int, *, device: torch.device) -> Tensor:
+    eye = torch.eye(k_dim, device=device, dtype=torch.float32)
+    return eye.view(1, k_dim, k_dim).expand(num_heads, k_dim, k_dim).contiguous()
+
+
+def local_affine_summary_recurrent(
+    key: Tensor,
+    value: Tensor,
+    g: Tensor,
+    beta: Tensor,
+    *,
+    cu_seqlens: Optional[Tensor] = None,
+    use_qk_l2norm: bool = True,
+    eps: float = 1e-6,
+) -> Tensor:
+    """Eager local ``hm=[he|M]`` for one CP rank (zero initial state).
+
+    Layouts match modeling GDN core (pre-transpose):
+      key/value: ``[1, T, H, K/V]`` (varlen packed) or ``[B, T, H, K/V]``
+      g/beta: ``[1, T, H]`` / ``[B, T, H]``
+      cu_seqlens: optional varlen boundaries on the T axis of batch 0.
+
+    Returns ``hm`` with shape ``[N, H, K, V+K]`` float32.
+    """
+    if key.ndim != 4 or value.ndim != 4:
+        raise ValueError(f"key/value must be 4D [B,T,H,D], got {tuple(key.shape)} / {tuple(value.shape)}")
+    if use_qk_l2norm:
+        key = key * torch.rsqrt(key.pow(2).sum(dim=-1, keepdim=True) + eps)
+    k = key.float()
+    v = value.float()
+    gg = g.float()
+    bb = beta.float()
+    bsz, _t, num_heads, k_dim = k.shape
+    v_dim = int(v.shape[-1])
+
+    if cu_seqlens is None:
+        ranges = [(b, 0, int(k.shape[1])) for b in range(bsz)]
+    else:
+        if bsz != 1:
+            raise ValueError("varlen affine summary expects batch=1 packed layout")
+        pts = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+        if not pts or pts[0] != 0:
+            raise ValueError(f"cu_seqlens must start at 0, got {pts[:3]}")
+        ranges = [(0, pts[i], pts[i + 1]) for i in range(len(pts) - 1)]
+
+    eye = _eye_m(num_heads, k_dim, device=k.device)
+    out = []
+    for _b, start, end in ranges:
+        he = torch.zeros(num_heads, k_dim, v_dim, device=k.device, dtype=torch.float32)
+        M = eye.clone()
+        for t in range(start, end):
+            eg = gg[_b, t].exp()  # [H]
+            kt = k[_b, t]  # [H, K]
+            vt = v[_b, t]  # [H, V]
+            bt = bb[_b, t]  # [H]
+            # M_step = eg * (I - beta * k⊗k); he_step = (beta*k)⊗v
+            outer = kt.unsqueeze(-1) * kt.unsqueeze(-2)  # [H,K,K]
+            M_step = eg[:, None, None] * (eye - bt[:, None, None] * outer)
+            he_step = (bt[:, None] * kt).unsqueeze(-1) * vt.unsqueeze(-2)  # [H,K,V]
+            he = torch.einsum("hki,hiv->hkv", M_step, he) + he_step
+            M = torch.einsum("hki,hij->hkj", M_step, M)
+        out.append(pack_affine_hm(he, M))
+    return torch.stack(out, dim=0)
+
+
+def prefix_merge_initial_state(
+    ag_hm: Tensor,
+    *,
+    cp_rank: int,
+    v_dim: int,
+) -> Tensor:
+    """Prefix-merge ``ag_hm[0..cp_rank)`` → ``S_init`` ``[N,H,K,V]`` float32.
+
+    ``ag_hm``: ``[CP, N, H, K, V+K]``.
+    """
+    if ag_hm.dtype != torch.float32:
+        raise ValueError("INV-7: ag_hm must be float32")
+    if ag_hm.ndim != 5:
+        raise ValueError(f"ag_hm must be [CP,N,H,K,V+K], got {tuple(ag_hm.shape)}")
+    cp_size, num_seqs, num_heads, k_dim, kvk = ag_hm.shape
+    if int(cp_rank) < 0 or int(cp_rank) >= cp_size:
+        raise ValueError(f"cp_rank {cp_rank} out of range for cp_size {cp_size}")
+    if kvk != k_dim + v_dim:
+        raise ValueError(f"hm last dim {kvk} != K+V ({k_dim}+{v_dim})")
+    s = torch.zeros(num_seqs, num_heads, k_dim, v_dim, device=ag_hm.device, dtype=torch.float32)
+    if int(cp_rank) == 0:
+        return s
+    for r in range(int(cp_rank)):
+        he, M = unpack_affine_hm(ag_hm[r], v_dim=v_dim)
+        s = torch.einsum("nhki,nhiv->nhkv", M, s) + he
+    return s
+
+
+class _KcpAllGatherHm(torch.autograd.Function):
+    """Differentiable all-gather for fp32 ``hm`` on ``cp_group``."""
+
+    @staticmethod
+    def forward(ctx: Any, local_hm: Tensor, group: ProcessGroup, cp_size: int, cp_rank: int) -> Tensor:
+        # INV-7: AG buffer fp32 — matches final_state; bf16 causes byte-misalign NaN
+        # (same pitfall as serial state_passing v6). Do not widen/narrow here.
+        if local_hm.dtype != torch.float32:
+            raise RuntimeError(
+                "INV-7: KCP all-gather buffer must be float32 "
+                "(align final_state; bf16 byte-misalign → NaN, serial v6 pitfall)"
+            )
+        if not torch.isfinite(local_hm).all():
+            raise RuntimeError(
+                f"kcp: refusing to all-gather non-finite hm (cp_rank={cp_rank})"
+            )
+        ctx.group = group
+        ctx.cp_size = int(cp_size)
+        ctx.cp_rank = int(cp_rank)
+        if int(cp_size) <= 1:
+            return local_hm.unsqueeze(0)
+        gathered = [torch.empty_like(local_hm) for _ in range(int(cp_size))]
+        dist.all_gather(gathered, local_hm.contiguous(), group=group)
+        return torch.stack(gathered, dim=0)
+
+    @staticmethod
+    def backward(ctx: Any, grad_ag: Tensor) -> Tuple[Tensor, None, None, None]:
+        if ctx.cp_size <= 1:
+            return grad_ag.squeeze(0), None, None, None
+        return grad_ag[ctx.cp_rank].contiguous(), None, None, None
+
+
+def all_gather_affine_hm(
+    local_hm: Tensor,
+    *,
+    cp_group: ProcessGroup,
+    cp_size: int,
+    cp_rank: int,
+) -> Tensor:
+    """All-gather local ``hm[N,H,K,V+K]`` → ``[CP,N,H,K,V+K]`` (fp32, INV-7)."""
+    return _KcpAllGatherHm.apply(local_hm, cp_group, int(cp_size), int(cp_rank))
+
+
+def resolve_kcp_initial_state(
+    key: Tensor,
+    value: Tensor,
+    g: Tensor,
+    beta: Tensor,
+    *,
+    cp_group: ProcessGroup,
+    cp_size: int,
+    cp_rank: int,
+    cu_seqlens: Optional[Tensor] = None,
+    use_qk_l2norm: bool = True,
+    sample_bos_on_rank: Optional[Sequence[bool]] = None,
+) -> Tensor:
+    """End-to-end KCP ``S_init`` for this rank (autograd-safe through AG+merge).
+
+    Last rank skips local summary (contributes zeros); first rank returns zeros
+    without merge. Sample-BOS ranks force that sample's ``S_init`` to zero.
+    """
+    v_dim = int(value.shape[-1])
+    if int(cp_size) <= 1:
+        n = 1 if cu_seqlens is None else int(cu_seqlens.numel() - 1)
+        if cu_seqlens is None:
+            n = int(key.shape[0])
+        return torch.zeros(
+            n,
+            int(key.shape[2]),
+            int(key.shape[3]),
+            v_dim,
+            device=key.device,
+            dtype=torch.float32,
+        )
+
+    if int(cp_rank) < int(cp_size) - 1:
+        local_hm = local_affine_summary_recurrent(
+            key,
+            value,
+            g,
+            beta,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm=use_qk_l2norm,
+        )
+    else:
+        # Shape probe without scan work.
+        if cu_seqlens is None:
+            n = int(key.shape[0])
+        else:
+            n = int(cu_seqlens.numel() - 1)
+        local_hm = torch.zeros(
+            n,
+            int(key.shape[2]),
+            int(key.shape[3]),
+            v_dim + int(key.shape[3]),
+            device=key.device,
+            dtype=torch.float32,
+        )
+
+    ag_hm = all_gather_affine_hm(
+        local_hm, cp_group=cp_group, cp_size=cp_size, cp_rank=cp_rank
+    )
+    s_init = prefix_merge_initial_state(ag_hm, cp_rank=cp_rank, v_dim=v_dim)
+
+    if sample_bos_on_rank is not None:
+        from .gdn_scan_cp import apply_sample_bos_zero_s_init
+
+        s_init = apply_sample_bos_zero_s_init(s_init, sample_bos_on_rank=sample_bos_on_rank)
+    return s_init
+
+
+def assert_kcp_comm_bytes_independent_of_seq(
+    *,
+    cp_size: int,
+    num_heads: int,
+    k_dim: int,
+    v_dim: int,
+    num_seqs: int = 1,
+) -> int:
+    """Return AG payload bytes; caller checks equality across seq lengths."""
+    # each rank contributes hm[N,H,K,V+K] fp32; AG receives cp copies
+    elems = int(num_seqs) * int(num_heads) * int(k_dim) * (int(v_dim) + int(k_dim))
+    return elems * 4 * int(cp_size)
+
+
+__all__ = [
+    "all_gather_affine_hm",
+    "assert_kcp_comm_bytes_independent_of_seq",
+    "local_affine_summary_recurrent",
+    "pack_affine_hm",
+    "prefix_merge_initial_state",
+    "resolve_kcp_initial_state",
+    "unpack_affine_hm",
+]

--- a/veomni/distributed/context_parallel/gdn_mem_probe.py
+++ b/veomni/distributed/context_parallel/gdn_mem_probe.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2025 VeOmni Authors.
+"""Layered GDN/FA/HBM memory probe for CP A/B contrasts.
+
+Enable with ``VEOMNI_GDN_MEM_PROBE=1``. Rank0 emits one JSON line per sample:
+
+``AI4SE_MEM_LAYER {...}``
+
+Buckets (contract for 256K serial vs gather_full):
+- ``gdn_act``: live GDN activation bytes (q/k/v/g/beta/mixed_qkv/core_out/state)
+- ``hbm_alloc`` / ``hbm_reserved``: device allocator snapshot (NPU/CUDA)
+- ``seq_tokens``: sequence length of the measured tensor (S_local or S_full)
+
+INV-1 evidence needs **same meter, paired runs**: compare ``gdn_act`` serial≪gather_full
+even when whole-device peak is FA-dominated.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Dict, Optional
+
+import torch
+
+_ENABLED: Optional[bool] = None
+_STEP: int = 0
+_IMPL: str = ""
+_SEEN: Dict[str, int] = {}
+
+
+def mem_probe_enabled() -> bool:
+    global _ENABLED
+    if _ENABLED is None:
+        _ENABLED = os.environ.get("VEOMNI_GDN_MEM_PROBE", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+    return bool(_ENABLED)
+
+
+def mem_probe_set_context(*, impl: str, step: Optional[int] = None) -> None:
+    global _IMPL, _STEP
+    if impl:
+        _IMPL = str(impl)
+    if step is not None:
+        _STEP = int(step)
+
+
+def _device_of(t: torch.Tensor) -> torch.device:
+    return t.device if isinstance(t, torch.Tensor) else torch.device("cpu")
+
+
+def _alloc_stats(device: torch.device) -> Dict[str, Optional[int]]:
+    out: Dict[str, Optional[int]] = {
+        "hbm_alloc_bytes": None,
+        "hbm_reserved_bytes": None,
+        "hbm_max_alloc_bytes": None,
+    }
+    if device.type == "cpu":
+        return out
+    try:
+        if device.type == "npu" and hasattr(torch, "npu"):
+            out["hbm_alloc_bytes"] = int(torch.npu.memory_allocated(device))
+            out["hbm_reserved_bytes"] = int(torch.npu.memory_reserved(device))
+            out["hbm_max_alloc_bytes"] = int(torch.npu.max_memory_allocated(device))
+        elif device.type == "cuda":
+            out["hbm_alloc_bytes"] = int(torch.cuda.memory_allocated(device))
+            out["hbm_reserved_bytes"] = int(torch.cuda.memory_reserved(device))
+            out["hbm_max_alloc_bytes"] = int(torch.cuda.max_memory_allocated(device))
+    except Exception:
+        pass
+    return out
+
+
+def tensor_nbytes(*tensors: Any) -> int:
+    total = 0
+    for t in tensors:
+        if t is None or not isinstance(t, torch.Tensor):
+            continue
+        total += int(t.numel()) * int(t.element_size())
+    return total
+
+
+def emit_mem_layer(
+    tag: str,
+    *,
+    tensors: Optional[Dict[str, Any]] = None,
+    extra: Optional[Dict[str, Any]] = None,
+    layer_idx: Optional[int] = None,
+    once_per_step: bool = True,
+) -> None:
+    """Emit a single probe sample. Rank>0 silent. Optional once-per-(step,tag,layer)."""
+    if not mem_probe_enabled():
+        return
+    try:
+        rank = int(os.environ.get("RANK", os.environ.get("LOCAL_RANK", "0")))
+    except Exception:
+        rank = 0
+    if rank != 0:
+        return
+
+    key = f"{_STEP}:{tag}:{layer_idx}"
+    if once_per_step:
+        # Keep first few layers + a late layer for variance; always allow layer 0/1/2.
+        if layer_idx is not None and layer_idx not in (0, 1, 2, 8, 16, 24, 32):
+            return
+        if key in _SEEN:
+            return
+        _SEEN[key] = 1
+
+    tensors = tensors or {}
+    nbytes_by = {k: tensor_nbytes(v) for k, v in tensors.items() if v is not None}
+    total = int(sum(nbytes_by.values()))
+    # Prefer a primary activation tensor for seq_tokens
+    seq_tokens = None
+    primary = None
+    for name in ("mixed_qkv", "query", "core_attn_out", "value"):
+        t = tensors.get(name)
+        if isinstance(t, torch.Tensor) and t.ndim >= 2:
+            primary = t
+            # assume [B, S, ...]
+            seq_tokens = int(t.shape[1])
+            break
+    device = _device_of(primary) if primary is not None else torch.device("cpu")
+    stats = _alloc_stats(device)
+    payload = {
+        "schema": "ai4se.mem_layer/v1",
+        "tag": tag,
+        "impl": _IMPL or os.environ.get("VEOMNI_GDN_CP_IMPL", ""),
+        "step": _STEP,
+        "layer_idx": layer_idx,
+        "gdn_act_bytes": total,
+        "gdn_act_by_tensor": nbytes_by,
+        "seq_tokens": seq_tokens,
+        "ts": time.time(),
+        **stats,
+    }
+    if extra:
+        payload.update(extra)
+    print("AI4SE_MEM_LAYER " + json.dumps(payload, sort_keys=True), flush=True)
+
+
+def reset_mem_probe_step(step: int) -> None:
+    global _STEP, _SEEN
+    _STEP = int(step)
+    _SEEN = {}

--- a/veomni/distributed/context_parallel/gdn_mem_probe.py
+++ b/veomni/distributed/context_parallel/gdn_mem_probe.py
@@ -143,7 +143,66 @@ def emit_mem_layer(
     print("AI4SE_MEM_LAYER " + json.dumps(payload, sort_keys=True), flush=True)
 
 
+_COMM_SEEN: Dict[str, int] = {}
+
+
+def emit_comm_layer(
+    *,
+    impl: str,
+    op: str,
+    payload_bytes_local: int,
+    payload_bytes_total: int,
+    shape: Optional[list] = None,
+    seq_len_local: Optional[int] = None,
+    depends_on_s: bool,
+    extra: Optional[Dict[str, Any]] = None,
+    layer_idx: Optional[int] = None,
+    once_per_step: bool = True,
+) -> None:
+    """Emit ``AI4SE_COMM_LAYER`` JSON (rank0). Used for INV-2 / Test-A comm evidence.
+
+    ``depends_on_s=False`` means payload volume is independent of sequence length
+    (KCP AG of ``hm``, serial P2P of ``S_final``). ``depends_on_s=True`` for
+    gather_full sequence all-gather (∝ S).
+    """
+    if not mem_probe_enabled():
+        return
+    try:
+        rank = int(os.environ.get("RANK", os.environ.get("LOCAL_RANK", "0")))
+    except Exception:
+        rank = 0
+    if rank != 0:
+        return
+
+    key = f"{_STEP}:comm:{op}:{layer_idx}"
+    if once_per_step:
+        if layer_idx is not None and layer_idx not in (0, 1, 2, 8, 16, 24, 32):
+            return
+        if key in _COMM_SEEN:
+            return
+        _COMM_SEEN[key] = 1
+
+    payload: Dict[str, Any] = {
+        "schema": "ai4se.comm_layer/v1",
+        "tag": "gdn_comm",
+        "impl": impl or _IMPL or os.environ.get("VEOMNI_GDN_CP_IMPL", ""),
+        "op": op,
+        "step": _STEP,
+        "layer_idx": layer_idx,
+        "payload_bytes_local": int(payload_bytes_local),
+        "payload_bytes_total": int(payload_bytes_total),
+        "shape": list(shape) if shape is not None else None,
+        "seq_len_local": seq_len_local,
+        "depends_on_s": bool(depends_on_s),
+        "ts": time.time(),
+    }
+    if extra:
+        payload.update(extra)
+    print("AI4SE_COMM_LAYER " + json.dumps(payload, sort_keys=True), flush=True)
+
+
 def reset_mem_probe_step(step: int) -> None:
-    global _STEP, _SEEN
+    global _STEP, _SEEN, _COMM_SEEN
     _STEP = int(step)
     _SEEN = {}
+    _COMM_SEEN = {}

--- a/veomni/distributed/context_parallel/gdn_scan_cp.py
+++ b/veomni/distributed/context_parallel/gdn_scan_cp.py
@@ -753,6 +753,23 @@ class _SerialSendFinalState(torch.autograd.Function):
                     "state_passing_serial: refusing to send non-finite S_final "
                     f"(cp_rank={cp_rank})"
                 )
+            try:
+                from .gdn_mem_probe import emit_comm_layer, mem_probe_enabled
+
+                if mem_probe_enabled():
+                    nbytes = int(payload.numel()) * int(payload.element_size())
+                    emit_comm_layer(
+                        impl="state_passing_serial",
+                        op="p2p_send_s_final",
+                        payload_bytes_local=nbytes,
+                        payload_bytes_total=nbytes,  # one hop; chain has (CP-1) hops
+                        shape=list(payload.shape),
+                        seq_len_local=None,
+                        depends_on_s=False,
+                        extra={"cp_rank": int(cp_rank), "cp_size": int(cp_size)},
+                    )
+            except Exception:
+                pass
             dist.send(payload, group_ranks[cp_rank + 1], group=group)
         return final_state
 

--- a/veomni/distributed/context_parallel/gdn_scan_cp.py
+++ b/veomni/distributed/context_parallel/gdn_scan_cp.py
@@ -1,0 +1,1017 @@
+# Copyright (c) 2025 VeOmni Authors.
+"""GDN state-passing CP: zigzag↔contiguous repartition, conv halo, serial/KCP scan.
+
+Contract: [[GDN State-Passing CP Implementation Contract 20260727]]
+
+* Softmax keeps zigzag Ring shards from the collator.
+* GDN must consume **contiguous** time blocks of length ``S/cp`` without ever
+  materializing ``S_full`` (INV-1 / INV-5).
+* ``gather_full_replicated`` remains in ``gdn_sp.py`` as the lossless baseline.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, List, Optional, Sequence, Tuple
+
+import torch
+import torch.distributed as dist
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+from .sharding import balanced_cp_slice
+
+
+# ---------------------------------------------------------------------------
+# Impl identity (lossless / lossy families)
+# ---------------------------------------------------------------------------
+
+GDN_CP_IMPL_GATHER_FULL = "gather_full"
+GDN_CP_IMPL_GATHER_FULL_REPLICATED = "gather_full_replicated"  # alias used in #969
+GDN_CP_IMPL_STATE_PASSING_SERIAL = "state_passing_serial"
+GDN_CP_IMPL_KCP = "kcp"
+GDN_CP_IMPL_NONE = "none"
+
+_LOSSLESS_IMPLS = frozenset(
+    {
+        GDN_CP_IMPL_GATHER_FULL,
+        GDN_CP_IMPL_GATHER_FULL_REPLICATED,
+        GDN_CP_IMPL_STATE_PASSING_SERIAL,
+        GDN_CP_IMPL_NONE,
+    }
+)
+
+
+def normalize_gdn_cp_impl(name: Optional[str]) -> str:
+    if name is None or name == "":
+        # Default stays gather_full until serial/kcp pass gates (contract).
+        return GDN_CP_IMPL_GATHER_FULL_REPLICATED
+    key = str(name).strip().lower()
+    aliases = {
+        "gather_full": GDN_CP_IMPL_GATHER_FULL_REPLICATED,
+        "gather_full_replicated": GDN_CP_IMPL_GATHER_FULL_REPLICATED,
+        "gather-full": GDN_CP_IMPL_GATHER_FULL_REPLICATED,
+        "serial": GDN_CP_IMPL_STATE_PASSING_SERIAL,
+        "state_passing": GDN_CP_IMPL_STATE_PASSING_SERIAL,
+        "state_passing_serial": GDN_CP_IMPL_STATE_PASSING_SERIAL,
+        "state-passing-serial": GDN_CP_IMPL_STATE_PASSING_SERIAL,
+        "kcp": GDN_CP_IMPL_KCP,
+        "none": GDN_CP_IMPL_NONE,
+    }
+    if key not in aliases:
+        raise ValueError(
+            f"Unknown gdn_cp_impl={name!r}. "
+            f"Expected one of {sorted(set(aliases.values()))}."
+        )
+    return aliases[key]
+
+
+def resolve_gdn_cp_impl_from_env(*, cp_size: int) -> str:
+    if int(cp_size) <= 1:
+        return GDN_CP_IMPL_NONE
+    return normalize_gdn_cp_impl(os.environ.get("VEOMNI_GDN_CP_IMPL"))
+
+
+def gdn_cp_impl_is_lossless(name: str) -> bool:
+    return normalize_gdn_cp_impl(name) in _LOSSLESS_IMPLS or normalize_gdn_cp_impl(name) == GDN_CP_IMPL_NONE
+
+
+def gdn_replication_factor_for_impl(name: str, *, cp_size: int) -> int:
+    impl = normalize_gdn_cp_impl(name) if int(cp_size) > 1 else GDN_CP_IMPL_NONE
+    if impl in (GDN_CP_IMPL_GATHER_FULL, GDN_CP_IMPL_GATHER_FULL_REPLICATED):
+        return max(int(cp_size), 1)
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Zigzag ↔ contiguous chunk index math (INV-5: permutation, not gather)
+# ---------------------------------------------------------------------------
+
+def _validate_cp(cp_size: int, cp_rank: int) -> None:
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be positive, got {cp_size}.")
+    if not 0 <= cp_rank < cp_size:
+        raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}.")
+
+
+def zigzag_owner_of_chunk(chunk_idx: int, cp_size: int) -> Tuple[int, int]:
+    """Return ``(zigzag_rank, half_idx)`` that holds canonical chunk ``chunk_idx``.
+
+    Balanced CP: rank ``r`` holds ``(chunk_r, chunk_{2C-1-r})`` as halves 0/1.
+    """
+    _validate_cp(cp_size, 0)
+    n = 2 * cp_size
+    if not 0 <= chunk_idx < n:
+        raise ValueError(f"chunk_idx must be in [0, {n}), got {chunk_idx}.")
+    if chunk_idx < cp_size:
+        return chunk_idx, 0
+    return n - 1 - chunk_idx, 1
+
+
+def contiguous_block_chunk_indices(cp_rank: int, cp_size: int) -> Tuple[int, int]:
+    """Canonical chunk indices owned by contiguous block rank ``cp_rank``."""
+    _validate_cp(cp_size, cp_rank)
+    return 2 * cp_rank, 2 * cp_rank + 1
+
+
+def zigzag_half_destination(cp_rank: int, half_idx: int, cp_size: int) -> int:
+    """Contiguous-block rank that should receive zigzag rank's half ``half_idx``."""
+    _validate_cp(cp_size, cp_rank)
+    if half_idx not in (0, 1):
+        raise ValueError(f"half_idx must be 0 or 1, got {half_idx}.")
+    n = 2 * cp_size
+    chunk_idx = cp_rank if half_idx == 0 else n - 1 - cp_rank
+    return chunk_idx // 2
+
+
+def _split_two_halves(tensor: Tensor, seq_dim: int) -> Tuple[Tensor, Tensor]:
+    seq_dim = seq_dim % tensor.ndim
+    length = tensor.size(seq_dim)
+    if length % 2 != 0:
+        raise ValueError(f"Zigzag local length ({length}) must be even.")
+    half = length // 2
+    return tensor.narrow(seq_dim, 0, half).contiguous(), tensor.narrow(seq_dim, half, half).contiguous()
+
+
+def _cat_two(a: Tensor, b: Tensor, seq_dim: int) -> Tensor:
+    return torch.cat((a, b), dim=seq_dim).contiguous()
+
+
+def simulate_zigzag_to_block(
+    zigzag_shards: Sequence[Tensor],
+    *,
+    cp_size: int,
+    seq_dim: int = 1,
+) -> List[Tensor]:
+    """Single-process reference for zigzag→contiguous (no full-sequence gather)."""
+    if len(zigzag_shards) != cp_size:
+        raise ValueError(f"Need {cp_size} zigzag shards, got {len(zigzag_shards)}.")
+    # Collect every canonical chunk without building S_full as one tensor first:
+    # we only keep per-chunk pieces then cat two per block.
+    chunks: dict[int, Tensor] = {}
+    for z_rank, shard in enumerate(zigzag_shards):
+        early, late = _split_two_halves(shard, seq_dim)
+        chunks[z_rank] = early
+        chunks[2 * cp_size - 1 - z_rank] = late
+    blocks = []
+    for c_rank in range(cp_size):
+        i0, i1 = contiguous_block_chunk_indices(c_rank, cp_size)
+        blocks.append(_cat_two(chunks[i0], chunks[i1], seq_dim))
+    return blocks
+
+
+def simulate_block_to_zigzag(
+    contig_blocks: Sequence[Tensor],
+    *,
+    cp_size: int,
+    seq_dim: int = 1,
+) -> List[Tensor]:
+    """Inverse of :func:`simulate_zigzag_to_block`."""
+    if len(contig_blocks) != cp_size:
+        raise ValueError(f"Need {cp_size} contiguous blocks, got {len(contig_blocks)}.")
+    chunks: dict[int, Tensor] = {}
+    for c_rank, block in enumerate(contig_blocks):
+        left, right = _split_two_halves(block, seq_dim)
+        i0, i1 = contiguous_block_chunk_indices(c_rank, cp_size)
+        chunks[i0] = left
+        chunks[i1] = right
+    zig = []
+    for z_rank in range(cp_size):
+        zig.append(_cat_two(chunks[z_rank], chunks[2 * cp_size - 1 - z_rank], seq_dim))
+    return zig
+
+
+def assert_no_full_sequence(tensor: Tensor, *, cp_size: int, seq_dim: int, full_length: int) -> None:
+    """INV-1 helper: local tensor must be ``full_length / cp_size``."""
+    if cp_size <= 1:
+        return
+    local = tensor.size(seq_dim % tensor.ndim)
+    expected = full_length // cp_size
+    if local != expected:
+        raise RuntimeError(
+            f"INV-1 violated: GDN local seq={local}, expected S/cp={expected} "
+            f"(S={full_length}, cp={cp_size}). Full-sequence materialization is forbidden."
+        )
+    if local == full_length and cp_size > 1:
+        raise RuntimeError("INV-1 violated: local seq equals S_full under cp_size>1.")
+
+
+# ---------------------------------------------------------------------------
+# Distributed permutation via all_to_all (INV-5)
+# ---------------------------------------------------------------------------
+
+def _all_to_all_halves(
+    local_zigzag: Tensor,
+    *,
+    group: ProcessGroup,
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int,
+) -> Tensor:
+    """Zigzag local → contiguous block via uniform all_to_all of half-chunks.
+
+    Each rank sends ``cp_size`` tensors of shape ``half`` (zeros if not destined
+    to that rank). Receiver concatenates the two nonzero halves for its block
+    in canonical chunk order. Never materializes ``S_full``.
+    """
+    seq_dim = seq_dim % local_zigzag.ndim
+    early, late = _split_two_halves(local_zigzag, seq_dim)
+    half_len = early.size(seq_dim)
+    zero = torch.zeros_like(early)
+
+    if cp_size == 1:
+        return local_zigzag
+
+    send_list: List[Tensor] = []
+    for dst in range(cp_size):
+        if zigzag_half_destination(cp_rank, 0, cp_size) == dst:
+            send_list.append(early)
+        elif zigzag_half_destination(cp_rank, 1, cp_size) == dst:
+            send_list.append(late)
+        else:
+            send_list.append(zero.clone())
+
+    for i, t in enumerate(send_list):
+        if t.size(seq_dim) != half_len:
+            raise RuntimeError(
+                f"Uniform half all_to_all broken: send[{i}] seq={t.size(seq_dim)} half={half_len}"
+            )
+
+    recv_list = [torch.empty_like(early) for _ in range(cp_size)]
+    dist.all_to_all(recv_list, send_list, group=group)
+
+    i0, i1 = contiguous_block_chunk_indices(cp_rank, cp_size)
+    src0, half0 = zigzag_owner_of_chunk(i0, cp_size)
+    src1, half1 = zigzag_owner_of_chunk(i1, cp_size)
+    left = recv_list[src0]
+    right = recv_list[src1]
+    if zigzag_half_destination(src0, half0, cp_size) != cp_rank:
+        raise RuntimeError("routing inconsistency for left chunk")
+    if zigzag_half_destination(src1, half1, cp_size) != cp_rank:
+        raise RuntimeError("routing inconsistency for right chunk")
+    out = _cat_two(left, right, seq_dim)
+    assert_no_full_sequence(
+        out,
+        cp_size=cp_size,
+        seq_dim=seq_dim,
+        full_length=local_zigzag.size(seq_dim) * cp_size,
+    )
+    return out
+
+
+def _all_to_all_halves_inverse(
+    local_block: Tensor,
+    *,
+    group: ProcessGroup,
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int,
+) -> Tensor:
+    """Contiguous block → zigzag local (inverse permutation)."""
+    seq_dim = seq_dim % local_block.ndim
+    left, right = _split_two_halves(local_block, seq_dim)
+    i0, i1 = contiguous_block_chunk_indices(cp_rank, cp_size)
+    # chunk i0 must go to zigzag owner as the correct half
+    # Build send_list indexed by zigzag destination rank.
+    early_like = left
+    zero = torch.zeros_like(early_like)
+    send_list: List[Tensor] = [zero.clone() for _ in range(cp_size)]
+
+    def _place(chunk: Tensor, chunk_idx: int) -> None:
+        z_rank, _half = zigzag_owner_of_chunk(chunk_idx, cp_size)
+        send_list[z_rank] = chunk
+
+    _place(left, i0)
+    _place(right, i1)
+
+    if cp_size == 1:
+        return local_block
+
+    recv_list = [torch.empty_like(early_like) for _ in range(cp_size)]
+    dist.all_to_all(recv_list, send_list, group=group)
+
+    early_chunk_idx = cp_rank
+    late_chunk_idx = 2 * cp_size - 1 - cp_rank
+    src_early = early_chunk_idx // 2
+    src_late = late_chunk_idx // 2
+    early = recv_list[src_early]
+    late = recv_list[src_late]
+    out = _cat_two(early, late, seq_dim)
+    assert_no_full_sequence(
+        out,
+        cp_size=cp_size,
+        seq_dim=seq_dim,
+        full_length=local_block.size(seq_dim) * cp_size,
+    )
+    return out
+
+
+class _RepartitionZigzagToBlock(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: Any,
+        tensor: Tensor,
+        group: ProcessGroup,
+        cp_size: int,
+        cp_rank: int,
+        seq_dim: int,
+    ) -> Tensor:
+        ctx.group = group
+        ctx.cp_size = cp_size
+        ctx.cp_rank = cp_rank
+        ctx.seq_dim = seq_dim
+        return _all_to_all_halves(
+            tensor, group=group, cp_size=cp_size, cp_rank=cp_rank, seq_dim=seq_dim
+        )
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None, None, None, None]:
+        grad_input = _all_to_all_halves_inverse(
+            grad_output.contiguous(),
+            group=ctx.group,
+            cp_size=ctx.cp_size,
+            cp_rank=ctx.cp_rank,
+            seq_dim=ctx.seq_dim,
+        )
+        return grad_input, None, None, None, None
+
+
+class _RepartitionBlockToZigzag(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: Any,
+        tensor: Tensor,
+        group: ProcessGroup,
+        cp_size: int,
+        cp_rank: int,
+        seq_dim: int,
+    ) -> Tensor:
+        ctx.group = group
+        ctx.cp_size = cp_size
+        ctx.cp_rank = cp_rank
+        ctx.seq_dim = seq_dim
+        return _all_to_all_halves_inverse(
+            tensor, group=group, cp_size=cp_size, cp_rank=cp_rank, seq_dim=seq_dim
+        )
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None, None, None, None]:
+        grad_input = _all_to_all_halves(
+            grad_output.contiguous(),
+            group=ctx.group,
+            cp_size=ctx.cp_size,
+            cp_rank=ctx.cp_rank,
+            seq_dim=ctx.seq_dim,
+        )
+        return grad_input, None, None, None, None
+
+
+def repartition_zigzag_to_block(
+    tensor: Tensor,
+    *,
+    cp_group: Optional[ProcessGroup],
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int = 1,
+) -> Tensor:
+    """Permute zigzag CP shard → contiguous time block (length still ``S/cp``)."""
+    if cp_size <= 1:
+        return tensor
+    if cp_group is None:
+        raise RuntimeError("cp_group is required for zigzag→block repartition.")
+    return _RepartitionZigzagToBlock.apply(tensor, cp_group, cp_size, cp_rank, seq_dim)
+
+
+def repartition_block_to_zigzag(
+    tensor: Tensor,
+    *,
+    cp_group: Optional[ProcessGroup],
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int = 1,
+) -> Tensor:
+    """Inverse of :func:`repartition_zigzag_to_block`."""
+    if cp_size <= 1:
+        return tensor
+    if cp_group is None:
+        raise RuntimeError("cp_group is required for block→zigzag repartition.")
+    return _RepartitionBlockToZigzag.apply(tensor, cp_group, cp_size, cp_rank, seq_dim)
+
+
+def _cu_lengths(cu_seqlens: Tensor) -> List[int]:
+    points = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+    if not points or points[0] != 0:
+        raise ValueError(f"cu_seqlens must start at 0, got {points[:3]}")
+    return [end - start for start, end in zip(points[:-1], points[1:])]
+
+
+def repartition_zigzag_to_block_packed(
+    tensor: Tensor,
+    *,
+    cp_local_cu_seqlens: Tensor,
+    cp_group: Optional[ProcessGroup],
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int = 1,
+) -> Tensor:
+    """Per-sample zigzag→block (packed). Each sample stays length ``L_s/cp``."""
+    if cp_size <= 1:
+        return tensor
+    lengths = _cu_lengths(cp_local_cu_seqlens)
+    if sum(lengths) != tensor.size(seq_dim % tensor.ndim):
+        raise ValueError(
+            f"Packed local length mismatch: sum(cu)={sum(lengths)} vs seq={tensor.size(seq_dim)}"
+        )
+    parts = tensor.split(lengths, dim=seq_dim % tensor.ndim)
+    out = [
+        repartition_zigzag_to_block(
+            p.contiguous(),
+            cp_group=cp_group,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            seq_dim=seq_dim,
+        )
+        for p in parts
+    ]
+    return torch.cat(out, dim=seq_dim % tensor.ndim).contiguous()
+
+
+def repartition_block_to_zigzag_packed(
+    tensor: Tensor,
+    *,
+    cp_local_cu_seqlens: Tensor,
+    cp_group: Optional[ProcessGroup],
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int = 1,
+) -> Tensor:
+    if cp_size <= 1:
+        return tensor
+    lengths = _cu_lengths(cp_local_cu_seqlens)
+    parts = tensor.split(lengths, dim=seq_dim % tensor.ndim)
+    out = [
+        repartition_block_to_zigzag(
+            p.contiguous(),
+            cp_group=cp_group,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            seq_dim=seq_dim,
+        )
+        for p in parts
+    ]
+    return torch.cat(out, dim=seq_dim % tensor.ndim).contiguous()
+
+
+# ---------------------------------------------------------------------------
+# Conv1d halo (after repartition)
+# ---------------------------------------------------------------------------
+
+class _Conv1dHaloExchange(torch.autograd.Function):
+    """Dense causal halo with gradient exchange on the trailing/leading edges."""
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        x_block: Tensor,
+        kernel_size: int,
+        group: ProcessGroup,
+        cp_size: int,
+        cp_rank: int,
+        seq_dim: int,
+    ) -> Tensor:
+        seq_dim = seq_dim % x_block.ndim
+        halo = int(kernel_size) - 1
+        if halo <= 0 or cp_size <= 1:
+            ctx.noop = True
+            return x_block
+        if x_block.size(seq_dim) < halo:
+            raise ValueError(
+                f"Contiguous block length ({x_block.size(seq_dim)}) < conv halo ({halo})."
+            )
+        send = x_block.narrow(seq_dim, x_block.size(seq_dim) - halo, halo).contiguous()
+        recv = torch.zeros_like(send)
+        group_ranks = dist.get_process_group_ranks(group)
+        ops = []
+        if cp_rank < cp_size - 1:
+            ops.append(dist.isend(send, group_ranks[cp_rank + 1], group=group))
+        if cp_rank > 0:
+            ops.append(dist.irecv(recv, group_ranks[cp_rank - 1], group=group))
+        for op in ops:
+            op.wait()
+        left = torch.zeros_like(send) if cp_rank == 0 else recv
+        ctx.noop = False
+        ctx.group = group
+        ctx.cp_size = cp_size
+        ctx.cp_rank = cp_rank
+        ctx.seq_dim = seq_dim
+        ctx.halo = halo
+        return torch.cat((left, x_block), dim=seq_dim).contiguous()
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None, None, None, None, None]:
+        if getattr(ctx, "noop", True):
+            return grad_output, None, None, None, None, None
+        seq_dim = ctx.seq_dim
+        halo = ctx.halo
+        grad_left = grad_output.narrow(seq_dim, 0, halo).contiguous()
+        grad_local = grad_output.narrow(
+            seq_dim, halo, grad_output.size(seq_dim) - halo
+        ).contiguous()
+        group_ranks = dist.get_process_group_ranks(ctx.group)
+        send_shape = list(grad_local.shape)
+        send_shape[seq_dim] = halo
+        grad_from_next = torch.zeros(send_shape, dtype=grad_local.dtype, device=grad_local.device)
+        ops = []
+        if ctx.cp_rank > 0:
+            ops.append(dist.isend(grad_left, group_ranks[ctx.cp_rank - 1], group=ctx.group))
+        if ctx.cp_rank < ctx.cp_size - 1:
+            ops.append(dist.irecv(grad_from_next, group_ranks[ctx.cp_rank + 1], group=ctx.group))
+        for op in ops:
+            op.wait()
+        if ctx.cp_rank < ctx.cp_size - 1:
+            # Add grads that the next rank attributed to our trailing halo tokens.
+            trailing = grad_local.narrow(seq_dim, grad_local.size(seq_dim) - halo, halo)
+            trailing.add_(grad_from_next)
+        return grad_local, None, None, None, None, None
+
+
+def conv1d_halo_exchange(
+    x_block: Tensor,
+    *,
+    kernel_size: int,
+    cp_group: Optional[ProcessGroup],
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int = 1,
+) -> Tensor:
+    """Prepend ``(kernel_size-1)`` tokens from rank ``r-1`` (zeros on rank 0).
+
+    Must run **after** zigzag→block repartition. Does not gather ``S_full``.
+    Dense (single-segment) helper; prefer :func:`conv1d_halo_exchange_packed` for varlen.
+    """
+    if kernel_size <= 1 or cp_size <= 1:
+        return x_block
+    if cp_group is None:
+        raise RuntimeError("cp_group is required for conv1d halo exchange.")
+    return _Conv1dHaloExchange.apply(
+        x_block, int(kernel_size), cp_group, int(cp_size), int(cp_rank), int(seq_dim)
+    )
+
+
+class _Conv1dHaloExchangePacked(torch.autograd.Function):
+    """Packed per-sample causal halo with autograd-safe edge exchange."""
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        x_block: Tensor,
+        cp_local_cu_seqlens: Tensor,
+        kernel_size: int,
+        group: ProcessGroup,
+        cp_size: int,
+        cp_rank: int,
+        seq_dim: int,
+    ) -> Tensor:
+        seq_dim = seq_dim % x_block.ndim
+        halo = int(kernel_size) - 1
+        lengths = _cu_lengths(cp_local_cu_seqlens)
+        if halo <= 0 or cp_size <= 1:
+            ctx.noop = True
+            ctx.lengths = lengths
+            ctx.halo = 0
+            ctx.seq_dim = seq_dim
+            return x_block
+        parts = list(x_block.split(lengths, dim=seq_dim))
+        for i, p in enumerate(parts):
+            if p.size(seq_dim) < halo:
+                raise ValueError(f"Sample {i} local length {p.size(seq_dim)} < conv halo {halo}.")
+        send = torch.cat(
+            [p.narrow(seq_dim, p.size(seq_dim) - halo, halo).contiguous() for p in parts],
+            dim=seq_dim,
+        )
+        recv = torch.zeros_like(send)
+        group_ranks = dist.get_process_group_ranks(group)
+        ops = []
+        if cp_rank < cp_size - 1:
+            ops.append(dist.isend(send, group_ranks[cp_rank + 1], group=group))
+        if cp_rank > 0:
+            ops.append(dist.irecv(recv, group_ranks[cp_rank - 1], group=group))
+        for op in ops:
+            op.wait()
+        left_parts = (
+            list(torch.zeros_like(send).split([halo] * len(parts), dim=seq_dim))
+            if cp_rank == 0
+            else list(recv.split([halo] * len(parts), dim=seq_dim))
+        )
+        out_parts = [
+            torch.cat((left_parts[i], parts[i]), dim=seq_dim).contiguous() for i in range(len(parts))
+        ]
+        ctx.noop = False
+        ctx.group = group
+        ctx.cp_size = cp_size
+        ctx.cp_rank = cp_rank
+        ctx.seq_dim = seq_dim
+        ctx.halo = halo
+        ctx.lengths = lengths
+        return torch.cat(out_parts, dim=seq_dim).contiguous()
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None, None, None, None, None, None]:
+        if getattr(ctx, "noop", True):
+            return grad_output, None, None, None, None, None, None
+        seq_dim = ctx.seq_dim
+        halo = ctx.halo
+        lengths = ctx.lengths
+        halo_lengths = [length + halo for length in lengths]
+        parts = list(grad_output.split(halo_lengths, dim=seq_dim))
+        grad_left = torch.cat(
+            [p.narrow(seq_dim, 0, halo).contiguous() for p in parts],
+            dim=seq_dim,
+        )
+        grad_local_parts = [
+            p.narrow(seq_dim, halo, p.size(seq_dim) - halo).contiguous() for p in parts
+        ]
+        group_ranks = dist.get_process_group_ranks(ctx.group)
+        grad_from_next = torch.zeros_like(grad_left)
+        ops = []
+        if ctx.cp_rank > 0:
+            ops.append(dist.isend(grad_left, group_ranks[ctx.cp_rank - 1], group=ctx.group))
+        if ctx.cp_rank < ctx.cp_size - 1:
+            ops.append(dist.irecv(grad_from_next, group_ranks[ctx.cp_rank + 1], group=ctx.group))
+        for op in ops:
+            op.wait()
+        if ctx.cp_rank < ctx.cp_size - 1:
+            next_parts = list(grad_from_next.split([halo] * len(grad_local_parts), dim=seq_dim))
+            for i, local in enumerate(grad_local_parts):
+                local.narrow(seq_dim, local.size(seq_dim) - halo, halo).add_(next_parts[i])
+        grad_local = torch.cat(grad_local_parts, dim=seq_dim).contiguous()
+        return grad_local, None, None, None, None, None, None
+
+
+def conv1d_halo_exchange_packed(
+    x_block: Tensor,
+    *,
+    cp_local_cu_seqlens: Tensor,
+    kernel_size: int,
+    cp_group: Optional[ProcessGroup],
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int = 1,
+) -> Tuple[Tensor, Tensor]:
+    """Per-sample causal halo. Returns ``(x_with_halo, cu_seqlens_with_halo)``."""
+    if kernel_size <= 1 or cp_size <= 1:
+        return x_block, cp_local_cu_seqlens
+    if cp_group is None:
+        raise RuntimeError("cp_group is required for packed conv1d halo.")
+    out = _Conv1dHaloExchangePacked.apply(
+        x_block,
+        cp_local_cu_seqlens,
+        int(kernel_size),
+        cp_group,
+        int(cp_size),
+        int(cp_rank),
+        int(seq_dim),
+    )
+    halo = int(kernel_size) - 1
+    lengths = _cu_lengths(cp_local_cu_seqlens)
+    new_lengths = [length + halo for length in lengths]
+    cu = torch.tensor([0] + new_lengths, dtype=torch.int32, device=x_block.device)
+    cu = cu.cumsum(0).to(dtype=torch.int32)
+    return out, cu
+
+
+def trim_conv_halo_packed(
+    x_with_halo: Tensor,
+    *,
+    cp_local_cu_seqlens_with_halo: Tensor,
+    kernel_size: int,
+    seq_dim: int = 1,
+) -> Tensor:
+    """Drop the leading ``(kernel_size-1)`` halo tokens from each packed sample."""
+    if kernel_size <= 1:
+        return x_with_halo
+    seq_dim = seq_dim % x_with_halo.ndim
+    halo = kernel_size - 1
+    lengths = _cu_lengths(cp_local_cu_seqlens_with_halo)
+    parts = x_with_halo.split(lengths, dim=seq_dim)
+    trimmed = [p.narrow(seq_dim, halo, p.size(seq_dim) - halo).contiguous() for p in parts]
+    return torch.cat(trimmed, dim=seq_dim).contiguous()
+
+
+class _SerialRecvInitialState(torch.autograd.Function):
+    """Forward: recv ``S_init`` from r-1 (zeros on rank 0). Backward: send ``dS_init`` to r-1."""
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        state_template: Tensor,
+        group: ProcessGroup,
+        cp_size: int,
+        cp_rank: int,
+    ) -> Tensor:
+        ctx.group = group
+        ctx.cp_size = cp_size
+        ctx.cp_rank = cp_rank
+        if cp_size <= 1 or cp_rank == 0:
+            return torch.zeros_like(state_template)
+        group_ranks = dist.get_process_group_ranks(group)
+        s_init = torch.empty_like(state_template)
+        dist.recv(s_init, group_ranks[cp_rank - 1], group=group)
+        return s_init
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[None, None, None, None]:
+        if ctx.cp_size > 1 and ctx.cp_rank > 0:
+            group_ranks = dist.get_process_group_ranks(ctx.group)
+            dist.send(grad_output.contiguous(), group_ranks[ctx.cp_rank - 1], group=ctx.group)
+        return None, None, None, None
+
+
+class _SerialSendFinalState(torch.autograd.Function):
+    """Forward: send ``S_final`` to r+1. Backward: recv ``dS_final`` from r+1 and add."""
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        final_state: Tensor,
+        group: ProcessGroup,
+        cp_size: int,
+        cp_rank: int,
+    ) -> Tensor:
+        ctx.group = group
+        ctx.cp_size = cp_size
+        ctx.cp_rank = cp_rank
+        if cp_size > 1 and cp_rank < cp_size - 1:
+            group_ranks = dist.get_process_group_ranks(group)
+            # Peer recv uses empty_like(state_template); Mojo S_final is fp32.
+            # Fail closed on non-finite / wrong dtype rather than silently corrupt.
+            payload = final_state.detach().contiguous()
+            if payload.dtype != torch.float32:
+                payload = payload.float().contiguous()
+            if not torch.isfinite(payload).all():
+                raise RuntimeError(
+                    "state_passing_serial: refusing to send non-finite S_final "
+                    f"(cp_rank={cp_rank})"
+                )
+            dist.send(payload, group_ranks[cp_rank + 1], group=group)
+        return final_state
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None, None, None]:
+        grad = grad_output.contiguous()
+        if ctx.cp_size > 1 and ctx.cp_rank < ctx.cp_size - 1:
+            group_ranks = dist.get_process_group_ranks(ctx.group)
+            grad_from_next = torch.empty_like(grad)
+            dist.recv(grad_from_next, group_ranks[ctx.cp_rank + 1], group=ctx.group)
+            grad = grad + grad_from_next
+        return grad, None, None, None
+
+
+def recv_serial_initial_state(
+    *,
+    cp_group: ProcessGroup,
+    cp_size: int,
+    cp_rank: int,
+    state_template: Tensor,
+) -> Tensor:
+    """Receive ``S_init`` from rank r-1 (zeros on rank 0). Autograd-safe."""
+    return _SerialRecvInitialState.apply(
+        state_template, cp_group, int(cp_size), int(cp_rank)
+    )
+
+
+def send_serial_final_state(
+    final_state: Tensor,
+    *,
+    cp_group: ProcessGroup,
+    cp_size: int,
+    cp_rank: int,
+) -> Tensor:
+    """Send ``S_final`` to rank r+1; returns ``final_state`` (identity) for autograd."""
+    return _SerialSendFinalState.apply(
+        final_state, cp_group, int(cp_size), int(cp_rank)
+    )
+
+
+def apply_sample_bos_zero_s_init(
+    s_init: Tensor,
+    *,
+    sample_bos_on_rank: Sequence[bool],
+) -> Tensor:
+    """Force ``S_init[i]=0`` when this rank's block starts a new packed sample.
+
+    Under per-sample balanced CP every sample BOS lives on ``cp_rank==0``, but
+    callers that ever repartition a *global* packed stream must mark BOS per
+    sample explicitly — serial state must not cross sample boundaries.
+    """
+    if s_init.ndim < 1:
+        raise ValueError(f"s_init must be at least 1D, got shape={tuple(s_init.shape)}")
+    n = int(s_init.shape[0])
+    if len(sample_bos_on_rank) != n:
+        raise ValueError(
+            f"sample_bos_on_rank length ({len(sample_bos_on_rank)}) != num_seqs ({n})"
+        )
+    if not any(sample_bos_on_rank):
+        return s_init
+    out = s_init
+    wrote = False
+    for i, is_bos in enumerate(sample_bos_on_rank):
+        if not is_bos:
+            continue
+        if not wrote:
+            out = s_init.clone()
+            wrote = True
+        out[i].zero_()
+    return out
+
+
+def assert_serial_initial_state_contract(
+    s_init: Tensor,
+    *,
+    cp_rank: int,
+    sample_bos_on_rank: Sequence[bool],
+    cu_seqlens: Optional[Tensor] = None,
+    atol: float = 0.0,
+) -> None:
+    """Fail-closed serial S_init checks (INV + sample-BOS).
+
+    * ``s_init`` must be finite.
+    * ``cp_rank==0`` ⇒ entire ``S_init`` is zero (no left neighbor).
+    * every sample marked BOS on this rank ⇒ that sample's ``S_init`` is zero.
+    * optional ``cu_seqlens``: ``cu[0]==0``, monotone, ``cu[-1]`` matches when known.
+    """
+    if not torch.isfinite(s_init.detach()).all():
+        raise RuntimeError("state_passing_serial: S_init has non-finite values")
+    absmax = float(s_init.detach().float().abs().max().item()) if s_init.numel() else 0.0
+    if int(cp_rank) == 0 and absmax > atol:
+        raise RuntimeError(
+            f"state_passing_serial: cp_rank0 S_init must be zero, absmax={absmax}"
+        )
+    n = int(s_init.shape[0])
+    if len(sample_bos_on_rank) != n:
+        raise RuntimeError(
+            f"state_passing_serial: sample_bos_on_rank length "
+            f"{len(sample_bos_on_rank)} != num_seqs {n}"
+        )
+    for i, is_bos in enumerate(sample_bos_on_rank):
+        if not is_bos:
+            continue
+        sample_abs = float(s_init[i].detach().float().abs().max().item())
+        if sample_abs > atol:
+            raise RuntimeError(
+                f"state_passing_serial: sample {i} BOS on cp_rank={cp_rank} "
+                f"but S_init absmax={sample_abs} (must be 0; serial must not "
+                f"carry previous sample state across packed boundary)"
+            )
+    if cu_seqlens is not None:
+        points = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+        if not points or points[0] != 0:
+            raise RuntimeError(f"state_passing_serial: cu_seqlens must start at 0, got {points[:3]}")
+        if any(end < start for start, end in zip(points[:-1], points[1:])):
+            raise RuntimeError(f"state_passing_serial: cu_seqlens not monotone: {points}")
+
+
+def sample_bos_flags_for_per_sample_cp(*, num_seqs: int, cp_rank: int) -> List[bool]:
+    """Per-sample balanced CP: every sample's time origin is on ``cp_rank==0``."""
+    bos = int(cp_rank) == 0
+    return [bos] * int(num_seqs)
+
+
+def make_gdn_state_template(
+    query: Tensor,
+    value: Tensor,
+    *,
+    cu_seqlens: Optional[Tensor],
+) -> Tensor:
+    """Allocate zero state matching chunk_gated_delta_rule layout.
+
+    Dense: ``[B, H, K, V]``. Varlen (``cu_seqlens``): ``[N, H, K, V]``.
+    ``query``/``value`` must already be head-expanded (GQA repeat done).
+
+    Dtype is **float32**: Mojo GDR returns fp32 ``final_state``. Serial CP
+    send/recv uses ``empty_like(template)`` byte buffers — a bf16 template with
+    an fp32 send silently corrupts ``S_init`` on the next rank (observed NaN on
+    U2×CP2 NPU seam).
+    """
+    num_heads = int(query.shape[2])
+    k_dim = int(query.shape[3])
+    v_dim = int(value.shape[3])
+    if cu_seqlens is None:
+        batch = int(query.shape[0])
+        return torch.zeros(
+            batch, num_heads, k_dim, v_dim, device=query.device, dtype=torch.float32
+        )
+    num_seqs = int(cu_seqlens.numel() - 1)
+    return torch.zeros(
+        num_seqs, num_heads, k_dim, v_dim, device=query.device, dtype=torch.float32
+    )
+
+
+# 910B4 Mojo GDR varlen wrapper (MR912) pads each segment to this chunk size and
+# refuse ``output_final_state=True`` when it must pad. Pre-align here so the
+# wrapper takes the raw path and state-passing can read ``S_final``.
+MOJO_GDR_CHUNK_SIZE = 32
+
+
+def _ceil_to_chunk(length: int, chunk_size: int) -> int:
+    return ((int(length) + chunk_size - 1) // chunk_size) * chunk_size
+
+
+def align_gdn_varlen_for_mojo_gdr(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    g: Tensor,
+    beta: Tensor,
+    cu_seqlens: Tensor,
+    *,
+    chunk_size: int = MOJO_GDR_CHUNK_SIZE,
+) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Optional[Tensor]]:
+    """Pad each varlen segment to ``chunk_size`` for Mojo GDR + final_state.
+
+    Pad slots use ``v=g=beta=0`` so recurrent state is preserved through the
+    tail (``S' = exp(0)*S + 0``). ``q``/``k`` copy the segment's last real
+    token to avoid ``l2norm(0)`` NaNs when ``use_qk_l2norm_in_kernel=True``.
+
+    Returns ``(q, k, v, g, beta, padded_cu, unpad_index)``. ``unpad_index`` is
+    ``None`` when no padding was required.
+    """
+    if query.ndim != 4 or key.ndim != 4 or value.ndim != 4:
+        raise ValueError(
+            "align_gdn_varlen_for_mojo_gdr expects q/k/v rank 4, "
+            f"got {(query.ndim, key.ndim, value.ndim)}"
+        )
+    if g.ndim != 3 or beta.ndim != 3:
+        raise ValueError(
+            f"align_gdn_varlen_for_mojo_gdr expects g/beta rank 3, got {(g.ndim, beta.ndim)}"
+        )
+    if int(query.shape[0]) != 1:
+        raise ValueError("align_gdn_varlen_for_mojo_gdr requires batch size 1")
+
+    lengths = _cu_lengths(cu_seqlens)
+    padded_lengths = [_ceil_to_chunk(length, chunk_size) for length in lengths]
+    if padded_lengths == lengths:
+        return query, key, value, g, beta, cu_seqlens, None
+
+    token_count = int(query.shape[1])
+    padded_cursor = sum(padded_lengths)
+    original_indices: List[int] = []
+    padded_boundaries = [0]
+    src_cursor = 0
+    dst_cursor = 0
+    for length, padded_length in zip(lengths, padded_lengths):
+        original_indices.extend(range(dst_cursor, dst_cursor + length))
+        src_cursor += length
+        dst_cursor += padded_length
+        padded_boundaries.append(dst_cursor)
+    if src_cursor != token_count:
+        raise RuntimeError(
+            f"align_gdn_varlen_for_mojo_gdr token mismatch: walked={src_cursor} dim={token_count}"
+        )
+
+    index = torch.tensor(original_indices, dtype=torch.long, device=query.device)
+
+    def _zeros_like_padded(tensor: Tensor) -> Tensor:
+        shape = list(tensor.shape)
+        shape[1] = padded_cursor
+        return tensor.new_zeros(shape)
+
+    # Zero-fill v/g/beta (state-preserving pads). Seed q/k from last real token.
+    q_pad = _zeros_like_padded(query)
+    k_pad = _zeros_like_padded(key)
+    v_pad = _zeros_like_padded(value)
+    g_pad = _zeros_like_padded(g)
+    beta_pad = _zeros_like_padded(beta)
+
+    q_pad.index_copy_(1, index, query)
+    k_pad.index_copy_(1, index, key)
+    v_pad.index_copy_(1, index, value)
+    g_pad.index_copy_(1, index, g)
+    beta_pad.index_copy_(1, index, beta)
+
+    dst_cursor = 0
+    src_cursor = 0
+    for length, padded_length in zip(lengths, padded_lengths):
+        pad = padded_length - length
+        if pad > 0:
+            last = src_cursor + length - 1
+            fill_q = query[:, last : last + 1].expand(-1, pad, *([-1] * (query.ndim - 2)))
+            fill_k = key[:, last : last + 1].expand(-1, pad, *([-1] * (key.ndim - 2)))
+            q_pad[:, dst_cursor + length : dst_cursor + padded_length] = fill_q
+            k_pad[:, dst_cursor + length : dst_cursor + padded_length] = fill_k
+        src_cursor += length
+        dst_cursor += padded_length
+
+    padded_cu = torch.tensor(
+        padded_boundaries,
+        dtype=cu_seqlens.dtype,
+        device=cu_seqlens.device,
+    )
+    return q_pad, k_pad, v_pad, g_pad, beta_pad, padded_cu, index
+
+
+def unpad_gdn_varlen_output(output: Tensor, unpad_index: Optional[Tensor]) -> Tensor:
+    """Drop Mojo chunk-alignment pad tokens from GDN output."""
+    if unpad_index is None:
+        return output
+    return output.index_select(1, unpad_index)

--- a/veomni/distributed/context_parallel/gdn_sp.py
+++ b/veomni/distributed/context_parallel/gdn_sp.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2025 VeOmni Authors.
+# Load-balancing helpers adapted from MindSpeed-LLM gdn_context_parallel (BSD-3-Clause).
+"""GDN sequence-parallel helpers for hybrid Ring-CP layouts."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch.distributed as dist
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+from ..parallel_state import get_parallel_state
+from .sharding import balanced_cp_restore, balanced_cp_to_rank_major
+
+
+def resolve_gdn_sp_group() -> tuple[Optional[ProcessGroup], int, int, bool]:
+    """Return (group, sp_size, head_rank, need_zigzag_restore) for GDN A2A.
+
+    - Ulysses-only: use ulysses group (no zigzag restore).
+    - CP enabled (with or without Ulysses): use unified SP group and restore
+      canonical order after gather / re-apply zigzag before scatter.
+    """
+    state = get_parallel_state()
+    if state.cp_enabled:
+        group = state.sp_group
+        if group is None and not state.ulysses_enabled:
+            group = state.cp_group
+        if group is None:
+            raise RuntimeError("CP-enabled GDN requires unified sequence-parallel group.")
+        sp_rank = state.sp_rank if state.sp_rank >= 0 else (state.cp_rank if state.cp_rank >= 0 else 0)
+        return group, state.sp_size, sp_rank, True
+    if state.ulysses_enabled:
+        return state.ulysses_group, state.ulysses_size, state.ulysses_rank, False
+    return None, 1, 0, False
+
+
+def maybe_restore_canonical(tensor: Tensor, *, enabled: bool, cp_size: int, dim: int = 1) -> Tensor:
+    if not enabled or cp_size <= 1:
+        return tensor
+    return balanced_cp_restore(tensor, cp_size=cp_size, dim=dim)
+
+
+def maybe_to_rank_major(tensor: Tensor, *, enabled: bool, cp_size: int, dim: int = 1) -> Tensor:
+    if not enabled or cp_size <= 1:
+        return tensor
+    return balanced_cp_to_rank_major(tensor, cp_size=cp_size, dim=dim)
+
+
+def gdn_sp_world_size(group: Optional[ProcessGroup]) -> int:
+    if group is None:
+        return 1
+    return dist.get_world_size(group)

--- a/veomni/distributed/context_parallel/gdn_sp.py
+++ b/veomni/distributed/context_parallel/gdn_sp.py
@@ -1,11 +1,26 @@
 # Copyright (c) 2025 VeOmni Authors.
 # Load-balancing helpers adapted from MindSpeed-LLM gdn_context_parallel (BSD-3-Clause).
-"""GDN sequence-parallel helpers for hybrid Ring-CP layouts."""
+"""GDN sequence-parallel helpers for hybrid Ulysses and context parallelism.
+
+Gated DeltaNet has two independent distributed dimensions:
+
+* Ulysses shards heads and gathers sequence with all-to-all.
+* Context parallelism shards sequence while leaving the Ulysses-local heads
+  unchanged.
+
+The current correctness path gathers the CP sequence for each Ulysses head
+shard, runs the recurrent core redundantly on every CP rank, and scatters the
+output sequence again. The paired gather/scatter autograd functions preserve
+the input-activation gradient. Only parameters consumed inside that repeated
+core need a ``1 / cp_size`` gradient factor.
+"""
 
 from __future__ import annotations
 
-from typing import Optional
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
 
+import torch
 import torch.distributed as dist
 from torch import Tensor
 from torch.distributed import ProcessGroup
@@ -14,25 +29,429 @@ from ..parallel_state import get_parallel_state
 from .sharding import balanced_cp_restore, balanced_cp_to_rank_major
 
 
-def resolve_gdn_sp_group() -> tuple[Optional[ProcessGroup], int, int, bool]:
-    """Return (group, sp_size, head_rank, need_zigzag_restore) for GDN A2A.
+# GDN CP impl family (see gdn_scan_cp + implementation contract):
+#   gather_full_replicated — lossless redundant full-seq (legacy / golden)
+#   state_passing_serial   — lossless S/cp + serial state pass (P0)
+#   kcp                    — lossy parallel prefix (P1, opt-in only)
+GDN_CP_IMPL_GATHER_FULL_REPLICATED = "gather_full_replicated"
+GDN_CP_IMPL_STATE_PASSING_SERIAL = "state_passing_serial"
+GDN_CP_IMPL_KCP = "kcp"
+GDN_CP_IMPL_NONE = "none"
+_GDN_CP_IMPL_LOGGED = False
 
-    - Ulysses-only: use ulysses group (no zigzag restore).
-    - CP enabled (with or without Ulysses): use unified SP group and restore
-      canonical order after gather / re-apply zigzag before scatter.
-    """
+
+def gdn_cp_impl_name(*, cp_size: int) -> str:
+    if int(cp_size) <= 1:
+        return GDN_CP_IMPL_NONE
+    from .gdn_scan_cp import resolve_gdn_cp_impl_from_env
+
+    return resolve_gdn_cp_impl_from_env(cp_size=cp_size)
+
+
+def gdn_replication_factor(*, cp_size: int) -> int:
+    """How many times the GDN core runs per global token under the active impl."""
+    if int(cp_size) <= 1:
+        return 1
+    from .gdn_scan_cp import gdn_replication_factor_for_impl
+
+    return gdn_replication_factor_for_impl(gdn_cp_impl_name(cp_size=cp_size), cp_size=cp_size)
+
+
+def gdn_cp_identity(*, cp_size: int) -> dict[str, object]:
+    """Stable identity dict for logs / wandb."""
+    cp = max(int(cp_size), 1)
+    impl = gdn_cp_impl_name(cp_size=cp)
+    return {
+        "gdn_cp_impl": impl,
+        "gdn_replication_factor": gdn_replication_factor(cp_size=cp),
+    }
+
+
+def log_gdn_cp_impl_once(*, cp_size: int, logger: Any = None) -> dict[str, object]:
+    """Rank-0 once: label active GDN CP impl (lossless/lossy)."""
+    global _GDN_CP_IMPL_LOGGED
+    identity = gdn_cp_identity(cp_size=cp_size)
+    if _GDN_CP_IMPL_LOGGED:
+        return identity
+    _GDN_CP_IMPL_LOGGED = True
+    impl = str(identity["gdn_cp_impl"])
+    if int(cp_size) <= 1:
+        note = "CP1: gdn_cp_impl=none"
+    elif impl in (GDN_CP_IMPL_GATHER_FULL_REPLICATED, "gather_full"):
+        note = "lossless gather→full GDN→scatter; NOT state-passing"
+    elif impl == GDN_CP_IMPL_STATE_PASSING_SERIAL:
+        note = "lossless zigzag→block + serial state pass; S/cp only"
+    elif impl == GDN_CP_IMPL_KCP:
+        note = "lossy KCP local+AG+merge; opt-in"
+    else:
+        note = f"impl={impl}"
+    msg = (
+        "AI4SE_GDN_CP_IMPL "
+        f"gdn_cp_impl={identity['gdn_cp_impl']} "
+        f"gdn_replication_factor={identity['gdn_replication_factor']} "
+        f"({note})"
+    )
+    try:
+        if dist.is_initialized() and dist.get_rank() != 0:
+            return identity
+    except Exception:
+        pass
+    if logger is not None:
+        try:
+            logger.warning(msg)
+        except Exception:
+            print(msg, flush=True)
+    else:
+        print(msg, flush=True)
+    return identity
+
+
+@dataclass(frozen=True)
+class GdnParallelPlan:
+    """Two-dimensional GDN plan without collapsing CP into head parallelism."""
+
+    ulysses_group: Optional[ProcessGroup]
+    ulysses_size: int
+    ulysses_rank: int
+    cp_group: Optional[ProcessGroup]
+    cp_size: int
+    cp_rank: int
+
+    @property
+    def head_parallel_enabled(self) -> bool:
+        return self.ulysses_size > 1
+
+    @property
+    def cp_sequence_enabled(self) -> bool:
+        return self.cp_size > 1
+
+    @property
+    def cp_seq_enabled(self) -> bool:
+        """Compatibility alias used by the Ring-CP generated model patches."""
+        return self.cp_sequence_enabled
+
+
+def resolve_gdn_parallel_plan() -> GdnParallelPlan:
+    """Resolve Ulysses head parallelism and CP sequence parallelism separately."""
     state = get_parallel_state()
-    if state.cp_enabled:
-        group = state.sp_group
-        if group is None and not state.ulysses_enabled:
-            group = state.cp_group
-        if group is None:
-            raise RuntimeError("CP-enabled GDN requires unified sequence-parallel group.")
-        sp_rank = state.sp_rank if state.sp_rank >= 0 else (state.cp_rank if state.cp_rank >= 0 else 0)
-        return group, state.sp_size, sp_rank, True
-    if state.ulysses_enabled:
-        return state.ulysses_group, state.ulysses_size, state.ulysses_rank, False
+
+    ulysses_group: Optional[ProcessGroup] = None
+    ulysses_size = 1
+    ulysses_rank = 0
+    if getattr(state, "ulysses_enabled", False):
+        ulysses_group = state.ulysses_group
+        if ulysses_group is None:
+            raise RuntimeError("Ulysses-enabled GDN requires ulysses_group.")
+        ulysses_size = int(state.ulysses_size)
+        ulysses_rank = int(state.ulysses_rank)
+
+    cp_group: Optional[ProcessGroup] = None
+    cp_size = 1
+    cp_rank = 0
+    if getattr(state, "cp_enabled", False):
+        cp_group = state.cp_group
+        if cp_group is None:
+            raise RuntimeError("CP-enabled GDN requires cp_group.")
+        cp_size = int(state.cp_size)
+        cp_rank = int(state.cp_rank)
+
+    return GdnParallelPlan(
+        ulysses_group=ulysses_group,
+        ulysses_size=ulysses_size,
+        ulysses_rank=ulysses_rank,
+        cp_group=cp_group,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+    )
+
+
+def resolve_gdn_sp_group() -> tuple[Optional[ProcessGroup], int, int, bool]:
+    """Return the Ulysses-only group used for GDN head all-to-all.
+
+    The final boolean is retained for compatibility with the original Ring-CP
+    helper API. CP ordering is now handled by ``cp_gather_sequence`` and
+    ``cp_scatter_sequence``, so no Ulysses tensor needs an inline zigzag
+    transform.
+    """
+    plan = resolve_gdn_parallel_plan()
+    if plan.head_parallel_enabled:
+        return plan.ulysses_group, plan.ulysses_size, plan.ulysses_rank, False
     return None, 1, 0, False
+
+
+def _cu_lengths(cu_seqlens: Tensor, *, expected_total: Optional[int] = None) -> list[int]:
+    points = [int(point) for point in cu_seqlens.detach().cpu().tolist()]
+    if not points or points[0] != 0:
+        raise ValueError(f"cu_seqlens must start at 0, got {points[:3]}.")
+    if any(end < start for start, end in zip(points[:-1], points[1:])):
+        raise ValueError("cu_seqlens must be monotonically non-decreasing.")
+    if expected_total is not None and points[-1] != expected_total:
+        raise ValueError(f"cu_seqlens end ({points[-1]}) does not match sequence length ({expected_total}).")
+    return [end - start for start, end in zip(points[:-1], points[1:])]
+
+
+def _cu_from_lengths(lengths: list[int], *, reference: Tensor) -> Tensor:
+    cu = torch.tensor([0] + lengths, dtype=torch.int32, device=reference.device)
+    return cu.cumsum(0).to(dtype=torch.int32)
+
+
+def derive_gdn_local_cu_seqlens(
+    global_cu_seqlens: Tensor,
+    *,
+    ulysses_size: int,
+    cp_size: int,
+) -> tuple[Tensor, Tensor]:
+    """Derive pre-Ulysses-local and post-Ulysses CP-local packed metadata."""
+    if ulysses_size < 1 or cp_size < 1:
+        raise ValueError(f"ulysses_size and cp_size must be positive, got {ulysses_size}, {cp_size}.")
+    global_lengths = _cu_lengths(global_cu_seqlens)
+    local_divisor = ulysses_size * cp_size
+    for sample_idx, length in enumerate(global_lengths):
+        if length % local_divisor != 0:
+            raise ValueError(
+                f"Packed GDN sample {sample_idx} length ({length}) must be divisible by "
+                f"ulysses_size * cp_size ({local_divisor})."
+            )
+    ulysses_local_lengths = [length // local_divisor for length in global_lengths]
+    cp_local_lengths = [length // cp_size for length in global_lengths]
+    return (
+        _cu_from_lengths(ulysses_local_lengths, reference=global_cu_seqlens),
+        _cu_from_lengths(cp_local_lengths, reference=global_cu_seqlens),
+    )
+
+
+def _packed_cp_restore(
+    rank_tensors: list[Tensor],
+    *,
+    local_lengths: list[int],
+    cp_size: int,
+    seq_dim: int,
+) -> Tensor:
+    offsets = [0]
+    for length in local_lengths:
+        offsets.append(offsets[-1] + length)
+    restored_samples = []
+    for sample_idx, local_length in enumerate(local_lengths):
+        rank_major = torch.cat(
+            [rank_tensor.narrow(seq_dim, offsets[sample_idx], local_length) for rank_tensor in rank_tensors],
+            dim=seq_dim,
+        )
+        restored_samples.append(balanced_cp_restore(rank_major, cp_size=cp_size, dim=seq_dim))
+    if restored_samples:
+        return torch.cat(restored_samples, dim=seq_dim).contiguous()
+    shape = list(rank_tensors[0].shape)
+    shape[seq_dim] = 0
+    return rank_tensors[0].new_empty(shape)
+
+
+def _packed_cp_rank_shard(
+    tensor: Tensor,
+    *,
+    local_lengths: list[int],
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int,
+) -> Tensor:
+    full_lengths = [length * cp_size for length in local_lengths]
+    samples = tensor.split(full_lengths, dim=seq_dim)
+    local_samples = []
+    for sample, local_length in zip(samples, local_lengths):
+        rank_major = balanced_cp_to_rank_major(sample.contiguous(), cp_size=cp_size, dim=seq_dim)
+        local_samples.append(rank_major.narrow(seq_dim, cp_rank * local_length, local_length))
+    if local_samples:
+        return torch.cat(local_samples, dim=seq_dim).contiguous()
+    shape = list(tensor.shape)
+    shape[seq_dim] = 0
+    return tensor.new_empty(shape)
+
+
+class _CpGatherSequence(torch.autograd.Function):
+    """Gather balanced CP shards and restore canonical sequence order.
+
+    This operation is paired with ``_CpScatterSequence``. Scatter backward
+    reconstructs the complete output gradient on every CP rank, so gather
+    backward only selects the current rank's input shard. It intentionally
+    does not scale or reduce the input-activation gradient.
+    """
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        tensor: Tensor,
+        group: ProcessGroup,
+        cp_size: int,
+        seq_dim: int,
+        cp_local_cu_seqlens: Tensor,
+    ) -> Tensor:
+        world_size = dist.get_world_size(group)
+        if world_size != cp_size:
+            raise RuntimeError(f"cp_group world size ({world_size}) does not match cp_size ({cp_size}).")
+
+        ctx.group = group
+        ctx.cp_size = cp_size
+        ctx.seq_dim = seq_dim
+        ctx.local_lengths = _cu_lengths(
+            cp_local_cu_seqlens,
+            expected_total=tensor.size(seq_dim),
+        )
+
+        gathered = [torch.empty_like(tensor) for _ in range(cp_size)]
+        dist.all_gather(gathered, tensor.contiguous(), group=group)
+        return _packed_cp_restore(
+            gathered,
+            local_lengths=ctx.local_lengths,
+            cp_size=cp_size,
+            seq_dim=seq_dim,
+        )
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None, None, None, None]:
+        local_grad = _packed_cp_rank_shard(
+            grad_output.contiguous(),
+            local_lengths=ctx.local_lengths,
+            cp_size=ctx.cp_size,
+            cp_rank=dist.get_rank(ctx.group),
+            seq_dim=ctx.seq_dim,
+        )
+        return local_grad, None, None, None, None
+
+
+class _CpScatterSequence(torch.autograd.Function):
+    """Select one balanced CP output shard from a canonical full sequence."""
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        tensor: Tensor,
+        group: ProcessGroup,
+        cp_size: int,
+        cp_rank: int,
+        seq_dim: int,
+        cp_local_cu_seqlens: Tensor,
+    ) -> Tensor:
+        world_size = dist.get_world_size(group)
+        if world_size != cp_size:
+            raise RuntimeError(f"cp_group world size ({world_size}) does not match cp_size ({cp_size}).")
+        if dist.get_rank(group) != cp_rank:
+            raise RuntimeError(f"cp_rank ({cp_rank}) does not match group-local rank ({dist.get_rank(group)}).")
+        local_lengths = _cu_lengths(cp_local_cu_seqlens)
+        expected_full_length = sum(local_lengths) * cp_size
+        if tensor.size(seq_dim) != expected_full_length:
+            raise ValueError(
+                f"GDN full sequence length ({tensor.size(seq_dim)}) does not match packed CP metadata "
+                f"({expected_full_length})."
+            )
+
+        ctx.group = group
+        ctx.cp_size = cp_size
+        ctx.seq_dim = seq_dim
+        ctx.local_lengths = local_lengths
+        return _packed_cp_rank_shard(
+            tensor.contiguous(),
+            local_lengths=local_lengths,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            seq_dim=seq_dim,
+        )
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None, None, None, None, None]:
+        # The recurrent core couples tokens across CP shards. Every rank needs
+        # the complete dOut to obtain the full gradient for its local dInput.
+        gathered = [torch.empty_like(grad_output) for _ in range(ctx.cp_size)]
+        dist.all_gather(gathered, grad_output.contiguous(), group=ctx.group)
+        canonical = _packed_cp_restore(
+            gathered,
+            local_lengths=ctx.local_lengths,
+            cp_size=ctx.cp_size,
+            seq_dim=ctx.seq_dim,
+        )
+        return canonical, None, None, None, None, None
+
+
+class _ScaleRepeatedParameterGrad(torch.autograd.Function):
+    """Identity in forward; scale only this tensor's backward gradient."""
+
+    @staticmethod
+    def forward(ctx: Any, tensor: Tensor, cp_size: int) -> Tensor:
+        ctx.cp_size = cp_size
+        return tensor
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None]:
+        return grad_output / ctx.cp_size, None
+
+
+def cp_gather_sequence(
+    tensor: Tensor,
+    *,
+    cp_group: Optional[ProcessGroup],
+    cp_size: int,
+    seq_dim: int = 1,
+    cp_local_cu_seqlens: Optional[Tensor] = None,
+) -> Tensor:
+    """Gather balanced CP sequence shards into canonical sequence order.
+
+    P0-C0: paired with full-sequence GDN on every CP rank (replicated compute).
+    """
+    if cp_size <= 1:
+        return tensor
+    log_gdn_cp_impl_once(cp_size=cp_size)
+    if cp_group is None:
+        raise RuntimeError("cp_group is required when cp_size > 1.")
+    if cp_local_cu_seqlens is None:
+        cp_local_cu_seqlens = torch.tensor(
+            [0, tensor.size(seq_dim)],
+            dtype=torch.int32,
+            device=tensor.device,
+        )
+    return _CpGatherSequence.apply(tensor, cp_group, cp_size, seq_dim, cp_local_cu_seqlens)
+
+
+def cp_scatter_sequence(
+    tensor: Tensor,
+    *,
+    cp_group: Optional[ProcessGroup],
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int = 1,
+    cp_local_cu_seqlens: Optional[Tensor] = None,
+) -> Tensor:
+    """Scatter a canonical sequence back to the current balanced CP shard."""
+    if cp_size <= 1:
+        return tensor
+    if cp_group is None:
+        raise RuntimeError("cp_group is required when cp_size > 1.")
+    if cp_local_cu_seqlens is None:
+        if tensor.size(seq_dim) % cp_size != 0:
+            raise ValueError(
+                f"GDN full sequence length ({tensor.size(seq_dim)}) must be divisible by cp_size ({cp_size})."
+            )
+        cp_local_cu_seqlens = torch.tensor(
+            [0, tensor.size(seq_dim) // cp_size],
+            dtype=torch.int32,
+            device=tensor.device,
+        )
+    return _CpScatterSequence.apply(
+        tensor,
+        cp_group,
+        cp_size,
+        cp_rank,
+        seq_dim,
+        cp_local_cu_seqlens,
+    )
+
+
+def scale_cp_repeated_parameter_grad(tensor: Tensor, *, cp_size: int) -> Tensor:
+    """Scale gradients for a parameter used by every redundant CP core.
+
+    Apply this only to parameters consumed between ``cp_gather_sequence`` and
+    ``cp_scatter_sequence``. Do not apply it to input activations or to
+    parameters used only before the gather or after the scatter.
+    """
+    if cp_size <= 1:
+        return tensor
+    return _ScaleRepeatedParameterGrad.apply(tensor, cp_size)
 
 
 def maybe_restore_canonical(tensor: Tensor, *, enabled: bool, cp_size: int, dim: int = 1) -> Tensor:

--- a/veomni/distributed/context_parallel/gdn_sp.py
+++ b/veomni/distributed/context_parallel/gdn_sp.py
@@ -295,6 +295,23 @@ class _CpGatherSequence(torch.autograd.Function):
             expected_total=tensor.size(seq_dim),
         )
 
+        try:
+            from .gdn_mem_probe import emit_comm_layer, mem_probe_enabled
+
+            if mem_probe_enabled():
+                local_bytes = int(tensor.numel()) * int(tensor.element_size())
+                emit_comm_layer(
+                    impl="gather_full_replicated",
+                    op="all_gather_sequence",
+                    payload_bytes_local=local_bytes,
+                    payload_bytes_total=local_bytes * int(cp_size),
+                    shape=list(tensor.shape),
+                    seq_len_local=int(tensor.size(seq_dim)),
+                    depends_on_s=True,
+                    extra={"seq_dim": int(seq_dim)},
+                )
+        except Exception:
+            pass
         gathered = [torch.empty_like(tensor) for _ in range(cp_size)]
         dist.all_gather(gathered, tensor.contiguous(), group=group)
         return _packed_cp_restore(

--- a/veomni/distributed/context_parallel/packed_sharding.py
+++ b/veomni/distributed/context_parallel/packed_sharding.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026 ByteDance AI4SE.
+# Sample-aware zigzag sharding adapted from MindSpeed get_index (BSD-3-Clause).
+"""Per-sample balanced CP / hybrid sharding for packed sequences."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+
+from .sharding import _validate_parallel_coordinate
+
+
+@dataclass(frozen=True)
+class PackedCPPartition:
+    """Gather indices and CP-local packed metadata for one rank."""
+
+    token_indices: Tensor  # int64 [T_local]
+    local_cu_seqlens: Tensor  # int32 [num_samples + 1]
+    local_max_seqlen: int
+    sample_multiple: int
+
+
+def _sample_lengths(cu_seqlens: Tensor) -> list[int]:
+    cu = cu_seqlens.detach().cpu().tolist()
+    if not cu or cu[0] != 0:
+        raise ValueError(f"cu_seqlens must start at 0, got {cu[:3]}...")
+    return [int(cu[i + 1] - cu[i]) for i in range(len(cu) - 1)]
+
+
+def build_packed_cp_partition(
+    cu_seqlens: Tensor,
+    *,
+    cp_size: int,
+    cp_rank: int,
+    ulysses_size: int = 1,
+    ulysses_rank: int = 0,
+) -> PackedCPPartition:
+    """Build sample-aware hybrid CP×Ulysses gather indices from global cu_seqlens."""
+    _validate_parallel_coordinate(cp_size, cp_rank, "cp")
+    _validate_parallel_coordinate(ulysses_size, ulysses_rank, "ulysses")
+    multiple = 2 * cp_size * ulysses_size
+    lengths = _sample_lengths(cu_seqlens)
+    for idx, length in enumerate(lengths):
+        if length % multiple != 0:
+            raise ValueError(
+                f"Packed sample {idx} length {length} must be divisible by "
+                f"2 * cp_size * ulysses_size ({multiple}) for Ring CP."
+            )
+
+    points = cu_seqlens.detach().cpu().tolist()
+    index_chunks: list[Tensor] = []
+    local_lengths: list[int] = []
+    for start, end in zip(points[:-1], points[1:]):
+        start, end = int(start), int(end)
+        # Per-sample zigzag CP, then contiguous Ulysses on the CP-local shard.
+        size = (end - start) // (2 * cp_size)
+        part1 = torch.arange(start + cp_rank * size, start + (cp_rank + 1) * size)
+        part2 = torch.arange(end - (cp_rank + 1) * size, end - cp_rank * size)
+        cp_local = torch.cat((part1, part2))
+        if ulysses_size > 1:
+            ulysses_chunk = cp_local.numel() // ulysses_size
+            begin = ulysses_rank * ulysses_chunk
+            cp_local = cp_local[begin : begin + ulysses_chunk]
+        index_chunks.append(cp_local)
+        local_lengths.append(int(cp_local.numel()))
+
+    token_indices = torch.cat(index_chunks) if index_chunks else torch.zeros(0, dtype=torch.long)
+    local_cu = torch.tensor([0] + local_lengths, dtype=torch.int32).cumsum(0).to(dtype=torch.int32)
+    local_max = max(local_lengths) if local_lengths else 0
+    return PackedCPPartition(
+        token_indices=token_indices,
+        local_cu_seqlens=local_cu,
+        local_max_seqlen=local_max,
+        sample_multiple=multiple,
+    )
+
+
+def apply_packed_cp_partition(tensor: Tensor, partition: PackedCPPartition, *, dim: int = -1) -> Tensor:
+    """Gather ``tensor`` along ``dim`` using packed CP indices."""
+    dim = dim % tensor.ndim
+    index = partition.token_indices.to(device=tensor.device)
+    if index.numel() == 0:
+        sizes = list(tensor.shape)
+        sizes[dim] = 0
+        return tensor.new_empty(sizes)
+    return tensor.index_select(dim, index).contiguous()
+
+
+def pad_sample_lengths_to_multiple(lengths: list[int], multiple: int) -> list[int]:
+    """Return padded lengths (each >= original, divisible by multiple)."""
+    if multiple < 1:
+        raise ValueError(f"multiple must be positive, got {multiple}.")
+    padded = []
+    for length in lengths:
+        rem = length % multiple
+        padded.append(length if rem == 0 else length + (multiple - rem))
+    return padded
+
+
+def pad_packed_tensor_to_sample_multiple(
+    tensor: Tensor,
+    cu_seqlens: Tensor,
+    *,
+    multiple: int,
+    dim: int = -1,
+    pad_value: int | float = 0,
+) -> tuple[Tensor, Tensor]:
+    """Pad each packed sample so its length is divisible by ``multiple``.
+
+    Returns ``(padded_tensor, new_cu_seqlens)``.
+    """
+    dim = dim % tensor.ndim
+    lengths = _sample_lengths(cu_seqlens)
+    padded_lengths = pad_sample_lengths_to_multiple(lengths, multiple)
+    if padded_lengths == lengths:
+        return tensor, cu_seqlens.to(dtype=torch.int32)
+
+    pieces = []
+    points = cu_seqlens.detach().cpu().tolist()
+    for (start, end), new_len, old_len in zip(zip(points[:-1], points[1:]), padded_lengths, lengths):
+        start, end = int(start), int(end)
+        piece = tensor.narrow(dim, start, end - start)
+        pad_n = new_len - old_len
+        if pad_n:
+            pad_shape = list(piece.shape)
+            pad_shape[dim] = pad_n
+            piece = torch.cat(
+                (piece, piece.new_full(pad_shape, fill_value=pad_value)),
+                dim=dim,
+            )
+        pieces.append(piece)
+    padded = torch.cat(pieces, dim=dim)
+    new_cu = torch.tensor([0] + padded_lengths, dtype=torch.int32).cumsum(0).to(dtype=torch.int32)
+    return padded.contiguous(), new_cu
+
+def ulysses_local_cu_to_cp_local_cu(local_cu_seqlens: Tensor, ulysses_size: int) -> Tensor:
+    """Scale Ulysses-local cu_seqlens to CP-local lengths after gather_seq."""
+    if ulysses_size <= 1:
+        return local_cu_seqlens.to(dtype=torch.int32)
+    lengths = local_cu_seqlens.diff() * int(ulysses_size)
+    out = torch.empty(local_cu_seqlens.numel(), dtype=torch.int32, device=local_cu_seqlens.device)
+    out[0] = 0
+    out[1:] = lengths.to(dtype=torch.int32).cumsum(0)
+    return out
+
+
+def reorder_ulysses_rank_major_to_sample_major(
+    tensor: Tensor,
+    ulysses_local_cu_seqlens: Tensor,
+    *,
+    ulysses_size: int,
+    seq_dim: int,
+) -> Tensor:
+    """Map post-Ulysses gather layout ``[u0_packed|u1_packed|...]`` to CP-local
+    sample-major ``[s0_u0|s0_u1|...|s1_u0|s1_u1|...]`` for Ring CP.
+    """
+    if ulysses_size <= 1:
+        return tensor
+    seq_dim = seq_dim % tensor.ndim
+    lengths = _sample_lengths(ulysses_local_cu_seqlens)
+    if not lengths:
+        return tensor
+    rank_span = sum(lengths)
+    expected = rank_span * ulysses_size
+    actual = int(tensor.size(seq_dim))
+    if actual != expected:
+        raise RuntimeError(
+            f"Ulysses gather seq length {actual} != sum(local_cu)*ulysses_size ({expected})"
+        )
+    rank_blocks = tensor.split(rank_span, dim=seq_dim)
+    per_sample: list[list[Tensor]] = [[] for _ in lengths]
+    for block in rank_blocks:
+        for i, chunk in enumerate(block.split(lengths, dim=seq_dim)):
+            per_sample[i].append(chunk)
+    samples = [torch.cat(chunks, dim=seq_dim) for chunks in per_sample]
+    return torch.cat(samples, dim=seq_dim).contiguous()
+
+
+def reorder_sample_major_to_ulysses_rank_major(
+    tensor: Tensor,
+    ulysses_local_cu_seqlens: Tensor,
+    *,
+    ulysses_size: int,
+    seq_dim: int,
+) -> Tensor:
+    """Inverse of :func:`reorder_ulysses_rank_major_to_sample_major` before Ulysses scatter."""
+    if ulysses_size <= 1:
+        return tensor
+    seq_dim = seq_dim % tensor.ndim
+    lengths = _sample_lengths(ulysses_local_cu_seqlens)
+    if not lengths:
+        return tensor
+    cp_lengths = [length * ulysses_size for length in lengths]
+    expected = sum(cp_lengths)
+    actual = int(tensor.size(seq_dim))
+    if actual != expected:
+        raise RuntimeError(
+            f"CP-local seq length {actual} != sum(local_cu)*ulysses_size ({expected})"
+        )
+    samples = tensor.split(cp_lengths, dim=seq_dim)
+    by_rank: list[list[Tensor]] = [[] for _ in range(ulysses_size)]
+    for sample, ulen in zip(samples, lengths):
+        for rank, chunk in enumerate(sample.split(ulen, dim=seq_dim)):
+            by_rank[rank].append(chunk)
+    ranks = [torch.cat(chunks, dim=seq_dim) for chunks in by_rank]
+    return torch.cat(ranks, dim=seq_dim).contiguous()

--- a/veomni/distributed/context_parallel/ring_attention.py
+++ b/veomni/distributed/context_parallel/ring_attention.py
@@ -1,0 +1,440 @@
+# Copyright (c) 2024, Huawei Technologies Co., Ltd.  All rights reserved.
+# Ported/adapted from MindSpeed AttentionWithCp (BSD-3-Clause) for Open-VeOmni.
+"""Minimal causal Ring context-parallel attention (CP>=2, BNSD, dropout=0)."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+import torch.distributed as dist
+from torch import Tensor
+
+from .attention_backend import (
+    has_npu_fusion_attention,
+    npu_attention_backward,
+    npu_attention_forward,
+    torch_attention_backward,
+    torch_attention_forward,
+)
+from .causal_schedule import (
+    as_balanced_halves,
+    causal_backward_fetch,
+    causal_forward_fetch,
+    causal_grad_update,
+    causal_out_update,
+    flatten_balanced_halves,
+)
+from .ring_p2p import RingP2P
+from .sharding import balanced_cp_restore, balanced_cp_slice
+
+
+def _attention_forward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    num_heads: int,
+    softmax_scale: float,
+    causal: bool,
+    backend: str,
+) -> tuple[Tensor, Tensor, Tensor]:
+    if backend == "npu":
+        return npu_attention_forward(
+            query,
+            key,
+            value,
+            num_heads=num_heads,
+            softmax_scale=softmax_scale,
+            causal=causal,
+        )
+    return torch_attention_forward(query, key, value, softmax_scale=softmax_scale, causal=causal)
+
+
+def _attention_backward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    dout: Tensor,
+    attn_out: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    *,
+    num_heads: int,
+    softmax_scale: float,
+    causal: bool,
+    backend: str,
+) -> tuple[Tensor, Tensor, Tensor]:
+    if backend == "npu":
+        return npu_attention_backward(
+            query,
+            key,
+            value,
+            dout,
+            attn_out,
+            softmax_max,
+            softmax_sum,
+            num_heads=num_heads,
+            softmax_scale=softmax_scale,
+            causal=causal,
+        )
+    return torch_attention_backward(
+        query,
+        key,
+        value,
+        dout,
+        attn_out,
+        softmax_max,
+        softmax_sum,
+        softmax_scale=softmax_scale,
+        causal=causal,
+    )
+
+
+def _default_backend(requested: Optional[str]) -> str:
+    if requested is not None:
+        return requested
+    return "npu" if has_npu_fusion_attention() else "torch"
+
+
+def simulate_ring_causal_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    cp_size: int,
+    softmax_scale: Optional[float] = None,
+    backend: str = "torch",
+) -> Tensor:
+    """Single-process causal Ring CP simulation with full KV visibility.
+
+    Used for Day-1 schedule/online-softmax correctness against dense attention.
+    Inputs are global BNSD tensors; output restores canonical sequence order.
+    """
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be positive, got {cp_size}.")
+    if softmax_scale is None:
+        softmax_scale = query.shape[-1] ** -0.5
+
+    num_heads = query.shape[1]
+    local_outputs = []
+    for cp_rank in range(cp_size):
+        local_q = as_balanced_halves(balanced_cp_slice(query, cp_size, cp_rank, dim=2))
+        local_k = as_balanced_halves(balanced_cp_slice(key, cp_size, cp_rank, dim=2))
+        local_v = as_balanced_halves(balanced_cp_slice(value, cp_size, cp_rank, dim=2))
+
+        # Collect every rank's balanced KV shard so we can emulate the ring.
+        kv_shards = [
+            (
+                as_balanced_halves(balanced_cp_slice(key, cp_size, rank, dim=2)),
+                as_balanced_halves(balanced_cp_slice(value, cp_size, rank, dim=2)),
+            )
+            for rank in range(cp_size)
+        ]
+
+        attn_out = softmax_max = softmax_sum = None
+        kv_block_id = cp_rank
+        for _ in range(cp_size):
+            cur_k, cur_v = kv_shards[kv_block_id]
+            cur_q, cur_k, cur_v, cur_mask = causal_forward_fetch(
+                cp_rank, kv_block_id, local_q, cur_k, cur_v, attn_mask=True
+            )
+            step_out, step_max, step_sum = _attention_forward(
+                cur_q,
+                cur_k,
+                cur_v,
+                num_heads=num_heads,
+                softmax_scale=softmax_scale,
+                causal=cur_mask is not None,
+                backend=backend,
+            )
+            attn_out, softmax_max, softmax_sum = causal_out_update(
+                cp_rank,
+                kv_block_id,
+                step_out,
+                step_max,
+                step_sum,
+                attn_out,
+                softmax_max,
+                softmax_sum,
+            )
+            kv_block_id = (kv_block_id - 1) % cp_size
+
+        local_outputs.append(attn_out)
+
+    return balanced_cp_restore(torch.cat(local_outputs, dim=2), cp_size=cp_size, dim=2)
+
+
+class AttentionWithCp(torch.autograd.Function):
+    """Causal Ring attention with context parallelism (single ring, full KV cache)."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        num_heads: int,
+        cp_group: dist.ProcessGroup,
+        cp_global_ranks: Sequence[int],
+        softmax_scale: Optional[float] = None,
+        backend: Optional[str] = None,
+        overlap_group: Optional[dist.ProcessGroup] = None,
+    ) -> Tensor:
+        backend = _default_backend(backend)
+        if softmax_scale is None:
+            softmax_scale = query.shape[-1] ** -0.5
+
+        cp_size = dist.get_world_size(cp_group)
+        rank = dist.get_rank(cp_group)
+        if cp_size < 2:
+            raise ValueError("AttentionWithCp requires cp_size >= 2.")
+
+        # Local shard is already balanced CP-sliced by the caller: [B,H,2S,D]
+        q = as_balanced_halves(query)
+        k = as_balanced_halves(key)
+        v = as_balanced_halves(value)
+
+        ring = RingP2P(cp_global_ranks, cp_group, overlap_group)
+        cur_kv = torch.cat((k.unsqueeze(0), v.unsqueeze(0)), dim=0)
+        next_kv = torch.empty_like(cur_kv)
+
+        attn_out = softmax_max = softmax_sum = None
+        kv_block_id = rank
+        cached_k = []
+        cached_v = []
+
+        for step in range(cp_size):
+            if step < cp_size - 1:
+                ring.async_send_recv(cur_kv, next_kv)
+
+            cur_k, cur_v = cur_kv[0], cur_kv[1]
+            cached_k.append(cur_k.clone())
+            cached_v.append(cur_v.clone())
+
+            cur_q, step_k, step_v, cur_mask = causal_forward_fetch(
+                rank, kv_block_id, q, cur_k, cur_v, attn_mask=True
+            )
+            step_out, step_max, step_sum = _attention_forward(
+                cur_q,
+                step_k,
+                step_v,
+                num_heads=num_heads,
+                softmax_scale=softmax_scale,
+                causal=cur_mask is not None,
+                backend=backend,
+            )
+            attn_out, softmax_max, softmax_sum = causal_out_update(
+                rank,
+                kv_block_id,
+                step_out,
+                step_max,
+                step_sum,
+                attn_out,
+                softmax_max,
+                softmax_sum,
+            )
+
+            if ring.wait():
+                cur_kv, next_kv = next_kv, cur_kv
+            kv_block_id = (kv_block_id - 1) % cp_size
+
+        # Save KV in reverse visitation order for backward replay:
+        # forward visits rank, rank-1, ..., so cache[0]=local, cache[-1]=last received.
+        # Backward visits in reverse: start from last received KV.
+        k_stack = torch.stack(cached_k[::-1], dim=0)
+        v_stack = torch.stack(cached_v[::-1], dim=0)
+        ctx.save_for_backward(q, k_stack, v_stack, attn_out, softmax_max, softmax_sum)
+        ctx.num_heads = num_heads
+        ctx.softmax_scale = float(softmax_scale)
+        ctx.backend = backend
+        ctx.cp_size = cp_size
+        ctx.rank = rank
+        ctx.cp_global_ranks = list(cp_global_ranks)
+        ctx.cp_group = cp_group
+        ctx.overlap_group = overlap_group
+        # Final kv_block_id after forward loop points at the next (unused) block;
+        # last computed block was (rank - (cp_size-1)) % cp_size.
+        ctx.final_kv_block_id = (rank - (cp_size - 1)) % cp_size
+        return attn_out
+
+    @staticmethod
+    def backward(ctx, dout: Tensor):
+        q, k_stack, v_stack, attn_out, softmax_max, softmax_sum = ctx.saved_tensors
+        cp_size = ctx.cp_size
+        rank = ctx.rank
+        backend = ctx.backend
+        softmax_scale = ctx.softmax_scale
+        num_heads = ctx.num_heads
+
+        dout_h = as_balanced_halves(dout)
+        attn_out_h = as_balanced_halves(attn_out)
+        softmax_max_h = as_balanced_halves(softmax_max)
+        softmax_sum_h = as_balanced_halves(softmax_sum)
+
+        # Full-cache replay: KV comes from forward saves; only dKV travels the ring.
+        dkv_ring = RingP2P(ctx.cp_global_ranks, ctx.cp_group, ctx.overlap_group, is_backward=True)
+        cur_dkv = torch.zeros((2, *k_stack[0].shape), dtype=k_stack[0].dtype, device=k_stack[0].device)
+        next_dkv = torch.zeros_like(cur_dkv)
+
+        dq = torch.zeros_like(q)
+        kv_block_id = ctx.final_kv_block_id
+
+        for step in range(cp_size):
+            cur_k = k_stack[step]
+            cur_v = v_stack[step]
+            step_q, step_k, step_v, step_out, step_dout, step_max, step_sum, step_mask = causal_backward_fetch(
+                rank,
+                kv_block_id,
+                q,
+                cur_k,
+                cur_v,
+                attn_out_h,
+                dout_h,
+                softmax_max_h,
+                softmax_sum_h,
+                attn_mask=True,
+            )
+            dq_step, dk_step, dv_step = _attention_backward(
+                step_q,
+                step_k,
+                step_v,
+                step_dout,
+                step_out,
+                step_max,
+                step_sum,
+                num_heads=num_heads,
+                softmax_scale=softmax_scale,
+                causal=step_mask is not None,
+                backend=backend,
+            )
+
+            if step > 0:
+                dkv_ring.wait()
+                cur_dkv, next_dkv = next_dkv, cur_dkv
+
+            dk, dv = cur_dkv[0], cur_dkv[1]
+            causal_grad_update(rank, kv_block_id, dq_step, dk_step, dv_step, dq, dk, dv)
+
+            if step < cp_size - 1:
+                dkv_ring.async_send_recv(cur_dkv, next_dkv)
+
+            kv_block_id = (kv_block_id + 1) % cp_size
+
+        if dkv_ring.wait():
+            cur_dkv, next_dkv = next_dkv, cur_dkv
+
+        dk, dv = cur_dkv[0], cur_dkv[1]
+        return (
+            flatten_balanced_halves(dq),
+            flatten_balanced_halves(dk),
+            flatten_balanced_halves(dv),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def ringattn_context_parallel(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    num_heads: int,
+    cp_group: dist.ProcessGroup,
+    cp_global_ranks: Sequence[int],
+    softmax_scale: Optional[float] = None,
+    backend: Optional[str] = None,
+    overlap_group: Optional[dist.ProcessGroup] = None,
+    cu_seqlens: Optional[Tensor] = None,
+) -> Tensor:
+    """Public entry for causal Ring CP attention over already-sliced local Q/K/V.
+
+    When ``cu_seqlens`` is provided, runs per-sample Ring (no cross-sample attention).
+    Local sample lengths must already match the packed CP partition.
+    """
+    if cu_seqlens is None:
+        return AttentionWithCp.apply(
+            query,
+            key,
+            value,
+            num_heads,
+            cp_group,
+            list(cp_global_ranks),
+            softmax_scale,
+            backend,
+            overlap_group,
+        )
+
+    cu = cu_seqlens.detach().to(device="cpu").tolist()
+    if query.size(0) != 1:
+        raise ValueError(f"Packed Ring CP currently supports batch=1, got {query.shape}.")
+    outs = []
+    for start, end in zip(cu[:-1], cu[1:]):
+        start, end = int(start), int(end)
+        if end <= start:
+            continue
+        outs.append(
+            AttentionWithCp.apply(
+                query[:, :, start:end],
+                key[:, :, start:end],
+                value[:, :, start:end],
+                num_heads,
+                cp_group,
+                list(cp_global_ranks),
+                softmax_scale,
+                backend,
+                overlap_group,
+            )
+        )
+    if not outs:
+        return query.new_empty(query.shape)
+    return torch.cat(outs, dim=2)
+
+
+def simulate_packed_ring_causal_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    cu_seqlens: Tensor,
+    *,
+    cp_size: int,
+    softmax_scale: Optional[float] = None,
+    backend: str = "torch",
+) -> Tensor:
+    """Per-sample Ring CP simulation (no cross-sample leakage)."""
+    from .attention_backend import torch_packed_causal_attention  # noqa: F401 — kept for API symmetry
+
+    if softmax_scale is None:
+        softmax_scale = query.shape[-1] ** -0.5
+    cu = cu_seqlens.detach().cpu().tolist()
+    outs = []
+    for start, end in zip(cu[:-1], cu[1:]):
+        start, end = int(start), int(end)
+        outs.append(
+            simulate_ring_causal_attention(
+                query[:, :, start:end],
+                key[:, :, start:end],
+                value[:, :, start:end],
+                cp_size=cp_size,
+                softmax_scale=softmax_scale,
+                backend=backend,
+            )
+        )
+    return torch.cat(outs, dim=2)
+
+
+def dense_causal_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    softmax_scale: Optional[float] = None,
+) -> Tensor:
+    """Reference dense causal attention (BNSD, GQA-aware)."""
+    if softmax_scale is None:
+        softmax_scale = query.shape[-1] ** -0.5
+    out, _, _ = torch_attention_forward(query, key, value, softmax_scale=softmax_scale, causal=True)
+    return out

--- a/veomni/distributed/context_parallel/ring_p2p.py
+++ b/veomni/distributed/context_parallel/ring_p2p.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2024, Huawei Technologies Co., Ltd.  All rights reserved.
+# Ported from MindSpeed RingP2P (BSD-3-Clause) for Open-VeOmni context parallel.
+"""Ring isend/irecv helpers for context-parallel KV exchange."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Union
+
+import torch
+import torch.distributed as dist
+from torch import Tensor
+
+
+TensorOrPair = Union[Tensor, List[Tensor]]
+
+
+class RingP2P:
+    """Even/odd ordered P2P send/recv on a ring of global ranks."""
+
+    def __init__(
+        self,
+        ring_global_ranks: Sequence[int],
+        group: dist.ProcessGroup,
+        group_for_send_recv_overlap: Optional[dist.ProcessGroup] = None,
+        is_backward: bool = False,
+    ) -> None:
+        self.group = group
+        self.group_for_send_recv_overlap = (
+            group if group_for_send_recv_overlap is None else group_for_send_recv_overlap
+        )
+
+        global_rank = dist.get_rank()
+        ring_rank = list(ring_global_ranks).index(global_rank)
+        ring_size = len(ring_global_ranks)
+        self.next = ring_global_ranks[(ring_rank + 1) % ring_size]
+        self.prev = ring_global_ranks[(ring_rank + ring_size - 1) % ring_size]
+        self.ring_rank = ring_rank
+        if is_backward:
+            self.next, self.prev = self.prev, self.next
+
+        self.send_recv_ops: list[dist.Work] = []
+        self._packed_recv = None
+
+    def async_send_recv(self, send_tensor: TensorOrPair, recv_tensor: TensorOrPair) -> None:
+        """Launch even/odd isend/irecv. Supports a single tensor or a mutable [K, V] list."""
+        self._packed_recv = None
+        packed = isinstance(send_tensor, list)
+        if packed:
+            if not isinstance(recv_tensor, list) or len(send_tensor) != 2 or len(recv_tensor) != 2:
+                raise ValueError("Packed RingP2P tensors must be length-2 mutable lists [K, V].")
+            k_send, v_send = send_tensor
+            k_recv, v_recv = recv_tensor
+            if k_send.shape != k_recv.shape or v_send.shape != v_recv.shape:
+                raise ValueError(
+                    "Shape mismatch in KV tensors:\n"
+                    f"  k_send: {k_send.shape} vs k_recv: {k_recv.shape}\n"
+                    f"  v_send: {v_send.shape} vs v_recv: {v_recv.shape}"
+                )
+            k_shape, v_shape = k_send.shape, v_send.shape
+            k_numel = k_send.numel()
+            send_payload = torch.cat((k_send.reshape(-1), v_send.reshape(-1)), dim=0).contiguous()
+            recv_payload = torch.empty_like(send_payload)
+        else:
+            send_payload = send_tensor.contiguous()
+            recv_payload = recv_tensor
+            k_numel = k_shape = v_shape = None
+
+        if self.ring_rank % 2 == 0:
+            send_op = dist.isend(send_payload, self.next, self.group)
+            recv_op = dist.irecv(recv_payload, self.prev, self.group_for_send_recv_overlap)
+            self.send_recv_ops.extend((send_op, recv_op))
+        else:
+            recv_op = dist.irecv(recv_payload, self.prev, self.group)
+            send_op = dist.isend(send_payload, self.next, self.group_for_send_recv_overlap)
+            self.send_recv_ops.extend((recv_op, send_op))
+
+        if packed:
+            self._packed_recv = (recv_tensor, recv_payload, k_numel, k_shape, v_shape)
+
+    def wait(self) -> int:
+        """Wait for outstanding P2P ops. Returns 1 if work completed, else 0."""
+        if not self.send_recv_ops:
+            return 0
+        for op in self.send_recv_ops:
+            op.wait()
+        self.send_recv_ops = []
+        if self._packed_recv is not None:
+            recv_tensor, recv_payload, k_numel, k_shape, v_shape = self._packed_recv
+            recv_tensor[0] = recv_payload[:k_numel].view(k_shape)
+            recv_tensor[1] = recv_payload[k_numel:].view(v_shape)
+            self._packed_recv = None
+        return 1

--- a/veomni/distributed/context_parallel/sharding.py
+++ b/veomni/distributed/context_parallel/sharding.py
@@ -1,0 +1,83 @@
+import torch
+from torch import Tensor
+
+
+def _validate_parallel_coordinate(size: int, rank: int, name: str) -> None:
+    if size < 1:
+        raise ValueError(f"{name}_size must be positive, got {size}.")
+    if not 0 <= rank < size:
+        raise ValueError(f"{name}_rank must be in [0, {size}), got {rank}.")
+
+
+def balanced_cp_slice(tensor: Tensor, cp_size: int, cp_rank: int, dim: int = 0) -> Tensor:
+    """Select the mirrored two-chunk causal partition for one CP rank."""
+    _validate_parallel_coordinate(cp_size, cp_rank, "cp")
+    dim = dim % tensor.ndim
+    sequence_length = tensor.size(dim)
+    num_chunks = 2 * cp_size
+    if sequence_length % num_chunks != 0:
+        raise ValueError(
+            f"Sequence length ({sequence_length}) must be divisible by 2 * cp_size ({num_chunks}) "
+            "for balanced causal CP sharding."
+        )
+
+    chunks = tensor.chunk(num_chunks, dim=dim)
+    return torch.cat((chunks[cp_rank], chunks[num_chunks - cp_rank - 1]), dim=dim).contiguous()
+
+
+def balanced_cp_restore(tensor: Tensor, cp_size: int, dim: int = 0) -> Tensor:
+    """Restore canonical sequence order from rank-major balanced CP shards."""
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be positive, got {cp_size}.")
+    dim = dim % tensor.ndim
+    num_chunks = 2 * cp_size
+    if tensor.size(dim) % num_chunks != 0:
+        raise ValueError(
+            f"Gathered sequence length ({tensor.size(dim)}) must be divisible by 2 * cp_size ({num_chunks})."
+        )
+
+    rank_major_chunks = tensor.chunk(num_chunks, dim=dim)
+    canonical_chunks = [None] * num_chunks
+    for cp_rank in range(cp_size):
+        canonical_chunks[cp_rank] = rank_major_chunks[2 * cp_rank]
+        canonical_chunks[num_chunks - cp_rank - 1] = rank_major_chunks[2 * cp_rank + 1]
+    return torch.cat(canonical_chunks, dim=dim).contiguous()
+
+
+def balanced_cp_to_rank_major(tensor: Tensor, cp_size: int, dim: int = 0) -> Tensor:
+    """Convert canonical sequence order to rank-major balanced CP layout."""
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be positive, got {cp_size}.")
+    dim = dim % tensor.ndim
+    num_chunks = 2 * cp_size
+    if tensor.size(dim) % num_chunks != 0:
+        raise ValueError(
+            f"Sequence length ({tensor.size(dim)}) must be divisible by 2 * cp_size ({num_chunks})."
+        )
+
+    canonical_chunks = tensor.chunk(num_chunks, dim=dim)
+    rank_major_chunks = []
+    for cp_rank in range(cp_size):
+        rank_major_chunks.append(canonical_chunks[cp_rank])
+        rank_major_chunks.append(canonical_chunks[num_chunks - cp_rank - 1])
+    return torch.cat(rank_major_chunks, dim=dim).contiguous()
+
+
+def hybrid_cp_slice(
+    tensor: Tensor,
+    cp_size: int,
+    cp_rank: int,
+    ulysses_size: int,
+    ulysses_rank: int,
+    dim: int = 0,
+) -> Tensor:
+    """Apply balanced Ring-CP sharding followed by contiguous Ulysses sharding."""
+    _validate_parallel_coordinate(ulysses_size, ulysses_rank, "ulysses")
+    cp_shard = balanced_cp_slice(tensor, cp_size=cp_size, cp_rank=cp_rank, dim=dim)
+    dim = dim % cp_shard.ndim
+    if cp_shard.size(dim) % ulysses_size != 0:
+        raise ValueError(
+            f"CP-local sequence length ({cp_shard.size(dim)}) must be divisible by "
+            f"ulysses_size ({ulysses_size})."
+        )
+    return cp_shard.chunk(ulysses_size, dim=dim)[ulysses_rank].contiguous()

--- a/veomni/distributed/context_parallel/softmax_update.py
+++ b/veomni/distributed/context_parallel/softmax_update.py
@@ -1,0 +1,78 @@
+import torch
+from torch import Tensor
+
+
+def _output_scale(statistic: Tensor, output: Tensor) -> Tensor:
+    scale = statistic[..., :1]
+    if scale.ndim != output.ndim:
+        raise ValueError(
+            f"Softmax statistic rank ({scale.ndim}) must match attention output rank ({output.ndim})."
+        )
+    if scale.shape[:-1] != output.shape[:-1]:
+        raise ValueError(
+            f"Softmax statistic prefix {scale.shape[:-1]} must match attention output prefix {output.shape[:-1]}."
+        )
+    return scale
+
+
+def merge_attention_blocks(
+    previous_output: Tensor,
+    previous_softmax_max: Tensor,
+    previous_softmax_sum: Tensor,
+    current_output: Tensor,
+    current_softmax_max: Tensor,
+    current_softmax_sum: Tensor,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Merge independently normalized attention blocks with online softmax."""
+    if previous_output.shape != current_output.shape:
+        raise ValueError(
+            f"Attention output shapes must match, got {previous_output.shape} and {current_output.shape}."
+        )
+    if previous_softmax_max.shape != current_softmax_max.shape:
+        raise ValueError(
+            "Softmax max shapes must match, got "
+            f"{previous_softmax_max.shape} and {current_softmax_max.shape}."
+        )
+    if previous_softmax_sum.shape != current_softmax_sum.shape:
+        raise ValueError(
+            "Softmax sum shapes must match, got "
+            f"{previous_softmax_sum.shape} and {current_softmax_sum.shape}."
+        )
+
+    accumulator_dtype = torch.promote_types(previous_output.dtype, current_output.dtype)
+    if accumulator_dtype in (torch.float16, torch.bfloat16):
+        accumulator_dtype = torch.float32
+    previous_max = previous_softmax_max.to(accumulator_dtype)
+    current_max = current_softmax_max.to(accumulator_dtype)
+    merged_max = torch.maximum(previous_max, current_max)
+
+    previous_finite = torch.isfinite(previous_max)
+    current_finite = torch.isfinite(current_max)
+    previous_scale = torch.where(
+        previous_finite,
+        torch.exp(previous_max - torch.where(previous_finite, merged_max, previous_max)),
+        torch.zeros_like(previous_max),
+    )
+    current_scale = torch.where(
+        current_finite,
+        torch.exp(current_max - torch.where(current_finite, merged_max, current_max)),
+        torch.zeros_like(current_max),
+    )
+
+    previous_sum_scaled = previous_softmax_sum.to(accumulator_dtype) * previous_scale
+    current_sum_scaled = current_softmax_sum.to(accumulator_dtype) * current_scale
+    merged_sum = previous_sum_scaled + current_sum_scaled
+    nonzero_sum = merged_sum > 0
+    previous_weight = torch.where(nonzero_sum, previous_sum_scaled / merged_sum, torch.zeros_like(merged_sum))
+    current_weight = torch.where(nonzero_sum, current_sum_scaled / merged_sum, torch.zeros_like(merged_sum))
+
+    previous_output_weight = _output_scale(previous_weight, previous_output)
+    current_output_weight = _output_scale(current_weight, current_output)
+    output = previous_output.to(accumulator_dtype) * previous_output_weight
+    output = output + current_output.to(accumulator_dtype) * current_output_weight
+
+    return (
+        output.to(previous_output.dtype),
+        merged_max.to(previous_softmax_max.dtype),
+        merged_sum.to(previous_softmax_sum.dtype),
+    )

--- a/veomni/distributed/context_parallel/topology.py
+++ b/veomni/distributed/context_parallel/topology.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 ByteDance AI4SE.
+"""Hybrid CP × Ulysses rank topology helpers.
+
+Canonical layout (matches ``init_sequence_parallel``):
+    sp_rank = cp_rank * ulysses_size + ulysses_rank
+
+DeviceMesh dim order must therefore be ``cp`` then ``ulysses`` (CP outer,
+Ulysses inner) so flattened ``sp`` ranks agree with legacy group construction.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def validate_hybrid_sizes(cp_size: int, ulysses_size: int) -> None:
+    if cp_size < 1 or ulysses_size < 1:
+        raise ValueError(f"cp_size and ulysses_size must be >= 1, got {cp_size}, {ulysses_size}.")
+
+
+def sp_rank_from_coords(cp_rank: int, ulysses_rank: int, ulysses_size: int) -> int:
+    validate_hybrid_sizes(1, ulysses_size)
+    return cp_rank * ulysses_size + ulysses_rank
+
+
+def coords_from_sp_rank(sp_rank: int, cp_size: int, ulysses_size: int) -> tuple[int, int]:
+    validate_hybrid_sizes(cp_size, ulysses_size)
+    if not 0 <= sp_rank < cp_size * ulysses_size:
+        raise ValueError(f"sp_rank {sp_rank} out of range for CP{cp_size}×U{ulysses_size}.")
+    cp_rank = sp_rank // ulysses_size
+    ulysses_rank = sp_rank % ulysses_size
+    return cp_rank, ulysses_rank
+
+
+def cp_global_ranks_for_ulysses_rank(
+    *,
+    dp_index: int,
+    ulysses_rank: int,
+    cp_size: int,
+    ulysses_size: int,
+) -> list[int]:
+    """Global ranks that form one CP ring (fixed DP + Ulysses coordinate)."""
+    validate_hybrid_sizes(cp_size, ulysses_size)
+    unified = cp_size * ulysses_size
+    start = dp_index * unified + ulysses_rank
+    return list(range(start, (dp_index + 1) * unified, ulysses_size))
+
+
+def ulysses_global_ranks_for_cp_rank(
+    *,
+    dp_index: int,
+    cp_rank: int,
+    cp_size: int,
+    ulysses_size: int,
+) -> list[int]:
+    """Global ranks that form one Ulysses group (fixed DP + CP coordinate)."""
+    validate_hybrid_sizes(cp_size, ulysses_size)
+    unified = cp_size * ulysses_size
+    start = dp_index * unified + cp_rank * ulysses_size
+    return list(range(start, start + ulysses_size))
+
+
+def ordered_cp_global_ranks(group_ranks: Sequence[int]) -> list[int]:
+    """Return CP ring ranks sorted by CP rank (ascending)."""
+    return sorted(group_ranks)

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -69,6 +69,9 @@ class ParallelState:
     device_type: str = get_device_type()
     include_sp_in_fsdp: bool = True
     device_mesh: Optional["DeviceMesh"] = None
+    # Ascend torch_npu may leave DeviceMesh._flatten_mapping empty; keep the
+    # 1D mesh returned by _flatten(mesh_dim_name="sp") for get_group/get_local_rank.
+    _sp_mesh: Optional["DeviceMesh"] = field(default=None, repr=False, compare=False)
     extra_parallel_names: Tuple[str] = ("ep",)
     extra_parallel_sizes: Dict[str, int] = field(default_factory=lambda: {"ep": 1})
     extra_parallel_fsdp_device_mesh: Dict[str, Optional["DeviceMesh"]] = field(default_factory=lambda: {"ep": None})
@@ -79,7 +82,11 @@ class ParallelState:
             raise NotImplementedError("Decoupled sequence parallel has not been implemented.")
 
         if self.cp_size > 1:
-            raise NotImplementedError("Ring attention is not supported yet.")
+            # Ring CP kernel lives in veomni.distributed.context_parallel.
+            logger.info_rank0(
+                f"Context parallel enabled: cp_size={self.cp_size}, "
+                f"ulysses_size={self.ulysses_size}, sp_size={self.sp_size}."
+            )
 
         if self.pp_size * self.dp_size * self.cp_size * self.ulysses_size * self.tp_size != self.world_size:
             raise ValueError("The product of parallel sizes should be equal to the world size.")
@@ -362,16 +369,43 @@ class ParallelState:
     # ------------------------------ SP ------------------------------ #
     @property
     def sp_group(self) -> Optional["ProcessGroup"]:
-        if self.device_mesh is not None and self.sp_enabled:
+        if self.device_mesh is None or not self.sp_enabled:
+            return None
+        # Prefer explicit flattened SP mesh (required on Ascend where root
+        # get_group("sp") KeyErrors despite init-time _flatten).
+        if self._sp_mesh is not None:
+            return self._sp_mesh.get_group()
+        try:
             return self.device_mesh.get_group("sp")
-
+        except Exception:
+            pass
+        if self.cp_enabled and not self.ulysses_enabled:
+            return self.device_mesh.get_group("cp")
+        if self.ulysses_enabled and not self.cp_enabled:
+            return self.device_mesh.get_group("ulysses")
+        if self.cp_enabled and self.ulysses_enabled:
+            # Last resort: flatten now and cache.
+            flat = self.device_mesh[("cp", "ulysses")]._flatten(mesh_dim_name="sp")
+            object.__setattr__(self, "_sp_mesh", flat)
+            return flat.get_group()
         return None
 
     @property
     def sp_rank(self) -> int:
-        if self.device_mesh is not None and self.sp_enabled:
+        if self.device_mesh is None or not self.sp_enabled:
+            return -1
+        if self._sp_mesh is not None:
+            return self._sp_mesh.get_local_rank()
+        try:
             return self.device_mesh.get_local_rank("sp")
-
+        except Exception:
+            pass
+        if self.cp_enabled and not self.ulysses_enabled:
+            return self.device_mesh.get_local_rank("cp")
+        if self.ulysses_enabled and not self.cp_enabled:
+            return self.device_mesh.get_local_rank("ulysses")
+        if self.cp_enabled and self.ulysses_enabled and self.sp_group is not None:
+            return dist.get_rank(self.sp_group)
         return -1
 
     @property
@@ -544,9 +578,11 @@ def init_parallel_state(
 
     mesh_shape = []
     mesh_dim_names = []
+    # CP outer / Ulysses inner: matches init_sequence_parallel layout
+    # sp_rank = cp_rank * ulysses_size + ulysses_rank.
     for d, dim_name in zip(
-        [pp_size, dp_replicate_size, dp_shard_size, ulysses_size, cp_size, tp_size],
-        ["pp", "dp_replicate", "dp_shard", "ulysses", "cp", "tp"],
+        [pp_size, dp_replicate_size, dp_shard_size, cp_size, ulysses_size, tp_size],
+        ["pp", "dp_replicate", "dp_shard", "cp", "ulysses", "tp"],
     ):
         if d > 1 or dim_name in ["dp_shard"]:
             mesh_shape.append(d)
@@ -574,14 +610,15 @@ def init_parallel_state(
         dp_mesh_dim_names.append("dp_shard")
         dp_shard_sp_mesh_dim_names.append("dp_shard")
         dp_sp_mesh_dim_names.append("dp_shard")
-    if ulysses_size > 1:
-        dp_shard_sp_mesh_dim_names.append("ulysses")
-        sp_mesh_dim_names.append("ulysses")
-        dp_sp_mesh_dim_names.append("ulysses")
+    # Flatten order must keep CP before Ulysses so sp_rank matches legacy groups.
     if cp_size > 1:
         dp_shard_sp_mesh_dim_names.append("cp")
         sp_mesh_dim_names.append("cp")
         dp_sp_mesh_dim_names.append("cp")
+    if ulysses_size > 1:
+        dp_shard_sp_mesh_dim_names.append("ulysses")
+        sp_mesh_dim_names.append("ulysses")
+        dp_sp_mesh_dim_names.append("ulysses")
 
     if dp_mesh_dim_names != []:
         device_mesh[tuple(dp_mesh_dim_names)]._flatten(mesh_dim_name="dp")
@@ -592,8 +629,9 @@ def init_parallel_state(
     if dp_sp_mesh_dim_names != []:
         device_mesh[tuple(dp_sp_mesh_dim_names)]._flatten(mesh_dim_name="dp_sp")
 
+    sp_mesh = None
     if sp_mesh_dim_names != []:
-        device_mesh[tuple(sp_mesh_dim_names)]._flatten(mesh_dim_name="sp")
+        sp_mesh = device_mesh[tuple(sp_mesh_dim_names)]._flatten(mesh_dim_name="sp")
 
     for para_size, para_outside, para_name in zip(
         extra_parallel_sizes, extra_parallel_placement_innermost, extra_parallel_names
@@ -642,6 +680,7 @@ def init_parallel_state(
         device_type=device_type,
         include_sp_in_fsdp=include_sp_in_fsdp,
         device_mesh=device_mesh,
+        _sp_mesh=sp_mesh,
         extra_parallel_names=extra_parallel_names,
         extra_parallel_sizes=dict(zip(extra_parallel_names, extra_parallel_sizes)),
         extra_parallel_fsdp_device_mesh=extra_parallel_fsdp_device_mesh,

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -662,19 +662,25 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
-        # Modification: Ulysses SP all-to-all for linear attention heads.
-        ulysses_enabled = get_parallel_state().ulysses_enabled
-        if ulysses_enabled:
-            ulysses_group = get_parallel_state().ulysses_group
-            ulysses_size = get_parallel_state().ulysses_size
-            ulysses_rank = get_parallel_state().ulysses_rank
-            assert self.num_k_heads % ulysses_size == 0 and self.num_v_heads % ulysses_size == 0, (
-                f"SP size ({ulysses_size}) must divide num_k_heads ({self.num_k_heads}) "
+        # Modification: Ulysses / unified-SP all-to-all for linear attention heads.
+        # CP>1 uses unified SP + zigzag restore (not Ring). Ulysses-only unchanged.
+        from veomni.distributed.context_parallel.gdn_sp import (
+            maybe_restore_canonical,
+            maybe_to_rank_major,
+            resolve_gdn_sp_group,
+        )
+
+        gdn_sp_group, gdn_sp_size, gdn_head_rank, gdn_need_zigzag = resolve_gdn_sp_group()
+        gdn_sp_enabled = gdn_sp_group is not None
+        cp_size_for_gdn = get_parallel_state().cp_size if gdn_need_zigzag else 1
+        if gdn_sp_enabled:
+            assert self.num_k_heads % gdn_sp_size == 0 and self.num_v_heads % gdn_sp_size == 0, (
+                f"SP size ({gdn_sp_size}) must divide num_k_heads ({self.num_k_heads}) "
                 f"and num_v_heads ({self.num_v_heads}) for gated deltanet LASP"
             )
 
-            local_num_k_heads = self.num_k_heads // ulysses_size
-            local_num_v_heads = self.num_v_heads // ulysses_size
+            local_num_k_heads = self.num_k_heads // gdn_sp_size
+            local_num_v_heads = self.num_v_heads // gdn_sp_size
             local_key_dim = self.head_k_dim * local_num_k_heads
             local_value_dim = self.head_v_dim * local_num_v_heads
 
@@ -685,14 +691,20 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             v_proj = v_proj.reshape(batch_size, seq_len, self.num_v_heads, self.head_v_dim)
 
             # All-to-all: gather full sequence, scatter heads -> [B, S_full, local_heads, head_dim]
-            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=ulysses_group)
-            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=ulysses_group)
-            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=ulysses_group)
+            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
 
             b = b.reshape(batch_size, seq_len, self.num_v_heads)
             a = a.reshape(batch_size, seq_len, self.num_v_heads)
-            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=ulysses_group)
-            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=ulysses_group)
+            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=gdn_sp_group)
+
+            q_proj = maybe_restore_canonical(q_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            k_proj = maybe_restore_canonical(k_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            v_proj = maybe_restore_canonical(v_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            b = maybe_restore_canonical(b, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            a = maybe_restore_canonical(a, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
 
             # Flatten heads back to channels and concat for conv1d: [B, S_full, local_dim]
             q_proj = q_proj.reshape(q_proj.shape[0], q_proj.shape[1], -1)
@@ -704,6 +716,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             local_num_v_heads = self.num_v_heads
             local_key_dim = self.key_dim
             local_value_dim = self.value_dim
+            gdn_head_rank = 0
 
         if use_precomputed_states:
             # Modification: keep this disabled until FLA causal_conv1d_update decode path is validated.
@@ -714,10 +727,10 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                 conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
                 cache_params.conv_states[self.layer_idx] = conv_state
             if self.causal_conv1d_fn is not None:
-                # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
-                if ulysses_enabled:
+                # Modification: shard conv1d weights per SP rank to match head-sharded channels.
+                if gdn_sp_enabled:
                     conv_weight = self._get_local_conv1d_weight(
-                        ulysses_rank=ulysses_rank,
+                        ulysses_rank=gdn_head_rank,
                         local_key_dim=local_key_dim,
                         local_value_dim=local_value_dim,
                     )
@@ -767,9 +780,9 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
         beta = b.sigmoid()
         # If the model is loaded in fp16, without the .float() here, A might be -inf
-        # Modification: slice A_log/dt_bias for local V-heads under Ulysses SP.
-        if ulysses_enabled:
-            v_head_offset = ulysses_rank * local_num_v_heads
+        # Modification: slice A_log/dt_bias for local V-heads under SP.
+        if gdn_sp_enabled:
+            v_head_offset = gdn_head_rank * local_num_v_heads
             v_head_slice = slice(v_head_offset, v_head_offset + local_num_v_heads)
             g = -self.A_log[v_head_slice].float().exp() * F.softplus(a.float() + self.dt_bias[v_head_slice])
         else:
@@ -821,9 +834,12 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
 
         # Modification: gather attention output back to sequence-sharded layout before gated norm.
-        if ulysses_enabled:
+        if gdn_sp_enabled:
+            core_attn_out = maybe_to_rank_major(
+                core_attn_out, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1
+            )
             core_attn_out = gather_heads_scatter_seq(
-                core_attn_out, head_dim=2, seq_dim=1, group=get_parallel_state().ulysses_group
+                core_attn_out, head_dim=2, seq_dim=1, group=gdn_sp_group
             )
 
         # reshape input data into 2D tensor

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -675,6 +675,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             resolve_gdn_parallel_plan,
             scale_cp_repeated_parameter_grad,
         )
+        from veomni.distributed.context_parallel.gdn_kcp import resolve_kcp_initial_state
         from veomni.distributed.context_parallel.gdn_scan_cp import (
             align_gdn_varlen_for_mojo_gdr,
             apply_sample_bos_zero_s_init,
@@ -698,12 +699,10 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         gdn_head_parallel = gdn_plan.head_parallel_enabled
         gdn_cp_sequence = gdn_plan.cp_sequence_enabled
         gdn_impl = gdn_cp_impl_name(cp_size=gdn_plan.cp_size)
-        gdn_state_passing = gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_STATE_PASSING_SERIAL
+        gdn_serial = gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_STATE_PASSING_SERIAL
+        gdn_kcp = gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_KCP
+        gdn_state_passing = gdn_serial or gdn_kcp
         gdn_gather_full = gdn_cp_sequence and not gdn_state_passing
-        if gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_KCP:
-            raise NotImplementedError(
-                "gdn_cp_impl=kcp is not implemented yet; use state_passing_serial or gather_full_replicated."
-            )
         if gdn_cp_sequence:
             log_gdn_cp_impl_once(cp_size=gdn_plan.cp_size)
         gdn_head_rank = gdn_plan.ulysses_rank if gdn_head_parallel else 0
@@ -969,26 +968,14 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                 )
             else:
                 if gdn_state_passing:
-                    state_template = make_gdn_state_template(query, value, cu_seqlens=gdn_core_cu)
-                    s_init = recv_serial_initial_state(
-                        cp_group=gdn_plan.cp_group,
-                        cp_size=gdn_plan.cp_size,
-                        cp_rank=gdn_plan.cp_rank,
-                        state_template=state_template,
-                    )
                     _bos = sample_bos_flags_for_per_sample_cp(
-                        num_seqs=int(state_template.shape[0]),
+                        num_seqs=int(
+                            (gdn_core_cu.numel() - 1)
+                            if gdn_core_cu is not None
+                            else query.shape[0]
+                        ),
                         cp_rank=gdn_plan.cp_rank,
                     )
-                    s_init = apply_sample_bos_zero_s_init(s_init, sample_bos_on_rank=_bos)
-                    assert_serial_initial_state_contract(
-                        s_init,
-                        cp_rank=gdn_plan.cp_rank,
-                        sample_bos_on_rank=_bos,
-                        cu_seqlens=gdn_core_cu,
-                    )
-                    # Keep GPU path aligned with NPU Mojo: pad segments to chunk=32
-                    # before requesting final_state (no-op when already aligned).
                     (
                         query_gdr,
                         key_gdr,
@@ -1000,28 +987,76 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                     ) = align_gdn_varlen_for_mojo_gdr(
                         query, key, value, g, beta, gdn_core_cu
                     )
-                    core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
-                        query_gdr,
-                        key_gdr,
-                        value_gdr,
-                        g=g_gdr,
-                        beta=beta_gdr,
-                        initial_state=s_init,
-                        output_final_state=True,
-                        use_qk_l2norm_in_kernel=True,
-                        cu_seqlens=gdn_cu_aligned,
-                    )
-                    core_attn_out = unpad_gdn_varlen_output(core_attn_out, gdr_unpad_index)
-                    if last_recurrent_state is None:
-                        raise RuntimeError(
-                            "state_passing_serial requires chunk_gated_delta_rule to return final_state."
+                    if gdn_kcp:
+                        s_init = resolve_kcp_initial_state(
+                            key_gdr,
+                            value_gdr,
+                            g_gdr,
+                            beta_gdr,
+                            cp_group=gdn_plan.cp_group,
+                            cp_size=gdn_plan.cp_size,
+                            cp_rank=gdn_plan.cp_rank,
+                            cu_seqlens=gdn_cu_aligned,
+                            use_qk_l2norm=True,
+                            sample_bos_on_rank=_bos,
                         )
-                    last_recurrent_state = send_serial_final_state(
-                        last_recurrent_state,
-                        cp_group=gdn_plan.cp_group,
-                        cp_size=gdn_plan.cp_size,
-                        cp_rank=gdn_plan.cp_rank,
-                    )
+                        assert_serial_initial_state_contract(
+                            s_init,
+                            cp_rank=gdn_plan.cp_rank,
+                            sample_bos_on_rank=_bos,
+                            cu_seqlens=gdn_cu_aligned,
+                        )
+                        core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                            query_gdr,
+                            key_gdr,
+                            value_gdr,
+                            g=g_gdr,
+                            beta=beta_gdr,
+                            initial_state=s_init,
+                            output_final_state=False,
+                            use_qk_l2norm_in_kernel=True,
+                            cu_seqlens=gdn_cu_aligned,
+                        )
+                        core_attn_out = unpad_gdn_varlen_output(core_attn_out, gdr_unpad_index)
+                    else:
+                        state_template = make_gdn_state_template(
+                            query_gdr, value_gdr, cu_seqlens=gdn_cu_aligned
+                        )
+                        s_init = recv_serial_initial_state(
+                            cp_group=gdn_plan.cp_group,
+                            cp_size=gdn_plan.cp_size,
+                            cp_rank=gdn_plan.cp_rank,
+                            state_template=state_template,
+                        )
+                        s_init = apply_sample_bos_zero_s_init(s_init, sample_bos_on_rank=_bos)
+                        assert_serial_initial_state_contract(
+                            s_init,
+                            cp_rank=gdn_plan.cp_rank,
+                            sample_bos_on_rank=_bos,
+                            cu_seqlens=gdn_cu_aligned,
+                        )
+                        core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                            query_gdr,
+                            key_gdr,
+                            value_gdr,
+                            g=g_gdr,
+                            beta=beta_gdr,
+                            initial_state=s_init,
+                            output_final_state=True,
+                            use_qk_l2norm_in_kernel=True,
+                            cu_seqlens=gdn_cu_aligned,
+                        )
+                        core_attn_out = unpad_gdn_varlen_output(core_attn_out, gdr_unpad_index)
+                        if last_recurrent_state is None:
+                            raise RuntimeError(
+                                "state_passing_serial requires chunk_gated_delta_rule to return final_state."
+                            )
+                        last_recurrent_state = send_serial_final_state(
+                            last_recurrent_state,
+                            cp_group=gdn_plan.cp_group,
+                            cp_size=gdn_plan.cp_size,
+                            cp_rank=gdn_plan.cp_rank,
+                        )
                 else:
                     # Modification: use direct args and pass cu_seqlens for varlen FLA attention.
                     core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -662,25 +662,71 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
-        # Modification: Ulysses / unified-SP all-to-all for linear attention heads.
-        # CP>1 uses unified SP + zigzag restore (not Ring). Ulysses-only unchanged.
+        # Modification: two-dimensional GDN parallelism.
+        # Ulysses shards heads; CP gathers/scatters sequence without changing heads.
         from veomni.distributed.context_parallel.gdn_sp import (
-            maybe_restore_canonical,
-            maybe_to_rank_major,
-            resolve_gdn_sp_group,
+            GDN_CP_IMPL_KCP,
+            GDN_CP_IMPL_STATE_PASSING_SERIAL,
+            cp_gather_sequence,
+            cp_scatter_sequence,
+            derive_gdn_local_cu_seqlens,
+            gdn_cp_impl_name,
+            log_gdn_cp_impl_once,
+            resolve_gdn_parallel_plan,
+            scale_cp_repeated_parameter_grad,
+        )
+        from veomni.distributed.context_parallel.gdn_scan_cp import (
+            align_gdn_varlen_for_mojo_gdr,
+            apply_sample_bos_zero_s_init,
+            assert_serial_initial_state_contract,
+            conv1d_halo_exchange_packed,
+            make_gdn_state_template,
+            recv_serial_initial_state,
+            repartition_block_to_zigzag_packed,
+            repartition_zigzag_to_block_packed,
+            sample_bos_flags_for_per_sample_cp,
+            send_serial_final_state,
+            trim_conv_halo_packed,
+            unpad_gdn_varlen_output,
+        )
+        from veomni.distributed.context_parallel.packed_sharding import (
+            reorder_sample_major_to_ulysses_rank_major,
+            reorder_ulysses_rank_major_to_sample_major,
         )
 
-        gdn_sp_group, gdn_sp_size, gdn_head_rank, gdn_need_zigzag = resolve_gdn_sp_group()
-        gdn_sp_enabled = gdn_sp_group is not None
-        cp_size_for_gdn = get_parallel_state().cp_size if gdn_need_zigzag else 1
-        if gdn_sp_enabled:
-            assert self.num_k_heads % gdn_sp_size == 0 and self.num_v_heads % gdn_sp_size == 0, (
-                f"SP size ({gdn_sp_size}) must divide num_k_heads ({self.num_k_heads}) "
-                f"and num_v_heads ({self.num_v_heads}) for gated deltanet LASP"
+        gdn_plan = resolve_gdn_parallel_plan()
+        gdn_head_parallel = gdn_plan.head_parallel_enabled
+        gdn_cp_sequence = gdn_plan.cp_sequence_enabled
+        gdn_impl = gdn_cp_impl_name(cp_size=gdn_plan.cp_size)
+        gdn_state_passing = gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_STATE_PASSING_SERIAL
+        gdn_gather_full = gdn_cp_sequence and not gdn_state_passing
+        if gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_KCP:
+            raise NotImplementedError(
+                "gdn_cp_impl=kcp is not implemented yet; use state_passing_serial or gather_full_replicated."
+            )
+        if gdn_cp_sequence:
+            log_gdn_cp_impl_once(cp_size=gdn_plan.cp_size)
+        gdn_head_rank = gdn_plan.ulysses_rank if gdn_head_parallel else 0
+        gdn_head_group = gdn_plan.ulysses_group if gdn_head_parallel else None
+        gdn_ulysses_local_cu = None
+        gdn_cp_local_cu = None
+        if gdn_cp_sequence:
+            if cu_seq_lens_q is None:
+                raise RuntimeError("CP-enabled packed GDN requires global cu_seq_lens_q metadata.")
+            gdn_ulysses_local_cu, gdn_cp_local_cu = derive_gdn_local_cu_seqlens(
+                cu_seq_lens_q,
+                ulysses_size=gdn_plan.ulysses_size,
+                cp_size=gdn_plan.cp_size,
+            )
+        if gdn_head_parallel:
+            assert self.num_k_heads % gdn_plan.ulysses_size == 0 and self.num_v_heads % gdn_plan.ulysses_size == 0, (
+                f"Ulysses size ({gdn_plan.ulysses_size}) must divide num_k_heads ({self.num_k_heads}) "
+                f"and num_v_heads ({self.num_v_heads}) for gated deltanet head parallel; "
+                f"CP size ({gdn_plan.cp_size}) is sequence-only"
             )
 
-            local_num_k_heads = self.num_k_heads // gdn_sp_size
-            local_num_v_heads = self.num_v_heads // gdn_sp_size
+            local_num_k_heads = self.num_k_heads // gdn_plan.ulysses_size
+            local_num_v_heads = self.num_v_heads // gdn_plan.ulysses_size
             local_key_dim = self.head_k_dim * local_num_k_heads
             local_value_dim = self.head_v_dim * local_num_v_heads
 
@@ -691,20 +737,46 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             v_proj = v_proj.reshape(batch_size, seq_len, self.num_v_heads, self.head_v_dim)
 
             # All-to-all: gather full sequence, scatter heads -> [B, S_full, local_heads, head_dim]
-            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
-            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
-            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=gdn_head_group)
+            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=gdn_head_group)
+            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=gdn_head_group)
 
             b = b.reshape(batch_size, seq_len, self.num_v_heads)
             a = a.reshape(batch_size, seq_len, self.num_v_heads)
-            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=gdn_sp_group)
-            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=gdn_head_group)
+            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=gdn_head_group)
 
-            q_proj = maybe_restore_canonical(q_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
-            k_proj = maybe_restore_canonical(k_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
-            v_proj = maybe_restore_canonical(v_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
-            b = maybe_restore_canonical(b, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
-            a = maybe_restore_canonical(a, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            if gdn_cp_sequence:
+                q_proj = reorder_ulysses_rank_major_to_sample_major(
+                    q_proj,
+                    gdn_ulysses_local_cu,
+                    ulysses_size=gdn_plan.ulysses_size,
+                    seq_dim=1,
+                )
+                k_proj = reorder_ulysses_rank_major_to_sample_major(
+                    k_proj,
+                    gdn_ulysses_local_cu,
+                    ulysses_size=gdn_plan.ulysses_size,
+                    seq_dim=1,
+                )
+                v_proj = reorder_ulysses_rank_major_to_sample_major(
+                    v_proj,
+                    gdn_ulysses_local_cu,
+                    ulysses_size=gdn_plan.ulysses_size,
+                    seq_dim=1,
+                )
+                b = reorder_ulysses_rank_major_to_sample_major(
+                    b,
+                    gdn_ulysses_local_cu,
+                    ulysses_size=gdn_plan.ulysses_size,
+                    seq_dim=1,
+                )
+                a = reorder_ulysses_rank_major_to_sample_major(
+                    a,
+                    gdn_ulysses_local_cu,
+                    ulysses_size=gdn_plan.ulysses_size,
+                    seq_dim=1,
+                )
 
             # Flatten heads back to channels and concat for conv1d: [B, S_full, local_dim]
             q_proj = q_proj.reshape(q_proj.shape[0], q_proj.shape[1], -1)
@@ -716,7 +788,61 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             local_num_v_heads = self.num_v_heads
             local_key_dim = self.key_dim
             local_value_dim = self.value_dim
-            gdn_head_rank = 0
+            b = b.reshape(batch_size, seq_len, self.num_v_heads)
+            a = a.reshape(batch_size, seq_len, self.num_v_heads)
+
+        gdn_conv_cu = cu_seq_lens_q
+        gdn_core_cu = cu_seq_lens_q
+        if gdn_gather_full:
+            mixed_qkv = cp_gather_sequence(
+                mixed_qkv,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                seq_dim=1,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+            )
+            b = cp_gather_sequence(
+                b,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                seq_dim=1,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+            )
+            a = cp_gather_sequence(
+                a,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                seq_dim=1,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+            )
+        elif gdn_state_passing:
+            # INV-5: zigzag→contiguous block permutation (still S/cp). Never gather S_full.
+            mixed_qkv = repartition_zigzag_to_block_packed(
+                mixed_qkv,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                cp_rank=gdn_plan.cp_rank,
+                seq_dim=1,
+            )
+            b = repartition_zigzag_to_block_packed(
+                b,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                cp_rank=gdn_plan.cp_rank,
+                seq_dim=1,
+            )
+            a = repartition_zigzag_to_block_packed(
+                a,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                cp_rank=gdn_plan.cp_rank,
+                seq_dim=1,
+            )
+            gdn_conv_cu = gdn_cp_local_cu
+            gdn_core_cu = gdn_cp_local_cu
 
         if use_precomputed_states:
             # Modification: keep this disabled until FLA causal_conv1d_update decode path is validated.
@@ -727,8 +853,8 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                 conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
                 cache_params.conv_states[self.layer_idx] = conv_state
             if self.causal_conv1d_fn is not None:
-                # Modification: shard conv1d weights per SP rank to match head-sharded channels.
-                if gdn_sp_enabled:
+                # Modification: shard conv1d weights per Ulysses rank.
+                if gdn_head_parallel:
                     conv_weight = self._get_local_conv1d_weight(
                         ulysses_rank=gdn_head_rank,
                         local_key_dim=local_key_dim,
@@ -736,16 +862,47 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                     )
                 else:
                     conv_weight = self.conv1d.weight.squeeze(1)
-                # mixed_qkv is [B, S, D] — FLA causal_conv1d expects [B, S, D].
-                mixed_qkv = self.causal_conv1d_fn(
-                    x=mixed_qkv,
-                    weight=conv_weight,
-                    bias=self.conv1d.bias,
-                    activation=self.activation,
-                    seq_idx=None,
-                    backend="triton",
-                    cu_seqlens=cu_seq_lens_q,
-                )[0]
+                if gdn_gather_full:
+                    conv_weight = scale_cp_repeated_parameter_grad(
+                        conv_weight,
+                        cp_size=gdn_plan.cp_size,
+                    )
+                if gdn_state_passing:
+                    mixed_qkv, gdn_conv_cu_halo = conv1d_halo_exchange_packed(
+                        mixed_qkv,
+                        cp_local_cu_seqlens=gdn_cp_local_cu,
+                        kernel_size=self.conv_kernel_size,
+                        cp_group=gdn_plan.cp_group,
+                        cp_size=gdn_plan.cp_size,
+                        cp_rank=gdn_plan.cp_rank,
+                        seq_dim=1,
+                    )
+                    mixed_qkv = self.causal_conv1d_fn(
+                        x=mixed_qkv,
+                        weight=conv_weight,
+                        bias=self.conv1d.bias,
+                        activation=self.activation,
+                        seq_idx=None,
+                        backend="triton",
+                        cu_seqlens=gdn_conv_cu_halo,
+                    )[0]
+                    mixed_qkv = trim_conv_halo_packed(
+                        mixed_qkv,
+                        cp_local_cu_seqlens_with_halo=gdn_conv_cu_halo,
+                        kernel_size=self.conv_kernel_size,
+                        seq_dim=1,
+                    )
+                else:
+                    # mixed_qkv is [B, S, D] — FLA causal_conv1d expects [B, S, D].
+                    mixed_qkv = self.causal_conv1d_fn(
+                        x=mixed_qkv,
+                        weight=conv_weight,
+                        bias=self.conv1d.bias,
+                        activation=self.activation,
+                        seq_idx=None,
+                        backend="triton",
+                        cu_seqlens=gdn_conv_cu,
+                    )[0]
             else:
                 raise NotImplementedError("This path is not supported yet because it can't process varlen now.")
 
@@ -780,13 +937,19 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
         beta = b.sigmoid()
         # If the model is loaded in fp16, without the .float() here, A might be -inf
-        # Modification: slice A_log/dt_bias for local V-heads under SP.
-        if gdn_sp_enabled:
+        # Modification: slice A_log/dt_bias for local V-heads under Ulysses.
+        if gdn_head_parallel:
             v_head_offset = gdn_head_rank * local_num_v_heads
             v_head_slice = slice(v_head_offset, v_head_offset + local_num_v_heads)
-            g = -self.A_log[v_head_slice].float().exp() * F.softplus(a.float() + self.dt_bias[v_head_slice])
+            a_log = self.A_log[v_head_slice]
+            dt_bias = self.dt_bias[v_head_slice]
         else:
-            g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+            a_log = self.A_log
+            dt_bias = self.dt_bias
+        if gdn_gather_full:
+            a_log = scale_cp_repeated_parameter_grad(a_log, cp_size=gdn_plan.cp_size)
+            dt_bias = scale_cp_repeated_parameter_grad(dt_bias, cp_size=gdn_plan.cp_size)
+        g = -a_log.float().exp() * F.softplus(a.float() + dt_bias)
 
         if self.num_v_heads // self.num_k_heads > 1:
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
@@ -805,18 +968,73 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                     "or 'flash_qla' (ships under the gpu extra, Hopper sm90 only) in OpsImplementationConfig."
                 )
             else:
-                # Modification: use direct args and pass cu_seqlens for varlen FLA attention.
-                core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
-                    query,
-                    key,
-                    value,
-                    g=g,
-                    beta=beta,
-                    initial_state=None,
-                    output_final_state=cache_params is not None,
-                    use_qk_l2norm_in_kernel=True,
-                    cu_seqlens=cu_seq_lens_q,
-                )
+                if gdn_state_passing:
+                    state_template = make_gdn_state_template(query, value, cu_seqlens=gdn_core_cu)
+                    s_init = recv_serial_initial_state(
+                        cp_group=gdn_plan.cp_group,
+                        cp_size=gdn_plan.cp_size,
+                        cp_rank=gdn_plan.cp_rank,
+                        state_template=state_template,
+                    )
+                    _bos = sample_bos_flags_for_per_sample_cp(
+                        num_seqs=int(state_template.shape[0]),
+                        cp_rank=gdn_plan.cp_rank,
+                    )
+                    s_init = apply_sample_bos_zero_s_init(s_init, sample_bos_on_rank=_bos)
+                    assert_serial_initial_state_contract(
+                        s_init,
+                        cp_rank=gdn_plan.cp_rank,
+                        sample_bos_on_rank=_bos,
+                        cu_seqlens=gdn_core_cu,
+                    )
+                    # Keep GPU path aligned with NPU Mojo: pad segments to chunk=32
+                    # before requesting final_state (no-op when already aligned).
+                    (
+                        query_gdr,
+                        key_gdr,
+                        value_gdr,
+                        g_gdr,
+                        beta_gdr,
+                        gdn_cu_aligned,
+                        gdr_unpad_index,
+                    ) = align_gdn_varlen_for_mojo_gdr(
+                        query, key, value, g, beta, gdn_core_cu
+                    )
+                    core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                        query_gdr,
+                        key_gdr,
+                        value_gdr,
+                        g=g_gdr,
+                        beta=beta_gdr,
+                        initial_state=s_init,
+                        output_final_state=True,
+                        use_qk_l2norm_in_kernel=True,
+                        cu_seqlens=gdn_cu_aligned,
+                    )
+                    core_attn_out = unpad_gdn_varlen_output(core_attn_out, gdr_unpad_index)
+                    if last_recurrent_state is None:
+                        raise RuntimeError(
+                            "state_passing_serial requires chunk_gated_delta_rule to return final_state."
+                        )
+                    last_recurrent_state = send_serial_final_state(
+                        last_recurrent_state,
+                        cp_group=gdn_plan.cp_group,
+                        cp_size=gdn_plan.cp_size,
+                        cp_rank=gdn_plan.cp_rank,
+                    )
+                else:
+                    # Modification: use direct args and pass cu_seqlens for varlen FLA attention.
+                    core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                        query,
+                        key,
+                        value,
+                        g=g,
+                        beta=beta,
+                        initial_state=None,
+                        output_final_state=cache_params is not None,
+                        use_qk_l2norm_in_kernel=True,
+                        cu_seqlens=gdn_core_cu,
+                    )
         else:
             core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
                 query,
@@ -833,13 +1051,38 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         if cache_params is not None:
             cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
 
-        # Modification: gather attention output back to sequence-sharded layout before gated norm.
-        if gdn_sp_enabled:
-            core_attn_out = maybe_to_rank_major(
-                core_attn_out, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1
+        # Reverse CP layout before Ulysses restores full heads.
+        if gdn_gather_full:
+            core_attn_out = cp_scatter_sequence(
+                core_attn_out,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                cp_rank=gdn_plan.cp_rank,
+                seq_dim=1,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
             )
+        elif gdn_state_passing:
+            core_attn_out = repartition_block_to_zigzag_packed(
+                core_attn_out,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                cp_rank=gdn_plan.cp_rank,
+                seq_dim=1,
+            )
+        if gdn_cp_sequence and gdn_head_parallel:
+            core_attn_out = reorder_sample_major_to_ulysses_rank_major(
+                core_attn_out,
+                gdn_ulysses_local_cu,
+                ulysses_size=gdn_plan.ulysses_size,
+                seq_dim=1,
+            )
+        if gdn_head_parallel:
             core_attn_out = gather_heads_scatter_seq(
-                core_attn_out, head_dim=2, seq_dim=1, group=gdn_sp_group
+                core_attn_out,
+                head_dim=2,
+                seq_dim=1,
+                group=gdn_head_group,
             )
 
         # reshape input data into 2D tensor
@@ -2415,7 +2658,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
             if get_parallel_state().sp_enabled:
                 input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
                 dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-                input_ids = torch.cat(input_ids_list, dim=1)
+                input_ids = torch.cat(input_ids_list, dim=0)
             image_mask, video_mask = self.get_placeholder_mask(input_ids)
         # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -661,19 +661,25 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
-        # Modification: Ulysses SP all-to-all for linear attention heads.
-        ulysses_enabled = get_parallel_state().ulysses_enabled
-        if ulysses_enabled:
-            ulysses_group = get_parallel_state().ulysses_group
-            ulysses_size = get_parallel_state().ulysses_size
-            ulysses_rank = get_parallel_state().ulysses_rank
-            assert self.num_k_heads % ulysses_size == 0 and self.num_v_heads % ulysses_size == 0, (
-                f"SP size ({ulysses_size}) must divide num_k_heads ({self.num_k_heads}) "
+        # Modification: Ulysses / unified-SP all-to-all for linear attention heads.
+        # CP>1 uses unified SP + zigzag restore (not Ring). Ulysses-only unchanged.
+        from veomni.distributed.context_parallel.gdn_sp import (
+            maybe_restore_canonical,
+            maybe_to_rank_major,
+            resolve_gdn_sp_group,
+        )
+
+        gdn_sp_group, gdn_sp_size, gdn_head_rank, gdn_need_zigzag = resolve_gdn_sp_group()
+        gdn_sp_enabled = gdn_sp_group is not None
+        cp_size_for_gdn = get_parallel_state().cp_size if gdn_need_zigzag else 1
+        if gdn_sp_enabled:
+            assert self.num_k_heads % gdn_sp_size == 0 and self.num_v_heads % gdn_sp_size == 0, (
+                f"SP size ({gdn_sp_size}) must divide num_k_heads ({self.num_k_heads}) "
                 f"and num_v_heads ({self.num_v_heads}) for gated deltanet LASP"
             )
 
-            local_num_k_heads = self.num_k_heads // ulysses_size
-            local_num_v_heads = self.num_v_heads // ulysses_size
+            local_num_k_heads = self.num_k_heads // gdn_sp_size
+            local_num_v_heads = self.num_v_heads // gdn_sp_size
             local_key_dim = self.head_k_dim * local_num_k_heads
             local_value_dim = self.head_v_dim * local_num_v_heads
 
@@ -684,14 +690,20 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             v_proj = v_proj.reshape(batch_size, seq_len, self.num_v_heads, self.head_v_dim)
 
             # All-to-all: gather full sequence, scatter heads -> [B, S_full, local_heads, head_dim]
-            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=ulysses_group)
-            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=ulysses_group)
-            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=ulysses_group)
+            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
 
             b = b.reshape(batch_size, seq_len, self.num_v_heads)
             a = a.reshape(batch_size, seq_len, self.num_v_heads)
-            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=ulysses_group)
-            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=ulysses_group)
+            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=gdn_sp_group)
+
+            q_proj = maybe_restore_canonical(q_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            k_proj = maybe_restore_canonical(k_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            v_proj = maybe_restore_canonical(v_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            b = maybe_restore_canonical(b, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            a = maybe_restore_canonical(a, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
 
             # Flatten heads back to channels and concat for conv1d: [B, S_full, local_dim]
             q_proj = q_proj.reshape(q_proj.shape[0], q_proj.shape[1], -1)
@@ -703,6 +715,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             local_num_v_heads = self.num_v_heads
             local_key_dim = self.key_dim
             local_value_dim = self.value_dim
+            gdn_head_rank = 0
 
         if use_precomputed_states:
             # Modification: keep this disabled until FLA causal_conv1d_update decode path is validated.
@@ -713,10 +726,10 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                 conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
                 cache_params.conv_states[self.layer_idx] = conv_state
             if self.causal_conv1d_fn is not None:
-                # Modification: shard conv1d weights per Ulysses rank to match head-sharded channels.
-                if ulysses_enabled:
+                # Modification: shard conv1d weights per SP rank to match head-sharded channels.
+                if gdn_sp_enabled:
                     conv_weight = self._get_local_conv1d_weight(
-                        ulysses_rank=ulysses_rank,
+                        ulysses_rank=gdn_head_rank,
                         local_key_dim=local_key_dim,
                         local_value_dim=local_value_dim,
                     )
@@ -751,9 +764,9 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
         beta = b.sigmoid()
         # If the model is loaded in fp16, without the .float() here, A might be -inf
-        # Modification: slice A_log/dt_bias for local V-heads under Ulysses SP.
-        if ulysses_enabled:
-            v_head_offset = ulysses_rank * local_num_v_heads
+        # Modification: slice A_log/dt_bias for local V-heads under SP.
+        if gdn_sp_enabled:
+            v_head_offset = gdn_head_rank * local_num_v_heads
             v_head_slice = slice(v_head_offset, v_head_offset + local_num_v_heads)
             g = -self.A_log[v_head_slice].float().exp() * F.softplus(a.float() + self.dt_bias[v_head_slice])
         else:
@@ -802,9 +815,12 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
 
         # Modification: gather attention output back to sequence-sharded layout before gated norm.
-        if ulysses_enabled:
+        if gdn_sp_enabled:
+            core_attn_out = maybe_to_rank_major(
+                core_attn_out, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1
+            )
             core_attn_out = gather_heads_scatter_seq(
-                core_attn_out, head_dim=2, seq_dim=1, group=get_parallel_state().ulysses_group
+                core_attn_out, head_dim=2, seq_dim=1, group=gdn_sp_group
             )
 
         # reshape input data into 2D tensor

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -661,25 +661,93 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
-        # Modification: Ulysses / unified-SP all-to-all for linear attention heads.
-        # CP>1 uses unified SP + zigzag restore (not Ring). Ulysses-only unchanged.
+        # Modification: two-dimensional GDN parallelism.
+        # Ulysses shards heads; CP gathers/scatters sequence without changing heads.
         from veomni.distributed.context_parallel.gdn_sp import (
-            maybe_restore_canonical,
-            maybe_to_rank_major,
-            resolve_gdn_sp_group,
+            GDN_CP_IMPL_KCP,
+            GDN_CP_IMPL_STATE_PASSING_SERIAL,
+            cp_gather_sequence,
+            cp_scatter_sequence,
+            derive_gdn_local_cu_seqlens,
+            gdn_cp_impl_name,
+            log_gdn_cp_impl_once,
+            resolve_gdn_parallel_plan,
+            scale_cp_repeated_parameter_grad,
+        )
+        from veomni.distributed.context_parallel.gdn_scan_cp import (
+            align_gdn_varlen_for_mojo_gdr,
+            apply_sample_bos_zero_s_init,
+            assert_serial_initial_state_contract,
+            conv1d_halo_exchange_packed,
+            make_gdn_state_template,
+            recv_serial_initial_state,
+            repartition_block_to_zigzag_packed,
+            repartition_zigzag_to_block_packed,
+            sample_bos_flags_for_per_sample_cp,
+            send_serial_final_state,
+            trim_conv_halo_packed,
+            unpad_gdn_varlen_output,
+        )
+        from veomni.distributed.context_parallel.packed_sharding import (
+            reorder_sample_major_to_ulysses_rank_major,
+            reorder_ulysses_rank_major_to_sample_major,
         )
 
-        gdn_sp_group, gdn_sp_size, gdn_head_rank, gdn_need_zigzag = resolve_gdn_sp_group()
-        gdn_sp_enabled = gdn_sp_group is not None
-        cp_size_for_gdn = get_parallel_state().cp_size if gdn_need_zigzag else 1
-        if gdn_sp_enabled:
-            assert self.num_k_heads % gdn_sp_size == 0 and self.num_v_heads % gdn_sp_size == 0, (
-                f"SP size ({gdn_sp_size}) must divide num_k_heads ({self.num_k_heads}) "
-                f"and num_v_heads ({self.num_v_heads}) for gated deltanet LASP"
+        gdn_plan = resolve_gdn_parallel_plan()
+        gdn_head_parallel = gdn_plan.head_parallel_enabled
+        gdn_cp_sequence = gdn_plan.cp_sequence_enabled
+        gdn_impl = gdn_cp_impl_name(cp_size=gdn_plan.cp_size)
+        gdn_state_passing = gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_STATE_PASSING_SERIAL
+        gdn_gather_full = gdn_cp_sequence and not gdn_state_passing
+        try:
+            from veomni.distributed.context_parallel.gdn_mem_probe import (
+                emit_mem_layer,
+                mem_probe_enabled,
+                mem_probe_set_context,
+                reset_mem_probe_step,
+            )
+        except Exception:  # pragma: no cover
+
+            def mem_probe_enabled() -> bool:  # type: ignore
+                return False
+
+            emit_mem_layer = None  # type: ignore
+            mem_probe_set_context = None  # type: ignore
+            reset_mem_probe_step = None  # type: ignore
+        if mem_probe_enabled():
+            if mem_probe_set_context is not None:
+                mem_probe_set_context(impl=str(gdn_impl))
+            if int(getattr(self, "layer_idx", 0) or 0) == 0 and reset_mem_probe_step is not None:
+                n = int(getattr(self, "_ai4se_mem_fwd", 0)) + 1
+                self._ai4se_mem_fwd = n
+                reset_mem_probe_step(n)
+        if gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_KCP:
+            raise NotImplementedError(
+                "gdn_cp_impl=kcp is not implemented yet; use state_passing_serial or gather_full_replicated."
+            )
+        if gdn_cp_sequence:
+            log_gdn_cp_impl_once(cp_size=gdn_plan.cp_size)
+        gdn_head_rank = gdn_plan.ulysses_rank if gdn_head_parallel else 0
+        gdn_head_group = gdn_plan.ulysses_group if gdn_head_parallel else None
+        gdn_ulysses_local_cu = None
+        gdn_cp_local_cu = None
+        if gdn_cp_sequence:
+            if cu_seq_lens_q is None:
+                raise RuntimeError("CP-enabled packed GDN requires global cu_seq_lens_q metadata.")
+            gdn_ulysses_local_cu, gdn_cp_local_cu = derive_gdn_local_cu_seqlens(
+                cu_seq_lens_q,
+                ulysses_size=gdn_plan.ulysses_size,
+                cp_size=gdn_plan.cp_size,
+            )
+        if gdn_head_parallel:
+            assert self.num_k_heads % gdn_plan.ulysses_size == 0 and self.num_v_heads % gdn_plan.ulysses_size == 0, (
+                f"Ulysses size ({gdn_plan.ulysses_size}) must divide num_k_heads ({self.num_k_heads}) "
+                f"and num_v_heads ({self.num_v_heads}) for gated deltanet head parallel; "
+                f"CP size ({gdn_plan.cp_size}) is sequence-only"
             )
 
-            local_num_k_heads = self.num_k_heads // gdn_sp_size
-            local_num_v_heads = self.num_v_heads // gdn_sp_size
+            local_num_k_heads = self.num_k_heads // gdn_plan.ulysses_size
+            local_num_v_heads = self.num_v_heads // gdn_plan.ulysses_size
             local_key_dim = self.head_k_dim * local_num_k_heads
             local_value_dim = self.head_v_dim * local_num_v_heads
 
@@ -690,20 +758,46 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             v_proj = v_proj.reshape(batch_size, seq_len, self.num_v_heads, self.head_v_dim)
 
             # All-to-all: gather full sequence, scatter heads -> [B, S_full, local_heads, head_dim]
-            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
-            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
-            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            q_proj = gather_seq_scatter_heads(q_proj, seq_dim=1, head_dim=2, group=gdn_head_group)
+            k_proj = gather_seq_scatter_heads(k_proj, seq_dim=1, head_dim=2, group=gdn_head_group)
+            v_proj = gather_seq_scatter_heads(v_proj, seq_dim=1, head_dim=2, group=gdn_head_group)
 
             b = b.reshape(batch_size, seq_len, self.num_v_heads)
             a = a.reshape(batch_size, seq_len, self.num_v_heads)
-            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=gdn_sp_group)
-            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=gdn_sp_group)
+            b = gather_seq_scatter_heads(b, seq_dim=1, head_dim=2, group=gdn_head_group)
+            a = gather_seq_scatter_heads(a, seq_dim=1, head_dim=2, group=gdn_head_group)
 
-            q_proj = maybe_restore_canonical(q_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
-            k_proj = maybe_restore_canonical(k_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
-            v_proj = maybe_restore_canonical(v_proj, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
-            b = maybe_restore_canonical(b, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
-            a = maybe_restore_canonical(a, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1)
+            if gdn_cp_sequence:
+                q_proj = reorder_ulysses_rank_major_to_sample_major(
+                    q_proj,
+                    gdn_ulysses_local_cu,
+                    ulysses_size=gdn_plan.ulysses_size,
+                    seq_dim=1,
+                )
+                k_proj = reorder_ulysses_rank_major_to_sample_major(
+                    k_proj,
+                    gdn_ulysses_local_cu,
+                    ulysses_size=gdn_plan.ulysses_size,
+                    seq_dim=1,
+                )
+                v_proj = reorder_ulysses_rank_major_to_sample_major(
+                    v_proj,
+                    gdn_ulysses_local_cu,
+                    ulysses_size=gdn_plan.ulysses_size,
+                    seq_dim=1,
+                )
+                b = reorder_ulysses_rank_major_to_sample_major(
+                    b,
+                    gdn_ulysses_local_cu,
+                    ulysses_size=gdn_plan.ulysses_size,
+                    seq_dim=1,
+                )
+                a = reorder_ulysses_rank_major_to_sample_major(
+                    a,
+                    gdn_ulysses_local_cu,
+                    ulysses_size=gdn_plan.ulysses_size,
+                    seq_dim=1,
+                )
 
             # Flatten heads back to channels and concat for conv1d: [B, S_full, local_dim]
             q_proj = q_proj.reshape(q_proj.shape[0], q_proj.shape[1], -1)
@@ -715,7 +809,72 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             local_num_v_heads = self.num_v_heads
             local_key_dim = self.key_dim
             local_value_dim = self.value_dim
-            gdn_head_rank = 0
+            b = b.reshape(batch_size, seq_len, self.num_v_heads)
+            a = a.reshape(batch_size, seq_len, self.num_v_heads)
+
+        gdn_conv_cu = cu_seq_lens_q
+        gdn_core_cu = cu_seq_lens_q
+        if gdn_gather_full:
+            mixed_qkv = cp_gather_sequence(
+                mixed_qkv,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                seq_dim=1,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+            )
+            b = cp_gather_sequence(
+                b,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                seq_dim=1,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+            )
+            a = cp_gather_sequence(
+                a,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                seq_dim=1,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+            )
+        elif gdn_state_passing:
+            # INV-5: zigzag→contiguous block permutation (still S/cp). Never gather S_full.
+            mixed_qkv = repartition_zigzag_to_block_packed(
+                mixed_qkv,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                cp_rank=gdn_plan.cp_rank,
+                seq_dim=1,
+            )
+            b = repartition_zigzag_to_block_packed(
+                b,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                cp_rank=gdn_plan.cp_rank,
+                seq_dim=1,
+            )
+            a = repartition_zigzag_to_block_packed(
+                a,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                cp_rank=gdn_plan.cp_rank,
+                seq_dim=1,
+            )
+            gdn_conv_cu = gdn_cp_local_cu
+            gdn_core_cu = gdn_cp_local_cu
+
+        if mem_probe_enabled() and emit_mem_layer is not None:
+            emit_mem_layer(
+                "gdn_act_post_layout",
+                tensors={"mixed_qkv": mixed_qkv, "b": b, "a": a},
+                layer_idx=int(getattr(self, "layer_idx", -1)),
+                extra={
+                    "path": "state_passing" if gdn_state_passing else ("gather_full" if gdn_gather_full else "none"),
+                    "cp_size": int(gdn_plan.cp_size) if gdn_plan is not None else 1,
+                },
+            )
 
         if use_precomputed_states:
             # Modification: keep this disabled until FLA causal_conv1d_update decode path is validated.
@@ -726,8 +885,8 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                 conv_state = F.pad(mixed_qkv_t, (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0))
                 cache_params.conv_states[self.layer_idx] = conv_state
             if self.causal_conv1d_fn is not None:
-                # Modification: shard conv1d weights per SP rank to match head-sharded channels.
-                if gdn_sp_enabled:
+                # Modification: shard conv1d weights per Ulysses rank.
+                if gdn_head_parallel:
                     conv_weight = self._get_local_conv1d_weight(
                         ulysses_rank=gdn_head_rank,
                         local_key_dim=local_key_dim,
@@ -735,16 +894,47 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                     )
                 else:
                     conv_weight = self.conv1d.weight.squeeze(1)
-                # mixed_qkv is [B, S, D] — FLA causal_conv1d expects [B, S, D].
-                mixed_qkv = self.causal_conv1d_fn(
-                    x=mixed_qkv,
-                    weight=conv_weight,
-                    bias=self.conv1d.bias,
-                    activation=self.activation,
-                    seq_idx=None,
-                    backend="triton",
-                    cu_seqlens=cu_seq_lens_q.npu(),
-                )[0]
+                if gdn_gather_full:
+                    conv_weight = scale_cp_repeated_parameter_grad(
+                        conv_weight,
+                        cp_size=gdn_plan.cp_size,
+                    )
+                if gdn_state_passing:
+                    mixed_qkv, gdn_conv_cu_halo = conv1d_halo_exchange_packed(
+                        mixed_qkv,
+                        cp_local_cu_seqlens=gdn_cp_local_cu,
+                        kernel_size=self.conv_kernel_size,
+                        cp_group=gdn_plan.cp_group,
+                        cp_size=gdn_plan.cp_size,
+                        cp_rank=gdn_plan.cp_rank,
+                        seq_dim=1,
+                    )
+                    mixed_qkv = self.causal_conv1d_fn(
+                        x=mixed_qkv,
+                        weight=conv_weight,
+                        bias=self.conv1d.bias,
+                        activation=self.activation,
+                        seq_idx=None,
+                        backend="triton",
+                        cu_seqlens=gdn_conv_cu_halo.npu() if hasattr(gdn_conv_cu_halo, "npu") else gdn_conv_cu_halo,
+                    )[0]
+                    mixed_qkv = trim_conv_halo_packed(
+                        mixed_qkv,
+                        cp_local_cu_seqlens_with_halo=gdn_conv_cu_halo,
+                        kernel_size=self.conv_kernel_size,
+                        seq_dim=1,
+                    )
+                else:
+                    # mixed_qkv is [B, S, D] — FLA causal_conv1d expects [B, S, D].
+                    mixed_qkv = self.causal_conv1d_fn(
+                        x=mixed_qkv,
+                        weight=conv_weight,
+                        bias=self.conv1d.bias,
+                        activation=self.activation,
+                        seq_idx=None,
+                        backend="triton",
+                        cu_seqlens=gdn_conv_cu.npu() if hasattr(gdn_conv_cu, "npu") else gdn_conv_cu,
+                    )[0]
             else:
                 raise NotImplementedError("This path is not supported yet because it can't process varlen now.")
 
@@ -764,13 +954,19 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
         beta = b.sigmoid()
         # If the model is loaded in fp16, without the .float() here, A might be -inf
-        # Modification: slice A_log/dt_bias for local V-heads under SP.
-        if gdn_sp_enabled:
+        # Modification: slice A_log/dt_bias for local V-heads under Ulysses.
+        if gdn_head_parallel:
             v_head_offset = gdn_head_rank * local_num_v_heads
             v_head_slice = slice(v_head_offset, v_head_offset + local_num_v_heads)
-            g = -self.A_log[v_head_slice].float().exp() * F.softplus(a.float() + self.dt_bias[v_head_slice])
+            a_log = self.A_log[v_head_slice]
+            dt_bias = self.dt_bias[v_head_slice]
         else:
-            g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+            a_log = self.A_log
+            dt_bias = self.dt_bias
+        if gdn_gather_full:
+            a_log = scale_cp_repeated_parameter_grad(a_log, cp_size=gdn_plan.cp_size)
+            dt_bias = scale_cp_repeated_parameter_grad(dt_bias, cp_size=gdn_plan.cp_size)
+        g = -a_log.float().exp() * F.softplus(a.float() + dt_bias)
 
         if self.num_v_heads // self.num_k_heads > 1:
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
@@ -783,21 +979,131 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                     "Varlen Qwen3.5 GatedDeltaNet training is GPU-only — NPU has no fla/flash_qla "
                     "backend registered today. On GPU, set chunk_gated_delta_rule_implementation='fla' "
                     "(and install flash-linear-attention) or 'flash_qla' (ships under the gpu extra, "
-                    "Hopper sm90 only) in OpsImplementationConfig."
+                    "Hopper sm90 only) in OpsImplementationConfig. "
+                    "On 910B4, bind chunk_gated_delta_rule_implementation='mojo'."
                 )
             else:
-                # Modification: use direct args and pass cu_seqlens for varlen FLA attention.
-                core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
-                    query,
-                    key,
-                    value,
-                    g=g,
-                    beta=beta,
-                    initial_state=None,
-                    output_final_state=cache_params is not None,
-                    use_qk_l2norm_in_kernel=True,
-                    cu_seqlens=cu_seq_lens_q.npu(),
-                )
+                gdn_cu = gdn_core_cu.npu() if hasattr(gdn_core_cu, "npu") else gdn_core_cu
+                if gdn_state_passing:
+                    state_template = make_gdn_state_template(query, value, cu_seqlens=gdn_core_cu)
+                    s_init = recv_serial_initial_state(
+                        cp_group=gdn_plan.cp_group,
+                        cp_size=gdn_plan.cp_size,
+                        cp_rank=gdn_plan.cp_rank,
+                        state_template=state_template,
+                    )
+                    # Fail-closed: sample BOS must not inherit previous-sample state.
+                    # Per-sample balanced CP ⇒ BOS only on cp_rank==0.
+                    _bos = sample_bos_flags_for_per_sample_cp(
+                        num_seqs=int(state_template.shape[0]),
+                        cp_rank=gdn_plan.cp_rank,
+                    )
+                    s_init = apply_sample_bos_zero_s_init(s_init, sample_bos_on_rank=_bos)
+                    assert_serial_initial_state_contract(
+                        s_init,
+                        cp_rank=gdn_plan.cp_rank,
+                        sample_bos_on_rank=_bos,
+                        cu_seqlens=gdn_core_cu,
+                    )
+                    if not torch.isfinite(query).all() or not torch.isfinite(g).all():
+                        raise RuntimeError(
+                            "state_passing_serial: non-finite q/g before GDR "
+                            f"(layer={self.layer_idx})"
+                        )
+                    # MR912 Mojo varlen wrapper refuses output_final_state when it
+                    # must internally pad to chunk=32. Pre-align so raw_gdr runs.
+                    (
+                        query_gdr,
+                        key_gdr,
+                        value_gdr,
+                        g_gdr,
+                        beta_gdr,
+                        gdn_cu_aligned,
+                        gdr_unpad_index,
+                    ) = align_gdn_varlen_for_mojo_gdr(
+                        query, key, value, g, beta, gdn_cu
+                    )
+                    core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                        query_gdr,
+                        key_gdr,
+                        value_gdr,
+                        g=g_gdr,
+                        beta=beta_gdr,
+                        initial_state=s_init,
+                        output_final_state=True,
+                        use_qk_l2norm_in_kernel=True,
+                        cu_seqlens=gdn_cu_aligned,
+                    )
+                    core_attn_out = unpad_gdn_varlen_output(core_attn_out, gdr_unpad_index)
+                    if last_recurrent_state is None:
+                        raise RuntimeError(
+                            "state_passing_serial requires chunk_gated_delta_rule to return final_state."
+                        )
+                    if mem_probe_enabled() and emit_mem_layer is not None:
+                        emit_mem_layer(
+                            "gdn_act_pre_gdr",
+                            tensors={
+                                "query": query_gdr,
+                                "key": key_gdr,
+                                "value": value_gdr,
+                                "g": g_gdr,
+                                "beta": beta_gdr,
+                                "s_init": s_init,
+                            },
+                            layer_idx=int(getattr(self, "layer_idx", -1)),
+                            extra={"path": "state_passing"},
+                        )
+                        emit_mem_layer(
+                            "gdn_act_post_gdr",
+                            tensors={
+                                "core_attn_out": core_attn_out,
+                                "final_state": last_recurrent_state,
+                            },
+                            layer_idx=int(getattr(self, "layer_idx", -1)),
+                            extra={"path": "state_passing"},
+                        )
+                    last_recurrent_state = send_serial_final_state(
+                        last_recurrent_state,
+                        cp_group=gdn_plan.cp_group,
+                        cp_size=gdn_plan.cp_size,
+                        cp_rank=gdn_plan.cp_rank,
+                    )
+                else:
+                    # Modification: use direct args and pass cu_seqlens for varlen FLA attention.
+                    if mem_probe_enabled() and emit_mem_layer is not None:
+                        emit_mem_layer(
+                            "gdn_act_pre_gdr",
+                            tensors={
+                                "query": query,
+                                "key": key,
+                                "value": value,
+                                "g": g,
+                                "beta": beta,
+                            },
+                            layer_idx=int(getattr(self, "layer_idx", -1)),
+                            extra={"path": "gather_full" if gdn_gather_full else "dense"},
+                        )
+                    core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                        query,
+                        key,
+                        value,
+                        g=g,
+                        beta=beta,
+                        initial_state=None,
+                        output_final_state=cache_params is not None,
+                        use_qk_l2norm_in_kernel=True,
+                        cu_seqlens=gdn_cu,
+                    )
+                    if mem_probe_enabled() and emit_mem_layer is not None:
+                        emit_mem_layer(
+                            "gdn_act_post_gdr",
+                            tensors={
+                                "core_attn_out": core_attn_out,
+                                "final_state": last_recurrent_state,
+                            },
+                            layer_idx=int(getattr(self, "layer_idx", -1)),
+                            extra={"path": "gather_full" if gdn_gather_full else "dense"},
+                        )
         else:
             core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
                 query,
@@ -814,13 +1120,38 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         if cache_params is not None:
             cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
 
-        # Modification: gather attention output back to sequence-sharded layout before gated norm.
-        if gdn_sp_enabled:
-            core_attn_out = maybe_to_rank_major(
-                core_attn_out, enabled=gdn_need_zigzag, cp_size=cp_size_for_gdn, dim=1
+        # Reverse CP layout before Ulysses restores full heads.
+        if gdn_gather_full:
+            core_attn_out = cp_scatter_sequence(
+                core_attn_out,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                cp_rank=gdn_plan.cp_rank,
+                seq_dim=1,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
             )
+        elif gdn_state_passing:
+            core_attn_out = repartition_block_to_zigzag_packed(
+                core_attn_out,
+                cp_local_cu_seqlens=gdn_cp_local_cu,
+                cp_group=gdn_plan.cp_group,
+                cp_size=gdn_plan.cp_size,
+                cp_rank=gdn_plan.cp_rank,
+                seq_dim=1,
+            )
+        if gdn_cp_sequence and gdn_head_parallel:
+            core_attn_out = reorder_sample_major_to_ulysses_rank_major(
+                core_attn_out,
+                gdn_ulysses_local_cu,
+                ulysses_size=gdn_plan.ulysses_size,
+                seq_dim=1,
+            )
+        if gdn_head_parallel:
             core_attn_out = gather_heads_scatter_seq(
-                core_attn_out, head_dim=2, seq_dim=1, group=gdn_sp_group
+                core_attn_out,
+                head_dim=2,
+                seq_dim=1,
+                group=gdn_head_group,
             )
 
         # reshape input data into 2D tensor
@@ -2382,7 +2713,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
             if get_parallel_state().sp_enabled:
                 input_ids_list = [torch.zeros_like(input_ids) for i in range(get_parallel_state().sp_size)]
                 dist.all_gather(input_ids_list, input_ids, group=get_parallel_state().sp_group)
-                input_ids = torch.cat(input_ids_list, dim=1)
+                input_ids = torch.cat(input_ids_list, dim=0)
             image_mask, video_mask = self.get_placeholder_mask(input_ids)
         # --- Patch.1 ---
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -674,6 +674,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             resolve_gdn_parallel_plan,
             scale_cp_repeated_parameter_grad,
         )
+        from veomni.distributed.context_parallel.gdn_kcp import resolve_kcp_initial_state
         from veomni.distributed.context_parallel.gdn_scan_cp import (
             align_gdn_varlen_for_mojo_gdr,
             apply_sample_bos_zero_s_init,
@@ -697,7 +698,10 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         gdn_head_parallel = gdn_plan.head_parallel_enabled
         gdn_cp_sequence = gdn_plan.cp_sequence_enabled
         gdn_impl = gdn_cp_impl_name(cp_size=gdn_plan.cp_size)
-        gdn_state_passing = gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_STATE_PASSING_SERIAL
+        gdn_serial = gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_STATE_PASSING_SERIAL
+        gdn_kcp = gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_KCP
+        # serial + kcp share zigzag↔block + conv halo; only state resolve differs.
+        gdn_state_passing = gdn_serial or gdn_kcp
         gdn_gather_full = gdn_cp_sequence and not gdn_state_passing
         try:
             from veomni.distributed.context_parallel.gdn_mem_probe import (
@@ -721,10 +725,6 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                 n = int(getattr(self, "_ai4se_mem_fwd", 0)) + 1
                 self._ai4se_mem_fwd = n
                 reset_mem_probe_step(n)
-        if gdn_cp_sequence and gdn_impl == GDN_CP_IMPL_KCP:
-            raise NotImplementedError(
-                "gdn_cp_impl=kcp is not implemented yet; use state_passing_serial or gather_full_replicated."
-            )
         if gdn_cp_sequence:
             log_gdn_cp_impl_once(cp_size=gdn_plan.cp_size)
         gdn_head_rank = gdn_plan.ulysses_rank if gdn_head_parallel else 0
@@ -985,29 +985,17 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             else:
                 gdn_cu = gdn_core_cu.npu() if hasattr(gdn_core_cu, "npu") else gdn_core_cu
                 if gdn_state_passing:
-                    state_template = make_gdn_state_template(query, value, cu_seqlens=gdn_core_cu)
-                    s_init = recv_serial_initial_state(
-                        cp_group=gdn_plan.cp_group,
-                        cp_size=gdn_plan.cp_size,
-                        cp_rank=gdn_plan.cp_rank,
-                        state_template=state_template,
-                    )
-                    # Fail-closed: sample BOS must not inherit previous-sample state.
-                    # Per-sample balanced CP ⇒ BOS only on cp_rank==0.
                     _bos = sample_bos_flags_for_per_sample_cp(
-                        num_seqs=int(state_template.shape[0]),
+                        num_seqs=int(
+                            (gdn_core_cu.numel() - 1)
+                            if gdn_core_cu is not None
+                            else query.shape[0]
+                        ),
                         cp_rank=gdn_plan.cp_rank,
-                    )
-                    s_init = apply_sample_bos_zero_s_init(s_init, sample_bos_on_rank=_bos)
-                    assert_serial_initial_state_contract(
-                        s_init,
-                        cp_rank=gdn_plan.cp_rank,
-                        sample_bos_on_rank=_bos,
-                        cu_seqlens=gdn_core_cu,
                     )
                     if not torch.isfinite(query).all() or not torch.isfinite(g).all():
                         raise RuntimeError(
-                            "state_passing_serial: non-finite q/g before GDR "
+                            f"{gdn_impl}: non-finite q/g before GDR "
                             f"(layer={self.layer_idx})"
                         )
                     # MR912 Mojo varlen wrapper refuses output_final_state when it
@@ -1023,22 +1011,79 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                     ) = align_gdn_varlen_for_mojo_gdr(
                         query, key, value, g, beta, gdn_cu
                     )
-                    core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
-                        query_gdr,
-                        key_gdr,
-                        value_gdr,
-                        g=g_gdr,
-                        beta=beta_gdr,
-                        initial_state=s_init,
-                        output_final_state=True,
-                        use_qk_l2norm_in_kernel=True,
-                        cu_seqlens=gdn_cu_aligned,
-                    )
-                    core_attn_out = unpad_gdn_varlen_output(core_attn_out, gdr_unpad_index)
-                    if last_recurrent_state is None:
-                        raise RuntimeError(
-                            "state_passing_serial requires chunk_gated_delta_rule to return final_state."
+                    if gdn_kcp:
+                        # P1: local affine + AG{he,M} + prefix-merge (no serial P2P).
+                        s_init = resolve_kcp_initial_state(
+                            key_gdr,
+                            value_gdr,
+                            g_gdr,
+                            beta_gdr,
+                            cp_group=gdn_plan.cp_group,
+                            cp_size=gdn_plan.cp_size,
+                            cp_rank=gdn_plan.cp_rank,
+                            cu_seqlens=gdn_cu_aligned,
+                            use_qk_l2norm=True,
+                            sample_bos_on_rank=_bos,
                         )
+                        assert_serial_initial_state_contract(
+                            s_init,
+                            cp_rank=gdn_plan.cp_rank,
+                            sample_bos_on_rank=_bos,
+                            cu_seqlens=gdn_cu_aligned,
+                        )
+                        core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                            query_gdr,
+                            key_gdr,
+                            value_gdr,
+                            g=g_gdr,
+                            beta=beta_gdr,
+                            initial_state=s_init,
+                            output_final_state=False,
+                            use_qk_l2norm_in_kernel=True,
+                            cu_seqlens=gdn_cu_aligned,
+                        )
+                        core_attn_out = unpad_gdn_varlen_output(core_attn_out, gdr_unpad_index)
+                        _path = "kcp"
+                    else:
+                        state_template = make_gdn_state_template(
+                            query_gdr, value_gdr, cu_seqlens=gdn_cu_aligned
+                        )
+                        s_init = recv_serial_initial_state(
+                            cp_group=gdn_plan.cp_group,
+                            cp_size=gdn_plan.cp_size,
+                            cp_rank=gdn_plan.cp_rank,
+                            state_template=state_template,
+                        )
+                        s_init = apply_sample_bos_zero_s_init(s_init, sample_bos_on_rank=_bos)
+                        assert_serial_initial_state_contract(
+                            s_init,
+                            cp_rank=gdn_plan.cp_rank,
+                            sample_bos_on_rank=_bos,
+                            cu_seqlens=gdn_cu_aligned,
+                        )
+                        core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                            query_gdr,
+                            key_gdr,
+                            value_gdr,
+                            g=g_gdr,
+                            beta=beta_gdr,
+                            initial_state=s_init,
+                            output_final_state=True,
+                            use_qk_l2norm_in_kernel=True,
+                            cu_seqlens=gdn_cu_aligned,
+                        )
+                        core_attn_out = unpad_gdn_varlen_output(core_attn_out, gdr_unpad_index)
+                        if last_recurrent_state is None:
+                            raise RuntimeError(
+                                "state_passing_serial requires chunk_gated_delta_rule to return final_state."
+                            )
+                        last_recurrent_state = send_serial_final_state(
+                            last_recurrent_state,
+                            cp_group=gdn_plan.cp_group,
+                            cp_size=gdn_plan.cp_size,
+                            cp_rank=gdn_plan.cp_rank,
+                        )
+                        _path = "state_passing"
                     if mem_probe_enabled() and emit_mem_layer is not None:
                         emit_mem_layer(
                             "gdn_act_pre_gdr",
@@ -1051,23 +1096,14 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                                 "s_init": s_init,
                             },
                             layer_idx=int(getattr(self, "layer_idx", -1)),
-                            extra={"path": "state_passing"},
+                            extra={"path": _path},
                         )
                         emit_mem_layer(
                             "gdn_act_post_gdr",
-                            tensors={
-                                "core_attn_out": core_attn_out,
-                                "final_state": last_recurrent_state,
-                            },
+                            tensors={"core_attn_out": core_attn_out},
                             layer_idx=int(getattr(self, "layer_idx", -1)),
-                            extra={"path": "state_passing"},
+                            extra={"path": _path},
                         )
-                    last_recurrent_state = send_serial_final_state(
-                        last_recurrent_state,
-                        cp_group=gdn_plan.cp_group,
-                        cp_size=gdn_plan.cp_size,
-                        cp_rank=gdn_plan.cp_rank,
-                    )
                 else:
                     # Modification: use direct args and pass cu_seqlens for varlen FLA attention.
                     if mem_probe_enabled() and emit_mem_layer is not None:

--- a/veomni/ops/kernels/attention/__init__.py
+++ b/veomni/ops/kernels/attention/__init__.py
@@ -280,50 +280,153 @@ def flash_attention_forward(
 
         # Only after all_to_all we got the full seq_len
         seq_len = query.shape[1]
-        s_aux = kwargs.get("s_aux")
-        if s_aux is not None and s_aux.ndim == 1 and s_aux.numel() == q_head_num:
-            local_q_head_num = query.shape[2]
-            head_start = dist.get_rank(ulysses_group) * local_q_head_num
-            kwargs["s_aux"] = s_aux.narrow(0, head_start, local_q_head_num).contiguous()
 
-    # Resolve the token that will be passed to Transformers' lazy_import_flash_attention.
-    #
-    # FA2 and FA3 have dedicated branches in transformers' _lazy_imports, so we
-    # use the plain transformers names and they are resolved without hitting the
-    # hub-kernel path.
-    #
-    # FA4 has no such branch; unrecognised names fall through to the hub-kernel
-    # loader. By keeping the VeOmni name here, our monkey-patch of
-    # ``load_and_register_attn_kernel`` intercepts it and loads
-    # ``flash_attn.cute`` locally.
-    if module.config._attn_implementation == "veomni_flash_attention_2_with_sp":
-        fa_kernel_implementation = "flash_attention_2"
-    elif module.config._attn_implementation == "veomni_flash_attention_3_with_sp":
-        fa_kernel_implementation = "flash_attention_3"
-    elif module.config._attn_implementation == "veomni_flash_attention_4_with_sp":
-        fa_kernel_implementation = "veomni_flash_attention_4_with_sp"  # intercepted by VeOmni hub-kernel patch
-    else:
-        raise ValueError(
-            f"unknown attn_implementation for veomni flash_attention with SP support: {module.config._attn_implementation}"
+    # Ring context-parallel attention (after optional Ulysses gather).
+    # Local sequence layout must already be balanced zigzag from the collator.
+    cp_enabled = get_parallel_state().cp_enabled and not skip_ulysses
+    # Hybrid: Ulysses gather concatenates rank-major packed shards; Ring needs
+    # sample-major CP-local order + scaled cu_seqlens (see packed_sharding).
+    _hybrid_ulysses_local_cu = None
+    if ulysses_enabled and cp_enabled and not skip_ulysses:
+        from ....distributed.context_parallel.packed_sharding import (
+            reorder_ulysses_rank_major_to_sample_major,
+            ulysses_local_cu_to_cp_local_cu,
         )
 
-    attn_output = _flash_attention_forward(
-        query,
-        key,
-        value,
-        attention_mask,
-        query_length=seq_len,
-        is_causal=is_causal,
-        dropout=dropout,
-        softmax_scale=scaling,
-        sliding_window=sliding_window,
-        softcap=softcap,
-        use_top_left_mask=False,
-        target_dtype=target_dtype,
-        attn_implementation=fa_kernel_implementation,
-        layer_idx=module.layer_idx if hasattr(module, "layer_idx") else None,
-        **kwargs,
-    )
+        _hybrid_ulysses_local_cu = kwargs.get("cu_seq_lens_q")
+        if _hybrid_ulysses_local_cu is None:
+            _hybrid_ulysses_local_cu = kwargs.get("cu_seqlens_q")
+        if _hybrid_ulysses_local_cu is not None:
+            seq_dim = 1 if query.ndim == 4 else 0
+            actual = int(query.size(seq_dim))
+            local_sum = int(_hybrid_ulysses_local_cu.diff().sum().item())
+            expected = local_sum * int(ulysses_size)
+            if actual != expected:
+                # ViT passes global cu_seqlens while Q is only Ulysses-gathered
+                # (CP-local). Skip LM hybrid reorder; drop cu to avoid packed-ring OOB.
+                _hybrid_ulysses_local_cu = None
+                kwargs = dict(kwargs)
+                for _k in (
+                    "cu_seq_lens_q",
+                    "cu_seq_lens_k",
+                    "cu_seqlens_q",
+                    "cu_seqlens_k",
+                ):
+                    kwargs.pop(_k, None)
+            else:
+                query = reorder_ulysses_rank_major_to_sample_major(
+                    query, _hybrid_ulysses_local_cu, ulysses_size=ulysses_size, seq_dim=seq_dim
+                )
+                key = reorder_ulysses_rank_major_to_sample_major(
+                    key, _hybrid_ulysses_local_cu, ulysses_size=ulysses_size, seq_dim=seq_dim
+                )
+                value = reorder_ulysses_rank_major_to_sample_major(
+                    value, _hybrid_ulysses_local_cu, ulysses_size=ulysses_size, seq_dim=seq_dim
+                )
+                cp_cu = ulysses_local_cu_to_cp_local_cu(_hybrid_ulysses_local_cu, ulysses_size)
+                kwargs = dict(kwargs)
+                kwargs["cu_seq_lens_q"] = cp_cu
+                kwargs["cu_seq_lens_k"] = cp_cu
+                kwargs["cu_seqlens_q"] = cp_cu
+                kwargs["cu_seqlens_k"] = cp_cu
+                if "max_length_q" in kwargs or "max_seqlen_q" in kwargs:
+                    max_cp = int(cp_cu.diff().max().item()) if cp_cu.numel() > 1 else 0
+                    kwargs["max_length_q"] = max_cp
+                    kwargs["max_length_k"] = max_cp
+                    kwargs["max_seqlen_q"] = max_cp
+                    kwargs["max_seqlen_k"] = max_cp
+                seq_len = query.shape[1] if query.ndim == 4 else query.shape[0]
+
+    if cp_enabled:
+        from ....distributed.context_parallel.attention_backend import has_npu_fusion_attention
+        from ....distributed.context_parallel.ring_attention import ringattn_context_parallel
+
+        cu_seqlens = kwargs.get("cu_seq_lens_q")
+        if cu_seqlens is None:
+            cu_seqlens = kwargs.get("cu_seqlens_q")
+        # HF packed/varlen SFT often passes is_causal=False; Ring path is causal-only for now.
+        # Proceed with causal Ring regardless of the flag (non-causal CP is out of cut).
+        if sliding_window is not None or softcap is not None:
+            raise NotImplementedError("Ring CP does not support sliding_window/softcap yet.")
+        if dropout not in (0, 0.0):
+            raise NotImplementedError("Ring CP does not support attention dropout yet.")
+
+        query_bnsd = query.transpose(1, 2).contiguous()
+        key_bnsd = key.transpose(1, 2).contiguous()
+        value_bnsd = value.transpose(1, 2).contiguous()
+        cp_group = get_parallel_state().cp_group
+        cp_global_ranks = dist.get_process_group_ranks(cp_group)
+        backend = "npu" if has_npu_fusion_attention() and query.device.type == "npu" else "torch"
+        attn_output_bnsd = ringattn_context_parallel(
+            query_bnsd,
+            key_bnsd,
+            value_bnsd,
+            query_bnsd.shape[1],
+            cp_group,
+            cp_global_ranks,
+            softmax_scale=scaling,
+            backend=backend,
+            cu_seqlens=cu_seqlens,
+        )
+        attn_output = attn_output_bnsd.transpose(1, 2).contiguous()
+    else:
+        # Resolve the token that will be passed to Transformers' lazy_import_flash_attention.
+        #
+        # FA2 and FA3 have dedicated branches in transformers' _lazy_imports, so we
+        # use the plain transformers names and they are resolved without hitting the
+        # hub-kernel path.
+        #
+        # FA4 has no such branch; unrecognised names fall through to the hub-kernel
+        # loader. By keeping the VeOmni name here, our monkey-patch of
+        # ``load_and_register_attn_kernel`` intercepts it and loads
+        # ``flash_attn.cute`` locally.
+        if module.config._attn_implementation == "veomni_flash_attention_2_with_sp":
+            fa_kernel_implementation = "flash_attention_2"
+        elif module.config._attn_implementation == "veomni_flash_attention_3_with_sp":
+            fa_kernel_implementation = "flash_attention_3"
+        elif module.config._attn_implementation == "veomni_flash_attention_4_with_sp":
+            fa_kernel_implementation = "veomni_flash_attention_4_with_sp"  # intercepted by VeOmni hub-kernel patch
+        else:
+            raise ValueError(
+                f"unknown attn_implementation for veomni flash_attention with SP support: {module.config._attn_implementation}"
+            )
+
+        attn_output = _flash_attention_forward(
+            query,
+            key,
+            value,
+            attention_mask,
+            query_length=seq_len,
+            is_causal=is_causal,
+            dropout=dropout,
+            softmax_scale=scaling,
+            sliding_window=sliding_window,
+            softcap=softcap,
+            use_top_left_mask=False,
+            target_dtype=target_dtype,
+            attn_implementation=fa_kernel_implementation,
+            layer_idx=module.layer_idx if hasattr(module, "layer_idx") else None,
+            **kwargs,
+        )
+
+    # Hybrid inverse reorder before Ulysses scatter (rank-major packed shards).
+    if (
+        ulysses_enabled
+        and cp_enabled
+        and not skip_ulysses
+        and _hybrid_ulysses_local_cu is not None
+    ):
+        from ....distributed.context_parallel.packed_sharding import (
+            reorder_sample_major_to_ulysses_rank_major,
+        )
+
+        seq_dim = 1 if attn_output.ndim == 4 else 0
+        attn_output = reorder_sample_major_to_ulysses_rank_major(
+            attn_output,
+            _hybrid_ulysses_local_cu,
+            ulysses_size=get_parallel_state().ulysses_size,
+            seq_dim=seq_dim,
+        )
 
     # Ulysses patch
     if ulysses_enabled and not skip_ulysses:


### PR DESCRIPTION
## Stacked on #985

**Depends on / merge after [#985](https://github.com/ByteDance-Seed/VeOmni/pull/985)** (`feat/gdn-state-passing-serial-p0` tip `ee30e8ac`).

GitHub base is `main` because the serial PR head lives on the fork and cannot be an upstream base (same stacking pattern as #985 → #969). The KCP delta vs #985 tip is the commits on this branch after `ee30e8ac`; until #985 merges, the files-changed view may also show serial/#969 commits.

## Summary

**KCP (P1)** = local-affine `{he,M}` → **fp32 all-gather** → prefix-merge → `S_init`, then local `chunk_gated_delta_rule` on `S/cp` tokens.

- Communication volume ∝ `CP × H × K × (K+V)` — **independent of sequence length S**
- **No serial P2P chain** (unlike `state_passing_serial`)
- Opt-in via `VEOMNI_GDN_CP_IMPL=kcp`
- **Default stays `gather_full_replicated`** (most conservative **legacy numerical** golden; does not claim mem savings / 1M). `state_passing_serial` / `kcp` are **opt-in** — production picks by context length. Default is not serial so a silent default never changes lossless-legacy behavior for existing jobs.
- Three-way flag: `gather_full` / `state_passing_serial` / `kcp` — **serial retained** as lossless golden for CP-C regression

This PR ships the **correct, communication-optimal KCP skeleton** (eager local pre-scan). P1.5a/b land on branch `feat/gdn-kcp-p15-affine-mojo` (see status below); **Ascend TTX fused body + throughput B are still follow-ups**.

## Correctness (NPU, CP-C) — ACCEPTABLE_LOSSY

Geometry: U8×CP2, seq=4K, seed=42, 5-step vs serial lossless reference.

| Check | Result |
|---|---|
| dtype / NaN | finite throughout; `fail_closed=[]`; `impl_seen=kcp` (INV-7 fp32 AG) |
| absdiff vs serial | `[0, 0, 0, 0, 0.01]`, mean `0.002`, **slope ≈ 0** → non-accumulating |
| magnitude | same order as serial↔gather_full anchor (≤0.01 non-accumulating) |

Host smoke: `tests/parallel/context_parallel/_run_gdn_kcp_prefix_smoke.py`.

## Test A (256K mem + comm) — four-cell GREEN

Same JR [`90e5a12d7dd14cd3`](https://ml.bytedance.net/development/instance/jobs/90e5a12d7dd14cd3?tabState=run_info&trialId=382427580), GBS8, 2-step, layered `AI4SE_MEM_LAYER` + `AI4SE_COMM_LAYER`.

| # | Cell | Pass line | Measured | Verdict |
|---|---|---|---|---|
| 1 | K ≈ S act | equal | **258 vs 258 MB** (`seq≈130752`) | ✅ |
| 2 | K/S ≈ G/2 | G ≈ 2×K | G **514 MB** / `seq≈261344` = **exactly 2×** | ✅ |
| 3 | K AG S-independent | K@256K ≈ K4@4K per-seq | **1,048,576 B == 1,048,576 B** (S differs 64×, AG unchanged) | ✅ |
| 4 | K AG vs G AG | G ∝ S, K flat | G local≈255 MB, `depends_on_s=true`; K `depends_on_s=false` | ✅ |

**U cross-anchor (read carefully):** U16×CP1 `gdn_act≈258 MB` with `seq≈261424` is **not** “Ulysses also shards sequence for GDN”. GDN is CP=1 (full seq); U16 head-shards channels. Head cut ≈ offsets full-seq length vs U8×CP2’s S/cp — **numerical coincidence at this geometry**, not GDN seq CP.

Optional probe: `VEOMNI_GDN_KCP_AFFINE_STUB=1` skips O(S) eager scan while preserving `hm` shape for AG byte measurement (default **off**; not for numerical gates).

## Why KCP (not just serial)

Serial (#985) already wins memory vs gather_full, but at CP2 it is only **~0.70× Ulysses** tok/s (256K speed matrix). The **serial P2P chain** worsens with CP: projected **~4× / ~7×** at CP8 / CP16 — cannot carry 1M at high CP.

KCP’s selling point is **comm S-independent + no serial chain** — now byte-proven in Test A cell 3. Local kernel speed is a separate track (P1.5).

## Known boundary — eager ~10× local pre-scan (P1.5, not a veto)

At NPU CP-C (4K), steady wall was roughly **serial ~47s vs kcp ~446s (~10×)**.

**This does not veto this PR.** It is a **P1.5 kernel** issue:

- Current eager local-affine is host-side per-token pre-scan; 128K+ is expected slow.
- P1 ships the correct communication-optimal skeleton.
- Local pre-scan hotspot is now **Ascend TTX** (`gdn_kcp_affine_ttx`, commit `d0b29d23`). AG / zigzag / prefix-merge unchanged. Host bf16 body remains optional contract ref (`VEOMNI_GDN_KCP_AFFINE_TORCH_BF16=1`).
- Reviewer question “why KCP if slower than serial today?” → serial’s chain dies at high CP; kcp is the scale-out path and is one kernel away.

### P1.5 stack status (honest layering — *kernel body not terminal yet*)

Branch `feat/gdn-kcp-p15-affine-mojo` (checkpoint `07eb18a0`) sits on this PR’s KCP skeleton. **Two rulers — do not mix:**

| Leg | Impl | vs eager | Status |
|---|---|---|---|
| **P1.5a** | `fused_torch` (fp32 same-domain rewrite) | **bit-close** (`max_absdiff=0`) | ✅ host 4K green |
| **P1.5b** | `mojo` → **Ascend TTX** fused pre-scan (`gdn_kcp_affine_ttx`, new op) → fp32 `hm`; miss→`fused_torch` | **ACCEPTABLE_LOSSY** per-token slope ≈ 0 | ✅ NPU 4K three-way green @90e5 (`body=ttx`, `slope(max/T)≈−9.7e−9`) |

**INV-7:** kernel-internal bf16 allowed; `{he,M}` / `hm` **must cast to fp32 before AG** (`ensure_affine_hm_fp32` after mojo return + again in `resolve_kcp_initial_state`). Communication/state buffers stay fp32.

**P1.5b-kernel PASS** (`d0b29d23`, new op `gdn_kcp_affine_ttx.py` — **not** GDR). User-confirmed **THREEWAY_OK** @90e5:

| Leg | Ruler | Result |
|---|---|---|
| fused_torch | bit-close boundary probe | max=0 / mean=0 @ all prefixes ✅ (AG/zigzag/merge/INV-7 untouched) |
| mojo-TTX | per-token slope ≈ 0 | `slope(max/T)≈−9.7e−9`, `slope(mean/T)≈−5.4e−10`, `rate_last/first≈0.13`, body=`ttx`×4 ✅ |
| fallback | miss → fused_torch (not eager) | contract-compliant ✅ |

Abs max ~0.03 (fp32 accum + bf16 load; ≪ torch-bf16 ~1.6 envelope) — dtype boundary, not accumulation.

**Before distributed throughput B** (technical unblock is done; avoid non-algorithm bias):
1. Single-op TTX microbench @ 4K–64K (no CP) — confirm HBM 64×64 tile is O(T) with sane slope (not a new bottleneck).
2. B matrix must keep **serial ~0.70× Ulysses** as horizontal anchor; success = KCP lifts that to **≥1.0×** and **advantage grows CP2→CP8**.

**Single-op microbench PASS** (`e0064133`, 90e5, H=4 K=V=128, no CP):

| T | ttx ms | fused ms | ttx µs/tok | ×fused |
|---|---:|---:|---:|---:|
| 4K | 68 | 688 | 16.6 | 10.1× |
| 8K | 101 | 1383 | 12.3 | 13.7× |
| 16K | 233 | 2594 | 14.2 | 11.1× |
| 32K | 375 | 5121 | 11.4 | 13.7× |
| 64K | 1021 | 10815 | 15.6 | 10.6× |

`us/token` max/min ≈ **1.45** (<3 warn); O(T) with stable per-token cost — HBM 64×64 tile is **not** a new bottleneck. Distributed B still pending user go.


Scope lock unchanged: local pre-scan only; Test A AG / zigzag / prefix-merge remain numerical anchors.

## INV-7 / checklist

- [x] `gdn_cp_impl` three-way; default **not** kcp
- [x] INV-7: AG/`hm`/`S_init` explicit **fp32** (serial v6 bf16 NaN pitfall)
- [x] serial retained; CP-C = kcp-vs-serial
- [x] stacked on #985 tip
- [x] Test A four-cell evidence (mem ×½ + AG S-indep byte-exact)

## Test plan / CI note

- [x] Host smoke: `_run_gdn_kcp_prefix_smoke.py` (affine identity, prefix-merge vs serial, comm bytes S-independent) — **covers algorithm correctness without new containers/components**
- [x] NPU CP-C vs serial (ACCEPTABLE_LOSSY)
- [x] NPU Test A 256K mem+comm (four cells)
- [ ] `test_gdn_kcp_prefix.py` once env pins allow (hf-hub pin currently blocks import on some hosts); same assertions as host smoke — **no new CI action/image**
- [ ] After #985 merge: confirm this PR diff shrinks to KCP-only

**CI default path:** `VEOMNI_GDN_MEM_PROBE` / `VEOMNI_GDN_KCP_AFFINE_STUB` default **off**. Probe emits and stub are opt-in debug only; they do not run in normal CI/train unless explicitly enabled.


