### PR TITLE
[data] fix: make mapping cycles deterministic

### DIFF
--- a/tests/data/test_mapping_dataset.py
+++ b/tests/data/test_mapping_dataset.py
@@ -16,7 +16,8 @@ import random
 
 import pytest
 
-from veomni.data.dataset import InterleavedMappingDataset, MappingDataset
+import veomni.data.dataset as dataset_module
+from veomni.data.dataset import InterleavedMappingDataset, MappingDataset, build_dataset
 
 
 def _read_cycle(dataset, cycle):
@@ -30,6 +31,7 @@ def test_mapping_dataset_overlength_indices_are_deterministic():
 
     expected = _read_cycle(first, 1)
     assert expected != list(range(8))
+    assert sorted(expected) == list(range(8))
     assert _read_cycle(second, 1) == expected
     assert [second[index] for index in (12, 8, 15, 9)] == [expected[index] for index in (4, 0, 7, 1)]
 
@@ -75,6 +77,16 @@ def test_mapping_dataset_seed_controls_overlength_order_without_global_rng_side_
     random.seed(123)
     first[len(first)]
     assert random.random() == expected
+
+
+def test_build_mapping_dataset_forwards_seed(monkeypatch):
+    monkeypatch.setattr(dataset_module, "get_data_files", lambda _: (["unused.jsonl"], "json"))
+    monkeypatch.setattr(dataset_module, "load_dataset", lambda *args, **kwargs: list(range(8)))
+
+    first = build_dataset(dataset_name="mapping", train_path="unused.jsonl", seed=3)
+    second = build_dataset(dataset_name="mapping", train_path="unused.jsonl", seed=4)
+
+    assert _read_cycle(first, 1) != _read_cycle(second, 1)
 
 
 def test_overlength_read_does_not_change_first_cycle_order():

--- a/tests/data/test_mapping_dataset.py
+++ b/tests/data/test_mapping_dataset.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+
+import pytest
+
+from veomni.data.dataset import InterleavedMappingDataset, MappingDataset
+
+
+def _read_cycle(dataset, cycle):
+    start = cycle * len(dataset)
+    return [dataset[index] for index in range(start, start + len(dataset))]
+
+
+def test_mapping_dataset_overlength_indices_are_deterministic():
+    first = MappingDataset(list(range(8)), seed=17)
+    second = MappingDataset(list(range(8)), seed=17)
+
+    expected = _read_cycle(first, 1)
+    assert expected != list(range(8))
+    assert _read_cycle(second, 1) == expected
+    assert [second[index] for index in (12, 8, 15, 9)] == [expected[index] for index in (4, 0, 7, 1)]
+
+
+def test_mapping_dataset_preserves_python_negative_index_semantics():
+    dataset = MappingDataset(list(range(8)), seed=17)
+    assert dataset[-1] == 7
+    with pytest.raises(IndexError, match="out of range"):
+        dataset[-9]
+
+
+def test_mapping_dataset_cycle_is_reproducible_after_restart():
+    uninterrupted = MappingDataset(list(range(8)), seed=9)
+    expected = _read_cycle(uninterrupted, 2)
+
+    resumed = MappingDataset(list(range(8)), seed=9)
+    assert [resumed[index] for index in range(19, 24)] == expected[3:]
+
+
+def test_mapping_dataset_mapping_is_independent_of_cycle_access_order():
+    dataset = MappingDataset(list(range(8)), seed=9)
+    expected = {index: dataset[index] for index in range(8, 32)}
+
+    for index in (25, 9, 17, 31, 8, 24, 16):
+        assert dataset[index] == expected[index]
+
+
+def test_empty_mapping_dataset_raises_index_error():
+    dataset = MappingDataset([], seed=9)
+    with pytest.raises(IndexError, match="empty dataset"):
+        dataset[0]
+    with pytest.raises(IndexError, match="empty dataset"):
+        dataset[-1]
+
+
+def test_mapping_dataset_seed_controls_overlength_order_without_global_rng_side_effect():
+    first = MappingDataset(list(range(8)), seed=3)
+    second = MappingDataset(list(range(8)), seed=4)
+    assert _read_cycle(first, 1) != _read_cycle(second, 1)
+
+    random.seed(123)
+    expected = random.random()
+    random.seed(123)
+    first[len(first)]
+    assert random.random() == expected
+
+
+def test_overlength_read_does_not_change_first_cycle_order():
+    dataset = MappingDataset(list(range(8)), seed=3)
+    dataset[len(dataset)]
+    assert _read_cycle(dataset, 0) == list(range(8))
+
+
+def test_interleaved_mapping_dataset_uses_same_deterministic_mapping():
+    data = [{"value": index, "ds_idx": index % 2} for index in range(8)]
+
+    first = InterleavedMappingDataset(data, seed=7)
+    second = InterleavedMappingDataset(data, seed=7)
+
+    assert _read_cycle(first, 1) == _read_cycle(second, 1)

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -57,34 +57,36 @@ class MappingDataset(Dataset):
 
     The first pass keeps source order. Each later cycle uses ``seed + cycle``
     without changing global RNG state, so the mapping is independent of access
