### PR TITLE
[lora, model] fix: resolve Wan attention projection dtype via parameters()

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -195,9 +195,12 @@ jobs:
         #   - moe_lora_ep2: EP=1 vs EP=2 trainer-driven integration + per-step loss/grad_norm alignment
         #   - moe_lora_ep_sharded_stream_load: PEFT ep_sharded_stream_load vs broadcast, bit-exact
         #     post-load LoRA weights (independent + shared) on a fused-base Qwen3-MoE at EP=2
+        #   - wan_lora_projection_dtype: CPU-only guard that Wan's three projection-dtype reads
+        #     resolve for a LoRA-wrapped `LoraLinear` (no `.weight`) as well as a plain `nn.Linear`
         # Order: cheap unit tests first to fail fast, trainer/ep2 last (multi-subprocess, ~5-10 min each).
         run: |
           uv run --frozen pytest -s -x tests/lora/test_target_mapping.py
+          uv run --frozen pytest -s -x tests/lora/test_wan_lora_projection_dtype.py
           uv run --frozen pytest -s -x tests/lora/test_veomni_lora_moe_native.py
           uv run --frozen pytest -s -x tests/lora/test_lora_trainer_saveload.py
           uv run --frozen pytest -s -x tests/lora/test_moe_lora_eager.py

--- a/tests/lora/test_wan_lora_projection_dtype.py
+++ b/tests/lora/test_wan_lora_projection_dtype.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU regression tests for Wan attention projection dtype resolution under LoRA.
+
+Wan reads the projection dtype off the ``to_*`` modules in three places. A
+LoRA-wrapped projection is a ``LoraLinear`` whose frozen weight lives at
+``base_layer``, so reading ``.weight`` directly raised ``AttributeError`` on the
+first attention forward of any Wan LoRA run. These tests pin both layouts.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from veomni.lora.layers import LoraLinear
+from veomni.models.diffusers.wan_t2v.wan_transformer.modeling_wan_transformer import (
+    WanAttentionKernelModule,
+    _assert_wan_flash_attention_bf16,
+    _projection_weight,
+)
+
+
+HIDDEN = 8
+DTYPE = torch.bfloat16
+
+
+class _StubWanAttention(nn.Module):
+    """The attribute surface the three dtype call sites touch, nothing more."""
+
+    def __init__(self, lora: bool):
+        super().__init__()
+
+        def projection() -> nn.Module:
+            linear = nn.Linear(HIDDEN, HIDDEN, bias=False, dtype=DTYPE)
+            if not lora:
+                return linear
+            return LoraLinear(linear, "default", r=4, lora_alpha=8)
+
+        self.to_q = projection()
+        self.to_k = projection()
+        self.to_v = projection()
+        self.to_out = nn.ModuleList([projection(), nn.Identity()])
+
+
+def _bf16_qkv() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return tuple(torch.zeros(1, 2, 3, HIDDEN, dtype=DTYPE) for _ in range(3))
+
+
+def test_lora_linear_has_no_weight_attribute():
+    """The failure this module guards against, pinned so the guard is not 'simplified' away."""
+    attn = _StubWanAttention(lora=True)
+
+    assert isinstance(attn.to_q, LoraLinear)
+    with pytest.raises(AttributeError):
+        _ = attn.to_q.weight
+
+
+@pytest.mark.parametrize("lora", [False, True])
+def test_projection_weight_resolves_to_the_base_weight(lora):
+    attn = _StubWanAttention(lora=lora)
+    expected = attn.to_q.base_layer.weight if lora else attn.to_q.weight
+
+    assert _projection_weight(attn.to_q) is expected
+    assert _projection_weight(attn.to_q).dtype == DTYPE
+
+
+@pytest.mark.parametrize("lora", [False, True])
+def test_kernel_module_resolves_pre_quantization_dtype(lora):
+    attn = _StubWanAttention(lora=lora)
+    config = SimpleNamespace(_attn_implementation="veomni_flash_attention_2_with_sp")
+
+    kernel_module = WanAttentionKernelModule(config, attn)
+
+    assert kernel_module.config._pre_quantization_dtype == torch.bfloat16
+    assert kernel_module.config._attn_implementation == config._attn_implementation
+
+
+@pytest.mark.parametrize("lora", [False, True])
+def test_flash_attention_bf16_assert_accepts_both_layouts(lora):
+    """The assert reads all of to_q/to_k/to_v, so it fails on a layout the kernel module misses."""
+    attn = _StubWanAttention(lora=lora)
+
+    _assert_wan_flash_attention_bf16(*_bf16_qkv(), attn)
+
+
+@pytest.mark.parametrize("lora", [False, True])
+def test_fp32_projections_are_promoted_to_bf16(lora):
+    """fp32 weights resolve through the same helper and still land on the bf16 kernel dtype."""
+    attn = _StubWanAttention(lora=lora)
+    attn.to(torch.float32)
+    config = SimpleNamespace(_attn_implementation="veomni_flash_attention_2_with_sp")
+
+    assert _projection_weight(attn.to_q).dtype == torch.float32
+    assert WanAttentionKernelModule(config, attn).config._pre_quantization_dtype == torch.bfloat16
+
+
+@pytest.mark.parametrize("lora", [False, True])
+def test_type_as_target_is_the_projection_weight(lora):
+    """`WanSPAttnProcessor` casts the attention output with this weight before `to_out[0]`."""
+    attn = _StubWanAttention(lora=lora)
+    hidden_states = torch.zeros(1, 3, HIDDEN, dtype=torch.float32)
+
+    assert hidden_states.type_as(_projection_weight(attn.to_out[0])).dtype == DTYPE

