### PR TITLE
[misc] chore: widen the uv required-version ceiling to <0.13

### DIFF
--- a/.agents/knowledge/uv.md
+++ b/.agents/knowledge/uv.md
@@ -4,7 +4,7 @@ VeOmni uses [uv](https://docs.astral.sh/uv/) for dependency management. This doc
 
 ## uv Version
 
-`pyproject.toml` declares a **range** (`>=0.9.8,<0.12`); the Dockerfiles and
+`pyproject.toml` declares a **range** (`>=0.9.8,<0.13`); the Dockerfiles and
 CI install a concrete pin and use `--locked` / `--frozen` for reproducibility.
 **Every concrete uv pin must stay inside the pyproject range.**
 

--- a/.github/workflows/check_patchgen.yml
+++ b/.github/workflows/check_patchgen.yml
@@ -35,7 +35,7 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           # Pin a concrete uv inside the pyproject required-version range
-          # (>=0.9.8,<0.12). This job runs on ubuntu-latest (not a prebuilt
+          # (>=0.9.8,<0.13). This job runs on ubuntu-latest (not a prebuilt
           # image), so without a pin setup-uv floats to the newest uv and would
           # fail the required-version check the moment uv ships a release above
           # the range ceiling. Keep this in sync with the docker/ uv pin.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ transformers-stable = [
 # is preserved because docker/CI install a concrete pin and use --locked /
 # --frozen. Concrete pins (docker/, .github/workflows/check_patchgen.yml)
 # must stay inside this range.
-required-version = ">=0.9.8,<0.12"
+required-version = ">=0.9.8,<0.13"
 
 default-groups = ["transformers-stable"]
 


### PR DESCRIPTION
Pinning the ceiling at <0.12 forces devboxes that already run it into a `uv self update` downgrade for no reproducibility gain — docker/ and CI install a concrete uv pin and use --locked / --frozen, which is what actually guarantees reproducibility.

The lower bound stays at 0.9.8: consumers bump the image's uv before the floor moves, otherwise every worker start triggers a `uv self update` that has to reach github.com. All concrete pins (docker/cuda/Dockerfile.cu130, docker/ascend/Dockerfile.*, docker/matrix.yaml, check_patchgen.yml) are 0.11.16 and stay inside the widened range, so none of them need to move.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
