### PR TITLE
[docs] feat: document NPU training for Qwen3.5, Qwen3-Omni and LTX-2.3

### DIFF
--- a/docs/examples/ltx-2.3.md
+++ b/docs/examples/ltx-2.3.md
@@ -129,7 +129,7 @@ data:
 The Gemma path is used by the preprocessing command; the shipped offline
 training configs consume the precomputed embeddings and do not reload Gemma.
 
-## Start training
+## Start training on GPU/NPU
 
 ### Audio-Video LoRA (default)
 

--- a/docs/examples/qwen3_5.md
+++ b/docs/examples/qwen3_5.md
@@ -110,6 +110,129 @@ bash train.sh tasks/train_text.py configs/text/qwen3_5_sft.yaml \
     --train.checkpoint.output_dir ./exp/qwen3_5_35b_a3b_sft
 ```
 
+## Start training on NPU
+
+Qwen3.5 runs on Ascend NPUs, but its GatedDeltaNet kernels are **not** auto-selected: all three
+OpSlot-driven ops (`rms_norm_gated`, `causal_conv1d`, `chunk_gated_delta_rule`) default to `fla`,
+which requires a GPU and raises on NPU. They must be set explicitly.
+
+### Kernel backends
+
+`npu` provides vendored MindSpeed-MM Triton kernels for all three ops:
+
+```yaml
+model:
+  ops_implementation:
+    rms_norm_gated_implementation: npu
+    causal_conv1d_implementation: npu
+    chunk_gated_delta_rule_implementation: npu
+```
+
+These kernels need the `triton-ascend` package, which is not a declared VeOmni dependency —
+install it on the NPU host. VeOmni main pins PyTorch and `torch_npu` 2.10.0; the corresponding
+CANN 9.0.0 stack uses v3.2.1:
+
+```bash
+pip install triton-ascend==3.2.1 --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple
+```
+
+See the [triton-ascend quick-start](https://github.com/triton-lang/triton-ascend/blob/main/docs/zh/quick_start.md)
+for the compatibility matrix and troubleshooting. Keep CANN, `torch_npu`,
+and `triton-ascend` on a mutually compatible release set.
+
+> **arch35 limitation:** the vendored `causal_conv1d` refuses to run on arch35 NPUs
+> (`Ascend910_95` / `Ascend950`) — its `is_arch35()` guard raises `NotImplementedError`
+> rather than mis-computing. Validated on `Ascend910B2C`. arch35 support would need to come
+> from upstream MindSpeed-MM.
+
+### `npu_ascendc` — AscendC fused backend (`chunk_gated_delta_rule` only)
+
+`npu_ascendc` is a second NPU backend for `chunk_gated_delta_rule` that delegates the heavy GDN
+compute to the external [`fla_npu`](https://github.com/flashserve/flash-linear-attention-npu)
+package (registered as `torch.ops.npu.*` fused ops); only the Triton glue stays vendored under
+`_ascend/triton_core`. It coexists with `npu` (pure vendored Triton), which remains the fallback.
+Set only `chunk_gated_delta_rule` to `npu_ascendc`; keep `rms_norm_gated` / `causal_conv1d` on `npu`:
+
+```yaml
+model:
+  ops_implementation:
+    rms_norm_gated_implementation: npu
+    causal_conv1d_implementation: npu
+    chunk_gated_delta_rule_implementation: npu_ascendc
+```
+
+`fla_npu` is not a declared VeOmni dependency (same as `triton-ascend`). It supports Ascend
+910B (A2) / 910_93 (A3), both non-arch35 chips where the `solve_tril` step runs the vendored
+Triton kernel (the arch35 native path is gated behind `is_arch35()`). arch35 (`Ascend910_95` /
+`Ascend950`) is not supported end-to-end: the vendored `causal_conv1d` raises there (see above).
+
+The prebuilt NPU images on [quay.io](https://quay.io/repository/ascend/veomni?tab=tags) already
+bundle `fla_npu`:
+
+- A2: `quay.io/ascend/veomni:v0.1.11-cann9.0.0-torch_npu2.10.0.post2-A2-ubuntu22.04-py3.11-veomni-latest`
+- A3: `quay.io/ascend/veomni:v0.1.11-cann9.0.0-torch_npu2.10.0.post2-A3-ubuntu22.04-py3.11-veomni-latest`
+
+To build on a bare host instead, install from the
+[`flash-linear-attention-npu`](https://github.com/flashserve/flash-linear-attention-npu) sources:
+
+```bash
+git clone https://github.com/flashserve/flash-linear-attention-npu
+cd flash-linear-attention-npu
+git checkout c2e3d83f
+
+source /usr/local/Ascend/cann/set_env.sh          # source your actual CANN path
+
+# --soc must match the chip: {ascend910b, ascend910_93, ascend950}
+bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu
+bash build_out/fla-npu_*.run
+cd torch_custom/fla_npu/ && bash build.sh
+
+pip list | grep fla_npu   # verify it is installed
+```
+
+If `fla_npu` is absent when `npu_ascendc` is selected, the backend raises an actionable error at
+`OpSlot.bind()` time (pointing back to the install step or to `npu` / `eager`).
+
+### Qwen3.5-9B VL Training
+
+There is no dedicated dense NPU config; reuse the GPU one and set the GatedDeltaNet kernels on the
+command line. Nothing else needs overriding: the YAML's `attn_implementation: flash_attention_2` is
+also the recommended NPU value (see [NPU-friendly operator
+configurations](../hardware_support/typical_usage.md)), and `rms_norm`, `rotary_pos_emb`,
+`swiglu_mlp` and `cross_entropy_loss` are left at their dataclass defaults there, so VeOmni
+normalizes them to NPU-compatible values automatically
+([`_NPU_DEFAULT_FALLBACK`](../../veomni/arguments/arguments_types.py#L979)). The three
+GatedDeltaNet ops are deliberately **not** in that table, which is why they must be explicit:
+
+```shell
+bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_5/qwen3_5_vl.yaml \
+    --model.model_path ${HOME}/Qwen3.5-9B \
+    --data.train_path ./configs/multimodal/data/tulu_sharegpt4v_llavavideo.yaml \
+    --model.ops_implementation.rms_norm_gated_implementation npu \
+    --model.ops_implementation.causal_conv1d_implementation npu \
+    --model.ops_implementation.chunk_gated_delta_rule_implementation npu_ascendc \
+    --train.max_steps 20
+```
+
+Drop `chunk_gated_delta_rule_implementation` to `npu` if `fla_npu` is not installed.
+
+### Qwen3.5 MoE 35B VL Training
+
+A ready-to-run MoE-VL config wired for `npu_ascendc` (plus `fused_npu` MoE, NPU RMSNorm/RoPE and
+Ulysses SP) is provided at
+[`configs/multimodal/qwen3_5_moe/qwen3_5_moe_vl_ascendc.yaml`](../../configs/multimodal/qwen3_5_moe/qwen3_5_moe_vl_ascendc.yaml):
+
+```shell
+bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_5_moe/qwen3_5_moe_vl_ascendc.yaml \
+    --model.model_path ${HOME}/Qwen3.5-35B-A3B \
+    --data.train_path ./configs/multimodal/data/tulu_sharegpt4v_llavavideo.yaml \
+    --train.max_steps 20
+```
+
+The config sets `ulysses_size: 4`, so the world size must be a multiple of 4. To run without
+sequence parallelism, override `--train.accelerator.ulysses_size 1`; the attention kernels adapt
+on their own.
+
 ## ChunkMBS
 
 Dense Qwen3.5 packed SFT supports decoder-layer ChunkMBS. It splits the packed sequence only at sample boundaries,
@@ -166,40 +289,11 @@ bash train.sh tasks/train_text.py configs/text/qwen3_5_sft.yaml \
 ### Selecting linear-attention kernels
 
 GatedDeltaNet has three OpSlot-driven kernels: `rms_norm_gated`, `causal_conv1d`, and
-`chunk_gated_delta_rule`. All three default to `fla`. Recommended value per platform:
-
-- **GPU** — `fla` (the FLA Triton kernels shipped under the `gpu` extra; required for
-  varlen training).
-- **NPU** — `npu` (vendored MindSpeed-MM Triton kernels for all three ops; needs the
-  `triton-ascend` package — see below). Not auto-selected — the default `fla`
-  requires a GPU and raises on NPU, so set the fields explicitly:
-
-```yaml
-model:
-  ops_implementation:
-    rms_norm_gated_implementation: npu
-    causal_conv1d_implementation: npu
-    chunk_gated_delta_rule_implementation: npu
-```
-
-Install `triton-ascend` on the NPU host. VeOmni main pins PyTorch and
-`torch_npu` 2.10.0; the corresponding CANN 9.0.0 stack uses v3.2.1:
-
-```bash
-pip install triton-ascend==3.2.1 --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple
-```
-
-See the [triton-ascend quick-start](https://github.com/triton-lang/triton-ascend/blob/main/docs/zh/quick_start.md)
-for the compatibility matrix and troubleshooting. Keep CANN, `torch_npu`,
-and `triton-ascend` on a mutually compatible release set.
-
-> **arch35 limitation:** the vendored `causal_conv1d` refuses to run on arch35 NPUs
-> (`Ascend910_95` / `Ascend950`) — its `is_arch35()` guard raises `NotImplementedError`
-> rather than mis-computing. Validated on `Ascend910B2C`. arch35 support would need to come
-> from upstream MindSpeed-MM.
+`chunk_gated_delta_rule`. All three default to `fla` — the FLA Triton kernels shipped under the
+`gpu` extra, which is the recommended value on GPU and required for varlen training.
 
 To switch `chunk_gated_delta_rule` to QwenLM's [`flash-qla`](https://github.com/QwenLM/FlashQLA)
-kernel (already shipped under the `gpu` extra), set the field explicitly:
+kernel (also shipped under the `gpu` extra), set the field explicitly:
 
 ```yaml
 model:
@@ -207,57 +301,8 @@ model:
     chunk_gated_delta_rule_implementation: flash_qla
 ```
 
-#### `npu_ascendc` — AscendC fused backend (NPU, `chunk_gated_delta_rule` only)
-
-`npu_ascendc` is a second NPU backend for `chunk_gated_delta_rule` that delegates the heavy GDN
-compute to the external [`fla_npu`](https://github.com/flashserve/flash-linear-attention-npu)
-package (registered as `torch.ops.npu.*` fused ops); only the Triton glue stays vendored under
-`_ascend/triton_core`. It coexists with `npu` (pure vendored Triton), which remains the fallback.
-Set only `chunk_gated_delta_rule` to `npu_ascendc`; keep `rms_norm_gated` / `causal_conv1d` on `npu`:
-
-```yaml
-model:
-  ops_implementation:
-    rms_norm_gated_implementation: npu
-    causal_conv1d_implementation: npu
-    chunk_gated_delta_rule_implementation: npu_ascendc
-```
-
-A ready-to-run MoE-VL training config wired for this backend (plus `fused_npu` MoE and
-Ulysses SP) is provided at
-[`configs/multimodal/qwen3_5_moe/qwen3_5_moe_vl_ascendc.yaml`](../../configs/multimodal/qwen3_5_moe/qwen3_5_moe_vl_ascendc.yaml).
-
-`fla_npu` is not a declared VeOmni dependency (same as `triton-ascend`). It supports Ascend
-910B (A2) / 910_93 (A3), both non-arch35 chips where the `solve_tril` step runs the vendored
-Triton kernel (the arch35 native path is gated behind `is_arch35()`). arch35 (`Ascend910_95` /
-`Ascend950`) is not supported end-to-end: the vendored `causal_conv1d` raises there (see above).
-
-The prebuilt NPU images on [quay.io](https://quay.io/repository/ascend/veomni?tab=tags) already
-bundle `fla_npu`:
-
-- A2: `quay.io/ascend/veomni:v0.1.11-cann9.0.0-torch_npu2.10.0.post2-A2-ubuntu22.04-py3.11-veomni-latest`
-- A3: `quay.io/ascend/veomni:v0.1.11-cann9.0.0-torch_npu2.10.0.post2-A3-ubuntu22.04-py3.11-veomni-latest`
-
-To build on a bare host instead, install from the
-[`flash-linear-attention-npu`](https://github.com/flashserve/flash-linear-attention-npu) sources:
-
-```bash
-git clone https://github.com/flashserve/flash-linear-attention-npu
-cd flash-linear-attention-npu
-git checkout c2e3d83f
-
-source /usr/local/Ascend/cann/set_env.sh          # source your actual CANN path
-
-# --soc must match the chip: {ascend910b, ascend910_93, ascend950}
-bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu
-bash build_out/fla-npu_*.run
-cd torch_custom/fla_npu/ && bash build.sh
-
-pip list | grep fla_npu   # verify it is installed
-```
-
-If `fla_npu` is absent when `npu_ascendc` is selected, the backend raises an actionable error at
-`OpSlot.bind()` time (pointing back to the install step or to `npu` / `eager`).
+On NPU the default `fla` raises, so all three fields must be set explicitly — see
+[Kernel backends](#kernel-backends) under *Start training on NPU*.
 
 ### How It Works
 

--- a/docs/examples/qwen3_omni_moe.md
+++ b/docs/examples/qwen3_omni_moe.md
@@ -119,7 +119,7 @@ python3 scripts/download_hf_model.py \
     --local_dir .
 ```
 
