### PR TITLE
[feat] Add training-time validation support

### DIFF
--- a/configs/examples/validation_example.yaml
+++ b/configs/examples/validation_example.yaml
@@ -1,0 +1,19 @@
+# Example: Training with validation
+# Add these fields to your existing training config to enable validation.
+
+data:
+  eval_path: /path/to/validation/data
+  train_path: /path/to/training/data
+  data_type: conversation
+  max_seq_len: 4096
+
+train:
+  eval_steps: 100          # Evaluate every 100 optimizer steps
+  eval_epochs: 0           # Set to 0 to disable epoch-based eval
+  validation_metrics:
+    - loss
+    - perplexity
+    - accuracy
+  micro_batch_size: 1
+  global_batch_size: 32
+  num_train_epochs: 3

--- a/docs/usage/training_with_validation.md
+++ b/docs/usage/training_with_validation.md
@@ -1,0 +1,113 @@
+# Training with Validation
+
+VeOmni supports training-time validation through the `EvaluateCallback`. When enabled, the trainer periodically evaluates the model on a validation dataset and logs metrics (loss, perplexity, accuracy, etc.) to stdout and wandb.
+
+## Configuration
+
+Validation is controlled by three config fields that already exist in `VeOmniArguments`:
+
+| Field | Location | Default | Description |
+|-------|----------|---------|-------------|
+| `data.eval_path` | `DataArguments` | `None` | Path to validation data. If `None`, validation is skipped. |
+| `train.eval_steps` | `TrainingArguments` | `0` | Evaluate every N optimizer steps. `0` disables step-based eval. |
+| `train.eval_epochs` | `TrainingArguments` | `1` | Evaluate every N epochs. `0` disables epoch-based eval. |
+
+This PR adds one new field:
+
+| Field | Location | Default | Description |
+|-------|----------|---------|-------------|
+| `train.validation_metrics` | `TrainingArguments` | `["loss"]` | List of metrics to compute. Options: `"loss"`, `"perplexity"`, `"accuracy"`, `"token_accuracy"`. |
+
+## Quick Start
+
+Add the following to your training YAML config:
+
+```yaml
+data:
+  eval_path: /path/to/validation/data
+  # ... other data config ...
+
+train:
+  eval_steps: 100        # Evaluate every 100 steps
+  eval_epochs: 0         # Disable epoch-based eval (optional)
+  validation_metrics:
+    - loss
+    - perplexity
+    - accuracy
+  # ... other train config ...
+```
+
+Or evaluate per-epoch only:
+
+```yaml
+data:
+  eval_path: /path/to/validation/data
+
+train:
+  eval_steps: 0          # Disable step-based eval
+  eval_epochs: 1         # Evaluate at the end of every epoch
+  validation_metrics:
+    - loss
+    - perplexity
+```
+
+## Available Metrics
+
+All metrics are distributed-aware: per-rank partial sums are aggregated via `all_reduce` so the final value reflects the entire validation set across all DP ranks.
+
+| Metric | Registry Key | Description |
+|--------|-------------|-------------|
+| Validation Loss | `"loss"` | Average cross-entropy loss. Uses the model's native loss when available. |
+| Perplexity | `"perplexity"` | Token-weighted perplexity: `exp(total_nll / total_tokens)`. Correctly handles variable-length sequences. |
+| Accuracy | `"accuracy"` | Classification accuracy: `argmax(logits) == labels`, averaged over valid (non-ignored) positions. |
+| Token Accuracy | `"token_accuracy"` | Same computation as accuracy, useful when both sequence-level and token-level metrics are needed. |
+
+## Adding Custom Metrics
+
+Evaluators use the `Registry` pattern. To add a custom metric:
+
+```python
+from veomni.data.evaluator import EVALUATOR_REGISTRY, Evaluator
+from typing import Dict
+import torch
+
+@EVALUATOR_REGISTRY.register("f1_score")
+class F1Evaluator(Evaluator):
+    def compute(self, logits: torch.Tensor, labels: torch.Tensor, **kwargs) -> Dict[str, torch.Tensor]:
+        # Compute per-rank partial sums
+        predictions = logits.argmax(dim=-1)
+        tp = ((predictions == 1) & (labels == 1)).sum()
+        fp = ((predictions == 1) & (labels == 0)).sum()
+        fn = ((predictions == 0) & (labels == 1)).sum()
+        return {"f1_tp": tp.float(), "f1_tp_count": tp.float(),
+                "f1_fp": fp.float(), "f1_fp_count": fp.float(),
+                "f1_fn": fn.float(), "f1_fn_count": fn.float()}
+
+    def aggregate(self, partial):
+        # all_reduce and compute final F1
+        ...
+```
+
+Then use it in your config:
+
+```yaml
+train:
+  validation_metrics:
+    - loss
+    - f1_score
+```
+
+## How It Works
+
+1. **Trigger**: `EvaluateCallback` checks `eval_steps` / `eval_epochs` at the end of each training step / epoch.
+2. **Data Loading**: On first call, `build_validation_dataloader` builds a `DistributedDataloader` from `data.eval_path` using the same `StatefulDistributedSampler` as training, but with `shuffle=False` and `drop_last=False`.
+3. **Forward Pass**: The model is switched to `eval()` mode and runs under `torch.no_grad()`. Each validation batch is forwarded through the model.
+4. **Metric Computation**: Each evaluator computes per-rank partial sums (e.g., total NLL and token count for perplexity). After all batches, partials are `all_reduce`d across DP ranks to produce global averages.
+5. **Logging**: Results are logged via `logger.info_rank0()` and optionally to wandb.
+
+## Notes
+
+- Validation does **not** affect training: gradients are not computed, optimizer is not stepped.
+- The model is restored to `train()` mode after validation.
+- Validation dataloader is built once and cached for subsequent evaluations.
+- All metrics respect the HuggingFace `ignore_index=-100` convention for masked positions.

--- a/docs/usage/training_with_validation.md
+++ b/docs/usage/training_with_validation.md
@@ -70,6 +70,7 @@ Evaluators use the `Registry` pattern. To add a custom metric:
 from veomni.data.evaluator import EVALUATOR_REGISTRY, Evaluator
 from typing import Dict
 import torch
+import torch.distributed as dist
 
 @EVALUATOR_REGISTRY.register("f1_score")
 class F1Evaluator(Evaluator):
@@ -79,13 +80,20 @@ class F1Evaluator(Evaluator):
         tp = ((predictions == 1) & (labels == 1)).sum()
         fp = ((predictions == 1) & (labels == 0)).sum()
         fn = ((predictions == 0) & (labels == 1)).sum()
-        return {"f1_tp": tp.float(), "f1_tp_count": tp.float(),
-                "f1_fp": fp.float(), "f1_fp_count": fp.float(),
-                "f1_fn": fn.float(), "f1_fn_count": fn.float()}
+        return {"f1_tp": tp.float(), "f1_fp": fp.float(), "f1_fn": fn.float()}
 
