### PR TITLE
[misc] fix: install flash-qla from its PyPI release instead of a git rev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,14 +58,17 @@ gpu = [
   "nvidia-cudnn-frontend>=1.24.0",
   "cuda-python==13.0.3",
   # See `[tool.uv.sources]` — FA2 is x86_64-only; FA3 and FlashMLA support
-  # x86_64/aarch64. flash-qla source-builds from git.
+  # x86_64/aarch64.
   "flash-attn; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "flash-attn-3; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'x86_64')",
   "flash-mla; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'x86_64')",
   # 4.0.0b16 is available from PyPI; newer fa4-v4.0.0.beta17 is tag-only
   # and not yet published as a package release.
   "flash-attn-4==4.0.0b16",
-  "flash-qla",
+  # PyPI release rather than a git rev: 0.1.2 is a pure-Python wheel whose static
+  # metadata (tilelang==0.1.9, apache-tvm-ffi==0.1.9) already matches the pins
+  # below, so it needs no source build and no dependency-metadata override.
+  "flash-qla==0.1.2",
   "liger-kernel",
   "flash-linear-attention",
   "quack-kernels[cu13]==0.5.0",
@@ -190,8 +193,8 @@ override-dependencies = [
     "torchaudio==2.10.0+cpu; (extra == 'npu')",
     "torchvision==0.25.0+cpu; (extra == 'npu')",
     "torchcodec==0.10.0; (extra == 'npu')",
-    # FlashQLA's setup metadata pins TileLang 0.1.8, while TileKernels 1.0.0
-    # requires >=0.1.9. Both backends are validated against this shared pin.
+    # TileKernels 1.0.0 requires TileLang >=0.1.9; FlashQLA 0.1.2 pins ==0.1.9.
+    # Kept as an explicit floor so both backends stay on the validated version.
     "tilelang==0.1.9; (extra == 'gpu')",
 ]
 
@@ -257,10 +260,6 @@ flash-mla = [
   { url = "https://github.com/Luosuu/flash-mla-wheels/releases/download/v1.0.0-9241ae3-torch211cu130/flash_mla-1.0.0%2B9241ae3-1torch211cu130cuda131sm90asm100f-cp311-cp311-linux_x86_64.whl", marker = "extra == 'gpu' and sys_platform == 'linux' and python_version == '3.11' and platform_machine == 'x86_64'" },
   { url = "https://github.com/Luosuu/flash-mla-wheels/releases/download/v1.0.0-9241ae3-torch211cu130/flash_mla-1.0.0%2B9241ae3-1torch211cu130cuda131sm90asm100f-cp312-cp312-linux_x86_64.whl", marker = "extra == 'gpu' and sys_platform == 'linux' and python_version == '3.12' and platform_machine == 'x86_64'" },
 ]
