### PR TITLE
[trainer, perf] fix: apply HSDP all-reduce control to custom trainers

### DIFF
--- a/tests/distributed/test_torch_compile.py
+++ b/tests/distributed/test_torch_compile.py
@@ -438,6 +438,7 @@ def test_vlm_train_step_marks_each_compile_micro_batch(monkeypatch):
         state=SimpleNamespace(global_step=0),
         model=SimpleNamespace(_veomni_compile_uses_cuda_graphs=True),
         model_reshard=lambda *_: None,
+        _configure_hsdp_allreduce=lambda *_: None,
         sync_before_train_step=lambda: None,
         forward_backward_step=lambda _: (torch.tensor(1.0), {}),
         optimizer=SimpleNamespace(step=lambda: None, zero_grad=lambda: None),

--- a/tests/trainer/test_step_sync.py
+++ b/tests/trainer/test_step_sync.py
@@ -31,3 +31,29 @@ def test_train_step_uses_sync_helper():
 
         assert "sync_before_train_step()" in source
         assert "synchronize()" not in source
+
+
+def test_configure_hsdp_allreduce_toggles_outer_micro_steps():
+    calls = []
+    trainer = BaseTrainer.__new__(BaseTrainer)
+    trainer.args = SimpleNamespace(
+        train=SimpleNamespace(
+            accelerator=SimpleNamespace(
+                fsdp_config=SimpleNamespace(fsdp_mode="fsdp2"),
+                dp_replicate_size=2,
+            )
+        )
+    )
+    trainer.model = SimpleNamespace(set_requires_all_reduce=calls.append)
+
+    for micro_step in range(4):
+        trainer._configure_hsdp_allreduce(micro_step, 4)
+
+    assert calls == [False, True]
+
+
+def test_train_step_uses_hsdp_allreduce_helper():
+    for wrapper_cls in (BaseTrainer, TextTrainer, VLMTrainer, TextDPOTrainer, DiTTrainer):
+        source = inspect.getsource(wrapper_cls.train_step)
+
+        assert "_configure_hsdp_allreduce(" in source

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -523,6 +523,7 @@ class DiTTrainer:
         for micro_step, micro_batch in enumerate(micro_batches):
             if self.training_task != "offline_embedding":
                 self.base.model_reshard(micro_step, num_micro_batches)
+                self.base._configure_hsdp_allreduce(micro_step, num_micro_batches)
 
             loss: torch.Tensor
             loss_dict: Dict[str, torch.Tensor]

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -424,6 +424,7 @@ class TextDPOTrainer:
         for micro_step, micro_batch in enumerate(micro_batches):
             mark_compile_step_begin(getattr(self.base.model, "_veomni_compile_uses_cuda_graphs", False))
             self.base.model_reshard(micro_step, num_micro_steps)
+            self.base._configure_hsdp_allreduce(micro_step, num_micro_steps)
             loss, loss_dict = self.forward_backward_step(micro_batch)
 
             total_loss += loss.item()

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -133,6 +133,7 @@ class TextTrainer:
         for micro_step, micro_batch in enumerate(micro_batches):
             mark_compile_step_begin(getattr(self.base.model, "_veomni_compile_uses_cuda_graphs", False))
             self.base.model_reshard(micro_step, num_micro_steps)
+            self.base._configure_hsdp_allreduce(micro_step, num_micro_steps)
             loss: torch.Tensor
             loss_dict: Dict[str, torch.Tensor]
             # token num for fixed_ce_loss in postforward

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -339,6 +339,7 @@ class VLMTrainer:
         for micro_step, micro_batch in enumerate(micro_batches):
             mark_compile_step_begin(getattr(self.base.model, "_veomni_compile_uses_cuda_graphs", False))
             self.base.model_reshard(micro_step, num_micro_steps)
+            self.base._configure_hsdp_allreduce(micro_step, num_micro_steps)
             loss: torch.Tensor
             loss_dict: Dict[str, torch.Tensor]
             # token num for fixed_ce_loss in postforward


### PR DESCRIPTION
### What does this PR do?

PR #781 added `_configure_hsdp_allreduce()` to avoid redundant synchronization over the HSDP replicated dimension during gradient accumulation. `BaseTrainer.train_step()` uses the helper, but the custom train loops in the text, VLM, DPO, and DiT trainers bypassed it.

This PR applies the existing helper in those train loops so replica all-reduce is disabled for the first accumulation micro-step and restored for the final micro-step. The DiT offline-embedding path remains unchanged because it does not execute model forward/backward.

Related: #781

### Checklist Before Starting

- Search for relative PRs/issues and link here: #781
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

Current head after rebasing onto `main`:

```text
make quality
All checks passed!
624 files already formatted

pytest tests/trainer/test_step_sync.py tests/distributed/test_torch_compile.py
47 passed, 1 skipped
```

Controlled A-B-B-A validation was performed on the pre-rebase feature commit `469f5c61` based on `main@84bc3601`. The only intervening upstream change before the current head was the unrelated SeedOss documentation PR #1023.

Configuration: 2 x NVIDIA A800 80GB, Qwen3-VL toy model, FSDP2, `dp_replicate_size=2`, `dp_shard_size=1`, gradient accumulation 4, BF16 parameters, FP32 reductions, and dynamic batching enabled.

- Both ranks disabled replica all-reduce at micro-step 0 and restored it at micro-step 3 of every optimizer step.
- Same-rank loss and gradient norm matched exactly across A1/B1/B2/A2.
- Mean median step time decreased from 20.4740 s to 19.8462 s (3.07%); derived throughput increased by 3.16%.
- Peak allocated memory was unchanged; peak reserved memory decreased by 0.287 GiB (1.83%).

The hardware result validates the VLM trainer path and tested two-GPU topology. It does not claim four-GPU scaling, `dp_shard_size > 1`, NPU behavior, or long-horizon convergence.

### API and Usage Example

No API or configuration changes.

### Design & Code Changes

- Call the existing HSDP all-reduce helper after `model_reshard()` in the text, VLM, and DPO micro-batch loops.
- Apply the same lifecycle in DiT training while preserving the offline-embedding path.
- Add a boundary test for the existing helper and verify every trainer train loop invokes it.
- Update the VLM torch-compile test fixture for the shared helper call.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added focused tests
- [x] No documentation update is required because there is no public API, configuration, or workflow change
- [x] Existing CI coverage exercises the modified trainer test files
