### PR TITLE
[dist, docs] feat: support outer extra-parallel mesh placement

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -169,6 +169,7 @@ jobs:
           uv run --frozen pytest -s -x tests/checkpoints/test_trainer_saveload.py
       - name: Run distributed tests
         run: |
+          uv run --frozen pytest -s -x tests/distributed/test_extra_parallel_mesh_topology.py
           uv run --frozen pytest -s -x tests/distributed/test_dummy_forward.py
           uv run --frozen pytest -s -x tests/distributed/test_torch_compile.py
       - name: Run data tests

--- a/docs/key_features/extra_parallel.md
+++ b/docs/key_features/extra_parallel.md
@@ -62,6 +62,25 @@ parallel_plan = ParallelPlan(
 )
 ```
 
+### Mesh placement
+
+The placement flag controls which mesh dimension is contiguous in row-major
+rank order. With 32 data-parallel ranks and `ep_size=8`:
+
+| Placement | Mesh dimensions | Contiguous groups |
+| --- | --- | --- |
+| `False` (default) | `(ep_fsdp=4, ep=8)` | EP8 |
+| `True` | `(ep=8, ep_fsdp=4)` | expert-FSDP4 |
+
+For expert parallelism, the convenience field
+`train.accelerator.ep_outside=true` appends `True` to the legacy
+`extra_parallel_placement_innermost` list and selects the second layout. Despite
+that legacy list name, `True` means that the extra-parallel dimension is placed
+outside the corresponding FSDP dimension. This can keep expert-FSDP traffic inside a node when four adjacent ranks
+share a fast local fabric, at the cost of making EP span those groups. It is a
+topology choice, not an unconditional performance optimization; benchmark the
+complete training step on the target interconnect before enabling it.
+
 
 
 ## Acknowledgements

--- a/tests/distributed/test_extra_parallel_mesh_topology.py
+++ b/tests/distributed/test_extra_parallel_mesh_topology.py
@@ -1,0 +1,99 @@
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "veomni" / "distributed" / "mesh_topology.py"
+SPEC = importlib.util.spec_from_file_location("veomni_mesh_topology_test", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+build_extra_parallel_mesh_spec = MODULE.build_extra_parallel_mesh_spec
+
+
+def _groups_for_dimension(
+    shape: tuple[int, ...],
+    dim_names: tuple[str, ...],
+    selected_dim: str,
+) -> tuple[tuple[int, ...], ...]:
+    selected_index = dim_names.index(selected_dim)
+    strides: list[int] = []
+    stride = 1
+    for size in reversed(shape):
+        strides.append(stride)
+        stride *= size
+    strides.reverse()
+
+    groups: list[tuple[int, ...]] = []
+    for rank in range(stride):
+        coordinates = [(rank // strides[index]) % shape[index] for index in range(len(shape))]
+        if coordinates[selected_index] != 0:
+            continue
+        members = []
+        for selected_coordinate in range(shape[selected_index]):
+            member_coordinates = list(coordinates)
+            member_coordinates[selected_index] = selected_coordinate
+            members.append(sum(member_coordinates[index] * strides[index] for index in range(len(shape))))
+        groups.append(tuple(members))
+    return tuple(groups)
+
+
+def test_inner_extra_parallel_keeps_ep_groups_contiguous() -> None:
+    spec = build_extra_parallel_mesh_spec(
+        dp_replicate_size=1,
+        dp_shard_sp_size=32,
+        parallel_size=8,
+        parallel_name="ep",
+        parallel_outside=False,
+    )
+
+    assert spec.shape == (4, 8)
+    assert spec.dim_names == ("ep_fsdp", "ep")
+    assert _groups_for_dimension(spec.shape, spec.dim_names, "ep") == tuple(
+        tuple(range(start, start + 8)) for start in range(0, 32, 8)
+    )
+
+
+def test_outer_extra_parallel_keeps_fsdp_groups_contiguous() -> None:
+    spec = build_extra_parallel_mesh_spec(
+        dp_replicate_size=1,
+        dp_shard_sp_size=32,
+        parallel_size=8,
+        parallel_name="ep",
+        parallel_outside=True,
+    )
+
+    assert spec.shape == (8, 4)
+    assert spec.dim_names == ("ep", "ep_fsdp")
+    assert spec.fsdp_dim_names == ("ep_fsdp",)
+    assert _groups_for_dimension(spec.shape, spec.dim_names, "ep_fsdp") == tuple(
+        tuple(range(start, start + 4)) for start in range(0, 32, 4)
+    )
+
+
+def test_hsdp_replicate_dimension_stays_outermost() -> None:
+    spec = build_extra_parallel_mesh_spec(
+        dp_replicate_size=2,
+        dp_shard_sp_size=32,
+        parallel_size=8,
+        parallel_name="ep",
+        parallel_outside=True,
+    )
+
+    assert spec.shape == (2, 8, 4)
+    assert spec.dim_names == ("ep_replicate", "ep", "ep_fsdp")
+    assert spec.fsdp_dim_names == ("ep_replicate", "ep_fsdp")
+
+
+def test_extra_parallel_size_must_divide_shard_domain() -> None:
+    try:
+        build_extra_parallel_mesh_spec(
+            dp_replicate_size=1,
+            dp_shard_sp_size=30,
+            parallel_size=8,
+            parallel_name="ep",
+            parallel_outside=True,
+        )
+    except ValueError as error:
+        assert "must divide" in str(error)
+    else:
+        raise AssertionError("expected a non-divisible mesh to be rejected")

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -170,6 +170,13 @@ def main():
     if ps.extra_parallel_group("emb") and ps.extra_parallel_fsdp_device_mesh["emb"] is not None:
         emb_fsdp_group = ps.extra_parallel_fsdp_device_mesh["emb"]["emb_fsdp"].get_group()
 
+    if args.train.accelerator.ep_outside:
+        rank = dist.get_rank()
+        expected_ep_group = list(range(rank % 2, dist.get_world_size(), 2))
+        expected_ep_fsdp_group = list(range(rank // 2 * 2, rank // 2 * 2 + 2))
+        assert dist.get_process_group_ranks(ep_group) == expected_ep_group
+        assert dist.get_process_group_ranks(ep_fsdp_group) == expected_ep_fsdp_group
+
     # build optimizer to register ep param groups when ep is enabled
     _ = build_optimizer(
         model,
@@ -287,7 +294,11 @@ def main():
 
 
 def _run_clip_grad_norm_fsdp2_test(
-    ep_size: int, emb_size: int, cpu_offload: bool, dp_replicate_size: int | None = None
+    ep_size: int,
+    emb_size: int,
+    cpu_offload: bool,
+    dp_replicate_size: int | None = None,
+    ep_outside: bool = False,
 ) -> None:
     command = [
         "torchrun",
@@ -296,7 +307,7 @@ def _run_clip_grad_norm_fsdp2_test(
         "--master_port=4321",
         "tests/utils/test_extra_parallel_clip_grad_norm.py",
         f"--train.accelerator.ep_size={ep_size}",
-        "--train.accelerator.ep_outside=False",
+        f"--train.accelerator.ep_outside={ep_outside}",
         f"--train.accelerator.extra_parallel_sizes={emb_size}",
         "--train.accelerator.extra_parallel_placement_innermost=False",
         "--train.accelerator.extra_parallel_names=emb",
@@ -329,6 +340,10 @@ def test_clip_grad_norm_fsdp2_ep4(cpu_offload: bool):
 @pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
 def test_clip_grad_norm_fsdp2_ep8(cpu_offload: bool):
     _run_clip_grad_norm_fsdp2_test(ep_size=8, emb_size=1, cpu_offload=cpu_offload)
+
+
+def test_clip_grad_norm_fsdp2_ep4_outside():
+    _run_clip_grad_norm_fsdp2_test(ep_size=4, emb_size=1, cpu_offload=False, ep_outside=True)
 
 
 @pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])

--- a/veomni/distributed/mesh_topology.py
+++ b/veomni/distributed/mesh_topology.py
@@ -1,0 +1,68 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ExtraParallelMeshSpec:
+    """Shape and named dimensions for one extra-parallel parameter mesh."""
+
+    shape: tuple[int, ...]
+    dim_names: tuple[str, ...]
+    fsdp_dim_names: tuple[str, ...]
+
+
+def build_extra_parallel_mesh_spec(
+    *,
+    dp_replicate_size: int,
+    dp_shard_sp_size: int,
+    parallel_size: int,
+    parallel_name: str,
+    parallel_outside: bool,
+) -> ExtraParallelMeshSpec:
+    """Build the rank-ordering contract for an extra-parallel mesh.
+
+    DeviceMesh uses row-major rank order, so the rightmost dimension forms
+    contiguous groups. ``parallel_outside`` swaps the parallel and FSDP
+    dimensions without moving an outer HSDP replicate dimension.
+    """
+
+    if min(dp_replicate_size, dp_shard_sp_size, parallel_size) < 1:
+        raise ValueError("mesh dimensions must be positive")
+    if not parallel_name:
+        raise ValueError("parallel_name must not be empty")
+    if dp_shard_sp_size % parallel_size != 0:
+        raise ValueError(f"{parallel_name}_size({parallel_size}) must divide dp_shard_sp_size({dp_shard_sp_size})")
+
+    parallel_fsdp_size = dp_shard_sp_size // parallel_size
+    shape: list[int] = []
+    dim_names: list[str] = []
+
+    if dp_replicate_size > 1:
+        shape.append(dp_replicate_size)
+        dim_names.append(f"{parallel_name}_replicate")
+
+    if parallel_outside:
+        shape.extend((parallel_size, parallel_fsdp_size))
+        dim_names.extend((parallel_name, f"{parallel_name}_fsdp"))
+    else:
+        shape.extend((parallel_fsdp_size, parallel_size))
+        dim_names.extend((f"{parallel_name}_fsdp", parallel_name))
+
+    return ExtraParallelMeshSpec(
+        shape=tuple(shape),
+        dim_names=tuple(dim_names),
+        fsdp_dim_names=tuple(dim_name for dim_name in dim_names if dim_name != parallel_name),
+    )

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -26,6 +26,7 @@ from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
 from ..utils import logging
 from ..utils.device import get_device_type
+from .mesh_topology import build_extra_parallel_mesh_spec
 
 
 if TYPE_CHECKING:
@@ -324,7 +325,9 @@ class ParallelState:
 
     @requires_mesh
     def extra_parallel_fsdp_mesh(self, para_name) -> "DeviceMesh":
-        return self.extra_parallel_fsdp_device_mesh[para_name][para_name, f"{para_name}_fsdp"]
+        para_mesh = self.extra_parallel_fsdp_device_mesh[para_name]
+        fsdp_dim_names = tuple(name for name in para_mesh.mesh_dim_names if name != para_name)
+        return para_mesh[fsdp_dim_names]
 
     @requires_mesh
     def extra_parallel_group(self, para_name) -> "ProcessGroup":
@@ -599,31 +602,22 @@ def init_parallel_state(
         extra_parallel_sizes, extra_parallel_placement_innermost, extra_parallel_names
     ):
         if para_size > 1:
-            # TODO: drop para_outside?
-            assert not para_outside, f"{para_name} is not supported when para_outside is True."
-
             # NOTE: Support HSDP for extra parallel. For example, world_size=1024
             # - dense param device_mesh: (dp_replicate, dp_shard_sp)=(4, 256)
             # - ep_size=8, expert parallel device_mesh: (ep_replicate, ep_fsdp, ep)=(4, 32, 8)
-            # Note that ep_size should be a factor of dp_shard_sp_size.
-            param_mesh_shape, para_mesh_dim_names = [], []
-            if dp_replicate_size > 1:
-                param_mesh_shape.append(dp_replicate_size)
-                para_mesh_dim_names.append(f"{para_name}_replicate")
             dp_shard_sp_size = device_mesh["dp_shard_sp"].size()
-            assert dp_shard_sp_size % para_size == 0, (
-                f"{para_name}_size({para_size}) must be a factor of dp_shard_sp_size({dp_shard_sp_size})"
+            mesh_spec = build_extra_parallel_mesh_spec(
+                dp_replicate_size=dp_replicate_size,
+                dp_shard_sp_size=dp_shard_sp_size,
+                parallel_size=para_size,
+                parallel_name=para_name,
+                parallel_outside=para_outside,
             )
-            para_fsdp_size = dp_shard_sp_size // para_size
-            param_mesh_shape.append(para_fsdp_size)
-            param_mesh_shape.append(para_size)
-            para_mesh_dim_names.append(f"{para_name}_fsdp")
-            para_mesh_dim_names.append(para_name)
 
             extra_parallel_fsdp_device_mesh[f"{para_name}"] = init_device_mesh(
                 device_type=device_type,
-                mesh_shape=param_mesh_shape,
-                mesh_dim_names=para_mesh_dim_names,
+                mesh_shape=mesh_spec.shape,
+                mesh_dim_names=mesh_spec.dim_names,
             )
 
     logger.info_rank0(f"Device mesh: {device_mesh}")

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -347,13 +347,8 @@ def parallelize_model_fsdp2(
     for para in parallel_state.extra_parallel_names:
         if parallel_state.extra_parallel_enabled(para):
             para_mesh = parallel_state.extra_parallel_fsdp_device_mesh[para]
-            para_mesh_dim_names = para_mesh.mesh_dim_names
-            # exclude para_size dimension:
-            # - (ep_fsdp, ep) -> (ep_fsdp,)
-            # - (ep_replicate, ep_fsdp, ep) -> (ep_replicate, ep_fsdp)
-            para_fsdp_mesh = para_mesh[para_mesh_dim_names[:-1]]
             para_fsdp_kwargs = dict(fsdp_kwargs)
-            para_fsdp_kwargs["mesh"] = para_fsdp_mesh
+            para_fsdp_kwargs["mesh"] = parallel_state.extra_parallel_fsdp_mesh(para)
             shard_dim_for_para = 1
             # Muon zero-comm needs whole experts per rank; otherwise keep the
             # default hidden-dim sharding.


### PR DESCRIPTION
### What does this PR do?

VeOmni exposes `ep_outside` and `extra_parallel_placement_innermost`, but `init_parallel_state()` currently rejects every true value. This PR implements the advertised alternate rank ordering for ExtraParallel + FSDP2 while preserving the existing default.

With 32 DP-shard ranks and EP8:

- default: `(ep_fsdp=4, ep=8)`, so EP8 groups are contiguous;
- outside: `(ep=8, ep_fsdp=4)`, so expert-FSDP4 groups are contiguous.

The HSDP replicate dimension remains outermost in both layouts.

### Checklist Before Starting

- Searched open issues and PRs for `ep_outside`, `extra_parallel_placement_innermost`, and outer ExtraParallel mesh placement; no duplicate implementation was found.
- PR title follows the enforced `[{modules}] {type}: {description}` format.

### Test

Local CPU contract tests:

```text
python -m pytest -q tests/distributed/test_extra_parallel_mesh_topology.py
4 passed
```

Existing single-process gradient-norm regressions:

```text
python -m pytest -q tests/utils/test_extra_parallel_clip_grad_norm.py -k inf_norm
3 passed, 19 deselected
```

Repository quality gate:

```text
make quality
All checks passed; 635 files already formatted
```

The existing 8-GPU FSDP2/ExtraParallel test suite now includes an `ep_outside=True` case. It verifies real EP and expert-FSDP process-group membership, then runs three forward/backward/gradient-clipping steps. This hardware case was not run on the local macOS host and is left to the repository's L20 CI.

### API and Usage Example

No new config field is added. The existing expert-parallel convenience flag now works:

```yaml
train:
  accelerator:
    ep_size: 8
    ep_outside: true
```

The flag changes rank ordering only. It is not an unconditional performance optimization; users should benchmark complete training steps on their target topology.

### Design & Code Changes

- Add a pure mesh-spec builder that keeps rank-ordering policy independent from process-group construction.
- Remove the unconditional rejection of outer ExtraParallel placement.
- Select the FSDP mesh by excluding the named ExtraParallel dimension, so both dimension orders and HSDP work.
- Add CPU topology-contract coverage for default, outside, HSDP, and invalid-divisibility cases.
- Extend the existing 8-GPU FSDP2 gradient test with actual group-membership and forward/backward coverage.
- Document the legacy `extra_parallel_placement_innermost` naming and the topology tradeoff.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied repository quality checks.
- [x] Added/updated documentation.
- [x] Added tests to the existing GPU CI workflow.
