### PR TITLE
[ops] fix: preserve fused-linear trunk gradients for non-contiguous inputs

### DIFF
--- a/tests/ops/test_chunked_fused_linear_grad_gating.py
+++ b/tests/ops/test_chunked_fused_linear_grad_gating.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for chunked fused-linear gradient gating."""
+
+import pytest
+import torch
+
+import veomni.ops.kernels.cross_entropy.chunk_logprobs as cl
+import veomni.ops.kernels.cross_entropy.chunk_topk_distill as ctkd
+
+
+class _FakePS:
+    sp_enabled = False
+
+
+@pytest.fixture(autouse=True)
+def _use_cpu_compatible_path(monkeypatch):
+    monkeypatch.setattr(cl, "_FA_CE_AVAILABLE", False)
+    monkeypatch.setattr(cl, "get_parallel_state", lambda: _FakePS())
+    monkeypatch.setattr(ctkd, "get_parallel_state", lambda: _FakePS())
+
+
+def _make_non_contiguous_hidden(batch_size: int, seq_len: int, hidden_size: int) -> tuple[torch.Tensor, torch.Tensor]:
+    leaf = torch.randn(batch_size, seq_len, hidden_size, requires_grad=True)
+    hidden = (leaf * 1.0).permute(1, 0, 2).contiguous().permute(1, 0, 2)
+    assert not hidden.is_contiguous()
+    assert hidden.reshape(-1, hidden_size).data_ptr() != hidden.data_ptr()
+    return leaf, hidden
+
+
+@pytest.mark.parametrize("weight_requires_grad", [True, False], ids=["trainable_weight", "frozen_weight"])
+def test_chunk_logprobs_non_contiguous_hidden_preserves_trunk_gradient(weight_requires_grad):
+    torch.manual_seed(0)
+    batch_size, seq_len, hidden_size, vocab_size = 2, 8, 4, 16
+    hidden_leaf, hidden = _make_non_contiguous_hidden(batch_size, seq_len, hidden_size)
+    weight = torch.randn(vocab_size, hidden_size, requires_grad=weight_requires_grad)
+    labels = torch.randint(0, vocab_size, (batch_size, seq_len))
+
+    log_probs, _ = cl.chunk_logprobs_function(
+        hidden,
+        weight,
+        labels,
+        shift_labels=labels,
+        chunk_size=5,
+    )
+    assert log_probs.requires_grad
+    log_probs.sum().backward()
+
+    assert hidden_leaf.grad is not None, "trunk gradient was silently dropped"
+    assert hidden_leaf.grad.abs().sum() > 0
+    assert (weight.grad is not None) == weight_requires_grad
+
+
+@pytest.mark.parametrize("weight_requires_grad", [True, False], ids=["trainable_weight", "frozen_weight"])
+def test_chunk_topk_distill_non_contiguous_hidden_preserves_trunk_gradient(weight_requires_grad):
+    torch.manual_seed(0)
+    batch_size, seq_len, hidden_size, vocab_size, topk = 2, 8, 4, 16, 3
+    hidden_leaf, hidden = _make_non_contiguous_hidden(batch_size, seq_len, hidden_size)
+    weight = torch.randn(vocab_size, hidden_size, requires_grad=weight_requires_grad)
+    labels = torch.randint(0, vocab_size, (batch_size, seq_len))
+    teacher_logits = torch.randn(batch_size, seq_len, vocab_size)
+    teacher_log_probs = teacher_logits.log_softmax(dim=-1)
+    teacher_topk_log_probs, teacher_topk_ids = teacher_log_probs.topk(topk, dim=-1)
+
+    _, _, distill, _, _ = ctkd.chunk_topk_distill_function(
+        hidden,
+        weight,
+        labels,
+        teacher_topk_ids,
+        teacher_topk_log_probs,
+        shift_labels=labels,
+        chunk_size=5,
+    )
+    assert distill.requires_grad
+    distill.sum().backward()
+
+    assert hidden_leaf.grad is not None, "trunk gradient was silently dropped"
+    assert hidden_leaf.grad.abs().sum() > 0
+    assert (weight.grad is not None) == weight_requires_grad

--- a/veomni/ops/kernels/cross_entropy/chunk_logprobs.py
+++ b/veomni/ops/kernels/cross_entropy/chunk_logprobs.py
@@ -147,11 +147,14 @@ class _ChunkedLinearLogProbs(torch.autograd.Function):
 
         orig_shape = labels.shape
         orig_hidden_shape = hidden_states.shape
+        # ``autograd.Function.forward`` runs with grad mode disabled. If
+        # ``reshape`` must copy a non-contiguous input, the copy does not retain
+        # ``requires_grad``. Capture the output requirement before flattening.
+        out_requires_grad = hidden_states.requires_grad or weight.requires_grad
         h_2d = hidden_states.reshape(-1, hidden_states.size(-1))
         l_1d = labels.reshape(-1)
         T = l_1d.shape[0]
 
-        out_requires_grad = h_2d.requires_grad or weight.requires_grad
         log_probs = torch.zeros(T, device=h_2d.device, dtype=torch.float32, requires_grad=out_requires_grad)
         # Entropy is returned in fp32; verl downcasts to ``hidden_states.dtype``
         # but downstream RL code reads it in fp32 so we keep the higher
@@ -203,8 +206,10 @@ class _ChunkedLinearLogProbs(torch.autograd.Function):
         dlog_probs_1d = dlog_probs.reshape(-1).float() if dlog_probs is not None else None
         dentropy_1d = dentropy.reshape(-1).float() if dentropy is not None else None
 
-        dhidden = torch.zeros_like(h_2d) if h_2d.requires_grad else None
-        dweight = torch.zeros_like(weight) if weight.requires_grad else None
+        # Saved tensors may have different ``requires_grad`` flags after a
+        # reshape copy. Gate gradients on the original Function inputs.
+        dhidden = torch.zeros_like(h_2d) if ctx.needs_input_grad[0] else None
+        dweight = torch.zeros_like(weight) if ctx.needs_input_grad[1] else None
 
         for chunk_start in range(0, T, ctx.chunk_size):
             chunk_end = min(chunk_start + ctx.chunk_size, T)

--- a/veomni/ops/kernels/cross_entropy/chunk_topk_distill.py
+++ b/veomni/ops/kernels/cross_entropy/chunk_topk_distill.py
@@ -123,13 +123,16 @@ class _ChunkedLinearTopkDistill(torch.autograd.Function):
         orig_hidden_shape = hidden_states.shape
         K = teacher_topk_ids.shape[-1]
 
+        # ``autograd.Function.forward`` runs with grad mode disabled. If
+        # ``reshape`` must copy a non-contiguous input, the copy does not retain
+        # ``requires_grad``. Capture the output requirement before flattening.
+        out_requires_grad = hidden_states.requires_grad or weight.requires_grad
         h_2d = hidden_states.reshape(-1, hidden_states.size(-1))
         l_1d = labels.reshape(-1)
         ids_2d = teacher_topk_ids.reshape(-1, K)
         tlp_2d = teacher_topk_log_probs.reshape(-1, K)
         T = l_1d.shape[0]
 
-        out_requires_grad = h_2d.requires_grad or weight.requires_grad
         log_probs = torch.zeros(T, device=h_2d.device, dtype=torch.float32, requires_grad=out_requires_grad)
         entropy = torch.zeros(T, device=h_2d.device, dtype=torch.float32, requires_grad=out_requires_grad)
         distill = torch.zeros(T, device=h_2d.device, dtype=torch.float32, requires_grad=out_requires_grad)
@@ -226,8 +229,10 @@ class _ChunkedLinearTopkDistill(torch.autograd.Function):
         dentropy_1d = dentropy.reshape(-1).float() if dentropy is not None else None
         ddistill_1d = ddistill.reshape(-1).float() if ddistill is not None else None
 
-        dhidden = torch.zeros_like(h_2d) if h_2d.requires_grad else None
-        dweight = torch.zeros_like(weight) if weight.requires_grad else None
+        # Saved tensors may have different ``requires_grad`` flags after a
+        # reshape copy. Gate gradients on the original Function inputs.
+        dhidden = torch.zeros_like(h_2d) if ctx.needs_input_grad[0] else None
+        dweight = torch.zeros_like(weight) if ctx.needs_input_grad[1] else None
 
         for chunk_start in range(0, T, ctx.chunk_size):
             chunk_end = min(chunk_start + ctx.chunk_size, T)


### PR DESCRIPTION
### What does this PR do?

Fixes a silent gradient drop in the chunked fused-linear `chunk_logprobs` and `chunk_topk_distill` backward paths.

`torch.autograd.Function.forward` runs with grad mode disabled. When flattening a non-contiguous `hidden_states` requires a copy, the copied tensor may have `requires_grad=False`. The kernels previously used that saved tensor flag to decide whether to allocate `dhidden`, so backward could return `None` for the model trunk while still updating `lm_head.weight`.

The fix captures the output gradient requirement before reshaping and gates backward allocations with `ctx.needs_input_grad`, which reflects the original Function inputs.

Related upstream fix in verl: https://github.com/verl-project/verl/pull/7235

### Trigger Conditions

The silent trunk-gradient drop requires all of the following:

- Execution enters `_ChunkedLinearLogProbs` or `_ChunkedLinearTopkDistill`. For the verl PPO/GRPO integration, this means `use_fused_kernels=True` and `use_remove_padding=True`, which requests fused `return_log_probs=True`; the distillation variant additionally requires teacher top-k inputs.
- The original `hidden_states` requires gradients.
- Flattening `hidden_states` with `reshape(-1, hidden_size)` must allocate a copy. Merely being non-contiguous is not sufficient if PyTorch can still implement the reshape as a view.
- The wrapper does not first normalize the layout with `.contiguous()`. The verl integration's explicit `shift_labels` path preserves the incoming layout and therefore exposes the bug. The sequence-parallel path can expose it for the same reason.
- To observe the characteristic “only `lm_head.weight` changes” symptom, `lm_head.weight.requires_grad` must be true: `dweight` is produced while `dhidden` is incorrectly omitted. If the head is frozen, the trunk gradient can instead disappear without the head update as a clue.

The common SFT path does not normally trigger this issue because it uses fused cross entropy with `return_log_probs=False`, rather than these chunked log-probability custom autograd functions. The ordinary non-sequence-parallel path without explicit `shift_labels` also calls `.contiguous()` after shifting hidden states, masking the faulty condition. Contiguous or reshape-viewable inputs are unaffected.

### Checklist Before Starting

- Searched open VeOmni PRs for `chunk_logprobs`, `needs_input_grad`, and non-contiguous hidden-state gradient fixes; no duplicate fix found.
- VeOmni #806 is related to fused-linear backward, but fixes FSDP2 root resharding and freed weight storage rather than this silent gradient-gating issue: https://github.com/ByteDance-Seed/VeOmni/pull/806
- PR title follows `[{modules}] {type}: {description}` format.

### Test

```text
python3 -m pytest -q \
  tests/ops/test_chunk_logprobs.py \
  tests/ops/test_chunk_topk_distill.py \
  tests/ops/test_chunked_fused_linear_grad_gating.py \
  -p no:cacheprovider

13 passed, 12 skipped
```

The skipped cases are existing GPU-only bitwise tests in the current CPU environment.

Full repository quality checks with the lockfile-pinned Ruff version:

```text
ruff check tasks tests veomni docs
ruff format --check tasks tests veomni docs

All checks passed.
623 files already formatted.
```

### API and Usage Example

No API or configuration changes.

### Design & Code Changes

- Capture `hidden_states.requires_grad or weight.requires_grad` before flattening in both custom autograd Functions.
- Use `ctx.needs_input_grad[0]` and `[1]` for `dhidden` and `dweight` allocation.
- Add CPU regression tests covering:
  - non-contiguous hidden states whose flatten operation creates a copy;
  - explicit `shift_labels`, matching the verl PPO/GRPO integration path;
  - trainable and frozen `lm_head` weights;
  - both `chunk_logprobs` and `chunk_topk_distill`.

The forward math, chunking behavior, output contract, and FSDP interaction are unchanged.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied Ruff lint and formatting checks across the repository.
- [x] Added regression tests to the existing ops test suite.
- [x] Documentation is not required because there is no API, configuration, or workflow change.
- [x] No task scripts were moved or renamed.
