### PR TITLE
[model] fix: apply attention mask in flux flash-attention path

### DIFF
--- a/veomni/models/transformers/flux/modeling_flux.py
+++ b/veomni/models/transformers/flux/modeling_flux.py
@@ -84,19 +84,19 @@ def flash_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, causal: b
     # bs, head_cont, seq, head_dim = q.shape
 
     if attn_mask is not None:
-        # flash_attn_func (FA2/FA3) does not accept an arbitrary attention mask. The
-        # mask is a (b, 1, s, s) additive bias (0 / -inf) built by `construct_mask`, so
-        # fall back to scaled_dot_product_attention, which supports it and still
-        # dispatches to an efficient fused backend. The flash-attn path below is for the
+        # flash_attn_func (FA2/FA3) does not accept an arbitrary attention mask, so fall
+        # back to scaled_dot_product_attention, which supports an additive mask. Note that
+        # supplying a mask rules out SDPA's flash backend, so this uses the memory-efficient
+        # kernel (or the math fallback) instead. The flash-attn path below is for the
         # mask-less case only.
         if causal:
-            # scaled_dot_product_attention cannot take both `attn_mask` and `is_causal`,
-            # so merge a lower-triangular causal bias into the additive mask to preserve
-            # the caller's causal intent.
-            seq = q.shape[-2]
-            causal_bias = torch.triu(
-                torch.full((seq, seq), float("-inf"), dtype=q.dtype, device=q.device), diagonal=1
-            )
+            # scaled_dot_product_attention cannot take both `attn_mask` and `is_causal`, so
+            # merge a lower-triangular causal bias into the additive mask to preserve the
+            # caller's causal intent. No in-tree caller passes a mask with causal=True; this
+            # is defensive for future callers.
+            if attn_mask.dtype == torch.bool:
+                attn_mask = torch.zeros_like(attn_mask, dtype=q.dtype).masked_fill_(~attn_mask, float("-inf"))
+            causal_bias = torch.triu(torch.full_like(attn_mask, float("-inf")), diagonal=1)
             attn_mask = attn_mask + causal_bias
         return F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
 

--- a/veomni/models/transformers/flux/modeling_flux.py
+++ b/veomni/models/transformers/flux/modeling_flux.py
@@ -83,6 +83,14 @@ def rearrange_qkv(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, rerange_typ
 def flash_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, causal: bool = False, attn_mask=None):
     # bs, head_cont, seq, head_dim = q.shape
 
+    if attn_mask is not None:
+        # flash_attn_func (FA2/FA3) does not accept an arbitrary attention mask. The
+        # mask is a (b, 1, s, s) additive bias (0 / -inf) built by `construct_mask`, so
+        # fall back to scaled_dot_product_attention, which supports it and still
+        # dispatches to an efficient fused backend. The flash-attn path below is for the
+        # mask-less case only.
+        return F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
+
     if FLASH_ATTN_3_AVAILABLE or FLASH_ATTN_2_AVAILABLE:
         rerange_type_seq_head = "b n s d -> b s n d"
         rerange_type_head_seq = "b s n d -> b n s d"

--- a/veomni/models/transformers/flux/modeling_flux.py
+++ b/veomni/models/transformers/flux/modeling_flux.py
@@ -89,6 +89,15 @@ def flash_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, causal: b
         # fall back to scaled_dot_product_attention, which supports it and still
         # dispatches to an efficient fused backend. The flash-attn path below is for the
         # mask-less case only.
+        if causal:
+            # scaled_dot_product_attention cannot take both `attn_mask` and `is_causal`,
+            # so merge a lower-triangular causal bias into the additive mask to preserve
+            # the caller's causal intent.
+            seq = q.shape[-2]
+            causal_bias = torch.triu(
+                torch.full((seq, seq), float("-inf"), dtype=q.dtype, device=q.device), diagonal=1
+            )
+            attn_mask = attn_mask + causal_bias
         return F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
 
     if FLASH_ATTN_3_AVAILABLE or FLASH_ATTN_2_AVAILABLE:


### PR DESCRIPTION
## Summary

Fix `flash_attention` dropping the attention mask on the flash-attention (GPU) path, so masked attention behaves consistently across backends.

## Problem

`flash_attention` applies `attn_mask` only in the CPU fallback branch (`F.scaled_dot_product_attention`). The flash-attention branches (FA2/FA3) call `flash_attn_func(q, k, v, causal=causal)` without passing the mask, so when the model uses `entity_masks` (the text-image conditioning mask built by `construct_mask`), the mask is silently ignored on GPU.

This makes GPU and CPU produce different attention behavior for the same masked inputs.

## Fix

When `attn_mask` is not `None`, fall back to `scaled_dot_product_attention`, which supports an arbitrary additive mask (note: supplying a mask rules out SDPA's flash backend, so this uses the memory-efficient kernel). The flash-attention fast path remains for the mask-less case.

The mask is a `(b, 1, s, s)` additive bias (`0` / `-inf`) built by `construct_mask`, which `scaled_dot_product_attention` accepts directly. When `causal=True`, a lower-triangular causal bias is merged into the additive mask first, since `scaled_dot_product_attention` cannot take both `attn_mask` and `is_causal` — this preserves the caller's causal intent instead of silently dropping it. A boolean mask is normalised to the additive `0`/`-inf` form first, since `bool + float` would otherwise promote to `float32` and corrupt the mask.

## Verification

- `ruff check` and `ruff format --check` pass.
- Verified numerically that a `(b, 1, s, s)` `0` / `-inf` mask is applied correctly: masked positions receive zero attention weight, and the result matches a manual `softmax(scores + mask) @ v` reference.
- Verified `causal=True` + float mask matches `softmax(scores + mask + causal_bias) @ v`, and `causal=True` + bool mask matches the same after normalisation (max abs diff ~1e-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention handling when masks are supplied.
  * Added reliable causal masking support for boolean and additive masks.
  * Preserved existing optimized attention behavior for inputs without masks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->