### PR TITLE
[dist, docs] fix: validate ExtraParallel FSDP shard dimensions

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -169,6 +169,7 @@ jobs:
           uv run --frozen pytest -s -x tests/checkpoints/test_trainer_saveload.py
       - name: Run distributed tests
         run: |
+          uv run --frozen pytest -s -x tests/distributed/test_fsdp_shard_validation.py
           uv run --frozen pytest -s -x tests/distributed/test_dummy_forward.py
           uv run --frozen pytest -s -x tests/distributed/test_torch_compile.py
       - name: Run data tests

--- a/docs/key_features/ep_fsdp2.md
+++ b/docs/key_features/ep_fsdp2.md
@@ -30,6 +30,13 @@ The expert parallelism (EP) is applied on dim-0 (expert number), while FSDP2 is 
 
 This is to enable more flexible parallelism setup. Otherwise, if we also choose dim-0 for FSDP2, EP size x FSDP2 size needs to be exact expert number.
 
+PyTorch FSDP2 supports uneven sharding on dim-0, but a nonzero shard dimension
+must divide evenly across its FSDP mesh. Therefore, every EP-local expert
+parameter dimension selected by `Shard(1)` must be divisible by the expert-FSDP
+degree. VeOmni validates this before `fully_shard()` and reports the offending
+parameter FQN, dimension, size, and mesh size. Choose a compatible EP/FSDP
+topology rather than padding model weights implicitly.
+
 ### Parallelism Setup
 
 ![ep_fsdp2](../assets/ep_fsdp2.png)