-## Start training on GPU
+## Start training on GPU/NPU
 
 ```shell
 bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_omni/qwen3_omni.yaml \


### PR DESCRIPTION
### What does this PR do?

> Documents how to train Qwen3.5 on Ascend NPU, and widens the Qwen3-Omni /
> LTX-2.3 training section titles to cover NPU.
>
> Qwen3.5's NPU material used to sit inside the "Ulysses Sequence Parallelism"
> section, even though kernel selection is required for any NPU run, SP or not.
> It now has its own top-level section, parallel to the GPU one.

### Checklist Before Starting

- Search for relative PRs/issues and link here: follow-up to #924 (`npu_ascendc`
  backend and `qwen3_5_moe_vl_ascendc.yaml`), which added the backend this guide
  now documents end to end.
- PR title follows `[{modules}] {type}: {description}` format

### Test

> Documentation only — no code paths touched, so no CI test is applicable.
>
> The documented commands were run on Ascend NPU hardware. The claims about
> which implementations are auto-resolved on NPU were checked against
> `_NPU_DEFAULT_FALLBACK` / `_apply_npu_default_fallback` in
> `veomni/arguments/arguments_types.py`.

### API and Usage Example

> N/A — no API change. The new sections document existing config fields.

### Design & Code Changes

> - `docs/examples/qwen3_5.md`: new top-level `## Start training on NPU`
>   section holding kernel backends (`npu`, `npu_ascendc`), the `triton-ascend`
>   and `fla_npu` install steps, the arch35 limitation, and dense-9B / MoE-35B
>   training commands. `## Ulysses Sequence Parallelism` keeps only the GPU
>   kernel choice (`fla`, `flash_qla`) and links across; `### How It Works` is
>   no longer separated from `### Requirements` by ~100 lines of NPU material.
> - `docs/examples/qwen3_omni_moe.md`: retitle `## Start training on GPU` to
>   `## Start training on GPU/NPU`. The command needs no NPU-specific flag: the
>   config's `moe_implementation: fused_triton` is the dataclass default and is
>   auto-resolved to `fused_npu` on Ascend, and `flash_attention_2` is already
>   the recommended NPU value.
> - `docs/examples/ltx-2.3.md`: retitle `## Start training` to
>   `## Start training on GPU/NPU`, reflecting that these runs work on NPU; all
>   three LTX configs pin every `ops_implementation` field to `eager`, which is
>   allowed on NPU.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added/updated documentation
- [ ] Added tests to CI workflow (or explained why not feasible) — documentation
      only, no testable code path