-    def aggregate(self, partial):
-        # all_reduce and compute final F1
-        ...
+    def aggregate(self, partial: Dict[str, torch.Tensor]) -> Dict[str, float]:
+        # F1 needs global sums (not averages), so override aggregate
+        # to all_reduce raw totals without dividing by a count.
+        result: Dict[str, float] = {}
+        for name in ("f1_tp", "f1_fp", "f1_fn"):
+            total = partial[name].detach().clone()
+            if dist.is_available() and dist.is_initialized():
+                dist.all_reduce(total, op=dist.ReduceOp.SUM)
+            result[name] = total.item()
+        tp, fp, fn = result["f1_tp"], result["f1_fp"], result["f1_fn"]
+        denom = 2 * tp + fp + fn
+        return {"f1_score": 2 * tp / denom if denom > 0 else float("nan")}
 ```
 
 Then use it in your config:

--- a/tests/data/test_evaluator.py
+++ b/tests/data/test_evaluator.py
@@ -328,19 +328,28 @@ class TestDistributedAggregation:
             torch.distributed.destroy_process_group()
 
     @pytest.mark.skipif(
-        not torch.distributed.is_available(),
-        reason="torch.distributed not available",
+        not torch.distributed.is_available() or not torch.distributed.is_gloo_available(),
+        reason="torch.distributed gloo backend not available",
     )
     def test_two_rank_perplexity_aggregation(self, tmp_path):
         """Verify token-weighted perplexity across two ranks via real all_reduce.
 
         Uses subprocess spawning with the gloo CPU backend so it runs anywhere
-        without GPU dependencies.
+        without GPU dependencies. Rank 0 has perfectly predicted tokens (NLL≈0)
+        while rank 1 has uniform logits (NLL=log(vocab)), so the aggregated
+        perplexity = exp((0*2 + log(10)*1) / 3) = 10^(1/3).
         """
         import os
+        import socket
         import subprocess
         import sys
         import textwrap
+
+        # Find a free port for the rendezvous
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        master_port = str(sock.getsockname()[1])
+        sock.close()
 
         script = tmp_path / "_two_rank_test.py"
         script.write_text(textwrap.dedent("""\
@@ -356,23 +365,26 @@ class TestDistributedAggregation:
                 dist.init_process_group("gloo", rank=rank, world_size=world_size)
 
                 vocab = 10
-                # Rank 0: labels [1, 2, 3], rank 1: labels [4, 5]
-                # Zero logits → uniform → NLL = log(vocab) per token
                 if rank == 0:
+                    # Perfect prediction: NLL ≈ 0 for 2 shifted tokens
                     labels = torch.tensor([[1, 2, 3]])
+                    logits = torch.full((1, 3, vocab), -10.0)
+                    logits[0, 0, 2] = 10.0  # predicts labels[1]=2
+                    logits[0, 1, 3] = 10.0  # predicts labels[2]=3
                 else:
+                    # Uniform prediction: NLL = log(vocab) for 1 shifted token
                     labels = torch.tensor([[4, 5]])
-                logits = torch.zeros(1, labels.size(1), vocab)
+                    logits = torch.zeros(1, 2, vocab)
 
                 evaluator = PerplexityEvaluator()
                 partial = evaluator.compute(logits, labels)
                 result = evaluator.aggregate(partial)
 
-                # Rank 0 shift: [2, 3] → 2 tokens
-                # Rank 1 shift: [5] → 1 token
-                # Total: 3 tokens, NLL = 3 * log(10)
-                # Perplexity = exp(log(10)) = 10
-                expected = float(vocab)
+                # Rank 0: 2 tokens, NLL ≈ 0
+                # Rank 1: 1 token, NLL = log(10)
+                # Total: 3 tokens, NLL = log(10)
+                # Perplexity = exp(log(10) / 3) = 10^(1/3) ≈ 2.154
+                expected = 10.0 ** (1.0 / 3.0)
                 actual = result["perplexity"]
                 assert abs(actual - expected) < 0.01, \\
                     f"Rank {rank}: expected {expected}, got {actual}"
@@ -386,11 +398,9 @@ class TestDistributedAggregation:
         """))
 
         env = os.environ.copy()
-        env["RANK"] = "0"
         env["WORLD_SIZE"] = "2"
         env["MASTER_ADDR"] = "127.0.0.1"
-        env["MASTER_PORT"] = "29512"
-        # Include current sys.path so the subprocess can import veomni
+        env["MASTER_PORT"] = master_port
         env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
         # Run two processes

--- a/tests/data/test_evaluator.py
+++ b/tests/data/test_evaluator.py
@@ -1,0 +1,289 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for veomni.data.evaluator."""
+
+import pytest
+import torch
+
+from veomni.data.evaluator import (
+    EVALUATOR_REGISTRY,
+    AccuracyEvaluator,
+    Evaluator,
+    LossEvaluator,
+    PerplexityEvaluator,
+    TokenAccuracyEvaluator,
+    build_evaluator,
+    compute_metrics,
+)
+
+
+class TestPerplexityEvaluator:
+    """Tests for PerplexityEvaluator."""
+
+    def test_perfect_prediction(self):
+        """When logits perfectly predict labels, perplexity should be ~1.0."""
+        # Create logits where the correct next token gets overwhelming probability.
+        # The evaluator applies a causal LM shift (logits[:-1] vs labels[1:]),
+        # so position s in logits should predict labels[s+1].
+        batch, seq, vocab = 2, 4, 10
+        labels = torch.randint(0, vocab, (batch, seq))
+        logits = torch.full((batch, seq, vocab), -10.0)
+        for b in range(batch):
+            for s in range(seq - 1):
+                logits[b, s, labels[b, s + 1]] = 10.0
+
+        evaluator = PerplexityEvaluator()
+        partial = evaluator.compute(logits, labels)
+        result = evaluator.aggregate(partial)
+
+        assert "perplexity" in result
+        assert result["perplexity"] < 2.0  # Should be very close to 1.0
+
+    def test_random_prediction(self):
+        """Random logits should give perplexity close to vocab_size."""
+        vocab = 100
+        batch, seq = 4, 16
+        labels = torch.randint(0, vocab, (batch, seq))
+        logits = torch.randn(batch, seq, vocab)
+
+        evaluator = PerplexityEvaluator()
+        partial = evaluator.compute(logits, labels)
+        result = evaluator.aggregate(partial)
+
+        # Random prediction perplexity ≈ vocab_size
+        assert 20 < result["perplexity"] < 200
+
+    def test_ignore_index(self):
+        """Positions with label -100 should be excluded."""
+        batch, seq, vocab = 1, 6, 10
+        labels = torch.tensor([[1, 2, -100, -100, 5, 6]])
+        logits = torch.randn(batch, seq, vocab)
+
+        evaluator = PerplexityEvaluator()
+        partial = evaluator.compute(logits, labels)
+
+        # After causal LM shift: shift_labels = [2, -100, -100, 5, 6] (5 positions)
+        # 2 positions are -100, so 3 valid tokens remain.
+        # Count is summed across all batches; with batch=1 it equals 3.
+        assert partial["perplexity_count"].item() > 0
+        assert partial["perplexity_count"].item() <= batch * (seq - 1)
+
+    def test_2d_logits(self):
+        """Should handle 2D logits (batch, vocab) for classification."""
+        batch, vocab = 4, 10
+        labels = torch.randint(0, vocab, (batch,))
+        logits = torch.randn(batch, vocab)
+
+        evaluator = PerplexityEvaluator()
+        partial = evaluator.compute(logits, labels)
+        result = evaluator.aggregate(partial)
+
+        assert "perplexity" in result
+        assert result["perplexity"] > 0
+
+
+class TestAccuracyEvaluator:
+    """Tests for AccuracyEvaluator."""
+
+    def test_perfect_accuracy(self):
+        """When argmax matches labels, accuracy should be 1.0."""
+        batch, seq, vocab = 2, 8, 10
+        labels = torch.randint(0, vocab, (batch, seq))
+        logits = torch.full((batch, seq, vocab), -10.0)
+        # Position s predicts labels[s+1] due to causal LM shift
+        for b in range(batch):
+            for s in range(seq - 1):
+                logits[b, s, labels[b, s + 1]] = 10.0
+
+        evaluator = AccuracyEvaluator()
+        partial = evaluator.compute(logits, labels)
+        result = evaluator.aggregate(partial)
+
+        assert result["accuracy"] == 1.0
+
+    def test_zero_accuracy(self):
+        """When argmax never matches, accuracy should be 0.0."""
+        batch, seq, vocab = 2, 8, 10
+        labels = torch.zeros(batch, seq, dtype=torch.long)
+        # Set logits so argmax is always 1 (never 0)
+        logits = torch.full((batch, seq, vocab), -10.0)
+        logits[:, :, 1] = 10.0
+
+        evaluator = AccuracyEvaluator()
+        partial = evaluator.compute(logits, labels)
+        result = evaluator.aggregate(partial)
+
+        assert result["accuracy"] == 0.0
+
+    def test_ignore_index(self):
+        """Ignored positions should not affect accuracy."""
+        labels = torch.tensor([[1, 2, -100, -100, 5, 6]])
+        logits = torch.randn(1, 6, 10)
+
+        evaluator = AccuracyEvaluator()
+        partial = evaluator.compute(logits, labels)
+
+        # Count should exclude -100 positions
+        assert partial["accuracy_count"].item() > 0
+
+
+class TestTokenAccuracyEvaluator:
+    """Tests for TokenAccuracyEvaluator."""
+
+    def test_basic(self):
+        batch, seq, vocab = 2, 4, 10
+        labels = torch.randint(0, vocab, (batch, seq))
+        logits = torch.randn(batch, seq, vocab)
+
+        evaluator = TokenAccuracyEvaluator()
+        partial = evaluator.compute(logits, labels)
+        result = evaluator.aggregate(partial)
+
+        assert 0.0 <= result["token_accuracy"] <= 1.0
+
+
+class TestLossEvaluator:
+    """Tests for LossEvaluator."""
+
+    def test_with_model_loss(self):
+        """Should use model's native loss when provided."""
+        batch, seq, vocab = 2, 4, 10
+        labels = torch.randint(0, vocab, (batch, seq))
+        logits = torch.randn(batch, seq, vocab)
+        loss = torch.tensor(2.5)
+
+        evaluator = LossEvaluator()
+        partial = evaluator.compute(logits, labels, loss=loss)
+        result = evaluator.aggregate(partial)
+
+        assert "val_loss" in result
+        assert abs(result["val_loss"] - 2.5) < 0.1
+
+    def test_without_model_loss(self):
+        """Should compute CE loss from logits when loss is None."""
+        batch, seq, vocab = 2, 4, 10
+        labels = torch.randint(0, vocab, (batch, seq))
+        logits = torch.randn(batch, seq, vocab)
+
+        evaluator = LossEvaluator()
+        partial = evaluator.compute(logits, labels, loss=None)
+        result = evaluator.aggregate(partial)
+
+        assert "val_loss" in result
+        assert result["val_loss"] > 0
+
+
+class TestRegistry:
+    """Tests for the evaluator registry."""
+
+    def test_build_perplexity(self):
+        evaluator = build_evaluator("perplexity")
+        assert isinstance(evaluator, PerplexityEvaluator)
+
+    def test_build_accuracy(self):
+        evaluator = build_evaluator("accuracy")
+        assert isinstance(evaluator, AccuracyEvaluator)
+
+    def test_build_token_accuracy(self):
+        evaluator = build_evaluator("token_accuracy")
+        assert isinstance(evaluator, TokenAccuracyEvaluator)
+
+    def test_build_loss(self):
+        evaluator = build_evaluator("loss")
+        assert isinstance(evaluator, LossEvaluator)
+
+    def test_build_unknown(self):
+        with pytest.raises(ValueError, match="Unknown evaluator name"):
+            build_evaluator("nonexistent_metric")
+
+    def test_registry_keys(self):
+        keys = EVALUATOR_REGISTRY.valid_keys()
+        assert "perplexity" in keys
+        assert "accuracy" in keys
+        assert "token_accuracy" in keys
+        assert "loss" in keys
+
+
+class TestComputeMetrics:
+    """Tests for the compute_metrics utility."""
+
+    def test_multiple_evaluators(self):
+        batch, seq, vocab = 2, 8, 10
+        labels = torch.randint(0, vocab, (batch, seq))
+        logits = torch.randn(batch, seq, vocab)
+
+        evaluators = [
+            PerplexityEvaluator(),
+            AccuracyEvaluator(),
+            LossEvaluator(),
+        ]
+        results = compute_metrics(evaluators, logits, labels, loss=None)
+
+        assert "perplexity" in results
+        assert "accuracy" in results
+        assert "val_loss" in results
+
+    def test_empty_list(self):
+        """Empty evaluator list returns empty dict."""
+        results = compute_metrics([], torch.randn(2, 4, 10), torch.randint(0, 10, (2, 4)))
+        assert results == {}
+
+
+class TestPackedBatch:
+    """Tests for packed-sample boundaries with IGNORE_INDEX=-100."""
+
+    def test_packed_boundaries_excluded_from_perplexity(self):
+        """Packed samples separated by -100 padding should not contribute to perplexity."""
+        # Simulate a packed batch: two short sequences concatenated with -100 padding
+        # Sequence 1: [1, 2, 3] followed by -100 padding
+        # Sequence 2: [4, 5] followed by -100 padding
+        # After causal LM shift, -100 positions must be excluded from NLL.
+        labels = torch.tensor([[1, 2, 3, -100, -100, 4, 5, -100, -100, -100]])
+        vocab = 10
+        batch, seq = labels.shape
+        logits = torch.randn(batch, seq, vocab)
+
+        evaluator = PerplexityEvaluator()
+        partial = evaluator.compute(logits, labels)
+
+        # After shift: shift_labels = [2, 3, -100, -100, 4, 5, -100, -100, -100]
+        # Valid positions: 2, 3, 4, 5 = 4 tokens (ignoring the -100s)
+        assert partial["perplexity_count"].item() == 4
+
+    def test_packed_boundaries_excluded_from_accuracy(self):
+        """Packed sample boundaries with -100 should not affect accuracy."""
+        labels = torch.tensor([[1, 2, -100, -100, 5, 6, -100, -100]])
+        vocab = 10
+        batch, seq = labels.shape
+        logits = torch.randn(batch, seq, vocab)
+
+        evaluator = AccuracyEvaluator()
+        partial = evaluator.compute(logits, labels)
+
+        # After shift: shift_labels = [2, -100, -100, 5, 6, -100, -100]
+        # Valid positions: 2, 5, 6 = 3 tokens
+        assert partial["accuracy_count"].item() == 3
+
+    def test_all_ignored_returns_nan(self):
+        """When all positions are -100, metrics should be NaN."""
+        labels = torch.tensor([[-100, -100, -100, -100]])
+        logits = torch.randn(1, 4, 10)
+
+        evaluator = PerplexityEvaluator()
+        partial = evaluator.compute(logits, labels)
+        result = evaluator.aggregate(partial)
+
+        assert partial["perplexity_count"].item() == 0
+        assert result["perplexity"] != result["perplexity"]  # NaN check

--- a/tests/data/test_evaluator.py
+++ b/tests/data/test_evaluator.py
@@ -34,11 +34,11 @@ class TestPerplexityEvaluator:
 
     def test_perfect_prediction(self):
         """When logits perfectly predict labels, perplexity should be ~1.0."""
-        # Create logits where the correct next token gets overwhelming probability.
+        # Fixed labels for deterministic testing.
         # The evaluator applies a causal LM shift (logits[:-1] vs labels[1:]),
         # so position s in logits should predict labels[s+1].
         batch, seq, vocab = 2, 4, 10
-        labels = torch.randint(0, vocab, (batch, seq))
+        labels = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
         logits = torch.full((batch, seq, vocab), -10.0)
         for b in range(batch):
             for s in range(seq - 1):
@@ -49,7 +49,7 @@ class TestPerplexityEvaluator:
         result = evaluator.aggregate(partial)
 
         assert "perplexity" in result
-        assert result["perplexity"] < 2.0  # Should be very close to 1.0
+        assert result["perplexity"] == pytest.approx(1.0, rel=1e-2)
 
     def test_random_prediction(self):
         """Zero logits give uniform distribution, perplexity = vocab_size."""
@@ -102,7 +102,7 @@ class TestAccuracyEvaluator:
     def test_perfect_accuracy(self):
         """When argmax matches labels, accuracy should be 1.0."""
         batch, seq, vocab = 2, 8, 10
-        labels = torch.randint(0, vocab, (batch, seq))
+        labels = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8], [1, 2, 3, 4, 5, 6, 7, 8]])
         logits = torch.full((batch, seq, vocab), -10.0)
         # Position s predicts labels[s+1] due to causal LM shift
         for b in range(batch):

--- a/tests/data/test_evaluator.py
+++ b/tests/data/test_evaluator.py
@@ -14,6 +14,8 @@
 
 """Unit tests for veomni.data.evaluator."""
 
+import math
+
 import pytest
 import torch
 
@@ -194,7 +196,6 @@ class TestLossEvaluator:
 
         # Zero logits → uniform distribution → CE loss = log(vocab) per token
         # After shift: 3 valid positions per sample, 6 total
-        import math
         expected_loss = math.log(vocab)
         assert partial["val_loss_count"].item() == 6
         assert result["val_loss"] == pytest.approx(expected_loss, rel=1e-4)

--- a/tests/data/test_evaluator.py
+++ b/tests/data/test_evaluator.py
@@ -52,46 +52,48 @@ class TestPerplexityEvaluator:
         assert result["perplexity"] < 2.0  # Should be very close to 1.0
 
     def test_random_prediction(self):
-        """Random logits should give perplexity close to vocab_size."""
+        """Zero logits give uniform distribution, perplexity = vocab_size."""
         vocab = 100
         batch, seq = 4, 16
-        labels = torch.randint(0, vocab, (batch, seq))
-        logits = torch.randn(batch, seq, vocab)
+        labels = torch.arange(batch * seq).reshape(batch, seq) % vocab
+        logits = torch.zeros(batch, seq, vocab)
 
         evaluator = PerplexityEvaluator()
         partial = evaluator.compute(logits, labels)
         result = evaluator.aggregate(partial)
 
-        # Random prediction perplexity ≈ vocab_size
-        assert 20 < result["perplexity"] < 200
+        assert result["perplexity"] == pytest.approx(float(vocab))
 
     def test_ignore_index(self):
         """Positions with label -100 should be excluded."""
         batch, seq, vocab = 1, 6, 10
         labels = torch.tensor([[1, 2, -100, -100, 5, 6]])
-        logits = torch.randn(batch, seq, vocab)
-
-        evaluator = PerplexityEvaluator()
-        partial = evaluator.compute(logits, labels)
-
-        # After causal LM shift: shift_labels = [2, -100, -100, 5, 6] (5 positions)
-        # 2 positions are -100, so 3 valid tokens remain.
-        # Count is summed across all batches; with batch=1 it equals 3.
-        assert partial["perplexity_count"].item() > 0
-        assert partial["perplexity_count"].item() <= batch * (seq - 1)
-
-    def test_2d_logits(self):
-        """Should handle 2D logits (batch, vocab) for classification."""
-        batch, vocab = 4, 10
-        labels = torch.randint(0, vocab, (batch,))
-        logits = torch.randn(batch, vocab)
+        logits = torch.zeros(batch, seq, vocab)
 
         evaluator = PerplexityEvaluator()
         partial = evaluator.compute(logits, labels)
         result = evaluator.aggregate(partial)
 
-        assert "perplexity" in result
-        assert result["perplexity"] > 0
+        # After causal LM shift: shift_labels = [2, -100, -100, 5, 6] (5 positions)
+        # 2 positions are -100, so 3 valid tokens remain.
+        assert partial["perplexity_count"].item() == 3
+        # Zero logits → uniform distribution → NLL = log(vocab) per token
+        # Perplexity = exp(log(vocab)) = vocab
+        assert result["perplexity"] == pytest.approx(float(vocab))
+
+    def test_2d_logits(self):
+        """Should handle 2D logits (batch, vocab) for classification."""
+        batch, vocab = 4, 10
+        labels = torch.tensor([1, 2, 3, 4])
+        logits = torch.zeros(batch, vocab)
+
+        evaluator = PerplexityEvaluator()
+        partial = evaluator.compute(logits, labels)
+        result = evaluator.aggregate(partial)
+
+        # Zero logits → uniform → perplexity = vocab
+        assert partial["perplexity_count"].item() == batch
+        assert result["perplexity"] == pytest.approx(float(vocab))
 
 
 class TestAccuracyEvaluator:
@@ -130,13 +132,17 @@ class TestAccuracyEvaluator:
     def test_ignore_index(self):
         """Ignored positions should not affect accuracy."""
         labels = torch.tensor([[1, 2, -100, -100, 5, 6]])
-        logits = torch.randn(1, 6, 10)
+        logits = torch.zeros(1, 6, 10)
 
         evaluator = AccuracyEvaluator()
         partial = evaluator.compute(logits, labels)
 
-        # Count should exclude -100 positions
-        assert partial["accuracy_count"].item() > 0
+        # After shift: shift_labels = [2, -100, -100, 5, 6]
+        # 3 valid positions; zero logits → argmax=0, none match labels
+        assert partial["accuracy_count"].item() == 3
+
+        result = evaluator.aggregate(partial)
+        assert result["accuracy"] == 0.0
 
 
 class TestTokenAccuracyEvaluator:
@@ -144,14 +150,17 @@ class TestTokenAccuracyEvaluator:
 
     def test_basic(self):
         batch, seq, vocab = 2, 4, 10
-        labels = torch.randint(0, vocab, (batch, seq))
-        logits = torch.randn(batch, seq, vocab)
+        labels = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
+        logits = torch.zeros(batch, seq, vocab)
 
         evaluator = TokenAccuracyEvaluator()
         partial = evaluator.compute(logits, labels)
         result = evaluator.aggregate(partial)
 
-        assert 0.0 <= result["token_accuracy"] <= 1.0
+        # Zero logits → argmax=0, none match labels (all > 0)
+        # After shift: 3 valid positions per sample, 6 total
+        assert partial["token_accuracy_count"].item() == 6
+        assert result["token_accuracy"] == 0.0
 
 
 class TestLossEvaluator:
@@ -160,29 +169,35 @@ class TestLossEvaluator:
     def test_with_model_loss(self):
         """Should use model's native loss when provided."""
         batch, seq, vocab = 2, 4, 10
-        labels = torch.randint(0, vocab, (batch, seq))
-        logits = torch.randn(batch, seq, vocab)
+        labels = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
+        logits = torch.zeros(batch, seq, vocab)
         loss = torch.tensor(2.5)
 
         evaluator = LossEvaluator()
         partial = evaluator.compute(logits, labels, loss=loss)
         result = evaluator.aggregate(partial)
 
-        assert "val_loss" in result
-        assert abs(result["val_loss"] - 2.5) < 0.1
+        # After shift: 3 valid positions per sample, 6 total
+        # LossEvaluator multiplies loss by token_count, aggregate divides by count
+        assert partial["val_loss_count"].item() == 6
+        assert result["val_loss"] == pytest.approx(2.5, rel=1e-4)
 
     def test_without_model_loss(self):
         """Should compute CE loss from logits when loss is None."""
         batch, seq, vocab = 2, 4, 10
-        labels = torch.randint(0, vocab, (batch, seq))
-        logits = torch.randn(batch, seq, vocab)
+        labels = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
+        logits = torch.zeros(batch, seq, vocab)
 
         evaluator = LossEvaluator()
         partial = evaluator.compute(logits, labels, loss=None)
         result = evaluator.aggregate(partial)
 
-        assert "val_loss" in result
-        assert result["val_loss"] > 0
+        # Zero logits → uniform distribution → CE loss = log(vocab) per token
+        # After shift: 3 valid positions per sample, 6 total
+        import math
+        expected_loss = math.log(vocab)
+        assert partial["val_loss_count"].item() == 6
+        assert result["val_loss"] == pytest.approx(expected_loss, rel=1e-4)
 
 
 class TestRegistry:
@@ -221,8 +236,8 @@ class TestComputeMetrics:
 
     def test_multiple_evaluators(self):
         batch, seq, vocab = 2, 8, 10
-        labels = torch.randint(0, vocab, (batch, seq))
-        logits = torch.randn(batch, seq, vocab)
+        labels = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8], [1, 2, 3, 4, 5, 6, 7, 8]])
+        logits = torch.zeros(batch, seq, vocab)
 
         evaluators = [
             PerplexityEvaluator(),
@@ -234,10 +249,13 @@ class TestComputeMetrics:
         assert "perplexity" in results
         assert "accuracy" in results
         assert "val_loss" in results
+        # Zero logits → perplexity = vocab, accuracy = 0
+        assert results["perplexity"] == pytest.approx(float(vocab))
+        assert results["accuracy"] == 0.0
 
     def test_empty_list(self):
         """Empty evaluator list returns empty dict."""
-        results = compute_metrics([], torch.randn(2, 4, 10), torch.randint(0, 10, (2, 4)))
+        results = compute_metrics([], torch.zeros(2, 4, 10), torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]]))
         assert results == {}
 
 
@@ -245,41 +263,48 @@ class TestPackedBatch:
     """Tests for packed-sample boundaries with IGNORE_INDEX=-100."""
 
     def test_packed_boundaries_excluded_from_perplexity(self):
-        """Packed samples separated by -100 padding should not contribute to perplexity."""
-        # Simulate a packed batch: two short sequences concatenated with -100 padding
-        # Sequence 1: [1, 2, 3] followed by -100 padding
-        # Sequence 2: [4, 5] followed by -100 padding
-        # After causal LM shift, -100 positions must be excluded from NLL.
-        labels = torch.tensor([[1, 2, 3, -100, -100, 4, 5, -100, -100, -100]])
+        """Packed samples separated by -100 padding should not contribute to perplexity.
+
+        In a packed batch, the first target after each boundary is also masked
+        because the model's context at that position includes padding tokens.
+        """
+        # Two packed samples: [1, 2, 3] and [4, 5]
+        # The first token of each new sample (4) is masked with -100 because
+        # the model cannot predict it from the preceding padding context.
+        labels = torch.tensor([[1, 2, 3, -100, -100, -100, 5, -100, -100, -100]])
         vocab = 10
         batch, seq = labels.shape
-        logits = torch.randn(batch, seq, vocab)
+        logits = torch.zeros(batch, seq, vocab)
 
         evaluator = PerplexityEvaluator()
         partial = evaluator.compute(logits, labels)
 
-        # After shift: shift_labels = [2, 3, -100, -100, 4, 5, -100, -100, -100]
-        # Valid positions: 2, 3, 4, 5 = 4 tokens (ignoring the -100s)
-        assert partial["perplexity_count"].item() == 4
+        # After shift: shift_labels = [2, 3, -100, -100, -100, 5, -100, -100, -100]
+        # Valid positions: 2, 3, 5 = 3 tokens
+        assert partial["perplexity_count"].item() == 3
 
     def test_packed_boundaries_excluded_from_accuracy(self):
-        """Packed sample boundaries with -100 should not affect accuracy."""
-        labels = torch.tensor([[1, 2, -100, -100, 5, 6, -100, -100]])
+        """Packed sample boundaries with -100 should not affect accuracy.
+
+        The first token after each boundary is masked because the model's
+        context includes padding, making the prediction meaningless.
+        """
+        labels = torch.tensor([[1, 2, -100, -100, -100, 6, -100, -100]])
         vocab = 10
         batch, seq = labels.shape
-        logits = torch.randn(batch, seq, vocab)
+        logits = torch.zeros(batch, seq, vocab)
 
         evaluator = AccuracyEvaluator()
         partial = evaluator.compute(logits, labels)
 
-        # After shift: shift_labels = [2, -100, -100, 5, 6, -100, -100]
-        # Valid positions: 2, 5, 6 = 3 tokens
-        assert partial["accuracy_count"].item() == 3
+        # After shift: shift_labels = [2, -100, -100, -100, 6, -100, -100]
+        # Valid positions: 2, 6 = 2 tokens
+        assert partial["accuracy_count"].item() == 2
 
     def test_all_ignored_returns_nan(self):
         """When all positions are -100, metrics should be NaN."""
         labels = torch.tensor([[-100, -100, -100, -100]])
-        logits = torch.randn(1, 4, 10)
+        logits = torch.zeros(1, 4, 10)
 
         evaluator = PerplexityEvaluator()
         partial = evaluator.compute(logits, labels)
@@ -287,3 +312,105 @@ class TestPackedBatch:
 
         assert partial["perplexity_count"].item() == 0
         assert result["perplexity"] != result["perplexity"]  # NaN check
+
+
+class TestDistributedAggregation:
+    """Integration tests for multi-rank metric aggregation.
+
+    These tests initialize a real process group with the gloo backend and
+    invoke the actual ``dist.all_reduce`` — no mocks.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _cleanup(self):
+        yield
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+    @pytest.mark.skipif(
+        not torch.distributed.is_available(),
+        reason="torch.distributed not available",
+    )
+    def test_two_rank_perplexity_aggregation(self, tmp_path):
+        """Verify token-weighted perplexity across two ranks via real all_reduce.
+
+        Uses subprocess spawning with the gloo CPU backend so it runs anywhere
+        without GPU dependencies.
+        """
+        import os
+        import subprocess
+        import sys
+        import textwrap
+
+        script = tmp_path / "_two_rank_test.py"
+        script.write_text(textwrap.dedent("""\
+            import math
+            import os
+            import torch
+            import torch.distributed as dist
+            from veomni.data.evaluator import PerplexityEvaluator
+
+            def main():
+                rank = int(os.environ["RANK"])
+                world_size = int(os.environ["WORLD_SIZE"])
+                dist.init_process_group("gloo", rank=rank, world_size=world_size)
+
+                vocab = 10
+                # Rank 0: labels [1, 2, 3], rank 1: labels [4, 5]
+                # Zero logits → uniform → NLL = log(vocab) per token
+                if rank == 0:
+                    labels = torch.tensor([[1, 2, 3]])
+                else:
+                    labels = torch.tensor([[4, 5]])
+                logits = torch.zeros(1, labels.size(1), vocab)
+
+                evaluator = PerplexityEvaluator()
+                partial = evaluator.compute(logits, labels)
+                result = evaluator.aggregate(partial)
+
+                # Rank 0 shift: [2, 3] → 2 tokens
+                # Rank 1 shift: [5] → 1 token
+                # Total: 3 tokens, NLL = 3 * log(10)
+                # Perplexity = exp(log(10)) = 10
+                expected = float(vocab)
+                actual = result["perplexity"]
+                assert abs(actual - expected) < 0.01, \\
+                    f"Rank {rank}: expected {expected}, got {actual}"
+                if rank == 0:
+                    print("DISTRIBUTED_TEST_PASSED")
+
+                dist.destroy_process_group()
+
+            if __name__ == "__main__":
+                main()
+        """))
+
+        env = os.environ.copy()
+        env["RANK"] = "0"
+        env["WORLD_SIZE"] = "2"
+        env["MASTER_ADDR"] = "127.0.0.1"
+        env["MASTER_PORT"] = "29512"
+        # Include current sys.path so the subprocess can import veomni
+        env["PYTHONPATH"] = os.pathsep.join(sys.path)
+
+        # Run two processes
+        procs = []
+        for r in range(2):
+            env_rank = env.copy()
+            env_rank["RANK"] = str(r)
+            p = subprocess.Popen(
+                [sys.executable, str(script)],
+                env=env_rank,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            procs.append(p)
+
+        outputs = []
+        for p in procs:
+            out, err = p.communicate(timeout=30)
+            outputs.append(out.decode())
+            if p.returncode != 0:
+                pytest.fail(f"Rank process failed: {err.decode()}")
+
+        assert "DISTRIBUTED_TEST_PASSED" in outputs[0], f"Rank 0 did not pass: {outputs[0]}"

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -550,6 +550,16 @@ class TrainingArguments:
         default=1,
         metadata={"help": "Number of epochs between two evaluations. 0 to disable."},
     )
+    validation_metrics: List[str] = field(
+        default_factory=lambda: ["loss"],
+        metadata={
+            "help": (
+                "List of metric names to compute during validation. "
+                "Available: 'loss', 'perplexity', 'accuracy', 'token_accuracy'. "
+                "Default: ['loss']."
+            ),
+        },
+    )
     seed: int = field(
         default=42,
         metadata={"help": "Random seed."},

--- a/veomni/data/__init__.py
+++ b/veomni/data/__init__.py
@@ -22,7 +22,18 @@ from .data_loader import DistributedDataloader, build_dataloader
 from .data_transform import DATA_TRANSFORM_REGISTRY, build_data_transform
 from .dataset import build_dataset
 from .dummy_dataset import build_dummy_dataset
+from .evaluator import (
+    EVALUATOR_REGISTRY,
+    Evaluator,
+    AccuracyEvaluator,
+    LossEvaluator,
+    PerplexityEvaluator,
+    TokenAccuracyEvaluator,
+    build_evaluator,
+    compute_metrics,
+)
 from .multimodal.multimodal_chat_template import build_multimodal_chat_template
+from .validation_loader import build_validation_dataloader
 
 
 __all__ = [
@@ -37,4 +48,13 @@ __all__ = [
     "UnpackDataCollator",
     "build_dataset",
     "DistributedDataloader",
+    "EVALUATOR_REGISTRY",
+    "Evaluator",
+    "AccuracyEvaluator",
+    "LossEvaluator",
+    "PerplexityEvaluator",
+    "TokenAccuracyEvaluator",
+    "build_evaluator",
+    "compute_metrics",
+    "build_validation_dataloader",
 ]

--- a/veomni/data/evaluator.py
+++ b/veomni/data/evaluator.py
@@ -22,11 +22,11 @@ add custom metrics without modifying trainer code::
         def compute(self, logits, labels, **kwargs):
             ...
 
-All evaluators are distrubuted-aware: per-rank partial sums are aggregated
+All evaluators are distributed-aware: per-rank partial sums are aggregated
 via ``all_reduce`` so the final metric reflects the global validation set.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import torch
 import torch.distributed as dist

--- a/veomni/data/evaluator.py
+++ b/veomni/data/evaluator.py
@@ -26,7 +26,8 @@ All evaluators are distributed-aware: per-rank partial sums are aggregated
 via ``all_reduce`` so the final metric reflects the global validation set.
 """
 
-from typing import Dict, List, Optional
+import math
+from typing import Dict, List
 
 import torch
 import torch.distributed as dist
@@ -133,9 +134,10 @@ class PerplexityEvaluator(Evaluator):
 
     def aggregate(self, partial: Dict[str, torch.Tensor]) -> Dict[str, float]:
         result = super().aggregate(partial)
-        # Convert NLL to perplexity
-        if "perplexity" in result and not (result["perplexity"] != result["perplexity"]):  # not NaN
-            result["perplexity"] = torch.exp(torch.tensor(result["perplexity"])).item()
+        # Convert average NLL to perplexity
+        val = result.get("perplexity")
+        if val is not None and not math.isnan(val):
+            result["perplexity"] = math.exp(val)
         return result
 
 

--- a/veomni/data/evaluator.py
+++ b/veomni/data/evaluator.py
@@ -1,0 +1,282 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Evaluation metrics for training-time validation.
+
+Evaluators are registered via :data:`EVALUATOR_REGISTRY` so that users can
+add custom metrics without modifying trainer code::
+
+    @EVALUATOR_REGISTRY.register("my_metric")
+    class MyEvaluator(Evaluator):
+        def compute(self, logits, labels, **kwargs):
+            ...
+
+All evaluators are distrubuted-aware: per-rank partial sums are aggregated
+via ``all_reduce`` so the final metric reflects the global validation set.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.distributed as dist
+
+from ..utils import logging
+from ..utils.registry import Registry
+
+
+logger = logging.get_logger(__name__)
+
+EVALUATOR_REGISTRY = Registry("evaluator")
+
+
+class Evaluator:
+    """Base class for evaluation metrics.
+
+    Subclasses implement :meth:`compute` which receives raw tensors from the
+    model forward pass and returns a dict of metric_name -> scalar value.
+
+    The base class handles distributed aggregation: each rank computes a
+    partial sum and count, then ``all_reduce`` combines them so the returned
+    metric is the global average across all DP ranks.
+    """
+
+    def compute(self, logits: torch.Tensor, labels: torch.Tensor, **kwargs) -> Dict[str, torch.Tensor]:
+        """Compute per-rank partial metrics.
+
+        Args:
+            logits: Model output logits of shape ``(batch, seq, vocab)`` or ``(batch, vocab)``.
+            labels: Ground-truth labels of shape ``(batch, seq)`` or ``(batch,)``.
+            **kwargs: Additional forward outputs (e.g. ``loss``).
+
+        Returns:
+            Dict with keys ``"<metric_name>"`` (per-rank sum) and
+            ``"<metric_name>_count"`` (per-rank sample/token count).
+        """
+        raise NotImplementedError
+
+    def aggregate(self, partial: Dict[str, torch.Tensor]) -> Dict[str, float]:
+        """All-reduce partial sums across DP ranks and compute final values.
+
+        Args:
+            partial: Output of :meth:`compute` from the local rank.
+
+        Returns:
+            Dict of metric_name -> float (global average).
+        """
+        result: Dict[str, float] = {}
+        metric_names = [k for k in partial if not k.endswith("_count")]
+
+        for name in metric_names:
+            count_key = f"{name}_count"
+            total = partial[name].detach().clone()
+            count = partial[count_key].detach().clone()
+
+            if dist.is_available() and dist.is_initialized():
+                dist.all_reduce(total, op=dist.ReduceOp.SUM)
+                dist.all_reduce(count, op=dist.ReduceOp.SUM)
+
+            if count.item() > 0:
+                result[name] = (total / count).item()
+            else:
+                result[name] = float("nan")
+
+        return result
+
+
+@EVALUATOR_REGISTRY.register("perplexity")
+class PerplexityEvaluator(Evaluator):
+    """Token-weighted perplexity.
+
+    Accumulates total negative log-likelihood and token count across all
+    validation batches, then computes ``exp(total_nll / total_tokens)``.
+    This correctly handles variable-length sequences and distributed shards.
+    """
+
+    def compute(self, logits: torch.Tensor, labels: torch.Tensor, **kwargs) -> Dict[str, torch.Tensor]:
+        # Handle both (batch, seq, vocab) and (batch, vocab) shapes
+        if logits.dim() == 3:
+            # Shift for causal LM: predict token t+1 from token t
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+        else:
+            shift_logits = logits
+            shift_labels = labels
+
+        # Ignore index -100 (HuggingFace convention)
+        ignore_index = -100
+        mask = shift_labels != ignore_index
+
+        # Compute per-token NLL using log_softmax for numerical stability
+        log_probs = torch.nn.functional.log_softmax(shift_logits.float(), dim=-1)
+        # Gather the log-prob of the correct token
+        gathered = log_probs.gather(dim=-1, index=shift_labels.clamp(min=0).unsqueeze(-1)).squeeze(-1)
+        # Zero out ignored positions
+        gathered = gathered * mask
+        total_nll = -gathered.sum()
+        total_tokens = mask.sum()
+
+        return {
+            "perplexity": total_nll,
+            "perplexity_count": total_tokens,
+        }
+
+    def aggregate(self, partial: Dict[str, torch.Tensor]) -> Dict[str, float]:
+        result = super().aggregate(partial)
+        # Convert NLL to perplexity
+        if "perplexity" in result and not (result["perplexity"] != result["perplexity"]):  # not NaN
+            result["perplexity"] = torch.exp(torch.tensor(result["perplexity"])).item()
+        return result
+
+
+@EVALUATOR_REGISTRY.register("accuracy")
+class AccuracyEvaluator(Evaluator):
+    """Classification accuracy.
+
+    Compares ``argmax(logits)`` to ``labels`` and averages over all valid
+    (non-ignored) positions. Works for both sequence classification and
+    token-level classification.
+    """
+
+    def compute(self, logits: torch.Tensor, labels: torch.Tensor, **kwargs) -> Dict[str, torch.Tensor]:
+        if logits.dim() == 3:
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+        else:
+            shift_logits = logits
+            shift_labels = labels
+
+        ignore_index = -100
+        mask = shift_labels != ignore_index
+
+        predictions = shift_logits.argmax(dim=-1)
+        correct = (predictions == shift_labels) & mask
+
+        return {
+            "accuracy": correct.sum().float(),
+            "accuracy_count": mask.sum().float(),
+        }
+
+
+@EVALUATOR_REGISTRY.register("token_accuracy")
+class TokenAccuracyEvaluator(Evaluator):
+    """Token-level accuracy (alias for accuracy with a different name).
+
+    Useful when both sequence-level and token-level metrics are needed
+    in the same validation run.
+    """
+
+    def compute(self, logits: torch.Tensor, labels: torch.Tensor, **kwargs) -> Dict[str, torch.Tensor]:
+        if logits.dim() == 3:
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+        else:
+            shift_logits = logits
+            shift_labels = labels
+
+        ignore_index = -100
+        mask = shift_labels != ignore_index
+
+        predictions = shift_logits.argmax(dim=-1)
+        correct = (predictions == shift_labels) & mask
+
+        return {
+            "token_accuracy": correct.sum().float(),
+            "token_accuracy_count": mask.sum().float(),
+        }
+
+
+@EVALUATOR_REGISTRY.register("loss")
+class LossEvaluator(Evaluator):
+    """Average validation loss.
+
+    Uses the model's native loss when available (``kwargs["loss"]``),
+    otherwise computes cross-entropy from logits and labels.
+    """
+
+    def compute(self, logits: torch.Tensor, labels: torch.Tensor, **kwargs) -> Dict[str, torch.Tensor]:
+        loss = kwargs.get("loss")
+        if loss is not None:
+            # Model already computed the loss; use it directly
+            if logits.dim() == 3:
+                shift_labels = labels[..., 1:].contiguous()
+            else:
+                shift_labels = labels
+            ignore_index = -100
+            token_count = (shift_labels != ignore_index).sum()
+            return {
+                "val_loss": loss * token_count,
+                "val_loss_count": token_count.float(),
+            }
+
+        # Fallback: compute CE loss from logits
+        if logits.dim() == 3:
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+        else:
+            shift_logits = logits
+            shift_labels = labels
+
+        ignore_index = -100
+        mask = shift_labels != ignore_index
+        ce_loss = torch.nn.functional.cross_entropy(
+            shift_logits.float().view(-1, shift_logits.size(-1)),
+            shift_labels.view(-1),
+            ignore_index=ignore_index,
+            reduction="sum",
+        )
+        token_count = mask.sum()
+
+        return {
+            "val_loss": ce_loss,
+            "val_loss_count": token_count.float(),
+        }
+
+
+def build_evaluator(name: str) -> Evaluator:
+    """Look up an evaluator by its registry name.
+
+    Args:
+        name: Registry key, e.g. ``"perplexity"``, ``"accuracy"``.
+
+    Returns:
+        An :class:`Evaluator` instance.
+    """
+    return EVALUATOR_REGISTRY[name]()
+
+
+def compute_metrics(
+    evaluators: List[Evaluator],
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    **kwargs,
+) -> Dict[str, float]:
+    """Run multiple evaluators and return aggregated metrics.
+
+    Each evaluator computes a per-rank partial, then all partials are
+    all-reduced to produce global averages.
+
+    Args:
+        evaluators: List of :class:`Evaluator` instances.
+        logits: Model output logits.
+        labels: Ground-truth labels.
+        **kwargs: Extra forward outputs passed to each evaluator.
+
+    Returns:
+        Dict mapping metric names to float values.
+    """
+    results: Dict[str, float] = {}
+    for evaluator in evaluators:
+        partial = evaluator.compute(logits, labels, **kwargs)
+        results.update(evaluator.aggregate(partial))
+    return results

--- a/veomni/data/validation_loader.py
+++ b/veomni/data/validation_loader.py
@@ -1,0 +1,121 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation dataloader builder.
+
+Reuses the existing :func:`veomni.data.build_dataloader` infrastructure so
+that validation data benefits from the same ``StatefulDistributedSampler``
+and ``DistributedDataloader`` used for training.
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+from ..utils import logging
+from .data_loader import DistributedDataloader, build_dataloader
+from .data_transform import build_data_transform
+from .dataset import build_dataset
+from .data_collator import MainCollator
+
+if TYPE_CHECKING:
+    from ..arguments import VeOmniArguments
+
+logger = logging.get_logger(__name__)
+
+
+def build_validation_dataloader(
+    args: "VeOmniArguments",
+    tokenizer,
+    chat_template=None,
+) -> Optional[DistributedDataloader]:
+    """Build a validation dataloader from ``args.data.eval_path``.
+
+    Reuses the same dataset / transform / collator / dataloader stack as
+    training, but with ``shuffle=False`` and ``drop_last=False`` so every
+    validation sample is seen exactly once per epoch.
+
+    Args:
+        args: Global :class:`VeOmniArguments`.
+        tokenizer: Tokenizer instance from the trainer.
+        chat_template: Optional chat template for conversation data.
+
+    Returns:
+        A :class:`DistributedDataloader` for validation, or ``None`` if
+        ``args.data.eval_path`` is not set.
+    """
+    if args.data.eval_path is None:
+        logger.warning_rank0(
+            "data.eval_path is not set; skipping validation dataloader build. "
+            "Set data.eval_path in your config to enable training-time validation."
+        )
+        return None
+
+    logger.info_rank0(f"Building validation dataloader from {args.data.eval_path}")
+
+    # Build data transform (same as training)
+    data_transform = build_data_transform(
+        args.data.data_type,
+        tokenizer=tokenizer,
+        chat_template=chat_template,
+        max_seq_len=args.data.max_seq_len,
+        text_keys=args.data.text_keys,
+    )
+
+    # Build validation dataset
+    val_dataset = build_dataset(
+        dataset_name=args.data.datasets_type,
+        transform=data_transform,
+        seed=args.train.seed,
+        train_path=args.data.eval_path,
+        data_type=args.data.data_type,
+        max_seq_len=args.data.max_seq_len,
+        text_keys=args.data.text_keys,
+        chat_template=args.data.chat_template,
+        source_name=args.data.source_name,
+        datasets_type=args.data.datasets_type,
+        multisource_datasets_type=args.data.multisource_datasets_type,
+        train_size=1.0,
+        train_sample=0,
+        silent_exception=args.data.silent_exception,
+    )
+
+    # Build collator (same as training)
+    seq_classification = args.data.data_type == "classification"
+    collate_fn = MainCollator(
+        pad_to_length=args.train.pad_to_length,
+        seq_classification=seq_classification,
+    )
+
+    # Build dataloader with validation-friendly defaults
+    # Use a fixed batch size (no dynamic batching) for deterministic eval
+    val_dataloader = build_dataloader(
+        dataloader_type=args.data.dataloader.type,
+        dataset=val_dataset,
+        micro_batch_size=args.train.micro_batch_size,
+        global_batch_size=args.train.micro_batch_size * args.train.accelerator.dp_size,
+        dataloader_batch_size=args.train.micro_batch_size,
+        max_seq_len=args.data.max_seq_len,
+        train_steps=0,  # Not used for validation
+        dyn_bsz=False,  # Fixed batch size for deterministic evaluation
+        collate_fn=collate_fn,
+        num_workers=args.data.dataloader.num_workers,
+        prefetch_factor=args.data.dataloader.prefetch_factor,
+        persistent_workers=args.data.dataloader.persistent_workers,
+        drop_last=False,  # Keep all validation samples
+        pin_memory=args.data.dataloader.pin_memory,
+        seed=args.train.seed,
+        shuffle=False,  # Deterministic order for validation
+        save_steps=0,
+    )
+
+    return val_dataloader

--- a/veomni/trainer/callbacks/evaluate_callback.py
+++ b/veomni/trainer/callbacks/evaluate_callback.py
@@ -95,78 +95,84 @@ class EvaluateCallback(Callback):
         was_training = model.training
         model.eval()
 
-        # Set epoch on the sampler for deterministic sharding
-        if hasattr(self._val_dataloader, "set_epoch"):
-            self._val_dataloader.set_epoch(state.epoch)
+        try:
+            # Set epoch on the sampler for deterministic sharding
+            if hasattr(self._val_dataloader, "set_epoch"):
+                self._val_dataloader.set_epoch(state.epoch)
 
-        logger.info_rank0(
-            f"Starting validation at step {state.global_step}, epoch {state.epoch}."
-        )
+            logger.info_rank0(
+                f"Starting validation at step {state.global_step}, epoch {state.epoch}."
+            )
 
-        # Accumulate partial sums per evaluator (each gets its own dict)
-        accumulated: List[Dict[str, torch.Tensor]] = [{} for _ in self._evaluators]
+            # Initialize accumulated partials with zero tensors for each evaluator's
+            # metric schema. This ensures every rank has the same keys in accumulated,
+            # so all_reduce calls are aligned even if a rank's iterable shard is empty.
+            accumulated: List[Dict[str, torch.Tensor]] = []
+            for evaluator in self._evaluators:
+                dummy_logits = torch.zeros(1, 2, 2, device=self.trainer.device)
+                dummy_labels = torch.zeros(1, 2, dtype=torch.long, device=self.trainer.device)
+                dummy_partial = evaluator.compute(dummy_logits, dummy_labels)
+                accumulated.append({k: torch.zeros_like(v) for k, v in dummy_partial.items()})
 
-        with torch.no_grad():
-            for batch_idx, micro_batches in enumerate(self._val_dataloader):
-                # The dataloader yields a list of micro-batches (same format as training).
-                # For validation we process each micro-batch and accumulate.
-                if not isinstance(micro_batches, list):
-                    micro_batches = [micro_batches]
+            with torch.no_grad():
+                for batch_idx, micro_batches in enumerate(self._val_dataloader):
+                    # The dataloader yields a list of micro-batches (same format as training).
+                    # For validation we process each micro-batch and accumulate.
+                    if not isinstance(micro_batches, list):
+                        micro_batches = [micro_batches]
 
-                for micro_batch in micro_batches:
-                    # Move tensors to device
-                    moved = {}
-                    for k, v in micro_batch.items():
-                        if isinstance(v, torch.Tensor):
-                            moved[k] = v.to(self.trainer.device, non_blocking=True)
-                        else:
-                            moved[k] = v
-
-                    # Forward pass
-                    forward_kwargs = dict(moved)
-                    if supports_use_cache:
-                        forward_kwargs["use_cache"] = False
-                    outputs = model(**forward_kwargs)
-
-                    logits = getattr(outputs, "logits", None)
-                    labels = moved.get("labels")
-                    if logits is None or labels is None:
-                        continue
-
-                    # Compute partial metrics for this batch, per evaluator
-                    for i, evaluator in enumerate(self._evaluators):
-                        partial = evaluator.compute(
-                            logits, labels, loss=getattr(outputs, "loss", None),
-                        )
-                        for k, v in partial.items():
-                            if k in accumulated[i]:
-                                accumulated[i][k] += v.detach()
+                    for micro_batch in micro_batches:
+                        # Move tensors to device
+                        moved = {}
+                        for k, v in micro_batch.items():
+                            if isinstance(v, torch.Tensor):
+                                moved[k] = v.to(self.trainer.device, non_blocking=True)
                             else:
-                                accumulated[i][k] = v.detach()
+                                moved[k] = v
 
-        # Aggregate using each evaluator's own aggregate() method
-        results: Dict[str, float] = {}
-        for i, evaluator in enumerate(self._evaluators):
-            results.update(evaluator.aggregate(accumulated[i]))
+                        # Forward pass
+                        forward_kwargs = dict(moved)
+                        if supports_use_cache:
+                            forward_kwargs["use_cache"] = False
+                        outputs = model(**forward_kwargs)
 
-        # Log results
-        metrics_str = ", ".join(f"{k}={v:.4f}" for k, v in results.items())
-        logger.info_rank0(
-            f"Validation results at step {state.global_step}: {metrics_str}"
-        )
+                        logits = getattr(outputs, "logits", None)
+                        labels = moved.get("labels")
+                        if logits is None or labels is None:
+                            continue
 
-        # Log to wandb if enabled (rank 0 only)
-        if args.train.wandb.enable and getattr(args.train, "global_rank", 0) == 0:
-            try:
-                import wandb
+                        # Compute partial metrics for this batch, per evaluator
+                        for i, evaluator in enumerate(self._evaluators):
+                            partial = evaluator.compute(
+                                logits, labels, loss=getattr(outputs, "loss", None),
+                            )
+                            for k, v in partial.items():
+                                accumulated[i][k] += v.detach()
 
-                wandb.log(
-                    {f"val/{k}": v for k, v in results.items()},
-                    step=state.global_step,
-                )
-            except Exception:
-                logger.warning_rank0("Failed to log validation metrics to wandb.")
+            # Aggregate using each evaluator's own aggregate() method
+            results: Dict[str, float] = {}
+            for i, evaluator in enumerate(self._evaluators):
+                results.update(evaluator.aggregate(accumulated[i]))
 
-        # Restore training mode
-        if was_training:
-            model.train()
+            # Log results
+            metrics_str = ", ".join(f"{k}={v:.4f}" for k, v in results.items())
+            logger.info_rank0(
+                f"Validation results at step {state.global_step}: {metrics_str}"
+            )
+
+            # Log to wandb if enabled (rank 0 only)
+            if args.train.wandb.enable and getattr(args.train, "global_rank", 0) == 0:
+                try:
+                    import wandb
+
+                    wandb.log(
+                        {f"val/{k}": v for k, v in results.items()},
+                        step=state.global_step,
+                    )
+                except Exception:
+                    logger.warning_rank0("Failed to log validation metrics to wandb.")
+
+        finally:
+            # Restore training mode on every exit path (including exceptions)
+            if was_training:
+                model.train()

--- a/veomni/trainer/callbacks/evaluate_callback.py
+++ b/veomni/trainer/callbacks/evaluate_callback.py
@@ -136,7 +136,7 @@ class EvaluateCallback(Callback):
                     # Compute partial metrics for this batch, per evaluator
                     for i, evaluator in enumerate(self._evaluators):
                         partial = evaluator.compute(
-                            logits, labels, loss=outputs.loss,
+                            logits, labels, loss=getattr(outputs, "loss", None),
                         )
                         for k, v in partial.items():
                             if k in accumulated[i]:
@@ -155,8 +155,8 @@ class EvaluateCallback(Callback):
             f"Validation results at step {state.global_step}: {metrics_str}"
         )
 
-        # Log to wandb if enabled
-        if args.train.wandb.enable:
+        # Log to wandb if enabled (rank 0 only)
+        if args.train.wandb.enable and getattr(args.train, "global_rank", 0) == 0:
             try:
                 import wandb
 

--- a/veomni/trainer/callbacks/evaluate_callback.py
+++ b/veomni/trainer/callbacks/evaluate_callback.py
@@ -14,6 +14,8 @@
 
 from typing import Dict, List
 
+import inspect
+
 import torch
 
 from veomni.data import build_evaluator, build_validation_dataloader
@@ -83,15 +85,11 @@ class EvaluateCallback(Callback):
         args = self.trainer.args
         model = self.trainer.model
 
-        # Guard: skip evaluation for models that don't produce logits
-        # (e.g. DiT diffusion models use a different forward signature)
-        if not hasattr(model, "use_cache"):
-            logger.info_rank0(
-                "Skipping validation: model does not support use_cache "
-                "(likely a non-causal-LM model). Evaluation is only supported "
-                "for text generation models."
-            )
-            return
+        # Check if the model's forward accepts use_cache (causal LM models do,
+        # but DiT and other non-text models do not).
+        unwrapped = model.module if hasattr(model, "module") else model
+        forward_params = inspect.signature(unwrapped.forward).parameters
+        supports_use_cache = "use_cache" in forward_params
 
         # Switch to eval mode
         was_training = model.training
@@ -125,7 +123,10 @@ class EvaluateCallback(Callback):
                             moved[k] = v
 
                     # Forward pass
-                    outputs = model(**moved, use_cache=False)
+                    forward_kwargs = dict(moved)
+                    if supports_use_cache:
+                        forward_kwargs["use_cache"] = False
+                    outputs = model(**forward_kwargs)
 
                     logits = getattr(outputs, "logits", None)
                     labels = moved.get("labels")

--- a/veomni/trainer/callbacks/evaluate_callback.py
+++ b/veomni/trainer/callbacks/evaluate_callback.py
@@ -12,28 +12,160 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import Dict, List
 
+import torch
+
+from veomni.data import build_evaluator, build_validation_dataloader
 from veomni.trainer.callbacks.base import TrainerState
+from veomni.utils import logging
 
 from .base import Callback
 
 
-if TYPE_CHECKING:
-    from ..base import Arguments
+logger = logging.get_logger(__name__)
 
 
 class EvaluateCallback(Callback):
+    """Runs validation evaluation at configured intervals.
+
+    Triggered by ``train.eval_steps`` (per-step) and ``train.eval_epochs``
+    (per-epoch) from :class:`VeOmniArguments`.  When triggered, builds a
+    validation dataloader from ``data.eval_path`` (cached on first use),
+    runs the model in ``eval`` mode under ``torch.no_grad``, computes the
+    metrics listed in ``train.validation_metrics``, and logs results to
+    stdout and wandb (if enabled).
+    """
+
+    _val_dataloader = None
+    _evaluators: List = None
+
     def on_epoch_end(self, state: TrainerState, **kwargs):
-        args: "Arguments" = self.trainer.args
+        args = self.trainer.args
         if args.train.eval_epochs and (state.epoch + 1) % args.train.eval_epochs == 0:
             self._evaluate(state)
 
     def on_step_end(self, state: TrainerState, **kwargs) -> None:
-        args: "Arguments" = self.trainer.args
+        args = self.trainer.args
         if args.train.eval_steps and state.global_step % args.train.eval_steps == 0:
             self._evaluate(state)
 
+    def _ensure_built(self):
+        """Lazily build the validation dataloader and evaluators."""
+        if self._val_dataloader is not None:
+            return
+
+        args = self.trainer.args
+
+        # Build validation dataloader
+        self._val_dataloader = build_validation_dataloader(
+            args=args,
+            tokenizer=self.trainer.tokenizer,
+            chat_template=getattr(self.trainer, "chat_template", None),
+        )
+
+        # Build evaluators from config
+        metric_names = getattr(args.train, "validation_metrics", ["loss"]) or ["loss"]
+        self._evaluators = [build_evaluator(name) for name in metric_names]
+
+        if self._val_dataloader is None:
+            logger.warning_rank0(
+                "Validation is enabled (eval_steps/eval_epochs > 0) but data.eval_path is not set. "
+                "Skipping evaluation."
+            )
+
     def _evaluate(self, state: TrainerState):
-        # TODO: implement evaluate
-        pass
+        """Run a full validation pass and log metrics."""
+        self._ensure_built()
+        if self._val_dataloader is None:
+            return
+
+        args = self.trainer.args
+        model = self.trainer.model
+
+        # Guard: skip evaluation for models that don't produce logits
+        # (e.g. DiT diffusion models use a different forward signature)
+        if not hasattr(model, "use_cache"):
+            logger.info_rank0(
+                "Skipping validation: model does not support use_cache "
+                "(likely a non-causal-LM model). Evaluation is only supported "
+                "for text generation models."
+            )
+            return
+
+        # Switch to eval mode
+        was_training = model.training
+        model.eval()
+
+        # Set epoch on the sampler for deterministic sharding
+        if hasattr(self._val_dataloader, "set_epoch"):
+            self._val_dataloader.set_epoch(state.epoch)
+
+        logger.info_rank0(
+            f"Starting validation at step {state.global_step}, epoch {state.epoch}."
+        )
+
+        # Accumulate partial sums per evaluator (each gets its own dict)
+        accumulated: List[Dict[str, torch.Tensor]] = [{} for _ in self._evaluators]
+
+        with torch.no_grad():
+            for batch_idx, micro_batches in enumerate(self._val_dataloader):
+                # The dataloader yields a list of micro-batches (same format as training).
+                # For validation we process each micro-batch and accumulate.
+                if not isinstance(micro_batches, list):
+                    micro_batches = [micro_batches]
+
+                for micro_batch in micro_batches:
+                    # Move tensors to device
+                    moved = {}
+                    for k, v in micro_batch.items():
+                        if isinstance(v, torch.Tensor):
+                            moved[k] = v.to(self.trainer.device, non_blocking=True)
+                        else:
+                            moved[k] = v
+
+                    # Forward pass
+                    outputs = model(**moved, use_cache=False)
+
+                    logits = getattr(outputs, "logits", None)
+                    labels = moved.get("labels")
+                    if logits is None or labels is None:
+                        continue
+
+                    # Compute partial metrics for this batch, per evaluator
+                    for i, evaluator in enumerate(self._evaluators):
+                        partial = evaluator.compute(
+                            logits, labels, loss=outputs.loss,
+                        )
+                        for k, v in partial.items():
+                            if k in accumulated[i]:
+                                accumulated[i][k] += v.detach()
+                            else:
+                                accumulated[i][k] = v.detach()
+
+        # Aggregate using each evaluator's own aggregate() method
+        results: Dict[str, float] = {}
+        for i, evaluator in enumerate(self._evaluators):
+            results.update(evaluator.aggregate(accumulated[i]))
+
+        # Log results
+        metrics_str = ", ".join(f"{k}={v:.4f}" for k, v in results.items())
+        logger.info_rank0(
+            f"Validation results at step {state.global_step}: {metrics_str}"
+        )
+
+        # Log to wandb if enabled
+        if args.train.wandb.enable:
+            try:
+                import wandb
+
+                wandb.log(
+                    {f"val/{k}": v for k, v in results.items()},
+                    step=state.global_step,
+                )
+            except Exception:
+                logger.warning_rank0("Failed to log validation metrics to wandb.")
+
+        # Restore training mode
+        if was_training:
+            model.train()


### PR DESCRIPTION
## Summary

Implements the `EvaluateCallback._evaluate()` TODO stub to enable periodic validation during training. This addresses the existing placeholder in `veomni/trainer/callbacks/evaluate_callback.py` (line 37-39: `# TODO: implement evaluate`).

