### PR TITLE
[dist] fix: reduce projection weight & bias grads over batch dim

### DIFF
--- a/tests/distributed/test_async_ulysses_grad.py
+++ b/tests/distributed/test_async_ulysses_grad.py
@@ -1,0 +1,52 @@
+import torch
+
+import veomni.distributed.sequence_parallel.async_ulysses as au
+
+
+def _mock_identity_comm(monkeypatch):
+    monkeypatch.setattr(au, "padding_tensor_for_seqeunce_parallel", lambda t, dim: t)
+    monkeypatch.setattr(au, "unpadding_tensor_for_seqeunce_parallel", lambda t, dim, size: t)
+
+    def fake_all_to_all(t, **kwargs):
+        return (lambda: t) if kwargs.get("async_op") else t
+
+    monkeypatch.setattr(au, "all_to_all_tensor", fake_all_to_all)
+
+
+def test_output_projection_weight_bias_grad_shapes(monkeypatch):
+    _mock_identity_comm(monkeypatch)
+
+    batch, seq, heads, head_dim = 2, 3, 4, 5
+    out_dim = 7
+    # attn_output layout: [batch, seq, num_heads, head_dim]; seq_dimension=1, head_dimension=2.
+    hidden_states = torch.randn(batch, seq, heads, head_dim, requires_grad=True)
+    proj_weight = torch.randn(out_dim, heads * head_dim, requires_grad=True)
+    proj_bias = torch.randn(out_dim, requires_grad=True)
+
+    out = au.AsyncUlyssesOutputProjection.apply(hidden_states, 1, 2, proj_weight, proj_bias, seq, object())
+    out.sum().backward()
+
+    # The weight grad must be reduced over the batch dim, and the bias grad over
+    # the batch and sequence dims, to match the parameter shapes.
+    assert proj_weight.grad is not None
+    assert proj_weight.grad.shape == proj_weight.shape
+    assert proj_bias.grad is not None
+    assert proj_bias.grad.shape == proj_bias.shape
+
+
+def test_output_projection_bias_grad_when_weight_frozen(monkeypatch):
+    _mock_identity_comm(monkeypatch)
+
+    batch, seq, heads, head_dim = 2, 3, 4, 5
+    out_dim = 7
+    hidden_states = torch.randn(batch, seq, heads, head_dim, requires_grad=True)
+    proj_weight = torch.randn(out_dim, heads * head_dim)  # frozen weight
+    proj_bias = torch.randn(out_dim, requires_grad=True)  # trainable bias
+
+    out = au.AsyncUlyssesOutputProjection.apply(hidden_states, 1, 2, proj_weight, proj_bias, seq, object())
+    out.sum().backward()
+
+    # needs_input_grad must be read at the bias index (4), not the weight index
+    # (3), so a trainable bias still receives its gradient.
+    assert proj_bias.grad is not None
+    assert proj_bias.grad.shape == proj_bias.shape

--- a/veomni/distributed/sequence_parallel/async_ulysses.py
+++ b/veomni/distributed/sequence_parallel/async_ulysses.py
@@ -352,9 +352,9 @@ class AsyncUlyssesQKVProjection(torch.autograd.Function):
         # v projection grad
         grad_v = grad_v.reshape(grad_v.shape[0], grad_v.shape[1], -1)
         grad_v_input = grad_v @ v_weight
-        grad_v_weight = grad_v.transpose(-1, -2) @ hidden_states
-        if v_bias is not None and ctx.needs_input_grad[7]:
-            grad_v_bias = grad_v.sum(0)
+        grad_v_weight = (grad_v.transpose(-1, -2) @ hidden_states).sum(0)
+        if v_bias is not None and ctx.needs_input_grad[8]:
+            grad_v_bias = grad_v.sum((0, 1))
 
         # k grad communication collect
         grad_k = grad_k_res()
@@ -376,9 +376,9 @@ class AsyncUlyssesQKVProjection(torch.autograd.Function):
         # k projection grad
         grad_k = grad_k.reshape(grad_k.shape[0], grad_k.shape[1], -1)
         grad_k_input = grad_k @ k_weight
-        grad_k_weight = grad_k.transpose(-1, -2) @ hidden_states
-        if k_bias is not None and ctx.needs_input_grad[5]:
-            grad_k_bias = grad_k.sum(0)
+        grad_k_weight = (grad_k.transpose(-1, -2) @ hidden_states).sum(0)
+        if k_bias is not None and ctx.needs_input_grad[6]:
+            grad_k_bias = grad_k.sum((0, 1))
 
         # q grad communication collect
         grad_q = grad_q_res()
@@ -386,9 +386,9 @@ class AsyncUlyssesQKVProjection(torch.autograd.Function):
         # q projection grad
         grad_q = grad_q.reshape(grad_q.shape[0], grad_q.shape[1], -1)
         grad_q_input = grad_q @ q_weight
