### PR TITLE
[data] fix: use current message role in CFG unconditioned generation

### DIFF
--- a/tests/data/multimodal/test_cfg_unconditioned_generation.py
+++ b/tests/data/multimodal/test_cfg_unconditioned_generation.py
@@ -1,0 +1,43 @@
+from veomni.data.multimodal.multimodal_chat_template import Qwen2VLPretrainTemplate
+
+
+class _T2ITokenizer:
+    pad_token_id = 0
+
+    def __init__(self):
+        self._ids = {
+            "<|im_start|>": [1],
+            "<|im_end|>\n": [2],
+            "a cat": [5, 6],
+            "<|vision_start|><|image_pad|><|vision_end|>": [7],
+        }
+
+    def convert_tokens_to_ids(self, token):
+        return {
+            "<|image_pad|>": 100,
+            "<|video_pad|>": 101,
+            "<|vision_start|>": 102,
+            "<|vision_end|>": 103,
+        }.get(token, -1)
+
+    def encode(self, text, add_special_tokens=False):
+        return self._ids[text]
+
+
+def test_unconditioned_generation_pads_user_turn_when_user_not_last():
+    tokenizer = _T2ITokenizer()
+    template = Qwen2VLPretrainTemplate(tokenizer, cfg_ratio=1.0)
+
+    # t2i conversation: a user text prompt followed by the assistant image
+    # turn. The unconditioned-generation path must pad the *user* turn even
+    # though it is not the last message (previously the stale `role` bound to
+    # the assistant turn skipped the padding).
+    conversations = [
+        ["user", ["text", "a cat"]],
+        ["assistant", ["image"]],
+    ]
+
+    encoded = template.encode_messages(conversations, num_tokens={"image": [1]})
+
+    # bos(1) + pad(0) * 2 (user text replaced) + image(7) + eos(2)
+    assert encoded["input_ids"].tolist() == [1, 0, 0, 7, 2]

--- a/veomni/data/multimodal/multimodal_chat_template.py
+++ b/veomni/data/multimodal/multimodal_chat_template.py
@@ -112,7 +112,9 @@ class Qwen2VLPretrainTemplate(Qwen2VLTemplate):  # For Omni Only
             loss_mask = message["loss_mask"]
             if content_str == "":  # eval
                 break
-            if role == "user" and data_type == "t2i" and self._unconditioned_generation:  # unconditioned generation
+            if (
+                message["role"] == "user" and data_type == "t2i" and self._unconditioned_generation
+            ):  # unconditioned generation
                 input_ids += [self.tokenizer.pad_token_id] * len(content_ids)
             else:
                 input_ids += content_ids
@@ -836,7 +838,9 @@ class LlamaPretrainTemplate(MultimodalChatTemplate):  # For Omni Only
             loss_mask = message["loss_mask"]
             if content_str == "":  # eval
                 break
-            if role == "user" and data_type == "t2i" and self._unconditioned_generation:  # unconditioned generation
+            if (
+                message["role"] == "user" and data_type == "t2i" and self._unconditioned_generation
+            ):  # unconditioned generation
                 input_ids += [self.pad_token_id] * len(content_ids)
             else:
                 input_ids += content_ids


### PR DESCRIPTION
Qwen2VLPretrainTemplate.encode_messages and LlamaPretrainTemplate.encode_messages build the token sequence in a second loop over `messages`, but the unconditioned-generation check read the `role` variable left over from the first loop (the last conversation turn) instead of the current message's role. For a t2i conversation ending with the assistant image turn, `role` was "assistant", so the user text prompt was never padded to pad tokens and unconditioned (classifier-free) generation silently degraded to conditioned generation.

Read message["role"] in the check so the user turn is padded regardless of message order. Add a regression test covering a user-turn-not-last t2i conversation.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed unconditioned text-to-image generation so user text is correctly replaced with padding when full image conditioning is enabled.
  - Preserved image and boundary tokens during multimodal message encoding.
  - Added regression coverage to help prevent future issues with unconditioned generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->