## Changes

### New Files

| File | Description |
|------|-------------|
| `veomni/data/evaluator.py` | Core evaluator module with Registry pattern and distributed-aware aggregation. Supports 4 metrics: `loss`, `perplexity`, `accuracy`, `token_accuracy`. |
| `veomni/data/validation_loader.py` | Builds validation dataloader reusing existing `build_dataloader` infrastructure with deterministic eval settings (`shuffle=False`, `drop_last=False`, `dyn_bsz=False`). |
| `tests/data/test_evaluator.py` | pytest unit tests covering all evaluators, packed-batch boundaries, and distributed aggregation. |
| `docs/usage/training_with_validation.md` | User documentation with configuration guide and custom metric registration example. |
| `configs/examples/validation_example.yaml` | Configuration example. |

### Modified Files

| File | Changes |
|------|---------|
| `veomni/trainer/callbacks/evaluate_callback.py` | Implements `_ensure_built()` for lazy init, `_evaluate()` with `model.eval()`, `torch.no_grad()`, batch iteration, per-evaluator `aggregate()`, wandb logging, `model.train()` restore. Uses `inspect.signature()` to check `use_cache` support for DiT compatibility. |
| `veomni/data/__init__.py` | Appends evaluator exports (preserves all existing exports). |
| `veomni/arguments/arguments_types.py` | Adds `validation_metrics: List[str]` field to `TrainingArguments` (default: `["loss"]`). |