--- a/veomni/models/diffusers/wan_t2v/wan_transformer/modeling_wan_transformer.py
+++ b/veomni/models/diffusers/wan_t2v/wan_transformer/modeling_wan_transformer.py
@@ -52,11 +52,21 @@ def wan_eager_attention_forward(
     return attn_output.transpose(1, 2), None
 
 
+def _projection_weight(module: torch.nn.Module) -> torch.Tensor:
+    """Return the projection's base weight for a plain ``nn.Linear`` or a LoRA-wrapped one.
+
+    ``LoraLinear`` keeps the frozen weight at ``base_layer`` and exposes no ``.weight``
+    of its own, so reading ``.weight`` directly raises ``AttributeError`` on any Wan run
+    with LoRA. Only dtype/device are read through this helper, which the adapters share
+    with the base weight; callers that need the effective projection must go through the
+    module's ``forward`` so the LoRA delta is applied.
+    """
+    return getattr(module, "base_layer", module).weight
+
+
 class WanAttentionKernelModule:
     def __init__(self, config: SimpleNamespace, attn: WanAttention):
-        # Read via ``parameters()`` so LoRA-wrapped projections (``LoraLinear``,
-        # which has no ``.weight`` attribute) resolve like a plain ``nn.Linear``.
-        target_dtype = next(attn.to_q.parameters()).dtype
+        target_dtype = _projection_weight(attn.to_q).dtype
         if target_dtype == torch.float32:
             target_dtype = torch.bfloat16
         self.config = SimpleNamespace(
@@ -128,16 +138,13 @@ def _assert_wan_flash_attention_bf16(
         "value": value.dtype,
     }
 
-    # Resolve the projection weight dtype via ``parameters()`` rather than
-    # ``.weight`` so LoRA-wrapped projections (``LoraLinear``, which has no
-    # ``.weight`` attribute) are handled the same as plain ``nn.Linear``.
-    def _proj_dtype(module):
-        return next(module.parameters()).dtype
-
+    # Keyed by module name rather than parameter path: under LoRA the tensor lives at
+    # ``to_q.base_layer.weight``, so naming ``to_q.weight`` would point at an attribute
+    # the model does not have.
     weight_dtypes = {
-        "to_q.weight": _proj_dtype(attn.to_q),
-        "to_k.weight": _proj_dtype(attn.to_k),
-        "to_v.weight": _proj_dtype(attn.to_v),
+        "to_q": _projection_weight(attn.to_q).dtype,
+        "to_k": _projection_weight(attn.to_k).dtype,
+        "to_v": _projection_weight(attn.to_v).dtype,
     }
     assert all(dtype == torch.bfloat16 for dtype in tensor_dtypes.values()), (
         f"Wan flash-attention expects bf16 Q/K/V tensors, got {tensor_dtypes}."
@@ -273,7 +280,7 @@ class WanSPAttnProcessor(WanAttnProcessor):
         if hidden_states_img is not None:
             hidden_states_out = hidden_states_out + hidden_states_img
 
-        hidden_states_out = hidden_states_out.type_as(next(attn.to_out[0].parameters()))
+        hidden_states_out = hidden_states_out.type_as(_projection_weight(attn.to_out[0]))
         hidden_states_out = attn.to_out[0](hidden_states_out)
         hidden_states_out = attn.to_out[1](hidden_states_out)
         return hidden_states_out

--- a/veomni/models/diffusers/wan_t2v/wan_transformer/modeling_wan_transformer.py
+++ b/veomni/models/diffusers/wan_t2v/wan_transformer/modeling_wan_transformer.py
@@ -54,7 +54,9 @@ def wan_eager_attention_forward(
 
 class WanAttentionKernelModule:
     def __init__(self, config: SimpleNamespace, attn: WanAttention):
-        target_dtype = attn.to_q.weight.dtype
+        # Read via ``parameters()`` so LoRA-wrapped projections (``LoraLinear``,
+        # which has no ``.weight`` attribute) resolve like a plain ``nn.Linear``.
+        target_dtype = next(attn.to_q.parameters()).dtype
         if target_dtype == torch.float32:
             target_dtype = torch.bfloat16
         self.config = SimpleNamespace(
@@ -125,10 +127,17 @@ def _assert_wan_flash_attention_bf16(
         "key": key.dtype,
         "value": value.dtype,
     }
+
+    # Resolve the projection weight dtype via ``parameters()`` rather than
+    # ``.weight`` so LoRA-wrapped projections (``LoraLinear``, which has no
+    # ``.weight`` attribute) are handled the same as plain ``nn.Linear``.
+    def _proj_dtype(module):
+        return next(module.parameters()).dtype
+
     weight_dtypes = {
-        "to_q.weight": attn.to_q.weight.dtype,
-        "to_k.weight": attn.to_k.weight.dtype,
-        "to_v.weight": attn.to_v.weight.dtype,
+        "to_q.weight": _proj_dtype(attn.to_q),
+        "to_k.weight": _proj_dtype(attn.to_k),
+        "to_v.weight": _proj_dtype(attn.to_v),
     }
     assert all(dtype == torch.bfloat16 for dtype in tensor_dtypes.values()), (
         f"Wan flash-attention expects bf16 Q/K/V tensors, got {tensor_dtypes}."
@@ -264,7 +273,7 @@ class WanSPAttnProcessor(WanAttnProcessor):
         if hidden_states_img is not None:
             hidden_states_out = hidden_states_out + hidden_states_img
 
-        hidden_states_out = hidden_states_out.type_as(attn.to_out[0].weight)
+        hidden_states_out = hidden_states_out.type_as(next(attn.to_out[0].parameters()))
         hidden_states_out = attn.to_out[0](hidden_states_out)
         hidden_states_out = attn.to_out[1](hidden_states_out)
         return hidden_states_out


### PR DESCRIPTION
WanAttention reads the projection dtype through `.weight` in three places. A LoRA-wrapped projection is a `LoraLinear`, which has no `.weight` attribute, so any Wan run with LoRA raises AttributeError on the first attention forward.

Read the dtype from `next(module.parameters())` instead, which resolves identically for a plain `nn.Linear` and leaves non-LoRA behaviour unchanged.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wan transformer compatibility with LoRA-wrapped attention projections.
  * Corrected projection dtype detection, Flash Attention validation, kernel initialization, and output casting.
  * Ensured fp32 projections are appropriately promoted to bf16 where required.

* **Tests**
  * Added regression coverage for standard and LoRA-wrapped projection modules.
  * Included GPU workflow coverage for the new Wan LoRA projection dtype tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->