### PR TITLE
[model] feat: Add SDPA fallback for BAGEL NPU attention

### DIFF
--- a/veomni/models/seed_omni/modules/bagel/flow_connector/modeling.py
+++ b/veomni/models/seed_omni/modules/bagel/flow_connector/modeling.py
@@ -25,6 +25,7 @@ class BagelFlowConnector(BagelFlowConnectorModuleMixin, PreTrainedModel):
     main_input_name = "hidden_states"
     _no_split_modules: list[str] = []
     supports_gradient_checkpointing = True
+    _supports_sdpa = True
 
     def __init__(self, config: BagelFlowConnectorConfig) -> None:
         super().__init__(config)

--- a/veomni/models/seed_omni/modules/bagel/qwen2_mot/modeling.py
+++ b/veomni/models/seed_omni/modules/bagel/qwen2_mot/modeling.py
@@ -31,6 +31,7 @@ class BagelQwen2MoT(BagelQwen2MoTModuleMixin, PreTrainedModel):
     main_input_name = "inputs_embeds"
     _no_split_modules = ["BagelQwen2MoTDecoderLayer"]
     supports_gradient_checkpointing = True
+    _supports_sdpa = True
 
     def __init__(self, config: BagelQwen2MoTConfig):
         super().__init__(config)

--- a/veomni/models/seed_omni/modules/bagel/siglip_navit/modeling.py
+++ b/veomni/models/seed_omni/modules/bagel/siglip_navit/modeling.py
@@ -15,6 +15,7 @@ from typing import Any
 import numpy as np
 import torch
 import torch.nn as nn
+from torch.nn.functional import scaled_dot_product_attention
 from transformers import PreTrainedModel
 
 from veomni.utils.device import IS_CUDA_AVAILABLE, IS_NPU_AVAILABLE
@@ -39,6 +40,7 @@ class BagelSiglipNavit(BagelSiglipNavitModuleMixin, BagelSiglipNavitMetricMeterM
     main_input_name = "patchified_pixel_values"
     _no_split_modules = ["BagelSiglipEncoderLayer"]
     supports_gradient_checkpointing = True
+    _supports_sdpa = True
 
     def __init__(self, config: BagelSiglipNavitConfig) -> None:
         super().__init__(config)
@@ -247,6 +249,20 @@ class BagelSiglipVisionEmbeddings(nn.Module):
         return patch_embeds + position_embeds.to(device=patch_embeds.device, dtype=patch_embeds.dtype)
 
 
+def _sdpa_varlen_attn(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, causal=False):
+    num_seqs = cu_seqlens_q.shape[0] - 1
+    outputs = []
+    for i in range(num_seqs):
+        q_start, q_end = cu_seqlens_q[i].item(), cu_seqlens_q[i + 1].item()
+        k_start, k_end = cu_seqlens_k[i].item(), cu_seqlens_k[i + 1].item()
+        qi = q[q_start:q_end].transpose(0, 1).unsqueeze(0)
+        ki = k[k_start:k_end].transpose(0, 1).unsqueeze(0)
+        vi = v[k_start:k_end].transpose(0, 1).unsqueeze(0)
+        oi = scaled_dot_product_attention(qi, ki, vi, is_causal=causal)
+        outputs.append(oi.squeeze(0).transpose(0, 1))
+    return torch.cat(outputs, dim=0)
+
+
 class BagelSiglipAttention(nn.Module):
     def __init__(self, config: BagelSiglipNavitConfig) -> None:
         super().__init__()
@@ -295,19 +311,31 @@ class BagelSiglipAttention(nn.Module):
                 causal=False,
             )
         else:
-            attn_output = torch_npu.npu_fusion_attention(
-                query_states.to(torch.bfloat16),
-                key_states.to(torch.bfloat16),
-                value_states.to(torch.bfloat16),
-                query_states.shape[1],
-                pse=None,
-                atten_mask=None,
-                scale=1.0 / math.sqrt(query_states.shape[-1]),
-                keep_prob=1,
-                input_layout="TND",
-                actual_seq_qlen=tuple(cu_seqlens[1:].cpu().numpy().tolist()),
-                actual_seq_kvlen=tuple(cu_seqlens[1:].cpu().numpy().tolist()),
-            )[0]
+            if self.config._attn_implementation in ("flash_attention_2", "veomni_flash_attention_2_with_sp"):
+                attn_output = torch_npu.npu_fusion_attention(
+                    query_states.to(torch.bfloat16),
+                    key_states.to(torch.bfloat16),
+                    value_states.to(torch.bfloat16),
+                    query_states.shape[1],
+                    pse=None,
+                    atten_mask=None,
+                    scale=1.0 / math.sqrt(query_states.shape[-1]),
+                    keep_prob=1,
+                    input_layout="TND",
+                    actual_seq_qlen=tuple(cu_seqlens[1:].cpu().numpy().tolist()),
+                    actual_seq_kvlen=tuple(cu_seqlens[1:].cpu().numpy().tolist()),
+                )[0]
+            else:
+                attn_output = _sdpa_varlen_attn(
+                    query_states.to(torch.bfloat16),
+                    key_states.to(torch.bfloat16),
+                    value_states.to(torch.bfloat16),
+                    cu_seqlens,
+                    cu_seqlens,
+                    max_seqlen,
+                    max_seqlen,
+                    causal=False,
+                )
         return self.out_proj(attn_output.reshape(total_q_len, -1).to(hidden_states.dtype))
 
 

--- a/veomni/models/seed_omni/modules/bagel/text_encoder/modeling.py
+++ b/veomni/models/seed_omni/modules/bagel/text_encoder/modeling.py
@@ -7,6 +7,7 @@ from .modulemixin import BagelTextEncoderModuleMixin
 
 class BagelTextEncoder(BagelTextEncoderModuleMixin, TextEncoder):
     config_class = BagelTextEncoderConfig
+    _supports_sdpa = True
 
 
 __all__ = ["BagelTextEncoder", "BagelTextEncoderConfig"]

--- a/veomni/models/seed_omni/modules/bagel/vae/modeling.py
+++ b/veomni/models/seed_omni/modules/bagel/vae/modeling.py
@@ -32,6 +32,7 @@ class BagelVAE(BagelVAEModuleMixin, PreTrainedModel):
     main_input_name = "pixel_values"
     _no_split_modules: list[str] = ["ResnetBlock", "AttnBlock"]
     supports_gradient_checkpointing = True
+    _supports_sdpa = True
 
     def __init__(self, config: BagelVAEConfig) -> None:
         super().__init__(config)


### PR DESCRIPTION
### What does this PR do?

> Add SDPA fallback for NPU attention in BagelSiglipAttention, controlled by ops_implementation.attn_implementation. Add _supports_sdpa flag to all 5 bagel modules.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
