### PR TITLE
[lora,model] feat: Add Qwen3.5-MoE LoRA training support

### DIFF
--- a/configs/text/qwen3_5_moe_lora.yaml
+++ b/configs/text/qwen3_5_moe_lora.yaml
@@ -1,0 +1,85 @@
+# Qwen3.5-MoE-35B LoRA on eight Ascend NPUs with FSDP2 and expert parallelism.
+# GPU validation uses this same file with the hardware backend overrides shown
+# in docs/examples/qwen3_5_moe_lora.md.
+
+model:
+  model_path: Qwen/Qwen3.5-35B-A3B
+  ops_implementation:
+    attn_implementation: flash_attention_2
+    moe_implementation: fused_npu
+    cross_entropy_loss_implementation: chunk_loss
+    rms_norm_implementation: npu
+    rotary_pos_emb_implementation: npu
+    swiglu_mlp_implementation: eager
+    load_balancing_loss_implementation: eager
+    rms_norm_gated_implementation: npu
+    causal_conv1d_implementation: npu
+    chunk_gated_delta_rule_implementation: npu
+  lora_config:
+    rank: 16
+    alpha: 32
+    use_rslora: false
+    lora_modules:
+      # Full-attention projections.
+      - q_proj
+      - k_proj
+      - v_proj
+      - o_proj
+      # GatedDeltaNet projections.
+      - in_proj_qkv
+      - in_proj_z
+      - in_proj_b
+      - in_proj_a
+      - out_proj
+      # Semantic expert targets, mapped to gate_up_proj/down_proj parameters.
+      - gate_proj
+      - up_proj
+      - down_proj
+    share_expert_lora: true
+
+data:
+  train_path: tulu-3-sft-mixture
+  data_type: conversation
+  chat_template: chatml
+  max_seq_len: 1024
+  train_size: 750000
+  text_keys: messages
+  dyn_bsz_buffer_size: 200
+
+train:
+  accelerator:
+    ulysses_size: 1
+    ep_size: 4
+    fsdp_config:
+      fsdp_mode: fsdp2
+      offload: false
+      mixed_precision:
+        enable: true
+  gradient_checkpointing:
+    enable: true
+    enable_reentrant: false
+  global_batch_size: 8
+  micro_batch_size: 1
+  bsz_warmup_ratio: 0
+  optimizer:
+    type: adamw
+    lr: 1.0e-4
+    lr_decay_style: cosine
+    max_grad_norm: 1.0
+  num_train_epochs: 1
+  max_steps: 500
+  init_device: meta
+  enable_full_determinism: false
+  ep_sharded_stream_load: true
+  broadcast_model_weights_from_rank0: false
+  empty_cache_steps: 100
+  checkpoint:
+    output_dir: Qwen3.5-35B-A3B-lora-tulu
+    manager: dcp
+    save_steps: 100
+    save_epochs: 0
+    save_hf_weights: true
+  wandb:
+    enable: false
+    project: VeOmni
+    name: Qwen3.5-35B-A3B-lora

