### PR TITLE
[parallel] fix: stabilize nested FSDP2 backward prefetch topology

### DIFF
--- a/tests/distributed/test_fsdp2_prefetch.py
+++ b/tests/distributed/test_fsdp2_prefetch.py
@@ -1,0 +1,166 @@
+from veomni.distributed.torch_parallelize import (
+    _build_fsdp2_backward_prefetch_chains,
+    _configure_fsdp2_manual_prefetch,
+    _get_fsdp2_prefetch_role,
+    _register_fsdp2_prefetch_module,
+)
+
+
+class _FakeFSDPModule:
+    def __init__(self, name):
+        self.name = name
+        self._fsdp_modules = []
+        self.forward_prefetch = None
+        self.backward_prefetch = None
+
+    def set_modules_to_forward_prefetch(self, modules):
+        self.forward_prefetch = modules
+
+    def set_modules_to_backward_prefetch(self, modules):
+        self.backward_prefetch = modules
+
+
+def _make_nested_blocks(num_blocks=3):
+    blocks = []
+    experts = []
+    for index in range(num_blocks):
+        block = _FakeFSDPModule(f"decoder.{index}")
+        expert = _FakeFSDPModule(f"decoder.{index}.experts")
+        block._fsdp_modules = [expert, block]
+        blocks.append(block)
+        experts.append(expert)
+    return blocks, experts
+
+
+def test_backward_prefetch_configures_every_nested_fsdp_chain():
+    blocks, experts = _make_nested_blocks()
+
+    _configure_fsdp2_manual_prefetch(
+        blocks,
+        {("extra_parallel", "ep", 0): experts, ("target",): blocks},
+        enable_forward_prefetch=False,
+    )
+
+    assert experts[0].backward_prefetch == [experts[0]]
+    assert experts[1].backward_prefetch == [experts[0]]
+    assert experts[2].backward_prefetch == [experts[1]]
+    assert blocks[0].backward_prefetch == [blocks[0]]
+    assert blocks[1].backward_prefetch == [blocks[0]]
+    assert blocks[2].backward_prefetch == [blocks[1]]
+    assert all(block.forward_prefetch is None for block in blocks)
+
+
+def test_forward_prefetch_keeps_existing_next_block_order():
+    blocks, experts = _make_nested_blocks()
+
+    _configure_fsdp2_manual_prefetch(
+        blocks,
+        {("extra_parallel", "ep", 0): experts, ("target",): blocks},
+        enable_forward_prefetch=True,
+    )
+
+    assert blocks[0].forward_prefetch == [blocks[1], experts[1]]
+    assert blocks[1].forward_prefetch == [blocks[2], experts[2]]
+    assert blocks[2].forward_prefetch is None
+
+
+def test_singleton_nested_chain_uses_self_target_to_disable_default_prefetch():
+    blocks, experts = _make_nested_blocks(num_blocks=1)
+
+    _configure_fsdp2_manual_prefetch(
+        blocks,
+        {("extra_parallel", "ep", 0): experts, ("target",): blocks},
+        enable_forward_prefetch=False,
+    )
+
+    assert experts[0].backward_prefetch == [experts[0]]
+    assert blocks[0].backward_prefetch == [blocks[0]]
+
+
+def test_heterogeneous_blocks_keep_independent_role_chains():
+    blocks, _ = _make_nested_blocks()
+    expert = _FakeFSDPModule("decoder.1.experts")
+    blocks[0]._fsdp_modules = [blocks[0]]
+    blocks[1]._fsdp_modules = [expert, blocks[1]]
+    blocks[2]._fsdp_modules = [blocks[2]]
+
+    _configure_fsdp2_manual_prefetch(
+        blocks,
+        {("extra_parallel", "ep", 0): [expert], ("target",): blocks},
+        enable_forward_prefetch=False,
+    )
+
+    assert expert.backward_prefetch == [expert]
+    assert blocks[0].backward_prefetch == [blocks[0]]
+    assert blocks[1].backward_prefetch == [blocks[0]]
+    assert blocks[2].backward_prefetch == [blocks[1]]
+
+
+def test_prefetch_roles_use_stable_stack_and_relative_module_fqns():
+    language_role_0 = _get_fsdp2_prefetch_role(
+        "extra_parallel",
+        "model.language_model.layers.0",
+        "model.language_model.layers.0.mlp.experts_b",
+        "ep",
+    )
+    language_role_1 = _get_fsdp2_prefetch_role(
+        "extra_parallel",
+        "model.language_model.layers.1",
+        "model.language_model.layers.1.mlp.experts_b",
+        "ep",
+    )
+    vision_role = _get_fsdp2_prefetch_role(
+        "extra_parallel",
+        "model.visual.blocks.0",
+        "model.visual.blocks.0.mlp.experts_b",
+        "ep",
+    )
+
+    assert language_role_0 == language_role_1
+    assert language_role_0 != vision_role
+
+
+def test_prefetch_roles_keep_outer_numeric_stack_namespaces():
+    tower_0_block_0 = _get_fsdp2_prefetch_role(
+        "target",
+        "model.vision_towers.0.blocks.0",
+        "model.vision_towers.0.blocks.0",
+    )
+    tower_0_block_1 = _get_fsdp2_prefetch_role(
+        "target",
+        "model.vision_towers.0.blocks.1",
+        "model.vision_towers.0.blocks.1",
+    )
+    tower_1_block_0 = _get_fsdp2_prefetch_role(
+        "target",
+        "model.vision_towers.1.blocks.0",
+        "model.vision_towers.1.blocks.0",
+    )
+
+    assert tower_0_block_0 == tower_0_block_1
+    assert tower_0_block_0 != tower_1_block_0
+
+
+def test_chain_builder_uses_original_module_order_and_registers_existing_wrappers():
+    block_0 = _FakeFSDPModule("model.layers.0")
+    block_1 = _FakeFSDPModule("model.layers.1")
+    block_10 = _FakeFSDPModule("model.layers.10")
+    roles_by_module_id = {}
+    target_modules = [
+        (block_0.name, block_0),
+        (block_1.name, block_1),
+        (block_10.name, block_10),
+    ]
+
+    # Register in a deliberately different wrapping order. The builder must
+    # recover the original model traversal order from target_modules.
+    for block in (block_0, block_10, block_1):
+        role = _get_fsdp2_prefetch_role("target", block.name, block.name)
+        _register_fsdp2_prefetch_module(block, block, role, roles_by_module_id)
+        _register_fsdp2_prefetch_module(block, block, role, roles_by_module_id)
+
+    chains = _build_fsdp2_backward_prefetch_chains(target_modules, roles_by_module_id)
+    target_role = _get_fsdp2_prefetch_role("target", block_0.name, block_0.name)
+
+    assert chains[target_role] == [block_0, block_1, block_10]
+    assert all(block._fsdp_modules == [block] for block in (block_0, block_1, block_10))

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -130,6 +130,96 @@ def _check_extra_parallel_dim0_divisibility(model: "nn.Module", para_name: str, 
     return True
 
 
+def _normalize_fsdp2_layer_fqn(layer_fqn: str) -> str:
+    """Replace the rightmost numeric layer index with a stack placeholder."""
+    parts = layer_fqn.split(".")
+    for index in range(len(parts) - 1, -1, -1):
+        if parts[index].isdecimal():
+            parts[index] = "*"
+            break
+    return ".".join(parts)
+
+
+def _get_fsdp2_prefetch_role(
+    role_kind: str,
+    layer_fqn: str,
+    module_fqn: str,
+    extra_parallel_name: Optional[str] = None,
+) -> tuple[object, ...]:
+    """Return a stable prefetch role within one model stack."""
+    layer_prefix = f"{layer_fqn}."
+    if module_fqn == layer_fqn:
+        relative_module_fqn = "<self>"
+    elif module_fqn.startswith(layer_prefix):
+        relative_module_fqn = module_fqn[len(layer_prefix) :]
+    else:
+        relative_module_fqn = module_fqn
+    return (
+        role_kind,
+        extra_parallel_name,
+        _normalize_fsdp2_layer_fqn(layer_fqn),
+        relative_module_fqn,
+    )
+
+
+def _register_fsdp2_prefetch_module(
+    block: nn.Module,
+    module: FSDPModule,
+    role: tuple[object, ...],
+    roles_by_module_id: dict[int, tuple[object, ...]],
+) -> None:
+    """Register an FSDP module once even if nested target scopes overlap."""
+    module_id = id(module)
+    if module_id in roles_by_module_id:
+        return
+    block._fsdp_modules.append(module)
+    roles_by_module_id[module_id] = role
+
+
+def _build_fsdp2_backward_prefetch_chains(
+    target_modules: list[tuple[str, nn.Module]],
+    roles_by_module_id: dict[int, tuple[object, ...]],
+) -> dict[tuple[object, ...], list[FSDPModule]]:
+    """Build role chains in the model's original module traversal order."""
+    chains: dict[tuple[object, ...], list[FSDPModule]] = {}
+    seen_module_ids: set[int] = set()
+    for _, block in target_modules:
+        for module in block._fsdp_modules:
+            module_id = id(module)
+            if module_id in seen_module_ids:
+                continue
+            seen_module_ids.add(module_id)
+            chains.setdefault(roles_by_module_id[module_id], []).append(module)
+    return chains
+
+
+def _configure_fsdp2_manual_prefetch(
+    blocks: list[nn.Module],
+    backward_prefetch_chains: dict[tuple[object, ...], list[FSDPModule]],
+    enable_forward_prefetch: bool,
+) -> None:
+    """Configure static prefetch topology for nested FSDP2 modules.
+
+    Activation recompute may append nested FSDP groups to PyTorch's dynamic
+    post-forward order. Explicit backward chains keep each group role on a
+    stable path and avoid mistargeted all-gathers. A chain's first group points
+    to itself as a no-op target so it does not fall back to dynamic prefetch.
+    """
+    if enable_forward_prefetch:
+        next_blocks = blocks[1:] + [None]
+        for current_block, next_block in zip(blocks, next_blocks):
+            if next_block is not None:
+                # Prefetch in the execution order expected by the next block.
+                current_block.set_modules_to_forward_prefetch(list(reversed(next_block._fsdp_modules)))
+
+    for chain in backward_prefetch_chains.values():
+        if not chain:
+            continue
+        chain[0].set_modules_to_backward_prefetch([chain[0]])
+        for current_module, previous_module in zip(chain[1:], chain):
+            current_module.set_modules_to_backward_prefetch([previous_module])
+
+
 def parallelize_model_fsdp2(
     model: "nn.Module",
     weights_path: Optional[str] = None,
@@ -182,6 +272,7 @@ def parallelize_model_fsdp2(
     target_modules: List[Tuple[str, nn.Module]] = [
         (fqn, mod) for fqn, mod in model.named_modules() if mod.__class__.__name__ in target_classes
     ]
+    module_fqn_by_id = {id(mod): fqn for fqn, mod in model.named_modules()}
     logger.info_rank0(f"target classes to shard: {target_classes}")
 
     model._veomni_compile_enabled = False
@@ -409,6 +500,8 @@ def parallelize_model_fsdp2(
     sorted_fqn_list = sort_fqn_by_submodule_first(list(layer_pairs.keys()))
     layer_pairs_list = [(fqn, layer_pairs[fqn]) for fqn in sorted_fqn_list]
 
+    prefetch_roles_by_module_id: dict[int, tuple[object, ...]] = {}
+
     for layer_fqn, (layer_mod, extra_parallel_mod) in layer_pairs_list:
         # register all the FSDPModule inside this decoder layer for the convenience of manual prefetching configuration
         layer_mod._fsdp_modules = []
@@ -420,30 +513,44 @@ def parallelize_model_fsdp2(
             if not parallel_state.extra_parallel_enabled(para):
                 continue
             for _para_mod in extra_parallel_mod[para]:
-                if isinstance(_para_mod, FSDPModule):
-                    continue
-                # shard para module (e.g. expert/decoder.moe, embed_tokens/decoder.embed_tokens)
-                fully_shard(_para_mod, **extra_parallel_fsdp_kwargs[para])
-                # average para (e.g. ep) grads across para (e.g. ep) ranks
-                # NOTE: in torch 2.8 and later we should use
-                # experts_mod.set_gradient_divide_factor(parallel_state.ep_size)
-                # but for torch 2.7 we still use set_reduce_scatter_divide_factor(parallel_state.ep_size)
-                gradient_divide_factor = parallel_state.extra_parallel_gradient_divide_factor(para)
-                logger.info(f"setting grad divide factor for {para} module to {gradient_divide_factor}")
-                if IS_NPU_AVAILABLE:
-                    # NPU is using torch 2.7
-                    _para_mod.set_reduce_scatter_divide_factor(gradient_divide_factor)
-                else:
-                    # from torch 2.8
-                    _para_mod.set_gradient_divide_factor(gradient_divide_factor)
-                layer_mod._fsdp_modules.append(_para_mod)
+                if not isinstance(_para_mod, FSDPModule):
+                    # shard para module (e.g. expert/decoder.moe, embed_tokens/decoder.embed_tokens)
+                    fully_shard(_para_mod, **extra_parallel_fsdp_kwargs[para])
+                    # average para (e.g. ep) grads across para (e.g. ep) ranks
+                    # NOTE: in torch 2.8 and later we should use
+                    # experts_mod.set_gradient_divide_factor(parallel_state.ep_size)
+                    # but for torch 2.7 we still use set_reduce_scatter_divide_factor(parallel_state.ep_size)
+                    gradient_divide_factor = parallel_state.extra_parallel_gradient_divide_factor(para)
+                    logger.info(f"setting grad divide factor for {para} module to {gradient_divide_factor}")
+                    if IS_NPU_AVAILABLE:
+                        # NPU is using torch 2.7
+                        _para_mod.set_reduce_scatter_divide_factor(gradient_divide_factor)
+                    else:
+                        # from torch 2.8
+                        _para_mod.set_gradient_divide_factor(gradient_divide_factor)
+                module_fqn = module_fqn_by_id.get(id(_para_mod), layer_fqn)
+                role = _get_fsdp2_prefetch_role("extra_parallel", layer_fqn, module_fqn, para)
+                _register_fsdp2_prefetch_module(
+                    layer_mod,
+                    _para_mod,
+                    role,
+                    prefetch_roles_by_module_id,
+                )
 
         # shard module that needs to ignore mixed precision control
         if mp_ignored_classes:
             for sub_mod in layer_mod.modules():
                 if isinstance(sub_mod, mp_ignored_classes) and sub_mod is not layer_mod:
-                    fully_shard(sub_mod, **fsdp_kwargs_without_mp)
-                    layer_mod._fsdp_modules.append(sub_mod)
+                    if not isinstance(sub_mod, FSDPModule):
+                        fully_shard(sub_mod, **fsdp_kwargs_without_mp)
+                    module_fqn = module_fqn_by_id.get(id(sub_mod), layer_fqn)
+                    role = _get_fsdp2_prefetch_role("mixed_precision_ignored", layer_fqn, module_fqn)
+                    _register_fsdp2_prefetch_module(
+                        layer_mod,
+                        sub_mod,
+                        role,
+                        prefetch_roles_by_module_id,
+                    )
 
         # Shard everything else in the module:
         #   Note:
@@ -453,7 +560,13 @@ def parallelize_model_fsdp2(
         #      no need to shard layer_mod again.
         if not isinstance(layer_mod, FSDPModule):
             fully_shard(layer_mod, **fsdp_kwargs)
-            layer_mod._fsdp_modules.append(layer_mod)
+        role = _get_fsdp2_prefetch_role("target", layer_fqn, layer_fqn)
+        _register_fsdp2_prefetch_module(
+            layer_mod,
+            layer_mod,
+            role,
+            prefetch_roles_by_module_id,
+        )
         logger.info_rank0(f"{layer_fqn=}, {layer_mod._fsdp_modules=}")
 
     # Shard root WITHOUT explicit `reshard_after_forward` so FSDP2's
@@ -468,26 +581,23 @@ def parallelize_model_fsdp2(
     root_fsdp_kwargs = {k: v for k, v in fsdp_kwargs.items() if k != "reshard_after_forward"}
     fully_shard(model, **root_fsdp_kwargs)
 
-    # configure manual prefetching when needed
-    need_manual_prefetch = (
-        parallel_state.any_extra_parallel_enabled or mp_ignored_classes is not None
-    ) and kwargs.pop("enable_forward_prefetch", True)
+    # Configure static prefetching for nested FSDP groups. Backward prefetch is
+    # independent from forward prefetch since activation recompute can make the
+    # default dynamic backward order unsafe even when forward prefetch is off.
+    enable_forward_prefetch = kwargs.pop("enable_forward_prefetch", True)
+    need_manual_prefetch = parallel_state.any_extra_parallel_enabled or mp_ignored_classes is not None
     if need_manual_prefetch:
         blocks = [pair[1][0] for pair in layer_pairs_list]  # all target modules
-        next_blocks = blocks[1:] + [None]
-        for current_block, next_block in zip(blocks, next_blocks):
-            if next_block is not None:
-                prefetch_modules = next_block._fsdp_modules
-                # prefetch in order of attn, gate, experts
-                current_block.set_modules_to_forward_prefetch(list(reversed(prefetch_modules)))
-
-        # configure backward prefetch
-        rev_blocks = list(reversed(blocks))
-        prev_blocks = rev_blocks[1:] + [None]
-        for current_block, prev_block in zip(rev_blocks, prev_blocks):
-            if prev_block is not None:
-                prefetch_modules = prev_block._fsdp_modules
-                current_block.set_modules_to_backward_prefetch(list(reversed(prefetch_modules)))
+        backward_prefetch_chains = _build_fsdp2_backward_prefetch_chains(
+            target_modules,
+            prefetch_roles_by_module_id,
+        )
+        _configure_fsdp2_manual_prefetch(blocks, backward_prefetch_chains, enable_forward_prefetch)
+        logger.info_rank0(
+            f"FSDP2 manual prefetch configured for {len(backward_prefetch_chains)} backward chain(s) "
+            f"and {sum(len(chain) for chain in backward_prefetch_chains.values())} group(s); "
+            f"forward prefetch enabled={enable_forward_prefetch}."
+        )
 
     # Handle meta initialization for FSDP2 (fallback if pre-load not done)
     assert kwargs.get("init_device") == "meta", "Please use init_device: meta for FSDP2"


### PR DESCRIPTION
### What does this PR do?

This PR fixes unbounded FSDP2 parameter all-gather retention observed with the following combination:

```text
activation checkpointing
+ nested FSDP2 groups
+ MoE expert parallelism
+ default backward prefetch
```

PyTorch's default FSDP2 backward prefetch infers the next group from the mutable post-forward execution order. Activation checkpoint recomputation appends nested Decoder and Expert groups to that order again. The heuristic can then prefetch an Expert group that is not consumed by the next `pre_backward`, leaving its all-gather result alive until final backward cleanup. On deep MoE models, one unconsumed Expert buffer may accumulate per layer and cause OOM before backward finishes.

This change assigns every nested FSDP group a stable role at parallelization time and builds independent backward prefetch chains for equivalent roles across sequential transformer blocks. For example:

```text
decoder[i] -> decoder[i - 1]
expert[i]  -> expert[i - 1]
```

The first group in each chain uses a self-target to prevent falling back to the dynamic default heuristic. Backward prefetch configuration is also decoupled from `forward_prefetch`, so disabling forward prefetch no longer disables the safe backward topology.

This PR does not change forward/backward math, parameter sharding, gradient reduction, optimizer updates, or activation checkpoint recomputation.

Related work:

- #871 proposes a broader decoupled-trigger FSDP2 approach for MoE recomputation. This PR keeps the existing composable FSDP2 path and stabilizes its manual prefetch topology.
- #101 reported a previous heterogeneous-layer prefetch failure. The role-based chains in this PR avoid assuming that every layer has the same nested-module layout.

### Checklist Before Starting

- Related PRs/issues:
  - https://github.com/ByteDance-Seed/VeOmni/pull/871
  - https://github.com/ByteDance-Seed/VeOmni/issues/101
- PR title follows the required format:
  - `[parallel] fix: stabilize nested FSDP2 backward prefetch topology`

### Test

Focused unit tests:

```bash
python -m pytest -q tests/distributed/test_fsdp2_prefetch.py
```

Result:

```text
7 passed
```

Code quality checks for the changed files:

```bash
ruff check \
  veomni/distributed/torch_parallelize.py \
  tests/distributed/test_fsdp2_prefetch.py

ruff format --check \
  veomni/distributed/torch_parallelize.py \
  tests/distributed/test_fsdp2_prefetch.py
```

Result:

```text
All checks passed.
2 files already formatted.
```

The same FSDP2 diff was validated in an Ascend NPU integration run:

```text
Model:                  Qwen3.5-35B-A3B
Devices:                4 x Ascend 910B
DP shard size:          4
EP size:                2
Sequence length:        4096
Activation checkpoint: enabled
Forward prefetch:       disabled
FSDP offload:           disabled
Activation offload:     disabled
```

The framework configured three static backward chains covering 107 non-root FSDP groups:

```text
FSDP2 manual prefetch configured for 3 backward chain(s) and 107 group(s);
forward prefetch enabled=False.
```

Pending prefetch memory remained bounded during backward:

```text
Decoder prefetch: approximately 0.0697 GiB
Expert prefetch:  approximately 0.7500 GiB
Total:            approximately 0.8197 GiB
```

Backward completed from the last layer to Layer 0. At `backward_post`:

```text
Decoder groups:           40/40 sharded
Expert groups:            40/40 sharded
Other groups:             27/27 sharded
Root group:                 1/1 sharded
pending_all_gather_groups:    []
```

The run subsequently OOMed during the first `AdamW.step()` while lazily creating `exp_avg_sq`. This is a four-device optimizer-state capacity limitation after backward has completed and is unrelated to FSDP prefetch.

Multi-step 397B validation and a stable-step throughput comparison are still in progress.

### API and Usage Example

No new public API or configuration field is introduced.

The existing option keeps its forward-only meaning:

```yaml
train:
  accelerator:
    fsdp_config:
      forward_prefetch: false
```

For models with nested extra-parallel or mixed-precision-ignored FSDP groups, static backward prefetch chains are still configured when forward prefetch is disabled.

### Design & Code Changes

- Assign each nested FSDP group a stable role using:
  - group kind;
  - extra-parallel name;
  - normalized model-stack path;
  - module-relative path.
- Register overlapping nested modules once by object identity.
- Build one backward chain per role in original model traversal order instead of lexicographic FQN order.
- Configure `group[i] -> group[i - 1]` backward prefetch targets.
- Use a self-target for the first group in each chain to suppress fallback to the mutable default heuristic.
- Configure backward prefetch independently from `forward_prefetch`.
- Preserve the existing forward-prefetch behavior when forward prefetch is enabled.
- Add tests covering:
  - every nested FSDP role;
  - forward/backward prefetch decoupling;
  - singleton self-target chains;
  - heterogeneous blocks;
  - multiple model-stack namespaces;
  - original traversal ordering;
  - duplicate module registration.

The static chain assumes that transformer target modules execute sequentially in model traversal order. Models with dynamic layer skipping, repeated module calls, or non-standard interleaving require separate validation.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [ ] Run `pre-commit run --all-files` before final submission.
- [x] Focused Ruff and unit-test checks pass.
- [x] No public API/configuration documentation update is required.
- [x] No `tasks/` training script was moved or renamed.
- [x] Tests are included under the existing `tests/distributed/` collection; no CI workflow change is required.