### PR TITLE
[docs] feat: add SeedOss training example guide

### DIFF
--- a/docs/examples/seed_oss.md
+++ b/docs/examples/seed_oss.md
@@ -1,0 +1,21 @@
+# Seed-OSS training guide
+
+## Download dataset
+
+Download the [fineweb 10BT sample](https://huggingface.co/datasets/HuggingFaceFW/fineweb/tree/main/sample/10BT) dataset.
+
+## Download SeedOss model
+
+```shell
+python3 scripts/download_hf_model.py \
+    --repo_id ByteDance-Seed/Seed-OSS-36B-Instruct \
+    --local_dir .
+```
+
+## Start training on GPU/NPU
+
+```shell
+bash train.sh tasks/train_text.py configs/text/seed_oss.yaml \
+    --model.model_path ./Seed-OSS-36B-Instruct \
+    --data.train_path ./fineweb/sample/10BT
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ examples/wan2.1.md
 examples/wan2.1_I2V_1.3B.md
 examples/ltx-2.3.md
 examples/qwen3_dpo.md
+examples/seed_oss.md
 ```
 
 ```{toctree}


### PR DESCRIPTION
### What does this PR do?

add SeedOss training example guide

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

N/A - documentation only.

### API and Usage Example

N/A - no API changes.

### Design & Code Changes

Add a training example guide for SeedOss model (docs/examples/seed_oss.md), following the format of existing example docs (e.g. qwen3.md). The guide covers:
- Dataset download (fineweb 10BT sample)
- Model download (Seed-OSS-36B-Instruct)
- GPU/NPU training commands
Also registered the new doc in docs/index.md under the Examples section.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
