### PR TITLE
[model] fix: use non-causal attention in flux modeling

### DIFF
--- a/tests/models/test_flux_non_causal.py
+++ b/tests/models/test_flux_non_causal.py
@@ -1,0 +1,63 @@
+import torch
+
+from veomni.models.transformers.flux.modeling_flux import (
+    FluxJointAttention,
+    FluxSingleTransformerBlock,
+)
+
+
+def _rotary_embedding(seq_len, head_dim):
+    # Per-position 2x2 rotation blocks with shape (1, 1, seq_len, head_dim // 2, 2, 2).
+    # RoPE is a fixed rotation applied identically to q and k, so its exact values do not
+    # affect the causal/non-causal distinction this test checks.
+    pos = torch.arange(seq_len, dtype=torch.float32)
+    half = torch.arange(head_dim // 2, dtype=torch.float32)
+    ang = torch.outer(pos, half)
+    cos, sin = torch.cos(ang), torch.sin(ang)
+    return torch.stack([cos, -sin, sin, cos], dim=-1).reshape(1, 1, seq_len, head_dim // 2, 2, 2)
+
+
+def test_flux_joint_attention_is_non_causal():
+    torch.manual_seed(0)
+    dim, num_heads, head_dim = 32, 4, 8
+    block = FluxJointAttention(dim, dim, num_heads, head_dim).eval()
+
+    seq_text, seq_img = 1, 2
+    text = torch.randn(1, seq_text, dim)  # text tokens come first in the sequence
+    image = torch.randn(1, seq_img, dim)  # image tokens come after
+    rotary = _rotary_embedding(seq_text + seq_img, head_dim)
+
+    def run(image):
+        with torch.no_grad():
+            _, out_b = block(image, text, rotary)
+        return out_b
+
+    out_b0 = run(image)
+    image_perturbed = image.clone()
+    image_perturbed[0, -1] += 1.0  # perturb a later (image) token
+    out_b1 = run(image_perturbed)
+
+    # The leading text token must be influenced by a later image token under
+    # bidirectional attention; under causal attention it would be unchanged.
+    assert not torch.allclose(out_b0[0, 0], out_b1[0, 0], atol=1e-5)
+
+
+def test_flux_single_transformer_block_is_non_causal():
+    torch.manual_seed(0)
+    dim, num_heads = 32, 4
+    head_dim = dim // num_heads
+    block = FluxSingleTransformerBlock(dim, num_heads).eval()
+
+    seq = 3
+    hidden_states = torch.randn(1, seq, 3 * num_heads * head_dim)
+    rotary = _rotary_embedding(seq, head_dim)
+
+    with torch.no_grad():
+        out0 = block.process_attention(hidden_states, rotary)
+
+    hidden_states_perturbed = hidden_states.clone()
+    hidden_states_perturbed[0, -1] += 1.0
+    with torch.no_grad():
+        out1 = block.process_attention(hidden_states_perturbed, rotary)
+
+    assert not torch.allclose(out0[0, 0], out1[0, 0], atol=1e-5)

--- a/veomni/models/transformers/flux/modeling_flux.py
+++ b/veomni/models/transformers/flux/modeling_flux.py
@@ -235,7 +235,7 @@ class FluxJointAttention(torch.nn.Module):
         k = torch.concat([k_b, k_a], dim=2)
         v = torch.concat([v_b, v_a], dim=2)
         q, k = self.apply_rope(q, k, image_rotary_emb)
-        hidden_states = flash_attention(q, k, v, causal=True, attn_mask=attn_mask)
+        hidden_states = flash_attention(q, k, v, causal=False, attn_mask=attn_mask)
 
         if get_parallel_state().ulysses_enabled:
             hidden_states = gather_heads_scatter_seq(hidden_states, seq_dim=2, head_dim=1)
@@ -385,7 +385,7 @@ class FluxSingleTransformerBlock(torch.nn.Module):
 
         q, k = self.apply_rope(q, k, image_rotary_emb)
 
-        hidden_states = flash_attention(q, k, v, causal=True, attn_mask=attn_mask)
+        hidden_states = flash_attention(q, k, v, causal=False, attn_mask=attn_mask)
 
         if get_parallel_state().ulysses_enabled:
             hidden_states = gather_heads_scatter_seq(hidden_states, seq_dim=2, head_dim=1)


### PR DESCRIPTION
## Summary

Fix the attention mode in the FLUX model from causal to non-causal, matching how a diffusion transformer (DiT) should attend.

## Problem

`flash_attention` is invoked with `causal=True` at two call sites in `veomni/models/transformers/flux/modeling_flux.py`:

- `FluxJointAttention.forward` (line 238)
- `FluxSingleTransformerBlock.process_attention` (line 388)

FLUX is a DiT: attention must be full/bidirectional, not causal. With `causal=True`, each token only attends to preceding tokens, silently degrading the global context. This is the issue reported in #74, which a maintainer acknowledged but that has not been fixed since.

There is also a backend inconsistency: on flash-attention (GPU), `causal` is applied; on the CPU fallback (`F.scaled_dot_product_attention`), `causal` is ignored and only `attn_mask` is applied.

## Fix

Change `causal=True` to `causal=False` at both call sites so the flash-attention path (full attention) is consistent with the CPU fallback path.

## Verification

- `ruff check` / `ruff format --check` pass.
- Verified numerically that `causal=True` and `causal=False` produce different attention outputs, and that non-causal attention allows every token to attend to the full sequence (expected for a DiT).
- Added a regression test (`tests/models/test_flux_non_causal.py`) asserting that a leading text token's output changes when a later image token is perturbed (i.e. bidirectional attention), covering both `FluxJointAttention` and `FluxSingleTransformerBlock`.

Fixes #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Flux attention processing to use non-causal behavior, allowing information to flow correctly across input tokens.
  * May improve output quality and consistency for Flux-based model operations.

* **Tests**
  * Added regression coverage confirming non-causal behavior across Flux attention and transformer components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