--- a/docs/key_features/lora.md
+++ b/docs/key_features/lora.md
@@ -365,22 +365,26 @@ DeepSeek-V3 also exposes **shared experts** (`mlp.shared_experts.{gate,up,down}_
 implemented as plain `nn.Linear`. Add them to `lora_modules` if you want PEFT to LoRA them
 too — they are orthogonal to the MoE-LoRA on the routed experts.
 
-### 5.3 Forward path: fused triton vs eager
+### 5.3 MoE-LoRA forward backends
 
 Each MoE-LoRA wrapper dispatches based on `model.ops_implementation.moe_implementation`:
 
 | `moe_implementation` | non-EP | EP | Notes |
 |---|---|---|---|
-| `fused_triton` | fused triton kernel | fused triton kernel | Recommended for training. |
-| `eager` | eager loop (reference) | not supported (raises) | Reference / fallback for NPU and Quack. |
+| `fused_triton` | fused Triton kernel | fused Triton kernel | Recommended on GPU. |
+| `fused_npu` | NPU GroupGEMM | NPU GroupGEMM | Recommended on Ascend NPU. |
+| `eager` | eager loop (reference) | not supported (raises) | Portable reference path. |
 
-The fused path lives in `veomni/lora/ops/moe_group_gemm.py` and reuses the same
+The fused GPU path lives in `veomni/lora/ops/moe_group_gemm.py` and reuses the same
 `group_gemm_same_nk` / `group_gemm_same_mn` primitives (from `veomni/ops/kernels/moe/_kernels/`)
 as the non-LoRA MoE forward, so it inherits the same EP `all-to-all` dispatch pipeline. The
 LoRA fused pointers are bound by `veomni.ops.kernels.moe.apply_veomni_fused_moe_patch` via
 `veomni.lora.ops.bind_lora_moe_kernels`.
 
 ### 5.4 Expert Parallelism (EP)
+
+Both `fused_triton` and `fused_npu` support the EP path; `fused_npu` uses the
+Ascend GroupGEMM implementation in `veomni/lora/ops/npu_moe_group_gemm.py`.
 
 When `train.accelerator.ep_size > 1`, base experts are sharded along the expert dim by
 `ParallelPlan` (`Shard(0)` on `gate_up_proj` / `down_proj`). MoE-LoRA tracks this layout:
@@ -395,7 +399,8 @@ When `train.accelerator.ep_size > 1`, base experts are sharded along the expert 
   `_collect_ep_replicated_lora_param_ids` in `veomni/optim/optimizer.py` — to skip the
   EP all-reduce for these replicated params so the global grad-norm matches EP=1.
 
-Both modes work with FSDP2 + EP. EP is only supported on the `fused_triton` forward path.
+Both modes work with FSDP2 + EP. EP requires a fused forward path:
+`fused_triton` on GPU or `fused_npu` on Ascend NPU; `eager` raises.
 
 ### 5.5 Save / load artefacts
 
@@ -424,6 +429,7 @@ ignored on its side, keeping the file loadable by both stacks.
 
 Text-only:
 - [`configs/text/qwen3_moe_lora.yaml`](../../configs/text/qwen3_moe_lora.yaml) — Qwen3-MoE
+- [`configs/text/qwen3_5_moe_lora.yaml`](../../configs/text/qwen3_5_moe_lora.yaml) — Qwen3.5-MoE-35B, Ascend NPU FSDP2 + EP
 - [`configs/text/deepseek_v3_lora.yaml`](../../configs/text/deepseek_v3_lora.yaml) — DeepSeek-V3 (v5), with EP=8
 
 Multimodal:
@@ -600,6 +606,9 @@ DeepSeek-V3 (v5) follows the same shape — see
 sets `ep_size: 8` and additionally LoRA-wraps DeepSeek's MLA projections
 (`q_a_proj` / `q_b_proj` / `kv_a_proj_with_mqa` / `kv_b_proj` / `o_proj`) via
 `lora_modules`.
+
+For the Qwen3.5-MoE-35B Ascend NPU and H200 commands, backend matrix, validation
+method, and measured results, see [Qwen3.5-MoE-35B LoRA practice](../examples/qwen3_5_moe_lora.md).
 
 ---
 

--- a/tests/lora/test_qwen3_5_moe_lora.py
+++ b/tests/lora/test_qwen3_5_moe_lora.py
@@ -37,10 +37,12 @@ _CAUSAL_EXPERT_PATTERNS = [
 
 
 def _production_lora_config():
+    """Load the LoRA section from the production Qwen3.5-MoE config."""
     return yaml.safe_load(_CONFIG_PATH.read_text(encoding="utf-8"))["model"]["lora_config"]
 
 
 def test_qwen3_5_moe_registers_semantic_expert_target_mapping_for_both_wrappers():
+    """Verify semantic expert targets resolve for both Qwen3.5-MoE wrappers."""
     lora_modules = [*_DENSE_TARGETS, *_SEMANTIC_EXPERT_TARGETS]
 
     conditional_cls = register_qwen3_5_moe_modeling("Qwen3_5MoeForConditionalGeneration")
@@ -57,6 +59,7 @@ def test_qwen3_5_moe_registers_semantic_expert_target_mapping_for_both_wrappers(
 
 
 def test_qwen3_5_moe_production_config_injects_all_targets_and_freezes_base_model():
+    """Verify the production config injects every target and freezes base weights."""
     model = build_foundation_model(
         config_path=_TOY_CONFIG_PATH,
         weights_path=None,

--- a/tests/lora/test_qwen3_5_moe_lora.py
+++ b/tests/lora/test_qwen3_5_moe_lora.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import yaml
+
+from veomni.lora import VeOmniLoraConfig, VeOmniLoraModel, resolve_fused_moe_lora_targets
+from veomni.models import build_foundation_model
+from veomni.models.transformers.qwen3_5_moe import (
+    register_qwen3_5_moe_modeling,
+    register_qwen3_5_moe_text_modeling,
+)
+
+from ..tools.training_utils import make_eager_ops_config
+
+
+_CONFIG_PATH = Path("configs/text/qwen3_5_moe_lora.yaml")
+_TOY_CONFIG_PATH = "tests/toy_config/qwen3_5_moe_toy/config.json"
+_DENSE_TARGETS = {
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "in_proj_qkv",
+    "in_proj_z",
+    "in_proj_b",
+    "in_proj_a",
+    "out_proj",
+}
+_SEMANTIC_EXPERT_TARGETS = {"gate_proj", "up_proj", "down_proj"}
+_CONDITIONAL_EXPERT_PATTERNS = [
+    "model.language_model.layers.*.mlp.experts.gate_up_proj",
+    "model.language_model.layers.*.mlp.experts.down_proj",
+]
+_CAUSAL_EXPERT_PATTERNS = [
+    "model.layers.*.mlp.experts.gate_up_proj",
+    "model.layers.*.mlp.experts.down_proj",
+]
+
+
+def _production_lora_config():
+    return yaml.safe_load(_CONFIG_PATH.read_text(encoding="utf-8"))["model"]["lora_config"]
+
+
+def test_qwen3_5_moe_registers_semantic_expert_target_mapping_for_both_wrappers():
+    lora_modules = [*_DENSE_TARGETS, *_SEMANTIC_EXPERT_TARGETS]
+
+    conditional_cls = register_qwen3_5_moe_modeling("Qwen3_5MoeForConditionalGeneration")
+    conditional_modules, conditional_parameters = conditional_cls._convert_lora_targets_to_parameters(
+        None, lora_modules, []
+    )
+    causal_cls = register_qwen3_5_moe_text_modeling("Qwen3_5MoeForCausalLM")
+    causal_modules, causal_parameters = causal_cls._convert_lora_targets_to_parameters(None, lora_modules, [])
+
+    assert set(conditional_modules) == _DENSE_TARGETS
+    assert conditional_parameters == _CONDITIONAL_EXPERT_PATTERNS
+    assert set(causal_modules) == _DENSE_TARGETS
+    assert causal_parameters == _CAUSAL_EXPERT_PATTERNS
+
+
+def test_qwen3_5_moe_production_config_injects_all_targets_and_freezes_base_model():
+    model = build_foundation_model(
+        config_path=_TOY_CONFIG_PATH,
+        weights_path=None,
+        torch_dtype="float32",
+        init_device="meta",
+        ops_implementation=make_eager_ops_config(),
+    )
+    resolved = resolve_fused_moe_lora_targets(model, _production_lora_config())
+
+    assert set(resolved["lora_modules"]) == _DENSE_TARGETS
+    assert resolved["target_parameters"] == _CONDITIONAL_EXPERT_PATTERNS
+
+    wrapped = VeOmniLoraModel(model, VeOmniLoraConfig.from_yaml(resolved))
+    dense_fqns = wrapped.base_model.wrapped_dense
+    moe_fqns = wrapped.base_model.wrapped_moe
+
+    for target in _DENSE_TARGETS:
+        assert any(fqn.endswith(f".{target}") for fqn in dense_fqns), target
+    assert moe_fqns
+
+    trainable_names = {name for name, param in wrapped.named_parameters() if param.requires_grad}
+    assert trainable_names
+    assert all(".lora_A." in name or ".lora_B." in name for name in trainable_names)
+
+    expert_trainable_names = {name for name in trainable_names if ".mlp.experts." in name}
+    for target in _SEMANTIC_EXPERT_TARGETS:
+        assert any(f".experts.{target}.lora_" in name for name in expert_trainable_names), target
+
+    for name, param in wrapped.named_parameters():
+        if ".lora_A." not in name and ".lora_B." not in name:
+            assert not param.requires_grad, name

--- a/veomni/models/transformers/qwen3_5_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_5_moe/__init__.py
@@ -11,16 +11,33 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from ....lora.target_mapping import convert_fused_moe_lora_targets
 from ....utils.device import IS_NPU_AVAILABLE
 from ...loader import MODELING_REGISTRY
 
 
-# Qwen3.5 GatedDeltaNet's three fused ops (FusedRMSNormGated, causal_conv1d,
-# chunk_gated_delta_rule) currently only ship GPU backends via FLA / FlashQLA.
-# Setting any of these to a non-eager value on NPU raises at OpSlot.bind via
-# KERNEL_REGISTRY.resolve's HardwareRequirement check; the varlen
-# (dyn_bsz=True) caveat is documented in docs/usage/arguments.md and on the
-# OpsImplementationConfig field metadata.
+def _convert_qwen3_5_moe_conditional_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "model.language_model.layers.*.mlp.experts.gate_up_proj",
+        "model.language_model.layers.*.mlp.experts.down_proj",
+    )
+
+
+def _convert_qwen3_5_moe_causal_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    return convert_fused_moe_lora_targets(
+        lora_modules,
+        target_parameter_patterns,
+        "model.layers.*.mlp.experts.gate_up_proj",
+        "model.layers.*.mlp.experts.down_proj",
+    )
+
+
+# Qwen3.5 GatedDeltaNet defaults are GPU-oriented. NPU configs must explicitly
+# select the NPU backends for rms_norm_gated, causal_conv1d, and
+# chunk_gated_delta_rule; the varlen caveat is documented in
+# docs/usage/arguments.md and on the OpsImplementationConfig field metadata.
 #
 # NPU branch is opt-in; everything else (CUDA, CPU-only) falls back to the GPU
 # generated file. The GPU generated module imports cleanly without an active
@@ -41,6 +58,12 @@ def register_qwen3_5_moe_modeling(architecture: str):
             Qwen3_5MoeForConditionalGeneration,
         )
 
+    Qwen3_5MoeForConditionalGeneration._convert_lora_targets_to_parameters = staticmethod(
+        _convert_qwen3_5_moe_conditional_lora_targets_to_parameters
+    )
+    Qwen3_5MoeForCausalLM._convert_lora_targets_to_parameters = staticmethod(
+        _convert_qwen3_5_moe_causal_lora_targets_to_parameters
+    )
     if "ForCausalLM" in architecture:
         return Qwen3_5MoeForCausalLM
     elif "ForConditionalGeneration" in architecture:
@@ -56,4 +79,7 @@ def register_qwen3_5_moe_text_modeling(architecture: str):
     else:
         from .generated.patched_modeling_qwen3_5_moe_gpu import Qwen3_5MoeForCausalLM
 
+    Qwen3_5MoeForCausalLM._convert_lora_targets_to_parameters = staticmethod(
+        _convert_qwen3_5_moe_causal_lora_targets_to_parameters
+    )
     return Qwen3_5MoeForCausalLM

--- a/veomni/models/transformers/qwen3_5_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_5_moe/__init__.py
@@ -34,10 +34,6 @@ def _convert_qwen3_5_moe_causal_lora_targets_to_parameters(_model, lora_modules,
     )
 
 
-# Qwen3.5 GatedDeltaNet defaults are GPU-oriented. NPU configs must explicitly
-# select the NPU backends for rms_norm_gated, causal_conv1d, and
-# chunk_gated_delta_rule; the varlen caveat is documented in
-# docs/usage/arguments.md and on the OpsImplementationConfig field metadata.
 #
 # NPU branch is opt-in; everything else (CUDA, CPU-only) falls back to the GPU
 # generated file. The GPU generated module imports cleanly without an active

--- a/veomni/models/transformers/qwen3_5_moe/__init__.py
+++ b/veomni/models/transformers/qwen3_5_moe/__init__.py
@@ -17,6 +17,7 @@ from ...loader import MODELING_REGISTRY
 
 
 def _convert_qwen3_5_moe_conditional_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    """Map semantic expert LoRA targets for the conditional-generation wrapper."""
     return convert_fused_moe_lora_targets(
         lora_modules,
         target_parameter_patterns,
@@ -26,6 +27,7 @@ def _convert_qwen3_5_moe_conditional_lora_targets_to_parameters(_model, lora_mod
 
 
 def _convert_qwen3_5_moe_causal_lora_targets_to_parameters(_model, lora_modules, target_parameter_patterns):
+    """Map semantic expert LoRA targets for the causal language-model wrapper."""
     return convert_fused_moe_lora_targets(
         lora_modules,
         target_parameter_patterns,
@@ -43,6 +45,7 @@ def _convert_qwen3_5_moe_causal_lora_targets_to_parameters(_model, lora_modules,
 
 @MODELING_REGISTRY.register("qwen3_5_moe")
 def register_qwen3_5_moe_modeling(architecture: str):
+    """Register and return the device-specific Qwen3.5-MoE modeling class."""
     if IS_NPU_AVAILABLE:
         from .generated.patched_modeling_qwen3_5_moe_npu import (
             Qwen3_5MoeForCausalLM,
@@ -70,6 +73,7 @@ def register_qwen3_5_moe_modeling(architecture: str):
 
 @MODELING_REGISTRY.register("qwen3_5_moe_text")
 def register_qwen3_5_moe_text_modeling(architecture: str):
+    """Register and return the device-specific text-only Qwen3.5-MoE class."""
     if IS_NPU_AVAILABLE:
         from .generated.patched_modeling_qwen3_5_moe_npu import Qwen3_5MoeForCausalLM
     else:


### PR DESCRIPTION
# Support Qwen3.5-MoE-35B LoRA Training #1034

## Background

This PR completes VeOmni's LoRA training support for `Qwen/Qwen3.5-35B-A3B`, covering the model's combination of Full Attention, GatedDeltaNet, and MoE expert layers. It also verifies that LoRA works with FSDP2, Expert Parallelism (EP), and the fused MoE backends on both GPUs and Ascend NPUs.

This implementation reuses VeOmni's existing LoRA, fused expert LoRA, FSDP2, EP, and GroupGEMM capabilities.

## Feature Overview

### LoRA Injection Scope

The following target modules are supported:

| Module Type | LoRA Targets |
|---|---|
| Full Attention | `q_proj`, `k_proj`, `v_proj`, `o_proj` |
| GatedDeltaNet | `in_proj_qkv`, `in_proj_z`, `in_proj_b`, `in_proj_a`, `out_proj` |
| MoE experts | `gate_proj`, `up_proj`, `down_proj` |

Qwen3.5-MoE stores expert weights in a fused format:

- `gate_proj` and `up_proj` physically correspond to the `gate_up_proj` parameter;
- `down_proj` corresponds to `down_proj`;
- Users still configure LoRA with the semantic targets `gate_proj`, `up_proj`, and `down_proj`. During model registration, these targets are converted into matching rules for the fused expert parameters.

This mapping covers both:

- `Qwen3_5MoeForConditionalGeneration`: `model.language_model.layers.*.mlp.experts.*`;
- `Qwen3_5MoeForCausalLM`: `model.layers.*.mlp.experts.*`.

### Distributed Training Support

- Uses FSDP2 to shard model parameters;
- Uses EP to shard MoE experts, with the validated configuration set to `ep_size: 4`;
- With 8 ranks, the EP mesh is `expert-FSDP=2 x EP=4`;
- Ascend NPU uses `fused_npu` and NPU GroupGEMM;
- GPU uses `fused_triton`;
- LoRA parameters participate in training, while the base model's non-LoRA parameters remain frozen;
- Supports EP-sharded streaming load to reduce host and device memory pressure while loading the 35B MoE model.

### `docs/key_features/lora.md`

- Added the `fused_npu` MoE-LoRA backend;
- Documented the applicable scenarios for GPU `fused_triton`, NPU `fused_npu`, and `eager`;
- Clarified that EP requires a fused MoE backend and that `eager` does not support EP;
- Added the Qwen3.5-MoE-35B configuration to the LoRA configuration index.

## Core Configuration

```yaml
model:
  model_path: Qwen/Qwen3.5-35B-A3B
  lora_config:
    rank: 16
    alpha: 32
    use_rslora: false
    share_expert_lora: true
    lora_modules:
      - q_proj
      - k_proj
      - v_proj
      - o_proj
      - in_proj_qkv
      - in_proj_z
      - in_proj_b
      - in_proj_a
      - out_proj
      - gate_proj
      - up_proj
      - down_proj

data:
  max_seq_len: 1024

train:
  global_batch_size: 8
  micro_batch_size: 1
  accelerator:
    ulysses_size: 1
    ep_size: 4
    fsdp_config:
      fsdp_mode: fsdp2
      offload: false
  gradient_checkpointing:
    enable: true
    enable_reentrant: false
  ep_sharded_stream_load: true
```

## Reproduction Commands

The following commands use the same model, data, LoRA injection scope, and distributed configuration. The GPU and NPU commands differ only in their hardware-specific operator backends.

### Ascend NPU, 8 Ranks

```bash
ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
bash train.sh \
  tasks/train_text.py \
  configs/text/qwen3_5_moe_lora.yaml \
  --model.model_path /path/to/Qwen3.5-35B-A3B \
  --data.train_path /path/to/train.jsonl \
  --train.max_steps 500 \
  --train.checkpoint.save_steps 0 \
  --train.checkpoint.save_hf_weights false \
  --train.checkpoint.output_dir /path/to/output/qwen35_lora_npu_8r
```

### NVIDIA H200, 8 Ranks

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
NCCL_NVLS_ENABLE=0 \
bash train.sh \
  tasks/train_text.py \
  configs/text/qwen3_5_moe_lora.yaml \
  --model.model_path /path/to/Qwen3.5-35B-A3B \
  --data.train_path /path/to/train.jsonl \
  --model.ops_implementation.moe_implementation fused_triton \
  --model.ops_implementation.rms_norm_implementation eager \
  --model.ops_implementation.rotary_pos_emb_implementation eager \
  --model.ops_implementation.rms_norm_gated_implementation fla \
  --model.ops_implementation.causal_conv1d_implementation fla \
  --model.ops_implementation.chunk_gated_delta_rule_implementation fla \
  --train.max_steps 500 \
  --train.checkpoint.save_steps 0 \
  --train.checkpoint.save_hf_weights false \
  --train.checkpoint.output_dir /path/to/output/qwen35_lora_h200_8r
```

## Acceptance Configuration

| Configuration | H200 | Ascend NPU |
|---|---:|---:|
| Model | Qwen3.5-35B-A3B | Qwen3.5-35B-A3B |
| Number of ranks | 8 | 8 |
| FSDP | FSDP2 | FSDP2 |
| EP | 4 | 4 |
| expert-FSDP | 2 | 2 |
| Global batch size | 8 | 8 |
| Micro batch size | 1 | 1 |
| Sequence length | 1024 | 1024 |
| LoRA rank / alpha | 16 / 32 | 16 / 32 |
| CPU offload | Disabled | Disabled |
| MoE backend | `fused_triton` | `fused_npu` |
| Optimizer steps | 500 | 500 |

## Acceptance Results

### 500-Step Training Results

| Metric | H200, 8 Ranks | Ascend NPU, 8 Ranks |
|---|---:|---:|
| Step 1 loss | 1.444840 | 1.443748 |
| Step 500 loss | 0.001111 | 0.001165 |
| Average loss over 500 steps | 0.164478 | 0.163990 |
| Median time per step, steps 2-500 | 1.350 s | 1.717 s |
| Median tokens/s, steps 2-500 | 6033 | 4768 |
| Peak allocated memory | 24.188 GiB | 34.149 GiB |
| Peak reserved memory | 36.332 GiB | 39.639 GiB |
| Number of valid loss records | 500 | 500 |
| Number of runtime errors | 0 | 0 |

Loss consistency results:

- Mean step-by-step symmetric relative error over the first 20 steps: `0.104%`;
- Symmetric relative difference between the average losses over 500 steps: `0.297%`;
- Loss-weighted step-by-step relative error over 500 steps: `1.063%`;
- All results are below the `2%` acceptance threshold.

On both platforms, the loss decreased normally from approximately `1.44` to approximately `0.0011`, with no NaN, Inf, OOM, distributed hang, or training interruption.

<img width="1055" height="1219" alt="image" src="https://github.com/user-attachments/assets/27da9f3f-12c1-4813-a011-b7ec24fbab40" />

## Notes

- The `eager` MoE backend is intended only for reference and non-EP scenarios. EP training should use `fused_triton` on GPUs and `fused_npu` on Ascend NPUs;
- GPU and NPU use different operator backends, so the performance data is intended to evaluate training capability and resource usage within each platform, not to compare performance across heterogeneous hardware;
- With dynamic batching, the number of effective tokens varies by step. This document therefore reports both median time per step and median tokens/s to reduce the impact of initialization, compilation, and periodic cache cleanup on the results;
- LoRA expert targets are configured using semantic names. Users do not need to specify the fused `gate_up_proj` parameter directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LoRA training support for Qwen3.5 MoE models on Ascend NPUs.
  * Added fused NPU and Triton backend support for MoE LoRA training.
  * Added a ready-to-use training configuration with expert parallelism, checkpointing, and memory optimizations.
  * Added automatic mapping for dense and expert LoRA targets across supported model variants.

* **Documentation**
  * Expanded MoE LoRA guidance with backend support details, configuration links, and practical training guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->