## Design Decisions

1. **Registry pattern**: Follows existing `DATA_TRANSFORM_REGISTRY` convention for extensibility
2. **Distributed-aware**: Per-rank partial sums aggregated via `dist.all_reduce()` 
3. **Lazy initialization**: Dataloader/evaluators built on first eval trigger, not at training start
4. **Backward compatible**: Default `validation_metrics=["loss"]`, eval disabled when `eval_steps=0` and `eval_epochs=0`
5. **Causal LM shift**: Evaluators apply standard `logits[:-1]` / `labels[1:]` shift
6. **ignore_index support**: `-100` labels automatically masked
7. **DiT compatibility**: Uses `inspect.signature()` to detect `use_cache` support, handles DDP-wrapped models via `model.module`

## Usage

```yaml
# In config YAML
train:
  eval_steps: 500        # Evaluate every 500 steps
  validation_metrics: ["loss", "perplexity", "accuracy"]

data:
  eval_path: /path/to/validation/data
```

## Testing

Verified on GPU (80GB) with PyTorch 2.3.1+cu118, Python 3.10.18:

- `verify_evaluators.py`: **7/7 PASSED** (including GPU large-scale test with batch=4, seq=512, vocab=32000)
- `pytest tests/data/test_evaluator.py`: **22/22 PASSED**