--- a/tests/distributed/test_fsdp_shard_validation.py
+++ b/tests/distributed/test_fsdp_shard_validation.py
@@ -1,0 +1,75 @@
+import pytest
+import torch.nn as nn
+
+from veomni.distributed.torch_parallelize import (
+    _extra_parallel_fsdp_shard_size,
+    _validate_fsdp_shard_divisibility,
+)
+
+
+class _FakeMeshDimension:
+    def __init__(self, size: int) -> None:
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+class _FakeHSDPExtraParallelMesh:
+    def __getitem__(self, dim_name: str) -> _FakeMeshDimension:
+        assert dim_name == "ep_fsdp"
+        return _FakeMeshDimension(2)
+
+
+class _FakeParallelState:
+    extra_parallel_fsdp_device_mesh = {"ep": _FakeHSDPExtraParallelMesh()}
+
+
+def test_shard_size_excludes_hsdp_replicate_dimension() -> None:
+    assert _extra_parallel_fsdp_shard_size(_FakeParallelState(), "ep") == 2
+
+
+def test_nonzero_shard_rejects_indivisible_parameter_with_fqn() -> None:
+    experts = nn.Linear(7, 16, bias=False)
+
+    with pytest.raises(ValueError, match=r"decoder\.moe.*weight.*dim 1.*size 7.*4"):
+        _validate_fsdp_shard_divisibility(
+            experts,
+            module_fqn="decoder.moe",
+            shard_dim=1,
+            shard_size=4,
+        )
+
+
+def test_nonzero_shard_accepts_even_parameter() -> None:
+    experts = nn.Linear(8, 16, bias=False)
+
+    _validate_fsdp_shard_divisibility(
+        experts,
+        module_fqn="decoder.moe",
+        shard_dim=1,
+        shard_size=4,
+    )
+
+
+def test_dim_zero_allows_uneven_parameter() -> None:
+    experts = nn.Linear(8, 15, bias=False)
+
+    _validate_fsdp_shard_divisibility(
+        experts,
+        module_fqn="decoder.moe",
+        shard_dim=0,
+        shard_size=4,
+    )
+
+
+def test_nonzero_shard_rejects_parameter_without_that_dimension() -> None:
+    experts = nn.LayerNorm(8)
+
+    with pytest.raises(ValueError, match=r"decoder\.moe.*weight.*has 1 dimensions.*dim 1"):
+        _validate_fsdp_shard_divisibility(
+            experts,
+            module_fqn="decoder.moe",
+            shard_dim=1,
+            shard_size=4,
+        )

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -130,6 +130,44 @@ def _check_extra_parallel_dim0_divisibility(model: "nn.Module", para_name: str, 
     return True
 
 
+def _validate_fsdp_shard_divisibility(
+    module: "nn.Module",
+    *,
+    module_fqn: str,
+    shard_dim: int,
+    shard_size: int,
+) -> None:
+    """Fail early when FSDP2 cannot evenly shard a nonzero dimension.
+
+    FSDP2 pads uneven dim-0 shards, but nonzero shard dimensions must divide
+    evenly across the mesh. ExtraParallel modules use ``Shard(1)`` by default,
+    so validate their EP-local parameters before entering ``fully_shard()`` to
+    report the model FQN and topology instead of a lower-level PyTorch error.
+    """
+    if shard_dim == 0 or shard_size == 1:
+        return
+
+    for param_name, param in module.named_parameters():
+        param_fqn = f"{module_fqn}.{param_name}" if param_name else module_fqn
+        if param.ndim <= shard_dim:
+            raise ValueError(
+                f"FSDP2 cannot shard parameter {param_fqn!r}: it has {param.ndim} dimensions, "
+                f"but the ExtraParallel layout selects dim {shard_dim}."
+            )
+        dim_size = param.size(shard_dim)
+        if dim_size % shard_size != 0:
+            raise ValueError(
+                f"FSDP2 cannot evenly shard parameter {param_fqn!r} on dim {shard_dim}: "
+                f"size {dim_size} is not divisible by the ExtraParallel FSDP mesh size {shard_size}."
+            )
+
+
+def _extra_parallel_fsdp_shard_size(parallel_state, para_name: str) -> int:
+    """Return only the named FSDP shard degree, excluding HSDP replication."""
+    para_mesh = parallel_state.extra_parallel_fsdp_device_mesh[para_name]
+    return para_mesh[f"{para_name}_fsdp"].size()
+
+
 def parallelize_model_fsdp2(
     model: "nn.Module",
     weights_path: Optional[str] = None,
@@ -344,6 +382,7 @@ def parallelize_model_fsdp2(
 
     # prepare extra_parallel_fsdp2 kwargs
     extra_parallel_fsdp_kwargs = {}
+    extra_parallel_fsdp_shard_dims = {}
     for para in parallel_state.extra_parallel_names:
         if parallel_state.extra_parallel_enabled(para):
             para_mesh = parallel_state.extra_parallel_fsdp_device_mesh[para]
@@ -375,6 +414,7 @@ def parallelize_model_fsdp2(
                     )
             para_fsdp_kwargs["shard_placement_fn"] = lambda param, _d=shard_dim_for_para: Shard(_d)
             extra_parallel_fsdp_kwargs[para] = para_fsdp_kwargs
+            extra_parallel_fsdp_shard_dims[para] = shard_dim_for_para
             # Record the FSDP shard dim on the spec_info so the checkpointer can
             # build correct DTensor placements (EP dim vs FSDP dim) on save/load.
             for spec_info in getattr(model, "_fqn2spec_info", {}).values():
@@ -382,6 +422,7 @@ def parallelize_model_fsdp2(
                     spec_info.fsdp_shard_dim = shard_dim_for_para
         else:
             extra_parallel_fsdp_kwargs[para] = None
+            extra_parallel_fsdp_shard_dims[para] = None
 
     # Here we have a basic assumption for target module (e.g. embed_tokens, decoder) hierarchy:
     # | -- target module A (e.g. decoder)
@@ -422,6 +463,15 @@ def parallelize_model_fsdp2(
             for _para_mod in extra_parallel_mod[para]:
                 if isinstance(_para_mod, FSDPModule):
                     continue
+                para_mod_fqn = next(
+                    fqn for fqn, candidate in _extra_parallel_map[para].items() if candidate is _para_mod
+                )
+                _validate_fsdp_shard_divisibility(
+                    _para_mod,
+                    module_fqn=para_mod_fqn,
+                    shard_dim=extra_parallel_fsdp_shard_dims[para],
+                    shard_size=_extra_parallel_fsdp_shard_size(parallel_state, para),
+                )
                 # shard para module (e.g. expert/decoder.moe, embed_tokens/decoder.embed_tokens)
                 fully_shard(_para_mod, **extra_parallel_fsdp_kwargs[para])
                 # average para (e.g. ep) grads across para (e.g. ep) ranks


### PR DESCRIPTION
### What does this PR do?

ExtraParallel modules use FSDP2 `Shard(1)` by default after EP slices dim-0. PyTorch FSDP2 can pad uneven dim-0 shards, but nonzero shard dimensions must divide evenly across the actual shard mesh. Today incompatible model/topology combinations fail inside `fully_shard()` with a lower-level error and little model context.

This PR validates each ExtraParallel module immediately before wrapping and raises an actionable error containing the parameter FQN, selected dimension, dimension size, and named ExtraParallel FSDP shard degree.

### Checklist Before Starting

- Searched open VeOmni issues and PRs for FSDP2 nonzero-dimension and `Shard(1)` divisibility validation; no duplicate was found.
- PR title follows the enforced `[{modules}] {type}: {description}` format.

### Test

```text
python -m pytest -q tests/distributed/test_fsdp_shard_validation.py
5 passed

make quality
All checks passed; 634 files already formatted
```

Tests cover:

- an indivisible `Shard(1)` parameter and its full FQN in the error;
- a valid evenly divisible nonzero shard;
- uneven dim-0, which remains supported;
- a parameter without the selected dimension;
- HSDP wiring, ensuring the replicate degree is excluded from validation.

No GPU benchmark is claimed because this is a fail-fast validation change, not a performance change.

### API and Usage Example

No public API or default behavior changes for valid topologies. Invalid configurations now fail earlier with a message such as:

```text
FSDP2 cannot evenly shard parameter 'model.layers.0.mlp.experts.weight' on dim 1:
size 7168 is not divisible by the ExtraParallel FSDP mesh size 10.
```

### Design & Code Changes

- Validate nonzero ExtraParallel FSDP shard dimensions before `fully_shard()`.
- Preserve PyTorch's supported uneven dim-0 behavior.
- Resolve module FQNs from the runtime ParallelPlan-derived module map.
- Read the named `{para}_fsdp` dimension directly so HSDP replication is not counted as sharding.
- Document the EP-local hidden-dimension divisibility constraint.
- Add the focused regression test to GPU CI collection.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied repository quality checks.
- [x] Added/updated documentation.
- [x] Added tests to the existing GPU CI workflow.