-        grad_q_weight = grad_q.transpose(-1, -2) @ hidden_states
-        if q_bias is not None and ctx.needs_input_grad[3]:
-            grad_q_bias = grad_q.sum(0)
+        grad_q_weight = (grad_q.transpose(-1, -2) @ hidden_states).sum(0)
+        if q_bias is not None and ctx.needs_input_grad[4]:
+            grad_q_bias = grad_q.sum((0, 1))
 
         # grad
         grad_hidden_states = grad_q_input + grad_k_input + grad_v_input
@@ -484,9 +484,9 @@ class AsyncUlyssesOutputProjection(torch.autograd.Function):
             grad_o, scatter_dim=head_dimension, gather_dim=seq_dimension, group=sp_group, async_op=True
         )
 
-        grad_proj_weight = grad_output[0].transpose(-1, -2) @ (hidden_states)
-        if proj_bias is not None and ctx.needs_input_grad[3]:
-            grad_proj_bias = grad_output[0].sum(0)
+        grad_proj_weight = (grad_output[0].transpose(-1, -2) @ hidden_states).sum(0)
+        if proj_bias is not None and ctx.needs_input_grad[4]:
+            grad_proj_bias = grad_output[0].sum((0, 1))
 
         # output grad communication collect
         grad_o = grad_out_res()

--- a/veomni/distributed/sequence_parallel/async_ulysses_dit.py
+++ b/veomni/distributed/sequence_parallel/async_ulysses_dit.py
@@ -247,9 +247,9 @@ class AsyncUlyssesQKVProjection(torch.autograd.Function):
 
         # v projection grad
         grad_v_input = grad_v @ v_weight
-        grad_v_weight = grad_v.transpose(-1, -2) @ hidden_states
+        grad_v_weight = (grad_v.transpose(-1, -2) @ hidden_states).sum(0)
         if v_bias is not None and ctx.needs_input_grad[8]:
-            grad_v_bias = grad_v.sum(0)
+            grad_v_bias = grad_v.sum((0, 1))
 
         # k grad communication collect
         grad_k = grad_k_res()
@@ -297,9 +297,9 @@ class AsyncUlyssesQKVProjection(torch.autograd.Function):
 
         # k projection grad
         grad_k_input = grad_k @ k_weight
-        grad_k_weight = grad_k.transpose(-1, -2) @ hidden_states
+        grad_k_weight = (grad_k.transpose(-1, -2) @ hidden_states).sum(0)
         if k_bias is not None and ctx.needs_input_grad[6]:
-            grad_k_bias = grad_k.sum(0)
+            grad_k_bias = grad_k.sum((0, 1))
 
         # q grad communication collect
         grad_q = grad_q_res()
@@ -335,9 +335,9 @@ class AsyncUlyssesQKVProjection(torch.autograd.Function):
 
         # q projection grad
         grad_q_input = grad_q @ q_weight
-        grad_q_weight = grad_q.transpose(-1, -2) @ hidden_states
+        grad_q_weight = (grad_q.transpose(-1, -2) @ hidden_states).sum(0)
         if q_bias is not None and ctx.needs_input_grad[4]:
-            grad_q_bias = grad_q.sum(0)
+            grad_q_bias = grad_q.sum((0, 1))
 
         # grad
         grad_hidden_states = grad_q_input + grad_k_input + grad_v_input
@@ -426,9 +426,9 @@ class AsyncUlyssesOutputProjection(torch.autograd.Function):
             grad_o, scatter_dim=head_dimension, gather_dim=seq_dimension, group=sp_group, async_op=True
         )
 
-        grad_proj_weight = grad_output[0].transpose(-1, -2) @ (hidden_states)
+        grad_proj_weight = (grad_output[0].transpose(-1, -2) @ hidden_states).sum(0)
         if proj_bias is not None and ctx.needs_input_grad[4]:
-            grad_proj_bias = grad_output[0].sum(0)
+            grad_proj_bias = grad_output[0].sum((0, 1))
 
         # output grad communication collect
         grad_o = grad_out_res()


### PR DESCRIPTION
The backward pass of AsyncUlyssesQKVProjection and AsyncUlyssesOutputProjection computed each weight gradient as

    grad_w = grad_x.transpose(-1, -2) @ hidden_states   # [B, out, in]

but the weight is [out, in], so the batch dim must be summed away. The bias gradient was reduced over only the batch dim (grad_x.sum(0) -> [S, out]) instead of batch and sequence dims. Since the returned gradient shapes did not match the parameters, autograd raised "invalid gradient at index N" for any trainable projection weight or bias, breaking sequence-parallel training through these kernels.

The needs_input_grad guard for each bias also read the weight's input index (off by one), so a frozen weight would silently skip the trainable bias gradient.

Reduce weight grads with .sum(0), bias grads with .sum((0, 1)), and point each needs_input_grad guard at the correct bias input index.

Add regression tests covering the weight/bias grad shapes and the frozen-weight / trainable-bias case.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gradient calculations for attention and output projections across batch and sequence dimensions.
  * Corrected bias-gradient propagation, including cases where projection weights are frozen.
  * Ensured parameter gradients maintain the expected shapes for distributed sequence-parallel operations.

* **Tests**
  * Added coverage validating weight and bias gradient shapes and propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->