### PR TITLE
[perf, data] fix: Avoid slow get_vocab for better preprocess performance.

### DIFF
--- a/veomni/data/data_transform.py
+++ b/veomni/data/data_transform.py
@@ -414,10 +414,9 @@ def process_sample_qwen_omni(
 
     def get_omni_token_ids(processor: "ProcessorMixin") -> tuple[int, int, int]:
         tokenizer = getattr(processor, "tokenizer", processor)
-        vocab = tokenizer.get_vocab()
-        image_token_id = vocab.get("<|image_pad|>", vocab.get("<|IMAGE|>"))
-        video_token_id = vocab.get("<|video_pad|>", vocab.get("<|VIDEO|>"))
-        audio_token_id = vocab.get("<|audio_pad|>", vocab.get("<|AUDIO|>"))
+        image_token_id = tokenizer.encode("<|image_pad|>", add_special_tokens=False)[0]
+        video_token_id = tokenizer.encode("<|video_pad|>", add_special_tokens=False)[0]
+        audio_token_id = tokenizer.encode("<|audio_pad|>", add_special_tokens=False)[0]
         if image_token_id is None:
             raise ValueError("Cannot find image token (<|image_pad|> or <|IMAGE|>) in tokenizer vocab.")
         if video_token_id is None:
@@ -536,9 +535,8 @@ def process_sample_qwen_omni(
 
     labels = torch.full_like(input_ids, fill_value=IGNORE_INDEX)
     tokenizer = getattr(processor, "tokenizer", processor)
-    vocab = tokenizer.get_vocab()
-    user_token_id = vocab.get("user")
-    assistant_token_id = vocab.get("assistant")
+    user_token_id = tokenizer.encode("user", add_special_tokens=False)[0]
+    assistant_token_id = tokenizer.encode("assistant", add_special_tokens=False)[0]
     if user_token_id is None or assistant_token_id is None:
         raise ValueError("Cannot find user/assistant tokens in tokenizer vocab.")
     user_start_index = torch.where(input_ids == user_token_id)[0].tolist()

--- a/veomni/data/data_transform.py
+++ b/veomni/data/data_transform.py
@@ -30,6 +30,18 @@ if TYPE_CHECKING:
 DATA_TRANSFORM_REGISTRY = Registry("DataTransform")
 
 
+def _get_exact_token_id(tokenizer: "PreTrainedTokenizer", token: str, fallback_token: str | None = None) -> int:
+    candidates = (token,) if fallback_token is None else (token, fallback_token)
+    unk_token_id = getattr(tokenizer, "unk_token_id", None)
+    for candidate in candidates:
+        token_id = tokenizer.convert_tokens_to_ids(candidate)
+        if token_id is not None and token_id != unk_token_id:
+            return token_id
+
+    token_names = " or ".join(candidates)
+    raise ValueError(f"Cannot find token ({token_names}) in tokenizer vocab.")
+
+
 def build_data_transform(transform_name: str, **kwargs) -> Callable:
     return partial(DATA_TRANSFORM_REGISTRY[transform_name], **kwargs)
 
@@ -414,15 +426,9 @@ def process_sample_qwen_omni(
 
     def get_omni_token_ids(processor: "ProcessorMixin") -> tuple[int, int, int]:
         tokenizer = getattr(processor, "tokenizer", processor)
-        image_token_id = tokenizer.encode("<|image_pad|>", add_special_tokens=False)[0]
-        video_token_id = tokenizer.encode("<|video_pad|>", add_special_tokens=False)[0]
-        audio_token_id = tokenizer.encode("<|audio_pad|>", add_special_tokens=False)[0]
-        if image_token_id is None:
-            raise ValueError("Cannot find image token (<|image_pad|> or <|IMAGE|>) in tokenizer vocab.")
-        if video_token_id is None:
-            raise ValueError("Cannot find video token (<|video_pad|> or <|VIDEO|>) in tokenizer vocab.")
-        if audio_token_id is None:
-            raise ValueError("Cannot find audio token (<|audio_pad|> or <|AUDIO|>) in tokenizer vocab.")
+        image_token_id = _get_exact_token_id(tokenizer, "<|image_pad|>", "<|IMAGE|>")
+        video_token_id = _get_exact_token_id(tokenizer, "<|video_pad|>", "<|VIDEO|>")
+        audio_token_id = _get_exact_token_id(tokenizer, "<|audio_pad|>", "<|AUDIO|>")
         return image_token_id, video_token_id, audio_token_id
 
     image_token_id, video_token_id, audio_token_id = get_omni_token_ids(processor)
@@ -535,10 +541,8 @@ def process_sample_qwen_omni(
 
     labels = torch.full_like(input_ids, fill_value=IGNORE_INDEX)
     tokenizer = getattr(processor, "tokenizer", processor)
-    user_token_id = tokenizer.encode("user", add_special_tokens=False)[0]
-    assistant_token_id = tokenizer.encode("assistant", add_special_tokens=False)[0]
-    if user_token_id is None or assistant_token_id is None:
-        raise ValueError("Cannot find user/assistant tokens in tokenizer vocab.")
+    user_token_id = _get_exact_token_id(tokenizer, "user")
+    assistant_token_id = _get_exact_token_id(tokenizer, "assistant")
     user_start_index = torch.where(input_ids == user_token_id)[0].tolist()
     assistant_start_index = torch.where(input_ids == assistant_token_id)[0].tolist()
     user_start_index.append(len(input_ids) + 1)


### PR DESCRIPTION
### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

Avoid slow get_vocab for better preprocess performance.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.
1. benchmark
```
import argparse
import gc
import os
import platform
import statistics
import time
import timeit
import tracemalloc
from dataclasses import dataclass
from typing import Any, Callable

from transformers import AutoTokenizer
from transformers import __version__ as transformers_version

from veomni.data.data_transform import _get_exact_token_id


MODEL_PATH_ENV = "QWEN3_OMNI_MODEL_PATH"
TOKEN_SPECS = (
    ("<|image_pad|>", "<|IMAGE|>"),
    ("<|video_pad|>", "<|VIDEO|>"),
    ("<|audio_pad|>", "<|AUDIO|>"),
    ("user", None),
    ("assistant", None),
)


@dataclass(frozen=True)
class BenchmarkResult:
    name: str
    number: int
    median_ms: float
    min_ms: float
    max_ms: float
    samples_per_second: float
    peak_bytes: int
    runs_ms: tuple[float, ...]


def old_get_vocab_lookup(tokenizer: Any) -> tuple[int | None, ...]:
    """Reproduce the pre-optimization implementation, including two get_vocab calls per sample."""
    vocab = tokenizer.get_vocab()
    image_token_id = vocab.get("<|image_pad|>", vocab.get("<|IMAGE|>"))
    video_token_id = vocab.get("<|video_pad|>", vocab.get("<|VIDEO|>"))
    audio_token_id = vocab.get("<|audio_pad|>", vocab.get("<|AUDIO|>"))

    vocab = tokenizer.get_vocab()
    user_token_id = vocab.get("user")
    assistant_token_id = vocab.get("assistant")
    return image_token_id, video_token_id, audio_token_id, user_token_id, assistant_token_id


def exact_token_lookup(tokenizer: Any) -> tuple[int, ...]:
    """Run the exact-token implementation from the current working tree."""
    return tuple(_get_exact_token_id(tokenizer, token, fallback) for token, fallback in TOKEN_SPECS)


def peak_allocated_bytes(function: Callable[[], tuple[int | None, ...]]) -> int:
    gc.collect()
    tracemalloc.start()
    try:
        function()
        _, peak_bytes = tracemalloc.get_traced_memory()
    finally:
        tracemalloc.stop()
    return peak_bytes


def benchmark(
    name: str,
    function: Callable[[], tuple[int | None, ...]],
    *,
    number: int,
    repeat: int,
    warmup: int,
) -> BenchmarkResult:
    print(f"\nRunning {name}: repeat={repeat}, number={number}, warmup={warmup}", flush=True)
    for _ in range(warmup):
        function()

    durations = timeit.repeat(function, number=number, repeat=repeat)
    runs_ms = tuple(duration * 1000 / number for duration in durations)
    median_ms = statistics.median(runs_ms)
    return BenchmarkResult(
        name=name,
        number=number,
        median_ms=median_ms,
        min_ms=min(runs_ms),
        max_ms=max(runs_ms),
        samples_per_second=1000 / median_ms,
        peak_bytes=peak_allocated_bytes(function),
        runs_ms=runs_ms,
    )


def format_bytes(num_bytes: int) -> str:
    if num_bytes < 1024:
        return f"{num_bytes} B"
    if num_bytes < 1024**2:
        return f"{num_bytes / 1024:.2f} KiB"
    return f"{num_bytes / 1024**2:.2f} MiB"


def print_token_ids(tokenizer: Any, expected_ids: tuple[int | None, ...]) -> None:
    print("\nToken ID equivalence")
    print("-" * 56)
    print(f"{'token':<24} {'id':>10} {'fallback present':>18}")
    for (token, fallback), token_id in zip(TOKEN_SPECS, expected_ids):
        fallback_id = tokenizer.convert_tokens_to_ids(fallback) if fallback is not None else None
        fallback_present = fallback_id is not None and fallback_id != getattr(tokenizer, "unk_token_id", None)
        print(f"{token:<24} {str(token_id):>10} {str(fallback_present):>18}")


def print_results(results: tuple[BenchmarkResult, ...], *, show_runs: bool) -> None:
    print("\nMicrobenchmark")
    print("-" * 100)
    print(
        f"{'method':<24} {'loops/run':>10} {'median ms/sample':>18} "
        f"{'min-max ms':>22} {'samples/s':>14} {'peak alloc':>12}"
    )
    for result in results:
        min_max = f"{result.min_ms:.6f}-{result.max_ms:.6f}"
        print(
            f"{result.name:<24} {result.number:>10} {result.median_ms:>18.6f} "
            f"{min_max:>22} {result.samples_per_second:>14.2f} {format_bytes(result.peak_bytes):>12}"
        )
        if show_runs:
            print(" " * 4 + "runs ms/sample: " + ", ".join(f"{value:.6f}" for value in result.runs_ms))

    old_result, exact_result = results
    print("\nSpeedup")
    print(f"exact vs old get_vocab: {old_result.median_ms / exact_result.median_ms:.2f}x")


def positive_int(value: str) -> int:
    parsed = int(value)
    if parsed <= 0:
        raise argparse.ArgumentTypeError("value must be positive")
    return parsed


def nonnegative_int(value: str) -> int:
    parsed = int(value)
    if parsed < 0:
        raise argparse.ArgumentTypeError("value must be non-negative")
    return parsed


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser(
        description="Validate and benchmark Qwen-Omni token ID lookup strategies without loading model weights."
    )
    parser.add_argument(
        "model_path",
        nargs="?",
        default=os.environ.get(MODEL_PATH_ENV),
        help=f"Tokenizer directory. Defaults to ${MODEL_PATH_ENV} when set.",
    )
    parser.add_argument("--repeat", type=positive_int, default=7)
    parser.add_argument("--warmup", type=nonnegative_int, default=5)
    parser.add_argument(
        "--old-number",
        type=positive_int,
        default=3,
        help="Calls per repeat for the allocation-heavy two-get_vocab baseline.",
    )
    parser.add_argument("--exact-number", type=positive_int, default=10_000)
    parser.add_argument("--trust-remote-code", action="store_true")
    parser.add_argument("--allow-download", action="store_true")
    parser.add_argument("--show-runs", action="store_true")
    args = parser.parse_args()
    if not args.model_path:
        parser.error(f"model_path is required, either as an argument or through ${MODEL_PATH_ENV}")
    return args


def main() -> None:
    args = parse_args()
    load_start = time.perf_counter()
    tokenizer = AutoTokenizer.from_pretrained(
        args.model_path,
        local_files_only=not args.allow_download,
        trust_remote_code=args.trust_remote_code,
    )
    load_seconds = time.perf_counter() - load_start

    def old_function() -> tuple[int | None, ...]:
        return old_get_vocab_lookup(tokenizer)

    def exact_function() -> tuple[int, ...]:
        return exact_token_lookup(tokenizer)

    old_ids = old_function()
    exact_ids = exact_function()
    if old_ids != exact_ids:
        raise RuntimeError(
            f"Token ID lookup strategies are not equivalent for this tokenizer: old={old_ids}, exact={exact_ids}"
        )

    print(f"Python: {platform.python_version()}")
    print(f"Transformers: {transformers_version}")
    print(f"Tokenizer: {type(tokenizer).__name__}")
    print(f"Vocabulary size: {len(tokenizer)}")
    print(f"Tokenizer load time: {load_seconds:.3f} s")
    print("Model weights loaded: no")
    print(
        "Benchmark config: "
        f"repeat={args.repeat}, warmup={args.warmup}, old_number={args.old_number}, "
        f"exact_number={args.exact_number}"
    )
    print_token_ids(tokenizer, old_ids)

    results = (
        benchmark(
            "old_get_vocab_x2",
            old_function,
            number=args.old_number,
            repeat=args.repeat,
            warmup=args.warmup,
        ),
        benchmark(
            "exact_convert_x5",
            exact_function,
            number=args.exact_number,
            repeat=args.repeat,
            warmup=args.warmup,
        ),
    )
    print_results(results, show_runs=args.show_runs)


if __name__ == "__main__":
    main()
```
```
python -u scripts/profile/benchmark_omni_token_lookup.py \
  /path/to/model \
  --repeat 9 \
  --warmup 5 \
  --old-number 3 \
  --exact-number 10000 \
  --show-runs
```
<img width="1522" height="330" alt="image" src="https://github.com/user-attachments/assets/b5d35ed5-346f-4f74-9388-80e10ce8d570" />


2. CI: `python -m pytest -s -x tests/data/test_omni_token_ids.py` 3 passed.
3. e2e test: in-house dataset+qwen3.6 model+NPU
before:
<img width="1820" height="834" alt="image" src="https://github.com/user-attachments/assets/cf5e35ac-4583-45f5-84fe-3b239ddc428b" />
after:
<img width="1820" height="810" alt="image" src="https://github.com/user-attachments/assets/7027ce07-60c0-4099-b790-7a6fa1780b13" />


### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
