### PR TITLE
[docker] feat: add Ascend GDN Dockerfiles

### DIFF
--- a/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm
@@ -39,7 +39,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install -e .[npu_aarch64]
+RUN pip install -e ".[npu_aarch64]"
 
 # Align the parquet/data stack with the uv lockfile. pip install -e (unlike x86's
 # uv sync --locked) ignores the lockfile and floats pyarrow/pandas to latest; pyarrow

--- a/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm
@@ -1,0 +1,106 @@
+FROM swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0.0-910b-ubuntu22.04-py3.11
+
+# Set default pip index
+ARG PIP_INDEX=https://pypi.org/simple
+
+# Define environments
+ENV MAX_JOBS=16
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV OMP_NUM_THREADS=4
+ENV OPENBLAS_NUM_THREADS=1
+ENV MKL_NUM_THREADS=1
+ENV NUMEXPR_NUM_THREADS=1
+
+RUN echo "Setting timezone to CST (China Standard Time)..." && \
+    ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc g++ cmake libnuma-dev sudo wget git curl jq vim build-essential ssh ca-certificates ffmpeg pkg-config gawk && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    pip install --upgrade pip setuptools packaging && \
+    pip cache purge
+
+RUN chmod +x /usr/bin/make /usr/bin/gmake /usr/bin/cc /usr/bin/c++
+
+RUN pip install --upgrade pip setuptools packaging --no-cache-dir --progress-bar off && \
+    pip cache purge
+
+RUN pip config set global.index-url "${PIP_INDEX}" && \
+    pip config set global.extra-index-url "${PIP_INDEX}" && \
+    pip config set global.no-cache-dir "true" && \
+    pip config --user set global.progress_bar off && \
+    python -m pip install --upgrade pip
+
+RUN pip3 install --no-cache-dir -U pip setuptools requests
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install -e .[npu_aarch64]
+
+# Align the parquet/data stack with the uv lockfile. pip install -e (unlike x86's
+# uv sync --locked) ignores the lockfile and floats pyarrow/pandas to latest; pyarrow
+# 25 / pandas 3.x SEGFAULT reading parquet on aarch64 (datasets is pinned to 2.21, which
+# targets the older pyarrow ABI). Pin to the versions the x86 lockfile uses.
+RUN pip install "pyarrow==21.0.0" "pandas==2.3.2"
+
+# ============================================================================
+# GDN / fla_npu (AscendC fused ops) — ported from Dockerfile.ascend_9.0.0_a2.x86.
+# The aarch64 image build is CI-validated; runtime behavior on a physical 910B remains
+# unverified. Differences vs x86: pip not uv, runs as root (so the .run writes the
+# CANN opp dir directly, no sudo), no venv.
+# ============================================================================
+
+# fla_npu's check_npu_env maps torch 2.10.0 -> torch_npu 2.10.0.post2 (npu_aarch64
+# extra pins plain 2.10.0). pybind11 is needed by the fla_npu torch-binding build.
+RUN pip install torch-npu==2.10.0.post2 pybind11
+
+# triton-ascend patches triton's libtriton.so with the ascend backend. Both packages ship
+# that shared .so (triton-ascend's is patched, community triton's is vanilla), and whoever
+# writes it LAST wins — so install triton FIRST then triton-ascend SEPARATELY so the patched
+# .so lands last (see the x86 Dockerfile comment for the full story). The trailing import
+# verifies the patch stuck.
+# aarch64 triton-ascend 3.2.1 requires triton==3.5.0 (x86's is 3.2.0) — an arch-specific
+# dep, confirmed via `pip install triton-ascend==3.2.1 --dry-run` on an aarch64 host.
+# pip tolerates the osinfra index behavior here; x86 uses uv with the Huawei Cloud mirror
+# because uv rejects wrong-name metadata returned by osinfra for transitive lookups.
+RUN (pip uninstall -y triton triton-ascend || true) && \
+    pip install triton==3.5.0 && \
+    pip install triton-ascend==3.2.1 \
+        --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple \
+        --trusted-host triton-ascend.osinfra.cn && \
+    echo "Verifying triton-ascend patched libtriton.so ..." && \
+    python -c "from triton._C.libtriton import ascend"
+
+# ONE RUN so the CANN env from set_env.sh persists. --soc=ascend910b (a2 base is 910b).
+# torch binding wheel is force-reinstalled with --no-deps (else pip pulls a CUDA torch).
+RUN git clone https://github.com/flashserve/flash-linear-attention-npu /tmp/fla-npu && \
+    cd /tmp/fla-npu && git checkout c2e3d83f && \
+    source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    python scripts/check_npu_env.py --build-only && \
+    bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu && \
+    bash build_out/*.run --quiet && \
+    cd torch_custom/fla_npu && bash build.sh && \
+    pip install --no-deps --force-reinstall dist/*.whl && \
+    cd / && rm -rf /tmp/fla-npu
+
+RUN git clone https://github.com/meta-pytorch/torchcodec.git
+
+WORKDIR /app/torchcodec
+
+RUN git checkout v0.5.0
+
+ENV CANN_PATH=/usr/local/Ascend
+
+RUN cp ../docs/get_started/installation/install_torchcodec_Ascend.sh .
+
+RUN chmod +x install_torchcodec_Ascend.sh
+
+RUN bash install_torchcodec_Ascend.sh ${CANN_PATH}/ascend-toolkit/set_env.sh
+
+WORKDIR /app
+
+CMD ["/bin/bash"]

--- a/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm
@@ -28,7 +28,6 @@ RUN pip install --upgrade pip setuptools packaging --no-cache-dir --progress-bar
     pip cache purge
 
 RUN pip config set global.index-url "${PIP_INDEX}" && \
-    pip config set global.extra-index-url "${PIP_INDEX}" && \
     pip config set global.no-cache-dir "true" && \
     pip config --user set global.progress_bar off && \
     python -m pip install --upgrade pip
@@ -39,7 +38,10 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install -e ".[npu_aarch64]"
+# pyproject.toml pins transformers==5.9.0 in the transformers-stable uv default
+# group. pip install -e does not install uv dependency groups, so pin and verify it here.
+RUN pip install -e ".[npu_aarch64]" "transformers==5.9.0" && \
+    python -c "import transformers; assert transformers.__version__ == '5.9.0'"
 
 # Align the parquet/data stack with the uv lockfile. pip install -e (unlike x86's
 # uv sync --locked) ignores the lockfile and floats pyarrow/pandas to latest; pyarrow
@@ -49,9 +51,9 @@ RUN pip install "pyarrow==21.0.0" "pandas==2.3.2"
 
 # ============================================================================
 # GDN / fla_npu (AscendC fused ops) — ported from Dockerfile.ascend_9.0.0_a2.x86.
-# The aarch64 image build is CI-validated; runtime behavior on a physical 910B remains
-# unverified. Differences vs x86: pip not uv, runs as root (so the .run writes the
-# CANN opp dir directly, no sudo), no venv.
+# The aarch64 image build is CI-validated, and GDN runtime behavior was validated
+# on physical A2 / 910B hardware. Differences vs x86: pip not uv, runs as root
+# (so the .run writes the CANN opp dir directly, no sudo), no venv.
 # ============================================================================
 
 # fla_npu's check_npu_env maps torch 2.10.0 -> torch_npu 2.10.0.post2 (npu_aarch64
@@ -65,11 +67,12 @@ RUN pip install torch-npu==2.10.0.post2 pybind11
 # verifies the patch stuck.
 # aarch64 triton-ascend 3.2.1 requires triton==3.5.0 (x86's is 3.2.0) — an arch-specific
 # dep, confirmed via `pip install triton-ascend==3.2.1 --dry-run` on an aarch64 host.
-# Use Huawei Cloud's Ascend package index so TLS verification remains enabled.
+# Install the pinned wheel directly from Huawei Cloud so only triton-ascend uses
+# that source; its dependencies continue to resolve from the configured PIP_INDEX.
 RUN (pip uninstall -y triton triton-ascend || true) && \
     pip install triton==3.5.0 && \
-    pip install triton-ascend==3.2.1 \
-        --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    pip install \
+        "https://mirrors.huaweicloud.com/ascend/repos/pypi/triton-ascend/triton_ascend-3.2.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl" && \
     echo "Verifying triton-ascend patched libtriton.so ..." && \
     python -c "from triton._C.libtriton import ascend"
 

--- a/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm
@@ -65,13 +65,11 @@ RUN pip install torch-npu==2.10.0.post2 pybind11
 # verifies the patch stuck.
 # aarch64 triton-ascend 3.2.1 requires triton==3.5.0 (x86's is 3.2.0) — an arch-specific
 # dep, confirmed via `pip install triton-ascend==3.2.1 --dry-run` on an aarch64 host.
-# pip tolerates the osinfra index behavior here; x86 uses uv with the Huawei Cloud mirror
-# because uv rejects wrong-name metadata returned by osinfra for transitive lookups.
+# Use Huawei Cloud's Ascend package index so TLS verification remains enabled.
 RUN (pip uninstall -y triton triton-ascend || true) && \
     pip install triton==3.5.0 && \
     pip install triton-ascend==3.2.1 \
-        --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple \
-        --trusted-host triton-ascend.osinfra.cn && \
+        --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     echo "Verifying triton-ascend patched libtriton.so ..." && \
     python -c "from triton._C.libtriton import ascend"
 

--- a/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86
@@ -1,0 +1,143 @@
+# docker hub: https://hub.docker.com/layers/ascendai/cann/9.0.0-910b-ubuntu22.04-py3.11/images/sha256-latest
+# cann web: https://www.hiascend.com/developer/ascendhub/detail/17da20d1c2b6493cb38765adeba85884
+# git repo: https://gitcode.com/Ascend/pytorch
+FROM swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0.0-910b-ubuntu22.04-py3.11
+
+# Define environments
+ENV MAX_JOBS=16
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_ROOT_USER_ACTION=ignore
+
+# Define installation arguments
+ARG APT_SOURCE=http://archive.ubuntu.com/ubuntu/
+ARG PIP_INDEX=https://pypi.org/simple
+
+# ubuntu 22.04 line-format /etc/apt/sources.list (not the deb822 format used
+# by 24.04+). Only override on non-default APT_SOURCE. Wider regex matches any
+# `…/ubuntu[/]` URL so CANN bases preconfigured with Huawei Cloud / Aliyun
+# mirrors get rewritten too — anchoring on archive.ubuntu.com would silently
+# no-op there.
+RUN if [ "${APT_SOURCE}" != "http://archive.ubuntu.com/ubuntu/" ]; then \
+    cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
+    sed -E -i "s#https?://[^[:space:]]+/ubuntu/?#${APT_SOURCE}#g" /etc/apt/sources.list; \
+    fi
+
+# Change pip source (only when --build-arg PIP_INDEX=... is overridden)
+RUN if [ "${PIP_INDEX}" != "https://pypi.org/simple" ]; then \
+        pip config set global.index-url "${PIP_INDEX}" && \
+        pip config set global.extra-index-url "${PIP_INDEX}"; \
+    fi && \
+    pip config set global.no-cache-dir "true" && \
+    python -m pip install --upgrade pip
+
+# Ubuntu 22.04 base does not preinstall tzdata, unlike the CUDA base.
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata && \
+    echo "Setting timezone to CST (China Standard Time)..." && \
+    ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata
+
+# gcc/g++/cmake/build-essential — compile sdists with no NPU/aarch64 wheel.
+# libnuma-dev — required by the Ascend runtime.
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        gcc g++ cmake libnuma-dev sudo wget git curl jq vim build-essential ssh ca-certificates ffmpeg gawk \
+    && apt-get clean
+
+# Add tiger user, remove default user if uid=1000 is occupied
+RUN userdel -r $(id -un 1000) 2>/dev/null || true && \
+    groupadd --non-unique -g 1000 tiger && \
+    useradd -g 1000 -u 1000 -d /home/tiger -m tiger && \
+    mkdir -p /home/tiger/.service/ && \
+    mkdir -p /home/tiger/.local/share/code-server/User/ && \
+    chown -R tiger:tiger /home/tiger && \
+    mkdir -p /opt/tiger && \
+    chown tiger:tiger /opt/tiger && \
+    mkdir -p /app && \
+    chown tiger:tiger /app && \
+    mkdir -p /opt/log/tiger && \
+    chown -R tiger:tiger /opt/log && \
+    mkdir -p /var/log/tiger && \
+    chown tiger:tiger /var/log/tiger
+
+# enable VFS (Virtual File System) used by UCX for tiger user
+RUN mkdir -p /run/user/1000 && chown tiger:tiger /run/user/1000
+
+# Enable sudo for tiger user
+RUN mkdir -p /etc/sudoers.d && \
+    echo "tiger ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/tiger && \
+    chmod 0440 /etc/sudoers.d/tiger
+
+# Add tiger python install permission
+RUN groupadd python-users && \
+    usermod -aG python-users root && \
+    usermod -aG python-users tiger && \
+    chown -R root:python-users /usr/local/python3.11.15/lib/python3.11/site-packages/ && \
+    chmod -R g+w /usr/local/python3.11.15/lib/python3.11/site-packages/ && \
+    chmod g+s /usr/local/python3.11.15/lib/python3.11/site-packages/
+
+USER tiger
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /uvx /bin/
+ENV PATH="/bin/:$PATH"
+ENV UV_CACHE_DIR=/home/tiger/.cache/uv
+
+# uv sync
+WORKDIR /app
+COPY --chown=tiger:tiger . ./
+RUN uv sync --python 3.11 --locked --extra npu --allow-insecure-host github.com --allow-insecure-host objects.githubusercontent.com --allow-insecure-host download-r2.pytorch.org
+
+# fla_npu needs a torch_npu post matched to torch: its scripts/check_npu_env.py maps
+# torch 2.10.0 -> torch_npu 2.10.0.post2. VeOmni's npu extra pins plain torch-npu
+# 2.10.0 (< post2), so bump to .post2 here. torch stays at main's 2.10.0 — no downgrade,
+# no divergence from VeOmni main. pybind11 is needed by the fla_npu torch-binding build.
+RUN uv pip install torch-npu==2.10.0.post2 pybind11
+
+# Install triton-ascend (a GDN kernel dep not in the lockfile), after uv sync so the
+# lockfile prune does not remove it. Both community triton and triton-ascend ship a
+# triton/_C/libtriton.so; triton-ascend's has the ascend backend, community triton's is
+# vanilla. Whoever writes that shared path LAST wins. `uv pip install triton triton-ascend`
+# is a single parallel transaction that does NOT guarantee order — on CI vanilla triton
+# won and clobbered the patch, so `from triton._C.libtriton import ascend` failed. So
+# install in TWO steps: triton first, then triton-ascend, so its patched .so lands last.
+# (pip on the aarch64 files installs sequentially in dependency order, so it doesn't hit
+# this; uv needs the split.) The trailing import verifies the patch stuck.
+# Use Huawei Cloud's package index: osinfra returns wrong-name metadata for transitive
+# package lookups, which uv correctly rejects during dependency resolution.
+RUN (uv pip uninstall triton triton-ascend || true) && \
+    uv pip install triton==3.2.0 && \
+    uv pip install triton-ascend==3.2.1 \
+    --index=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    echo "Verifying triton-ascend patched libtriton.so ..." && \
+    /app/.venv/bin/python -c "from triton._C.libtriton import ascend"
+
+# Build & install fla_npu (AscendC fused GDN ops exposed as torch.ops.npu.*).
+# Kept as ONE RUN so the CANN env sourced from set_env.sh persists across the
+# compile steps (every Dockerfile RUN is otherwise a fresh shell). Must come after
+# triton-ascend: fla_npu's operator build depends on it. Its build scripts do NOT
+# honor the activated venv — they install into the base image's system python — so
+# the torch binding wheel is re-installed into /app/.venv explicitly with --no-deps
+# (without --no-deps, uv would pull a CUDA torch and clobber the +cpu / triton stack).
+# The .run installs the AscendC operators (opp) into the CANN vendor dir
+# ($ASCEND_OPP_PATH/vendors), which is root-owned while this RUN executes as tiger —
+# so chown it to tiger (tiger has passwordless sudo) before the .run. Keeping the ops
+# in the standard CANN opp path means they are found at runtime with no extra env var,
+# and they survive a bind-mount over /app.
+# NOTE: base image ships CANN 9.0.0 while fla-npu's README recommends 8.5.2 — verified
+# working here; set_env.sh path and the .run's --quiet flag likewise confirmed.
+RUN git clone https://github.com/flashserve/flash-linear-attention-npu /tmp/fla-npu && \
+    cd /tmp/fla-npu && git checkout c2e3d83f && \
+    source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    . /app/.venv/bin/activate && \
+    python scripts/check_npu_env.py --build-only && \
+    bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu && \
+    sudo mkdir -p "$ASCEND_OPP_PATH/vendors" && \
+    sudo chown -R tiger:tiger "$ASCEND_OPP_PATH/vendors" && \
+    bash build_out/*.run --quiet && \
+    cd torch_custom/fla_npu && bash build.sh && \
+    uv pip install --no-deps dist/*.whl && \
+    cd / && rm -rf /tmp/fla-npu
+
+USER root

--- a/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86
@@ -87,7 +87,7 @@ ENV UV_CACHE_DIR=/home/tiger/.cache/uv
 # uv sync
 WORKDIR /app
 COPY --chown=tiger:tiger . ./
-RUN uv sync --python 3.11 --locked --extra npu --allow-insecure-host github.com --allow-insecure-host objects.githubusercontent.com --allow-insecure-host download-r2.pytorch.org
+RUN uv sync --system-certs --python 3.11 --locked --extra npu
 
 # fla_npu needs a torch_npu post matched to torch: its scripts/check_npu_env.py maps
 # torch 2.10.0 -> torch_npu 2.10.0.post2. VeOmni's npu extra pins plain torch-npu

--- a/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3
@@ -40,7 +40,6 @@ RUN pip install --upgrade pip setuptools packaging --no-cache-dir --progress-bar
     pip cache purge
 
 RUN pip config set global.index-url "${PIP_INDEX}" && \
-    pip config set global.extra-index-url "${PIP_INDEX}" && \
     pip config set global.no-cache-dir "true" && \
     pip config --user set global.progress_bar off && \
     python -m pip install --upgrade pip
@@ -51,7 +50,10 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install -e ".[npu_aarch64]"
+# pyproject.toml pins transformers==5.9.0 in the transformers-stable uv default
+# group. pip install -e does not install uv dependency groups, so pin and verify it here.
+RUN pip install -e ".[npu_aarch64]" "transformers==5.9.0" && \
+    python -c "import transformers; assert transformers.__version__ == '5.9.0'"
 
 # Align the parquet/data stack with the uv lockfile. pip install -e (unlike x86's
 # uv sync --locked) ignores the lockfile and floats pyarrow/pandas to latest; pyarrow
@@ -77,11 +79,12 @@ RUN pip install torch-npu==2.10.0.post2 pybind11
 # verifies the patch stuck.
 # aarch64 triton-ascend 3.2.1 requires triton==3.5.0 (x86's is 3.2.0) — an arch-specific
 # dep, confirmed via `pip install triton-ascend==3.2.1 --dry-run` on an aarch64 host.
-# Use Huawei Cloud's Ascend package index so TLS verification remains enabled.
+# Install the pinned wheel directly from Huawei Cloud so only triton-ascend uses
+# that source; its dependencies continue to resolve from the configured PIP_INDEX.
 RUN (pip uninstall -y triton triton-ascend || true) && \
     pip install triton==3.5.0 && \
-    pip install triton-ascend==3.2.1 \
-        --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    pip install \
+        "https://mirrors.huaweicloud.com/ascend/repos/pypi/triton-ascend/triton_ascend-3.2.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl" && \
     echo "Verifying triton-ascend patched libtriton.so ..." && \
     python -c "from triton._C.libtriton import ascend"
 

--- a/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3
@@ -51,7 +51,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install -e .[npu_aarch64]
+RUN pip install -e ".[npu_aarch64]"
 
 # Align the parquet/data stack with the uv lockfile. pip install -e (unlike x86's
 # uv sync --locked) ignores the lockfile and floats pyarrow/pandas to latest; pyarrow

--- a/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3
@@ -1,0 +1,119 @@
+FROM swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0.0-a3-ubuntu22.04-py3.11
+
+# Set default pip index
+ARG PIP_INDEX=https://pypi.org/simple
+
+# Define environments
+ENV MAX_JOBS=16
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV OMP_NUM_THREADS=4
+ENV OPENBLAS_NUM_THREADS=1
+ENV MKL_NUM_THREADS=1
+ENV NUMEXPR_NUM_THREADS=1
+
+RUN echo "Setting timezone to CST (China Standard Time)..." && \
+    ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone
+
+# aarch64 base uses ports.ubuntu.com/ubuntu-ports, which is unreachable on some
+# restricted networks. Override with a reachable mirror, e.g.
+#   --build-arg APT_SOURCE=http://mirrors.huaweicloud.com/ubuntu-ports/
+# Guarded so the default is a no-op. ubuntu 22.04 uses the line-format
+# /etc/apt/sources.list (not the deb822 format of 24.04+); the regex rewrites the
+# host before /ubuntu-ports regardless of what the base preconfigured.
+ARG APT_SOURCE=http://ports.ubuntu.com/ubuntu-ports/
+RUN if [ "${APT_SOURCE}" != "http://ports.ubuntu.com/ubuntu-ports/" ]; then \
+    cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
+    sed -E -i "s#https?://[^[:space:]]+/ubuntu-ports/?#${APT_SOURCE}#g" /etc/apt/sources.list; \
+    fi
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc g++ cmake libnuma-dev sudo wget git curl jq vim build-essential ssh ca-certificates ffmpeg pkg-config gawk && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    pip install --upgrade pip setuptools packaging && \
+    pip cache purge
+
+RUN chmod +x /usr/bin/make /usr/bin/gmake /usr/bin/cc /usr/bin/c++
+
+RUN pip install --upgrade pip setuptools packaging --no-cache-dir --progress-bar off && \
+    pip cache purge
+
+RUN pip config set global.index-url "${PIP_INDEX}" && \
+    pip config set global.extra-index-url "${PIP_INDEX}" && \
+    pip config set global.no-cache-dir "true" && \
+    pip config --user set global.progress_bar off && \
+    python -m pip install --upgrade pip
+
+RUN pip3 install --no-cache-dir -U pip setuptools requests
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install -e .[npu_aarch64]
+
+# Align the parquet/data stack with the uv lockfile. pip install -e (unlike x86's
+# uv sync --locked) ignores the lockfile and floats pyarrow/pandas to latest; pyarrow
+# 25 / pandas 3.x SEGFAULT reading parquet on aarch64 (datasets is pinned to 2.21, which
+# targets the older pyarrow ABI). Pin to the versions the x86 lockfile uses.
+RUN pip install "pyarrow==21.0.0" "pandas==2.3.2"
+
+# ============================================================================
+# GDN / fla_npu (AscendC fused ops) — ported from Dockerfile.ascend_9.0.0_a2.x86.
+# The aarch64 A3 image build is CI-validated, and GDN runtime behavior was validated
+# on physical A3 hardware. Differences vs x86: pip not uv, runs as root (.run writes
+# the CANN opp dir directly, no sudo), no venv, and the A3 SOC target below.
+# ============================================================================
+
+# fla_npu's check_npu_env maps torch 2.10.0 -> torch_npu 2.10.0.post2 (npu_aarch64
+# extra pins plain 2.10.0). pybind11 is needed by the fla_npu torch-binding build.
+RUN pip install torch-npu==2.10.0.post2 pybind11
+
+# triton-ascend patches triton's libtriton.so with the ascend backend. Both packages ship
+# that shared .so (triton-ascend's is patched, community triton's is vanilla), and whoever
+# writes it LAST wins — so install triton FIRST then triton-ascend SEPARATELY so the patched
+# .so lands last (see the x86 Dockerfile comment for the full story). The trailing import
+# verifies the patch stuck.
+# aarch64 triton-ascend 3.2.1 requires triton==3.5.0 (x86's is 3.2.0) — an arch-specific
+# dep, confirmed via `pip install triton-ascend==3.2.1 --dry-run` on an aarch64 host.
+# pip tolerates the osinfra index behavior here; x86 uses uv with the Huawei Cloud mirror
+# because uv rejects wrong-name metadata returned by osinfra for transitive lookups.
+RUN (pip uninstall -y triton triton-ascend || true) && \
+    pip install triton==3.5.0 && \
+    pip install triton-ascend==3.2.1 \
+        --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple \
+        --trusted-host triton-ascend.osinfra.cn && \
+    echo "Verifying triton-ascend patched libtriton.so ..." && \
+    python -c "from triton._C.libtriton import ascend"
+
+# ONE RUN so the CANN env from set_env.sh persists. The ascend910_93 SOC target was
+# validated by building and running GDN on physical A3 hardware (x86/a2 uses ascend910b).
+# torch binding wheel is force-reinstalled with --no-deps (else pip pulls a CUDA torch).
+RUN git clone https://github.com/flashserve/flash-linear-attention-npu /tmp/fla-npu && \
+    cd /tmp/fla-npu && git checkout c2e3d83f && \
+    source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    python scripts/check_npu_env.py --build-only && \
+    bash build.sh --soc=ascend910_93 --pkg --vendor_name=fla_npu && \
+    bash build_out/*.run --quiet && \
+    cd torch_custom/fla_npu && bash build.sh && \
+    pip install --no-deps --force-reinstall dist/*.whl && \
+    cd / && rm -rf /tmp/fla-npu
+
+RUN git clone https://github.com/meta-pytorch/torchcodec.git
+
+WORKDIR /app/torchcodec
+
+RUN git checkout v0.5.0
+
+ENV CANN_PATH=/usr/local/Ascend
+
+RUN cp ../docs/get_started/installation/install_torchcodec_Ascend.sh .
+
+RUN chmod +x install_torchcodec_Ascend.sh
+
+RUN bash install_torchcodec_Ascend.sh ${CANN_PATH}/ascend-toolkit/set_env.sh
+
+WORKDIR /app
+
+CMD ["/bin/bash"]

--- a/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3
+++ b/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3
@@ -77,13 +77,11 @@ RUN pip install torch-npu==2.10.0.post2 pybind11
 # verifies the patch stuck.
 # aarch64 triton-ascend 3.2.1 requires triton==3.5.0 (x86's is 3.2.0) — an arch-specific
 # dep, confirmed via `pip install triton-ascend==3.2.1 --dry-run` on an aarch64 host.
-# pip tolerates the osinfra index behavior here; x86 uses uv with the Huawei Cloud mirror
-# because uv rejects wrong-name metadata returned by osinfra for transitive lookups.
+# Use Huawei Cloud's Ascend package index so TLS verification remains enabled.
 RUN (pip uninstall -y triton triton-ascend || true) && \
     pip install triton==3.5.0 && \
     pip install triton-ascend==3.2.1 \
-        --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple \
-        --trusted-host triton-ascend.osinfra.cn && \
+        --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     echo "Verifying triton-ascend patched libtriton.so ..." && \
     python -c "from triton._C.libtriton import ascend"
 

--- a/docs/hardware_support/AscendDockerUsage/build_a2_docker.md
+++ b/docs/hardware_support/AscendDockerUsage/build_a2_docker.md
@@ -27,7 +27,14 @@ docker pull --platform=amd64 swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0
 ```
 
 ## Step 2: Build the Custom Image
-Build the GDN-ready VeOmni Ascend A2 image using the appropriate Dockerfile for your architecture. These Dockerfiles include `torch-npu==2.10.0.post2`, `triton-ascend`, and `fla_npu`. The existing `Dockerfile.ascend_9.0.0_a2.x86` and `Dockerfile.ascend_9.0.0_a2.arm` remain available for the general-purpose images.
+
+Build the GDN-ready VeOmni Ascend A2 image using
+`Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86` for x86 or
+`Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm` for ARM64. These Dockerfiles include
+`torch-npu==2.10.0.post2`, `triton-ascend`, and `fla_npu`.
+
+The existing `Dockerfile.ascend_9.0.0_a2.x86` and `Dockerfile.ascend_9.0.0_a2.arm` remain available for
+general-purpose images.
 
 **Note:** Proxy settings are optional and only needed if your server requires proxy access to the internet. Remove the proxy arguments if not needed.
 
@@ -242,14 +249,14 @@ Update the proxy settings in both the build and run commands to match your envir
 
 ### Dockerfile Details
 
-#### x86 Dockerfile (Dockerfile.ascend_9.0.0_a2)
+#### x86 Dockerfile (Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86)
 1. Sets up the Ubuntu 22.04 base with Ascend CANN
 2. Configures system dependencies and development tools
 3. Installs and configures `uv` for dependency management
 4. Uses `uv` to install VeOmni framework with NPU support
 5. Sets up the virtual environment
 
-#### ARM64 Dockerfile (Dockerfile.ascend_9.0.0_a2.arm)
+#### ARM64 Dockerfile (Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm)
 1. Sets up the Ubuntu 22.04 base with Ascend CANN
 2. Configures system dependencies and development tools
 3. Uses `pip` to install VeOmni framework with NPU support

--- a/docs/hardware_support/AscendDockerUsage/build_a2_docker.md
+++ b/docs/hardware_support/AscendDockerUsage/build_a2_docker.md
@@ -176,7 +176,7 @@ For x86 architecture, you need to activate the virtual environment created by `u
 source /app/.venv/bin/activate
 ```
 
-### Training Command Example
+### General Qwen3-VL Smoke Test
 
 After starting the container with appropriate mounts (and activating the environment for x86), you can run training commands. Here's an example for Qwen3-VL training using generic paths:
 
@@ -191,6 +191,24 @@ bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_vl/qwen3_vl_dense.yaml
 ```
 
 **Note:** Replace `/app/ckpt/your-model-checkpoint` and `/app/dataset/your-dataset.json` with the actual paths you used in your mount configuration.
+
+### Qwen3.5 GDN Training Example
+
+The GDN-ready image includes `triton-ascend` and `fla_npu`. Select the NPU
+implementations explicitly when running Qwen3.5:
+
+```bash
+bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_5/qwen3_5_vl.yaml \
+    --model.model_path /app/ckpt/Qwen3.5-9B \
+    --data.train_path ./configs/multimodal/data/tulu_sharegpt4v_llavavideo.yaml \
+    --model.ops_implementation.rms_norm_gated_implementation npu \
+    --model.ops_implementation.causal_conv1d_implementation npu \
+    --model.ops_implementation.chunk_gated_delta_rule_implementation npu_ascendc \
+    --train.max_steps 20
+```
+
+See the [Qwen3.5 training guide](../../examples/qwen3_5.md#start-training-on-npu)
+for backend details and the Qwen3.5 MoE example.
 
 ## Step 5: Stop and Remove the Container
 When you're done, stop and remove the container:

--- a/docs/hardware_support/AscendDockerUsage/build_a2_docker.md
+++ b/docs/hardware_support/AscendDockerUsage/build_a2_docker.md
@@ -27,9 +27,11 @@ docker pull --platform=amd64 swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0
 ```
 
 ## Step 2: Build the Custom Image
-Build the VeOmni Ascend A2 image using the appropriate Dockerfile for your architecture.
+Build the GDN-ready VeOmni Ascend A2 image using the appropriate Dockerfile for your architecture. These Dockerfiles include `torch-npu==2.10.0.post2`, `triton-ascend`, and `fla_npu`. The existing `Dockerfile.ascend_9.0.0_a2.x86` and `Dockerfile.ascend_9.0.0_a2.arm` remain available for the general-purpose images.
 
 **Note:** Proxy settings are optional and only needed if your server requires proxy access to the internet. Remove the proxy arguments if not needed.
+
+The x86 Dockerfile also accepts `APT_SOURCE` and `PIP_INDEX` build arguments. The ARM64 Dockerfile accepts `PIP_INDEX`.
 
 ### For x86 Architecture
 
@@ -40,7 +42,7 @@ docker build \
   --build-arg https_proxy=http://<user>:<pass>@<host>:<port> \
   --build-arg no_proxy=localhost,127.0.0.1 \
   -t ascend-a2-env:v1 \
-  -f docker/ascend/Dockerfile.ascend_9.0.0_a2.x86 \
+  -f docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86 \
   .
 ```
 
@@ -53,7 +55,7 @@ docker build \
   --build-arg https_proxy=http://<user>:<pass>@<host>:<port> \
   --build-arg no_proxy=localhost,127.0.0.1 \
   -t ascend-a2-env:v1 \
-  -f docker/ascend/Dockerfile.ascend_9.0.0_a2.arm \
+  -f docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm \
   .
 ```
 
@@ -63,7 +65,7 @@ For x86:
 ```bash
 docker build \
   -t ascend-a2-env:v1 \
-  -f docker/ascend/Dockerfile.ascend_9.0.0_a2.x86 \
+  -f docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86 \
   .
 ```
 
@@ -71,7 +73,7 @@ For ARM64:
 ```bash
 docker build \
   -t ascend-a2-env:v1 \
-  -f docker/ascend/Dockerfile.ascend_9.0.0_a2.arm \
+  -f docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm \
   .
 ```
 
@@ -80,6 +82,7 @@ The built image includes:
 - Ubuntu 22.04 with Python 3.11
 - Ascend CANN 9.0.0 runtime
 - VeOmni framework with NPU support
+- torch-npu 2.10.0.post2, triton-ascend, and fla_npu for GDN
 - TorchCodec for efficient video processing
 - All necessary development tools and dependencies
 

--- a/docs/hardware_support/AscendDockerUsage/build_a3_docker.md
+++ b/docs/hardware_support/AscendDockerUsage/build_a3_docker.md
@@ -19,9 +19,11 @@ docker pull --platform=arm64 swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0
 ```
 
 ## Step 2: Build the Custom Image
-Build the VeOmni Ascend A3 image using the provided Dockerfile.
+Build the GDN-ready VeOmni Ascend A3 image using the provided Dockerfile. It includes `torch-npu==2.10.0.post2`, `triton-ascend`, and `fla_npu`. The existing `Dockerfile.ascend_9.0.0_a3` remains available for the general-purpose image.
 
 **Note:** Proxy settings are optional and only needed if your server requires proxy access to the internet. Remove the proxy arguments if not needed.
+
+The GDN-ready Dockerfile also accepts `PIP_INDEX` and `APT_SOURCE` build arguments. `APT_SOURCE` must point to an Ubuntu Ports mirror.
 
 ```bash
 # Optional proxy settings (remove if not needed)
@@ -30,7 +32,7 @@ docker build \
   --build-arg https_proxy=http://<user>:<pass>@<host>:<port> \
   --build-arg no_proxy=localhost,127.0.0.1 \
   -t ascend-a3-env:v1 \
-  -f docker/ascend/Dockerfile.ascend_9.0.0_a3 \
+  -f docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3 \
   .
 ```
 
@@ -38,7 +40,7 @@ Without proxy (simplified):
 ```bash
 docker build \
   -t ascend-a3-env:v1 \
-  -f docker/ascend/Dockerfile.ascend_9.0.0_a3 \
+  -f docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3 \
   .
 ```
 
@@ -47,6 +49,7 @@ The built image includes:
 - Ubuntu 22.04 with Python 3.11
 - Ascend CANN 9.0.0 runtime
 - VeOmni framework with NPU support
+- torch-npu 2.10.0.post2, triton-ascend, and fla_npu for GDN
 - TorchCodec for efficient video processing
 - All necessary development tools and dependencies
 

--- a/docs/hardware_support/AscendDockerUsage/build_a3_docker.md
+++ b/docs/hardware_support/AscendDockerUsage/build_a3_docker.md
@@ -133,6 +133,9 @@ docker run --runtime=runc -it \
 ```
 
 ## Step 4: Run Training Inside the Container
+
+### General Qwen3-VL Smoke Test
+
 After starting the container with appropriate mounts, you can run training commands. Here's an example for Qwen3-VL training using generic paths:
 
 ```bash
@@ -146,6 +149,24 @@ bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_vl/qwen3_vl_dense.yaml
 ```
 
 **Note:** Replace `/app/ckpt/your-model-checkpoint` and `/app/dataset/your-dataset.json` with the actual paths you used in your mount configuration.
+
+### Qwen3.5 GDN Training Example
+
+The GDN-ready image includes `triton-ascend` and `fla_npu`. Select the NPU
+implementations explicitly when running Qwen3.5:
+
+```bash
+bash train.sh tasks/train_vlm.py configs/multimodal/qwen3_5/qwen3_5_vl.yaml \
+    --model.model_path /app/ckpt/Qwen3.5-9B \
+    --data.train_path ./configs/multimodal/data/tulu_sharegpt4v_llavavideo.yaml \
+    --model.ops_implementation.rms_norm_gated_implementation npu \
+    --model.ops_implementation.causal_conv1d_implementation npu \
+    --model.ops_implementation.chunk_gated_delta_rule_implementation npu_ascendc \
+    --train.max_steps 20
+```
+
+See the [Qwen3.5 training guide](../../examples/qwen3_5.md#start-training-on-npu)
+for backend details and the Qwen3.5 MoE example.
 
 ## Step 5: Stop and Remove the Container
 When you're done, stop and remove the container:

--- a/docs/hardware_support/AscendDockerUsage/overview.md
+++ b/docs/hardware_support/AscendDockerUsage/overview.md
@@ -41,8 +41,8 @@ All image tags follow this pattern:
 
 | Chip Series | Architecture | Tag Example | Dockerfile |
 |---|---|---|---|
-| 910B (A2) | amd64 + arm64 | `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-910b-ubuntu22.04-py3.11-veomni` | [x86](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_a2.x86) / [arm](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_a2.arm) |
-| A3 | arm64 | `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-a3-ubuntu22.04-py3.11-veomni` | [a3](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_a3) |
+| 910B (A2) | amd64 + arm64 | `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-910b-ubuntu22.04-py3.11-veomni` | [x86](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86) / [arm](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm) |
+| A3 | arm64 | `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-a3-ubuntu22.04-py3.11-veomni` | [a3](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3) |
 
 Notes:
 

--- a/docs/hardware_support/AscendDockerUsage/supported_tags.md
+++ b/docs/hardware_support/AscendDockerUsage/supported_tags.md
@@ -10,10 +10,9 @@ Two tag schemes coexist on quay.io:
 - **Product-based** (current): `<veomni_version>-cann<CANN>-torch_npu<torch_npu>-<chip_series>-<os>-py<python>-veomni`
 - **Legacy**: `veomni-<cann>-<chip_series>-<os>-py<python>[-torch<torch>][-<suffix>]`
 
-> The product-based tags are built from the `image-tooling` branch, whose 9.0.0
-> Dockerfiles add the fla_npu / triton-ascend GDN stack. That branch is not yet
-> merged upstream; the `main`-branch Dockerfiles linked below predate those
-> additions.
+> The product-based tags use the dedicated CANN 9.0.0 / torch-npu 2.10.0.post2
+> Dockerfiles below, which include the triton-ascend and fla_npu GDN stack. The
+> general-purpose Dockerfiles remain available for the legacy tags.
 
 ## CANN 9.0.0
 
@@ -21,10 +20,10 @@ Two tag schemes coexist on quay.io:
 
 | Tag | Dockerfile | Content |
 |---|---|---|
-| `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-910b-ubuntu22.04-py3.11-veomni` | [Dockerfile] [a2.x86](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_a2.x86) / [a2.arm](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_a2.arm) | veomni / torch-npu / triton-ascend / fla_npu |
-| `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-a3-ubuntu22.04-py3.11-veomni` | [Dockerfile] [a3](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_a3) | veomni / torch-npu / triton-ascend / fla_npu |
-| `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-A2-ubuntu22.04-py3.11-veomni-latest` | [Dockerfile] [a2.x86](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_a2.x86) / [a2.arm](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_a2.arm) | veomni / torch-npu / triton-ascend / fla_npu |
-| `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-A3-ubuntu22.04-py3.11-veomni-latest` | [Dockerfile] [a3](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_a3) | veomni / torch-npu / triton-ascend / fla_npu |
+| `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-910b-ubuntu22.04-py3.11-veomni` | [Dockerfile] [a2.x86](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86) / [a2.arm](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm) | veomni / torch-npu / triton-ascend / fla_npu |
+| `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-a3-ubuntu22.04-py3.11-veomni` | [Dockerfile] [a3](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3) | veomni / torch-npu / triton-ascend / fla_npu |
+| `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-A2-ubuntu22.04-py3.11-veomni-latest` | [Dockerfile] [a2.x86](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.x86) / [a2.arm](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_910b.arm) | veomni / torch-npu / triton-ascend / fla_npu |
+| `v0.1.11-cann9.0.0-torch_npu2.10.0.post2-A3-ubuntu22.04-py3.11-veomni-latest` | [Dockerfile] [a3](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.0.0_torch_npu2.10.0.post2_a3) | veomni / torch-npu / triton-ascend / fla_npu |
 
 ### Legacy tags
 


### PR DESCRIPTION
### What does this PR do?

> Add three new CANN 9.0.0 / torch-npu 2.10.0.post2 Dockerfiles for running
> Qwen3.5 GatedDeltaNet (GDN) on Ascend A2 / 910B amd64, A2 / 910B arm64,
> and A3 arm64.
>
> The GDN NPU backends were introduced in #879 and #924. These Dockerfiles
> provide the two additional libraries required by those backends:
>
> - `triton-ascend==3.2.1` for the Triton-based NPU backend from #879.
> - `fla_npu`, built from `flash-linear-attention-npu` commit `c2e3d83f`, for
>   the AscendC backend from #924.
>
> All three files are added alongside the existing CANN 9.0.0 Dockerfiles.
> No existing Dockerfile is replaced or modified.

### Checklist Before Starting

- Search for relative PRs/issues and link here: #879 and #924.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

> GitHub Actions build validation:
>
> - A2 / 910B amd64 image built successfully.
> - A2 / 910B arm64 image built successfully.
> - A3 arm64 image built successfully.
>
> Physical NPU validation:
>
> - The A2 images and GDN runtime were validated successfully on physical A2
>   hardware.
> - The A3 image and GDN runtime were validated successfully on physical A3
>   hardware.

### API and Usage Example

> N/A. This PR adds Dockerfiles and does not change any Python API or
> configuration field.

### Design & Code Changes

> - Add separate GDN-ready Dockerfiles for A2 amd64, A2 arm64, and A3 arm64,
>   while keeping the existing Ascend Dockerfiles unchanged.
> - Install `torch-npu==2.10.0.post2`, `triton-ascend==3.2.1`.
> - Build and install the `fla_npu` AscendC operators and PyTorch bindings from
>   pinned commit `c2e3d83f`.
> - Verify the Triton Ascend backend import during the image build before
>   compiling and installing `fla_npu`.
> - Update the Ascend image overview, supported-tag links, and A2/A3 build
>   commands for the new GDN-ready Dockerfiles.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- Applied pre-commit checks: `git diff --check` passed, and all Docker builds
  passed in GitHub Actions.
- Added/updated documentation: updated the Ascend image overview, supported
  tags, and A2/A3 build guides for the new Dockerfiles.
- If `tasks/` training scripts were moved or renamed: N/A. No training script
  is changed.
- Added tests to CI workflow (or explained why not feasible): no workflow is
  included in this Dockerfile-only PR; all three Dockerfiles were validated by
  build-only GitHub Actions before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ascend 910B and A3 Docker images for ARM64 and x86 platforms.
  * Added NPU acceleration support with `torch-npu`, `triton-ascend`, and `fla_npu`.
  * Included TorchCodec support in applicable images.
  * Added GDN-ready configurations with architecture-specific dependencies and build options.

* **Documentation**
  * Updated Ascend build guides, supported tags, image links, architectures, and included components.
  * Added Qwen3-VL smoke tests and Qwen3.5 GDN training examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->