### PR TITLE
[data] fix: resolve Janus image token id after adding the special token

### DIFF
--- a/tests/data/multimodal/test_multimodal_chat_template.py
+++ b/tests/data/multimodal/test_multimodal_chat_template.py
@@ -1,0 +1,36 @@
+from veomni.data.multimodal.multimodal_chat_template import JanusChatTemplate
+
+
+class _JanusTokenizer:
+    """Minimal tokenizer whose `<image_placeholder>` is added on demand."""
+
+    unk_token_id = 3
+
+    def __init__(self):
+        self._vocab = {"<begin_of_image>": 10, "<end_of_image>": 11}
+        self._next_id = 20
+
+    def convert_tokens_to_ids(self, token):
+        return self._vocab.get(token, self.unk_token_id)
+
+    def add_special_tokens(self, special_tokens_dict):
+        added = 0
+        for token in special_tokens_dict["additional_special_tokens"]:
+            if token not in self._vocab:
+                self._vocab[token] = self._next_id
+                self._next_id += 1
+                added += 1
+        return added
+
+    def encode(self, text, add_special_tokens=False):
+        return [0]
+
+
+def test_janus_image_token_id_resolved_after_registering_special_token():
+    tokenizer = _JanusTokenizer()
+    template = JanusChatTemplate(tokenizer)
+
+    # The image placeholder id must reflect the token id assigned by
+    # add_special_tokens, not the unk id captured before registration.
+    assert template.image_token_id != tokenizer.unk_token_id
+    assert template.image_token_id == tokenizer.convert_tokens_to_ids("<image_placeholder>")

--- a/veomni/data/multimodal/multimodal_chat_template.py
+++ b/veomni/data/multimodal/multimodal_chat_template.py
@@ -577,7 +577,6 @@ class JanusChatTemplate(ChatmlTemplate):
         self.image_pad = "<image_placeholder>"
         self.image_start_tag = "<begin_of_image>"
         self.image_end_tag = "<end_of_image>"
-        self.image_token_id = self.tokenizer.convert_tokens_to_ids(self.image_pad)
         self.image_start_id = self.tokenizer.convert_tokens_to_ids(self.image_start_tag)
         self.use_system_prompt = use_system_prompt
         self.system_prompt = (
@@ -586,6 +585,9 @@ class JanusChatTemplate(ChatmlTemplate):
             "and assist the user with a variety of tasks using natural language."
         )
         self.tokenizer.add_special_tokens({"additional_special_tokens": [self.image_pad]})
+        # Resolve the image placeholder id AFTER registering it as a special
+        # token; before that, convert_tokens_to_ids returns the unk id.
+        self.image_token_id = self.tokenizer.convert_tokens_to_ids(self.image_pad)
         self.sep1 = "\n\n"
         self.sep2 = "<｜end▁of▁sentence｜>"  # eos
         self.eos = self.tokenizer.encode(self.sep2, add_special_tokens=False)


### PR DESCRIPTION
JanusChatTemplate.__init__ captured self.image_token_id via convert_tokens_to_ids("<image_placeholder>") before calling add_special_tokens, so it stored the unk token id (or None) instead of the freshly assigned placeholder id. The image_mask built from self.image_token_id then matched the wrong tokens (or nothing) when locating image positions.

Move the lookup after add_special_tokens so the id matches the registered token. Add a regression test with a minimal tokenizer that adds the placeholder on demand.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)
