### PR TITLE
[ci] feat: add CodeRabbit review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,11 +1,10 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 tone_instructions: >
-  You are reviewing VeOmni, a PyTorch-native distributed training framework
-  for multimodal models (text, vision, audio, diffusion, omni) on GPU and NPU.
-  Prefer correctness, distributed safety, and hard-constraint violations over
-  style nits. Ruff already enforces formatting; do not request style-only
-  changes. Write all review comments in English.
+  Review VeOmni, a PyTorch-native distributed trainer for multimodal models
+  on GPU and NPU. Prioritize correctness, distributed safety, and
+  hard-constraint violations over style nits; ruff already enforces
+  formatting. Write all comments in English.
 reviews:
   profile: "chill"
   request_changes_workflow: false
@@ -17,11 +16,12 @@ reviews:
     enabled: true
     drafts: false
     base_branches:
-      - "main"
-      - "master"
+      - ".*"
   path_filters:
     - "!**/*.diff"
     - "!docs/assets/**"
+    - "!veomni/models/transformers/**/generated/**"
+    - "!uv.lock"
   path_instructions:
     - path: "veomni/distributed/**"
       instructions: |
@@ -66,7 +66,7 @@ knowledge_base:
       - files: "AGENTS.md"
         applyTo: "**/*"
       - files: ".agents/knowledge/constraints.md"
-        applyTo: "veomni/**/*.{py,yaml,yml}"
+        applyTo: "veomni/**/*.py,veomni/**/*.yaml,veomni/**/*.yml"
       - files: "CONTRIBUTING.md"
         applyTo: "**/*"
 chat:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+tone_instructions: >
+  You are reviewing VeOmni, a PyTorch-native distributed training framework
+  for multimodal models (text, vision, audio, diffusion, omni) on GPU and NPU.
+  Prefer correctness, distributed safety, and hard-constraint violations over
+  style nits. Ruff already enforces formatting; do not request style-only
+  changes. Write all review comments in English.
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  collapse_walkthrough: true
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "main"
+      - "master"
+  path_filters:
+    - "!**/*.diff"
+    - "!docs/assets/**"
+  path_instructions:
+    - path: "veomni/distributed/**"
+      instructions: |
+        Focus on distributed correctness.
+        - VeOmni uses FSDP2 only. FSDP1 has been removed.
+        - Collectives and DCP checkpoint save/load must include every rank. Rank-0-only collective calls deadlock.
+        - Sequence parallel uses all-to-all head/sequence exchange, not all-gather.
+        - SP collation order is load-bearing: pad, slice batch tensors, compute FlashAttention kwargs on full position_ids, then slice position_ids last.
+        - Device-agnostic code must use veomni.utils.device helpers, not raw torch.cuda calls.
+        Flag tensor-shape mismatches, missing rank participation, and ambient ParallelState misuse.
+    - path: "veomni/data/**"
+      instructions: |
+        Focus on data-pipeline contracts.
+        - position_ids == 0 marks FlashAttention varlen segment boundaries and must exist before model forward.
+        - IGNORE_INDEX is -100 and must be preserved for loss masking, including packed-sample boundaries.
+        - Dynamic batching token counting must match dyn_bsz_count_mode.
+        - Multimodal placeholder IDs and masks must stay consistent with TYPE2INDEX.
+    - path: "veomni/models/**"
+      instructions: |
+        Focus on model loading and patchgen.
+        - Do not request edits under veomni/models/transformers/*/generated/. Change patch_spec.py or modeling_*_patch.py instead.
+        - Model registration must happen at import time.
+        - config model_type must match the registry key.
+        - New modeling must target transformers 5.9.0 and FSDP2.
+        - NPU-only imports must be guarded with is_torch_npu_available() or IS_NPU_AVAILABLE.
+    - path: "veomni/checkpoint/**"
+      instructions: |
+        Focus on DCP safety: all ranks must participate, checkpoint keys must match the model state dict, and integer or boolean buffers must not be treated as floating tensors during consolidation.
+    - path: "veomni/trainer/**"
+      instructions: |
+        Trainer callback or forward_backward_step changes must also cover composed trainers such as TextDPOTrainer and DiTTrainer. Do not assume every trainer inherits BaseTrainer.forward_backward_step.
+    - path: "tests/**"
+      instructions: |
+        Prefer tests that catch rank, shape, device, and packing bugs. Flag tests that mock away the behavior under test, or that only run on one hardware path when the change is device-sensitive.
+    - path: "docs/**"
+      instructions: |
+        Check that examples still match current APIs, config fields, and tasks/ script paths. Flag stale trainer or parallelism guidance.
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - files: "AGENTS.md"
+        applyTo: "**/*"
+      - files: ".agents/knowledge/constraints.md"
+        applyTo: "veomni/**/*.{py,yaml,yml}"
+      - files: "CONTRIBUTING.md"
+        applyTo: "**/*"
+chat:
+  auto_reply: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Title: `[{modules}] {type}: {description}`
 
 - Allowed modules and types are defined in `.github/workflows/check_pr_title.yml` (the CI source of truth).
 - Breaking: prepend `[BREAKING]`
+- GitHub PRs are also reviewed by CodeRabbit (`.coderabbit.yaml`). On an existing PR, comment `@coderabbitai review` or `@coderabbitai full review`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,4 +43,16 @@ git rebase origin/master
 git push -u origin dev_your_branch
 ```
 
-6. Create a merge request from your branch `dev_your_branch`
+6. Create a pull request from your branch `dev_your_branch`
+
+## Code review
+
+GitHub pull requests are reviewed automatically by [CodeRabbit](https://docs.coderabbit.ai) once the `coderabbitai` GitHub App is installed on the repository.
+
+- New PRs receive a walkthrough and inline comments within a few minutes.
+- Already-open PRs: comment `@coderabbitai full review`.
+- Review only new commits: `@coderabbitai review`.
+- Skip one PR: add `@coderabbitai ignore` to the description.
+- Command list: `@coderabbitai help`.
+
+Review behavior is configured in `.coderabbit.yaml`.


### PR DESCRIPTION
### What does this PR do?

> Wire up the already-installed `coderabbitai` GitHub App with a VeOmni-specific `.coderabbit.yaml`, so new PRs get automated walkthroughs and inline reviews that follow project constraints.

### Checklist Before Starting

- Search for relative PRs/issues and link here: no existing CodeRabbit config or related issue; the GitHub App is installed but has not commented on any PR yet.
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))

### Test

> Config-only change. After merge (or on this PR if the App is already enabled), CodeRabbit should post a walkthrough. Existing PRs still need `@coderabbitai full review`.

### API and Usage Example

> On a pull request comment:
>
> ```text
> @coderabbitai review
> @coderabbitai full review
> @coderabbitai help
> ```
>
> Skip one PR by adding `@coderabbitai ignore` to the description.

### Design & Code Changes

> - Add `.coderabbit.yaml` with chill auto-review, generated-diff path filters, and path instructions for distributed / data / model / checkpoint / trainer / tests / docs.
> - Point CodeRabbit knowledge base at `AGENTS.md`, `.agents/knowledge/constraints.md`, and `CONTRIBUTING.md`.
> - Document commands in `CONTRIBUTING.md` and `AGENTS.md`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (YAML/Markdown only; no Python surface)
- [x] Added/updated documentation
- [x] If `tasks/` training scripts were moved or renamed: N/A
- [x] Added tests to CI workflow (or explained why not feasible): CodeRabbit is a GitHub App, not a CI job
