### PR TITLE
[data, trainer] feat: add text training-time validation

### DIFF
--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -201,7 +201,7 @@ NPU validation runs at two times:
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | train_path | `str` | **Required** | Path of the training dataset. Use comma to separate multiple datasets. |
-| eval_path | `Optional[str]` | `None` | Path of the evaluation dataset. |
+| eval_path | `Optional[str]` | `None` | Path of the evaluation dataset for Text SFT training-time validation. `None` disables validation. See [Training-time validation](trainer.md#training-time-validation) for the current support boundary. |
 | train_size | `int` | `10_000_000` | Number of tokens for training (used to compute steps under dynamic batch). |
 | train_sample | `int` | `10_000` | Number of samples for training (used to compute steps under non-dynamic batch). |
 | data_type | `Literal["plaintext", "conversation", "diffusion", "classification", "dpo"]` | `"conversation"` | Type of the training data. |

--- a/docs/usage/trainer.md
+++ b/docs/usage/trainer.md
@@ -179,7 +179,7 @@ The initial support boundary is intentionally narrow: single-source conversation
 Text SFT with the native dataloader under pure DP/FSDP2. Plaintext is rejected because one raw row can
 expand into multiple chunks, and weighted multisource YAML is rejected because its interleave schedule
 does not represent an exact union of source samples. Iterable datasets, VLM, DPO, diffusion, RL,
-sequence/tensor/pipeline/extra parallelism, async sequence parallelism, ChunkMBS, and `torch.compile`
+sequence/tensor/pipeline/extra parallelism, async sequence parallelism, and `torch.compile`
 are rejected explicitly until their task-specific data, forward, and collective contracts are implemented.
 MoE router monitoring and torch profiling are also rejected so validation forwards cannot pollute
 training-only observability state.

--- a/docs/usage/trainer.md
+++ b/docs/usage/trainer.md
@@ -155,6 +155,37 @@ VeOmni includes several built-in callbacks:
 - **[HuggingfaceCkptCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/checkpoint_callback.py)**: Saves HuggingFace checkpoints.
 - **[EvaluateCallback](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/evaluate_callback.py)**: Runs evaluation on the validation set.
 
+### Training-time validation
+
+`TextTrainer` can report globally weighted `validation/loss` from a separate map-style dataset
+(token-weighted for causal LM and sample-weighted for classification). Set `data.eval_path` and
+enable at least one schedule with `train.eval_steps` or `train.eval_epochs`.
+Validation uses fixed sample batching even when training uses dynamic batching, preserves the source
+order, visits every validation sample exactly once, and restores the training/evaluation mode of every
+model module after a successful or failed validation run.
+Validation reuses the configured worker count but disables persistent validation workers, so its
+second worker pool is released after each pass instead of remaining resident for the trainer lifetime.
+
+```yaml
+data:
+  eval_path: /path/to/validation.jsonl
+  datasets_type: mapping
+train:
+  eval_steps: 100
+  eval_epochs: 0
+```
+
+The initial support boundary is intentionally narrow: single-source conversation and classification
+Text SFT with the native dataloader under pure DP/FSDP2. Plaintext is rejected because one raw row can
+expand into multiple chunks, and weighted multisource YAML is rejected because its interleave schedule
+does not represent an exact union of source samples. Iterable datasets, VLM, DPO, diffusion, RL,
+sequence/tensor/pipeline/extra parallelism, async sequence parallelism, ChunkMBS, and `torch.compile`
+are rejected explicitly until their task-specific data, forward, and collective contracts are implemented.
+MoE router monitoring and torch profiling are also rejected so validation forwards cannot pollute
+training-only observability state.
+Every data-parallel rank must receive a non-empty batch on every validation step; increase the validation
+dataset or `train.micro_batch_size` if exact, equally stepped partitioning is impossible.
+
 ### Custom Callbacks
 
 You can create custom callbacks by inheriting from [`Callback`](https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/trainer/callbacks/base.py) and registering them with `trainer.add_callback`.

--- a/tests/data/test_validation_sampler.py
+++ b/tests/data/test_validation_sampler.py
@@ -1,0 +1,159 @@
+import math
+import random
+import types
+
+import pytest
+import torch
+from torch.utils.data import Dataset
+
+from veomni.data import build_dataloader
+from veomni.data.data_loader import ExactDistributedBatchSampler
+
+
+@pytest.mark.parametrize(
+    ("dataset_size", "num_replicas", "batch_size"),
+    [(1, 1, 1), (3, 2, 2), (5, 2, 2), (8, 3, 2), (16, 4, 1), (23, 4, 3), (97, 8, 4)],
+)
+def test_exact_distributed_batch_sampler_is_an_exact_equal_step_partition(
+    dataset_size: int, num_replicas: int, batch_size: int
+):
+    batches_by_rank = [
+        list(ExactDistributedBatchSampler(dataset_size, batch_size, num_replicas, rank))
+        for rank in range(num_replicas)
+    ]
+
+    assert len({len(batches) for batches in batches_by_rank}) == 1
+    for batches in batches_by_rank:
+        assert all(1 <= len(batch) <= batch_size for batch in batches)
+
+    step_major_indices = [
+        index
+        for step in range(len(batches_by_rank[0]))
+        for rank in range(num_replicas)
+        for index in batches_by_rank[rank][step]
+    ]
+    assert step_major_indices == list(range(dataset_size))
+
+
+def test_exact_distributed_batch_sampler_is_repeatable_without_touching_rng_state():
+    sampler = ExactDistributedBatchSampler(dataset_size=23, batch_size=3, num_replicas=4, rank=2)
+    python_state = random.getstate()
+    torch_state = torch.random.get_rng_state().clone()
+
+    first = [tuple(batch) for batch in sampler]
+    sampler.set_epoch(9)
+    second = [tuple(batch) for batch in sampler]
+
+    assert first == second
+    assert random.getstate() == python_state
+    assert torch.equal(torch.random.get_rng_state(), torch_state)
+
+
+def test_exact_distributed_batch_sampler_small_grid_property():
+    for dataset_size in range(1, 41):
+        for num_replicas in range(1, 9):
+            for batch_size in range(1, 9):
+                schedulable = math.ceil(dataset_size / (num_replicas * batch_size)) * num_replicas <= dataset_size
+                if not schedulable:
+                    with pytest.raises(ValueError, match="cannot be partitioned"):
+                        ExactDistributedBatchSampler(dataset_size, batch_size, num_replicas, rank=0)
+                    continue
+
+                batches_by_rank = [
+                    list(ExactDistributedBatchSampler(dataset_size, batch_size, num_replicas, rank))
+                    for rank in range(num_replicas)
+                ]
+                assert len({len(batches) for batches in batches_by_rank}) == 1
+                indices = [index for batches in batches_by_rank for batch in batches for index in batch]
+                assert sorted(indices) == list(range(dataset_size))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"dataset_size": 0, "batch_size": 1, "num_replicas": 1, "rank": 0}, "non-empty"),
+        ({"dataset_size": 1, "batch_size": 0, "num_replicas": 1, "rank": 0}, "positive"),
+        ({"dataset_size": 1, "batch_size": 1, "num_replicas": 0, "rank": 0}, "positive"),
+        ({"dataset_size": 2, "batch_size": 1, "num_replicas": 2, "rank": 2}, "Rank must be"),
+        (
+            {"dataset_size": 5, "batch_size": 1, "num_replicas": 2, "rank": 0},
+            "cannot be partitioned",
+        ),
+    ],
+)
+def test_exact_distributed_batch_sampler_rejects_invalid_or_unschedulable_inputs(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        ExactDistributedBatchSampler(**kwargs)
+
+
+class _IndexDataset(Dataset):
+    def __len__(self):
+        return 5
+
+    def __getitem__(self, index):
+        return [{"id": torch.tensor(index)}]
+
+
+def _collate_ids(features):
+    return {"id": torch.stack([feature["id"] for feature in features])}
+
+
+def test_native_dataloader_accepts_exact_batch_sampler(monkeypatch):
+    import veomni.data.data_loader as data_loader_module
+
+    parallel_state = types.SimpleNamespace(dp_size=2, dp_rank=0, sp_enabled=False, sp_size=1)
+    monkeypatch.setattr(data_loader_module, "get_parallel_state", lambda: parallel_state)
+    batch_sampler = ExactDistributedBatchSampler(dataset_size=5, batch_size=2, num_replicas=2, rank=0)
+    generator = torch.Generator().manual_seed(17)
+    global_rng_state = torch.random.get_rng_state().clone()
+
+    dataloader = build_dataloader(
+        "native",
+        dataset=_IndexDataset(),
+        micro_batch_size=2,
+        global_batch_size=4,
+        dataloader_batch_size=2,
+        max_seq_len=8,
+        train_steps=len(batch_sampler),
+        dyn_bsz=False,
+        num_workers=0,
+        prefetch_factor=None,
+        pin_memory=False,
+        collate_fn=_collate_ids,
+        batch_sampler=batch_sampler,
+        generator=generator,
+    )
+
+    assert torch.equal(torch.random.get_rng_state(), global_rng_state)
+    observed = [micro_batches[0]["id"].tolist() for micro_batches in dataloader]
+    assert observed == [[0, 1], [3]]
+    assert torch.equal(torch.random.get_rng_state(), global_rng_state)
+    dataloader.set_epoch(1)
+    generator.manual_seed(17)
+    assert [micro_batches[0]["id"].tolist() for micro_batches in dataloader] == observed
+    assert torch.equal(torch.random.get_rng_state(), global_rng_state)
+
+
+def test_native_dataloader_rejects_custom_batch_sampler_with_dynamic_batching(monkeypatch):
+    import veomni.data.data_loader as data_loader_module
+
+    parallel_state = types.SimpleNamespace(dp_size=1, dp_rank=0, sp_enabled=False, sp_size=1)
+    monkeypatch.setattr(data_loader_module, "get_parallel_state", lambda: parallel_state)
+    batch_sampler = ExactDistributedBatchSampler(dataset_size=5, batch_size=2, num_replicas=1, rank=0)
+
+    with pytest.raises(ValueError, match="only when dyn_bsz=False"):
+        build_dataloader(
+            "native",
+            dataset=_IndexDataset(),
+            micro_batch_size=2,
+            global_batch_size=2,
+            dataloader_batch_size=1,
+            max_seq_len=8,
+            train_steps=1,
+            dyn_bsz=True,
+            num_workers=0,
+            prefetch_factor=None,
+            pin_memory=False,
+            collate_fn=_collate_ids,
+            batch_sampler=batch_sampler,
+        )

--- a/tests/trainer/test_training_validation.py
+++ b/tests/trainer/test_training_validation.py
@@ -1,0 +1,541 @@
+import os
+import sys
+from contextlib import nullcontext
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.utils.data import Dataset, IterableDataset
+
+import veomni.trainer.callbacks.base as callback_base_module
+import veomni.trainer.text_trainer as text_trainer_module
+import veomni.trainer.validation as validation_module
+from veomni.data.data_collator import MainCollator
+from veomni.data.data_loader import ExactDistributedBatchSampler
+from veomni.trainer.base import BaseTrainer
+from veomni.trainer.callbacks.base import TrainerState
+from veomni.trainer.callbacks.evaluate_callback import EvaluateCallback
+from veomni.trainer.text_trainer import TextTrainer
+from veomni.trainer.validation import TextValidationRunner
+
+
+def _parallel_state(**overrides):
+    values = {
+        "dp_size": 1,
+        "dp_rank": 0,
+        "dp_group": None,
+        "sp_size": 1,
+        "sp_rank": 0,
+        "sp_enabled": False,
+        "tp_enabled": False,
+        "pp_enabled": False,
+        "any_extra_parallel_enabled": False,
+        "async_enabled": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _ValidationModel(torch.nn.Module):
+    def __init__(self, fail_on_call=None):
+        super().__init__()
+        self.dropout = torch.nn.Dropout()
+        self.fail_on_call = fail_on_call
+        self.calls = 0
+
+    def forward(self, labels, loss_value, use_cache=False):
+        self.calls += 1
+        if self.calls == self.fail_on_call:
+            raise RuntimeError("validation forward failed")
+        return SimpleNamespace(loss=loss_value)
+
+
+class _ValidationDataloader:
+    def __init__(self, batches):
+        self.batches = batches
+        self.epochs = []
+
+    def set_epoch(self, epoch):
+        self.epochs.append(epoch)
+
+    def __iter__(self):
+        return iter(self.batches)
+
+
+def _runner(model, batches):
+    trainer = SimpleNamespace(
+        model=model,
+        device=torch.device("cpu"),
+        model_fwd_context=nullcontext(),
+        args=SimpleNamespace(
+            data=SimpleNamespace(data_type="conversation"),
+            train=SimpleNamespace(enable_batch_invariant_mode=False, seed=0),
+        ),
+    )
+    runner = TextValidationRunner.__new__(TextValidationRunner)
+    runner.trainer = trainer
+    runner.parallel_state = _parallel_state()
+    runner.dataloader = _ValidationDataloader(batches)
+    runner.dataloader_generator = torch.Generator().manual_seed(0)
+    return runner
+
+
+def test_text_validation_runner_computes_weighted_loss_and_restores_mixed_module_modes(monkeypatch):
+    monkeypatch.setattr(validation_module, "use_parallel_state", lambda _name: nullcontext())
+    monkeypatch.setattr(validation_module, "set_batch_invariant_mode", lambda _enabled: nullcontext())
+    model = _ValidationModel()
+    model.train()
+    model.dropout.eval()
+    batches = [
+        [{"labels": torch.tensor([[-100, 1, 2]]), "loss_value": torch.tensor(2.0)}],
+        [{"labels": torch.tensor([[-100, 3]]), "loss_value": torch.tensor(4.0)}],
+    ]
+    runner = _runner(model, batches)
+    global_rng_state = torch.random.get_rng_state().clone()
+
+    metrics = runner.run()
+
+    assert metrics == {"loss": pytest.approx(8 / 3)}
+    assert model.training is True
+    assert model.dropout.training is False
+    assert runner.dataloader.epochs == [0]
+    assert torch.equal(torch.random.get_rng_state(), global_rng_state)
+    assert runner.run() == metrics
+    assert runner.dataloader.epochs == [0, 0]
+    assert torch.equal(torch.random.get_rng_state(), global_rng_state)
+
+
+def test_text_validation_runner_restores_module_modes_when_forward_fails(monkeypatch):
+    monkeypatch.setattr(validation_module, "use_parallel_state", lambda _name: nullcontext())
+    monkeypatch.setattr(validation_module, "set_batch_invariant_mode", lambda _enabled: nullcontext())
+    model = _ValidationModel(fail_on_call=1)
+    model.train()
+    model.dropout.eval()
+    runner = _runner(
+        model,
+        [[{"labels": torch.tensor([[-100, 1]]), "loss_value": torch.tensor(2.0)}]],
+    )
+
+    with pytest.raises(RuntimeError, match="validation forward failed"):
+        runner.run()
+
+    assert model.training is True
+    assert model.dropout.training is False
+
+
+def test_text_validation_runner_rejects_zero_loss_targets(monkeypatch):
+    monkeypatch.setattr(validation_module, "use_parallel_state", lambda _name: nullcontext())
+    monkeypatch.setattr(validation_module, "set_batch_invariant_mode", lambda _enabled: nullcontext())
+    runner = _runner(
+        _ValidationModel(),
+        [[{"labels": torch.tensor([[-100, -100]]), "loss_value": torch.tensor(float("nan"))}]],
+    )
+
+    with pytest.raises(ValueError, match="no non-ignored loss targets"):
+        runner.run()
+
+
+def test_text_validation_runner_reduces_weighted_stats_over_captured_dp_group(monkeypatch):
+    monkeypatch.setattr(validation_module, "use_parallel_state", lambda _name: nullcontext())
+    monkeypatch.setattr(validation_module, "set_batch_invariant_mode", lambda _enabled: nullcontext())
+    group = object()
+    calls = []
+
+    def fake_all_reduce(tensor, op, group):
+        calls.append((tensor.dtype, op, group))
+        if tensor.dtype == torch.float32:
+            tensor += 12.0
+        else:
+            tensor += 3
+
+    monkeypatch.setattr(validation_module.dist, "all_reduce", fake_all_reduce)
+    runner = _runner(
+        _ValidationModel(),
+        [[{"labels": torch.tensor([[-100, 1, 2]]), "loss_value": torch.tensor(2.0)}]],
+    )
+    runner.parallel_state = _parallel_state(dp_size=2, dp_group=group)
+
+    metrics = runner.run()
+
+    assert metrics == {"loss": pytest.approx(16 / 5)}
+    assert calls == [
+        (torch.float32, torch.distributed.ReduceOp.SUM, group),
+        (torch.int64, torch.distributed.ReduceOp.SUM, group),
+    ]
+
+
+def _two_rank_validation_worker(rank, world_size, init_file):
+    os.environ.setdefault("GLOO_SOCKET_IFNAME", "lo0" if sys.platform == "darwin" else "lo")
+    dist.init_process_group("gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size)
+    try:
+        validation_module.use_parallel_state = lambda _name: nullcontext()
+        validation_module.set_batch_invariant_mode = lambda _enabled: nullcontext()
+        sampler = ExactDistributedBatchSampler(dataset_size=5, batch_size=2, num_replicas=world_size, rank=rank)
+        batches = []
+        for batch_indices in sampler:
+            loss_values = [index + 1 for index in batch_indices]
+            batches.append(
+                [
+                    {
+                        "labels": torch.tensor([[-100, *loss_values]]),
+                        "loss_value": torch.tensor(sum(loss_values) / len(loss_values), dtype=torch.float32),
+                    }
+                ]
+            )
+
+        model = _ValidationModel()
+        runner = _runner(model, batches)
+        runner.parallel_state = _parallel_state(
+            dp_size=world_size,
+            dp_rank=rank,
+            dp_group=dist.group.WORLD,
+        )
+        metrics = runner.run()
+
+        assert metrics == {"loss": pytest.approx(3.0)}
+        assert [len(micro_batches[0]["labels"][0]) - 1 for micro_batches in batches] == (
+            [2, 1] if rank == 0 else [1, 1]
+        )
+        assert model.training is True
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not dist.is_gloo_available(), reason="Gloo is required for the CPU collective test.")
+def test_text_validation_runner_two_rank_gloo_uneven_batches(tmp_path):
+    mp.spawn(
+        _two_rank_validation_worker,
+        args=(2, str(tmp_path / "validation_pg")),
+        nprocs=2,
+        join=True,
+    )
+
+
+@dataclass
+class _DataloaderArgs:
+    type: str = "native"
+    num_workers: int = 0
+    worker_num_threads: int | None = None
+    prefetch_factor: int | None = None
+    persistent_workers: bool = False
+    in_order: bool = False
+    drop_last: bool = True
+    pin_memory: bool = False
+    use_background_prefetcher: bool = False
+
+
+@dataclass
+class _DataArgs:
+    train_path: str = "train.jsonl"
+    eval_path: str = "eval.jsonl"
+    data_type: str = "conversation"
+    datasets_type: str = "mapping"
+    multisource_datasets_type: str = "interleave"
+    max_seq_len: int = 128
+    dataloader: _DataloaderArgs = field(default_factory=_DataloaderArgs)
+
+
+def _builder_trainer():
+    return SimpleNamespace(
+        args=SimpleNamespace(
+            data=_DataArgs(),
+            train=SimpleNamespace(
+                eval_steps=10,
+                eval_epochs=1,
+                seed=7,
+                micro_batch_size=2,
+                moe_load_balance_monitor_interval=0,
+                profile=SimpleNamespace(enable=False),
+                chunk_mbs_config=SimpleNamespace(enable=False),
+                torch_compile=SimpleNamespace(enable=False),
+            ),
+        ),
+        model_config=SimpleNamespace(num_experts=8),
+        data_transform=object(),
+        collate_fn=object(),
+    )
+
+
+class _MapDataset(Dataset):
+    def __len__(self):
+        return 5
+
+    def __getitem__(self, index):
+        return index
+
+
+class _PackedDataset(Dataset):
+    def __init__(self, samples):
+        self.samples = samples
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, index):
+        return [{name: value.clone() for name, value in self.samples[index].items()}]
+
+
+class _TinyPackedLossModel(torch.nn.Module):
+    def __init__(self, classification):
+        super().__init__()
+        self.classification = classification
+
+    def forward(self, labels, use_cache=False, **_kwargs):
+        targets = labels if self.classification else labels[..., 1:]
+        valid_targets = targets[targets != -100]
+        return SimpleNamespace(loss=valid_targets.float().mean())
+
+
+def test_text_validation_runner_builds_single_source_eval_path_with_exact_sampler(monkeypatch):
+    captured = {}
+    dataloader_sentinel = object()
+    trainer = _builder_trainer()
+    trainer.args.data.dataloader.persistent_workers = True
+
+    def fake_build_dataset(**kwargs):
+        captured["dataset"] = kwargs
+        return _MapDataset()
+
+    def fake_build_dataloader(**kwargs):
+        captured["dataloader"] = kwargs
+        return dataloader_sentinel
+
+    monkeypatch.setattr(validation_module, "get_parallel_state", lambda: _parallel_state(dp_size=2, dp_rank=1))
+    monkeypatch.setattr(validation_module, "build_dataset", fake_build_dataset)
+    monkeypatch.setattr(validation_module, "build_dataloader", fake_build_dataloader)
+
+    runner = TextValidationRunner(trainer)
+
+    assert captured["dataset"]["dataset_name"] == "mapping"
+    assert captured["dataset"]["train_path"] == "eval.jsonl"
+    assert captured["dataset"]["shuffle"] is False
+    assert captured["dataset"]["split_by_node"] is False
+    assert captured["dataloader"]["dyn_bsz"] is False
+    assert captured["dataloader"]["in_order"] is True
+    assert captured["dataloader"]["persistent_workers"] is False
+    assert isinstance(captured["dataloader"]["batch_sampler"], ExactDistributedBatchSampler)
+    assert captured["dataloader"]["generator"] is runner.dataloader_generator
+    assert runner.dataloader is dataloader_sentinel
+
+
+@pytest.mark.parametrize(
+    ("data_type", "classification", "samples", "expected_loss"),
+    [
+        (
+            "conversation",
+            False,
+            [
+                {
+                    "input_ids": torch.tensor([0, 1, 2]),
+                    "attention_mask": torch.ones(3, dtype=torch.long),
+                    "labels": torch.tensor([-100, 1, 2]),
+                },
+                {
+                    "input_ids": torch.tensor([3, 4]),
+                    "attention_mask": torch.ones(2, dtype=torch.long),
+                    "labels": torch.tensor([-100, 4]),
+                },
+            ],
+            7 / 3,
+        ),
+        (
+            "classification",
+            True,
+            [
+                {
+                    "input_ids": torch.tensor([0, 1]),
+                    "attention_mask": torch.ones(2, dtype=torch.long),
+                    "labels": torch.tensor([-100, 2]),
+                },
+                {
+                    "input_ids": torch.tensor([3, 4]),
+                    "attention_mask": torch.ones(2, dtype=torch.long),
+                    "labels": torch.tensor([-100, 4]),
+                },
+            ],
+            3.0,
+        ),
+    ],
+)
+def test_text_validation_runner_real_collator_and_dataloader_integration(
+    monkeypatch, data_type, classification, samples, expected_loss
+):
+    import veomni.data.data_collator as data_collator_module
+    import veomni.data.data_loader as data_loader_module
+
+    parallel_state = _parallel_state()
+    monkeypatch.setattr(validation_module, "get_parallel_state", lambda: parallel_state)
+    monkeypatch.setattr(data_loader_module, "get_parallel_state", lambda: parallel_state)
+    monkeypatch.setattr(data_collator_module, "get_parallel_state", lambda: parallel_state)
+    monkeypatch.setattr(validation_module, "use_parallel_state", lambda _name: nullcontext())
+    monkeypatch.setattr(validation_module, "set_batch_invariant_mode", lambda _enabled: nullcontext())
+    monkeypatch.setattr(validation_module, "build_dataset", lambda **_kwargs: _PackedDataset(samples))
+    trainer = _builder_trainer()
+    trainer.args.data.data_type = data_type
+    trainer.collate_fn = MainCollator(seq_classification=classification)
+    trainer.model = _TinyPackedLossModel(classification=classification)
+    trainer.device = torch.device("cpu")
+    trainer.model_fwd_context = nullcontext()
+    trainer.args.train.enable_batch_invariant_mode = False
+
+    runner = TextValidationRunner(trainer)
+
+    assert runner.run() == {"loss": pytest.approx(expected_loss)}
+
+
+class _IterableValidationDataset(IterableDataset):
+    def __iter__(self):
+        return iter(())
+
+
+def test_text_validation_runner_rejects_iterable_validation_data(monkeypatch):
+    monkeypatch.setattr(validation_module, "get_parallel_state", lambda: _parallel_state())
+    monkeypatch.setattr(validation_module, "build_dataset", lambda **_kwargs: _IterableValidationDataset())
+
+    with pytest.raises(ValueError, match="requires a map-style dataset"):
+        TextValidationRunner(_builder_trainer())
+
+
+@pytest.mark.parametrize(
+    ("data_type", "eval_path", "match"),
+    [
+        ("plaintext", "eval.jsonl", "data_type='plaintext'"),
+        ("conversation", "eval.yaml", "multisource evaluation YAML"),
+    ],
+)
+def test_text_validation_runner_rejects_non_exact_dataset_semantics(monkeypatch, data_type, eval_path, match):
+    monkeypatch.setattr(validation_module, "get_parallel_state", lambda: _parallel_state())
+    trainer = _builder_trainer()
+    trainer.args.data.data_type = data_type
+    trainer.args.data.eval_path = eval_path
+
+    with pytest.raises(ValueError, match=match):
+        TextValidationRunner(trainer)
+
+
+@pytest.mark.parametrize(
+    ("parallel_overrides", "match"),
+    [
+        ({"sp_enabled": True}, "sequence/context parallelism"),
+        ({"tp_enabled": True}, "tensor parallelism"),
+        ({"pp_enabled": True}, "pipeline parallelism"),
+        ({"any_extra_parallel_enabled": True}, "ExtraParallel/EP"),
+        ({"async_enabled": True}, "async sequence parallelism"),
+    ],
+)
+def test_text_validation_runner_rejects_unimplemented_parallel_semantics(monkeypatch, parallel_overrides, match):
+    monkeypatch.setattr(
+        validation_module,
+        "get_parallel_state",
+        lambda: _parallel_state(**parallel_overrides),
+    )
+
+    with pytest.raises(ValueError, match=match):
+        TextValidationRunner(_builder_trainer())
+
+
+@pytest.mark.parametrize(
+    ("config_name", "match"),
+    [
+        ("chunk_mbs_config", "ChunkMBS"),
+        ("torch_compile", "torch.compile"),
+        ("moe_load_balance_monitor_interval", "MoE router monitoring"),
+        ("profile", "torch profiler"),
+    ],
+)
+def test_text_validation_runner_rejects_unimplemented_execution_modes(monkeypatch, config_name, match):
+    monkeypatch.setattr(validation_module, "get_parallel_state", lambda: _parallel_state())
+    trainer = _builder_trainer()
+    config = getattr(trainer.args.train, config_name)
+    if hasattr(config, "enable"):
+        config.enable = True
+    else:
+        setattr(trainer.args.train, config_name, 1)
+
+    with pytest.raises(ValueError, match=match):
+        TextValidationRunner(trainer)
+
+
+def test_base_trainer_rejects_validation_without_task_owned_runner():
+    trainer = BaseTrainer.__new__(BaseTrainer)
+    trainer.args = SimpleNamespace(
+        data=SimpleNamespace(eval_path="eval.jsonl"),
+        train=SimpleNamespace(eval_steps=10, eval_epochs=1),
+    )
+
+    with pytest.raises(ValueError, match="supported only by TextTrainer"):
+        trainer._validate_validation_configuration()
+
+    trainer.validation_runner = object()
+    trainer._validate_validation_configuration()
+
+
+@pytest.mark.parametrize(
+    ("eval_path", "eval_steps", "eval_epochs", "expected"),
+    [("eval.jsonl", 10, 0, True), ("eval.jsonl", 0, 1, True), ("eval.jsonl", 0, 0, False), (None, 10, 1, False)],
+)
+def test_text_trainer_installs_validation_runner_only_when_scheduled(
+    monkeypatch, eval_path, eval_steps, eval_epochs, expected
+):
+    installed = []
+
+    class _Runner:
+        is_requested = staticmethod(TextValidationRunner.is_requested)
+
+        def __init__(self, trainer):
+            installed.append(trainer)
+
+    monkeypatch.setattr(text_trainer_module, "TextValidationRunner", _Runner)
+    trainer = TextTrainer.__new__(TextTrainer)
+    trainer.base = SimpleNamespace(
+        args=SimpleNamespace(
+            data=SimpleNamespace(eval_path=eval_path),
+            train=SimpleNamespace(eval_steps=eval_steps, eval_epochs=eval_epochs),
+        )
+    )
+
+    trainer._build_validation_runner()
+
+    assert bool(installed) is expected
+    assert hasattr(trainer.base, "validation_runner") is expected
+
+
+def test_evaluate_callback_deduplicates_step_and_epoch_trigger(monkeypatch):
+    monkeypatch.setattr(callback_base_module, "get_parallel_state", lambda: _parallel_state())
+
+    class _Runner:
+        def __init__(self):
+            self.calls = 0
+
+        def run(self):
+            self.calls += 1
+            return {"loss": 1.25}
+
+    runner = _Runner()
+    trainer = SimpleNamespace(
+        validation_runner=runner,
+        args=SimpleNamespace(
+            train=SimpleNamespace(
+                eval_steps=2,
+                eval_epochs=1,
+                global_rank=0,
+                wandb=SimpleNamespace(enable=False),
+            )
+        ),
+    )
+    callback = EvaluateCallback(trainer)
+    state = TrainerState(global_step=2, epoch=0)
+
+    callback.on_step_end(state)
+    callback.on_epoch_end(state)
+
+    assert runner.calls == 1
+    assert trainer.last_validation_metrics == {"loss": 1.25}
+
+    state.global_step = 3
+    state.epoch = 1
+    callback.on_epoch_end(state)
+    assert runner.calls == 2

--- a/tests/trainer/test_training_validation.py
+++ b/tests/trainer/test_training_validation.py
@@ -265,7 +265,6 @@ def _builder_trainer():
                 micro_batch_size=2,
                 moe_load_balance_monitor_interval=0,
                 profile=SimpleNamespace(enable=False),
-                chunk_mbs_config=SimpleNamespace(enable=False),
                 torch_compile=SimpleNamespace(enable=False),
             ),
         ),