-    order and worker-local dataset state.
+    order and worker-local dataset state. Only the most recently used later
+    cycle is cached to bound per-worker memory; non-monotonic reads remain
+    correct but may rebuild a cycle permutation.
     """
 
     def __init__(self, data: "Dataset", transform: Optional[Callable] = None, seed: int = 42):
         self._data = data
         self._transform = transform
         self.seed = seed
-        self.indices = list(range(len(self._data)))
-        self.data_len = len(self.indices)
-        self._current_cycle = 0
-        self._cycle_indices = self.indices
+        self.data_len = len(self._data)
+        self._current_cycle: Optional[int] = None
+        self._cycle_indices: Optional[List[int]] = None
 
     def __len__(self) -> int:
         return self.data_len
 
     def _get_mapped_index(self, index: int) -> int:
-        if not self.indices:
+        if self.data_len == 0:
             raise IndexError("Cannot index an empty dataset")
-        if index < -len(self.indices):
-            raise IndexError(f"Index {index} out of range for dataset of length {len(self.indices)}")
-        if index < len(self.indices):
-            return self.indices[index]
+        if index < -self.data_len:
+            raise IndexError(f"Index {index} out of range for dataset of length {self.data_len}")
+        if index < 0:
+            return self.data_len + index
+        if index < self.data_len:
+            return index
 
-        cycle, index = divmod(index, len(self.indices))
-        if cycle == self._current_cycle:
-            cycle_indices = self._cycle_indices
-        else:
-            cycle_indices = self.indices.copy()
+        cycle, index = divmod(index, self.data_len)
+        cycle_indices = self._cycle_indices
+        if cycle != self._current_cycle or cycle_indices is None:
+            cycle_indices = list(range(self.data_len))
             random.Random(self.seed + cycle).shuffle(cycle_indices)
             self._current_cycle = cycle
             self._cycle_indices = cycle_indices
@@ -143,9 +145,6 @@ class InterleavedIterableDataset(IterativeDataset):
 
 
 class InterleavedMappingDataset(MappingDataset):
-    def __init__(self, data: "Dataset", transform: Optional[Callable] = None, seed: int = 42):
-        super().__init__(data, transform, seed)
-
     def __getitem__(self, index: int) -> List[Dict[str, "torch.Tensor"]]:
         mapped_idx = self._get_mapped_index(index)
         if self._transform is not None:

--- a/veomni/data/dataset.py
+++ b/veomni/data/dataset.py
@@ -53,20 +53,45 @@ def build_dataset(dataset_name: str, **kwargs) -> "Dataset":
 
 
 class MappingDataset(Dataset):
-    def __init__(self, data: "Dataset", transform: Optional[Callable] = None):
+    """Map every global index to a reproducible sample.
+
+    The first pass keeps source order. Each later cycle uses ``seed + cycle``
+    without changing global RNG state, so the mapping is independent of access
+    order and worker-local dataset state.
+    """
+
+    def __init__(self, data: "Dataset", transform: Optional[Callable] = None, seed: int = 42):
         self._data = data
         self._transform = transform
+        self.seed = seed
         self.indices = list(range(len(self._data)))
         self.data_len = len(self.indices)
+        self._current_cycle = 0
+        self._cycle_indices = self.indices
 
     def __len__(self) -> int:
         return self.data_len
 
+    def _get_mapped_index(self, index: int) -> int:
+        if not self.indices:
+            raise IndexError("Cannot index an empty dataset")
+        if index < -len(self.indices):
+            raise IndexError(f"Index {index} out of range for dataset of length {len(self.indices)}")
+        if index < len(self.indices):
+            return self.indices[index]
+
+        cycle, index = divmod(index, len(self.indices))
+        if cycle == self._current_cycle:
+            cycle_indices = self._cycle_indices
+        else:
+            cycle_indices = self.indices.copy()
+            random.Random(self.seed + cycle).shuffle(cycle_indices)
+            self._current_cycle = cycle
+            self._cycle_indices = cycle_indices
+        return cycle_indices[index]
+
     def __getitem__(self, index: int) -> List[Dict[str, "torch.Tensor"]]:
-        if index >= len(self.indices):
-            random.shuffle(self.indices)
-            index = index % len(self.indices)
-        mapped_idx = self.indices[index]
+        mapped_idx = self._get_mapped_index(index)
         if self._transform is not None:
             return self._transform(self._data[mapped_idx])
         else:
@@ -118,14 +143,11 @@ class InterleavedIterableDataset(IterativeDataset):
 
 
 class InterleavedMappingDataset(MappingDataset):
-    def __init__(self, data: "Dataset", transform: Optional[Callable] = None):
-        super().__init__(data, transform)
+    def __init__(self, data: "Dataset", transform: Optional[Callable] = None, seed: int = 42):
+        super().__init__(data, transform, seed)
 
     def __getitem__(self, index: int) -> List[Dict[str, "torch.Tensor"]]:
-        if index >= len(self.indices):
-            random.shuffle(self.indices)
-            index = index % len(self.indices)
-        mapped_idx = self.indices[index]
+        mapped_idx = self._get_mapped_index(index)
         if self._transform is not None:
             sample = self._data[mapped_idx]
             ds_idx = sample["ds_idx"]
@@ -1430,6 +1452,7 @@ def build_mapping_dataset(
     train_path: str,
     transform: Optional[Callable] = None,
     namespace: Literal["train", "test"] = "train",
+    seed: int = 42,
     source_name: Optional[str] = None,
     **kwargs,
 ) -> "Dataset":
@@ -1439,6 +1462,7 @@ def build_mapping_dataset(
         train_path (str): data path
         transform (Optional[Callable]): transform function
         namespace (Literal["train", "test"]): dataset namespace
+        seed (int): random seed
         source_name (Optional[str]): source name
     Returns:
         Dataset: mapping dataset
@@ -1450,7 +1474,7 @@ def build_mapping_dataset(
 
     if transform:
         transform = partial(transform, source_name=source_name)
-    return MappingDataset(data=dataset, transform=transform)
+    return MappingDataset(data=dataset, transform=transform, seed=seed)
 
 
 @DATASET_REGISTRY.register("iterable")
@@ -1561,6 +1585,7 @@ def build_interleave_dataset(
         interleave_dataset = InterleavedMappingDataset(
             interleave_datasets(datasets=datasets, probabilities=weights, seed=seed),
             transform=transform,
+            seed=seed,
         )
     else:
         raise ValueError(f"Unsupported datasets_type: {datasets_type}")


### PR DESCRIPTION
### What does this PR do?

Fixes #630 by replacing process-global in-place shuffling in `MappingDataset` with a reproducible global-index mapping.

The first dataset cycle preserves source order. Each later cycle uses a local RNG seeded by `seed + cycle`, so the selected sample depends only on the global index and seed, not on worker access order, prior reads, or global RNG state. `InterleavedMappingDataset` uses the same mapping.

### Checklist Before Starting

- Search for relative PRs/issues and link here: #630; no matching open PR was returned for #630 or deterministic `MappingDataset` before publication.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

```text
python -m pytest -q tests/data/test_mapping_dataset.py
9 passed

python -m pytest -q tests/data/test_dataloader.py \
  -k 'test_build_dataloader_dyn_bsz_sp_filling and mapping'
8 passed, 14 deselected, 16 warnings
```

The warnings are existing torchdata pin-memory warnings in the CPU test environment.

```text
make quality
All checks passed!
627 files already formatted
```

An independent two-pass review was completed after the final task-code change; it found no remaining correctness or integration blocker.

### API and Usage Example

`build_mapping_dataset` and `InterleavedMappingDataset` accept an optional `seed` (default `42`). Existing callers retain the default behavior contract and the trainer already forwards `args.train.seed`.

```python
dataset = MappingDataset(data, transform=transform, seed=42)
```

### Design & Code Changes

- derive overflow-cycle permutations from a local `random.Random(seed + cycle)` instance;
- retain only the most recently used overflow-cycle permutation and allocate it lazily, avoiding a persistent identity index list per DataLoader worker;
- preserve Python negative-index behavior and raise `IndexError` for empty datasets;
- keep cycle-zero ordering stable after overflow reads and ensure every later cycle is a full permutation;
- inherit the `MappingDataset` constructor directly in `InterleavedMappingDataset`;
- test deterministic access order, restart, seed forwarding through the registered builder, global-RNG isolation, empty input, negative indexing, and interleaved datasets.

### Checklist Before Submitting

- Read the Contribute Guide.
- Applied quality checks.
- API documentation is included in the builder docstring; no user workflow changes.
- Added tests under `tests/data`, which is already included by the GPU unit-test workflow.
