### PR TITLE
[trainer, ops] feat: add memory-efficient channel loss core

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -351,10 +351,16 @@ NPU validation runs at two times:
 
 This is an observability-only side channel. It computes detached per-token CE
 from the model loss inputs, aggregates by packed-sequence source metadata, and
-adds metrics such as `channel_loss/<source-id>__<source>` to the normal step metrics. It does
-not change the returned training loss or gradients. Fused-loss backends may
-recompute the LM-head projection on sampled steps, so the default interval is
-10 steps; set `interval=1` for per-step metrics. DiT trainers and
+adds metrics such as `channel_loss/<source-id>__<source>` to the normal step metrics.
+This side channel does not change the returned training loss or gradients.
+The default `chunk_loss` backend reuses the main loss projection, but the detached
+per-token CE still needs a chunk-sized full-vocabulary workspace. Other fused-loss
+backends may recompute the LM-head projection on sampled steps, so the default
+interval is 10 steps; set `interval=1` for per-step metrics. On memory-constrained
+profiles, `release_cache=true` synchronizes and releases the detached CE
+workspace after each sampled forward and before training backward. This does
+not change the objective or gradients, but adds synchronization and allocator
+churn. DiT trainers and
 `data.data_type="classification"` are not supported because they do not optimize
 a causal-LM objective. SeedOmni's `Qwen3MoeFoundationModel` is also unsupported
 because its legacy forward bypasses the observable loss dispatch. `BaseRLTrainer`
@@ -377,6 +383,7 @@ distinct from the first emission.
 | token_count_metric_prefix | `str` | `"channel_tokens"` | Prefix for supervised token-count metrics. |
 | log_weighted_loss | `bool` | `True` | Log weighted loss metrics. |
 | log_token_count | `bool` | `True` | Log token-count metrics. |
+| release_cache | `bool` | `False` | Synchronize and release detached CE allocator cache after sampled forwards to lower memory carried into backward. |
 | strict | `bool` | `False` | Raise when source metadata is missing or cannot be aligned with packed segments; otherwise skip invalid batches. |
 
 ### GradientCheckpointingConfig

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -1648,6 +1648,26 @@ def test_base_step_begin_allows_missing_channel_loss_callback():
     assert calls == [micro_batches]
 
 
+def test_base_step_begin_skips_unregistered_channel_loss_callback():
+    calls = []
+
+    class RecordingCallback:
+        def __init__(self, name):
+            self.name = name
+
+        def on_step_begin(self, state, micro_batches=None, **kwargs):
+            calls.append(self.name)
+
+    trainer = object.__new__(BaseTrainer)
+    trainer.state = TrainerState(global_step=1)
+    trainer.channel_loss_callback = RecordingCallback("unregistered-channel")
+    trainer._callbacks = [RecordingCallback("registered")]
+
+    BaseTrainer.on_step_begin(trainer, micro_batches=[{"input_ids": torch.tensor([1, 2])}])
+
+    assert calls == ["registered"]
+
+
 def test_base_forward_backward_allows_missing_channel_loss_callback(monkeypatch):
     _install_test_parallel_state(monkeypatch)
     trainer = object.__new__(BaseTrainer)

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -909,6 +909,8 @@ def test_channel_loss_sp_uses_rank_local_cu_for_headwise_padding():
         # zero positions. Position-only segmentation would find six sources.
         position_ids=torch.tensor([[0, 1, 0, 0, 0, 1, 2, 0, 0, 0]]),
         packed_cu_seqlens=[0, 4, 8, 10],
+        packed_global_cu_seqlens=[0, 4, 8, 10],
+        packed_global_physical_seq_len=10,
         tail_padding_length=2,
         ignore_index=IGNORE_INDEX,
         sp_enabled=True,
@@ -933,6 +935,55 @@ def test_channel_loss_sp_uses_rank_local_cu_for_headwise_padding():
             "input_token_count": 3,
         },
     ]
+
+
+def test_channel_loss_sp_validates_production_headwise_tail_geometry():
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_size=4)
+
+    result = ChannelLossComputer._aggregate_by_source(
+        per_token_loss=torch.arange(1, 9, dtype=torch.float32),
+        labels_flat=torch.tensor([1, 1, 1, 1, IGNORE_INDEX, IGNORE_INDEX, IGNORE_INDEX, IGNORE_INDEX]),
+        attention_mask_flat=torch.tensor([1, 1, 1, 1, 1, 0, 1, 0]),
+        source_ids=["first", "second"],
+        position_ids=torch.tensor([[0, 1, 0, 1, 0, 0, 0, 0]]),
+        packed_cu_seqlens=[0, 2, 4, 8],
+        packed_global_cu_seqlens=[0, 3, 5, 16],
+        packed_global_physical_seq_len=32,
+        tail_padding_length=11,
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=parallel_state,
+        strict=True,
+    )
+
+    assert result == [
+        {"source_id": "first", "loss_sum": 3.0, "token_count": 2},
+        {"source_id": "second", "loss_sum": 7.0, "token_count": 2},
+    ]
+
+
+def test_channel_loss_sp_rejects_stale_global_cu_for_headwise_tail():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+    kwargs = dict(
+        per_token_loss=torch.arange(1, 11, dtype=torch.float32),
+        labels_flat=torch.tensor(
+            [1, 1, IGNORE_INDEX, IGNORE_INDEX, 1, 1, 1, IGNORE_INDEX, IGNORE_INDEX, IGNORE_INDEX]
+        ),
+        attention_mask_flat=torch.ones(10, dtype=torch.long),
+        source_ids=["first", "second"],
+        position_ids=torch.tensor([[0, 1, 0, 0, 0, 1, 2, 0, 0, 0]]),
+        packed_cu_seqlens=[0, 4, 8, 10],
+        packed_global_cu_seqlens=[0, 2, 8, 10],
+        packed_global_physical_seq_len=10,
+        tail_padding_length=2,
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=parallel_state,
+    )
+
+    assert ChannelLossComputer._aggregate_by_source(**kwargs, strict=False) == []
+    with pytest.raises(ChannelLossMetadataError, match="do not describe the same headwise microbatch"):
+        ChannelLossComputer._aggregate_by_source(**kwargs, strict=True)
 
 
 def test_channel_loss_sp_rank_local_cu_rejects_unproven_extra_source():
@@ -972,6 +1023,93 @@ def test_channel_loss_sp_rank_local_cu_rejects_unsupervised_one_token_without_ta
 
     assert ChannelLossComputer._aggregate_by_source(**kwargs, strict=False) == []
     with pytest.raises(ChannelLossMetadataError, match="source metadata count"):
+        ChannelLossComputer._aggregate_by_source(**kwargs, strict=True)
+
+
+def test_channel_loss_sp_rank_local_cu_rejects_inconsistent_tail_provenance():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+
+    kwargs = dict(
+        per_token_loss=torch.arange(1, 6, dtype=torch.float32),
+        labels_flat=torch.tensor([1, 1, 1, 1, IGNORE_INDEX]),
+        attention_mask_flat=torch.ones(5, dtype=torch.long),
+        source_ids=["first", "second"],
+        position_ids=torch.tensor([[0, 1, 0, 1, 0]]),
+        packed_cu_seqlens=[0, 2, 4, 5],
+        packed_global_cu_seqlens=[0, 2, 4, 5],
+        packed_global_physical_seq_len=5,
+        tail_padding_length=2,
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=parallel_state,
+    )
+
+    assert ChannelLossComputer._aggregate_by_source(**kwargs, strict=False) == []
+    with pytest.raises(ChannelLossMetadataError, match="tail_padding_length"):
+        ChannelLossComputer._aggregate_by_source(**kwargs, strict=True)
+
+
+def test_channel_loss_sp_rejects_malformed_local_cu_instead_of_falling_back_to_positions():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+
+    kwargs = dict(
+        per_token_loss=torch.arange(1, 5, dtype=torch.float32),
+        labels_flat=torch.ones(4, dtype=torch.long),
+        attention_mask_flat=torch.ones(4, dtype=torch.long),
+        source_ids=["first", "second"],
+        position_ids=torch.tensor([[0, 1, 0, 1]]),
+        packed_cu_seqlens=[0, 2, 1, 4],
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=parallel_state,
+    )
+
+    assert ChannelLossComputer._aggregate_by_source(**kwargs, strict=False) == []
+    with pytest.raises(ChannelLossMetadataError, match="invalid packed CU metadata"):
+        ChannelLossComputer._aggregate_by_source(**kwargs, strict=True)
+
+
+def test_channel_loss_sp_valid_global_cu_falls_back_for_standard_ulysses_slice():
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_size=2)
+
+    result = ChannelLossComputer._aggregate_by_source(
+        per_token_loss=torch.arange(1, 5, dtype=torch.float32),
+        labels_flat=torch.ones(4, dtype=torch.long),
+        attention_mask_flat=torch.ones(4, dtype=torch.long),
+        source_ids=["first", "second"],
+        position_ids=torch.tensor([[0, 1, 0, 1]]),
+        packed_cu_seqlens=[0, 4, 8],
+        packed_global_cu_seqlens=[0, 4, 8],
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=parallel_state,
+        strict=True,
+    )
+
+    assert result == [
+        {"source_id": "first", "loss_sum": 3.0, "token_count": 2},
+        {"source_id": "second", "loss_sum": 7.0, "token_count": 2},
+    ]
+
+
+def test_channel_loss_sp_rejects_stale_cu_endpoint_instead_of_falling_back_to_positions():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+
+    kwargs = dict(
+        per_token_loss=torch.arange(1, 5, dtype=torch.float32),
+        labels_flat=torch.ones(4, dtype=torch.long),
+        attention_mask_flat=torch.ones(4, dtype=torch.long),
+        source_ids=["first", "second"],
+        position_ids=torch.tensor([[0, 1, 0, 1]]),
+        packed_cu_seqlens=[0, 2, 5],
+        packed_global_cu_seqlens=[0, 2, 5],
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=parallel_state,
+    )
+
+    assert ChannelLossComputer._aggregate_by_source(**kwargs, strict=False) == []
+    with pytest.raises(ChannelLossMetadataError, match="standard-Ulysses global provenance"):
         ChannelLossComputer._aggregate_by_source(**kwargs, strict=True)
 
 
@@ -1674,6 +1812,18 @@ def test_channel_loss_computer_aggregates_step_results_locally():
     assert tuple(value.item() for value in computer.step_data_totals["a"]) == (2, 7, 3)
 
 
+def test_channel_loss_begin_step_rejects_parallel_metadata_list_mismatch():
+    computer = ChannelLossComputer(parallel_state=_test_parallel_state())
+
+    with pytest.raises(ChannelLossMetadataError, match="per-microbatch metadata list lengths"):
+        computer.begin_step(
+            [["a"]],
+            [torch.tensor([[0]])],
+            [torch.ones(1, 1, dtype=torch.long)],
+            per_mb_packed_global_physical_seq_lens=[],
+        )
+
+
 def test_base_step_begin_captures_channel_metadata_before_multisource_meter():
     calls = []
     step_end_calls = []
@@ -2235,20 +2385,28 @@ def test_channel_loss_metadata_prefers_rank_local_router_mask_and_cu():
     local_router_mask = torch.tensor([[1, 1, 0, 0]], dtype=torch.long)
     local_cu = [0, 2, 4]
 
-    source_ids, source_names, position_ids, attention_mask, packed_cu_seqlens, tail_padding_length = (
-        callback._extract_metadata(
-            {
-                "ds_idx": torch.tensor([3, 4]),
-                "source_name": ["train/a", "train/b"],
-                "labels": torch.tensor([[1, 2, IGNORE_INDEX, IGNORE_INDEX]]),
-                "position_ids": torch.tensor([[0, 1, 0, 0]]),
-                "attention_mask": global_attention_mask,
-                "router_attention_mask": local_router_mask,
-                "cu_seq_lens_q": torch.tensor([0, 2, 4], dtype=torch.int32),
-                "cu_seqlens_list_q": local_cu,
-                "tail_padding_length": torch.tensor(8, dtype=torch.int32),
-            }
-        )
+    (
+        source_ids,
+        source_names,
+        position_ids,
+        attention_mask,
+        packed_cu_seqlens,
+        packed_global_cu_seqlens,
+        packed_global_physical_seq_len,
+        tail_padding_length,
+    ) = callback._extract_metadata(
+        {
+            "ds_idx": torch.tensor([3, 4]),
+            "source_name": ["train/a", "train/b"],
+            "labels": torch.tensor([[1, 2, IGNORE_INDEX, IGNORE_INDEX]]),
+            "position_ids": torch.tensor([[0, 1, 0, 0]]),
+            "attention_mask": global_attention_mask,
+            "router_attention_mask": local_router_mask,
+            "cu_seq_lens_q": torch.tensor([0, 2, 4], dtype=torch.int32),
+            "cu_seqlens_list_q": local_cu,
+            "linear_attn_cu_seqlens_list_q": [0, 8, 16],
+            "tail_padding_length": torch.tensor(8, dtype=torch.int32),
+        }
     )
 
     assert source_ids == [3, 4]
@@ -2256,6 +2414,8 @@ def test_channel_loss_metadata_prefers_rank_local_router_mask_and_cu():
     assert position_ids.shape == (1, 4)
     assert attention_mask is local_router_mask
     assert packed_cu_seqlens is local_cu
+    assert packed_global_cu_seqlens == [0, 8, 16]
+    assert packed_global_physical_seq_len == 16
     assert tail_padding_length == 8
 
 
@@ -2304,18 +2464,20 @@ def test_channel_loss_sp_rank_local_cu_keeps_multiple_empty_sources():
     ]
 
 