-# Strictly newer than v0.1.0 — picks up fixes for backward gradient count (#10),
-# auto_cp UnboundLocalError (#8), and l2norm dtype preservation (#13).
-flash-qla = { git = "https://github.com/QwenLM/FlashQLA", rev = "6ef4858b5446e05bd461d9658d877e548182dbcb" }
-
 # Pinned wheels avoid FFmpeg build dep in CI. x86_64: 3.11 → 14.4.0,
 # 3.12 → 14.2.0. aarch64: 14.2.0 for both (14.4.0 has no aarch64 wheel).
 av = [
@@ -279,21 +278,6 @@ explicit = true
 name = "pytorch-cpu"
 url = "https://download.pytorch.org/whl/cpu/"
 explicit = true
-
-# Static metadata bypasses the build hook during resolution. flash-qla has no
-# pyproject.toml, so without explicit `version` uv runs its setup.py on a
-# fresh (unseeded) venv and crashes with `ModuleNotFoundError: No module
-# named 'setuptools'`. The `requires-dist` mirrors flash-qla's own
-# install_requires — flash_qla/__init__.py top-level imports tilelang
-# (which itself transitively requires apache-tvm-ffi), so any code that
-# imports flash_qla (including VeOmni's lazy factory in
-# veomni/ops/kernels/gated_delta_rule) needs them present, not just users
-# who opt into the kernel at runtime.
-# Version: flash_qla setup.py = "0.1.0".
-[[tool.uv.dependency-metadata]]
-name = "flash-qla"
-version = "0.1.0"
-requires-dist = ["torch", "tilelang==0.1.8", "apache-tvm-ffi==0.1.9"]
 
 # The Magi packages below intentionally use empty static runtime metadata.
 # Their companion extensions declare no runtime requirements upstream, while
@@ -328,7 +312,6 @@ requires-dist = []
 create-block-mask-cuda = ["setuptools", "wheel", "packaging", "ninja", { requirement = "torch", match-runtime = true }]
 flash-attn-4 = ["setuptools", "wheel", "packaging", "ninja", "torch"]
 flash-attn-cute = ["setuptools", "wheel"]
-flash-qla = ["setuptools", "wheel", "packaging", "ninja", "torch"]
 magi-attention = ["setuptools>=78.1.1", "wheel", "packaging>=24.2", "ninja", "torch", "versioningit"]
 magi-to-hstu-cuda = ["setuptools", "wheel", "packaging", "ninja", { requirement = "torch", match-runtime = true }]
 

--- a/uv.lock
+++ b/uv.lock
@@ -76,11 +76,6 @@ name = "flash-attn-cute"
 version = "0.0.2"
 
 [[manifest.dependency-metadata]]
-name = "flash-qla"
-version = "0.1.0"
-requires-dist = ["torch", "tilelang==0.1.8", "apache-tvm-ffi==0.1.9"]
-
-[[manifest.dependency-metadata]]
 name = "magi-attention"
 version = "1.1.1"
 
@@ -93,12 +88,12 @@ name = "accelerate"
 version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "packaging", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "psutil", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "pyyaml", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "safetensors", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/8e/ac2a9566747a93f8be36ee08532eb0160558b07630a081a6056a9f89bf1d/accelerate-1.12.0.tar.gz", hash = "sha256:70988c352feb481887077d2ab845125024b2a137a5090d6d7a32b57d03a45df6", size = 398399, upload-time = "2025-11-21T11:27:46.973Z" }
 wheels = [
@@ -110,13 +105,13 @@ name = "aiobotocore"
 version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "aioitertools", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "botocore", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "jmespath", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "multidict", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "python-dateutil", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "wrapt", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "aiohttp" },
+    { name = "aioitertools" },
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "multidict" },
+    { name = "python-dateutil" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/f8/99fa90d9c25b78292899fd4946fce97b6353838b5ecc139ad8ba1436e70c/aiobotocore-2.26.0.tar.gz", hash = "sha256:50567feaf8dfe2b653570b4491f5bc8c6e7fb9622479d66442462c021db4fadc", size = 122026, upload-time = "2025-11-28T07:54:59.956Z" }
 wheels = [
@@ -385,9 +380,9 @@ name = "botocore"
 version = "1.41.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jmespath", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "python-dateutil", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "urllib3", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/22/7fe08c726a2e3b11a0aef8bf177e83891c9cb2dc1809d35c9ed91a9e60e6/botocore-1.41.5.tar.gz", hash = "sha256:0367622b811597d183bfcaab4a350f0d3ede712031ce792ef183cabdee80d3bf", size = 14668152, upload-time = "2025-11-26T20:27:38.026Z" }
 wheels = [
@@ -426,7 +421,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "(implementation_name != 'PyPy' and extra == 'extra-6-veomni-gpu') or (implementation_name != 'PyPy' and extra == 'extra-6-veomni-npu') or (implementation_name != 'PyPy' and extra == 'extra-6-veomni-npu-aarch64') or (extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu') or (extra == 'extra-6-veomni-gpu' and extra == 'extra-6-veomni-npu-aarch64') or (extra == 'extra-6-veomni-npu' and extra == 'extra-6-veomni-npu-aarch64')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -648,37 +643,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -746,7 +741,7 @@ name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
@@ -758,15 +753,15 @@ name = "diffusers"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "httpx", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "huggingface-hub", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "importlib-metadata", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "pillow", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "regex", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "requests", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "safetensors", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "filelock" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "importlib-metadata" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/3b/01d0ff800b811c5ad8bba682f4c6abf1d7071cd81464c01724333fefb7ba/diffusers-0.37.0.tar.gz", hash = "sha256:408789af73898585f525afd07ca72b3955affea4216a669558e9f59b5b1fe704", size = 4141136, upload-time = "2026-03-05T14:58:39.704Z" }
 wheels = [
@@ -1010,10 +1005,13 @@ wheels = [
 
 [[package]]
 name = "flash-qla"
-version = "0.1.0"
-source = { git = "https://github.com/QwenLM/FlashQLA?rev=6ef4858b5446e05bd461d9658d877e548182dbcb#6ef4858b5446e05bd461d9658d877e548182dbcb" }
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/a6/07ddef0a8073ee721f3cc67fc0ee0d2bf91bc5637659d9e9ff4d1943249c/flash_qla-0.1.2-py3-none-any.whl", hash = "sha256:fb9dfa8607df9c545cd583dd8c0248ac9b0b673a8fb0af042ba9ef07bbc30446", size = 85860, upload-time = "2026-07-09T07:03:49.343Z" },
 ]
 
 [[package]]
@@ -1103,7 +1101,7 @@ name = "ftfy"
 version = "6.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "wcwidth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927, upload-time = "2024-10-26T00:50:35.149Z" }
 wheels = [
@@ -1264,7 +1262,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1285,7 +1283,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -1315,10 +1313,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "jsonschema-specifications", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "referencing", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "rpds-py", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -1330,7 +1328,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "referencing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -1398,7 +1396,7 @@ name = "lazy-loader"
 version = "0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6b/c875b30a1ba490860c93da4cabf479e03f584eba06fe5963f6f6644653d8/lazy_loader-0.4.tar.gz", hash = "sha256:47c75182589b91a4e1a85a136c074285a5ad4d9f39c63e0d7fb76391c4574cd1", size = 15431, upload-time = "2024-04-05T13:03:12.261Z" }
 wheels = [
@@ -1410,19 +1408,19 @@ name = "librosa"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioread", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "decorator", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "joblib", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "lazy-loader", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "msgpack", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "numba", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "pooch", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "scikit-learn", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "scipy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "soundfile", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "soxr", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "typing-extensions", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "audioread" },
+    { name = "decorator" },
+    { name = "joblib" },
+    { name = "lazy-loader" },
+    { name = "msgpack" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pooch" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "soundfile" },
+    { name = "soxr" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/36/360b5aafa0238e29758729e9486c6ed92a6f37fa403b7875e06c115cdf4a/librosa-0.11.0.tar.gz", hash = "sha256:f5ed951ca189b375bbe2e33b2abd7e040ceeee302b9bbaeeffdfddb8d0ace908", size = 327001, upload-time = "2025-03-11T15:09:54.884Z" }
 wheels = [
@@ -1610,18 +1608,18 @@ name = "megatron-energon"
 version = "7.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "braceexpand", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "click", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "filetype", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "mfusepy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "multi-storage-client", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "pillow", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "pyyaml", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "rapidyaml", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "s3fs", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "tqdm", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "webdataset", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "braceexpand" },
+    { name = "click" },
+    { name = "filetype" },
+    { name = "mfusepy" },
+    { name = "multi-storage-client" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pyyaml" },
+    { name = "rapidyaml" },
+    { name = "s3fs" },
+    { name = "tqdm" },
+    { name = "webdataset" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fb/fb/bcc8a5b457887b1b477789464e8d16468d977deb73a931874e714e7ace6d/megatron_energon-7.3.2.tar.gz", hash = "sha256:24b6605731c374afa3369fae3fa284c8923ee7a11dc2d137d278b98cc1bb4713", size = 206666, upload-time = "2026-02-04T12:41:15.245Z" }
 wheels = [
@@ -1700,19 +1698,19 @@ name = "multi-storage-client"
 version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "jmespath", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "jsonschema", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "lark", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "opentelemetry-api", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "prettytable", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "psutil", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "python-dateutil", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "pyyaml", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "tqdm", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "tzdata", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "wcmatch", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "xattr", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "filelock" },
+    { name = "jmespath" },
+    { name = "jsonschema" },
+    { name = "lark" },
+    { name = "opentelemetry-api" },
+    { name = "prettytable" },
+    { name = "psutil" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "tzdata" },
+    { name = "wcmatch" },
+    { name = "xattr" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/94/cf7facd2f413e4effddd3aeddf99a09d61c2b79208077366fab08c72e05c/multi_storage_client-0.50.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3a4300ae5805a2dc415af938f5aafa7768382b914d9acd08187ad19f440ffba3", size = 10136766, upload-time = "2026-06-05T21:58:57.751Z" },
@@ -1833,8 +1831,8 @@ name = "numba"
 version = "0.62.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "llvmlite", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "llvmlite" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/96/66dae7911cb331e99bf9afe35703317d8da0fad81ff49fed77f4855e4b60/numba-0.62.0.tar.gz", hash = "sha256:2afcc7899dc93fefecbb274a19c592170bc2dbfae02b00f83e305332a9857a5a", size = 2749680, upload-time = "2025-09-18T17:58:11.394Z" }
 wheels = [
@@ -1972,7 +1970,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64') or (python_full_version >= '3.12' and platform_machine == 'x86_64') or (platform_machine != 'aarch64' and platform_machine != 'x86_64') or sys_platform == 'linux'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -1998,7 +1996,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64') or (python_full_version >= '3.12' and platform_machine == 'x86_64') or (platform_machine != 'aarch64' and platform_machine != 'x86_64') or sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2062,9 +2060,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64') or (python_full_version >= '3.12' and platform_machine == 'x86_64') or (platform_machine != 'aarch64' and platform_machine != 'x86_64') or sys_platform == 'linux'" },
-    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64') or (python_full_version >= '3.12' and platform_machine == 'x86_64') or (platform_machine != 'aarch64' and platform_machine != 'x86_64') or sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64') or (python_full_version >= '3.12' and platform_machine == 'x86_64') or (platform_machine != 'aarch64' and platform_machine != 'x86_64') or sys_platform == 'linux'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2092,7 +2090,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and platform_machine == 'aarch64') or (python_full_version >= '3.12' and platform_machine == 'x86_64') or (platform_machine != 'aarch64' and platform_machine != 'x86_64') or sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2263,7 +2261,7 @@ name = "opentelemetry-api"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
 wheels = [
@@ -2328,15 +2326,15 @@ name = "peft"
 version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "accelerate", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "huggingface-hub", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "packaging", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "psutil", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "pyyaml", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "safetensors", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "tqdm", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "transformers", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "tqdm" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/48/147b3ea999560b40a34fd78724c7777aa9d18409c2250bdcaf9c4f2db7fc/peft-0.18.1.tar.gz", hash = "sha256:2dd0d6bfce936d1850e48aaddbd250941c5c02fc8ef3237cd8fd5aac35e0bae2", size = 635030, upload-time = "2026-01-09T13:08:01.136Z" }
 wheels = [
@@ -2403,9 +2401,9 @@ name = "pooch"
 version = "1.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "platformdirs", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "requests", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c6/77/b3d3e00c696c16cf99af81ef7b1f5fe73bd2a307abca41bd7605429fe6e5/pooch-1.8.2.tar.gz", hash = "sha256:76561f0de68a01da4df6af38e9955c4c9d1a5c90da73f7e40276a5728ec83d10", size = 59353, upload-time = "2024-06-06T16:53:46.224Z" }
 wheels = [
@@ -2433,7 +2431,7 @@ name = "prettytable"
 version = "3.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "wcwidth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
@@ -2731,7 +2729,7 @@ name = "rapidyaml"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "deprecation" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/03/23/c74d6f060a7583a187787ca9c0d7273ddb7c2351ab835635eac1997d9848/rapidyaml-0.15.0.tar.gz", hash = "sha256:5800735cbcc30231ddb0de2c4fa48db7e946cdbbfcff340b04490bfef67a32f4", size = 495270, upload-time = "2026-06-08T13:02:39.928Z" }
 wheels = [
@@ -2760,9 +2758,9 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "rpds-py", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "typing-extensions", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -2918,9 +2916,9 @@ name = "s3fs"
 version = "2024.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiobotocore", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "aiohttp", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "fsspec", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "aiobotocore" },
+    { name = "aiohttp" },
+    { name = "fsspec" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/4e/9e32f7e5c37f42ff1b14b40eae260303a20f5bb4b518ec1bc9787bc6aa23/s3fs-2024.6.1.tar.gz", hash = "sha256:6c2106d6c34fbfbb88e3d20c6f3572896d5ee3d3512896696301c21a3c541bea", size = 74958, upload-time = "2024-06-27T14:45:45.118Z" }
 wheels = [
@@ -2954,10 +2952,10 @@ name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "joblib", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "scipy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "threadpoolctl", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -2978,7 +2976,7 @@ name = "scipy"
 version = "1.16.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4c/3b/546a6f0bfe791bbb7f8d591613454d15097e53f906308ec6f7c1ce588e8e/scipy-1.16.2.tar.gz", hash = "sha256:af029b153d243a80afb6eabe40b0a07f8e35c9adc269c019f364ad747f826a6b", size = 30580599, upload-time = "2025-09-11T17:48:08.271Z" }
 wheels = [
@@ -3058,8 +3056,8 @@ name = "soundfile"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "cffi" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/41/9b873a8c055582859b239be17902a85339bec6a30ad162f98c9b0288a2cc/soundfile-0.13.1.tar.gz", hash = "sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b", size = 46156, upload-time = "2025-01-25T09:17:04.831Z" }
 wheels = [
@@ -3077,7 +3075,7 @@ name = "soxr"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/7e/f4b461944662ad75036df65277d6130f9411002bfb79e9df7dff40a31db9/soxr-1.0.0.tar.gz", hash = "sha256:e07ee6c1d659bc6957034f4800c60cb8b98de798823e34d2a2bba1caa85a4509", size = 171415, upload-time = "2025-09-07T13:22:21.317Z" }
 wheels = [
@@ -3098,7 +3096,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "mpmath" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -4291,7 +4289,7 @@ requires-dist = [
     { name = "flash-mla", marker = "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/Luosuu/flash-mla-wheels/releases/download/v1.0.0-9241ae3-torch211cu130/flash_mla-1.0.0%2B9241ae3-1torch211cu130cuda130sm90asm100f-cp312-cp312-linux_aarch64.whl" },
     { name = "flash-mla", marker = "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/Luosuu/flash-mla-wheels/releases/download/v1.0.0-9241ae3-torch211cu130/flash_mla-1.0.0%2B9241ae3-1torch211cu130cuda131sm90asm100f-cp311-cp311-linux_x86_64.whl" },
     { name = "flash-mla", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/Luosuu/flash-mla-wheels/releases/download/v1.0.0-9241ae3-torch211cu130/flash_mla-1.0.0%2B9241ae3-1torch211cu130cuda131sm90asm100f-cp312-cp312-linux_x86_64.whl" },
-    { name = "flash-qla", marker = "extra == 'gpu'", git = "https://github.com/QwenLM/FlashQLA?rev=6ef4858b5446e05bd461d9658d877e548182dbcb" },
+    { name = "flash-qla", marker = "extra == 'gpu'", specifier = "==0.1.2" },
     { name = "ftfy", marker = "extra == 'gpu'" },
     { name = "ftfy", marker = "extra == 'npu'" },
     { name = "ftfy", marker = "extra == 'npu-aarch64'" },
@@ -4429,7 +4427,7 @@ name = "wcmatch"
 version = "10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bracex", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "bracex" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
 wheels = [
@@ -4450,9 +4448,9 @@ name = "webdataset"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "braceexpand", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "numpy", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
-    { name = "pyyaml", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "braceexpand" },
+    { name = "numpy" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/3a/68800d92e065cf4750ebecf973b13979c0c929b439e1293012938862038d/webdataset-1.0.2.tar.gz", hash = "sha256:7f0498be827cfa46cc5430a58768a24e2c6a410676a61be1838f53d61afdaab4", size = 80090, upload-time = "2025-06-19T23:26:21.945Z" }
 wheels = [
@@ -4493,7 +4491,7 @@ name = "xattr"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "extra == 'extra-6-veomni-gpu' or extra == 'extra-6-veomni-npu' or extra == 'extra-6-veomni-npu-aarch64'" },
+    { name = "cffi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/d5/25f7b19af3a2cb4000cac4f9e5525a40bec79f4f5d0ac9b517c0544586a0/xattr-1.3.0.tar.gz", hash = "sha256:30439fabd7de0787b27e9a6e1d569c5959854cb322f64ce7380fedbfa5035036", size = 17148, upload-time = "2025-10-13T22:16:47.353Z" }
 wheels = [

--- a/veomni/ops/README.md
+++ b/veomni/ops/README.md
@@ -139,8 +139,8 @@ post, and head kernels behind registry `OpSlot`s.
 The package does not import TileLang eagerly, so CPU and NPU installations can
 still import VeOmni. Callers that use a TileLang entry point must have the GPU
 extra installed. The GPU extra pins `tilelang==0.1.9` and
-`tile-kernels==1.0.0`; the uv override resolves FlashQLA's older 0.1.8 metadata
-pin against the shared, validated TileLang version.
+`tile-kernels==1.0.0`; FlashQLA 0.1.2 pins the same TileLang version, so all
+three TileLang consumers share one validated build.
 
 DeepSeek-V4 selects these kernels with `dsa_indexer_implementation: tilelang` and
 `dsa_attention_implementation: tilelang`. Both default to `eager`; unsupported


### PR DESCRIPTION
The pinned rev `6ef4858` predates FlashQLA v0.1.1 and still calls `T.gemm_v1`, which TileLang removed in 0.1.9 — the very version the gpu extra forces for TileKernels. So the `flash_qla` backend cannot run as pinned:

    AttributeError: module 'tilelang.language' has no attribute 'gemm_v1'

FlashQLA has since published 0.1.2 to PyPI as a pure-Python wheel. Its static metadata is `torch>=2.8`, `tilelang==0.1.9`, `apache-tvm-ffi==0.1.9`, which already matches the gpu extra's own pins, so switching to the release both fixes the break and removes the workarounds the git source needed:

- the `[tool.uv.sources]` git pin
- the `[[tool.uv.dependency-metadata]]` block (only existed because FlashQLA ships no pyproject.toml, so uv ran setup.py in an unseeded build venv)
- the `[tool.uv.extra-build-dependencies]` seeding entry

A wheel also means no source build during `uv sync`.

Verified on H100 (SM90):
- before: `KERNEL FAILED: AttributeError: ... has no attribute 'gemm_v1'`
- after:  flash_qla vs FLA fwd 7.3e-4, bwd 3.9e-3
- `tests/ops/test_kernel_registry_numerical.py::test_chunk_gated_delta_rule_flash_qla_matches_fla` passes

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Updated the GPU installation option to use the released FlashQLA 0.1.2 package from PyPI.
  * Simplified dependency configuration by removing obsolete package metadata adjustments and source-build setup.
  * Retained compatible Flash Attention build configuration.

* **Documentation**
  * Updated DeepSeek V4 dependency guidance to reflect FlashQLA 0.1.2 compatibility with TileLang 0.1.9 and Tile Kernels 1.0.0.
  * Clarified the required shared versions for a more consistent installation experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->