### PR TITLE
[lora, model] fix: resolve Wan attention projection dtype via parameters()

### DIFF
--- a/veomni/models/diffusers/wan_t2v/wan_transformer/modeling_wan_transformer.py
+++ b/veomni/models/diffusers/wan_t2v/wan_transformer/modeling_wan_transformer.py
@@ -54,7 +54,9 @@ def wan_eager_attention_forward(
 
 class WanAttentionKernelModule:
     def __init__(self, config: SimpleNamespace, attn: WanAttention):
-        target_dtype = attn.to_q.weight.dtype
+        # Read via ``parameters()`` so LoRA-wrapped projections (``LoraLinear``,
+        # which has no ``.weight`` attribute) resolve like a plain ``nn.Linear``.
+        target_dtype = next(attn.to_q.parameters()).dtype
         if target_dtype == torch.float32:
             target_dtype = torch.bfloat16
         self.config = SimpleNamespace(
@@ -125,10 +127,17 @@ def _assert_wan_flash_attention_bf16(
         "key": key.dtype,
         "value": value.dtype,
     }
+
+    # Resolve the projection weight dtype via ``parameters()`` rather than
+    # ``.weight`` so LoRA-wrapped projections (``LoraLinear``, which has no
+    # ``.weight`` attribute) are handled the same as plain ``nn.Linear``.
+    def _proj_dtype(module):
+        return next(module.parameters()).dtype
+
     weight_dtypes = {
-        "to_q.weight": attn.to_q.weight.dtype,
-        "to_k.weight": attn.to_k.weight.dtype,
-        "to_v.weight": attn.to_v.weight.dtype,
+        "to_q.weight": _proj_dtype(attn.to_q),
+        "to_k.weight": _proj_dtype(attn.to_k),
+        "to_v.weight": _proj_dtype(attn.to_v),
     }
     assert all(dtype == torch.bfloat16 for dtype in tensor_dtypes.values()), (
         f"Wan flash-attention expects bf16 Q/K/V tensors, got {tensor_dtypes}."
@@ -264,7 +273,7 @@ class WanSPAttnProcessor(WanAttnProcessor):
         if hidden_states_img is not None:
             hidden_states_out = hidden_states_out + hidden_states_img
 
-        hidden_states_out = hidden_states_out.type_as(attn.to_out[0].weight)
+        hidden_states_out = hidden_states_out.type_as(next(attn.to_out[0].parameters()))
         hidden_states_out = attn.to_out[0](hidden_states_out)
         hidden_states_out = attn.to_out[1](hidden_states_out)
         return hidden_states_out


### PR DESCRIPTION
WanAttention reads the projection dtype through `.weight` in three places. A LoRA-wrapped projection is a `LoraLinear`, which has no `.weight` attribute, so any Wan run with LoRA raises AttributeError on the first attention forward.

Read the dtype from `next(module.parameters())` instead, which resolves identically for a plain `nn.Linear` and leaves non-LoRA behaviour unchanged.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
