### PR TITLE
[perf] fix: correct Qwen2.5-VL window attention FLOPs

### DIFF
--- a/tests/toy_config/qwen25vl_toy/config.json
+++ b/tests/toy_config/qwen25vl_toy/config.json
@@ -41,10 +41,7 @@
       "spatial_patch_size": 14,
       "window_size": 112,
       "fullatt_block_indexes": [
-        7,
-        15,
-        23,
-        31
+        0
       ],
       "tokens_per_second": 2,
       "temporal_patch_size": 2

--- a/tests/utils/test_count_flops.py
+++ b/tests/utils/test_count_flops.py
@@ -362,6 +362,32 @@ class TestQwen3Flops:
         assert flops == pytest.approx(expected_flops / 1e12, rel=1e-9)
 
 
+class TestQwen25VLFlops:
+    def test_window_size_is_converted_from_pixels_to_tokens(self):
+        config = _load_toy_config("tests/toy_config/qwen25vl_toy").vision_config
+        images_seqlens = [128]
+        counter = VeomniFlopsCounter(_load_toy_config("tests/toy_config/qwen25vl_toy"))
+
+        window_flops = counter._estimate_qwen_vit_flop(images_seqlens, config)
+
+        full_attention_config = deepcopy(config)
+        full_attention_config.fullatt_block_indexes = list(range(config.depth))
+        full_attention_flops = counter._estimate_qwen_vit_flop(images_seqlens, full_attention_config)
+
+        head_dim = config.hidden_size // config.num_heads
+        full_attention_layer_flops = 12 * sum(seqlen**2 for seqlen in images_seqlens) * head_dim * config.num_heads
+        merger_window_size = config.window_size // config.spatial_merge_size // config.patch_size
+        window_token_size = merger_window_size * config.spatial_merge_size
+        window_attention_layer_flops = 12 * sum(images_seqlens) * window_token_size**2 * head_dim * config.num_heads
+        window_layer_num = config.depth - len(config.fullatt_block_indexes)
+
+        assert window_token_size == 8
+        assert window_layer_num == 1
+        assert window_flops == full_attention_flops + window_layer_num * (
+            window_attention_layer_flops - full_attention_layer_flops
+        )
+
+
 class TestAllQwenLoraFlops:
     pytestmark = pytest.mark.usefixtures("mock_device_flops")
 

--- a/veomni/utils/count_flops.py
+++ b/veomni/utils/count_flops.py
@@ -895,7 +895,12 @@ class VeomniFlopsCounter:
 
         # If window attention is used, add the window attention flops
         if window_attn_layer_num > 0:
-            window_attn_compute_flops = attention_factor * tokens_sum * (config.window_size**2) * head_dim * num_heads
+            # Qwen2.5-VL configures window_size in pixels. Mirror get_vision_window_index's
+            # conversion to the number of ViT tokens on each side of a window. This remains
+            # an upper bound for partially filled windows at image boundaries.
+            merger_window_size = config.window_size // spatial_merge_size // config.patch_size
+            window_token_size = merger_window_size * spatial_merge_size
+            window_attn_compute_flops = attention_factor * tokens_sum * (window_token_size**2) * head_dim * num_heads
             attn_qkv_flops += window_attn_compute_flops * window_attn_layer_num
 
         vit_flops = dense_N_flops + attn_qkv_flops


### PR DESCRIPTION
## What changed

- convert Qwen2.5-VL's pixel-level `vision_config.window_size` to the corresponding ViT-token window size before estimating window-attention FLOPs
- add a regression test for the standard `window_size=112`, `patch_size=14` configuration

## Why

Qwen2.5-VL defines `window_size` in pixels. The vision window-index construction converts it through `patch_size` (and `spatial_merge_size`), so the standard configuration produces an 8-by-8 window, or 64 ViT tokens.

The FLOPs counter previously used `window_size ** 2` directly, treating 112 pixels as 112 tokens per side. That overestimated the quadratic window-attention term by `patch_size ** 2` (196x for the standard 14-pixel patch size), inflating reported achieved FLOPs and MFU.

The updated calculation mirrors `get_vision_window_index`:

```python
merger_window_size = window_size // spatial_merge_size // patch_size
window_token_size = merger_window_size * spatial_merge_size
```

## Validation

- `ruff check veomni/utils/count_flops.py tests/utils/test_count_flops.py`
- `ruff format --check veomni/utils/count_flops.py tests/utils/test_count_flops.py`
- `pytest -q tests/utils/test_count_flops.py` (22 passed)