@@ -456,7 +455,6 @@ def test_text_validation_runner_rejects_unimplemented_parallel_semantics(monkeyp
 @pytest.mark.parametrize(
     ("config_name", "match"),
     [
-        ("chunk_mbs_config", "ChunkMBS"),
         ("torch_compile", "torch.compile"),
         ("moe_load_balance_monitor_interval", "MoE router monitoring"),
         ("profile", "torch profiler"),

--- a/tests/trainer/test_training_validation.py
+++ b/tests/trainer/test_training_validation.py
@@ -108,6 +108,22 @@ def test_text_validation_runner_computes_weighted_loss_and_restores_mixed_module
     assert torch.equal(torch.random.get_rng_state(), global_rng_state)
 
 
+@pytest.mark.parametrize(
+    ("labels", "expected_units"),
+    [
+        ([[7, 8, 9]], 2),
+        ([[7]], 0),
+        ([[7, -100, 9]], 1),
+        ([[-100, 8, 9]], 2),
+    ],
+)
+def test_text_validation_runner_counts_only_shifted_causal_targets(labels, expected_units):
+    runner = _runner(_ValidationModel(), [])
+
+    # Position zero has no preceding logit, even when its label is valid.
+    assert runner._count_loss_units(torch.tensor(labels)).item() == expected_units
+
+
 def test_text_validation_runner_restores_module_modes_when_forward_fails(monkeypatch):
     monkeypatch.setattr(validation_module, "use_parallel_state", lambda _name: nullcontext())
     monkeypatch.setattr(validation_module, "set_batch_invariant_mode", lambda _enabled: nullcontext())

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -1445,7 +1445,7 @@ class DataArguments:
     )
     eval_path: Optional[str] = field(
         default=None,
-        metadata={"help": "path of the evaluation data. If None, use a subset of train_path."},
+        metadata={"help": "Path of the evaluation data. If None, training-time validation is disabled."},
     )
     train_size: int = field(
         default=10_000_000,

--- a/veomni/data/data_loader.py
+++ b/veomni/data/data_loader.py
@@ -14,10 +14,10 @@
 
 
 import math
-from typing import Any, Callable, Dict, Literal, Optional
+from typing import Any, Callable, Dict, Iterator, Literal, Optional, Sequence
 
 import torch
-from torch.utils.data import Dataset, IterableDataset
+from torch.utils.data import Dataset, IterableDataset, Sampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from torchdata.stateful_dataloader.sampler import StatefulDistributedSampler
 
@@ -53,10 +53,62 @@ class DistributedDataloader(StatefulDataLoader):
     sampler: "StatefulDistributedSampler"
 
     def set_epoch(self, epoch: int) -> None:
-        if self.sampler is not None and hasattr(self.sampler, "set_epoch"):
+        if self.batch_sampler is not None and hasattr(self.batch_sampler, "set_epoch"):
+            self.batch_sampler.set_epoch(epoch)
+        elif self.sampler is not None and hasattr(self.sampler, "set_epoch"):
             self.sampler.set_epoch(epoch)
         elif hasattr(self.dataset, "set_epoch"):
             self.dataset.set_epoch(epoch)
+
+
+class ExactDistributedBatchSampler(Sampler[Sequence[int]]):
+    """Partition map-style evaluation data without padding or materializing indices.
+
+    Every rank yields the same number of batches so distributed forwards stay
+    collective-safe. Across all ranks, every dataset index is visited exactly
+    once. Configurations that cannot satisfy both properties without an empty
+    batch are rejected instead of duplicating samples.
+    """
+
+    def __init__(self, dataset_size: int, batch_size: int, num_replicas: int, rank: int) -> None:
+        if dataset_size <= 0:
+            raise ValueError(f"Validation dataset must be non-empty, got {dataset_size} samples.")
+        if batch_size <= 0:
+            raise ValueError(f"Validation batch size must be positive, got {batch_size}.")
+        if num_replicas <= 0:
+            raise ValueError(f"Number of replicas must be positive, got {num_replicas}.")
+        if not 0 <= rank < num_replicas:
+            raise ValueError(f"Rank must be in [0, {num_replicas}), got {rank}.")
+
+        num_steps = math.ceil(dataset_size / (num_replicas * batch_size))
+        num_batch_slots = num_steps * num_replicas
+        if num_batch_slots > dataset_size:
+            raise ValueError(
+                "Validation dataset cannot be partitioned into non-empty batches with equal steps per rank: "
+                f"dataset_size={dataset_size}, batch_size={batch_size}, num_replicas={num_replicas}. "
+                "Increase the validation dataset or batch size."
+            )
+
+        self.dataset_size = dataset_size
+        self.batch_size = batch_size
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.num_steps = num_steps
+        self._num_batch_slots = num_batch_slots
+        self._base_batch_size, self._remainder = divmod(dataset_size, num_batch_slots)
+
+    def __iter__(self) -> Iterator[Sequence[int]]:
+        for step in range(self.num_steps):
+            slot = step * self.num_replicas + self.rank
+            size = self._base_batch_size + int(slot < self._remainder)
+            start = slot * self._base_batch_size + min(slot, self._remainder)
+            yield range(start, start + size)
+
+    def __len__(self) -> int:
+        return self.num_steps
+
+    def set_epoch(self, _epoch: int) -> None:
+        """Keep the exact source order across validation epochs."""
 
 
 def _build_worker_init_fn(worker_num_threads: int) -> Callable[[int], None]:
@@ -96,6 +148,8 @@ def build_native_dataloader(
     collate_fn_kwargs: Optional[Dict[str, Any]] = None,
     multiprocessing_context=None,
     save_steps: int = 0,
+    batch_sampler: Optional[Sampler[Sequence[int]]] = None,
+    generator: Optional[torch.Generator] = None,
 ) -> "DistributedDataloader":
     """Build the native training dataloader.
 
@@ -145,10 +199,17 @@ def build_native_dataloader(
             Use ``"spawn"`` when worker-side code must be pickle-safe and should not
             inherit parent-process state; keep ``"fork"`` for the legacy Linux behavior.
             Example: ``multiprocessing_context="spawn"``.
+        batch_sampler: Optional custom map-style batch sampler. It is mutually
+            exclusive with dynamic batching and replaces the native distributed
+            sampler, batch size, and ``drop_last`` configuration.
+        generator: Optional dedicated RNG used by the underlying dataloader.
     """
     if collate_fn_kwargs is None:
         collate_fn_kwargs = {}
     parallel_state = get_parallel_state()
+
+    if batch_sampler is not None and dyn_bsz:
+        raise ValueError("A custom batch_sampler is supported only when dyn_bsz=False.")
 
     if collate_fn is None:
         if build_collate_fn:
@@ -233,7 +294,7 @@ def build_native_dataloader(
         collate_fn = MakeMicroBatchCollator(num_micro_batch=num_micro_batch, internal_data_collator=collate_fn)
 
     sampler = None
-    if not isinstance(dataset, IterableDataset):
+    if batch_sampler is None and not isinstance(dataset, IterableDataset):
         sampler = StatefulDistributedSampler(
             dataset,
             num_replicas=parallel_state.dp_size,
@@ -253,22 +314,28 @@ def build_native_dataloader(
         snapshot_every_n_steps = save_steps
     else:
         snapshot_every_n_steps = 1
-    dataloader = DistributedDataloader(
-        dataset,
-        batch_size=dataloader_batch_size,
-        sampler=sampler,
+    dataloader_kwargs = dict(
         num_workers=num_workers,
         collate_fn=collate_fn,
         pin_memory=pin_memory,
         pin_memory_device=get_device_type(),
-        drop_last=drop_last,
         prefetch_factor=prefetch_factor,
         persistent_workers=persistent_workers and num_workers > 0,
         in_order=in_order,
         worker_init_fn=worker_init_fn,
         multiprocessing_context=multiprocessing_context,
+        generator=generator,
         snapshot_every_n_steps=snapshot_every_n_steps,
     )
+    if batch_sampler is None:
+        dataloader_kwargs.update(
+            batch_size=dataloader_batch_size,
+            sampler=sampler,
+            drop_last=drop_last,
+        )
+    else:
+        dataloader_kwargs["batch_sampler"] = batch_sampler
+    dataloader = DistributedDataloader(dataset, **dataloader_kwargs)
 
     if dyn_bsz and dyn_bsz_runtime == "main":
         dataloader = DynamicBatchSizeDataLoader(

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -616,8 +616,19 @@ class BaseTrainer(Stateful, ABC):
             self.args.train.accelerator.offload_config.activation_gpu_limit,
         )
 
+    def _validate_validation_configuration(self) -> None:
+        args = self.args
+        requested = args.data.eval_path is not None and bool(args.train.eval_steps or args.train.eval_epochs)
+        if requested and getattr(self, "validation_runner", None) is None:
+            raise ValueError(
+                "Training-time validation is currently supported only by TextTrainer. "
+                "VLMTrainer, TextDPOTrainer, DiTTrainer, and RL trainers must provide task-specific validation "
+                "data and forward semantics before using data.eval_path."
+            )
+
     def _init_callbacks(self):
         """Initialize callbacks."""
+        self._validate_validation_configuration()
         self.environ_meter_callback = EnvironMeterCallback(self)
         self.tqdm_callback = TqdmCallback(self)
         self.wandb_callback = WandbTraceCallback(self)

--- a/veomni/trainer/callbacks/evaluate_callback.py
+++ b/veomni/trainer/callbacks/evaluate_callback.py
@@ -24,6 +24,10 @@ if TYPE_CHECKING:
 
 
 class EvaluateCallback(Callback):
+    def __init__(self, trainer) -> None:
+        super().__init__(trainer)
+        self._last_evaluated_step = None
+
     def on_epoch_end(self, state: TrainerState, **kwargs):
         args: "Arguments" = self.trainer.args
         if args.train.eval_epochs and (state.epoch + 1) % args.train.eval_epochs == 0:
@@ -35,5 +39,17 @@ class EvaluateCallback(Callback):
             self._evaluate(state)
 
     def _evaluate(self, state: TrainerState):
-        # TODO: implement evaluate
-        pass
+        runner = getattr(self.trainer, "validation_runner", None)
+        if runner is None or self._last_evaluated_step == state.global_step:
+            return None
+
+        metrics = runner.run()
+        self._last_evaluated_step = state.global_step
+        self.trainer.last_validation_metrics = metrics
+
+        args: "Arguments" = self.trainer.args
+        if args.train.global_rank == 0 and args.train.wandb.enable:
+            import wandb
+
+            wandb.log({f"validation/{name}": value for name, value in metrics.items()}, step=state.global_step)
+        return metrics

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -30,6 +30,7 @@ from ..utils import helper
 from ..utils.device import synchronize
 from ..utils.loss_utils import count_loss_token, reduce_global_loss_token
 from .base import BaseTrainer, VeOmniIter, mean_aux_metrics
+from .validation import TextValidationRunner
 
 
 logger = helper.create_logger(__name__)
@@ -63,11 +64,16 @@ class TextTrainer:
             self.base._build_dataset()
             self.base._build_collate_fn()
             self.base._build_dataloader()
+            self._build_validation_runner()
             self.base._build_parallelized_model()
             self.base._build_optimizer()
             self.base._build_lr_scheduler()
             self.base._build_training_context()
             self.base._init_callbacks()
+
+    def _build_validation_runner(self):
+        if TextValidationRunner.is_requested(self.base):
+            self.base.validation_runner = TextValidationRunner(self.base)
 
     def _build_model_assets(self):
         args: VeOmniArguments = self.base.args

--- a/veomni/trainer/validation.py
+++ b/veomni/trainer/validation.py
@@ -1,0 +1,210 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any, Iterator
+
+import torch
+import torch.distributed as dist
+from torch.utils.data import IterableDataset
+
+from ..data import build_dataloader, build_dataset
+from ..data.data_loader import ExactDistributedBatchSampler
+from ..distributed.parallel_state import get_parallel_state, use_parallel_state
+from ..ops.batch_invariant_ops import set_batch_invariant_mode
+from ..utils import logging
+from ..utils.constants import IGNORE_INDEX
+
+
+if TYPE_CHECKING:
+    from .base import BaseTrainer
+
+
+logger = logging.get_logger(__name__)
+
+
+@contextmanager
+def _preserve_module_training_modes(model: torch.nn.Module) -> Iterator[None]:
+    modes = [(module, module.training) for module in model.modules()]
+    model.eval()
+    try:
+        yield
+    finally:
+        model.train(modes[0][1])
+        for module, mode in modes[1:]:
+            if module.training != mode:
+                module.train(mode)
+
+
+def _move_to_device(value: Any, device: torch.device) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.to(device, non_blocking=True)
+    if isinstance(value, dict):
+        return {key: _move_to_device(item, device) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_move_to_device(item, device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_move_to_device(item, device) for item in value)
+    return value
+
+
+class TextValidationRunner:
+    """Own Text SFT validation data and forward semantics.
+
+    The callback only schedules this runner. This owner is installed by
+    ``TextTrainer`` alone so composed trainers cannot silently inherit causal-LM
+    evaluation semantics that do not match their objectives.
+    """
+
+    def __init__(self, trainer: "BaseTrainer") -> None:
+        self.trainer = trainer
+        self.parallel_state = get_parallel_state()
+        self._validate_support()
+        self.dataset, self.dataloader = self._build_data()
+
+    @staticmethod
+    def is_requested(trainer: "BaseTrainer") -> bool:
+        args = trainer.args
+        return args.data.eval_path is not None and bool(args.train.eval_steps or args.train.eval_epochs)
+
+    def _validate_support(self) -> None:
+        args = self.trainer.args
+        parallel_state = self.parallel_state
+        unsupported = []
+        if args.data.data_type not in {"conversation", "classification"}:
+            unsupported.append(f"data_type={args.data.data_type!r}")
+        if args.data.eval_path.endswith(".yaml"):
+            unsupported.append("multisource evaluation YAML")
+        if args.data.dataloader.type != "native":
+            unsupported.append(f"data.dataloader.type={args.data.dataloader.type!r}")
+        if parallel_state.sp_enabled:
+            unsupported.append("sequence/context parallelism")
+        if parallel_state.tp_enabled:
+            unsupported.append("tensor parallelism")
+        if parallel_state.pp_enabled:
+            unsupported.append("pipeline parallelism")
+        if parallel_state.any_extra_parallel_enabled:
+            unsupported.append("ExtraParallel/EP")
+        if parallel_state.async_enabled:
+            unsupported.append("async sequence parallelism")
+        if args.train.chunk_mbs_config.enable:
+            unsupported.append("ChunkMBS")
+        if args.train.torch_compile.enable:
+            unsupported.append("torch.compile")
+        if args.train.moe_load_balance_monitor_interval > 0 and hasattr(self.trainer.model_config, "num_experts"):
+            unsupported.append("MoE router monitoring")
+        if args.train.profile.enable:
+            unsupported.append("torch profiler")
+        if unsupported:
+            raise ValueError(
+                "Training-time validation currently supports TextTrainer with map-style data and pure DP/FSDP2 "
+                f"only; unsupported configuration: {', '.join(unsupported)}."
+            )
+
+    def _build_data(self):
+        args = self.trainer.args
+        eval_path = args.data.eval_path
+        data_kwargs = asdict(args.data)
+        data_kwargs.update(train_path=eval_path, shuffle=False, split_by_node=False)
+        dataset = build_dataset(
+            dataset_name=args.data.datasets_type,
+            transform=self.trainer.data_transform,
+            seed=args.train.seed,
+            **data_kwargs,
+        )
+        if isinstance(dataset, IterableDataset):
+            raise ValueError(
+                "Training-time validation requires a map-style dataset so every sample can be evaluated exactly "
+                "once with collective-safe rank cardinality."
+            )
+
+        batch_sampler = ExactDistributedBatchSampler(
+            dataset_size=len(dataset),
+            batch_size=args.train.micro_batch_size,
+            num_replicas=self.parallel_state.dp_size,
+            rank=self.parallel_state.dp_rank,
+        )
+        self.dataloader_generator = torch.Generator().manual_seed(args.train.seed)
+        dataloader_kwargs = asdict(args.data.dataloader)
+        dataloader_type = dataloader_kwargs.pop("type")
+        dataloader_kwargs.pop("use_background_prefetcher", None)
+        dataloader_kwargs["in_order"] = True
+        dataloader_kwargs["persistent_workers"] = False
+        dataloader = build_dataloader(
+            dataloader_type=dataloader_type,
+            dataset=dataset,
+            micro_batch_size=args.train.micro_batch_size,
+            global_batch_size=args.train.micro_batch_size * self.parallel_state.dp_size,
+            dataloader_batch_size=args.train.micro_batch_size,
+            max_seq_len=args.data.max_seq_len,
+            train_steps=len(batch_sampler),
+            dyn_bsz=False,
+            seed=args.train.seed,
+            collate_fn=self.trainer.collate_fn,
+            batch_sampler=batch_sampler,
+            generator=self.dataloader_generator,
+            **dataloader_kwargs,
+        )
+        return dataset, dataloader
+
+    def _count_loss_units(self, labels: torch.Tensor) -> torch.Tensor:
+        if self.trainer.args.data.data_type == "classification":
+            return torch.count_nonzero(labels != IGNORE_INDEX)
+        if labels.ndim == 0 or labels.shape[-1] < 2:
+            return labels.new_zeros((), dtype=torch.long)
+        return torch.count_nonzero(labels[..., 1:] != IGNORE_INDEX)
+
+    @torch.no_grad()
+    def run(self) -> dict[str, float]:
+        trainer = self.trainer
+        self.dataloader_generator.manual_seed(trainer.args.train.seed)
+        self.dataloader.set_epoch(0)
+        loss_sum = torch.zeros((), dtype=torch.float32, device=trainer.device)
+        loss_units = torch.zeros((), dtype=torch.int64, device=trainer.device)
+
+        with _preserve_module_training_modes(trainer.model):
+            for micro_batches in self.dataloader:
+                if len(micro_batches) != 1:
+                    raise RuntimeError(
+                        "Validation requires exactly one micro-batch per forward, "
+                        f"but the dataloader produced {len(micro_batches)}."
+                    )
+                micro_batch = _move_to_device(micro_batches[0], trainer.device)
+                labels = micro_batch.get("labels")
+                if not isinstance(labels, torch.Tensor):
+                    raise TypeError("Validation batches must contain a tensor 'labels' field.")
+                with (
+                    use_parallel_state("base"),
+                    trainer.model_fwd_context,
+                    set_batch_invariant_mode(trainer.args.train.enable_batch_invariant_mode),
+                ):
+                    outputs = trainer.model(**micro_batch, use_cache=False)
+                loss = outputs.loss
+                if not isinstance(loss, torch.Tensor) or loss.numel() != 1:
+                    raise TypeError("Text validation expects model outputs.loss to be a scalar tensor.")
+                unit_count = self._count_loss_units(labels)
+                weighted_loss = loss.detach().to(torch.float32) * unit_count
+                loss_sum += torch.where(unit_count > 0, weighted_loss, loss_sum.new_zeros(()))
+                loss_units += unit_count
+
+        if self.parallel_state.dp_size > 1:
+            dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM, group=self.parallel_state.dp_group)
+            dist.all_reduce(loss_units, op=dist.ReduceOp.SUM, group=self.parallel_state.dp_group)
+        if loss_units.item() == 0:
+            raise ValueError("Validation produced no non-ignored loss targets.")
+
+        validation_loss = (loss_sum / loss_units).item()
+        logger.info_rank0(f"Validation completed: loss={validation_loss:.6f}, loss_units={loss_units.item()}.")
+        return {"loss": validation_loss}

--- a/veomni/trainer/validation.py
+++ b/veomni/trainer/validation.py
@@ -99,8 +99,6 @@ class TextValidationRunner:
             unsupported.append("ExtraParallel/EP")
         if parallel_state.async_enabled:
             unsupported.append("async sequence parallelism")
-        if args.train.chunk_mbs_config.enable:
-            unsupported.append("ChunkMBS")
         if args.train.torch_compile.enable:
             unsupported.append("torch.compile")
         if args.train.moe_load_balance_monitor_interval > 0 and hasattr(self.trainer.model_config, "num_experts"):


### PR DESCRIPTION
### What does this PR do?

> Add training-time validation for text SFT without carrying forward the unsafe cross-trainer semantics from closed PR #1077.
>
> The initial scope is intentionally narrow: single-source, map-style conversation or classification data with the native dataloader under pure DP/FSDP2. Unsupported trainer, modality, data, parallel, and observability modes fail closed.

### Checklist Before Starting

- Search for relative PRs/issues and link here: replaces closed #1077. A live open-PR scan found path overlap with #936, #994, #1076, and #1082, but no open PR implementing validation or `eval_path` semantics.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

> Passed on Python 3.12.13 / PyTorch 2.11.0:
>
> - `PYTHONPATH=. python -m pytest -q tests/data/test_validation_sampler.py tests/trainer/test_training_validation.py` — 46 passed, including a real two-rank Gloo reduction with uneven local batch sizes and causal-target counting regressions for valid first labels and one-token sequences.
> - `PYTHONPATH=. python -m pytest -q tests/data/test_dataloader.py` — 22 passed.
> - `PYTHONPATH=. python -m pytest -q tests/data/test_collators.py tests/data/test_classification_data_processor.py` — 15 passed.
> - `make quality` and `git diff --check` passed.
>
> Two-GPU FSDP2 functional smoke passed on the exact current PR head `5ebf719d7e9c8e97f5bc0abdadc81cc3c72b27e6` against `main@cf5dd272d616fc2ae14025225dc036948e6440ae`:
>
> - 2× NVIDIA A800 80GB, one node, two-rank NCCL, pure DP with FSDP2 shard degree 2; all other parallel dimensions were 1.
> - A randomly initialized two-layer Qwen2 toy model ran three BF16 AdamW optimizer updates over deterministic synthetic map-style data (6 train / 4 validation samples, sequence length 128, seed 1083).
> - Training losses were `12.279469`, `12.272757`, and `12.123192`; gradient norms were `10.614016`, `10.838994`, and `11.004934`.
> - The two-rank NCCL preflight returned the expected all-reduce sum `3.0`.
> - Validation ran exactly at global steps 2 and 3 with losses `12.261265` and `12.258946`; each pass aggregated exactly 508 shifted causal targets, restored all module modes, and returned the model to training mode.
> - Slurm job `310084` completed with exit code 0. The runtime was Python 3.12.3, PyTorch 2.10.0+cu129, CUDA 12.9, and Transformers 5.9.0.
> - This validates accelerator batch transfer, FSDP2 forward execution, NCCL collectives, weighted distributed validation reduction, callback scheduling, and module-mode restoration on the current PR head.

### API and Usage Example

```yaml
data:
  eval_path: /path/to/validation.jsonl
  datasets_type: mapping
train:
  eval_steps: 100
  eval_epochs: 0
```

> `eval_path: null` disables training-time validation. See `docs/usage/trainer.md` for the complete support and rejection matrix.

### Design & Code Changes

> - Let `TextTrainer` own a dedicated validation runner while the callback only schedules it; other composed trainers reject validation until they provide task-specific contracts.
> - Add an O(1) exact distributed batch sampler that visits every record once, preserves source order, keeps equal non-empty forward counts across ranks, and rejects impossible partitions instead of padding or duplicating data.
> - Aggregate causal loss by shifted non-ignored tokens and classification loss by non-ignored sample labels over the captured DP group.
> - Restore every module's prior train/eval mode on success or failure, isolate dataloader RNG, and disable persistent validation workers.
> - Reject plaintext chunk expansion, weighted multisource YAML, iterable data, non-text trainers, SP/TP/PP/EP, async SP, compile, profiler, and MoE router monitoring until their contracts are implemented.
> - Add property, fault-injection, real collator/dataloader, cross-trainer rejection, and two-process collective tests; document the public configuration boundary.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- Applied scoped pre-commit checks; the unrelated repository-wide formatting baseline is documented above.
- Added/updated documentation.
- Added CPU tests for sampler, runner, callback, collator/dataloader integration, and distributed aggregation; completed the two-GPU FSDP2 functional smoke documented above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added training-time validation for text SFT workflows.
  * Validation reports loss weighted by non-ignored targets and supports distributed evaluation.
  * Added deterministic, non-padding validation batching with equal step distribution.
  * Validation preserves model state and restores it after evaluation.
  * Validation metrics can be logged through evaluation callbacks and Weights & Biases.

* **Bug Fixes**
  * Added clear errors for unsupported validation configurations and invalid batches.

* **Documentation**
  * Documented validation setup, behavior, supported scope, limitations, and configuration options.
  * Clarified how auxiliary metrics are handled during training.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

