### PR TITLE
[dist] fix: drop spurious sp_world_size factor in ReduceLoss backward

### DIFF
--- a/tests/distributed/test_reduce_loss.py
+++ b/tests/distributed/test_reduce_loss.py
@@ -1,0 +1,40 @@
+import torch
+import torch.distributed as dist
+
+from veomni.distributed.sequence_parallel.loss import ReduceLoss
+
+
+def test_reduce_loss_backward_is_token_weighted_mean(monkeypatch):
+    # Simulate a 2-rank sequence-parallel group without a real process group:
+    #   rank 0: local mean loss 2.0 over n0=3 valid tokens
+    #   rank 1: local mean loss 4.0 over n1=5 valid tokens
+    # ReduceLoss.forward computes the token-weighted global mean
+    #   (2.0*3 + 4.0*5) / (3 + 5),
+    # so d(loss_out)/d(loss_0) must be n0 / (n0 + n1) = 3 / 8, with no extra
+    # world-size factor.
+    n0, n1 = 3.0, 5.0
+    loss1 = 4.0
+
+    calls = []
+
+    def fake_all_reduce(t, group=None):
+        calls.append(t)
+        if len(calls) == 1:
+            # First call reduces `loss` (already multiplied by local n0); add
+            # rank 1's contribution loss1 * n1.
+            t.add_(loss1 * n1)
+        else:
+            # Second call reduces `num_valid_tokens`; add rank 1's token count.
+            t.add_(n1)
+
+    monkeypatch.setattr(dist, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(dist, "get_world_size", lambda group=None: 2)
+
+    loss = torch.tensor([2.0], requires_grad=True)
+    num_valid_tokens = torch.tensor([n0])
+    out = ReduceLoss.apply(loss, num_valid_tokens, object())
+
+    assert torch.allclose(out, torch.tensor([26.0 / 8.0]), atol=1e-6)
+
+    out.backward()
+    assert torch.allclose(loss.grad, torch.tensor([3.0 / 8.0]), atol=1e-6)

--- a/veomni/distributed/sequence_parallel/loss.py
+++ b/veomni/distributed/sequence_parallel/loss.py
@@ -42,7 +42,6 @@ class ReduceLoss(torch.autograd.Function):
         dist.all_reduce(loss, group=group)
         dist.all_reduce(num_valid_tokens, group=group)
         ctx.save_for_backward(local_num_tokens, num_valid_tokens)
-        ctx.sp_world_size = dist.get_world_size(group) if group else 1
 
         # FIX: When ALL ranks in the SP group have zero valid tokens,
         # global num_valid_tokens = 0 after all_reduce, causing 0/0 = NaN.
@@ -59,7 +58,11 @@ class ReduceLoss(torch.autograd.Function):
 
         # FIX: Mirror the forward guard — zero grad when global tokens = 0,
         # preventing NaN grad_output from corrupting downstream parameters.
-        grad_output = ctx.sp_world_size * local_num_tokens * grad_output / global_num_tokens.clamp(min=1)
+        # The forward computes a token-weighted global mean
+        #   loss_out = (sum_j loss_j * n_j) / (sum_j n_j),
+        # whose gradient w.r.t. the local mean loss_j is n_j / sum_j n_j. There
+        # is no sequence-parallel world-size factor here.
+        grad_output = local_num_tokens * grad_output / global_num_tokens.clamp(min=1)
         return grad_output, None, None
 
 


### PR DESCRIPTION
ReduceLoss.forward computes a token-weighted global mean loss

    loss_out = (sum_j loss_j * n_j) / (sum_j n_j)

whose gradient w.r.t. the local mean loss loss_j is n_j / sum_j n_j. The backward multiplied this by ctx.sp_world_size, so enabling sequence parallel silently scaled the entire model gradient (and effective learning rate) by the SP world size. Remove the extra factor and the now-unused sp_world_size bookkeeping.

Add a regression test that simulates a 2-rank SP reduce and asserts d(loss_out)/d(loss_0) == n0 / (n0 + n1) with no world-size factor.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sequence-parallel loss gradient scaling for token-weighted global loss calculations.
  * Improved handling of batches with zero valid tokens to prevent invalid gradient scaling.

* **Tests**
  * Added coverage for distributed loss reduction and backward gradient behavior across multiple ranks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->