-def test_channel_loss_sp_rank_local_cu_drops_zero_length_synthetic_tail():
+def test_channel_loss_sp_rank_local_cu_drops_proven_synthetic_tail():
     parallel_state = _test_parallel_state(sp_enabled=True)
 
     result = ChannelLossComputer._aggregate_sp(
-        per_token_loss=torch.tensor([2.0, 3.0]),
-        labels_flat=torch.tensor([1, 1]),
-        attention_mask_flat=torch.ones(2, dtype=torch.long),
+        per_token_loss=torch.tensor([2.0, 3.0, 4.0, 5.0]),
+        labels_flat=torch.tensor([1, 1, IGNORE_INDEX, IGNORE_INDEX]),
+        attention_mask_flat=torch.ones(4, dtype=torch.long),
         source_ids=["source"],
-        positions=torch.tensor([[0, 1]]),
-        packed_cu_seqlens=[0, 2, 2],
+        positions=torch.tensor([[0, 1, 0, 0]]),
+        packed_cu_seqlens=[0, 2, 4],
+        packed_global_cu_seqlens=[0, 2, 3],
+        packed_global_physical_seq_len=4,
         tail_padding_length=1,
-        seq_len=2,
+        seq_len=4,
         ignore_index=IGNORE_INDEX,
         parallel_state=parallel_state,
         strict=True,
@@ -2330,7 +2492,7 @@ def test_channel_loss_metadata_rejects_misaligned_router_mask():
     callback = ChannelLossCallback(trainer)
     global_attention_mask = torch.ones(1, 4, dtype=torch.long)
 
-    _, _, _, attention_mask, _, _ = callback._extract_metadata(
+    _, _, _, attention_mask, _, _, _, _ = callback._extract_metadata(
         {
             "ds_idx": torch.tensor([3]),
             "labels": torch.tensor([[1, 2, 3, 4]]),

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -1,8 +1,12 @@
 import importlib.util
 import math
 import os
+import queue
 import sys
+import time
+import traceback
 from contextlib import nullcontext
+from datetime import timedelta
 from functools import partial
 from importlib.machinery import ModuleSpec
 from types import SimpleNamespace
@@ -28,8 +32,10 @@ def _find_spec_without_torch_npu(name: str, package: str | None = None) -> Modul
 
 importlib.util.find_spec = _find_spec_without_torch_npu  # type: ignore[assignment]
 try:
+    import veomni.distributed.parallel_state as parallel_state_module
     import veomni.trainer.callbacks.channel_loss_callback as channel_loss_module
     from veomni.arguments.arguments_types import ChannelLossConfig, ChunkMBSConfig
+    from veomni.distributed.parallel_state import use_parallel_state
     from veomni.models.seed_omni.foundation.qwen3_moe_foundation.modeling_qwen3_moe_foundation import (
         Qwen3MoeFoundationModel,
     )
@@ -45,6 +51,7 @@ try:
     from veomni.trainer.callbacks.base import TrainerState
     from veomni.trainer.callbacks.channel_loss_callback import (
         ChannelLossCallback,
+        ChannelLossCollectiveError,
         ChannelLossComputer,
         ChannelLossMetadataError,
     )
@@ -82,6 +89,32 @@ def _expected_segment(logits, labels, start, end):
     return losses[start : end + 1][valid].sum().item(), valid.sum().item()
 
 
+def _test_parallel_state(
+    *,
+    sp_enabled=False,
+    sp_group=None,
+    sp_size=1,
+    sp_rank=0,
+    dp_size=1,
+    dp_group=None,
+):
+    return SimpleNamespace(
+        sp_enabled=sp_enabled,
+        sp_group=sp_group,
+        sp_size=sp_size,
+        sp_rank=sp_rank,
+        dp_size=dp_size,
+        dp_group=dp_group,
+    )
+
+
+def _install_test_parallel_state(monkeypatch, parallel_state=None):
+    parallel_state = parallel_state or _test_parallel_state()
+    monkeypatch.setattr(parallel_state_module, "_PARALLEL_STATE", parallel_state)
+    monkeypatch.setitem(parallel_state_module._PARALLEL_STATE_REGISTRY, "base", parallel_state)
+    return parallel_state
+
+
 def test_channel_loss_computer_aggregates_packed_logits_by_source():
     torch.manual_seed(0)
     vocab_size = 32
@@ -107,8 +140,16 @@ def test_channel_loss_computer_aggregates_packed_logits_by_source():
     loss_0, tokens_0 = _expected_segment(logits, labels, 0, 2)
     loss_1, tokens_1 = _expected_segment(logits, labels, 3, 4)
     assert result == [
-        {"source_id": 0, "loss_sum": pytest.approx(loss_0), "token_count": tokens_0},
-        {"source_id": 1, "loss_sum": pytest.approx(loss_1), "token_count": tokens_1},
+        {
+            "source_id": 0,
+            "loss_sum": pytest.approx(loss_0),
+            "token_count": tokens_0,
+        },
+        {
+            "source_id": 1,
+            "loss_sum": pytest.approx(loss_1),
+            "token_count": tokens_1,
+        },
     ]
 
 
@@ -151,6 +192,25 @@ def test_channel_loss_computer_hidden_states_path_matches_logits_path():
     )
 
     assert hs_result == logits_result
+
+
+def test_channel_loss_computer_counts_data_metrics_with_sequence_parallel():
+    result = ChannelLossComputer._aggregate_by_source(
+        per_token_loss=torch.ones(4),
+        labels_flat=torch.tensor([1, 2, 3, IGNORE_INDEX]),
+        attention_mask_flat=torch.tensor([1, 1, 1, 0]),
+        source_ids=["repoqa", "other"],
+        position_ids=torch.tensor([[0, 1, 0, 1]]),
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=_test_parallel_state(sp_enabled=True),
+        strict=True,
+        include_data_stats=True,
+    )
+
+    assert [item["sample_count"].item() for item in result] == [1, 1]
+    assert [item["input_token_count"].item() for item in result] == [2, 1]
+    assert [item["token_count"].item() for item in result] == [2, 1]
 
 
 def test_channel_loss_wrapper_forwards_original_call_unchanged():
@@ -262,6 +322,104 @@ def test_channel_loss_extracts_fused_inputs_from_variadic_loss_signatures(signat
     assert computer._result
     assert computer._result[0]["source_id"] == 0
     assert computer._result[0]["token_count"].item() == 2
+
+
+def test_channel_loss_chunk_kernel_reuses_main_projection(monkeypatch):
+    from veomni.ops.kernels.cross_entropy import _chunk_loss_dispatch
+
+    _install_test_parallel_state(monkeypatch)
+    module = sys.modules[__name__]
+    old_slot = getattr(module, "veomni_causal_lm_loss", None)
+    module.veomni_causal_lm_loss = _DummyOpSlot(_chunk_loss_dispatch)
+
+    class DummyModel(torch.nn.Module):
+        pass
+
+    seq_len = 1026
+    hidden_states = torch.randn(1, seq_len, 4, requires_grad=True)
+    weights = torch.randn(7, 4, requires_grad=True)
+    labels = (torch.arange(seq_len) % weights.size(0)).unsqueeze(0)
+    reference_hidden_states = hidden_states.detach().clone().requires_grad_()
+    reference_weights = weights.detach().clone().requires_grad_()
+    reference_loss, _, _ = _chunk_loss_dispatch(
+        logits=None,
+        labels=labels,
+        vocab_size=weights.size(0),
+        hidden_states=reference_hidden_states,
+        weights=reference_weights,
+    )
+    reference_loss.backward()
+
+    computer = ChannelLossComputer()
+    computer._source_ids = ["source"]
+    computer._position_ids = torch.arange(seq_len).unsqueeze(0)
+
+    linear_calls = []
+    original_linear = F.linear
+
+    def counted_linear(input, weight, bias=None):
+        linear_calls.append(tuple(input.shape))
+        return original_linear(input, weight, bias)
+
+    monkeypatch.setattr(F, "linear", counted_linear)
+    try:
+        computer.install(DummyModel())
+        with computer.capture():
+            loss, logits, aux = module.veomni_causal_lm_loss(
+                logits=None,
+                labels=labels,
+                vocab_size=weights.size(0),
+                hidden_states=hidden_states,
+                weights=weights,
+            )
+        loss.backward()
+    finally:
+        computer.uninstall()
+        if old_slot is None:
+            delattr(module, "veomni_causal_lm_loss")
+        else:
+            module.veomni_causal_lm_loss = old_slot
+
+    assert logits is None
+    assert aux is None
+    # The 1025 causal tokens use two main chunks. Channel loss must consume
+    # their CE instead of projecting the original 1026-token input again.
+    assert linear_calls == [(1024, 4), (1, 4)]
+    assert hidden_states.grad is not None
+    assert weights.grad is not None
+    torch.testing.assert_close(loss, reference_loss, rtol=0, atol=0)
+    torch.testing.assert_close(hidden_states.grad, reference_hidden_states.grad, rtol=0, atol=0)
+    torch.testing.assert_close(weights.grad, reference_weights.grad, rtol=0, atol=0)
+    assert computer._result
+    assert computer._result[0]["token_count"].item() == seq_len - 1
+    assert computer._result[0]["loss_sum"].item() == pytest.approx(loss.item() * (seq_len - 1), rel=1e-6)
+
+
+@pytest.mark.parametrize("capture_count", [0, 2])
+def test_channel_loss_reuse_fallback_warns(monkeypatch, capture_count):
+    computer = ChannelLossComputer()
+    warnings = []
+
+    def original_kernel():
+        from veomni.utils.loss_observer import get_chunk_loss_consumer
+
+        consumer = get_chunk_loss_consumer()
+        for _ in range(capture_count):
+            consumer(torch.zeros(1))
+        return "main-loss"
+
+    dispatcher = channel_loss_module._OpSlotDispatcher(object(), original_kernel)
+    dispatcher.owners.add(computer)
+    monkeypatch.setattr(channel_loss_module.logger, "warning_once", warnings.append)
+    token = channel_loss_module._ACTIVE_CHANNEL_LOSS_COMPUTER.set(computer)
+    try:
+        assert dispatcher() == "main-loss"
+    finally:
+        channel_loss_module._ACTIVE_CHANNEL_LOSS_COMPUTER.reset(token)
+
+    assert len(warnings) == 1
+    assert f"observed {capture_count}" in warnings[0]
+    assert "falling back" in warnings[0]
 
 
 def test_channel_loss_unwraps_native_lora_model_for_eager_loss():
@@ -441,6 +599,8 @@ def test_channel_loss_opslot_dispatch_is_scoped_and_reference_counted():
 
 
 def test_channel_loss_sp_reduce_preserves_batch_order_for_multiple_sources(monkeypatch):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
     rank1_metadata = [
         {"batch_idx": 0, "sp_rank": 1, "local_order": 0, "is_start": False},
         {"batch_idx": 1, "sp_rank": 1, "local_order": 0, "is_start": False},
@@ -459,9 +619,6 @@ def test_channel_loss_sp_reduce_preserves_batch_order_for_multiple_sources(monke
             gathered[1].copy_(torch.tensor([[1, 0, 0], [1, 0, 0]], dtype=torch.int64))
         gather_inputs.append((local_values.dtype, tuple(local_values.shape)))
 
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: object())
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 2)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
 
@@ -473,6 +630,7 @@ def test_channel_loss_sp_reduce_preserves_batch_order_for_multiple_sources(monke
         positions=torch.tensor([[0, 1], [0, 1]]),
         seq_len=4,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -484,6 +642,7 @@ def test_channel_loss_sp_reduce_preserves_batch_order_for_multiple_sources(monke
 
 
 def test_channel_loss_sp_reduce_handles_empty_local_rank(monkeypatch):
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=object(), sp_size=2)
     rank1_metadata = [{"batch_idx": 0, "sp_rank": 1, "local_order": 0, "is_start": True}]
 
     def fake_all_gather_object(gathered, local_metadata, group=None):
@@ -498,8 +657,6 @@ def test_channel_loss_sp_reduce_handles_empty_local_rank(monkeypatch):
         else:
             gathered[1].copy_(torch.tensor([[2, 0, 0]], dtype=torch.int64))
 
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: object())
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 2)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
 
@@ -507,6 +664,7 @@ def test_channel_loss_sp_reduce_handles_empty_local_rank(monkeypatch):
         local_segments=[],
         source_ids=["remote"],
         device=torch.device("cpu"),
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -514,6 +672,7 @@ def test_channel_loss_sp_reduce_handles_empty_local_rank(monkeypatch):
 
 
 def test_channel_loss_sp_reduce_filters_uneven_remote_padding_segments(monkeypatch):
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=object(), sp_size=2)
     rank1_metadata = [
         {"batch_idx": 0, "sp_rank": 1, "local_order": 0, "is_start": True},
         {"batch_idx": 0, "sp_rank": 1, "local_order": 1, "is_start": True},
@@ -531,9 +690,6 @@ def test_channel_loss_sp_reduce_filters_uneven_remote_padding_segments(monkeypat
         else:
             gathered[1].copy_(torch.tensor([[0, 1, 1], [0, 1, 1]], dtype=torch.int64))
 
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: object())
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 2)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
     monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
 
@@ -545,6 +701,7 @@ def test_channel_loss_sp_reduce_filters_uneven_remote_padding_segments(monkeypat
         positions=torch.tensor([[0, 1]]),
         seq_len=2,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -552,9 +709,7 @@ def test_channel_loss_sp_reduce_filters_uneven_remote_padding_segments(monkeypat
 
 
 def test_channel_loss_sp_aggregation_does_not_extract_segment_scalars(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
 
     def fail_item(tensor):
         raise AssertionError(f"SP segment aggregation extracted a scalar with shape={tuple(tensor.shape)}")
@@ -569,6 +724,7 @@ def test_channel_loss_sp_aggregation_does_not_extract_segment_scalars(monkeypatc
             positions=torch.tensor([[0, 1, 0, 1, 0, 1]]),
             seq_len=6,
             ignore_index=IGNORE_INDEX,
+            parallel_state=parallel_state,
             strict=True,
         )
 
@@ -644,8 +800,7 @@ def test_channel_loss_preserves_zero_supervision_tail_when_later_row_has_padding
 
 
 def test_channel_loss_compute_uses_position_aligned_mask_for_padding_evidence(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "_is_sp_enabled", lambda: False)
-    computer = ChannelLossComputer()
+    computer = ChannelLossComputer(parallel_state=_test_parallel_state())
     computer.strict = True
     computer._source_ids = ["row0_normal", "row0_zero", "row1_normal"]
     computer._position_ids = torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]])
@@ -700,9 +855,7 @@ def test_channel_loss_keeps_zero_supervision_segment_before_tail_padding():
 
 
 def test_channel_loss_sp_ignores_padding_only_position_zero_segments(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
 
     result = ChannelLossComputer._aggregate_sp(
         per_token_loss=torch.tensor([1.0, 2.0, 100.0, 100.0]),
@@ -712,6 +865,7 @@ def test_channel_loss_sp_ignores_padding_only_position_zero_segments(monkeypatch
         positions=torch.tensor([[0, 1, 0, 0]]),
         seq_len=4,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -719,9 +873,7 @@ def test_channel_loss_sp_ignores_padding_only_position_zero_segments(monkeypatch
 
 
 def test_channel_loss_sp_filters_padding_tail_per_batch_row(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
 
     result = ChannelLossComputer._aggregate_sp(
         per_token_loss=torch.tensor([1.0, 2.0, 100.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
@@ -731,6 +883,7 @@ def test_channel_loss_sp_filters_padding_tail_per_batch_row(monkeypatch):
         positions=torch.tensor([[0, 1, 0, 0], [0, 1, 0, 0]]),
         seq_len=8,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -741,9 +894,7 @@ def test_channel_loss_sp_filters_padding_tail_per_batch_row(monkeypatch):
 
 
 def test_channel_loss_sp_preserves_zero_supervision_tail_when_later_row_has_padding(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
 
     result = ChannelLossComputer._aggregate_sp(
         per_token_loss=torch.tensor([1.0, 2.0, 3.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
@@ -753,6 +904,7 @@ def test_channel_loss_sp_preserves_zero_supervision_tail_when_later_row_has_padd
         positions=torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]]),
         seq_len=8,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -764,9 +916,7 @@ def test_channel_loss_sp_preserves_zero_supervision_tail_when_later_row_has_padd
 
 
 def test_channel_loss_sp_rejects_ambiguous_per_row_padding_without_mask_evidence(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
     kwargs = dict(
         per_token_loss=torch.tensor([1.0, 2.0, 3.0, 100.0, 3.0, 4.0, 100.0, 100.0]),
         labels_flat=torch.tensor([1, 1, 1, IGNORE_INDEX, 1, 1, IGNORE_INDEX, IGNORE_INDEX]),
@@ -775,6 +925,7 @@ def test_channel_loss_sp_rejects_ambiguous_per_row_padding_without_mask_evidence
         positions=torch.tensor([[0, 1, 2, 0], [0, 1, 0, 0]]),
         seq_len=8,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
     )
 
     assert ChannelLossComputer._aggregate_sp(**kwargs, strict=False) == []
@@ -783,9 +934,7 @@ def test_channel_loss_sp_rejects_ambiguous_per_row_padding_without_mask_evidence
 
 
 def test_channel_loss_sp_keeps_zero_supervision_segment_before_tail_padding(monkeypatch):
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_rank", lambda: 0)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_group", lambda: None)
-    monkeypatch.setattr(channel_loss_module, "get_unified_sequence_parallel_world_size", lambda: 1)
+    parallel_state = _test_parallel_state(sp_enabled=True)
 
     result = ChannelLossComputer._aggregate_sp(
         per_token_loss=torch.tensor([100.0, 2.0, 100.0]),
@@ -795,6 +944,7 @@ def test_channel_loss_sp_keeps_zero_supervision_segment_before_tail_padding(monk
         positions=torch.tensor([[0, 0, 0]]),
         seq_len=3,
         ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
         strict=True,
     )
 
@@ -802,6 +952,323 @@ def test_channel_loss_sp_keeps_zero_supervision_segment_before_tail_padding(monk
         {"source_id": "one_token", "loss_sum": 0.0, "token_count": 0},
         {"source_id": "normal", "loss_sum": 2.0, "token_count": 1},
     ]
+
+
+def _ready_sp_observation(parallel_state, *, loss_sum=1.0):
+    segment = {
+        "batch_idx": 0,
+        "sp_rank": 0,
+        "local_order": 0,
+        "is_start": True,
+        "has_explicit_padding_mask": torch.tensor(False),
+        "has_only_zero_positions": torch.tensor(False),
+        "loss_sum": torch.tensor(loss_sum),
+        "token_count": torch.tensor(1),
+        "sample_count": torch.tensor(1),
+        "input_token_count": torch.tensor(2),
+    }
+    return ChannelLossComputer._prepare_sp_observation_payload(
+        [segment],
+        ["source-a"],
+        device=torch.device("cpu"),
+        payload_capacity=2,
+        parallel_state=parallel_state,
+        include_data_stats=True,
+    )
+
+
+def test_channel_loss_sp_capture_reuses_cached_parallel_state_descriptor():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    computer._position_ids = torch.tensor([[0, 1]])
+
+    with computer.capture():
+        descriptor = computer._capture_sp_descriptor
+        assert descriptor is not None
+        assert descriptor.parallel_state is parallel_state
+        parallel_state.sp_rank = 7
+        computer.compute_side_channel(
+            logits=torch.randn(1, 2, 4),
+            labels=torch.tensor([[1, 2]]),
+            vocab_size=4,
+            hidden_states=None,
+            weights=None,
+        )
+        observation = computer._pending_observations[0]
+        assert observation.capture_descriptor is descriptor
+        assert observation.integer_payload[0, 1].item() == 0
+
+    assert computer.strict_observation_errors == []
+    assert computer._micro_step_observation_count == 1
+    assert computer._result is not None
+
+
+def test_channel_loss_world_descriptor_preflight_validates_sp_group_partition():
+    statuses = [
+        {
+            "global_rank": rank,
+            "global_world": 4,
+            "enabled": True,
+            "sp_world": 2,
+            "sp_rank": rank % 2,
+            "group_ranks": (0, 1) if rank < 2 else (2, 3),
+            "errors": [],
+        }
+        for rank in range(4)
+    ]
+
+    assert ChannelLossComputer._validate_capture_descriptor_preflight(statuses) is None
+
+    statuses[1] = {**statuses[1], "group_ranks": (1, 2)}
+    assert "rank-local SP capture descriptor divergence" in (
+        ChannelLossComputer._validate_capture_descriptor_preflight(statuses) or ""
+    )
+
+
+def test_channel_loss_sp_preflight_precedes_all_ordered_payloads_and_cache_release(monkeypatch):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
+    observations = iter(
+        [_ready_sp_observation(parallel_state, loss_sum=1.0), _ready_sp_observation(parallel_state, loss_sum=3.0)]
+    )
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer.strict = True
+    computer.release_cache = True
+    computer._source_ids = ["source-a"]
+    events = []
+
+    monkeypatch.setattr(computer, "_preflight_capture_descriptor", lambda descriptor: None)
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: next(observations))
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_all_gather_object(gathered, local_value, group=None):
+        assert group is parallel_state.sp_group
+        if isinstance(local_value, dict):
+            events.append("preflight")
+            gathered[0] = local_value
+            gathered[1] = dict(local_value)
+            return
+
+    def fake_all_gather(gathered, local_value, group=None):
+        assert group is parallel_state.sp_group
+        events.append("loss" if local_value.dtype.is_floating_point else "integer")
+        for rank_idx, output in enumerate(gathered):
+            output.copy_(local_value)
+            if not local_value.dtype.is_floating_point and rank_idx == 1:
+                output[:, 1] = 1
+                output[:, 3] = 0
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather", fake_all_gather)
+    monkeypatch.setattr(channel_loss_module, "_release_observer_cache", lambda device: events.append("release"))
+
+    with computer.capture():
+        for _ in range(2):
+            computer.compute_side_channel(
+                logits=torch.randn(1, 2, 4),
+                labels=torch.tensor([[1, 2]]),
+                vocab_size=4,
+                hidden_states=None,
+                weights=None,
+            )
+
+    assert events == [
+        "preflight",
+        "loss",
+        "integer",
+        "loss",
+        "integer",
+        "release",
+    ]
+    assert computer._micro_step_observation_count == 2
+    assert [item["loss_sum"].item() for item in computer._result] == [2.0, 6.0]
+
+
+@pytest.mark.parametrize(
+    ("field", "remote_value"),
+    [
+        ("has_source", False),
+        ("observation_count", 2),
+        ("source_ids", (("str", "'source-b'"),)),
+        ("descriptor_spec", (True, 3, True)),
+        ("errors", [("generic", "rank-local observer failure")]),
+    ],
+)
+def test_channel_loss_sp_preflight_rejects_any_rank_mismatch_before_payload(
+    monkeypatch,
+    field,
+    remote_value,
+):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    prepared = _ready_sp_observation(parallel_state)
+    preflight_calls = 0
+
+    monkeypatch.setattr(computer, "_preflight_capture_descriptor", lambda descriptor: None)
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: prepared)
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_preflight(gathered, local_status, group=None):
+        nonlocal preflight_calls
+        preflight_calls += 1
+        assert isinstance(local_status, dict)
+        gathered[0] = local_status
+        remote_status = dict(local_status)
+        remote_status[field] = remote_value
+        gathered[1] = remote_status
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_preflight)
+    monkeypatch.setattr(
+        channel_loss_module.dist,
+        "all_gather",
+        lambda *args, **kwargs: pytest.fail("SP payload collective entered after a rejected preflight"),
+    )
+
+    with computer.capture():
+        computer.compute_side_channel(
+            logits=torch.randn(1, 2, 4),
+            labels=torch.tensor([[1, 2]]),
+            vocab_size=4,
+            hidden_states=None,
+            weights=None,
+        )
+
+    assert preflight_calls == 1
+    assert computer._result is None
+    assert "SP preflight rejected" in computer.strict_observation_errors[0][1]
+
+
+def test_channel_loss_sp_preflight_rejects_observation_descriptor_mismatch(monkeypatch):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    monkeypatch.setattr(computer, "_preflight_capture_descriptor", lambda descriptor: None)
+    prepared = _ready_sp_observation(parallel_state)
+    prepared.capture_descriptor = channel_loss_module._SPCaptureDescriptor(
+        enabled=True,
+        parallel_state=parallel_state,
+        group=group,
+        world=3,
+        rank=0,
+    )
+
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_preflight(gathered, local_status, group=None):
+        gathered[0] = local_status
+        gathered[1] = dict(local_status)
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_preflight)
+    monkeypatch.setattr(
+        channel_loss_module.dist,
+        "all_gather",
+        lambda *args, **kwargs: pytest.fail("descriptor mismatch must be rejected before payload collectives"),
+    )
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: prepared)
+
+    with computer.capture():
+        computer.compute_side_channel(
+            logits=torch.randn(1, 2, 4),
+            labels=torch.tensor([[1, 2]]),
+            vocab_size=4,
+            hidden_states=None,
+            weights=None,
+        )
+
+    assert computer._result is None
+    assert "different SP capture descriptor" in computer.strict_observation_errors[0][1]
+
+
+def test_channel_loss_sp_payload_failure_does_not_enter_later_observation(monkeypatch):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
+    observations = iter(
+        [_ready_sp_observation(parallel_state, loss_sum=1.0), _ready_sp_observation(parallel_state, loss_sum=3.0)]
+    )
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    payload_collective_calls = 0
+    monkeypatch.setattr(computer, "_preflight_capture_descriptor", lambda descriptor: None)
+
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: next(observations))
+
+    def fake_preflight(gathered, local_value, group=None):
+        gathered[0] = local_value
+        gathered[1] = dict(local_value)
+
+    def fail_first_payload(*args, **kwargs):
+        nonlocal payload_collective_calls
+        payload_collective_calls += 1
+        raise RuntimeError("payload collective failed locally")
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_preflight)
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather", fail_first_payload)
+
+    with pytest.raises(ChannelLossCollectiveError, match="process group must not be reused"):
+        with computer.capture():
+            for _ in range(2):
+                computer.compute_side_channel(
+                    logits=torch.randn(1, 2, 4),
+                    labels=torch.tensor([[1, 2]]),
+                    vocab_size=4,
+                    hidden_states=None,
+                    weights=None,
+                )
+
+    assert payload_collective_calls == 1
+    assert computer._result is None
+    assert computer.strict_observation_errors == []
+
+
+def test_channel_loss_sp_nonstrict_mismatch_skips_consistently(monkeypatch):
+    group = object()
+    parallel_state = _test_parallel_state(sp_enabled=True, sp_group=group, sp_size=2)
+    computer = ChannelLossComputer(parallel_state=parallel_state)
+    computer._source_ids = ["source-a"]
+    prepared = _ready_sp_observation(parallel_state)
+
+    monkeypatch.setattr(computer, "_preflight_capture_descriptor", lambda descriptor: None)
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: prepared)
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_preflight(gathered, local_status, group=None):
+        gathered[0] = local_status
+        remote_status = dict(local_status)
+        remote_status["observation_count"] = 2
+        gathered[1] = remote_status
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_preflight)
+    monkeypatch.setattr(
+        channel_loss_module.dist,
+        "all_gather",
+        lambda *args, **kwargs: pytest.fail("nonstrict ranks must consistently skip rejected payloads"),
+    )
+
+    with computer.capture():
+        computer.compute_side_channel(
+            logits=torch.randn(1, 2, 4),
+            labels=torch.tensor([[1, 2]]),
+            vocab_size=4,
+            hidden_states=None,
+            weights=None,
+        )
+
+    assert computer._result is None
+    assert computer.strict_observation_errors == []
 
 
 def test_channel_loss_logits_path_computes_ce_in_chunks(monkeypatch):
@@ -833,17 +1300,287 @@ def test_channel_loss_logits_path_computes_ce_in_chunks(monkeypatch):
 
 def test_channel_loss_config_validates_sampling_interval():
     assert ChannelLossConfig().interval == 10
+    assert ChannelLossConfig().release_cache is False
     with pytest.raises(ValueError, match="interval must be at least 1"):
         ChannelLossConfig(interval=0)
+
+
+def test_channel_loss_releases_observer_cache_after_side_channel(monkeypatch):
+    events = []
+    computer = ChannelLossComputer()
+    computer.release_cache = True
+
+    def compute(**kwargs):
+        events.append("compute")
+        return []
+
+    def release(device):
+        assert device.type == "cpu"
+        assert events == ["compute"]
+        events.append("release")
+
+    monkeypatch.setattr(computer, "_compute_channel_loss", compute)
+    monkeypatch.setattr(channel_loss_module, "_release_observer_cache", release)
+    computer.compute_side_channel(
+        logits=torch.randn(1, 2, 4),
+        labels=torch.tensor([[1, 2]]),
+        vocab_size=4,
+        hidden_states=None,
+        weights=None,
+    )
+
+    assert events == ["compute", "release"]
+
+
+def test_channel_loss_observer_cache_cleanup_orders_sync_before_empty(monkeypatch):
+    events = []
+
+    class _DeviceContext:
+        def __init__(self, device):
+            self.device = device
+
+        def __enter__(self):
+            events.append(("enter", self.device))
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            events.append(("exit", self.device))
+
+    class _Accelerator:
+        def device(self, device):
+            return _DeviceContext(device)
+
+    device = SimpleNamespace(type="npu")
+    monkeypatch.setattr(channel_loss_module, "get_torch_device", lambda: _Accelerator())
+    monkeypatch.setattr(channel_loss_module, "stream_synchronize", lambda: events.append("synchronize"))
+    monkeypatch.setattr(channel_loss_module, "empty_cache", lambda: events.append("empty_cache"))
+
+    channel_loss_module._release_observer_cache(device)
+
+    assert events == [
+        ("enter", device),
+        "synchronize",
+        "empty_cache",
+        ("exit", device),
+    ]
+
+
+def test_channel_loss_observer_cache_cleanup_is_noop_on_cpu(monkeypatch):
+    monkeypatch.setattr(
+        channel_loss_module,
+        "get_torch_device",
+        lambda: pytest.fail("CPU cleanup must not resolve an accelerator"),
+    )
+
+    channel_loss_module._release_observer_cache(torch.device("cpu"))
+
+
+def test_channel_loss_cleanup_failure_does_not_abort_observation(monkeypatch):
+    computer = ChannelLossComputer()
+    computer.release_cache = True
+    computer._source_ids = ["source-a"]
+    observed = [
+        {
+            "source_id": "source-a",
+            "loss_sum": torch.tensor(2.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(2),
+        }
+    ]
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: observed)
+    monkeypatch.setattr(
+        channel_loss_module,
+        "_release_observer_cache",
+        lambda device: (_ for _ in ()).throw(RuntimeError("cleanup failed")),
+    )
+
+    computer.compute_side_channel(
+        logits=torch.randn(1, 2, 4),
+        labels=torch.tensor([[1, 2]]),
+        vocab_size=4,
+        hidden_states=None,
+        weights=None,
+    )
+
+    assert computer._result == observed
+
+
+def test_channel_loss_cleanup_failure_preserves_deferred_strict_metadata_error(monkeypatch):
+    computer = ChannelLossComputer()
+    computer.strict = True
+    computer.release_cache = True
+
+    def fail_compute(**kwargs):
+        raise ChannelLossMetadataError("metadata failed")
+
+    monkeypatch.setattr(computer, "_compute_channel_loss", fail_compute)
+    monkeypatch.setattr(
+        channel_loss_module,
+        "_release_observer_cache",
+        lambda device: (_ for _ in ()).throw(RuntimeError("cleanup failed")),
+    )
+
+    computer.compute_side_channel(
+        logits=torch.randn(1, 2, 4),
+        labels=torch.tensor([[1, 2]]),
+        vocab_size=4,
+        hidden_states=None,
+        weights=None,
+    )
+
+    assert computer._result is None
+    assert computer.strict_observation_errors
+    assert "metadata failed" in computer.strict_observation_errors[0][1]
+
+
+def test_channel_loss_multiple_observations_accumulate_all_totals(monkeypatch):
+    computer = ChannelLossComputer(parallel_state=_test_parallel_state())
+    computer._source_ids = ["source-a"]
+    computer._position_ids = torch.tensor([[0, 1]])
+    results = iter(
+        [
+            [
+                {
+                    "source_id": "source-a",
+                    "loss_sum": torch.tensor(2.0),
+                    "token_count": torch.tensor(1),
+                    "sample_count": torch.tensor(1),
+                    "input_token_count": torch.tensor(2),
+                }
+            ],
+            [
+                {
+                    "source_id": "source-a",
+                    "loss_sum": torch.tensor(5.0),
+                    "token_count": torch.tensor(2),
+                    "sample_count": torch.tensor(1),
+                    "input_token_count": torch.tensor(3),
+                }
+            ],
+        ]
+    )
+    monkeypatch.setattr(computer, "_compute_channel_loss", lambda **kwargs: next(results))
+
+    with computer.capture():
+        for _ in range(2):
+            computer.compute_side_channel(
+                logits=torch.randn(1, 2, 4),
+                labels=torch.tensor([[1, 2]]),
+                vocab_size=4,
+                hidden_states=None,
+                weights=None,
+            )
+    computer.after_micro_step()
+
+    loss_sum, token_count = computer.step_totals["source-a"]
+    sample_count, input_token_count, label_token_count = computer.step_data_totals["source-a"]
+    assert (loss_sum.item(), token_count.item()) == (7.0, 3)
+    assert (sample_count.item(), input_token_count.item(), label_token_count.item()) == (2, 5, 3)
+
+
+def test_channel_loss_strict_success_plus_failure_discards_partial_evidence(monkeypatch):
+    computer = ChannelLossComputer(parallel_state=_test_parallel_state())
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    successful = [
+        {
+            "source_id": "source-a",
+            "loss_sum": torch.tensor(2.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(2),
+        }
+    ]
+    calls = 0
+
+    def observe(**kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return successful
+        raise RuntimeError("second observation failed")
+
+    monkeypatch.setattr(computer, "_compute_channel_loss", observe)
+    with computer.capture():
+        for _ in range(2):
+            computer.compute_side_channel(
+                logits=torch.randn(1, 2, 4),
+                labels=torch.tensor([[1, 2]]),
+                vocab_size=4,
+                hidden_states=None,
+                weights=None,
+            )
+
+    assert computer._result is None
+    assert computer._micro_step_observation_count == 0
+    assert "second observation failed" in computer.strict_observation_errors[0][1]
+
+
+def test_channel_loss_strict_failure_blocks_later_capture_evidence(monkeypatch):
+    computer = ChannelLossComputer(parallel_state=_test_parallel_state())
+    computer.strict = True
+    computer._source_ids = ["source-a"]
+    successful = [
+        {
+            "source_id": "source-a",
+            "loss_sum": torch.tensor(2.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(2),
+        }
+    ]
+    outcomes = iter([successful, RuntimeError("middle capture failed"), successful])
+
+    def observe(**kwargs):
+        outcome = next(outcomes)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(computer, "_compute_channel_loss", observe)
+    for _ in range(3):
+        with computer.capture():
+            computer.compute_side_channel(
+                logits=torch.randn(1, 2, 4),
+                labels=torch.tensor([[1, 2]]),
+                vocab_size=4,
+                hidden_states=None,
+                weights=None,
+            )
+
+    assert computer._result is None
+    assert computer._micro_step_observation_count == 0
+    assert computer._micro_step_failed
+    computer.after_micro_step()
+    assert computer.step_totals == {}
+    assert computer.step_data_totals == {}
 
 
 def test_channel_loss_computer_aggregates_step_results_locally():
     computer = ChannelLossComputer()
     computer.begin_step([], [], [])
     computer._result = [
-        {"source_id": "a", "loss_sum": torch.tensor(2.0), "token_count": torch.tensor(1)},
-        {"source_id": "a", "loss_sum": torch.tensor(4.0), "token_count": torch.tensor(2)},
-        {"source_id": "b", "loss_sum": torch.tensor(3.0), "token_count": torch.tensor(1)},
+        {
+            "source_id": "a",
+            "loss_sum": torch.tensor(2.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(3),
+        },
+        {
+            "source_id": "a",
+            "loss_sum": torch.tensor(4.0),
+            "token_count": torch.tensor(2),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(4),
+        },
+        {
+            "source_id": "b",
+            "loss_sum": torch.tensor(3.0),
+            "token_count": torch.tensor(1),
+            "sample_count": torch.tensor(1),
+            "input_token_count": torch.tensor(2),
+        },
     ]
 
     computer.after_micro_step()
@@ -851,9 +1588,56 @@ def test_channel_loss_computer_aggregates_step_results_locally():
     assert set(computer.step_totals) == {"a", "b"}
     assert computer.step_totals["a"][0].item() == 6.0
     assert computer.step_totals["a"][1].item() == 3
+    assert tuple(value.item() for value in computer.step_data_totals["a"]) == (2, 7, 3)
 
 
-def test_base_forward_backward_allows_missing_channel_loss_callback():
+def test_base_step_begin_captures_channel_metadata_before_multisource_meter():
+    calls = []
+
+    class RecordingCallback:
+        def __init__(self, name, consume_metadata=False):
+            self.name = name
+            self.consume_metadata = consume_metadata
+
+        def on_step_begin(self, state, micro_batches=None, **kwargs):
+            calls.append((self.name, "ds_idx" in micro_batches[0], kwargs["channel_loss_source_repeat"]))
+            if self.consume_metadata:
+                micro_batches[0].pop("ds_idx")
+                micro_batches[0].pop("source_name")
+
+    trainer = object.__new__(BaseTrainer)
+    trainer.state = TrainerState(global_step=1)
+    trainer.channel_loss_callback = RecordingCallback("channel")
+    meter = RecordingCallback("meter", consume_metadata=True)
+    tail = RecordingCallback("tail")
+    trainer._callbacks = [trainer.channel_loss_callback, meter, tail]
+    micro_batches = [{"ds_idx": torch.tensor([7]), "source_name": ["repoqa"]}]
+
+    BaseTrainer.on_step_begin(trainer, micro_batches=micro_batches, channel_loss_source_repeat=2)
+
+    assert calls == [("channel", True, 2), ("meter", True, 2), ("tail", False, 2)]
+
+
+def test_base_step_begin_allows_missing_channel_loss_callback():
+    calls = []
+
+    class RecordingCallback:
+        def on_step_begin(self, state, micro_batches=None, **kwargs):
+            calls.append(micro_batches)
+
+    trainer = object.__new__(BaseTrainer)
+    trainer.state = TrainerState(global_step=1)
+    trainer.channel_loss_callback = None
+    trainer._callbacks = [RecordingCallback()]
+    micro_batches = [{"input_ids": torch.tensor([1, 2])}]
+
+    BaseTrainer.on_step_begin(trainer, micro_batches=micro_batches)
+
+    assert calls == [micro_batches]
+
+
+def test_base_forward_backward_allows_missing_channel_loss_callback(monkeypatch):
+    _install_test_parallel_state(monkeypatch)
     trainer = object.__new__(BaseTrainer)
     trainer.state = TrainerState(global_step=1)
     trainer.device = torch.device("cpu")
@@ -878,7 +1662,8 @@ def test_base_forward_backward_allows_missing_channel_loss_callback():
     assert trainer.model.weight.grad.item() == 2.0
 
 
-def test_base_forward_backward_strips_channel_metadata_after_preforward():
+def test_base_forward_backward_strips_channel_metadata_after_preforward(monkeypatch):
+    _install_test_parallel_state(monkeypatch)
     cfg = ChannelLossConfig(enable=True)
     trainer = object.__new__(BaseTrainer)
     trainer.state = TrainerState(global_step=1)
@@ -1051,7 +1836,8 @@ def test_base_forward_backward_composes_channel_loss_and_chunk_mbs_contexts(monk
     assert chunk_mbs._chunk_mbs_ranges.get() is None
 
 
-def test_dpo_forward_backward_scopes_channel_loss_to_policy_model():
+def test_dpo_forward_backward_scopes_channel_loss_to_policy_model(monkeypatch):
+    _install_test_parallel_state(monkeypatch)
     cfg = ChannelLossConfig(enable=True, interval=1)
     state = TrainerState(global_step=1)
     policy_model = object()
@@ -1117,7 +1903,9 @@ def test_dpo_forward_backward_scopes_channel_loss_to_policy_model():
     assert base.channel_loss_callback.computer._source_ids == []
 
 
-def test_dpo_channel_loss_emits_policy_totals():
+def test_dpo_channel_loss_real_base_dispatch_repeats_metadata_and_emits_policy_totals(monkeypatch):
+    _install_test_parallel_state(monkeypatch)
+
     class DpoLossModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
@@ -1140,35 +1928,24 @@ def test_dpo_channel_loss_emits_policy_totals():
     state = TrainerState(global_step=1)
     policy_model = DpoLossModel()
     reference_model = DpoLossModel()
-    base = SimpleNamespace(
-        args=SimpleNamespace(
-            train=SimpleNamespace(channel_loss=cfg, enable_batch_invariant_mode=False),
-            dpo_config=SimpleNamespace(
-                beta=0.1,
-                label_smoothing=0.0,
-                loss_type="sigmoid",
-                reference_free=False,
-                average_log_prob=False,
-            ),
+    base = object.__new__(BaseTrainer)
+    base.args = SimpleNamespace(
+        train=SimpleNamespace(channel_loss=cfg, enable_batch_invariant_mode=False),
+        dpo_config=SimpleNamespace(
+            beta=0.1,
+            label_smoothing=0.0,
+            loss_type="sigmoid",
+            reference_free=False,
+            average_log_prob=False,
         ),
-        state=state,
-        model=policy_model,
-        model_fwd_context=nullcontext(),
-        model_bwd_context=nullcontext(),
-        preforward=lambda micro_batch: micro_batch,
     )
+    base.state = state
+    base.model = policy_model
+    base.model_fwd_context = nullcontext()
+    base.model_bwd_context = nullcontext()
+    base.preforward = lambda micro_batch: micro_batch
     base.channel_loss_callback = ChannelLossCallback(base)
-    step_begin_args = {}
-
-    def on_step_begin(micro_batches=None, **kwargs):
-        step_begin_args["source_repeat"] = kwargs.get("source_repeat", 1)
-        base.channel_loss_callback.on_step_begin(
-            state,
-            micro_batches=micro_batches,
-            **kwargs,
-        )
-
-    base.on_step_begin = on_step_begin
+    base._callbacks = [base.channel_loss_callback]
     trainer = object.__new__(TextDPOTrainer)
     trainer.base = base
     trainer.reference_model = reference_model
@@ -1185,7 +1962,6 @@ def test_dpo_channel_loss_emits_policy_totals():
     try:
         base.channel_loss_callback.computer.install(policy_model)
         TextDPOTrainer.on_step_begin(trainer, micro_batches=[micro_batch])
-        assert step_begin_args == {"source_repeat": 2}
         assert base.channel_loss_callback.computer._per_mb_source_ids == [[3, 3, 4, 4]]
         TextDPOTrainer.forward_backward_step(trainer, micro_batch)
 
@@ -1405,9 +2181,9 @@ def test_channel_loss_callback_reduces_compact_totals_and_syncs_names(monkeypatc
     callback.computer.source_names = {0: "source/a"}
     callback.computer.step_totals = {0: (torch.tensor(6.0), torch.tensor(3))}
     group = object()
+    callback.parallel_state = _test_parallel_state(dp_size=2, dp_group=group)
     observed = {}
 
-    monkeypatch.setattr(channel_loss_module, "get_parallel_state", lambda: SimpleNamespace(dp_size=2, dp_group=group))
     monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
     monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
 
@@ -1420,8 +2196,11 @@ def test_channel_loss_callback_reduces_compact_totals_and_syncs_names(monkeypatc
         assert group is not None
         if value.dtype.is_floating_point:
             value.add_(torch.tensor([0.0, 3.0]))
-        else:
+        elif value.ndim == 1:
             value.add_(torch.tensor([0, 1]))
+        else:
+            assert value.shape == (2, 3)
+            value.add_(torch.tensor([[0, 0, 0], [1, 4, 1]]))
 
     monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
     monkeypatch.setattr(channel_loss_module.dist, "all_reduce", fake_all_reduce)
@@ -1446,12 +2225,11 @@ def test_channel_loss_callback_strict_rejects_cross_rank_name_mismatch(monkeypat
     callback._collect_step = True
     callback.computer.source_names = {0: "source-a"}
     callback.computer.step_totals = {0: (torch.tensor(1.0), torch.tensor(1))}
+    callback.parallel_state = _test_parallel_state(dp_size=2, dp_group=object())
 
-    monkeypatch.setattr(
-        channel_loss_module, "get_parallel_state", lambda: SimpleNamespace(dp_size=2, dp_group=object())
-    )
     monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
     monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "all_reduce", lambda value, group=None: None)
 
     def fake_all_gather_object(gathered, local_metadata, group=None):
         gathered[0] = local_metadata
@@ -1463,9 +2241,466 @@ def test_channel_loss_callback_strict_rejects_cross_rank_name_mismatch(monkeypat
         callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
 
 
+def _strict_reduction_callback(*, source_name="source-a", with_totals=True):
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=True)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        device=torch.device("cpu"),
+        step_train_metrics={},
+        step_env_metrics={},
+    )
+    callback = ChannelLossCallback(trainer)
+    callback._collect_step = True
+    callback.computer.source_names = {0: source_name}
+    if with_totals:
+        callback.computer.step_totals = {0: (torch.tensor(1.0), torch.tensor(1))}
+    return callback, trainer
+
+
+def _mock_strict_reduction_collectives(
+    monkeypatch,
+    callback,
+    *,
+    remote_metadata=None,
+    fail_postflight=False,
+):
+    dp_group = object()
+    parallel_state = _test_parallel_state(dp_size=2, dp_group=dp_group)
+    callback.parallel_state = parallel_state
+    callback.computer.parallel_state = parallel_state
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+    events = []
+    world_calls = 0
+
+    def fake_all_gather_object(gathered, local_metadata, group=None):
+        assert group is dp_group
+        events.append("group-metadata")
+        gathered[0] = local_metadata
+        gathered[1] = local_metadata if remote_metadata is None else remote_metadata
+
+    def fake_all_reduce(value, group=None):
+        nonlocal world_calls
+        if group is None:
+            world_calls += 1
+            events.append(f"world-{world_calls}")
+            if fail_postflight and world_calls == 2:
+                value.fill_(1)
+        elif value.dtype.is_floating_point:
+            events.append("group-loss")
+        elif value.ndim == 1:
+            events.append("group-token")
+        else:
+            events.append("group-data")
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(channel_loss_module.dist, "all_reduce", fake_all_reduce)
+    return events
+
+
+def test_channel_loss_callback_strict_finishes_group_collectives_before_world_name_failure(monkeypatch):
+    callback, trainer = _strict_reduction_callback()
+    events = _mock_strict_reduction_collectives(
+        monkeypatch,
+        callback,
+        remote_metadata=[(0, "source-b")],
+    )
+
+    with pytest.raises(ChannelLossMetadataError, match="inconsistent names"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert events == [
+        "world-1",
+        "group-metadata",
+        "group-loss",
+        "group-token",
+        "world-2",
+    ]
+    assert trainer.step_env_metrics == {}
+
+
+def test_channel_loss_callback_strict_world_syncs_remote_group_reduction_failure(monkeypatch):
+    callback, trainer = _strict_reduction_callback()
+    events = _mock_strict_reduction_collectives(monkeypatch, callback, fail_postflight=True)
+
+    with pytest.raises(ChannelLossMetadataError, match="at least one rank"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert events == [
+        "world-1",
+        "group-metadata",
+        "group-loss",
+        "group-token",
+        "world-2",
+    ]
+    assert trainer.step_env_metrics == {}
+
+
+def test_channel_loss_callback_strict_world_syncs_no_totals_after_group_metadata(monkeypatch):
+    callback, _ = _strict_reduction_callback(with_totals=False)
+    callback.computer._per_mb_source_ids = [[0]]
+    events = _mock_strict_reduction_collectives(monkeypatch, callback)
+
+    with pytest.raises(ChannelLossMetadataError, match="no causal-LM CE totals"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert events == ["world-1", "group-metadata", "world-2"]
+
+
+def test_channel_loss_callback_strict_defers_cross_step_registry_conflict(monkeypatch):
+    callback, _ = _strict_reduction_callback(source_name="source-b")
+    callback._source_registry = {0: "source-a"}
+    events = _mock_strict_reduction_collectives(monkeypatch, callback)
+
+    with pytest.raises(ChannelLossMetadataError, match="inconsistent names across sampled steps"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert events == [
+        "world-1",
+        "group-metadata",
+        "group-loss",
+        "group-token",
+        "world-2",
+    ]
+
+
 def test_channel_loss_callback_strict_requires_source_id():
     cfg = ChannelLossConfig(enable=True, strict=True)
     trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
     callback = ChannelLossCallback(trainer)
     with pytest.raises(ValueError, match="no configured source ID"):
         callback.on_step_begin(TrainerState(global_step=1), micro_batches=[{"input_ids": torch.tensor([[1]])}])
+
+
+def test_channel_loss_callback_strict_syncs_missing_source_id_globally(monkeypatch):
+    cfg = ChannelLossConfig(enable=True, strict=True)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        device=torch.device("cpu"),
+    )
+    callback = ChannelLossCallback(trainer)
+    local_batch = {"position_ids": torch.tensor([[0, 1]]), "ds_idx": torch.tensor([3])}
+    observed_groups = []
+
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_all_reduce(value, group=None):
+        observed_groups.append(group)
+        value.fill_(1)
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_reduce", fake_all_reduce)
+
+    with pytest.raises(ValueError, match="no configured source ID"):
+        callback.on_step_begin(TrainerState(global_step=1), micro_batches=[local_batch])
+
+    assert observed_groups == [None]
+
+
+def test_channel_loss_callback_strict_defers_observer_failure_until_step_end(monkeypatch):
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=True)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        step_train_metrics={},
+        step_env_metrics={},
+    )
+    callback = ChannelLossCallback(trainer)
+    batch = {"position_ids": torch.tensor([[0, 1]]), "ds_idx": torch.tensor([3])}
+    state = TrainerState(global_step=1)
+    callback.on_step_begin(state, micro_batches=[batch])
+    callback.on_micro_step_begin(state, micro_batch=batch)
+    monkeypatch.setattr(
+        callback.computer,
+        "_compute_channel_loss",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("observer failed")),
+    )
+
+    with callback.model_forward_context():
+        callback.computer.compute_side_channel(
+            logits=torch.randn(1, 2, 4),
+            labels=torch.tensor([[1, 2]]),
+            vocab_size=4,
+            hidden_states=None,
+            weights=None,
+        )
+    callback.on_micro_step_end(state)
+
+    assert callback.computer.strict_observation_errors
+    with pytest.raises(ChannelLossMetadataError, match="observation error"):
+        callback.on_step_end(state, loss=0.0, loss_dict={}, grad_norm=0.0)
+
+
+def test_channel_loss_callback_strict_syncs_missing_observation_before_group_collectives(monkeypatch):
+    cfg = ChannelLossConfig(enable=True, interval=1, strict=True)
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)),
+        device=torch.device("cpu"),
+        step_train_metrics={},
+        step_env_metrics={},
+    )
+    callback = ChannelLossCallback(trainer)
+    callback._collect_step = True
+    callback.computer.step_totals = {0: (torch.tensor(1.0), torch.tensor(1))}
+    observed_groups = []
+
+    monkeypatch.setattr(channel_loss_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(channel_loss_module.dist, "is_initialized", lambda: True)
+
+    def fake_all_reduce(value, group=None):
+        observed_groups.append(group)
+        value.fill_(1)
+
+    monkeypatch.setattr(channel_loss_module.dist, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(
+        callback,
+        "_reduce_step_totals",
+        lambda *args, **kwargs: pytest.fail("group collective entered after world preflight failure"),
+    )
+
+    with pytest.raises(ChannelLossMetadataError, match="sampled micro-step.*no causal-LM CE observation"):
+        callback.on_step_end(TrainerState(global_step=1), loss=0.0, loss_dict={}, grad_norm=0.0)
+
+    assert observed_groups == [None]
+
+
+def _observe_real_sp_channel_loss(computer):
+    computer.compute_side_channel(
+        logits=torch.arange(16, dtype=torch.float32).reshape(1, 2, 8) / 10,
+        labels=torch.tensor([[1, 2]]),
+        vocab_size=8,
+        hidden_states=None,
+        weights=None,
+    )
+
+
+def _gloo_sp_preflight_worker(rank, world_size, init_file, result_queue):
+    try:
+        torch.distributed.init_process_group(
+            "gloo",
+            init_method=f"file://{init_file}",
+            rank=rank,
+            world_size=world_size,
+            timeout=timedelta(seconds=15),
+        )
+        parallel_state = _test_parallel_state(
+            sp_enabled=True,
+            sp_group=torch.distributed.group.WORLD,
+            sp_size=world_size,
+            sp_rank=rank,
+        )
+        singleton_groups = [
+            torch.distributed.new_group(ranks=[singleton_rank]) for singleton_rank in range(world_size)
+        ]
+
+        class _BrokenParallelState:
+            @property
+            def sp_enabled(self):
+                raise RuntimeError("cached parallel-state descriptor resolution failed")
+
+        for scenario in (
+            "valid",
+            "source",
+            "missing",
+            "generic",
+            "count",
+            "metadata",
+            "malformed",
+            "descriptor_resolution_failure",
+            "descriptor_mismatch",
+            "outer_descriptor_disabled",
+            "outer_descriptor_group",
+            "outer_descriptor_world",
+        ):
+            scenario_state = parallel_state
+            if scenario == "descriptor_resolution_failure":
+                scenario_state = _BrokenParallelState()
+            elif scenario == "outer_descriptor_disabled" and rank == 1:
+                scenario_state = _test_parallel_state()
+            elif scenario == "outer_descriptor_group" and rank == 1:
+                scenario_state = _test_parallel_state(
+                    sp_enabled=True,
+                    sp_group=singleton_groups[rank],
+                    sp_size=1,
+                    sp_rank=0,
+                )
+            elif scenario == "outer_descriptor_world" and rank == 1:
+                scenario_state = _test_parallel_state(
+                    sp_enabled=True,
+                    sp_group=torch.distributed.group.WORLD,
+                    sp_size=world_size + 1,
+                    sp_rank=rank,
+                )
+
+            computer = ChannelLossComputer(parallel_state=scenario_state)
+            computer.strict = True
+            computer._source_ids = ["source-a"]
+            computer._position_ids = torch.tensor([[0, 1]]) if rank == 0 else torch.tensor([[2, 3]])
+            prepare_descriptor = ChannelLossComputer.__dict__["_prepare_sp_observation_payload"]
+
+            if scenario == "source" and rank == 1:
+                computer._source_ids = ["source-b"]
+            elif scenario == "missing" and rank == 1:
+                computer._source_ids = []
+            elif scenario == "generic" and rank == 1:
+                computer._compute_channel_loss = lambda **kwargs: (_ for _ in ()).throw(
+                    RuntimeError("rank-local CE preparation failed")
+                )
+            elif scenario == "metadata" and rank == 1:
+                computer._position_ids = None
+            elif scenario == "malformed" and rank == 1:
+
+                def fail_ready_payload(**kwargs):
+                    raise RuntimeError("rank-local malformed segment stack")
+
+                ChannelLossComputer._prepare_sp_observation_payload = staticmethod(fail_ready_payload)
+
+            try:
+                with computer.capture():
+                    if computer._source_ids:
+                        _observe_real_sp_channel_loss(computer)
+                        if scenario == "count" and rank == 1:
+                            _observe_real_sp_channel_loss(computer)
+                        if scenario == "descriptor_mismatch" and rank == 1:
+                            observation = computer._pending_observations[0]
+                            observation.capture_descriptor = channel_loss_module._SPCaptureDescriptor(
+                                enabled=True,
+                                parallel_state=scenario_state,
+                                group=parallel_state.sp_group,
+                                world=world_size + 1,
+                                rank=rank,
+                            )
+            finally:
+                ChannelLossComputer._prepare_sp_observation_payload = prepare_descriptor
+
+            if scenario == "valid":
+                assert computer._result is not None
+                assert computer._micro_step_observation_count == 1
+                assert computer.strict_observation_errors == []
+                assert computer._result[0]["source_id"] == "source-a"
+                assert computer._result[0]["token_count"].item() == 4
+            else:
+                assert computer._result is None
+                assert computer._micro_step_observation_count == 0
+                assert computer.strict_observation_errors
+                if scenario == "descriptor_resolution_failure":
+                    assert (
+                        "cached parallel-state descriptor resolution failed"
+                        in (computer.strict_observation_errors[0][1])
+                    )
+            torch.distributed.barrier()
+        result_queue.put((rank, "ok"))
+    except Exception:
+        result_queue.put((rank, traceback.format_exc()))
+        raise
+    finally:
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+def _gloo_two_stripe_worker(rank, world_size, init_file, result_queue):
+    try:
+        torch.distributed.init_process_group(
+            "gloo",
+            init_method=f"file://{init_file}",
+            rank=rank,
+            world_size=world_size,
+            timeout=timedelta(seconds=15),
+        )
+        stripe_groups = [
+            torch.distributed.new_group(ranks=[0, 1]),
+            torch.distributed.new_group(ranks=[2, 3]),
+        ]
+        stripe_idx = rank // 2
+        local_sp_rank = rank % 2
+        parallel_state = _test_parallel_state(
+            sp_enabled=True,
+            sp_group=stripe_groups[stripe_idx],
+            sp_size=2,
+            sp_rank=local_sp_rank,
+        )
+        config = ChannelLossConfig(enable=True, interval=1, strict=True)
+        trainer = SimpleNamespace(
+            args=SimpleNamespace(train=SimpleNamespace(channel_loss=config)),
+            device=torch.device("cpu"),
+            step_train_metrics={},
+            step_env_metrics={},
+        )
+        with use_parallel_state(parallel_state):
+            callback = ChannelLossCallback(trainer)
+        batch = {
+            "position_ids": torch.tensor([[0, 1]]) if local_sp_rank == 0 else torch.tensor([[2, 3]]),
+            "ds_idx": torch.tensor([3]),
+        }
+        state = TrainerState(global_step=1)
+        callback.on_step_begin(state, micro_batches=[batch])
+        callback.on_micro_step_begin(state, micro_batch=batch)
+        with callback.model_forward_context():
+            if rank != 3:
+                _observe_real_sp_channel_loss(callback.computer)
+        callback.on_micro_step_end(state)
+
+        raised = False
+        try:
+            callback.on_step_end(state, loss=0.0, loss_dict={}, grad_norm=0.0)
+        except ChannelLossMetadataError:
+            raised = True
+        assert raised
+        assert trainer.step_env_metrics == {}
+        result_queue.put((rank, "ok"))
+    except Exception:
+        result_queue.put((rank, traceback.format_exc()))
+        raise
+    finally:
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+def _run_gloo_workers(worker, *, world_size, init_file, timeout_seconds=30):
+    context = torch.multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    processes = [
+        context.Process(target=worker, args=(rank, world_size, str(init_file), result_queue))
+        for rank in range(world_size)
+    ]
+    for process in processes:
+        process.start()
+
+    deadline = time.monotonic() + timeout_seconds
+    for process in processes:
+        process.join(max(deadline - time.monotonic(), 0))
+    hung = [process for process in processes if process.is_alive()]
+    if hung:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+        for process in processes:
+            process.join(5)
+        pytest.fail(f"distributed channel-loss test timed out on {len(hung)} process(es)")
+
+    results = []
+    for _ in range(world_size):
+        try:
+            results.append(result_queue.get(timeout=3))
+        except queue.Empty:
+            break
+    failures = [detail for _, detail in results if detail != "ok"]
+    exit_codes = [process.exitcode for process in processes]
+    assert len(results) == world_size, (results, exit_codes)
+    assert not failures, "\n".join(failures)
+    assert exit_codes == [0] * world_size
+
+
+def test_channel_loss_real_gloo_sp_preflight_avoids_divergent_payload_collectives(tmp_path):
+    _run_gloo_workers(
+        _gloo_sp_preflight_worker,
+        world_size=2,
+        init_file=tmp_path / "sp-preflight-init",
+    )
+
+
+def test_channel_loss_real_gloo_two_sp_stripes_propagate_strict_failure_worldwide(tmp_path):
+    _run_gloo_workers(
+        _gloo_two_stripe_worker,
+        world_size=4,
+        init_file=tmp_path / "sp-stripes-init",
+    )

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -901,12 +901,15 @@ def test_channel_loss_sp_uses_rank_local_cu_for_headwise_padding():
         labels_flat=torch.tensor(
             [1, 1, IGNORE_INDEX, IGNORE_INDEX, 1, 1, 1, IGNORE_INDEX, IGNORE_INDEX, IGNORE_INDEX]
         ),
-        attention_mask_flat=torch.tensor([1, 1, 0, 0, 1, 1, 1, 0, 0, 0]),
+        # FlashAttention keeps the known pad-to-length tail visible (mask=1),
+        # while labels and positions still identify it as synthetic padding.
+        attention_mask_flat=torch.tensor([1, 1, 0, 0, 1, 1, 1, 0, 1, 1]),
         source_ids=["first", "second"],
         # Per-sample CP padding and the synthetic pad-to-length tail all use
         # zero positions. Position-only segmentation would find six sources.
         position_ids=torch.tensor([[0, 1, 0, 0, 0, 1, 2, 0, 0, 0]]),
         packed_cu_seqlens=[0, 4, 8, 10],
+        tail_padding_length=2,
         ignore_index=IGNORE_INDEX,
         sp_enabled=True,
         parallel_state=parallel_state,
@@ -930,6 +933,46 @@ def test_channel_loss_sp_uses_rank_local_cu_for_headwise_padding():
             "input_token_count": 3,
         },
     ]
+
+
+def test_channel_loss_sp_rank_local_cu_rejects_unproven_extra_source():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+
+    kwargs = dict(
+        per_token_loss=torch.arange(1, 7, dtype=torch.float32),
+        labels_flat=torch.tensor([1, 1, 1, 1, 1, 1]),
+        attention_mask_flat=torch.ones(6, dtype=torch.long),
+        source_ids=["first", "second"],
+        position_ids=torch.tensor([[0, 1, 0, 1, 0, 1]]),
+        packed_cu_seqlens=[0, 2, 4, 6],
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=parallel_state,
+    )
+
+    assert ChannelLossComputer._aggregate_by_source(**kwargs, strict=False) == []
+    with pytest.raises(ChannelLossMetadataError, match="source metadata count"):
+        ChannelLossComputer._aggregate_by_source(**kwargs, strict=True)
+
+
+def test_channel_loss_sp_rank_local_cu_rejects_unsupervised_one_token_without_tail_provenance():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+
+    kwargs = dict(
+        per_token_loss=torch.arange(1, 6, dtype=torch.float32),
+        labels_flat=torch.tensor([1, 1, 1, 1, IGNORE_INDEX]),
+        attention_mask_flat=torch.ones(5, dtype=torch.long),
+        source_ids=["first", "second"],
+        position_ids=torch.tensor([[0, 1, 0, 1, 0]]),
+        packed_cu_seqlens=[0, 2, 4, 5],
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=parallel_state,
+    )
+
+    assert ChannelLossComputer._aggregate_by_source(**kwargs, strict=False) == []
+    with pytest.raises(ChannelLossMetadataError, match="source metadata count"):
+        ChannelLossComputer._aggregate_by_source(**kwargs, strict=True)
 
 
 def test_channel_loss_sp_preserves_zero_supervision_tail_when_later_row_has_padding(monkeypatch):
@@ -2192,17 +2235,20 @@ def test_channel_loss_metadata_prefers_rank_local_router_mask_and_cu():
     local_router_mask = torch.tensor([[1, 1, 0, 0]], dtype=torch.long)
     local_cu = [0, 2, 4]
 
-    source_ids, source_names, position_ids, attention_mask, packed_cu_seqlens = callback._extract_metadata(
-        {
-            "ds_idx": torch.tensor([3, 4]),
-            "source_name": ["train/a", "train/b"],
-            "labels": torch.tensor([[1, 2, IGNORE_INDEX, IGNORE_INDEX]]),
-            "position_ids": torch.tensor([[0, 1, 0, 0]]),
-            "attention_mask": global_attention_mask,
-            "router_attention_mask": local_router_mask,
-            "cu_seq_lens_q": torch.tensor([0, 2, 4], dtype=torch.int32),
-            "cu_seqlens_list_q": local_cu,
-        }
+    source_ids, source_names, position_ids, attention_mask, packed_cu_seqlens, tail_padding_length = (
+        callback._extract_metadata(
+            {
+                "ds_idx": torch.tensor([3, 4]),
+                "source_name": ["train/a", "train/b"],
+                "labels": torch.tensor([[1, 2, IGNORE_INDEX, IGNORE_INDEX]]),
+                "position_ids": torch.tensor([[0, 1, 0, 0]]),
+                "attention_mask": global_attention_mask,
+                "router_attention_mask": local_router_mask,
+                "cu_seq_lens_q": torch.tensor([0, 2, 4], dtype=torch.int32),
+                "cu_seqlens_list_q": local_cu,
+                "tail_padding_length": torch.tensor(8, dtype=torch.int32),
+            }
+        )
     )
 
     assert source_ids == [3, 4]
@@ -2210,6 +2256,7 @@ def test_channel_loss_metadata_prefers_rank_local_router_mask_and_cu():
     assert position_ids.shape == (1, 4)
     assert attention_mask is local_router_mask
     assert packed_cu_seqlens is local_cu
+    assert tail_padding_length == 8
 
 
 def test_channel_loss_sp_rank_local_cu_keeps_empty_source():
@@ -2267,6 +2314,7 @@ def test_channel_loss_sp_rank_local_cu_drops_zero_length_synthetic_tail():
         source_ids=["source"],
         positions=torch.tensor([[0, 1]]),
         packed_cu_seqlens=[0, 2, 2],
+        tail_padding_length=1,
         seq_len=2,
         ignore_index=IGNORE_INDEX,
         parallel_state=parallel_state,
@@ -2282,7 +2330,7 @@ def test_channel_loss_metadata_rejects_misaligned_router_mask():
     callback = ChannelLossCallback(trainer)
     global_attention_mask = torch.ones(1, 4, dtype=torch.long)
 
-    _, _, _, attention_mask, _ = callback._extract_metadata(
+    _, _, _, attention_mask, _, _ = callback._extract_metadata(
         {
             "ds_idx": torch.tensor([3]),
             "labels": torch.tensor([[1, 2, 3, 4]]),

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -893,6 +893,45 @@ def test_channel_loss_sp_filters_padding_tail_per_batch_row(monkeypatch):
     ]
 
 
+def test_channel_loss_sp_uses_rank_local_cu_for_headwise_padding():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+
+    result = ChannelLossComputer._aggregate_by_source(
+        per_token_loss=torch.arange(1, 11, dtype=torch.float32),
+        labels_flat=torch.tensor(
+            [1, 1, IGNORE_INDEX, IGNORE_INDEX, 1, 1, 1, IGNORE_INDEX, IGNORE_INDEX, IGNORE_INDEX]
+        ),
+        attention_mask_flat=torch.tensor([1, 1, 0, 0, 1, 1, 1, 0, 0, 0]),
+        source_ids=["first", "second"],
+        # Per-sample CP padding and the synthetic pad-to-length tail all use
+        # zero positions. Position-only segmentation would find six sources.
+        position_ids=torch.tensor([[0, 1, 0, 0, 0, 1, 2, 0, 0, 0]]),
+        packed_cu_seqlens=[0, 4, 8, 10],
+        ignore_index=IGNORE_INDEX,
+        sp_enabled=True,
+        parallel_state=parallel_state,
+        strict=True,
+        include_data_stats=True,
+    )
+
+    assert result == [
+        {
+            "source_id": "first",
+            "loss_sum": 3.0,
+            "token_count": 2,
+            "sample_count": 1,
+            "input_token_count": 2,
+        },
+        {
+            "source_id": "second",
+            "loss_sum": 18.0,
+            "token_count": 3,
+            "sample_count": 1,
+            "input_token_count": 3,
+        },
+    ]
+
+
 def test_channel_loss_sp_preserves_zero_supervision_tail_when_later_row_has_padding(monkeypatch):
     parallel_state = _test_parallel_state(sp_enabled=True)
 
@@ -1093,6 +1132,7 @@ def test_channel_loss_sp_preflight_precedes_all_ordered_payloads_and_cache_relea
         ("has_source", False),
         ("observation_count", 2),
         ("source_ids", (("str", "'source-b'"),)),
+        ("alignment_modes", ["packed_cu"]),
         ("descriptor_spec", (True, 3, True)),
         ("errors", [("generic", "rank-local observer failure")]),
     ],
@@ -2142,6 +2182,117 @@ def test_channel_loss_callback_strips_metadata_after_preforward():
     assert "position_ids" in micro_batch
     assert callback.computer._source_ids == [3]
     assert callback.computer.source_names == {3: "train/a"}
+
+
+def test_channel_loss_metadata_prefers_rank_local_router_mask_and_cu():
+    cfg = ChannelLossConfig(enable=True, interval=1)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    global_attention_mask = torch.ones(1, 16, dtype=torch.long)
+    local_router_mask = torch.tensor([[1, 1, 0, 0]], dtype=torch.long)
+    local_cu = [0, 2, 4]
+
+    source_ids, source_names, position_ids, attention_mask, packed_cu_seqlens = callback._extract_metadata(
+        {
+            "ds_idx": torch.tensor([3, 4]),
+            "source_name": ["train/a", "train/b"],
+            "labels": torch.tensor([[1, 2, IGNORE_INDEX, IGNORE_INDEX]]),
+            "position_ids": torch.tensor([[0, 1, 0, 0]]),
+            "attention_mask": global_attention_mask,
+            "router_attention_mask": local_router_mask,
+            "cu_seq_lens_q": torch.tensor([0, 2, 4], dtype=torch.int32),
+            "cu_seqlens_list_q": local_cu,
+        }
+    )
+
+    assert source_ids == [3, 4]
+    assert source_names == ["train/a", "train/b"]
+    assert position_ids.shape == (1, 4)
+    assert attention_mask is local_router_mask
+    assert packed_cu_seqlens is local_cu
+
+
+def test_channel_loss_sp_rank_local_cu_keeps_empty_source():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+
+    result = ChannelLossComputer._aggregate_sp(
+        per_token_loss=torch.empty(0),
+        labels_flat=torch.empty(0, dtype=torch.long),
+        attention_mask_flat=torch.empty(0, dtype=torch.long),
+        source_ids=["empty"],
+        positions=torch.empty((1, 0), dtype=torch.long),
+        packed_cu_seqlens=[0, 0],
+        seq_len=0,
+        ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
+        strict=True,
+    )
+
+    assert result == [{"source_id": "empty", "loss_sum": 0.0, "token_count": 0}]
+
+
+def test_channel_loss_sp_rank_local_cu_keeps_multiple_empty_sources():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+
+    prepared = ChannelLossComputer._aggregate_sp(
+        per_token_loss=torch.empty(0),
+        labels_flat=torch.empty(0, dtype=torch.long),
+        attention_mask_flat=torch.empty(0, dtype=torch.long),
+        source_ids=["empty-a", "empty-b"],
+        positions=torch.empty((1, 0), dtype=torch.long),
+        packed_cu_seqlens=[0, 0, 0],
+        seq_len=0,
+        ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
+        strict=True,
+        defer_reduce=True,
+    )
+
+    assert isinstance(prepared, channel_loss_module._PendingSPObservation)
+    assert prepared.segment_count == 2
+    result = ChannelLossComputer._reconstruct_prepared_sp_payload(prepared, strict=True)
+    assert result == [
+        {"source_id": "empty-a", "loss_sum": 0.0, "token_count": 0},
+        {"source_id": "empty-b", "loss_sum": 0.0, "token_count": 0},
+    ]
+
+
+def test_channel_loss_sp_rank_local_cu_drops_zero_length_synthetic_tail():
+    parallel_state = _test_parallel_state(sp_enabled=True)
+
+    result = ChannelLossComputer._aggregate_sp(
+        per_token_loss=torch.tensor([2.0, 3.0]),
+        labels_flat=torch.tensor([1, 1]),
+        attention_mask_flat=torch.ones(2, dtype=torch.long),
+        source_ids=["source"],
+        positions=torch.tensor([[0, 1]]),
+        packed_cu_seqlens=[0, 2, 2],
+        seq_len=2,
+        ignore_index=IGNORE_INDEX,
+        parallel_state=parallel_state,
+        strict=True,
+    )
+
+    assert result == [{"source_id": "source", "loss_sum": 5.0, "token_count": 2}]
+
+
+def test_channel_loss_metadata_rejects_misaligned_router_mask():
+    cfg = ChannelLossConfig(enable=True, interval=1)
+    trainer = SimpleNamespace(args=SimpleNamespace(train=SimpleNamespace(channel_loss=cfg)))
+    callback = ChannelLossCallback(trainer)
+    global_attention_mask = torch.ones(1, 4, dtype=torch.long)
+
+    _, _, _, attention_mask, _ = callback._extract_metadata(
+        {
+            "ds_idx": torch.tensor([3]),
+            "labels": torch.tensor([[1, 2, 3, 4]]),
+            "position_ids": torch.tensor([[0, 1, 2, 3]]),
+            "attention_mask": global_attention_mask,
+            "router_attention_mask": torch.ones(1, 2, dtype=torch.long),
+        }
+    )
+
+    assert attention_mask is global_attention_mask
 
 
 def test_channel_loss_callback_samples_steps_but_always_strips_metadata():

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -1593,6 +1593,7 @@ def test_channel_loss_computer_aggregates_step_results_locally():
 
 def test_base_step_begin_captures_channel_metadata_before_multisource_meter():
     calls = []
+    step_end_calls = []
 
     class RecordingCallback:
         def __init__(self, name, consume_metadata=False):
@@ -1605,17 +1606,28 @@ def test_base_step_begin_captures_channel_metadata_before_multisource_meter():
                 micro_batches[0].pop("ds_idx")
                 micro_batches[0].pop("source_name")
 
+        def on_step_end(self, state, **kwargs):
+            step_end_calls.append(self.name)
+
     trainer = object.__new__(BaseTrainer)
     trainer.state = TrainerState(global_step=1)
     trainer.channel_loss_callback = RecordingCallback("channel")
     meter = RecordingCallback("meter", consume_metadata=True)
     tail = RecordingCallback("tail")
-    trainer._callbacks = [trainer.channel_loss_callback, meter, tail]
+    # Production keeps the meter before channel loss for ``on_step_end`` so
+    # the meter resets step metrics before channel loss publishes its values.
+    # ``on_step_begin`` must still let channel loss snapshot source metadata
+    # before the meter consumes it.
+    trainer._callbacks = [meter, trainer.channel_loss_callback, tail]
     micro_batches = [{"ds_idx": torch.tensor([7]), "source_name": ["repoqa"]}]
 
     BaseTrainer.on_step_begin(trainer, micro_batches=micro_batches, channel_loss_source_repeat=2)
 
     assert calls == [("channel", True, 2), ("meter", True, 2), ("tail", False, 2)]
+
+    BaseTrainer.on_step_end(trainer)
+
+    assert step_end_calls == ["meter", "channel", "tail"]
 
 
 def test_base_step_begin_allows_missing_channel_loss_callback():

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -334,6 +334,15 @@ class ChannelLossConfig:
         default=True,
         metadata={"help": "Log supervised token count for each channel."},
     )
+    release_cache: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Synchronize and release allocator cache after detached channel-loss CE on sampled steps. "
+                "This can lower peak memory before backward at the cost of extra synchronization."
+            )
+        },
+    )
     strict: bool = field(
         default=False,
         metadata={

--- a/veomni/ops/kernels/cross_entropy/chunk_loss.py
+++ b/veomni/ops/kernels/cross_entropy/chunk_loss.py
@@ -37,6 +37,7 @@ import torch.nn.functional as F
 
 from ....distributed.parallel_state import get_parallel_state
 from ....distributed.sequence_parallel import reduce_sequence_parallel_loss
+from ....utils.loss_observer import get_chunk_loss_consumer
 from .eager import eager_cross_entropy
 
 
@@ -62,17 +63,33 @@ class ChunkLoss(torch.autograd.Function):
         grad_inputs_chunks = torch.split(grad_inputs, chunk_size, dim=1)
 
         hidden_states_chunks = torch.split(hidden_states, chunk_size, dim=1)
+        observer = get_chunk_loss_consumer()
+        observed_loss_chunks: list[torch.Tensor] = []
 
         for i in range(len(hidden_states_chunks)):
             hidden_states_chunk = hidden_states_chunks[i]
             grad_inputs_chunk = grad_inputs_chunks[i]
-            (chunk_grad_input, chunk_grad_weight), (chunk_loss, _) = torch.func.grad_and_value(
+            (chunk_grad_input, chunk_grad_weight), (chunk_loss, chunk_logits) = torch.func.grad_and_value(
                 loss_forward, argnums=(0, 1), has_aux=True
             )(hidden_states_chunk, head_weight, None, **loss_kwargs_chunks[i])
+
+            if observer is not None:
+                chunk_labels = loss_kwargs_chunks[i]["labels"]
+                with torch.no_grad():
+                    per_token_loss = F.cross_entropy(
+                        chunk_logits,
+                        chunk_labels.reshape(-1).to(chunk_logits.device),
+                        ignore_index=loss_kwargs_chunks[i]["ignore_index"],
+                        reduction="none",
+                    )
+                observed_loss_chunks.append(per_token_loss.reshape(chunk_labels.shape).detach())
 
             accumulated_loss.add_(chunk_loss)
             grad_inputs_chunk.copy_(chunk_grad_input)
             grad_weight.add_(chunk_grad_weight)
+
+        if observer is not None and observed_loss_chunks:
+            observer(torch.cat(observed_loss_chunks, dim=-1))
 
         ctx.save_for_backward(grad_inputs, grad_weight)
         return accumulated_loss

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -641,9 +641,11 @@ class BaseTrainer(Stateful, ABC):
         # (EnvironMeter, DCP checkpointer) are handed the state directly, so
         # no ambient ``use_parallel_state`` scope is needed around hook dispatch.
         #
-        # ``channel_loss_callback`` is ordered after the meter (which resets
-        # ``step_*_metrics`` in ``on_step_end``) and before ``wandb`` (which
-        # logs them), so its per-source metrics survive into the logged payload.
+        # ``channel_loss_callback`` is ordered after the meter for
+        # ``on_step_end`` (the meter resets ``step_*_metrics``) and before
+        # ``wandb`` (which logs them), so its per-source metrics survive into
+        # the logged payload. ``on_step_begin`` snapshots channel metadata first
+        # because multi-source accounting consumes it.
         self._callbacks = [
             self.environ_meter_callback,
             self.tqdm_callback,
@@ -674,7 +676,16 @@ class BaseTrainer(Stateful, ABC):
             callback.on_epoch_end(self.state)
 
     def on_step_begin(self, micro_batches=None, **kwargs):
+        # Multi-source accounting consumes ``ds_idx`` / ``source_name`` from the
+        # micro-batches. Channel loss must snapshot that metadata first, while
+        # keeping its on_step_end position after the meter so its metrics are not
+        # overwritten by the meter's per-step reset.
+        channel_loss_callback = getattr(self, "channel_loss_callback", None)
+        if channel_loss_callback is not None:
+            channel_loss_callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
         for callback in self._callbacks:
+            if callback is channel_loss_callback:
+                continue
             callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
 
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -681,10 +681,13 @@ class BaseTrainer(Stateful, ABC):
         # keeping its on_step_end position after the meter so its metrics are not
         # overwritten by the meter's per-step reset.
         channel_loss_callback = getattr(self, "channel_loss_callback", None)
-        if channel_loss_callback is not None:
+        channel_loss_registered = channel_loss_callback is not None and any(
+            callback is channel_loss_callback for callback in self._callbacks
+        )
+        if channel_loss_registered:
             channel_loss_callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
         for callback in self._callbacks:
-            if callback is channel_loss_callback:
+            if channel_loss_registered and callback is channel_loss_callback:
                 continue
             callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
 

--- a/veomni/trainer/callbacks/channel_loss_callback.py
+++ b/veomni/trainer/callbacks/channel_loss_callback.py
@@ -215,6 +215,7 @@ class ChannelLossComputer:
         self._position_ids: torch.Tensor | None = None
         self._attention_mask: torch.Tensor | None = None
         self._packed_cu_seqlens: Any | None = None
+        self._tail_padding_length: Any | None = None
         self._result: list[dict[str, Any]] | None = None
         self._pending_observations: list[_PendingSPObservation | list[dict[str, Any]]] = []
         self._observation_attempt_count = 0
@@ -225,6 +226,7 @@ class ChannelLossComputer:
         self._per_mb_position_ids: list[torch.Tensor | None] = []
         self._per_mb_attention_masks: list[torch.Tensor | None] = []
         self._per_mb_packed_cu_seqlens: list[Any | None] = []
+        self._per_mb_tail_padding_lengths: list[Any | None] = []
         self._micro_step = 0
         self._micro_step_observation_count = 0
         self._micro_step_failed = False
@@ -824,12 +826,16 @@ class ChannelLossComputer:
         per_mb_position_ids: list[torch.Tensor | None],
         per_mb_attention_masks: list[torch.Tensor | None],
         per_mb_packed_cu_seqlens: list[Any | None] | None = None,
+        per_mb_tail_padding_lengths: list[Any | None] | None = None,
     ) -> None:
         self._per_mb_source_ids = per_mb_source_ids
         self._per_mb_position_ids = per_mb_position_ids
         self._per_mb_attention_masks = per_mb_attention_masks
         self._per_mb_packed_cu_seqlens = (
             per_mb_packed_cu_seqlens if per_mb_packed_cu_seqlens is not None else [None] * len(per_mb_source_ids)
+        )
+        self._per_mb_tail_padding_lengths = (
+            per_mb_tail_padding_lengths if per_mb_tail_padding_lengths is not None else [None] * len(per_mb_source_ids)
         )
         self._micro_step = 0
         self._micro_step_observation_count = 0
@@ -846,11 +852,13 @@ class ChannelLossComputer:
             self._position_ids = self._per_mb_position_ids[step]
             self._attention_mask = self._per_mb_attention_masks[step]
             self._packed_cu_seqlens = self._per_mb_packed_cu_seqlens[step]
+            self._tail_padding_length = self._per_mb_tail_padding_lengths[step]
         else:
             self._source_ids = []
             self._position_ids = None
             self._attention_mask = None
             self._packed_cu_seqlens = None
+            self._tail_padding_length = None
         self._result = None
         self._micro_step_observation_count = 0
         self._micro_step_failed = False
@@ -885,6 +893,7 @@ class ChannelLossComputer:
         self._position_ids = None
         self._attention_mask = None
         self._packed_cu_seqlens = None
+        self._tail_padding_length = None
         self._result = None
         self._reset_capture_state()
         self._micro_step += 1
@@ -1032,6 +1041,7 @@ class ChannelLossComputer:
             source_ids=self._source_ids,
             position_ids=self._position_ids,
             packed_cu_seqlens=self._packed_cu_seqlens,
+            tail_padding_length=self._tail_padding_length,
             ignore_index=ignore_index,
             sp_enabled=sp_enabled,
             parallel_state=descriptor.parallel_state if sp_enabled else None,
@@ -1135,6 +1145,7 @@ class ChannelLossComputer:
         position_ids: torch.Tensor | None,
         ignore_index: int,
         packed_cu_seqlens: Any | None = None,
+        tail_padding_length: Any | None = None,
         sp_enabled: bool = False,
         parallel_state: ParallelState | None = None,
         capture_descriptor: _SPCaptureDescriptor | None = None,
@@ -1169,6 +1180,7 @@ class ChannelLossComputer:
                     source_ids=source_ids,
                     positions=pos_2d,
                     packed_cu_seqlens=packed_cu_seqlens,
+                    tail_padding_length=tail_padding_length,
                     seq_len=seq_len,
                     ignore_index=ignore_index,
                     parallel_state=parallel_state,
@@ -1248,6 +1260,7 @@ class ChannelLossComputer:
         seq_len: int,
         ignore_index: int,
         packed_cu_seqlens: Any | None = None,
+        tail_padding_length: Any | None = None,
         parallel_state: ParallelState | None = None,
         capture_descriptor: _SPCaptureDescriptor | None = None,
         strict: bool = False,
@@ -1326,11 +1339,15 @@ class ChannelLossComputer:
                 )
             segments.append(segment)
 
-        packed_source_spans = _rank_local_packed_source_spans(
+        packed_source_spans, packed_segment_count = _rank_local_packed_source_spans(
             packed_cu_seqlens,
             source_count=len(source_ids),
             seq_len=seq_len,
+            labels_flat=labels_flat,
+            positions_flat=positions_cpu.reshape(-1)[:seq_len],
             attention_mask_flat=attention_mask_flat,
+            ignore_index=ignore_index,
+            tail_padding_length=tail_padding_length,
         )
         if packed_source_spans is not None:
             alignment_mode = "packed_cu"
@@ -1348,6 +1365,14 @@ class ChannelLossComputer:
                     local_order=0,
                     flat_indices=True,
                 )
+        elif packed_segment_count is not None:
+            _validate_segment_count(
+                packed_segment_count,
+                len(source_ids),
+                strict,
+                "SP packed segment count",
+            )
+            return []
         else:
             alignment_mode = "positions"
             for batch_idx, row_pos in enumerate(positions_cpu):
@@ -1851,7 +1876,7 @@ class ChannelLossCallback(Callback):
             if self.config.strict:
                 missing_source_micro_steps = []
                 for micro_step, micro_batch in enumerate(micro_batches or []):
-                    source_ids, _, _, _, _ = self._extract_metadata(micro_batch)
+                    source_ids, _, _, _, _, _ = self._extract_metadata(micro_batch)
                     if not source_ids:
                         missing_source_micro_steps.append(micro_step)
                 self._raise_if_missing_source_ids(missing_source_micro_steps)
@@ -1861,10 +1886,11 @@ class ChannelLossCallback(Callback):
         per_mb_position_ids: list[torch.Tensor | None] = []
         per_mb_attention_masks: list[torch.Tensor | None] = []
         per_mb_packed_cu_seqlens: list[Any | None] = []
+        per_mb_tail_padding_lengths: list[Any | None] = []
         missing_source_micro_steps = []
         for micro_step, micro_batch in enumerate(micro_batches or []):
-            source_ids, source_names, position_ids, attention_mask, packed_cu_seqlens = self._extract_metadata(
-                micro_batch
+            source_ids, source_names, position_ids, attention_mask, packed_cu_seqlens, tail_padding_length = (
+                self._extract_metadata(micro_batch)
             )
             if self.config.strict and not source_ids:
                 missing_source_micro_steps.append(micro_step)
@@ -1878,12 +1904,14 @@ class ChannelLossCallback(Callback):
             per_mb_position_ids.append(position_ids)
             per_mb_attention_masks.append(attention_mask)
             per_mb_packed_cu_seqlens.append(packed_cu_seqlens)
+            per_mb_tail_padding_lengths.append(tail_padding_length)
 
         self.computer.begin_step(
             per_mb_source_ids,
             per_mb_position_ids,
             per_mb_attention_masks,
             per_mb_packed_cu_seqlens,
+            per_mb_tail_padding_lengths,
         )
         if self.config.strict:
             self._raise_if_missing_source_ids(missing_source_micro_steps)
@@ -2216,7 +2244,7 @@ class ChannelLossCallback(Callback):
     def _extract_metadata(
         self,
         micro_batch: Any,
-    ) -> tuple[list[ChannelKey], list[str], torch.Tensor | None, torch.Tensor | None, Any | None]:
+    ) -> tuple[list[ChannelKey], list[str], torch.Tensor | None, torch.Tensor | None, Any | None, Any | None]:
         if isinstance(micro_batch, dict):
             source_ids = self._first_present_list(micro_batch, self.config.source_id_keys, _as_channel_key_list)
             source_names = self._first_present_list(micro_batch, self.config.source_name_keys, _as_str_list)
@@ -2239,12 +2267,14 @@ class ChannelLossCallback(Callback):
             packed_cu_seqlens = micro_batch.get("cu_seqlens_list_q")
             if packed_cu_seqlens is None:
                 packed_cu_seqlens = micro_batch.get("cu_seq_lens_q")
+            tail_padding_length = micro_batch.get("tail_padding_length")
             return (
                 source_ids,
                 source_names,
                 position_ids if isinstance(position_ids, torch.Tensor) else None,
                 attention_mask if isinstance(attention_mask, torch.Tensor) else None,
                 packed_cu_seqlens,
+                tail_padding_length,
             )
 
         if isinstance(micro_batch, (list, tuple)):
@@ -2255,9 +2285,9 @@ class ChannelLossCallback(Callback):
                     continue
                 source_ids.extend(self._first_present_list(sample, self.config.source_id_keys, _as_channel_key_list))
                 source_names.extend(self._first_present_list(sample, self.config.source_name_keys, _as_str_list))
-            return source_ids, source_names, None, None, None
+            return source_ids, source_names, None, None, None, None
 
-        return [], [], None, None, None
+        return [], [], None, None, None, None
 
     @staticmethod
     def _first_present_list(
@@ -2334,8 +2364,12 @@ def _rank_local_packed_source_spans(
     *,
     source_count: int,
     seq_len: int,
+    labels_flat: torch.Tensor,
+    positions_flat: torch.Tensor,
     attention_mask_flat: torch.Tensor | None,
-) -> list[tuple[int, int]] | None:
+    ignore_index: int,
+    tail_padding_length: Any | None,
+) -> tuple[list[tuple[int, int]] | None, int | None]:
     """Resolve authoritative rank-local packed spans when they match sources.
 
     Standard contiguous Ulysses can retain global CU metadata after slicing;
@@ -2346,37 +2380,50 @@ def _rank_local_packed_source_spans(
     """
 
     if packed_cu_seqlens is None:
-        return None
+        return None, None
     if isinstance(packed_cu_seqlens, torch.Tensor):
         if packed_cu_seqlens.ndim != 1 or packed_cu_seqlens.dtype not in (torch.int32, torch.int64):
-            return None
+            return None, None
         raw_points = packed_cu_seqlens.detach().cpu().tolist()
     elif isinstance(packed_cu_seqlens, (list, tuple)):
         raw_points = list(packed_cu_seqlens)
     else:
-        return None
+        return None, None
 
     points: list[int] = []
     for point in raw_points:
         if isinstance(point, bool) or not isinstance(point, Integral):
-            return None
+            return None, None
         points.append(int(point))
     if not points or points[0] != 0 or points[-1] != seq_len:
-        return None
+        return None, None
     if any(end < start for start, end in zip(points, points[1:])):
-        return None
+        return None, None
 
     spans = list(zip(points, points[1:]))
     if len(spans) == source_count:
-        return spans
-    if len(spans) != source_count + 1 or attention_mask_flat is None:
-        return None
+        return spans, len(spans)
+    if len(spans) != source_count + 1:
+        return None, len(spans)
+    # ``tail_padding_length`` is emitted by the collator from the exact
+    # pre-padding sequence length. Without that provenance, an empty or
+    # unsupervised real sample is indistinguishable from synthetic padding.
+    tail_padding_length = _optional_non_negative_int(tail_padding_length)
+    if tail_padding_length is None or tail_padding_length <= 0:
+        return None, len(spans)
 
     tail_start, tail_end = spans[-1]
-    tail_mask = attention_mask_flat[tail_start:tail_end]
-    if tail_mask.numel() > 0 and tail_mask.to(torch.bool).any().item():
-        return None
-    return spans[:-1]
+    if tail_start == tail_end:
+        return spans[:-1], len(spans) - 1
+    tail_mask = attention_mask_flat[tail_start:tail_end] if attention_mask_flat is not None else None
+    if not _is_padding_only_segment(
+        labels_slice=labels_flat[tail_start:tail_end],
+        positions_slice=positions_flat[tail_start:tail_end],
+        attention_mask_slice=tail_mask,
+        ignore_index=ignore_index,
+    ):
+        return None, len(spans)
+    return spans[:-1], len(spans) - 1
 
 
 def _filter_surplus_tail_padding_segments(
@@ -2536,6 +2583,17 @@ def _validate_segment_count(segment_count: int, source_count: int, strict: bool,
         raise ChannelLossMetadataError(msg)
     logger.warning_rank0(msg)
     return False
+
+
+def _optional_non_negative_int(value: Any) -> int | None:
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1 or value.dtype not in (torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8):
+            return None
+        value = value.detach().cpu().item()
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        return None
+    value = int(value)
+    return value if value >= 0 else None
 
 
 def _as_channel_key_list(value: Any) -> list[ChannelKey]:

--- a/veomni/trainer/callbacks/channel_loss_callback.py
+++ b/veomni/trainer/callbacks/channel_loss_callback.py
@@ -215,6 +215,8 @@ class ChannelLossComputer:
         self._position_ids: torch.Tensor | None = None
         self._attention_mask: torch.Tensor | None = None
         self._packed_cu_seqlens: Any | None = None
+        self._packed_global_cu_seqlens: Any | None = None
+        self._packed_global_physical_seq_len: int | None = None
         self._tail_padding_length: Any | None = None
         self._result: list[dict[str, Any]] | None = None
         self._pending_observations: list[_PendingSPObservation | list[dict[str, Any]]] = []
@@ -226,6 +228,8 @@ class ChannelLossComputer:
         self._per_mb_position_ids: list[torch.Tensor | None] = []
         self._per_mb_attention_masks: list[torch.Tensor | None] = []
         self._per_mb_packed_cu_seqlens: list[Any | None] = []
+        self._per_mb_packed_global_cu_seqlens: list[Any | None] = []
+        self._per_mb_packed_global_physical_seq_lens: list[int | None] = []
         self._per_mb_tail_padding_lengths: list[Any | None] = []
         self._micro_step = 0
         self._micro_step_observation_count = 0
@@ -826,6 +830,8 @@ class ChannelLossComputer:
         per_mb_position_ids: list[torch.Tensor | None],
         per_mb_attention_masks: list[torch.Tensor | None],
         per_mb_packed_cu_seqlens: list[Any | None] | None = None,
+        per_mb_packed_global_cu_seqlens: list[Any | None] | None = None,
+        per_mb_packed_global_physical_seq_lens: list[int | None] | None = None,
         per_mb_tail_padding_lengths: list[Any | None] | None = None,
     ) -> None:
         self._per_mb_source_ids = per_mb_source_ids
@@ -834,9 +840,33 @@ class ChannelLossComputer:
         self._per_mb_packed_cu_seqlens = (
             per_mb_packed_cu_seqlens if per_mb_packed_cu_seqlens is not None else [None] * len(per_mb_source_ids)
         )
+        self._per_mb_packed_global_cu_seqlens = (
+            per_mb_packed_global_cu_seqlens
+            if per_mb_packed_global_cu_seqlens is not None
+            else [None] * len(per_mb_source_ids)
+        )
+        self._per_mb_packed_global_physical_seq_lens = (
+            per_mb_packed_global_physical_seq_lens
+            if per_mb_packed_global_physical_seq_lens is not None
+            else [None] * len(per_mb_source_ids)
+        )
         self._per_mb_tail_padding_lengths = (
             per_mb_tail_padding_lengths if per_mb_tail_padding_lengths is not None else [None] * len(per_mb_source_ids)
         )
+        metadata_lengths = {
+            "position_ids": len(self._per_mb_position_ids),
+            "attention_masks": len(self._per_mb_attention_masks),
+            "packed_cu_seqlens": len(self._per_mb_packed_cu_seqlens),
+            "packed_global_cu_seqlens": len(self._per_mb_packed_global_cu_seqlens),
+            "packed_global_physical_seq_lens": len(self._per_mb_packed_global_physical_seq_lens),
+            "tail_padding_lengths": len(self._per_mb_tail_padding_lengths),
+        }
+        mismatched = {name: length for name, length in metadata_lengths.items() if length != len(per_mb_source_ids)}
+        if mismatched:
+            raise ChannelLossMetadataError(
+                "Channel loss: per-microbatch metadata list lengths do not match source metadata "
+                f"(source_microbatches={len(per_mb_source_ids)}, mismatched={mismatched})."
+            )
         self._micro_step = 0
         self._micro_step_observation_count = 0
         self._micro_step_failed = False
@@ -852,12 +882,16 @@ class ChannelLossComputer:
             self._position_ids = self._per_mb_position_ids[step]
             self._attention_mask = self._per_mb_attention_masks[step]
             self._packed_cu_seqlens = self._per_mb_packed_cu_seqlens[step]
+            self._packed_global_cu_seqlens = self._per_mb_packed_global_cu_seqlens[step]
+            self._packed_global_physical_seq_len = self._per_mb_packed_global_physical_seq_lens[step]
             self._tail_padding_length = self._per_mb_tail_padding_lengths[step]
         else:
             self._source_ids = []
             self._position_ids = None
             self._attention_mask = None
             self._packed_cu_seqlens = None
+            self._packed_global_cu_seqlens = None
+            self._packed_global_physical_seq_len = None
             self._tail_padding_length = None
         self._result = None
         self._micro_step_observation_count = 0
@@ -893,6 +927,8 @@ class ChannelLossComputer:
         self._position_ids = None
         self._attention_mask = None
         self._packed_cu_seqlens = None
+        self._packed_global_cu_seqlens = None
+        self._packed_global_physical_seq_len = None
         self._tail_padding_length = None
         self._result = None
         self._reset_capture_state()
@@ -1041,6 +1077,8 @@ class ChannelLossComputer:
             source_ids=self._source_ids,
             position_ids=self._position_ids,
             packed_cu_seqlens=self._packed_cu_seqlens,
+            packed_global_cu_seqlens=self._packed_global_cu_seqlens,
+            packed_global_physical_seq_len=self._packed_global_physical_seq_len,
             tail_padding_length=self._tail_padding_length,
             ignore_index=ignore_index,
             sp_enabled=sp_enabled,
@@ -1145,6 +1183,8 @@ class ChannelLossComputer:
         position_ids: torch.Tensor | None,
         ignore_index: int,
         packed_cu_seqlens: Any | None = None,
+        packed_global_cu_seqlens: Any | None = None,
+        packed_global_physical_seq_len: int | None = None,
         tail_padding_length: Any | None = None,
         sp_enabled: bool = False,
         parallel_state: ParallelState | None = None,
@@ -1180,6 +1220,8 @@ class ChannelLossComputer:
                     source_ids=source_ids,
                     positions=pos_2d,
                     packed_cu_seqlens=packed_cu_seqlens,
+                    packed_global_cu_seqlens=packed_global_cu_seqlens,
+                    packed_global_physical_seq_len=packed_global_physical_seq_len,
                     tail_padding_length=tail_padding_length,
                     seq_len=seq_len,
                     ignore_index=ignore_index,
@@ -1260,6 +1302,8 @@ class ChannelLossComputer:
         seq_len: int,
         ignore_index: int,
         packed_cu_seqlens: Any | None = None,
+        packed_global_cu_seqlens: Any | None = None,
+        packed_global_physical_seq_len: int | None = None,
         tail_padding_length: Any | None = None,
         parallel_state: ParallelState | None = None,
         capture_descriptor: _SPCaptureDescriptor | None = None,
@@ -1276,6 +1320,11 @@ class ChannelLossComputer:
             sp_rank = int(parallel_state.sp_rank)
             if sp_rank < 0:
                 sp_rank = dist.get_rank(sp_group) if sp_group is not None else 0
+        sp_size = int(
+            capture_descriptor.world if capture_descriptor is not None else getattr(parallel_state, "sp_size", 1)
+        )
+        if sp_size < 1:
+            raise ChannelLossMetadataError(f"Channel loss: invalid sequence-parallel size {sp_size}.")
         segments: list[dict[str, Any]] = []
 
         if positions.dim() == 1:
@@ -1339,16 +1388,24 @@ class ChannelLossComputer:
                 )
             segments.append(segment)
 
-        packed_source_spans, packed_segment_count = _rank_local_packed_source_spans(
+        packed_source_spans, packed_segment_count, packed_metadata_error = _rank_local_packed_source_spans(
             packed_cu_seqlens,
+            packed_global_cu_seqlens=packed_global_cu_seqlens,
+            packed_global_physical_seq_len=packed_global_physical_seq_len,
             source_count=len(source_ids),
             seq_len=seq_len,
+            sp_size=sp_size,
             labels_flat=labels_flat,
             positions_flat=positions_cpu.reshape(-1)[:seq_len],
             attention_mask_flat=attention_mask_flat,
             ignore_index=ignore_index,
             tail_padding_length=tail_padding_length,
         )
+        if packed_metadata_error is not None:
+            if strict:
+                raise ChannelLossMetadataError(packed_metadata_error)
+            logger.warning_rank0(packed_metadata_error)
+            return []
         if packed_source_spans is not None:
             alignment_mode = "packed_cu"
             # Headwise CP keeps one rank-local span per original packed sample.
@@ -1876,7 +1933,7 @@ class ChannelLossCallback(Callback):
             if self.config.strict:
                 missing_source_micro_steps = []
                 for micro_step, micro_batch in enumerate(micro_batches or []):
-                    source_ids, _, _, _, _, _ = self._extract_metadata(micro_batch)
+                    source_ids, _, _, _, _, _, _, _ = self._extract_metadata(micro_batch)
                     if not source_ids:
                         missing_source_micro_steps.append(micro_step)
                 self._raise_if_missing_source_ids(missing_source_micro_steps)
@@ -1886,12 +1943,21 @@ class ChannelLossCallback(Callback):
         per_mb_position_ids: list[torch.Tensor | None] = []
         per_mb_attention_masks: list[torch.Tensor | None] = []
         per_mb_packed_cu_seqlens: list[Any | None] = []
+        per_mb_packed_global_cu_seqlens: list[Any | None] = []
+        per_mb_packed_global_physical_seq_lens: list[int | None] = []
         per_mb_tail_padding_lengths: list[Any | None] = []
         missing_source_micro_steps = []
         for micro_step, micro_batch in enumerate(micro_batches or []):
-            source_ids, source_names, position_ids, attention_mask, packed_cu_seqlens, tail_padding_length = (
-                self._extract_metadata(micro_batch)
-            )
+            (
+                source_ids,
+                source_names,
+                position_ids,
+                attention_mask,
+                packed_cu_seqlens,
+                packed_global_cu_seqlens,
+                packed_global_physical_seq_len,
+                tail_padding_length,
+            ) = self._extract_metadata(micro_batch)
             if self.config.strict and not source_ids:
                 missing_source_micro_steps.append(micro_step)
             source_ids, source_names = self._repeat_source_metadata(
@@ -1904,6 +1970,8 @@ class ChannelLossCallback(Callback):
             per_mb_position_ids.append(position_ids)
             per_mb_attention_masks.append(attention_mask)
             per_mb_packed_cu_seqlens.append(packed_cu_seqlens)
+            per_mb_packed_global_cu_seqlens.append(packed_global_cu_seqlens)
+            per_mb_packed_global_physical_seq_lens.append(packed_global_physical_seq_len)
             per_mb_tail_padding_lengths.append(tail_padding_length)
 
         self.computer.begin_step(
@@ -1911,6 +1979,8 @@ class ChannelLossCallback(Callback):
             per_mb_position_ids,
             per_mb_attention_masks,
             per_mb_packed_cu_seqlens,
+            per_mb_packed_global_cu_seqlens,
+            per_mb_packed_global_physical_seq_lens,
             per_mb_tail_padding_lengths,
         )
         if self.config.strict:
@@ -2244,7 +2314,16 @@ class ChannelLossCallback(Callback):
     def _extract_metadata(
         self,
         micro_batch: Any,
-    ) -> tuple[list[ChannelKey], list[str], torch.Tensor | None, torch.Tensor | None, Any | None, Any | None]:
+    ) -> tuple[
+        list[ChannelKey],
+        list[str],
+        torch.Tensor | None,
+        torch.Tensor | None,
+        Any | None,
+        Any | None,
+        int | None,
+        Any | None,
+    ]:
         if isinstance(micro_batch, dict):
             source_ids = self._first_present_list(micro_batch, self.config.source_id_keys, _as_channel_key_list)
             source_names = self._first_present_list(micro_batch, self.config.source_name_keys, _as_str_list)
@@ -2255,6 +2334,8 @@ class ChannelLossCallback(Callback):
             # local labels/positions rather than the global full-attention
             # shape.
             labels = micro_batch.get("labels")
+            global_attention_mask = micro_batch.get("attention_mask")
+            packed_global_physical_seq_len = None
             router_attention_mask = micro_batch.get("router_attention_mask")
             if (
                 isinstance(router_attention_mask, torch.Tensor)
@@ -2262,11 +2343,16 @@ class ChannelLossCallback(Callback):
                 and router_attention_mask.numel() == labels.numel()
             ):
                 attention_mask = router_attention_mask
+                if isinstance(global_attention_mask, torch.Tensor):
+                    packed_global_physical_seq_len = int(global_attention_mask.numel())
             else:
-                attention_mask = micro_batch.get("attention_mask")
+                attention_mask = global_attention_mask
             packed_cu_seqlens = micro_batch.get("cu_seqlens_list_q")
             if packed_cu_seqlens is None:
                 packed_cu_seqlens = micro_batch.get("cu_seq_lens_q")
+            packed_global_cu_seqlens = micro_batch.get("linear_attn_cu_seqlens_list_q")
+            if packed_global_cu_seqlens is None:
+                packed_global_cu_seqlens = micro_batch.get("linear_attn_cu_seq_lens_q")
             tail_padding_length = micro_batch.get("tail_padding_length")
             return (
                 source_ids,
@@ -2274,6 +2360,8 @@ class ChannelLossCallback(Callback):
                 position_ids if isinstance(position_ids, torch.Tensor) else None,
                 attention_mask if isinstance(attention_mask, torch.Tensor) else None,
                 packed_cu_seqlens,
+                packed_global_cu_seqlens,
+                packed_global_physical_seq_len,
                 tail_padding_length,
             )
 
@@ -2285,9 +2373,9 @@ class ChannelLossCallback(Callback):
                     continue
                 source_ids.extend(self._first_present_list(sample, self.config.source_id_keys, _as_channel_key_list))
                 source_names.extend(self._first_present_list(sample, self.config.source_name_keys, _as_str_list))
-            return source_ids, source_names, None, None, None, None
+            return source_ids, source_names, None, None, None, None, None, None
 
-        return [], [], None, None, None, None
+        return [], [], None, None, None, None, None, None
 
     @staticmethod
     def _first_present_list(
@@ -2362,14 +2450,17 @@ def _position_aligned_attention_mask_flat(
 def _rank_local_packed_source_spans(
     packed_cu_seqlens: Any | None,
     *,
+    packed_global_cu_seqlens: Any | None,
+    packed_global_physical_seq_len: int | None,
     source_count: int,
     seq_len: int,
+    sp_size: int,
     labels_flat: torch.Tensor,
     positions_flat: torch.Tensor,
     attention_mask_flat: torch.Tensor | None,
     ignore_index: int,
     tail_padding_length: Any | None,
-) -> tuple[list[tuple[int, int]] | None, int | None]:
+) -> tuple[list[tuple[int, int]] | None, int | None, str | None]:
     """Resolve authoritative rank-local packed spans when they match sources.
 
     Standard contiguous Ulysses can retain global CU metadata after slicing;
@@ -2379,42 +2470,109 @@ def _rank_local_packed_source_spans(
     padding-only tail span introduced by ``pad_to_length``.
     """
 
-    if packed_cu_seqlens is None:
-        return None, None
-    if isinstance(packed_cu_seqlens, torch.Tensor):
-        if packed_cu_seqlens.ndim != 1 or packed_cu_seqlens.dtype not in (torch.int32, torch.int64):
-            return None, None
-        raw_points = packed_cu_seqlens.detach().cpu().tolist()
-    elif isinstance(packed_cu_seqlens, (list, tuple)):
-        raw_points = list(packed_cu_seqlens)
-    else:
-        return None, None
-
-    points: list[int] = []
-    for point in raw_points:
-        if isinstance(point, bool) or not isinstance(point, Integral):
-            return None, None
-        points.append(int(point))
-    if not points or points[0] != 0 or points[-1] != seq_len:
-        return None, None
-    if any(end < start for start, end in zip(points, points[1:])):
-        return None, None
+    points, points_error = _packed_cu_points(packed_cu_seqlens)
+    if points_error is not None:
+        return None, None, f"Channel loss: invalid packed CU metadata: {points_error}."
+    if points is None:
+        return None, None, None
+    if points[-1] != seq_len:
+        # Standard contiguous Ulysses retains the same authoritative global CU
+        # in both FA and linear-attention metadata while labels/loss are sliced.
+        # Do not infer that provenance from an endpoint mismatch alone: stale
+        # rank-local metadata must fail closed instead of falling back to
+        # position-based source alignment.
+        global_points, global_points_error = _packed_cu_points(packed_global_cu_seqlens)
+        if global_points_error is not None:
+            return None, None, f"Channel loss: invalid global packed CU metadata: {global_points_error}."
+        expected_global_width = seq_len * sp_size
+        if global_points is None or global_points != points or points[-1] != expected_global_width:
+            return (
+                None,
+                None,
+                (
+                    "Channel loss: packed CU endpoint does not match the local loss width and lacks "
+                    "standard-Ulysses global provenance "
+                    f"(endpoint={points[-1]}, local_width={seq_len}, sp_size={sp_size})."
+                ),
+            )
+        return None, None, None
 
     spans = list(zip(points, points[1:]))
     if len(spans) == source_count:
-        return spans, len(spans)
+        return spans, len(spans), None
     if len(spans) != source_count + 1:
-        return None, len(spans)
+        return None, len(spans), None
     # ``tail_padding_length`` is emitted by the collator from the exact
     # pre-padding sequence length. Without that provenance, an empty or
     # unsupervised real sample is indistinguishable from synthetic padding.
     tail_padding_length = _optional_non_negative_int(tail_padding_length)
     if tail_padding_length is None or tail_padding_length <= 0:
-        return None, len(spans)
+        return None, len(spans), None
+
+    global_points, global_points_error = _packed_cu_points(packed_global_cu_seqlens)
+    if global_points_error is not None:
+        return None, None, f"Channel loss: invalid global packed CU metadata: {global_points_error}."
+    if global_points is None:
+        return None, len(spans), None
+    global_spans = list(zip(global_points, global_points[1:]))
+    if len(global_spans) != source_count + 1:
+        return (
+            None,
+            None,
+            (
+                "Channel loss: global packed CU metadata does not prove the synthetic tail "
+                f"(source_count={source_count}, global_segment_count={len(global_spans)})."
+            ),
+        )
+    global_tail_start, global_tail_end = global_spans[-1]
+    if global_tail_end - global_tail_start != tail_padding_length:
+        return (
+            None,
+            None,
+            (
+                "Channel loss: tail_padding_length does not match the global packed CU tail "
+                f"({tail_padding_length} != {global_tail_end - global_tail_start})."
+            ),
+        )
+
+    global_physical_seq_len = _optional_non_negative_int(packed_global_physical_seq_len)
+    if global_physical_seq_len is None:
+        return (
+            None,
+            None,
+            "Channel loss: synthetic tail requires the global physical packed width from the same microbatch.",
+        )
+    if global_physical_seq_len != seq_len * sp_size:
+        return (
+            None,
+            None,
+            (
+                "Channel loss: global physical packed width does not match the local SP shard "
+                f"({global_physical_seq_len} != {seq_len} * {sp_size})."
+            ),
+        )
+
+    sample_multiple = 2 * sp_size
+    global_lengths = [end - start for start, end in global_spans]
+    padded_global_lengths = [
+        ((length + sample_multiple - 1) // sample_multiple) * sample_multiple for length in global_lengths
+    ]
+    local_lengths = [end - start for start, end in spans]
+    expected_local_lengths = [length // sp_size for length in padded_global_lengths]
+    if sum(padded_global_lengths) != global_physical_seq_len or local_lengths != expected_local_lengths:
+        return (
+            None,
+            None,
+            (
+                "Channel loss: global/local packed CU metadata do not describe the same headwise microbatch "
+                f"(global_physical_width={global_physical_seq_len}, "
+                f"expected_local_lengths={expected_local_lengths}, local_lengths={local_lengths})."
+            ),
+        )
 
     tail_start, tail_end = spans[-1]
     if tail_start == tail_end:
-        return spans[:-1], len(spans) - 1
+        return spans[:-1], len(spans) - 1, None
     tail_mask = attention_mask_flat[tail_start:tail_end] if attention_mask_flat is not None else None
     if not _is_padding_only_segment(
         labels_slice=labels_flat[tail_start:tail_end],
@@ -2422,8 +2580,32 @@ def _rank_local_packed_source_spans(
         attention_mask_slice=tail_mask,
         ignore_index=ignore_index,
     ):
-        return None, len(spans)
-    return spans[:-1], len(spans) - 1
+        return None, len(spans), None
+    return spans[:-1], len(spans) - 1, None
+
+
+def _packed_cu_points(value: Any | None) -> tuple[list[int] | None, str | None]:
+    if value is None:
+        return None, None
+    if isinstance(value, torch.Tensor):
+        if value.ndim != 1 or value.dtype not in (torch.int32, torch.int64):
+            return None, "expected a one-dimensional int32/int64 tensor"
+        raw_points = value.detach().cpu().tolist()
+    elif isinstance(value, (list, tuple)):
+        raw_points = list(value)
+    else:
+        return None, f"expected a tensor/list/tuple, got {type(value).__name__}"
+
+    points: list[int] = []
+    for point in raw_points:
+        if isinstance(point, bool) or not isinstance(point, Integral):
+            return None, "all CU points must be integers"
+        points.append(int(point))
+    if not points or points[0] != 0:
+        return None, "CU points must start at zero"
+    if any(end < start for start, end in zip(points, points[1:])):
+        return None, "CU points must be non-decreasing"
+    return points, None
 
 
 def _filter_surplus_tail_padding_segments(

--- a/veomni/trainer/callbacks/channel_loss_callback.py
+++ b/veomni/trainer/callbacks/channel_loss_callback.py
@@ -28,6 +28,7 @@ from collections import defaultdict
 from collections.abc import Hashable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 from numbers import Integral
 from typing import TYPE_CHECKING, Any, Callable
 from weakref import WeakSet
@@ -38,7 +39,9 @@ import torch.nn.functional as F
 
 from ...distributed.parallel_state import get_parallel_state
 from ...utils.constants import IGNORE_INDEX
+from ...utils.device import empty_cache, get_torch_device, stream_synchronize
 from ...utils.logging import get_logger
+from ...utils.loss_observer import capture_chunk_loss_per_token
 from .base import Callback, TrainerState
 
 
@@ -66,10 +69,26 @@ class _OpSlotDispatcher:
         self.owners: WeakSet[Any] = WeakSet()
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        result = self.original_kernel(*args, **kwargs)
         owner = _ACTIVE_CHANNEL_LOSS_COMPUTER.get()
-        if owner is not None and owner in self.owners:
-            owner._observe_opslot_call(self.original_kernel, args, kwargs)
+        if owner is None or owner not in self.owners:
+            return self.original_kernel(*args, **kwargs)
+
+        reused_per_token_losses: list[torch.Tensor] = []
+        with capture_chunk_loss_per_token(reused_per_token_losses.append):
+            result = self.original_kernel(*args, **kwargs)
+        if len(reused_per_token_losses) != 1:
+            logger.warning_once(
+                "Channel loss expected exactly one reusable per-token CE capture from chunk_loss, "
+                f"but observed {len(reused_per_token_losses)}; falling back to detached CE recomputation. "
+                "This can occur with a non-chunk loss backend or a forward that invokes the causal loss "
+                "multiple times."
+            )
+        owner._observe_opslot_call(
+            self.original_kernel,
+            args,
+            kwargs,
+            reused_per_token_loss=(reused_per_token_losses[0].detach() if len(reused_per_token_losses) == 1 else None),
+        )
         return result
 
 
@@ -78,6 +97,103 @@ _OP_SLOT_DISPATCHERS: dict[Any, _OpSlotDispatcher] = {}
 
 class ChannelLossMetadataError(ValueError):
     """Raised when channel metadata cannot be aligned with packed segments."""
+
+
+class ChannelLossCollectiveError(RuntimeError):
+    """Raised when an observer collective fails and its process group is unsafe."""
+
+
+@dataclass(frozen=True, eq=False)
+class _SPCaptureDescriptor:
+    """Authoritative cached SP topology for one outer capture."""
+
+    enabled: bool
+    parallel_state: ParallelState | None
+    group: Any | None
+    world: int
+    rank: int
+    resolution_error: str | None = None
+
+
+@dataclass
+class _PendingSPObservation:
+    """Fully materialized SP payload prepared before forward-finally preflight."""
+
+    source_ids: list[ChannelKey]
+    device: torch.device
+    parallel_state: ParallelState
+    include_data_stats: bool
+    group: Any | None
+    world: int
+    capture_descriptor: _SPCaptureDescriptor
+    segment_count: int
+    loss_payload: torch.Tensor
+    integer_payload: torch.Tensor
+    gathered_segment_counts: list[int]
+    gathered_loss_payloads: list[torch.Tensor]
+    gathered_integer_payloads: list[torch.Tensor]
+
+
+def _sp_descriptor_from_parallel_state(parallel_state: ParallelState | None) -> _SPCaptureDescriptor:
+    if parallel_state is None or not bool(parallel_state.sp_enabled):
+        return _SPCaptureDescriptor(enabled=False, parallel_state=parallel_state, group=None, world=1, rank=0)
+    group = parallel_state.sp_group
+    rank = int(parallel_state.sp_rank)
+    if rank < 0:
+        rank = dist.get_rank(group) if group is not None else 0
+    return _SPCaptureDescriptor(
+        enabled=True,
+        parallel_state=parallel_state,
+        group=group,
+        world=int(parallel_state.sp_size),
+        rank=rank,
+    )
+
+
+def _sp_descriptors_match(left: _SPCaptureDescriptor, right: _SPCaptureDescriptor) -> bool:
+    return (
+        left.enabled == right.enabled
+        and left.parallel_state is right.parallel_state
+        and left.group is right.group
+        and left.world == right.world
+        and left.rank == right.rank
+        and left.resolution_error == right.resolution_error
+    )
+
+
+def _unresolved_sp_descriptor(
+    parallel_state: ParallelState | None,
+    message: str,
+) -> _SPCaptureDescriptor:
+    resolution_error = message if dist.is_available() and dist.is_initialized() else None
+    return _SPCaptureDescriptor(
+        enabled=False,
+        parallel_state=parallel_state,
+        group=None,
+        world=1,
+        rank=0,
+        resolution_error=resolution_error,
+    )
+
+
+def _resolve_cached_sp_capture_descriptor(parallel_state: ParallelState) -> _SPCaptureDescriptor:
+    try:
+        return _sp_descriptor_from_parallel_state(parallel_state)
+    except Exception as error:
+        return _unresolved_sp_descriptor(
+            parallel_state,
+            f"cached SP descriptor resolution failed: {type(error).__name__}: {error}",
+        )
+
+
+def _release_observer_cache(device: torch.device) -> None:
+    """Release detached CE workspaces before the training backward pass."""
+    if device.type == "cpu":
+        return
+    accelerator = get_torch_device()
+    with accelerator.device(device):
+        stream_synchronize()
+        empty_cache()
 
 
 class ChannelLossComputer:
@@ -98,13 +214,24 @@ class ChannelLossComputer:
         self._position_ids: torch.Tensor | None = None
         self._attention_mask: torch.Tensor | None = None
         self._result: list[dict[str, Any]] | None = None
+        self._pending_observations: list[_PendingSPObservation | list[dict[str, Any]]] = []
+        self._observation_attempt_count = 0
+        self._capture_errors: list[tuple[str, str]] = []
+        self._observer_devices: list[torch.device] = []
+        self._capture_sp_descriptor: _SPCaptureDescriptor | None = None
         self._per_mb_source_ids: list[list[ChannelKey]] = []
         self._per_mb_position_ids: list[torch.Tensor | None] = []
         self._per_mb_attention_masks: list[torch.Tensor | None] = []
         self._micro_step = 0
+        self._micro_step_observation_count = 0
+        self._micro_step_failed = False
+        self.missing_observation_micro_steps: list[int] = []
+        self.strict_observation_errors: list[tuple[int, str]] = []
         self.step_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor]] = {}
+        self.step_data_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         self.source_names: dict[ChannelKey, str] = {}
         self.strict = False
+        self.release_cache = False
 
     @staticmethod
     def _resolve_loss_fn_host(model: torch.nn.Module) -> torch.nn.Module | None:
@@ -260,17 +387,402 @@ class ChannelLossComputer:
 
     @contextmanager
     def capture(self) -> Iterator[None]:
+        nested = self.capture_active
+        if not nested:
+            self._reset_capture_state()
+            self._capture_sp_descriptor = _resolve_cached_sp_capture_descriptor(self.parallel_state)
         token = _ACTIVE_CHANNEL_LOSS_COMPUTER.set(self)
         try:
             yield
         finally:
             _ACTIVE_CHANNEL_LOSS_COMPUTER.reset(token)
+            if not nested:
+                self._finalize_capture()
+
+    def _reset_capture_state(self) -> None:
+        self._pending_observations = []
+        self._observation_attempt_count = 0
+        self._capture_errors = []
+        self._observer_devices = []
+
+    def _finalize_capture(self) -> None:
+        """Finalize detached observations before model backward can begin."""
+
+        observer_devices = list(self._observer_devices)
+        collective_failed = False
+        try:
+            descriptor = self._capture_sp_descriptor
+            descriptor_error = self._preflight_capture_descriptor(descriptor)
+            if descriptor_error is not None:
+                self._record_capture_failure(descriptor_error)
+            elif descriptor is not None and descriptor.enabled:
+                self._finalize_sp_capture(descriptor)
+            else:
+                self._finalize_local_capture()
+        except ChannelLossCollectiveError:
+            # A failed process-group operation cannot safely be converted into
+            # rank-local observer state or followed by another collective.
+            collective_failed = True
+            raise
+        except Exception as error:
+            # Local preparation/reconstruction failures must never escape a
+            # rank before strict world coordination at step end.
+            self._record_capture_failure(
+                f"channel-loss forward finalization failed with {type(error).__name__}: {error}"
+            )
+        finally:
+            if self.release_cache and not collective_failed:
+                released_devices: list[torch.device] = []
+                for device in observer_devices:
+                    if device in released_devices:
+                        continue
+                    released_devices.append(device)
+                    try:
+                        _release_observer_cache(device)
+                    except Exception:
+                        logger.warning_rank0(
+                            "Channel loss: failed to release detached CE allocator cache; continuing training.",
+                            exc_info=True,
+                        )
+            self._pending_observations = []
+            self._capture_errors = []
+            self._observer_devices = []
+            self._capture_sp_descriptor = None
+
+    @staticmethod
+    def _preflight_capture_descriptor(descriptor: _SPCaptureDescriptor | None) -> str | None:
+        """Reject rank-local SP topology divergence before any SP collective."""
+
+        if not dist.is_available() or not dist.is_initialized():
+            if descriptor is None:
+                return "Channel loss: capture has no authoritative SP descriptor."
+            if descriptor.resolution_error is not None:
+                return f"Channel loss: capture SP descriptor resolution failed: {descriptor.resolution_error}."
+            if descriptor.enabled and (
+                descriptor.world < 1
+                or descriptor.rank < 0
+                or descriptor.rank >= descriptor.world
+                or (descriptor.world > 1 and descriptor.group is None)
+            ):
+                return f"Channel loss: capture has an invalid SP descriptor: {descriptor}."
+            return None
+
+        try:
+            global_rank = dist.get_rank()
+            global_world = dist.get_world_size()
+        except Exception as error:
+            raise ChannelLossCollectiveError(
+                "Channel loss could not inspect the initialized default process group for descriptor preflight."
+            ) from error
+
+        errors: list[str] = []
+        group_ranks: tuple[int, ...] = ()
+        if descriptor is None:
+            errors.append("missing capture descriptor")
+            enabled = False
+            sp_world = -1
+            sp_rank = -1
+        else:
+            enabled = descriptor.enabled
+            sp_world = descriptor.world
+            sp_rank = descriptor.rank
+            if descriptor.resolution_error is not None:
+                errors.append(descriptor.resolution_error)
+            if enabled:
+                if descriptor.group is None:
+                    if sp_world == 1:
+                        group_ranks = (global_rank,)
+                    else:
+                        errors.append("enabled multi-rank SP descriptor has no process group")
+                else:
+                    try:
+                        get_process_group_ranks = getattr(dist, "get_process_group_ranks", None)
+                        if get_process_group_ranks is not None:
+                            group_ranks = tuple(int(rank) for rank in get_process_group_ranks(descriptor.group))
+                        else:
+                            group_ranks = tuple(
+                                int(dist.get_global_rank(descriptor.group, local_rank))
+                                for local_rank in range(sp_world)
+                            )
+                    except Exception as error:
+                        errors.append(f"failed to resolve SP group membership: {type(error).__name__}: {error}")
+
+        status = {
+            "global_rank": global_rank,
+            "global_world": global_world,
+            "enabled": enabled,
+            "sp_world": sp_world,
+            "sp_rank": sp_rank,
+            "group_ranks": group_ranks,
+            "errors": errors,
+        }
+        gathered_statuses: list[dict[str, Any] | None] = [None] * global_world
+        try:
+            dist.all_gather_object(gathered_statuses, status)
+        except Exception as error:
+            raise ChannelLossCollectiveError(
+                "Channel loss world descriptor preflight collective failed; the process group is unsafe."
+            ) from error
+        statuses = [item or {} for item in gathered_statuses]
+        return ChannelLossComputer._validate_capture_descriptor_preflight(statuses)
+
+    @staticmethod
+    def _validate_capture_descriptor_preflight(statuses: list[dict[str, Any]]) -> str | None:
+        if not statuses:
+            return "Channel loss: world SP descriptor preflight returned no statuses."
+
+        expected_ranks = list(range(len(statuses)))
+        global_ranks = [status.get("global_rank") for status in statuses]
+        global_worlds = [status.get("global_world") for status in statuses]
+        enabled_values = [status.get("enabled") for status in statuses]
+        errors = [status.get("errors") or [] for status in statuses]
+        valid = (
+            global_ranks == expected_ranks
+            and all(world == len(statuses) for world in global_worlds)
+            and all(isinstance(enabled, bool) for enabled in enabled_values)
+            and len(set(enabled_values)) == 1
+            and all(not rank_errors for rank_errors in errors)
+        )
+
+        if valid and bool(enabled_values[0]):
+            for status_idx, status in enumerate(statuses):
+                sp_world = status.get("sp_world")
+                sp_rank = status.get("sp_rank")
+                group_ranks = status.get("group_ranks")
+                if (
+                    not isinstance(sp_world, int)
+                    or not isinstance(sp_rank, int)
+                    or not isinstance(group_ranks, (list, tuple))
+                    or sp_world < 1
+                    or len(group_ranks) != sp_world
+                    or sp_rank < 0
+                    or sp_rank >= sp_world
+                    or any(
+                        not isinstance(member, int) or member < 0 or member >= len(statuses) for member in group_ranks
+                    )
+                    or len(set(group_ranks)) != sp_world
+                    or group_ranks[sp_rank] != status_idx
+                ):
+                    valid = False
+                    break
+                member_tuple = tuple(group_ranks)
+                if any(tuple(statuses[member].get("group_ranks") or ()) != member_tuple for member in member_tuple):
+                    valid = False
+                    break
+
+        if valid:
+            return None
+        return (
+            "Channel loss: world preflight rejected rank-local SP capture descriptor divergence before "
+            f"group-specific collectives (statuses={statuses})."
+        )
+
+    def _finalize_local_capture(self) -> None:
+        errors = list(self._capture_errors)
+        if self._source_ids and self._observation_attempt_count == 0:
+            errors.append(("metadata", "source metadata was present but no causal-LM loss hook was observed"))
+        if len(self._pending_observations) != self._observation_attempt_count:
+            errors.append(
+                (
+                    "metadata",
+                    "successful observation count does not match the number of observed causal-LM loss calls",
+                )
+            )
+        if any(isinstance(observation, _PendingSPObservation) for observation in self._pending_observations):
+            errors.append(("generic", "an SP payload was prepared while sequence parallelism was disabled"))
+        if errors:
+            self._record_capture_failure(_format_capture_errors(errors))
+            return
+
+        observations = [observation for observation in self._pending_observations if isinstance(observation, list)]
+        self._append_observations(observations)
+
+    def _finalize_sp_capture(self, descriptor: _SPCaptureDescriptor) -> None:
+        group = descriptor.group
+        world = descriptor.world
+        pending_sp = [
+            observation for observation in self._pending_observations if isinstance(observation, _PendingSPObservation)
+        ]
+        descriptor_errors: list[tuple[str, str]] = []
+        if not descriptor.enabled or descriptor.world < 1:
+            descriptor_errors.append(("generic", "capture has an invalid enabled SP descriptor"))
+        for observation_idx, observation in enumerate(pending_sp):
+            if not _sp_descriptors_match(observation.capture_descriptor, descriptor):
+                descriptor_errors.append(
+                    (
+                        "generic",
+                        f"observation {observation_idx} was prepared with a different SP capture descriptor",
+                    )
+                )
+            if (
+                observation.parallel_state is not descriptor.parallel_state
+                or observation.group is not descriptor.group
+                or observation.world != descriptor.world
+            ):
+                descriptor_errors.append(
+                    (
+                        "generic",
+                        f"observation {observation_idx} SP group/world does not match its capture descriptor",
+                    )
+                )
+        status = {
+            "has_source": bool(self._source_ids),
+            "observation_count": self._observation_attempt_count,
+            "successful_count": len(self._pending_observations),
+            "source_ids": _source_id_signature(self._source_ids),
+            "observation_source_ids": [_source_id_signature(observation.source_ids) for observation in pending_sp],
+            "sp_payload_count": len(pending_sp),
+            "payload_specs": [
+                (
+                    observation.loss_payload.numel(),
+                    observation.integer_payload.size(1),
+                    observation.include_data_stats,
+                )
+                for observation in pending_sp
+            ],
+            "segment_counts": [observation.segment_count for observation in pending_sp],
+            "descriptor_spec": (descriptor.enabled, descriptor.world, descriptor.group is not None),
+            "errors": [*self._capture_errors, *descriptor_errors],
+        }
+
+        if world > 1 and group is None:
+            status["errors"].append(("generic", "SP process group is unavailable"))
+
+        if world > 1 and group is not None and dist.is_available() and dist.is_initialized():
+            gathered_statuses: list[dict[str, Any] | None] = [None] * world
+            # This is the sole SP collective that decides whether any
+            # conditional observation payload collective may follow.
+            try:
+                dist.all_gather_object(gathered_statuses, status, group=group)
+            except Exception as error:
+                raise ChannelLossCollectiveError(
+                    "Channel loss SP payload preflight collective failed; the process group is unsafe."
+                ) from error
+            statuses = [item or {} for item in gathered_statuses]
+        else:
+            statuses = [status]
+
+        preflight_error = self._validate_sp_preflight(statuses)
+        if preflight_error is not None:
+            self._record_capture_failure(preflight_error)
+            return
+        for observation_idx, observation in enumerate(pending_sp):
+            observation.gathered_segment_counts = [
+                int(status["segment_counts"][observation_idx]) for status in statuses
+            ]
+
+        # No observer-owned tensor construction, conversion, or validation
+        # is permitted in this loop. All buffers were materialized before the
+        # preflight, so approved ranks execute an unconditional fixed sequence.
+        for observation in pending_sp:
+            self._gather_prepared_sp_payload(observation, descriptor)
+
+        reduced_observations: list[list[dict[str, Any]]] = []
+        reconstruction_errors: list[tuple[str, str]] = []
+        for observation_idx, observation in enumerate(pending_sp):
+            try:
+                reduced = self._reconstruct_prepared_sp_payload(observation, strict=True)
+                if not reduced:
+                    raise ChannelLossMetadataError("SP reduction produced no source-aligned CE payload")
+                reduced_observations.append(reduced)
+            except Exception as error:
+                reconstruction_errors.append(
+                    (
+                        "metadata" if isinstance(error, ChannelLossMetadataError) else "generic",
+                        f"observation {observation_idx}: {type(error).__name__}: {error}",
+                    )
+                )
+
+        if reconstruction_errors:
+            self._record_capture_failure(_format_capture_errors(reconstruction_errors))
+            return
+        self._append_observations(reduced_observations)
+
+    @staticmethod
+    def _validate_sp_preflight(statuses: list[dict[str, Any]]) -> str | None:
+        has_source = [bool(status.get("has_source")) for status in statuses]
+        observation_counts = [int(status.get("observation_count", -1)) for status in statuses]
+        successful_counts = [int(status.get("successful_count", -1)) for status in statuses]
+        payload_counts = [int(status.get("sp_payload_count", -1)) for status in statuses]
+        source_ids = [status.get("source_ids") for status in statuses]
+        errors = [status.get("errors") or [] for status in statuses]
+        observation_sources = [status.get("observation_source_ids") or [] for status in statuses]
+        payload_specs = [status.get("payload_specs") or [] for status in statuses]
+        segment_counts = [status.get("segment_counts") or [] for status in statuses]
+        descriptor_specs = [status.get("descriptor_spec") for status in statuses]
+        expected_observation_count = observation_counts[0] if observation_counts else -1
+        segment_count_contract_valid = True
+        for rank_specs, rank_counts in zip(payload_specs, segment_counts):
+            if len(rank_specs) != expected_observation_count or len(rank_counts) != expected_observation_count:
+                segment_count_contract_valid = False
+                break
+            for observation_idx, segment_count in enumerate(rank_counts):
+                if (
+                    not isinstance(segment_count, int)
+                    or segment_count < 0
+                    or segment_count > int(rank_specs[observation_idx][0])
+                ):
+                    segment_count_contract_valid = False
+                    break
+
+        valid = (
+            bool(statuses)
+            and all(has_source)
+            and len(set(observation_counts)) == 1
+            and expected_observation_count > 0
+            and successful_counts == observation_counts
+            and payload_counts == observation_counts
+            and all(source_id == source_ids[0] for source_id in source_ids)
+            and all(payload_spec == payload_specs[0] for payload_spec in payload_specs)
+            and all(descriptor_spec == descriptor_specs[0] for descriptor_spec in descriptor_specs)
+            and all(not rank_errors for rank_errors in errors)
+            and segment_count_contract_valid
+            and all(
+                len(rank_sources) == expected_observation_count
+                and all(observation_source == source_ids[rank_idx] for observation_source in rank_sources)
+                for rank_idx, rank_sources in enumerate(observation_sources)
+            )
+        )
+        if valid:
+            return None
+
+        return (
+            "Channel loss: SP preflight rejected observation payload before conditional collectives "
+            f"(has_source={has_source}, observation_counts={observation_counts}, "
+            f"successful_counts={successful_counts}, payload_counts={payload_counts}, "
+            f"source_ids={source_ids}, payload_specs={payload_specs}, "
+            f"segment_counts={segment_counts}, descriptor_specs={descriptor_specs}, errors={errors})."
+        )
+
+    def _append_observations(self, observations: list[list[dict[str, Any]]]) -> None:
+        if not observations or (self.strict and self._micro_step_failed):
+            return
+        if self._result is None:
+            self._result = []
+        for observation in observations:
+            self._result.extend(observation)
+        self._micro_step_observation_count += len(observations)
+
+    def _record_capture_failure(self, message: str) -> None:
+        if self.strict:
+            # A strict micro-step is atomic evidence: one failed observation
+            # invalidates successful observations from the same micro-step.
+            self._micro_step_failed = True
+            self._result = None
+            self._micro_step_observation_count = 0
+            self.strict_observation_errors.append((self._micro_step, message))
+            logger.warning_rank0(
+                f"Channel loss: deferring strict observation failure until globally synchronized step end: {message}"
+            )
+            return
+        logger.warning_rank0(f"Channel loss: {message} Skipping this model forward.")
 
     def _observe_opslot_call(
         self,
         original_kernel: Callable[..., Any],
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
+        reused_per_token_loss: torch.Tensor | None = None,
     ) -> None:
         call_args = _bind_loss_call_args(original_kernel, args, kwargs)
         labels = call_args.get("labels")
@@ -286,6 +798,7 @@ class ChannelLossComputer:
                 weights=call_args.get("weights"),
                 shift_labels=call_args.get("shift_labels"),
                 ignore_index=ignore_index,
+                reused_per_token_loss=reused_per_token_loss,
             )
 
     def begin_step(
@@ -298,7 +811,12 @@ class ChannelLossComputer:
         self._per_mb_position_ids = per_mb_position_ids
         self._per_mb_attention_masks = per_mb_attention_masks
         self._micro_step = 0
+        self._micro_step_observation_count = 0
+        self._micro_step_failed = False
+        self.missing_observation_micro_steps = []
+        self.strict_observation_errors = []
         self.step_totals = {}
+        self.step_data_totals = {}
 
     def before_micro_step(self) -> None:
         step = self._micro_step
@@ -311,8 +829,13 @@ class ChannelLossComputer:
             self._position_ids = None
             self._attention_mask = None
         self._result = None
+        self._micro_step_observation_count = 0
+        self._micro_step_failed = False
+        self._reset_capture_state()
 
     def after_micro_step(self) -> None:
+        if self.strict and self._source_ids and self._micro_step_observation_count == 0:
+            self.missing_observation_micro_steps.append(self._micro_step)
         if self._result:
             for item in self._result:
                 source_id = item["source_id"]
@@ -323,10 +846,23 @@ class ChannelLossComputer:
                     self.step_totals[source_id] = (loss_sum, token_count)
                 else:
                     self.step_totals[source_id] = (previous[0] + loss_sum, previous[1] + token_count)
+
+                sample_count = item.get("sample_count", token_count.new_ones(()).to(dtype=torch.int64)).detach()
+                input_token_count = item.get("input_token_count", token_count).detach()
+                data_previous = self.step_data_totals.get(source_id)
+                if data_previous is None:
+                    self.step_data_totals[source_id] = (sample_count, input_token_count, token_count)
+                else:
+                    self.step_data_totals[source_id] = (
+                        data_previous[0] + sample_count,
+                        data_previous[1] + input_token_count,
+                        data_previous[2] + token_count,
+                    )
         self._source_ids = []
         self._position_ids = None
         self._attention_mask = None
         self._result = None
+        self._reset_capture_state()
         self._micro_step += 1
 
     def record_source_names(self, source_ids: list[ChannelKey], source_names: list[str]) -> None:
@@ -372,9 +908,25 @@ class ChannelLossComputer:
         weights: torch.Tensor | None,
         shift_labels: torch.Tensor | None = None,
         ignore_index: int = IGNORE_INDEX,
+        reused_per_token_loss: torch.Tensor | None = None,
     ) -> None:
+        observer_device = next(
+            (
+                tensor.device
+                for tensor in (reused_per_token_loss, logits, hidden_states, weights, labels)
+                if isinstance(tensor, torch.Tensor)
+            ),
+            None,
+        )
+        standalone = not self.capture_active
+        if standalone:
+            self._reset_capture_state()
+            self._capture_sp_descriptor = _resolve_cached_sp_capture_descriptor(self.parallel_state)
+        self._observation_attempt_count += 1
+        if observer_device is not None:
+            self._observer_devices.append(observer_device)
         try:
-            self._result = self._compute_channel_loss(
+            result = self._compute_channel_loss(
                 logits=logits,
                 labels=labels,
                 vocab_size=vocab_size,
@@ -383,15 +935,22 @@ class ChannelLossComputer:
                 attention_mask=self._attention_mask,
                 shift_labels=shift_labels,
                 ignore_index=ignore_index,
+                defer_sp=True,
+                reused_per_token_loss=reused_per_token_loss,
             )
-        except ChannelLossMetadataError:
-            if self.strict:
-                raise
-            logger.warning_rank0("Channel loss: metadata mismatch; skipping this micro-batch.", exc_info=True)
-            self._result = None
-        except Exception:
-            logger.warning_rank0("Channel loss: per-token CE failed; skipping this micro-batch.", exc_info=True)
-            self._result = None
+            if result:
+                self._pending_observations.append(result)
+            else:
+                self._capture_errors.append(
+                    ("metadata", "channel-loss observation produced no source-aligned CE payload")
+                )
+        except ChannelLossMetadataError as error:
+            self._capture_errors.append(("metadata", str(error)))
+        except Exception as error:
+            self._capture_errors.append(("generic", f"{type(error).__name__}: {error}"))
+        finally:
+            if standalone:
+                self._finalize_capture()
 
     @torch.no_grad()
     def _compute_channel_loss(
@@ -404,8 +963,13 @@ class ChannelLossComputer:
         attention_mask: torch.Tensor | None,
         shift_labels: torch.Tensor | None,
         ignore_index: int,
-    ) -> list[dict[str, Any]]:
-        sp_enabled = bool(self.parallel_state.sp_enabled)
+        defer_sp: bool = False,
+        reused_per_token_loss: torch.Tensor | None = None,
+    ) -> list[dict[str, Any]] | _PendingSPObservation:
+        descriptor = self._capture_sp_descriptor
+        if descriptor is None:
+            descriptor = _resolve_cached_sp_capture_descriptor(self.parallel_state)
+        sp_enabled = descriptor.enabled
         if sp_enabled:
             effective_labels = labels
         elif shift_labels is not None:
@@ -413,13 +977,24 @@ class ChannelLossComputer:
         else:
             effective_labels = F.pad(labels, (0, 1), value=ignore_index)[..., 1:].contiguous()
 
+        if reused_per_token_loss is not None:
+            reused_per_token_loss = self._align_reused_per_token_loss(
+                reused_per_token_loss,
+                effective_labels,
+                sp_enabled=sp_enabled,
+            )
+
         labels_flat = effective_labels.reshape(-1)
         attention_mask_flat = _position_aligned_attention_mask_flat(
             attention_mask=attention_mask,
             labels=labels,
             effective_labels=effective_labels,
         )
-        per_token_loss = self._per_token_ce(logits, labels_flat, vocab_size, hidden_states, weights, ignore_index)
+        per_token_loss = (
+            reused_per_token_loss.reshape(-1)
+            if reused_per_token_loss is not None
+            else self._per_token_ce(logits, labels_flat, vocab_size, hidden_states, weights, ignore_index)
+        )
         if per_token_loss is None:
             return []
         labels_flat = labels_flat.to(per_token_loss.device)
@@ -434,8 +1009,34 @@ class ChannelLossComputer:
             position_ids=self._position_ids,
             ignore_index=ignore_index,
             sp_enabled=sp_enabled,
-            parallel_state=self.parallel_state,
+            parallel_state=descriptor.parallel_state if sp_enabled else None,
+            capture_descriptor=descriptor,
             strict=self.strict,
+            include_data_stats=False,
+            defer_sp=defer_sp,
+        )
+
+    @staticmethod
+    def _align_reused_per_token_loss(
+        per_token_loss: torch.Tensor,
+        effective_labels: torch.Tensor,
+        *,
+        sp_enabled: bool,
+    ) -> torch.Tensor:
+        """Align causal ``S-1`` main-loss observations with callback ``S`` labels."""
+
+        if per_token_loss.shape == effective_labels.shape:
+            return per_token_loss
+        if (
+            not sp_enabled
+            and per_token_loss.dim() == effective_labels.dim()
+            and per_token_loss.shape[:-1] == effective_labels.shape[:-1]
+            and per_token_loss.size(-1) + 1 == effective_labels.size(-1)
+        ):
+            return F.pad(per_token_loss, (0, 1), value=0.0)
+        raise ChannelLossMetadataError(
+            "Channel loss: reused main-loss CE shape does not align with effective labels "
+            f"({tuple(per_token_loss.shape)} vs {tuple(effective_labels.shape)})."
         )
 
     def _per_token_ce(
@@ -510,8 +1111,11 @@ class ChannelLossComputer:
         ignore_index: int,
         sp_enabled: bool = False,
         parallel_state: ParallelState | None = None,
+        capture_descriptor: _SPCaptureDescriptor | None = None,
         strict: bool = False,
-    ) -> list[dict[str, Any]]:
+        include_data_stats: bool = False,
+        defer_sp: bool = False,
+    ) -> list[dict[str, Any]] | _PendingSPObservation:
         if not source_ids:
             return []
 
@@ -541,7 +1145,10 @@ class ChannelLossComputer:
                     seq_len=seq_len,
                     ignore_index=ignore_index,
                     parallel_state=parallel_state,
+                    capture_descriptor=capture_descriptor,
                     strict=strict,
+                    include_data_stats=include_data_stats,
+                    defer_reduce=defer_sp,
                 )
 
             row_width = pos_2d.size(1)
@@ -558,6 +1165,12 @@ class ChannelLossComputer:
                     (batch_idx, row_offset + int(start), row_offset + int(end) - 1)
                     for start, end in zip(row_starts.tolist(), row_ends.tolist())
                 )
+        elif sp_enabled:
+            msg = "Channel loss: sequence-parallel source alignment requires position_ids; skipping this micro-batch."
+            if strict:
+                raise ChannelLossMetadataError(msg)
+            logger.warning_rank0(msg)
+            return []
         else:
             segments = [(0, 0, seq_len - 1)]
 
@@ -579,16 +1192,23 @@ class ChannelLossComputer:
         for i, (_, start, end) in enumerate(segments):
             labels_slice = labels_flat[start : end + 1]
             loss_slice = per_token_loss[start : end + 1]
+            mask_slice = attention_mask_flat[start : end + 1] if attention_mask_flat is not None else None
             valid = labels_slice != ignore_index
             token_count = valid.sum()
             loss_sum = loss_slice[valid].sum()
-            channel_loss.append(
-                {
-                    "source_id": source_ids[i],
-                    "loss_sum": loss_sum,
-                    "token_count": token_count,
-                }
-            )
+            item = {
+                "source_id": source_ids[i],
+                "loss_sum": loss_sum,
+                "token_count": token_count,
+            }
+            if include_data_stats:
+                item["sample_count"] = torch.ones((), device=labels_slice.device, dtype=torch.int64)
+                item["input_token_count"] = (
+                    mask_slice.to(torch.bool).sum(dtype=torch.int64)
+                    if mask_slice is not None
+                    else torch.as_tensor(labels_slice.numel(), device=labels_slice.device, dtype=torch.int64)
+                )
+            channel_loss.append(item)
         return channel_loss
 
     @staticmethod
@@ -601,12 +1221,20 @@ class ChannelLossComputer:
         seq_len: int,
         ignore_index: int,
         parallel_state: ParallelState | None = None,
+        capture_descriptor: _SPCaptureDescriptor | None = None,
         strict: bool = False,
-    ) -> list[dict[str, Any]]:
-        if parallel_state is None:
+        include_data_stats: bool = False,
+        defer_reduce: bool = False,
+    ) -> list[dict[str, Any]] | _PendingSPObservation:
+        if capture_descriptor is not None:
+            sp_rank = capture_descriptor.rank
+        elif parallel_state is None:
             raise ValueError("parallel_state is required for SP channel-loss aggregation.")
-        sp_group = parallel_state.sp_group
-        sp_rank = dist.get_rank(sp_group) if sp_group is not None else 0
+        else:
+            sp_group = parallel_state.sp_group
+            sp_rank = int(parallel_state.sp_rank)
+            if sp_rank < 0:
+                sp_rank = dist.get_rank(sp_group) if sp_group is not None else 0
         segments: list[dict[str, Any]] = []
 
         if positions.dim() == 1:
@@ -645,18 +1273,24 @@ class ChannelLossComputer:
                 else false_flag
             )
             has_only_zero_positions = bool(pos_slice.eq(0).all().tolist()) if pos_slice.numel() > 0 else False
-            segments.append(
-                {
-                    "batch_idx": batch_idx,
-                    "sp_rank": sp_rank,
-                    "local_order": local_order,
-                    "is_start": is_start,
-                    "has_explicit_padding_mask": has_explicit_padding_mask,
-                    "has_only_zero_positions": has_only_zero_positions,
-                    "loss_sum": loss_sum,
-                    "token_count": token_count,
-                }
-            )
+            segment = {
+                "batch_idx": batch_idx,
+                "sp_rank": sp_rank,
+                "local_order": local_order,
+                "is_start": is_start,
+                "has_explicit_padding_mask": has_explicit_padding_mask,
+                "has_only_zero_positions": has_only_zero_positions,
+                "loss_sum": loss_sum,
+                "token_count": token_count,
+            }
+            if include_data_stats:
+                segment["sample_count"] = torch.as_tensor(int(is_start), device=labels_slice.device, dtype=torch.int64)
+                segment["input_token_count"] = (
+                    mask_slice.to(torch.bool).sum(dtype=torch.int64)
+                    if mask_slice is not None
+                    else torch.as_tensor(labels_slice.numel(), device=labels_slice.device, dtype=torch.int64)
+                )
+            segments.append(segment)
 
         for batch_idx, row_pos in enumerate(positions_cpu):
             row_len = min(local_width, max(seq_len - batch_idx * local_width, 0))
@@ -677,21 +1311,207 @@ class ChannelLossComputer:
                 _partial(batch_idx, start, end, is_start=True, local_order=local_order)
                 local_order += 1
 
+        if defer_reduce:
+            return ChannelLossComputer._prepare_sp_observation_payload(
+                local_segments=segments,
+                source_ids=source_ids,
+                device=per_token_loss.device,
+                payload_capacity=max(seq_len, 1),
+                parallel_state=parallel_state,
+                capture_descriptor=capture_descriptor,
+                include_data_stats=include_data_stats,
+            )
+
         reduced = ChannelLossComputer._reduce_sp(
             segments,
             source_ids,
             device=per_token_loss.device,
             parallel_state=parallel_state,
             strict=strict,
+            include_data_stats=include_data_stats,
         )
-        return [
-            {
+        result = []
+        for item in reduced:
+            converted = {
                 "source_id": item["source_id"],
                 "loss_sum": torch.as_tensor(item["loss_sum"], device=per_token_loss.device, dtype=torch.float32),
                 "token_count": torch.as_tensor(item["token_count"], device=per_token_loss.device, dtype=torch.int64),
             }
-            for item in reduced
-        ]
+            if include_data_stats:
+                converted["sample_count"] = torch.as_tensor(
+                    item["sample_count"], device=per_token_loss.device, dtype=torch.int64
+                )
+                converted["input_token_count"] = torch.as_tensor(
+                    item["input_token_count"], device=per_token_loss.device, dtype=torch.int64
+                )
+            result.append(converted)
+        return result
+
+    @staticmethod
+    def _prepare_sp_observation_payload(
+        local_segments: list[dict[str, Any]],
+        source_ids: list[ChannelKey],
+        device: torch.device,
+        payload_capacity: int,
+        parallel_state: ParallelState | None = None,
+        capture_descriptor: _SPCaptureDescriptor | None = None,
+        include_data_stats: bool = False,
+    ) -> _PendingSPObservation:
+        """Materialize every rank-local buffer before the SP preflight."""
+
+        if payload_capacity < len(local_segments):
+            raise ChannelLossMetadataError(
+                "Channel loss: local SP segment count exceeds its deterministic payload capacity "
+                f"({len(local_segments)} > {payload_capacity})."
+            )
+        if capture_descriptor is None:
+            if parallel_state is None:
+                raise ValueError("parallel_state is required to prepare an SP channel-loss observation.")
+            capture_descriptor = _sp_descriptor_from_parallel_state(parallel_state)
+        group = capture_descriptor.group
+        world = capture_descriptor.world
+
+        loss_values: list[torch.Tensor] = []
+        integer_rows: list[torch.Tensor] = []
+        integer_column_count = 9 if include_data_stats else 7
+        for segment in local_segments:
+            loss_values.append(
+                _as_scalar_tensor(segment["loss_sum"], device=device, dtype=torch.float32, name="loss_sum")
+            )
+            integer_values = [
+                _as_scalar_tensor(segment["batch_idx"], device=device, dtype=torch.int64, name="batch_idx"),
+                _as_scalar_tensor(segment["sp_rank"], device=device, dtype=torch.int64, name="sp_rank"),
+                _as_scalar_tensor(segment["local_order"], device=device, dtype=torch.int64, name="local_order"),
+                _as_scalar_tensor(segment["is_start"], device=device, dtype=torch.int64, name="is_start"),
+                _as_scalar_tensor(segment["token_count"], device=device, dtype=torch.int64, name="token_count"),
+            ]
+            if include_data_stats:
+                integer_values.extend(
+                    [
+                        _as_scalar_tensor(
+                            segment["sample_count"], device=device, dtype=torch.int64, name="sample_count"
+                        ),
+                        _as_scalar_tensor(
+                            segment["input_token_count"],
+                            device=device,
+                            dtype=torch.int64,
+                            name="input_token_count",
+                        ),
+                    ]
+                )
+            integer_values.extend(
+                [
+                    _as_scalar_tensor(
+                        segment["has_explicit_padding_mask"],
+                        device=device,
+                        dtype=torch.int64,
+                        name="has_explicit_padding_mask",
+                    ),
+                    _as_scalar_tensor(
+                        segment["has_only_zero_positions"],
+                        device=device,
+                        dtype=torch.int64,
+                        name="has_only_zero_positions",
+                    ),
+                ]
+            )
+            integer_rows.append(torch.stack(integer_values))
+
+        loss_payload = torch.zeros(payload_capacity, dtype=torch.float32, device=device)
+        integer_payload = torch.zeros((payload_capacity, integer_column_count), dtype=torch.int64, device=device)
+        if loss_values:
+            loss_payload[: len(loss_values)].copy_(torch.stack(loss_values))
+            integer_payload[: len(integer_rows)].copy_(torch.stack(integer_rows))
+
+        if world > 1:
+            gathered_loss_payloads = [torch.empty_like(loss_payload) for _ in range(world)]
+            gathered_integer_payloads = [torch.empty_like(integer_payload) for _ in range(world)]
+        else:
+            gathered_loss_payloads = [loss_payload]
+            gathered_integer_payloads = [integer_payload]
+
+        return _PendingSPObservation(
+            source_ids=list(source_ids),
+            device=device,
+            parallel_state=parallel_state,
+            include_data_stats=include_data_stats,
+            group=group,
+            world=world,
+            capture_descriptor=capture_descriptor,
+            segment_count=len(local_segments),
+            loss_payload=loss_payload,
+            integer_payload=integer_payload,
+            gathered_segment_counts=[len(local_segments)] if world <= 1 else [0] * world,
+            gathered_loss_payloads=gathered_loss_payloads,
+            gathered_integer_payloads=gathered_integer_payloads,
+        )
+
+    @staticmethod
+    def _gather_prepared_sp_payload(
+        observation: _PendingSPObservation,
+        descriptor: _SPCaptureDescriptor,
+    ) -> None:
+        if descriptor.group is None or descriptor.world <= 1:
+            return
+        try:
+            dist.all_gather(
+                observation.gathered_loss_payloads,
+                observation.loss_payload,
+                group=descriptor.group,
+            )
+            dist.all_gather(
+                observation.gathered_integer_payloads,
+                observation.integer_payload,
+                group=descriptor.group,
+            )
+        except Exception as error:
+            raise ChannelLossCollectiveError(
+                "Channel loss payload collective failed; the SP process group must not be reused by the observer."
+            ) from error
+
+    @staticmethod
+    def _reconstruct_prepared_sp_payload(
+        observation: _PendingSPObservation,
+        strict: bool,
+    ) -> list[dict[str, Any]]:
+        all_segments: list[dict[str, Any]] = []
+        for rank_idx, segment_count in enumerate(observation.gathered_segment_counts):
+            metadata_values = (
+                observation.gathered_integer_payloads[rank_idx][:segment_count, :4].to(device="cpu").tolist()
+            )
+            for segment_idx, (batch_idx, sp_rank, local_order, is_start) in enumerate(metadata_values):
+                if (
+                    int(batch_idx) < 0
+                    or int(sp_rank) != rank_idx
+                    or int(local_order) < 0
+                    or int(is_start) not in (0, 1)
+                ):
+                    raise ChannelLossMetadataError(
+                        "Channel loss: gathered SP segment metadata does not match its fixed payload rank/order."
+                    )
+                integer_stats = observation.gathered_integer_payloads[rank_idx][segment_idx]
+                stats_offset = 2 if observation.include_data_stats else 0
+                segment = {
+                    "batch_idx": int(batch_idx),
+                    "sp_rank": int(sp_rank),
+                    "local_order": int(local_order),
+                    "is_start": bool(is_start),
+                    "loss_sum": observation.gathered_loss_payloads[rank_idx][segment_idx],
+                    "token_count": integer_stats[4],
+                    "has_explicit_padding_mask": integer_stats[5 + stats_offset].to(torch.bool),
+                    "has_only_zero_positions": integer_stats[6 + stats_offset].to(torch.bool),
+                }
+                if observation.include_data_stats:
+                    segment["sample_count"] = integer_stats[5]
+                    segment["input_token_count"] = integer_stats[6]
+                all_segments.append(segment)
+
+        return ChannelLossComputer._merge_sp_segments(
+            all_segments,
+            observation.source_ids,
+            strict=strict,
+            include_data_stats=observation.include_data_stats,
+        )
 
     @staticmethod
     def _reduce_sp(
@@ -700,6 +1520,7 @@ class ChannelLossComputer:
         device: torch.device,
         parallel_state: ParallelState | None = None,
         strict: bool = False,
+        include_data_stats: bool = False,
     ) -> list[dict[str, Any]]:
         if local_segments:
             local_zero_position_flags = torch.tensor(
@@ -747,12 +1568,24 @@ class ChannelLossComputer:
                     local_zero_position_flags = torch.stack(
                         [segment["has_only_zero_positions"] for segment in local_segments]
                     ).to(device=device, dtype=torch.int64)
-                    local_integer_stats = torch.stack(
-                        [local_token_counts, local_explicit_padding_flags, local_zero_position_flags], dim=1
-                    )
+                    integer_columns = [local_token_counts]
+                    if include_data_stats:
+                        integer_columns.extend(
+                            [
+                                torch.stack([segment["sample_count"] for segment in local_segments]).to(
+                                    device=device, dtype=torch.int64
+                                ),
+                                torch.stack([segment["input_token_count"] for segment in local_segments]).to(
+                                    device=device, dtype=torch.int64
+                                ),
+                            ]
+                        )
+                    integer_columns.extend([local_explicit_padding_flags, local_zero_position_flags])
+                    local_integer_stats = torch.stack(integer_columns, dim=1)
                 else:
                     local_loss_sums = torch.empty(0, dtype=torch.float32, device=device)
-                    local_integer_stats = torch.empty((0, 3), dtype=torch.int64, device=device)
+                    integer_column_count = 5 if include_data_stats else 3
+                    local_integer_stats = torch.empty((0, integer_column_count), dtype=torch.int64, device=device)
 
                 loss_padding = local_loss_sums.new_zeros(max_segment_count - local_loss_sums.size(0))
                 integer_padding = local_integer_stats.new_zeros(
@@ -768,16 +1601,33 @@ class ChannelLossComputer:
                 for rank_idx, rank_metadata in enumerate(gathered_metadata):
                     for segment_idx, metadata in enumerate(rank_metadata or []):
                         integer_stats = gathered_integer_stats[rank_idx][segment_idx]
-                        all_segments.append(
-                            {
-                                **metadata,
-                                "loss_sum": gathered_loss_sums[rank_idx][segment_idx],
-                                "token_count": integer_stats[0],
-                                "has_explicit_padding_mask": integer_stats[1].to(torch.bool),
-                                "has_only_zero_positions": integer_stats[2].to(torch.bool),
-                            }
-                        )
+                        stats_offset = 2 if include_data_stats else 0
+                        segment = {
+                            **metadata,
+                            "loss_sum": gathered_loss_sums[rank_idx][segment_idx],
+                            "token_count": integer_stats[0],
+                            "has_explicit_padding_mask": integer_stats[1 + stats_offset].to(torch.bool),
+                            "has_only_zero_positions": integer_stats[2 + stats_offset].to(torch.bool),
+                        }
+                        if include_data_stats:
+                            segment["sample_count"] = integer_stats[1]
+                            segment["input_token_count"] = integer_stats[2]
+                        all_segments.append(segment)
 
+        return ChannelLossComputer._merge_sp_segments(
+            all_segments,
+            source_ids,
+            strict=strict,
+            include_data_stats=include_data_stats,
+        )
+
+    @staticmethod
+    def _merge_sp_segments(
+        all_segments: list[dict[str, Any]],
+        source_ids: list[ChannelKey],
+        strict: bool,
+        include_data_stats: bool,
+    ) -> list[dict[str, Any]]:
         all_segments.sort(
             key=lambda segment: (
                 int(segment.get("batch_idx", 0)),
@@ -808,13 +1658,15 @@ class ChannelLossComputer:
         for segment in all_segments:
             batch_idx = int(segment.get("batch_idx", 0))
             if segment["is_start"]:
-                result.append(
-                    {
-                        "source_id": source_ids[doc_idx],
-                        "loss_sum": segment["loss_sum"],
-                        "token_count": segment["token_count"],
-                    }
-                )
+                item = {
+                    "source_id": source_ids[doc_idx],
+                    "loss_sum": segment["loss_sum"],
+                    "token_count": segment["token_count"],
+                }
+                if include_data_stats:
+                    item["sample_count"] = segment["sample_count"]
+                    item["input_token_count"] = segment["input_token_count"]
+                result.append(item)
                 last_result_idx_by_batch[batch_idx] = len(result) - 1
                 doc_idx += 1
                 continue
@@ -831,6 +1683,9 @@ class ChannelLossComputer:
                 continue
             result[result_idx]["loss_sum"] += segment["loss_sum"]
             result[result_idx]["token_count"] += segment["token_count"]
+            if include_data_stats:
+                result[result_idx]["sample_count"] += segment["sample_count"]
+                result[result_idx]["input_token_count"] += segment["input_token_count"]
         return result
 
 
@@ -860,6 +1715,7 @@ class ChannelLossCallback(Callback):
         self._strip_keys.update(self.config.source_name_keys)
         self._strip_keys.update(self.config.extra_strip_keys)
         self.computer.strict = bool(self.config.strict)
+        self.computer.release_cache = bool(self.config.release_cache)
         self._collect_step = False
         self._source_registry: dict[ChannelKey, str | None] = {}
 
@@ -917,38 +1773,51 @@ class ChannelLossCallback(Callback):
         self,
         state: TrainerState,
         micro_batches: list[dict[str, Any]] = None,
-        source_repeat: int = 1,
+        channel_loss_source_repeat: int = 1,
         **kwargs: Any,
     ) -> None:
         if not self.enabled:
             self._collect_step = False
             return
-        if source_repeat < 1:
-            raise ValueError(f"Channel loss source_repeat must be >= 1, got {source_repeat}.")
+        if channel_loss_source_repeat < 1:
+            raise ValueError(
+                "Channel loss channel_loss_source_repeat must be >= 1, "
+                f"got {channel_loss_source_repeat}."
+            )
 
         self._collect_step = state.global_step % self.config.interval == 0
         if not self._collect_step:
             self.computer.begin_step([], [], [])
             if self.config.strict:
-                for micro_batch in micro_batches or []:
+                missing_source_micro_steps = []
+                for micro_step, micro_batch in enumerate(micro_batches or []):
                     source_ids, _, _, _ = self._extract_metadata(micro_batch)
-                    self._require_source_ids(source_ids)
+                    if not source_ids:
+                        missing_source_micro_steps.append(micro_step)
+                self._raise_if_missing_source_ids(missing_source_micro_steps)
             return
 
         per_mb_source_ids: list[list[ChannelKey]] = []
         per_mb_position_ids: list[torch.Tensor | None] = []
         per_mb_attention_masks: list[torch.Tensor | None] = []
-        for micro_batch in micro_batches or []:
+        missing_source_micro_steps = []
+        for micro_step, micro_batch in enumerate(micro_batches or []):
             source_ids, source_names, position_ids, attention_mask = self._extract_metadata(micro_batch)
-            if self.config.strict:
-                self._require_source_ids(source_ids)
-            source_ids, source_names = self._repeat_source_metadata(source_ids, source_names, source_repeat)
+            if self.config.strict and not source_ids:
+                missing_source_micro_steps.append(micro_step)
+            source_ids, source_names = self._repeat_source_metadata(
+                source_ids,
+                source_names,
+                channel_loss_source_repeat,
+            )
             self.computer.record_source_names(source_ids, source_names)
             per_mb_source_ids.append(source_ids)
             per_mb_position_ids.append(position_ids)
             per_mb_attention_masks.append(attention_mask)
 
         self.computer.begin_step(per_mb_source_ids, per_mb_position_ids, per_mb_attention_masks)
+        if self.config.strict:
+            self._raise_if_missing_source_ids(missing_source_micro_steps)
 
     @staticmethod
     def _repeat_source_metadata(
@@ -964,12 +1833,13 @@ class ChannelLossCallback(Callback):
             source_names = [source_name for source_name in source_names for _ in range(repeat)]
         return repeated_ids, source_names
 
-    def _require_source_ids(self, source_ids: list[ChannelKey]) -> None:
-        if source_ids:
+    def _raise_if_missing_source_ids(self, local_missing_micro_steps: list[int]) -> None:
+        if not self._synchronize_strict_failure(bool(local_missing_micro_steps)):
             return
         raise ValueError(
-            "train.channel_loss.enable=True but no configured source ID was found in a micro-batch. "
-            f"Checked keys: {self.config.source_id_keys}."
+            "train.channel_loss.enable=True but no configured source ID was found in a micro-batch on at least "
+            f"one rank. Checked keys: {self.config.source_id_keys}; "
+            f"local missing micro-batch indices: {local_missing_micro_steps}."
         )
 
     def on_micro_step_begin(
@@ -1022,9 +1892,31 @@ class ChannelLossCallback(Callback):
         if not self._collect_step:
             return
 
-        totals, source_names = self._reduce_step_totals(self.computer.step_totals)
+        if self.config.strict and self._synchronize_missing_observation():
+            raise ChannelLossMetadataError(
+                "Channel loss: sampled micro-step had source metadata but produced no causal-LM CE observation "
+                "or raised a channel-loss observation error "
+                f"(local missing micro-step indices: {self.computer.missing_observation_micro_steps}; "
+                f"local observation errors: {self.computer.strict_observation_errors})."
+            )
+
+        strict_reduction_errors: list[str] = []
+        totals, source_names = self._reduce_step_totals(
+            self.computer.step_totals,
+            strict_errors=strict_reduction_errors if self.config.strict else None,
+        )
         if not totals:
+            if self.config.strict and any(self.computer._per_mb_source_ids):
+                strict_reduction_errors.append(
+                    "Channel loss: sampled optimizer step had source metadata but produced no causal-LM CE totals. "
+                    "The model forward did not invoke an observed loss path."
+                )
+            if self.config.strict:
+                self._raise_if_strict_post_collective_failure(strict_reduction_errors)
             return
+
+        if self.config.strict:
+            self._raise_if_strict_post_collective_failure(strict_reduction_errors)
 
         metrics = self._build_metrics(totals, source_names)
         if not metrics:
@@ -1038,9 +1930,35 @@ class ChannelLossCallback(Callback):
         self.trainer.step_train_metrics.update(metrics)
         self.trainer.step_env_metrics.update(metrics)
 
+    def _synchronize_missing_observation(self) -> bool:
+        missing = bool(self.computer.missing_observation_micro_steps or self.computer.strict_observation_errors)
+        return self._synchronize_strict_failure(missing)
+
+    def _synchronize_strict_failure(self, failed: bool) -> bool:
+        if not dist.is_available() or not dist.is_initialized():
+            return failed
+
+        device = self._totals_device(self.computer.step_totals)
+        failure_count = torch.tensor(int(failed), dtype=torch.int64, device=device)
+        # This helper is called only at a common world boundary, before any
+        # group-specific collective or after every such collective completes.
+        dist.all_reduce(failure_count)
+        return bool(failure_count.cpu().item())
+
+    def _raise_if_strict_post_collective_failure(self, local_errors: list[str]) -> None:
+        if not self._synchronize_strict_failure(bool(local_errors)):
+            return
+        local_detail = " | ".join(local_errors) if local_errors else "none on this rank"
+        raise ChannelLossMetadataError(
+            "Channel loss: strict reduction/registry validation failed on at least one rank after all "
+            f"group-specific collectives completed (local errors: {local_detail})."
+        )
+
     def _reduce_step_totals(
         self,
         local_totals: dict[ChannelKey, tuple[torch.Tensor, torch.Tensor]],
+        *,
+        strict_errors: list[str] | None = None,
     ) -> tuple[dict[ChannelKey, tuple[float, int]], dict[ChannelKey, str]]:
         ps = self.parallel_state
         dp_size = ps.dp_size
@@ -1076,8 +1994,11 @@ class ChannelLossCallback(Callback):
             if len(candidates) > 1:
                 msg = f"Channel loss: source_id={source_id!r} has inconsistent names across DP ranks: {candidates}."
                 if self.config.strict:
-                    raise ChannelLossMetadataError(msg)
-                logger.warning_rank0(msg + " Using the lexicographically first name.")
+                    if strict_errors is None:
+                        raise ChannelLossMetadataError(msg)
+                    strict_errors.append(msg)
+                else:
+                    logger.warning_rank0(msg + " Using the lexicographically first name.")
             if candidates:
                 synchronized_names[source_id] = candidates[0]
 
@@ -1100,13 +2021,19 @@ class ChannelLossCallback(Callback):
             source_id: (float(loss_values[index]), int(token_values[index]))
             for index, source_id in enumerate(source_ids)
         }
-        registered_names = self._register_sources(source_ids, synchronized_names)
+        registered_names = self._register_sources(
+            source_ids,
+            synchronized_names,
+            strict_errors=strict_errors,
+        )
         return totals, registered_names
 
     def _register_sources(
         self,
         source_ids: list[ChannelKey],
         source_names: dict[ChannelKey, str] | None = None,
+        *,
+        strict_errors: list[str] | None = None,
     ) -> dict[ChannelKey, str]:
         source_names = source_names or {}
         for source_id in source_ids:
@@ -1125,8 +2052,11 @@ class ChannelLossCallback(Callback):
             candidates = sorted({registered_name, incoming_name})
             msg = f"Channel loss: source_id={source_id!r} has inconsistent names across sampled steps: {candidates}."
             if self.config.strict:
-                raise ChannelLossMetadataError(msg)
-            logger.warning_once(msg + " Using the lexicographically first name.")
+                if strict_errors is None:
+                    raise ChannelLossMetadataError(msg)
+                strict_errors.append(msg)
+            else:
+                logger.warning_once(msg + " Using the lexicographically first name.")
             self._source_registry[source_id] = candidates[0]
 
         registered_names = {
@@ -1498,6 +2428,31 @@ def _as_str_list(value: Any) -> list[str]:
         if text:
             result.append(text)
     return result
+
+
+def _as_scalar_tensor(
+    value: Any,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    name: str,
+) -> torch.Tensor:
+    tensor = torch.as_tensor(value, device=device, dtype=dtype)
+    if tensor.numel() != 1:
+        raise ChannelLossMetadataError(
+            f"Channel loss: local SP {name} must be scalar, got shape={tuple(tensor.shape)}."
+        )
+    return tensor.reshape(())
+
+
+def _source_id_signature(source_ids: list[ChannelKey]) -> tuple[tuple[str, str], ...]:
+    return tuple((type(source_id).__name__, repr(source_id)) for source_id in source_ids)
+
+
+def _format_capture_errors(errors: list[tuple[str, str]]) -> str:
+    return "Channel loss observation failed: " + " | ".join(
+        f"{error_type}: {message}" for error_type, message in errors
+    )
 
 
 def _sanitize_metric_fragment(value: Any) -> str:

--- a/veomni/trainer/callbacks/channel_loss_callback.py
+++ b/veomni/trainer/callbacks/channel_loss_callback.py
@@ -127,6 +127,7 @@ class _PendingSPObservation:
     world: int
     capture_descriptor: _SPCaptureDescriptor
     segment_count: int
+    alignment_mode: str
     loss_payload: torch.Tensor
     integer_payload: torch.Tensor
     gathered_segment_counts: list[int]
@@ -213,6 +214,7 @@ class ChannelLossComputer:
         self._source_ids: list[ChannelKey] = []
         self._position_ids: torch.Tensor | None = None
         self._attention_mask: torch.Tensor | None = None
+        self._packed_cu_seqlens: Any | None = None
         self._result: list[dict[str, Any]] | None = None
         self._pending_observations: list[_PendingSPObservation | list[dict[str, Any]]] = []
         self._observation_attempt_count = 0
@@ -222,6 +224,7 @@ class ChannelLossComputer:
         self._per_mb_source_ids: list[list[ChannelKey]] = []
         self._per_mb_position_ids: list[torch.Tensor | None] = []
         self._per_mb_attention_masks: list[torch.Tensor | None] = []
+        self._per_mb_packed_cu_seqlens: list[Any | None] = []
         self._micro_step = 0
         self._micro_step_observation_count = 0
         self._micro_step_failed = False
@@ -641,6 +644,7 @@ class ChannelLossComputer:
                 for observation in pending_sp
             ],
             "segment_counts": [observation.segment_count for observation in pending_sp],
+            "alignment_modes": [observation.alignment_mode for observation in pending_sp],
             "descriptor_spec": (descriptor.enabled, descriptor.world, descriptor.group is not None),
             "errors": [*self._capture_errors, *descriptor_errors],
         }
@@ -709,11 +713,19 @@ class ChannelLossComputer:
         observation_sources = [status.get("observation_source_ids") or [] for status in statuses]
         payload_specs = [status.get("payload_specs") or [] for status in statuses]
         segment_counts = [status.get("segment_counts") or [] for status in statuses]
+        alignment_modes = [status.get("alignment_modes") or [] for status in statuses]
         descriptor_specs = [status.get("descriptor_spec") for status in statuses]
         expected_observation_count = observation_counts[0] if observation_counts else -1
         segment_count_contract_valid = True
-        for rank_specs, rank_counts in zip(payload_specs, segment_counts):
-            if len(rank_specs) != expected_observation_count or len(rank_counts) != expected_observation_count:
+        for rank_idx, (rank_specs, rank_counts, rank_modes) in enumerate(
+            zip(payload_specs, segment_counts, alignment_modes)
+        ):
+            if (
+                len(rank_specs) != expected_observation_count
+                or len(rank_counts) != expected_observation_count
+                or len(rank_modes) != expected_observation_count
+                or any(mode not in ("packed_cu", "positions") for mode in rank_modes)
+            ):
                 segment_count_contract_valid = False
                 break
             for observation_idx, segment_count in enumerate(rank_counts):
@@ -721,6 +733,9 @@ class ChannelLossComputer:
                     not isinstance(segment_count, int)
                     or segment_count < 0
                     or segment_count > int(rank_specs[observation_idx][0])
+                    or (
+                        rank_modes[observation_idx] == "packed_cu" and segment_count != len(source_ids[rank_idx] or ())
+                    )
                 ):
                     segment_count_contract_valid = False
                     break
@@ -734,6 +749,7 @@ class ChannelLossComputer:
             and payload_counts == observation_counts
             and all(source_id == source_ids[0] for source_id in source_ids)
             and all(payload_spec == payload_specs[0] for payload_spec in payload_specs)
+            and all(alignment_mode == alignment_modes[0] for alignment_mode in alignment_modes)
             and all(descriptor_spec == descriptor_specs[0] for descriptor_spec in descriptor_specs)
             and all(not rank_errors for rank_errors in errors)
             and segment_count_contract_valid
@@ -751,7 +767,8 @@ class ChannelLossComputer:
             f"(has_source={has_source}, observation_counts={observation_counts}, "
             f"successful_counts={successful_counts}, payload_counts={payload_counts}, "
             f"source_ids={source_ids}, payload_specs={payload_specs}, "
-            f"segment_counts={segment_counts}, descriptor_specs={descriptor_specs}, errors={errors})."
+            f"segment_counts={segment_counts}, alignment_modes={alignment_modes}, "
+            f"descriptor_specs={descriptor_specs}, errors={errors})."
         )
 
     def _append_observations(self, observations: list[list[dict[str, Any]]]) -> None:
@@ -806,10 +823,14 @@ class ChannelLossComputer:
         per_mb_source_ids: list[list[ChannelKey]],
         per_mb_position_ids: list[torch.Tensor | None],
         per_mb_attention_masks: list[torch.Tensor | None],
+        per_mb_packed_cu_seqlens: list[Any | None] | None = None,
     ) -> None:
         self._per_mb_source_ids = per_mb_source_ids
         self._per_mb_position_ids = per_mb_position_ids
         self._per_mb_attention_masks = per_mb_attention_masks
+        self._per_mb_packed_cu_seqlens = (
+            per_mb_packed_cu_seqlens if per_mb_packed_cu_seqlens is not None else [None] * len(per_mb_source_ids)
+        )
         self._micro_step = 0
         self._micro_step_observation_count = 0
         self._micro_step_failed = False
@@ -824,10 +845,12 @@ class ChannelLossComputer:
             self._source_ids = self._per_mb_source_ids[step]
             self._position_ids = self._per_mb_position_ids[step]
             self._attention_mask = self._per_mb_attention_masks[step]
+            self._packed_cu_seqlens = self._per_mb_packed_cu_seqlens[step]
         else:
             self._source_ids = []
             self._position_ids = None
             self._attention_mask = None
+            self._packed_cu_seqlens = None
         self._result = None
         self._micro_step_observation_count = 0
         self._micro_step_failed = False
@@ -861,6 +884,7 @@ class ChannelLossComputer:
         self._source_ids = []
         self._position_ids = None
         self._attention_mask = None
+        self._packed_cu_seqlens = None
         self._result = None
         self._reset_capture_state()
         self._micro_step += 1
@@ -1007,6 +1031,7 @@ class ChannelLossComputer:
             attention_mask_flat=attention_mask_flat,
             source_ids=self._source_ids,
             position_ids=self._position_ids,
+            packed_cu_seqlens=self._packed_cu_seqlens,
             ignore_index=ignore_index,
             sp_enabled=sp_enabled,
             parallel_state=descriptor.parallel_state if sp_enabled else None,
@@ -1109,6 +1134,7 @@ class ChannelLossComputer:
         source_ids: list[ChannelKey],
         position_ids: torch.Tensor | None,
         ignore_index: int,
+        packed_cu_seqlens: Any | None = None,
         sp_enabled: bool = False,
         parallel_state: ParallelState | None = None,
         capture_descriptor: _SPCaptureDescriptor | None = None,
@@ -1142,6 +1168,7 @@ class ChannelLossComputer:
                     attention_mask_flat=attention_mask_flat,
                     source_ids=source_ids,
                     positions=pos_2d,
+                    packed_cu_seqlens=packed_cu_seqlens,
                     seq_len=seq_len,
                     ignore_index=ignore_index,
                     parallel_state=parallel_state,
@@ -1220,6 +1247,7 @@ class ChannelLossComputer:
         positions: torch.Tensor,
         seq_len: int,
         ignore_index: int,
+        packed_cu_seqlens: Any | None = None,
         parallel_state: ParallelState | None = None,
         capture_descriptor: _SPCaptureDescriptor | None = None,
         strict: bool = False,
@@ -1252,14 +1280,20 @@ class ChannelLossComputer:
             end: int,
             is_start: bool,
             local_order: int,
+            *,
+            flat_indices: bool = False,
         ) -> None:
-            if end <= start:
+            if end < start:
                 return
-            flat_start = batch_idx * local_width + start
-            flat_end = min(batch_idx * local_width + end, seq_len)
+            flat_start = start if flat_indices else batch_idx * local_width + start
+            flat_end = min(end if flat_indices else batch_idx * local_width + end, seq_len)
             labels_slice = labels_flat[flat_start:flat_end]
             loss_slice = per_token_loss[flat_start:flat_end]
-            pos_slice = positions_cpu[batch_idx, start:end].reshape(-1)[: labels_slice.numel()]
+            pos_slice = (
+                positions_cpu.reshape(-1)[flat_start:flat_end]
+                if flat_indices
+                else positions_cpu[batch_idx, start:end].reshape(-1)[: labels_slice.numel()]
+            )
             mask_slice = None
             if attention_mask_flat is not None:
                 mask_slice = attention_mask_flat[flat_start:flat_end]
@@ -1292,34 +1326,59 @@ class ChannelLossComputer:
                 )
             segments.append(segment)
 
-        for batch_idx, row_pos in enumerate(positions_cpu):
-            row_len = min(local_width, max(seq_len - batch_idx * local_width, 0))
-            if row_len <= 0:
-                continue
-            local_starts = row_pos[:row_len].eq(0).nonzero(as_tuple=True)[0].tolist()
-            local_order = 0
-            if not local_starts:
-                _partial(batch_idx, 0, row_len, is_start=False, local_order=local_order)
-                continue
+        packed_source_spans = _rank_local_packed_source_spans(
+            packed_cu_seqlens,
+            source_count=len(source_ids),
+            seq_len=seq_len,
+            attention_mask_flat=attention_mask_flat,
+        )
+        if packed_source_spans is not None:
+            alignment_mode = "packed_cu"
+            # Headwise CP keeps one rank-local span per original packed sample.
+            # Use those authoritative boundaries instead of interpreting every
+            # padding ``position_id == 0`` as a new sample. Exactly one SP rank
+            # owns each logical start; all other ranks contribute continuation
+            # totals for the same source index.
+            for source_idx, (start, end) in enumerate(packed_source_spans):
+                _partial(
+                    source_idx,
+                    start,
+                    end,
+                    is_start=sp_rank == 0,
+                    local_order=0,
+                    flat_indices=True,
+                )
+        else:
+            alignment_mode = "positions"
+            for batch_idx, row_pos in enumerate(positions_cpu):
+                row_len = min(local_width, max(seq_len - batch_idx * local_width, 0))
+                if row_len <= 0:
+                    continue
+                local_starts = row_pos[:row_len].eq(0).nonzero(as_tuple=True)[0].tolist()
+                local_order = 0
+                if not local_starts:
+                    _partial(batch_idx, 0, row_len, is_start=False, local_order=local_order)
+                    continue
 
-            first = local_starts[0]
-            if first > 0:
-                _partial(batch_idx, 0, first, is_start=False, local_order=local_order)
-                local_order += 1
-            ends = local_starts[1:] + [row_len]
-            for start, end in zip(local_starts, ends):
-                _partial(batch_idx, start, end, is_start=True, local_order=local_order)
-                local_order += 1
+                first = local_starts[0]
+                if first > 0:
+                    _partial(batch_idx, 0, first, is_start=False, local_order=local_order)
+                    local_order += 1
+                ends = local_starts[1:] + [row_len]
+                for start, end in zip(local_starts, ends):
+                    _partial(batch_idx, start, end, is_start=True, local_order=local_order)
+                    local_order += 1
 
         if defer_reduce:
             return ChannelLossComputer._prepare_sp_observation_payload(
                 local_segments=segments,
                 source_ids=source_ids,
                 device=per_token_loss.device,
-                payload_capacity=max(seq_len, 1),
+                payload_capacity=max(seq_len, len(source_ids), 1),
                 parallel_state=parallel_state,
                 capture_descriptor=capture_descriptor,
                 include_data_stats=include_data_stats,
+                alignment_mode=alignment_mode,
             )
 
         reduced = ChannelLossComputer._reduce_sp(
@@ -1356,6 +1415,7 @@ class ChannelLossComputer:
         parallel_state: ParallelState | None = None,
         capture_descriptor: _SPCaptureDescriptor | None = None,
         include_data_stats: bool = False,
+        alignment_mode: str = "positions",
     ) -> _PendingSPObservation:
         """Materialize every rank-local buffer before the SP preflight."""
 
@@ -1439,6 +1499,7 @@ class ChannelLossComputer:
             world=world,
             capture_descriptor=capture_descriptor,
             segment_count=len(local_segments),
+            alignment_mode=alignment_mode,
             loss_payload=loss_payload,
             integer_payload=integer_payload,
             gathered_segment_counts=[len(local_segments)] if world <= 1 else [0] * world,
@@ -1781,8 +1842,7 @@ class ChannelLossCallback(Callback):
             return
         if channel_loss_source_repeat < 1:
             raise ValueError(
-                "Channel loss channel_loss_source_repeat must be >= 1, "
-                f"got {channel_loss_source_repeat}."
+                f"Channel loss channel_loss_source_repeat must be >= 1, got {channel_loss_source_repeat}."
             )
 
         self._collect_step = state.global_step % self.config.interval == 0
@@ -1791,7 +1851,7 @@ class ChannelLossCallback(Callback):
             if self.config.strict:
                 missing_source_micro_steps = []
                 for micro_step, micro_batch in enumerate(micro_batches or []):
-                    source_ids, _, _, _ = self._extract_metadata(micro_batch)
+                    source_ids, _, _, _, _ = self._extract_metadata(micro_batch)
                     if not source_ids:
                         missing_source_micro_steps.append(micro_step)
                 self._raise_if_missing_source_ids(missing_source_micro_steps)
@@ -1800,9 +1860,12 @@ class ChannelLossCallback(Callback):
         per_mb_source_ids: list[list[ChannelKey]] = []
         per_mb_position_ids: list[torch.Tensor | None] = []
         per_mb_attention_masks: list[torch.Tensor | None] = []
+        per_mb_packed_cu_seqlens: list[Any | None] = []
         missing_source_micro_steps = []
         for micro_step, micro_batch in enumerate(micro_batches or []):
-            source_ids, source_names, position_ids, attention_mask = self._extract_metadata(micro_batch)
+            source_ids, source_names, position_ids, attention_mask, packed_cu_seqlens = self._extract_metadata(
+                micro_batch
+            )
             if self.config.strict and not source_ids:
                 missing_source_micro_steps.append(micro_step)
             source_ids, source_names = self._repeat_source_metadata(
@@ -1814,8 +1877,14 @@ class ChannelLossCallback(Callback):
             per_mb_source_ids.append(source_ids)
             per_mb_position_ids.append(position_ids)
             per_mb_attention_masks.append(attention_mask)
+            per_mb_packed_cu_seqlens.append(packed_cu_seqlens)
 
-        self.computer.begin_step(per_mb_source_ids, per_mb_position_ids, per_mb_attention_masks)
+        self.computer.begin_step(
+            per_mb_source_ids,
+            per_mb_position_ids,
+            per_mb_attention_masks,
+            per_mb_packed_cu_seqlens,
+        )
         if self.config.strict:
             self._raise_if_missing_source_ids(missing_source_micro_steps)
 
@@ -2147,17 +2216,35 @@ class ChannelLossCallback(Callback):
     def _extract_metadata(
         self,
         micro_batch: Any,
-    ) -> tuple[list[ChannelKey], list[str], torch.Tensor | None, torch.Tensor | None]:
+    ) -> tuple[list[ChannelKey], list[str], torch.Tensor | None, torch.Tensor | None, Any | None]:
         if isinstance(micro_batch, dict):
             source_ids = self._first_present_list(micro_batch, self.config.source_id_keys, _as_channel_key_list)
             source_names = self._first_present_list(micro_batch, self.config.source_name_keys, _as_str_list)
             position_ids = micro_batch.get("position_ids")
-            attention_mask = micro_batch.get("attention_mask")
+            # Headwise CP keeps the full attention mask for full-attention
+            # kernels, while its router mask is rank-local and excludes the
+            # per-sample CP padding. Channel-loss metadata must follow the
+            # local labels/positions rather than the global full-attention
+            # shape.
+            labels = micro_batch.get("labels")
+            router_attention_mask = micro_batch.get("router_attention_mask")
+            if (
+                isinstance(router_attention_mask, torch.Tensor)
+                and isinstance(labels, torch.Tensor)
+                and router_attention_mask.numel() == labels.numel()
+            ):
+                attention_mask = router_attention_mask
+            else:
+                attention_mask = micro_batch.get("attention_mask")
+            packed_cu_seqlens = micro_batch.get("cu_seqlens_list_q")
+            if packed_cu_seqlens is None:
+                packed_cu_seqlens = micro_batch.get("cu_seq_lens_q")
             return (
                 source_ids,
                 source_names,
                 position_ids if isinstance(position_ids, torch.Tensor) else None,
                 attention_mask if isinstance(attention_mask, torch.Tensor) else None,
+                packed_cu_seqlens,
             )
 
         if isinstance(micro_batch, (list, tuple)):
@@ -2168,9 +2255,9 @@ class ChannelLossCallback(Callback):
                     continue
                 source_ids.extend(self._first_present_list(sample, self.config.source_id_keys, _as_channel_key_list))
                 source_names.extend(self._first_present_list(sample, self.config.source_name_keys, _as_str_list))
-            return source_ids, source_names, None, None
+            return source_ids, source_names, None, None, None
 
-        return [], [], None, None
+        return [], [], None, None, None
 
     @staticmethod
     def _first_present_list(
@@ -2240,6 +2327,56 @@ def _position_aligned_attention_mask_flat(
     if attention_mask.numel() == labels.numel() or attention_mask.numel() == effective_labels.numel():
         return attention_mask.reshape(-1)
     return None
+
+
+def _rank_local_packed_source_spans(
+    packed_cu_seqlens: Any | None,
+    *,
+    source_count: int,
+    seq_len: int,
+    attention_mask_flat: torch.Tensor | None,
+) -> list[tuple[int, int]] | None:
+    """Resolve authoritative rank-local packed spans when they match sources.
+
+    Standard contiguous Ulysses can retain global CU metadata after slicing;
+    its final CU point therefore does not match the rank-local loss width and
+    deliberately falls back to position-based alignment. Headwise CP instead
+    publishes one local CU span per packed source, plus at most one explicit
+    padding-only tail span introduced by ``pad_to_length``.
+    """
+
+    if packed_cu_seqlens is None:
+        return None
+    if isinstance(packed_cu_seqlens, torch.Tensor):
+        if packed_cu_seqlens.ndim != 1 or packed_cu_seqlens.dtype not in (torch.int32, torch.int64):
+            return None
+        raw_points = packed_cu_seqlens.detach().cpu().tolist()
+    elif isinstance(packed_cu_seqlens, (list, tuple)):
+        raw_points = list(packed_cu_seqlens)
+    else:
+        return None
+
+    points: list[int] = []
+    for point in raw_points:
+        if isinstance(point, bool) or not isinstance(point, Integral):
+            return None
+        points.append(int(point))
+    if not points or points[0] != 0 or points[-1] != seq_len:
+        return None
+    if any(end < start for start, end in zip(points, points[1:])):
+        return None
+
+    spans = list(zip(points, points[1:]))
+    if len(spans) == source_count:
+        return spans
+    if len(spans) != source_count + 1 or attention_mask_flat is None:
+        return None
+
+    tail_start, tail_end = spans[-1]
+    tail_mask = attention_mask_flat[tail_start:tail_end]
+    if tail_mask.numel() > 0 and tail_mask.to(torch.bool).any().item():
+        return None
+    return spans[:-1]
 
 
 def _filter_surplus_tail_padding_segments(

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -402,7 +402,7 @@ class TextDPOTrainer:
     def on_step_begin(self, micro_batches=None):
         # Each DPO preference pair is packed as two consecutive causal-LM
         # segments (chosen, rejected) but carries one source metadata entry.
-        self.base.on_step_begin(micro_batches=micro_batches, source_repeat=2)
+        self.base.on_step_begin(micro_batches=micro_batches, channel_loss_source_repeat=2)
 
     def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
         self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)

--- a/veomni/utils/loss_observer.py
+++ b/veomni/utils/loss_observer.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Forward-scoped taps for detached loss observability."""
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+import torch
+
+
+_ACTIVE_CHUNK_LOSS_CONSUMER: ContextVar[Callable[[torch.Tensor], None] | None] = ContextVar(
+    "veomni_active_chunk_loss_consumer",
+    default=None,
+)
+
+
+@contextmanager
+def capture_chunk_loss_per_token(consumer: Callable[[torch.Tensor], None]) -> Iterator[None]:
+    """Route the main chunk-loss kernel's detached per-token CE to ``consumer``."""
+
+    token = _ACTIVE_CHUNK_LOSS_CONSUMER.set(consumer)
+    try:
+        yield
+    finally:
+        _ACTIVE_CHUNK_LOSS_CONSUMER.reset(token)
+
+
+def get_chunk_loss_consumer() -> Callable[[torch.Tensor], None] | None:
+    """Return the consumer active for the current model-forward context."""
+
+    return _ACTIVE_CHUNK_LOSS_CONSUMER.get()


### PR DESCRIPTION
## Summary

- report detached per-source CE, weighted loss contribution, and supervised-token counts;
- keep observation separate from the returned objective and gradients;
- make strict observation safe across sequence-parallel ranks and multiple causal-loss calls;
- reuse the main chunked-CE vocabulary projection instead of launching a second observer projection;
- warn when reuse is unavailable and Channel Loss falls back to detached CE recomputation.

## Memory behavior

The default chunked-CE path already materializes each
`[chunk_tokens, vocab]` logits tensor for the training objective. Channel Loss
reuses that projection and retains only `O(tokens)` detached per-token values
for source aggregation.

This removes the second observer `F.linear`, but it does **not** eliminate every
`O(chunk_tokens * vocab)` temporary: detached
`F.cross_entropy(..., reduction="none")` still needs a chunk-sized
full-vocabulary workspace. The fallback warning identifies non-chunk backends
or multi-loss forwards where projection reuse was not taken.

`release_cache` remains an optional diagnostic setting. It is disabled by
default because synchronization and allocator eviction can reduce throughput.

## Scope

This PR is the loader-independent Channel Loss core. It intentionally excludes:

- the four optional data-composition metrics;
- HTML/dashboard rendering;
- canonical loader metadata and checkpoint migration;
- Byted loader, HDFS, parquet locator, sample-head, or internal trace code.

The four compact data-composition metrics are stacked separately in #1006.

## Validation

- `84 passed`: `tests/trainer/test_channel_loss_callback.py`;
- the reuse regression verifies that projection calls equal the main chunk
  count and that scalar loss, hidden-state gradients, and LM-head gradients
  match the observer-disabled path exactly (`rtol=0`, `atol=0`);
- zero- and multi-capture fallback cases are covered and emit a warning;
- Python compile and `git diff --check` passed.

## Revision

- base: `29e65e1c89a5d9a7622ebb896c3480b94e217c97`
- head: `03490152`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `release_cache` option to synchronize and release detached cross-entropy workspaces after sampled loss calculations.
  * Improved channel-loss tracking with per-token loss reuse, sequence-parallel aggregation, packed-sequence metadata, and token/sample statistics.
  * Added validation for packed-sequence padding and stronger synchronized error handling in distributed processing.
  * Improved integration with DPO preference-pair training and multi-source observations.
  * Ensured channel-loss processing runs only when properly registered.

* **Documentation**
  * Expanded channel-loss configuration guidance, including backend workspace requirements and cache-release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->