```
===== test session starts =====
platform linux -- Python 3.10.18, pytest-9.1.1, pluggy-1.6.0
collected 22 items

tests/data/test_evaluator.py ......................                     [100%]

===== 22 passed in 3.29s =====
```

Test coverage includes:
- Deterministic logits with exact metric value assertions
- Packed-batch boundary masking (IGNORE_INDEX at sample boundaries)
- Multi-rank distributed aggregation via real `dist.all_reduce` (gloo backend)
- Registry lookup and error handling

## Checklist

- [x] Apache 2.0 license headers on all new files
- [x] Follows existing code style (Registry pattern, `logging.get_logger`, `info_rank0`)
- [x] No new dependencies required (uses only `torch`, `torch.distributed`, `inspect`)
- [x] All existing exports preserved in `__init__.py`
- [x] Unit tests included and passing (deterministic, exact assertions)
- [x] Documentation included
- [x] Configuration example included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added training-time validation with configurable evaluation intervals.
  * Added loss, perplexity, accuracy, and token accuracy metrics.
  * Added distributed metric aggregation and support for custom evaluators.
  * Added deterministic validation data loading and optional experiment tracking.
* **Documentation**
  * Added validation configuration examples and usage guidance.
* **Tests**
  * Added comprehensive coverage for evaluators, metric aggregation, batching, and distributed validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->