### PR TITLE
[ops, perf] fix: cut DeepSeek-V4 sparse MLA kernel time

### DIFF
--- a/tests/ops/test_deepseek_v4_kernels.py
+++ b/tests/ops/test_deepseek_v4_kernels.py
@@ -248,6 +248,82 @@ def test_tilelang_sparse_attention_forward_backward_with_invalid_indices():
     for actual_grad, expected_grad in zip((q.grad, kv.grad, sinks.grad), expected_grads, strict=True):
         assert actual_grad is not None and torch.isfinite(actual_grad).all()
         assert _cosine_similarity(actual_grad, expected_grad) > 0.95
+    # dAttnSink is accumulated by an atomic under a replicated T.Parallel loop, so a
+    # lost replication guard would scale it by the warp count -- which cosine, being
+    # scale-invariant, cannot see.
+    torch.testing.assert_close(sinks.grad, expected_grads[2], rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize(
+    "block_H, block_size, expected",
+    [
+        (16, 32, 128),
+        (32, 32, 256),
+        (64, 32, 256),
+        # block_size is a bwd parameter, so the bound has to follow it: at 16 the
+        # column split halves and block_H=32 no longer affords 8 warps.
+        (32, 16, 128),
+        (64, 16, 256),
+        # The one tile where the derived width drops below the historical 128, which
+        # was in fact illegal there -- two warps is all this tile can partition.
+        (16, 16, 64),
+    ],
+)
+def test_tilelang_bwd_cta_threads_respects_warp_tile_bound(block_H, block_size, expected):
+    """``cta_threads`` must stay inside the GEMM warp tile it derives its bound from.
+
+    A width above ``block_size * block_H // 4`` is a TileLang compile-time assertion
+    rather than a slow kernel, so this pins both the chosen values and the warp split
+    they come from. The production tile is (64, 32); (16, 32) is what every other
+    TileLang test in this file exercises, which is why it must stay at 128.
+    """
+    pytest.importorskip("tilelang")
+    from veomni.ops.kernels.deepseek_v4 import tilelang_sparse_mla_bwd
+
+    threads = tilelang_sparse_mla_bwd.cta_threads(block_H, block_size)
+
+    assert threads == expected
+    assert threads % 32 == 0 and threads & (threads - 1) == 0
+    # Restate TileLang's own partition rather than the closed form above: it splits the
+    # columns over at most block_size // 8 warps and gives the rest to the rows, and an
+    # MMA row tile below 16 is a hard compile error.
+    num_warps = threads // 32
+    column_warps = min(num_warps, block_size // 8)
+    assert block_H // (num_warps // column_warps) >= 16
+
+
+def test_tilelang_sparse_attention_backward_matches_reference_on_wide_head_tile():
+    """Cover the head tile that gets the widened CTA; the rest of this file does not.
+
+    ``bwd`` derives its CTA width from ``block_H = min(64, max(next_power_of_2(H), 16))``,
+    and every other TileLang test here uses 8 heads, i.e. block_H=16, which keeps the
+    historical 128 threads. 32 heads is the smallest tile that actually widens to 256,
+    so without this case the wide path is never run.
+    """
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4 import sparse_attn_tilelang
+
+    torch.manual_seed(6)
+    batch, seqlen, heads, dim, kv_len, topk = 1, 16, 32, 512, 64, 64
+    q = torch.randn(batch, seqlen, heads, dim, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+    kv = torch.randn(batch, kv_len, dim, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+    sinks = torch.randn(heads, device=DEVICE, requires_grad=True)
+    indices = torch.randint(kv_len, (batch, seqlen, topk), device=DEVICE, dtype=torch.int32)
+    indices[..., -1] = -1
+    scale = dim**-0.5
+
+    actual = sparse_attn_tilelang(q, kv, sinks, indices, scale)
+    expected = _sparse_attention_reference(q, kv, sinks, indices, scale)
+    grad = torch.randn_like(actual)
+    expected_grads = torch.autograd.grad((expected * grad.float()).sum(), (q, kv, sinks))
+    actual.backward(grad)
+    for actual_grad, expected_grad in zip((q.grad, kv.grad, sinks.grad), expected_grads, strict=True):
+        assert actual_grad is not None and torch.isfinite(actual_grad).all()
+        assert _cosine_similarity(actual_grad, expected_grad) > 0.95
+    # The CTA width sets the replicate extent of the T.Parallel loop that atomically
+    # accumulates dAttnSink, so a lost replication guard would scale it by the warp
+    # count while leaving every cosine above intact.
+    torch.testing.assert_close(sinks.grad, expected_grads[2], rtol=2e-2, atol=2e-2)
 
 
 def test_tilelang_sparse_attention_backward_shares_kernel_across_kv_lengths(monkeypatch):

--- a/tests/ops/test_deepseek_v4_kernels.py
+++ b/tests/ops/test_deepseek_v4_kernels.py
@@ -265,13 +265,29 @@ def test_tilelang_sparse_attention_forward_pipelines_the_gather_without_changing
         assert torch.equal(lse, expected_lse)
 
     # The depth is bounded by shared memory, so it is derived from the device rather than
-    # left to surface as an opaque launch failure. The bound scales with the head tile
-    # and with block_I, which is why both are checked at the production head count and
-    # why the 8-head tile above can afford a depth that 64 heads cannot.
-    with pytest.raises(AssertionError, match="shared memory per block"):
-        sparse_mqa_fwd(64, dim, topk, scale, num_stages=3)
-    with pytest.raises(AssertionError, match="shared memory per block"):
-        sparse_mqa_fwd(64, dim, topk, scale, block_I=128, num_stages=2)
+    # left to surface as an opaque launch failure. Walk the depth up until the guard
+    # refuses, then show the deepest depth it did allow really launches: that measures the
+    # bound against the device instead of against a copy of its own formula, and it holds
+    # on any opt-in shared-memory limit rather than assuming Hopper's 227 KB.
+    wide_heads = 64
+    wide_q = torch.randn(batch, seqlen, wide_heads, dim, device=DEVICE, dtype=torch.bfloat16)
+    wide_sinks = torch.randn(wide_heads, device=DEVICE)
+    deepest = None
+    for depth in range(1, 9):
+        try:
+            candidate = sparse_mqa_fwd(wide_heads, dim, topk, scale, num_stages=depth)
+        except AssertionError as exc:
+            assert "shared memory per block" in str(exc)
+            break
+        deepest = candidate
+    else:
+        pytest.fail("the shared-memory guard never rejected a gather depth")
+
+    assert deepest is not None, "the guard rejected even a single-stage gather"
+    deep_out, _ = deepest(wide_q, kv, wide_sinks, indices)
+    # Reading the result into a Python bool is the synchronization point: a launch that
+    # could not get its shared memory surfaces here rather than staying pending.
+    assert torch.isfinite(deep_out).all().item()
 
 
 def test_tilelang_sparse_attention_forward_defaults_to_no_pipelining():

--- a/tests/ops/test_deepseek_v4_kernels.py
+++ b/tests/ops/test_deepseek_v4_kernels.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib
+import inspect
 import sys
 import types
 from types import SimpleNamespace
@@ -220,6 +221,74 @@ def _sparse_attention_reference(q, kv, sinks, indices, scale):
     numerator = torch.einsum("bmhk,bmkd->bmhd", exp_scores, gathered.float())
     denominator = exp_scores.sum(-1) + (sinks.view(1, 1, -1) - max_score.squeeze(-1)).exp()
     return numerator / denominator.unsqueeze(-1)
+
+
+def test_tilelang_sparse_attention_forward_pipelines_the_gather_without_changing_output():
+    """Pipelining the forward's sparse gather must stay legal, real, and exact.
+
+    Legality is load-bearing on the gather reading its row index straight from global
+    memory. Indexing a register fragment there instead puts the gather in pipeline
+    stage 0 while the fragment's producer lands in a later stage, which is a hard
+    TileLang failure -- so a future change of that shape breaks compilation here rather
+    than silently losing the overlap. The async-copy check is what distinguishes "still
+    pipelined" from "compiles but the pipelining was dropped".
+
+    Pipelining is off by default because it is a loss at the production shape, so this
+    only pins that it remains available and exact when asked for.
+    """
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_fwd import sparse_mqa_fwd, sparse_mqa_fwd_interface
+
+    torch.manual_seed(4)
+    batch, seqlen, heads, dim, kv_len, topk = 1, 64, 8, 512, 128, 640
+    q = torch.randn(batch, seqlen, heads, dim, device=DEVICE, dtype=torch.bfloat16)
+    kv = torch.randn(batch, kv_len, dim, device=DEVICE, dtype=torch.bfloat16)
+    sinks = torch.randn(heads, device=DEVICE)
+    indices = torch.randint(kv_len, (batch, seqlen, topk), device=DEVICE, dtype=torch.int32)
+    # topk=640 is 10 gather tiles, so the loop has a real steady state; plant sentinels
+    # in every tile so a one-tile skew between the mask and the gather cannot hide.
+    indices[..., ::64] = -1
+    indices[..., 63::64] = kv_len
+    scale = dim**-0.5
+
+    pipelined = sparse_mqa_fwd(heads, dim, topk, scale, num_stages=1)
+    serial = sparse_mqa_fwd(heads, dim, topk, scale, num_stages=0)
+    assert "cp_async_gs" in pipelined.get_kernel_source()
+    assert "cp_async_gs" not in serial.get_kernel_source()
+
+    expected_out, expected_lse = serial(q, kv, sinks, indices)
+    for out, lse in (
+        pipelined(q, kv, sinks, indices),
+        sparse_mqa_fwd_interface(q, kv, sinks, indices, scale, num_stages=1),
+    ):
+        assert torch.equal(out, expected_out)
+        assert torch.equal(lse, expected_lse)
+
+    # The depth is bounded by shared memory, so it is derived from the device rather than
+    # left to surface as an opaque launch failure. The bound scales with the head tile
+    # and with block_I, which is why both are checked at the production head count and
+    # why the 8-head tile above can afford a depth that 64 heads cannot.
+    with pytest.raises(AssertionError, match="shared memory per block"):
+        sparse_mqa_fwd(64, dim, topk, scale, num_stages=3)
+    with pytest.raises(AssertionError, match="shared memory per block"):
+        sparse_mqa_fwd(64, dim, topk, scale, block_I=128, num_stages=2)
+
+
+def test_tilelang_sparse_attention_forward_defaults_to_no_pipelining():
+    """The shipped gather depth is a performance choice that no output can reveal.
+
+    Both depths are bitwise identical, so the numerics test above cannot catch a flipped
+    default -- and the depth it would flip to cost 5% of a production step. This lives
+    outside that test because it needs no GPU, while the test it would otherwise sit in
+    skips below SM90 and therefore never runs on CI's L20 runners.
+    """
+    pytest.importorskip("tilelang")
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_fwd import sparse_mqa_fwd, sparse_mqa_fwd_interface
+
+    for entry in (sparse_mqa_fwd, sparse_mqa_fwd_interface):
+        # tilelang.jit re-exports the kernel as (*args, **kwargs), hiding its defaults.
+        params = inspect.signature(getattr(entry, "func", entry)).parameters
+        assert params["num_stages"].default == 0
 
 
 def test_tilelang_sparse_attention_forward_backward_with_invalid_indices():

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py
@@ -30,6 +30,31 @@ from tilelang import language as T
 KV_BLOCK = 1024
 
 
+def cta_threads(block_H, block_size):
+    """Pick the backward CTA width for a ``(block_H, block_size)`` tile.
+
+    The accumulator fragments are spread over the CTA's threads, so this sets their
+    per-thread register footprint. ``acc_dq`` alone is ``block_H * D`` floats: at
+    block_H=64 that is 256 registers per thread on 4 warps, past the 255-register
+    limit, so ptxas spills ~1.8 KB per thread. Doubling to 8 warps halves every
+    fragment and drops the spill to 72 B. It costs nothing in occupancy -- the tile
+    shapes do not depend on the CTA width, and at ~200 KB of shared memory per CTA
+    only one CTA fits per SM either way, so the wider CTA just doubles the resident
+    warps. Measured on one GB200 at D=512, topk=640, B=1, S=4096, S_kv=5120, bf16:
+    14.97 -> 7.68 ms for block_H=64, and 8.08 -> 5.92 ms for block_H=32.
+
+    The ceiling is the GEMM tiling. ``FullCol`` splits the ``block_size`` columns
+    over at most ``block_size // 8`` warps (the MMA n-tile is 8) and the remaining
+    warps divide ``block_H`` rows, so each warp's row tile is
+    ``block_H * (block_size // 8) / num_warps`` and a warp needs a whole 16-row MMA
+    tile. That bounds the width at ``block_size * block_H // 4``; exceeding it is a
+    hard TileLang assertion ("warp_row_tiles must be greater than 16"), not a slow
+    kernel. Past 256 the extra warps are a net loss anyway (measured: 5.43 ms at 512
+    vs 4.32 ms at 256 for block_H=64 with a 1024-length KV).
+    """
+    return min(256, block_size * block_H // 4)
+
+
 @tilelang.jit(out_idx=[-1])
 def preprocess(
     B,
@@ -114,7 +139,7 @@ def bwd(
     sm_scale=None,
     block_size=32,
     num_stages=0,
-    threads=128,
+    threads=None,
     indices_dtype=T.int32,
     dtype=T.bfloat16,
     accum_dtype=T.float32,
@@ -141,6 +166,20 @@ def bwd(
     NH = padded_H // block_H
     BS = block_size
     NS = tilelang.cdiv(topk, block_size)
+
+    if threads is None:
+        threads = cta_threads(block_H, BS)
+    # Fail here rather than inside TileLang's MMA macro generator, which reports the
+    # violated warp tile with no hint of which kernel asked for it. The power-of-two
+    # requirement is separate from the bound: the row/column warp split must multiply
+    # back to the warp count, so e.g. 96 threads clears the bound and still fails.
+    assert threads % 32 == 0 and threads & (threads - 1) == 0, (
+        f"threads ({threads}) must be a power-of-two multiple of the 32-lane warp"
+    )
+    assert 4 * threads <= BS * block_H, (
+        f"threads ({threads}) exceeds the GEMM warp-tile bound {BS * block_H // 4} "
+        f"for block_H={block_H}, block_size={BS}"
+    )
 
     split_store = 2
 

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py
@@ -187,8 +187,18 @@ def bwd(
                 for h_i, bi_i in T.Parallel(block_H, BS):
                     acc_p[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_p.dtype))
 
+                # Read the row index straight from global memory and clamp it, instead of
+                # going through the safe_indices fragment. A fragment index would tie this
+                # copy to the fragment's inferred layout, which collapses the whole tile
+                # onto the handful of threads that own the BS axis; reading Indices
+                # directly lets layout inference pick a coalesced whole-CTA copy instead.
+                # Clamping is equivalent to substituting row 0: out-of-range candidates
+                # have their scores pre-set to -inf above, which absorbs the finite QK
+                # product from whichever row is fetched here, so their softmax weight is
+                # exactly zero. The dKV scatter stays mask-guarded, so no gradient is ever
+                # written to the clamped row.
                 for bi_i, d_i in T.Parallel(BS, D):
-                    KV_shared[bi_i, d_i] = KV[by, safe_indices[bi_i], d_i]
+                    KV_shared[bi_i, d_i] = KV[by, T.max(T.min(Indices[by, s_i, i_i * BS + bi_i], S_kv - 1), 0), d_i]
 
                 T.gemm(Q_shared, KV_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
@@ -282,6 +292,8 @@ def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale=N
     assert topk_idxs.is_contiguous() and lse.is_contiguous()
     B, S, H, D = q.shape
     unpadded_S_kv = kv.shape[1]
+    # The gather clamps candidate rows into [0, S_kv - 1], which needs a row to exist.
+    assert unpadded_S_kv > 0, "kv must have at least one row"
     topk = topk_idxs.shape[-1]
 
     # Pad topk to next multiple of block_size (kernel requires divisibility)

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_bwd.py
@@ -176,7 +176,7 @@ def bwd(
     assert threads % 32 == 0 and threads & (threads - 1) == 0, (
         f"threads ({threads}) must be a power-of-two multiple of the 32-lane warp"
     )
-    assert 4 * threads <= BS * block_H, (
+    assert threads <= BS * block_H // 4, (
         f"threads ({threads}) exceeds the GEMM warp-tile bound {BS * block_H // 4} "
         f"for block_H={block_H}, block_size={BS}"
     )

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_fwd.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_fwd.py
@@ -42,10 +42,10 @@ def sparse_mqa_fwd(
     num_stages=0,
     threads=256,
 ):
-    # The bounds-safe indirect gather depends on per-iteration register indices.
-    # TileLang 0.1.9 cannot legally software-pipeline that dependency, so keep
-    # this loop unpipelined (num_stages=0).
-    assert num_stages == 0, "bounds-safe sparse gathers do not support software pipelining"
+    # The KV rows are gathered through a data-dependent index, which TileLang 0.1.9
+    # cannot lower into a multi-stage async copy, so keep this loop unpipelined
+    # (num_stages=0).
+    assert num_stages == 0, "data-dependent sparse gathers do not support software pipelining"
     assert dim == tilelang.math.next_power_of_2(dim), f"dim must be power of 2, got {dim}"
     assert topk % block_I == 0, f"topk ({topk}) must be divisible by block_I ({block_I})"
     if sm_scale is None:
@@ -96,7 +96,6 @@ def sparse_mqa_fwd(
             O_shared = T.alloc_shared([H_per_block, D], dtype)
             Lse_shared = T.alloc_shared([H_per_block], accum_dtype)
             mask = T.alloc_fragment([BI], "bool")
-            safe_indices = T.alloc_fragment([BI], indices_dtype)
 
             acc_o = T.alloc_fragment([H_per_block, D], accum_dtype)
             acc_s = T.alloc_fragment([H_per_block, BI], accum_dtype)
@@ -124,10 +123,20 @@ def sparse_mqa_fwd(
                     mask[bi_i] = (
                         Indices[b_i, s_i, i_i * BI + bi_i] >= 0 and Indices[b_i, s_i, i_i * BI + bi_i] < seq_len_kv
                     )
-                    safe_indices[bi_i] = T.if_then_else(mask[bi_i], Indices[b_i, s_i, i_i * BI + bi_i], 0)
 
+                # Read the row index straight from global memory and clamp it, instead of
+                # going through a register fragment. A fragment index would tie this copy
+                # to the fragment's inferred layout, which collapses the whole tile onto
+                # the handful of threads that own the BI axis; reading Indices directly
+                # lets layout inference pick a coalesced whole-CTA copy instead.
+                # Clamping is equivalent to substituting row 0: out-of-range candidates
+                # have their scores pre-set to -inf below, which absorbs the finite QK
+                # product from whichever real row is fetched here, so their softmax
+                # weight is exactly zero and they contribute nothing to the PV GEMM.
                 for bi_i, d_i in T.Parallel(BI, D):
-                    KV_shared[bi_i, d_i] = KV[b_i, safe_indices[bi_i], d_i]
+                    KV_shared[bi_i, d_i] = KV[
+                        b_i, T.max(T.min(Indices[b_i, s_i, i_i * BI + bi_i], seq_len_kv - 1), 0), d_i
+                    ]
 
                 for h_i, bi_i in T.Parallel(H_per_block, BI):
                     acc_s[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_s.dtype))
@@ -191,6 +200,8 @@ def sparse_mqa_fwd_interface(q, kv, attn_sink, topk_idxs, sm_scale=None, block_I
     batch, seq_len, heads, dim = q.shape
     _, seq_len_kv, kv_dim = kv.shape
     assert kv_dim == dim
+    # The gather clamps candidate rows into [0, seq_len_kv - 1], which needs a row to exist.
+    assert seq_len_kv > 0, "kv must have at least one row"
     _, _, topk = topk_idxs.shape
 
     # Pad topk to next multiple of block_I (kernel requires divisibility)

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_fwd.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_fwd.py
@@ -25,6 +25,8 @@ import tilelang
 import torch
 from tilelang import language as T
 
+from ....utils.device import get_torch_device
+
 
 @tilelang.jit(
     out_idx=[-2, -1],
@@ -42,10 +44,24 @@ def sparse_mqa_fwd(
     num_stages=0,
     threads=256,
 ):
-    # The KV rows are gathered through a data-dependent index, which TileLang 0.1.9
-    # cannot lower into a multi-stage async copy, so keep this loop unpipelined
-    # (num_stages=0).
-    assert num_stages == 0, "data-dependent sparse gathers do not support software pipelining"
+    # ``num_stages >= 1`` pipelines the KV gather, and that is only legal because the
+    # gather takes its row index straight from ``Indices`` in global memory. This is
+    # load-bearing: if the index ever comes from a register fragment again -- as it did
+    # before the clamp rewrite -- TileLang's IsPureCopyStmt puts the gather in stage 0
+    # while the loop writing that fragment lands in a later stage, and the pipeliner dies
+    # on `Check failed: src_info.stage <= dst_info.stage (1 vs. 0)`. Only the gather's own
+    # index matters; the ``mask`` fragment is fine where it is, since it and its consumer
+    # both stay in the compute stage.
+    #
+    # It stays off by default: enabling it cost 5% of a production step. An isolated
+    # benchmark of this kernel had predicted a win, and why it was wrong matters more
+    # than its numbers -- in training every gather slowed by 46-69%, including the
+    # compress-ratio-4 layers whose working set that benchmark measured a 19% gain on.
+    # The commit/wait only pays for itself if the gather is HBM-bound, and no isolated
+    # measurement reproduced the cache and bandwidth state of a real step. So re-enable
+    # this on an end-to-end measurement, never on a microbenchmark. Nothing plumbs the
+    # parameter to a config, so opting in is a source change by construction.
+    assert num_stages >= 0, f"num_stages must be non-negative, got {num_stages}"
     assert dim == tilelang.math.next_power_of_2(dim), f"dim must be power of 2, got {dim}"
     assert topk % block_I == 0, f"topk ({topk}) must be divisible by block_I ({block_I})"
     if sm_scale is None:
@@ -80,6 +96,23 @@ def sparse_mqa_fwd(
         REPLICATE_H = 1
 
     H_per_block = padded_H if REPLICATE_H == 1 else 64
+
+    # Every stage past the first double-buffers the BI x D KV tile, so the depth is
+    # bounded by shared memory rather than by anything in the algorithm -- and by
+    # block_I and dim, not by a fixed depth. Sum the tiles rather than hardcoding a
+    # ceiling: the estimate ignores TileLang's inter-buffer alignment, so it under-counts
+    # and can only ever under-reject, and a depth that slips through still fails loudly
+    # at launch naming the bytes it could not allocate.
+    smem_lower_bound = (
+        H_per_block * D * 2  # Q_shared, bf16
+        + H_per_block * BI * 2  # S_shared, bf16
+        + max(num_stages, 1) * BI * D * 2  # KV_shared, one buffer per stage
+    )
+    smem_limit = get_torch_device().get_device_properties(None).shared_memory_per_block_optin
+    assert smem_lower_bound <= smem_limit, (
+        f"num_stages={num_stages} at block_I={block_I}, dim={dim} needs at least "
+        f"{smem_lower_bound} B of shared memory per block, above this device's {smem_limit} B"
+    )
 
     @T.prim_func
     def main(

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_fwd.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_fwd.py
@@ -99,15 +99,27 @@ def sparse_mqa_fwd(
 
     # Every stage past the first double-buffers the BI x D KV tile, so the depth is
     # bounded by shared memory rather than by anything in the algorithm -- and by
-    # block_I and dim, not by a fixed depth. Sum the tiles rather than hardcoding a
-    # ceiling: the estimate ignores TileLang's inter-buffer alignment, so it under-counts
-    # and can only ever under-reject, and a depth that slips through still fails loudly
-    # at launch naming the bytes it could not allocate.
+    # block_I and dim too, which is why the shipped depth is checked as well and not
+    # only the opt-in ones.
+    #
+    # O_shared and Lse_shared are deliberately absent from the sum: TileLang merges
+    # them into buffers that are dead by the time the output accumulates, so they cost
+    # nothing on top. Measured across heads in {8, 16, 64}, block_I in {64, 128} and
+    # depths 0-2, the launch requests exactly this sum plus 2048 B of inter-buffer
+    # alignment -- adding O_shared would over-count by ~32% and falsely reject depths
+    # that run today. The 2048 stays out because it is TileLang's own padding rule
+    # rather than ours; leaving the sum a lower bound means it can only under-reject,
+    # and a depth that slips through still fails loudly at launch naming its bytes.
     smem_lower_bound = (
         H_per_block * D * 2  # Q_shared, bf16
         + H_per_block * BI * 2  # S_shared, bf16
         + max(num_stages, 1) * BI * D * 2  # KV_shared, one buffer per stage
     )
+    # Every kernel here is CUDA-only, so the device-agnostic helper reads as more
+    # portable than it is -- but it stays: `device-api-check` rejects a vendor-namespaced
+    # device reference under veomni/ unless `veomni/utils/device.py` has no equivalent,
+    # and here it does. Reaching this line already implies an accelerator anyway, since
+    # the module imports tilelang at import time and only a compiling kernel gets here.
     smem_limit = get_torch_device().get_device_properties(None).shared_memory_per_block_optin
     assert smem_lower_bound <= smem_limit, (
         f"num_stages={num_stages} at block_I={block_I}, dim={dim} needs at least "


### PR DESCRIPTION
### What does this PR do?

Four changes to the DeepSeek-V4 TileLang sparse MLA kernels. The first two are
the substantial ones: both the forward and the backward serialized their KV
gather behind a register fragment, which cost most of the forward kernel's time.
Reading the row index straight from global memory removes that, giving **2.45x
on the forward** and **1.16x on the backward**, with bitwise-identical output.

Follows #981, which landed the recompile and device-sync fixes for the same
model.

### Checklist Before Starting

- Related: #981 (merged, same SP path), #961 (draft, also reduces DeepSeek-V4 SP
  overhead but on the model side rather than the kernels)
- PR title follows `[{modules}] {type}: {description}` format

### Test

All four changes were measured on a single GB200. `pytest tests/ops/test_deepseek_v4_kernels.py`
passes (27 tests).

Kernel timings, and end-to-end on a 4-layer DeepSeek-V4-Flash-Base over 200
steps at 16K sequence length:

| Change | Kernel | End to end |
|---|---|---|
| Forward gather | 3.950 -> 1.611 ms (2.45x) | — |
| Backward gather | 17.400 -> 14.974 ms (1.16x) | 1.1667 -> 1.1198 s/step (-4.0%) with the forward fix |
| Backward CTA width | 14.94 -> 7.67 ms at `block_H=64` (1.95x), 8.08 -> 5.92 ms at 32 | 1.119 -> 1.072 s/step (-4.2%), against a 0.007 s/step same-code noise floor |
| Pipelining assert | no change by default | no change by default |

Correctness is checked by comparison against the pre-change kernels rather than
only against a reference: `dQ` and the forward output are bitwise identical, and
`dKV`/`dAttnSink` differ only by atomic-accumulation ordering noise. Peak memory
is unchanged throughout.

One caveat worth stating plainly: **the backward CTA widening is a no-op at
`ulysses_size=8`**. With 64 attention heads over 8 SP ranks, `block_H` lands at
16 and the derived width comes back to the same 128 threads as before, which a
production trace confirmed byte for byte. It is a real win for larger head
tiles, so it is included, but it should not be expected to move a run that
shards heads that far.

### API and Usage Example

No API change. `num_stages` on `sparse_mqa_fwd` / `sparse_mqa_fwd_interface`
becomes meaningful (it previously had to be 0), but nothing plumbs it to a
config and the default is unchanged, so opting in is a source change.

### Design & Code Changes

- **Forward and backward KV gather** (`tilelang_sparse_mla_fwd.py`,
  `tilelang_sparse_mla_bwd.py`): the gather clamped its index in a register
  fragment first, so only 4 of the CTA's 256 threads did useful work while the
  rest waited. Clamp inline against the real KV length and index `KV` directly
  from global memory instead. The clamp keeps out-of-range and sentinel `-1`
  entries in bounds, and the existing mask still zeroes their contribution.

- **Backward CTA width** (`tilelang_sparse_mla_bwd.py`): the width was hardcoded
  to 128 threads, which spills registers once `block_H` reaches 64. Derive it as
  `min(256, block_size * block_H // 4)`, the bound the GEMM warp tile imposes,
  and assert both that bound and power-of-two-multiple-of-32.

- **Pipelining assert** (`tilelang_sparse_mla_fwd.py`): the forward asserted
  `num_stages == 0` because a data-dependent gather could not lower into a
  multi-stage async copy. That ceased to be true with the gather fix above --
  TileLang compiles depth 1 and 2 cleanly and emits real `cp_async_gs` copies.
  The assert now only rejects negatives, and depth is bounded against the
  device's shared memory rather than surfacing as an opaque launch failure.

  **The default stays 0.** Depth 1 was tried in production and lost: a 64K step
  ran 5% slower, with every layer's gather 46-69% slower, including layers an
  isolated benchmark had measured a 19% gain on. The comment records that gap so
  the next reader re-enables it on an end-to-end measurement, not a
  microbenchmark. The default has its own GPU-free test, because the two depths
  are bitwise identical and therefore indistinguishable by any numerical check,
  and the numerics test that would otherwise host that assertion skips below
  SM90 and so never runs on CI's L20 runners.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks (`make quality` passes)
- Added/updated documentation — n/a, no user-facing surface changes
- Added tests to CI workflow: yes, in `tests/ops/test_deepseek_v4_kernels.py`.
  The numerics tests need TileLang on SM90+, so they skip on the L20 CI runners;
  the CTA-width bound and the pipelining default are covered by GPU-free tests
  that do run there.
