### PR TITLE
[dist, ckpt, lora, docs] feat: support outer extra-parallel mesh placement

### DIFF
--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -135,7 +135,7 @@ YAML Config -> VeOmniArguments -> Trainer
 
 VeOmni uses FSDP2 exclusively.
 
-1. `init_parallel_state()` -> global `DeviceMesh` with named dims (`dp_shard`, `ulysses`, `cp`, etc.) + per-ExtraParallel submeshes (`[ep × ep_fsdp]`)
+1. `init_parallel_state()` -> global `DeviceMesh` with named dims (`dp_shard`, `ulysses`, `cp`, etc.) + per-ExtraParallel named submeshes. ExtraParallel/FSDP order is configurable, so consumers select submeshes and DTensor placements by dimension name.
 2. Model-specific `parallel_plan.py` -> define EP/embedding weight sharding via `ParallelPlan`
 3. `build_parallelize_model()` -> `parallelize_model_fsdp2()`:
    - `ParallelPlan.apply()` wraps EP/embedding params as DTensors on para mesh

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -36,6 +36,7 @@ VeOmni uses FSDP2 exclusively. FSDP1 has been removed.
 
 Core entry points:
 - `veomni/distributed/parallel_state.py` — `init_parallel_state()`, `ParallelState` dataclass
+- `veomni/distributed/mesh_topology.py` — named ExtraParallel mesh layout policy
 - `veomni/distributed/torch_parallelize.py` — `build_parallelize_model()`, `parallelize_model_fsdp2()`
 - `veomni/distributed/parallel_plan.py` — `ParallelPlan`, `SpecInfo`
 
@@ -50,7 +51,8 @@ Core entry points:
 6. **Device mesh initialization (`init_parallel_state()`)**
    - Builds a global `DeviceMesh` with named dimensions: `pp`, `dp_replicate`, `dp_shard`, `ulysses`, `cp`, `tp` (each included only if size > 1).
    - Flattens subviews for common usage: `dp` (all data-parallel), `sp` (ulysses+cp), `dp_shard_sp` (FSDP shard × SP), `dp_sp` (for loss/grad sync across SP+DP).
-   - For each ExtraParallel name (e.g. `ep`), builds a `[para_size × para_fsdp_size]` submesh via `init_para_mesh_matrix()`.
+   - For each ExtraParallel name (e.g. `ep`), builds a named submesh from `build_extra_parallel_mesh_spec()`. The default layout is `(para_fsdp, para)`; an outside layout is `(para, para_fsdp)`. HSDP keeps `para_replicate` outermost.
+   - Consumers must select ExtraParallel, FSDP, and replicate dimensions by name. Positional slicing such as `mesh_dim_names[:-1]` is invalid because the ExtraParallel/FSDP order is configurable.
 
 ### Sequence Parallel (Ulysses)
 
@@ -75,7 +77,7 @@ Core entry points:
    - Weight sharding: `ParallelPlan` in `parallel_plan.py` defines which expert parameters get `Shard(0)` on the EP mesh. `ParallelPlan.apply()` wraps matching params as DTensors and redistributes to local shards.
    - Token routing: `veomni/distributed/moe/moe_layer.py` — `preprocess()` computes dispatch counts, `token_pre_all2all()` / `tokens_post_all2all()` exchange tokens between EP ranks via `all_to_all` / `all_to_all_async` in `moe/comm.py`.
    - Expert computation: `EPGroupGemm` runs fused expert MLP on grouped tokens per rank.
-   - Device mesh: `init_parallel_state()` builds `[ep × ep_fsdp]` submesh; accessed via `ParallelState.extra_parallel_mesh("ep")`, `ep_group`, `ep_rank`.
+   - Device mesh: `init_parallel_state()` builds a named EP/FSDP submesh whose order depends on placement; access it via `ParallelState.extra_parallel_mesh("ep")`, `ParallelState.extra_parallel_fsdp_mesh("ep")`, `ep_group`, and `ep_rank` rather than positional slicing.
    - In FSDP2: expert modules get `fully_shard()` on the `ep_fsdp` submesh with `Shard(1)` placement so hidden-dim sharding composes with EP's dim-0 sharding.
 
 ## Data Pipeline

--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -169,6 +169,7 @@ jobs:
           uv run --frozen pytest -s -x tests/checkpoints/test_trainer_saveload.py
       - name: Run distributed tests
         run: |
+          uv run --frozen pytest -s -x tests/distributed/test_extra_parallel_mesh_topology.py
           uv run --frozen pytest -s -x tests/distributed/test_dummy_forward.py
           uv run --frozen pytest -s -x tests/distributed/test_torch_compile.py
       - name: Run data tests

--- a/docs/key_features/extra_parallel.md
+++ b/docs/key_features/extra_parallel.md
@@ -62,6 +62,25 @@ parallel_plan = ParallelPlan(
 )
 ```
 
+### Mesh placement
+
+The placement flag controls which mesh dimension is contiguous in row-major
+rank order. With 32 data-parallel ranks and `ep_size=8`:
+
+| Placement | Mesh dimensions | Contiguous groups |
+| --- | --- | --- |
+| `False` (default) | `(ep_fsdp=4, ep=8)` | EP8 |
+| `True` | `(ep=8, ep_fsdp=4)` | expert-FSDP4 |
+
+For expert parallelism, the convenience field
+`train.accelerator.ep_outside=true` appends `True` to the legacy
+`extra_parallel_placement_innermost` list and selects the second layout. Despite
+that legacy list name, `True` means that the extra-parallel dimension is placed
+outside the corresponding FSDP dimension. This can keep expert-FSDP traffic inside a node when four adjacent ranks
+share a fast local fabric, at the cost of making EP span those groups. It is a
+topology choice, not an unconditional performance optimization; benchmark the
+complete training step on the target interconnect before enabling it.
+
 
 
 ## Acknowledgements

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -429,7 +429,7 @@ validation instead of applying ChunkMBS to multiple stacks.
 | ep_size | `int` | `1` | Expert parallel size, should be fit into dp_shard group if HSDP enabled |
 | ep_outside | `bool` | `False` | Expert parallelism outside in EP-FSDP. |
 | extra_parallel_sizes | `List[int]` | `[]` | Sizes of additional parallel dimensions; EP is appended automatically. |
-| extra_parallel_placement_innermost | `List[bool]` | `[]` | Whether each additional parallel dimension is placed innermost relative to FSDP. |
+| extra_parallel_placement_innermost | `List[bool]` | `[]` | Legacy/misnamed placement flags; `True` places each additional parallel dimension outside its FSDP dimension. |
 | extra_parallel_names | `List[str]` | `[]` | Names of additional parallel dimensions; `ep` is appended automatically. |
 | pp_size | `int` | `1` | Pipeline parallel size. |
 | ulysses_size | `int` | `1` | Ulysses sequence parallel size. |

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -22,11 +22,6 @@ from veomni.trainer.callbacks.base import TrainerState
 from veomni.utils.checkpoint_utils import should_skip_hf_weight_load
 
 
-# ---------------------------------------------------------------------------
-# ExtraParallel checkpoint mesh semantics
-# ---------------------------------------------------------------------------
-
-
 class _NamedMeshStub:
     def __init__(self, *mesh_dim_names):
         self.mesh_dim_names = mesh_dim_names

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -23,6 +23,134 @@ from veomni.utils.checkpoint_utils import should_skip_hf_weight_load
 
 
 # ---------------------------------------------------------------------------
+# ExtraParallel checkpoint mesh semantics
+# ---------------------------------------------------------------------------
+
+
+class _NamedMeshStub:
+    def __init__(self, *mesh_dim_names):
+        self.mesh_dim_names = mesh_dim_names
+        self.ndim = len(mesh_dim_names)
+
+    def __getitem__(self, mesh_dim_names):
+        if isinstance(mesh_dim_names, str):
+            mesh_dim_names = (mesh_dim_names,)
+        return _NamedMeshStub(*mesh_dim_names)
+
+
+class TestExtraParallelCheckpointMeshSemantics:
+    @pytest.mark.parametrize(
+        ("mesh_dim_names", "expected_placements"),
+        [
+            (("ep_fsdp", "ep"), (("shard", 1), ("shard", 0))),
+            (("ep", "ep_fsdp"), (("shard", 0), ("shard", 1))),
+            (("ep_replicate", "ep", "ep_fsdp"), (("replicate", None), ("shard", 0), ("shard", 1))),
+        ],
+    )
+    def test_restore_maps_placements_to_named_mesh_dimensions(self, monkeypatch, mesh_dim_names, expected_placements):
+        import veomni.checkpoint.dcp_checkpointer as checkpointer
+
+        captured = {}
+
+        class FakeDTensor:
+            def __init__(self, local_tensor):
+                self._local_tensor = local_tensor
+
+            @classmethod
+            def from_local(cls, local_tensor, *, device_mesh, placements):
+                captured["mesh_dim_names"] = device_mesh.mesh_dim_names
+                captured["placements"] = placements
+                return cls(local_tensor)
+
+        monkeypatch.setattr(checkpointer, "DTensor", FakeDTensor)
+        full_mesh = _NamedMeshStub(*mesh_dim_names)
+        fsdp_mesh = full_mesh[tuple(name for name in mesh_dim_names if name != "ep")]
+
+        checkpointer.restore_extra_parallel_dim(
+            FakeDTensor(torch.ones(2, 2)),
+            full_mesh,
+            fsdp_mesh,
+            ep_shard_dim=0,
+            fsdp_shard_dim=1,
+        )
+
+        actual_placements = tuple(
+            ("shard", placement.dim) if isinstance(placement, checkpointer.Shard) else ("replicate", None)
+            for placement in captured["placements"]
+        )
+        assert captured["mesh_dim_names"] == mesh_dim_names
+        assert actual_placements == expected_placements
+
+    def test_preprocess_excludes_extra_parallel_dimension_by_name(self, monkeypatch):
+        import veomni.checkpoint.dcp_checkpointer as checkpointer
+
+        full_mesh = _NamedMeshStub("ep", "ep_fsdp")
+        spec_info = SimpleNamespace(
+            para_name="ep",
+            placement=checkpointer.Shard(0),
+            para_fsdp_mesh=full_mesh,
+            fsdp_shard_dim=1,
+        )
+        parallel_state = SimpleNamespace(extra_parallel_names=("ep",))
+        captured = {}
+
+        monkeypatch.setattr(checkpointer, "_validate_extra_parallel_meshes", lambda _: None)
+
+        def capture_drop(tensor, device_mesh, fsdp_shard_dim, extra_parallel_name):
+            captured["mesh_dim_names"] = device_mesh.mesh_dim_names
+            captured["fsdp_shard_dim"] = fsdp_shard_dim
+            captured["extra_parallel_name"] = extra_parallel_name
+            return tensor
+
+        monkeypatch.setattr(checkpointer, "drop_extra_parallel_dim", capture_drop)
+
+        checkpointer._apply_extra_parallel_dim(
+            {"experts.weight": torch.ones(2, 2)},
+            {"experts.weight": spec_info},
+            parallel_state,
+            "drop",
+            key_match="exact",
+        )
+
+        assert captured == {
+            "mesh_dim_names": ("ep_fsdp",),
+            "fsdp_shard_dim": 1,
+            "extra_parallel_name": "ep",
+        }
+
+    def test_preprocess_forwards_non_ep_parallel_name_when_dropping(self, monkeypatch):
+        import veomni.checkpoint.dcp_checkpointer as checkpointer
+
+        full_mesh = _NamedMeshStub("embedding", "embedding_fsdp")
+        spec_info = SimpleNamespace(
+            para_name="embedding",
+            placement=checkpointer.Shard(0),
+            para_fsdp_mesh=full_mesh,
+            fsdp_shard_dim=1,
+        )
+        parallel_state = SimpleNamespace(extra_parallel_names=("embedding",))
+        captured = {}
+
+        monkeypatch.setattr(checkpointer, "_validate_extra_parallel_meshes", lambda _: None)
+
+        def capture_drop(tensor, device_mesh, fsdp_shard_dim, extra_parallel_name="ep"):
+            captured["extra_parallel_name"] = extra_parallel_name
+            return tensor
+
+        monkeypatch.setattr(checkpointer, "drop_extra_parallel_dim", capture_drop)
+
+        checkpointer._apply_extra_parallel_dim(
+            {"embedding.weight": torch.ones(2, 2)},
+            {"embedding.weight": spec_info},
+            parallel_state,
+            "drop",
+            key_match="exact",
+        )
+
+        assert captured["extra_parallel_name"] == "embedding"
+
+
+# ---------------------------------------------------------------------------
 # OptimizerState: no fill, partial load
 # ---------------------------------------------------------------------------
 

--- a/tests/checkpoints/test_trainer_saveload.py
+++ b/tests/checkpoints/test_trainer_saveload.py
@@ -249,8 +249,18 @@ if __name__ == "__main__":
     main()
 
 
-def _run_trainer_saveload_and_verify(model_name: str, ep_size: int, dp_replicate_size: Optional[int] = None):
-    exec_command = get_checkpoint_test_command(model_name, ep_size, dp_replicate_size=dp_replicate_size)
+def _run_trainer_saveload_and_verify(
+    model_name: str,
+    ep_size: int,
+    dp_replicate_size: Optional[int] = None,
+    ep_outside: bool = False,
+):
+    exec_command = get_checkpoint_test_command(
+        model_name,
+        ep_size,
+        dp_replicate_size=dp_replicate_size,
+        ep_outside=ep_outside,
+    )
     merge_command = get_merge_dcp_to_hf_command(model_name, ep_size, dp_replicate_size=dp_replicate_size)
 
     exec_result = subprocess.run(exec_command, shell=True, check=True)
@@ -319,6 +329,19 @@ def test_trainer_saveload(model_name: str, ep_size: int):
 @pytest.mark.parametrize("ep_size", [2, 4])
 def test_trainer_saveload_hsdp(ep_size: int):
     _run_trainer_saveload_and_verify("qwen3_moe", ep_size, dp_replicate_size=2)
+
+
+# The outside layout changes the named mesh order to (ep, ep_fsdp), or
+# (ep_replicate, ep, ep_fsdp) with HSDP. Exercise model and optimizer DCP
+# round-trip plus DCP-to-HF consolidation for both forms.
+@pytest.mark.parametrize(("ep_size", "dp_replicate_size"), [(4, None), (2, 2)])
+def test_trainer_saveload_ep_outside(ep_size: int, dp_replicate_size: Optional[int]):
+    _run_trainer_saveload_and_verify(
+        "qwen3_moe",
+        ep_size,
+        dp_replicate_size=dp_replicate_size,
+        ep_outside=True,
+    )
 
 
 @pytest.mark.parametrize("ep_size", TEST_EP_SIZES)

--- a/tests/checkpoints/utils.py
+++ b/tests/checkpoints/utils.py
@@ -64,6 +64,7 @@ def get_checkpoint_test_command(
     ep_size,
     save_hf_weights=False,
     dp_replicate_size=None,
+    ep_outside=False,
 ):
     config_path = MODEL_CONFIGS[model_name]["config_path"]
     tokenizer_path = hf_local_or_remote(MODEL_CONFIGS[model_name]["tokenizer_path"])
@@ -110,6 +111,8 @@ def get_checkpoint_test_command(
     # 3-placement save/load path in the DCP checkpointer.
     if dp_replicate_size is not None:
         params.append(f"--train.accelerator.dp_replicate_size {dp_replicate_size}")
+    if ep_outside:
+        params.append("--train.accelerator.ep_outside True")
 
     exec_script = " \\\n".join(params)
 

--- a/tests/distributed/test_extra_parallel_mesh_topology.py
+++ b/tests/distributed/test_extra_parallel_mesh_topology.py
@@ -1,0 +1,99 @@
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "veomni" / "distributed" / "mesh_topology.py"
+SPEC = importlib.util.spec_from_file_location("veomni_mesh_topology_test", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+build_extra_parallel_mesh_spec = MODULE.build_extra_parallel_mesh_spec
+
+
+def _groups_for_dimension(
+    shape: tuple[int, ...],
+    dim_names: tuple[str, ...],
+    selected_dim: str,
+) -> tuple[tuple[int, ...], ...]:
+    selected_index = dim_names.index(selected_dim)
+    strides: list[int] = []
+    stride = 1
+    for size in reversed(shape):
+        strides.append(stride)
+        stride *= size
+    strides.reverse()
+
+    groups: list[tuple[int, ...]] = []
+    for rank in range(stride):
+        coordinates = [(rank // strides[index]) % shape[index] for index in range(len(shape))]
+        if coordinates[selected_index] != 0:
+            continue
+        members = []
+        for selected_coordinate in range(shape[selected_index]):
+            member_coordinates = list(coordinates)
+            member_coordinates[selected_index] = selected_coordinate
+            members.append(sum(member_coordinates[index] * strides[index] for index in range(len(shape))))
+        groups.append(tuple(members))
+    return tuple(groups)
+
+
+def test_inner_extra_parallel_keeps_ep_groups_contiguous() -> None:
+    spec = build_extra_parallel_mesh_spec(
+        dp_replicate_size=1,
+        dp_shard_sp_size=32,
+        parallel_size=8,
+        parallel_name="ep",
+        parallel_outside=False,
+    )
+
+    assert spec.shape == (4, 8)
+    assert spec.dim_names == ("ep_fsdp", "ep")
+    assert _groups_for_dimension(spec.shape, spec.dim_names, "ep") == tuple(
+        tuple(range(start, start + 8)) for start in range(0, 32, 8)
+    )
+
+
+def test_outer_extra_parallel_keeps_fsdp_groups_contiguous() -> None:
+    spec = build_extra_parallel_mesh_spec(
+        dp_replicate_size=1,
+        dp_shard_sp_size=32,
+        parallel_size=8,
+        parallel_name="ep",
+        parallel_outside=True,
+    )
+
+    assert spec.shape == (8, 4)
+    assert spec.dim_names == ("ep", "ep_fsdp")
+    assert spec.fsdp_dim_names == ("ep_fsdp",)
+    assert _groups_for_dimension(spec.shape, spec.dim_names, "ep_fsdp") == tuple(
+        tuple(range(start, start + 4)) for start in range(0, 32, 4)
+    )
+
+
+def test_hsdp_replicate_dimension_stays_outermost() -> None:
+    spec = build_extra_parallel_mesh_spec(
+        dp_replicate_size=2,
+        dp_shard_sp_size=32,
+        parallel_size=8,
+        parallel_name="ep",
+        parallel_outside=True,
+    )
+
+    assert spec.shape == (2, 8, 4)
+    assert spec.dim_names == ("ep_replicate", "ep", "ep_fsdp")
+    assert spec.fsdp_dim_names == ("ep_replicate", "ep_fsdp")
+
+
+def test_extra_parallel_size_must_divide_shard_domain() -> None:
+    try:
+        build_extra_parallel_mesh_spec(
+            dp_replicate_size=1,
+            dp_shard_sp_size=30,
+            parallel_size=8,
+            parallel_name="ep",
+            parallel_outside=True,
+        )
+    except ValueError as error:
+        assert "must divide" in str(error)
+    else:
+        raise AssertionError("expected a non-divisible mesh to be rejected")

--- a/tests/lora/test_moe_lora_ep2.py
+++ b/tests/lora/test_moe_lora_ep2.py
@@ -665,7 +665,7 @@ def test_moe_lora_ep_save_load_parallel_align(tmp_path, toy_base_dir, mode):
     _torchrun_capture(
         seeder_yaml,
         seeder_dir,
-        extra_overrides=base_overrides + ["--train.accelerator.ep_size=2"],
+        extra_overrides=base_overrides + ["--train.accelerator.ep_size=2", "--train.accelerator.ep_outside=True"],
         nproc=nproc,
     )
     seeder_adapter = _writer_adapter_path(seeder_dir, save_step=_ALIGN_MAX_STEPS)
@@ -709,7 +709,7 @@ def test_moe_lora_ep_save_load_parallel_align(tmp_path, toy_base_dir, mode):
     _torchrun_capture(
         adapter_yaml,
         ep2_adapter_dir,
-        extra_overrides=base_overrides + ["--train.accelerator.ep_size=2"],
+        extra_overrides=base_overrides + ["--train.accelerator.ep_size=2", "--train.accelerator.ep_outside=True"],
         nproc=nproc,
     )
 
@@ -718,7 +718,7 @@ def test_moe_lora_ep_save_load_parallel_align(tmp_path, toy_base_dir, mode):
     _torchrun_capture(
         dcp_yaml,
         ep2_dcp_dir,
-        extra_overrides=base_overrides + ["--train.accelerator.ep_size=2"],
+        extra_overrides=base_overrides + ["--train.accelerator.ep_size=2", "--train.accelerator.ep_outside=True"],
         nproc=nproc,
     )
 

--- a/tests/lora/test_moe_lora_ep2.py
+++ b/tests/lora/test_moe_lora_ep2.py
@@ -381,13 +381,13 @@ def _assert_metric_close(
 
 @pytest.mark.parametrize("mode", ["shared", "independent"])
 def test_ep2_trainer_integration(tmp_path, toy_base_dir, mode):
-    """End-to-end EP=2 trainer run: assert plan-bridge + slice + DCP-consolidate.
+    """End-to-end outside-EP=2 run: assert plan-bridge + slice + DCP-consolidate.
 
     Runs the merged trainer twice on the same toy yaml + base + seed --
     once at ``ep_size=1`` to provide reference adapter shapes, once at
     ``ep_size=2`` to exercise the production EP path -- and asserts:
 
-    * ep2 trainer completes the same 4 steps without error;
+    * ep2 trainer completes the same 4 steps with the outside mesh order;
     * ep2 ``parallel_plan.shard_tensor`` log shows every layer's
       ``mlp.experts.gate_up_proj`` and ``mlp.experts.down_proj`` got
       sliced 16 -> 8 (= ``ep_size=2``);
@@ -428,7 +428,7 @@ def test_ep2_trainer_integration(tmp_path, toy_base_dir, mode):
     ep2_stdout = _torchrun_capture(
         yaml_path,
         ep2_dir,
-        extra_overrides=base_overrides + ["--train.accelerator.ep_size=2"],
+        extra_overrides=base_overrides + ["--train.accelerator.ep_size=2", "--train.accelerator.ep_outside=True"],
         nproc=nproc,
     )
 

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -170,6 +170,13 @@ def main():
     if ps.extra_parallel_group("emb") and ps.extra_parallel_fsdp_device_mesh["emb"] is not None:
         emb_fsdp_group = ps.extra_parallel_fsdp_device_mesh["emb"]["emb_fsdp"].get_group()
 
+    if args.train.accelerator.ep_outside:
+        rank = dist.get_rank()
+        expected_ep_group = list(range(rank % 2, dist.get_world_size(), 2))
+        expected_ep_fsdp_group = list(range(rank // 2 * 2, rank // 2 * 2 + 2))
+        assert dist.get_process_group_ranks(ep_group) == expected_ep_group
+        assert dist.get_process_group_ranks(ep_fsdp_group) == expected_ep_fsdp_group
+
     # build optimizer to register ep param groups when ep is enabled
     _ = build_optimizer(
         model,
@@ -287,7 +294,11 @@ def main():
 
 
 def _run_clip_grad_norm_fsdp2_test(
-    ep_size: int, emb_size: int, cpu_offload: bool, dp_replicate_size: int | None = None
+    ep_size: int,
+    emb_size: int,
+    cpu_offload: bool,
+    dp_replicate_size: int | None = None,
+    ep_outside: bool = False,
 ) -> None:
     command = [
         "torchrun",
@@ -296,7 +307,7 @@ def _run_clip_grad_norm_fsdp2_test(
         "--master_port=4321",
         "tests/utils/test_extra_parallel_clip_grad_norm.py",
         f"--train.accelerator.ep_size={ep_size}",
-        "--train.accelerator.ep_outside=False",
+        f"--train.accelerator.ep_outside={ep_outside}",
         f"--train.accelerator.extra_parallel_sizes={emb_size}",
         "--train.accelerator.extra_parallel_placement_innermost=False",
         "--train.accelerator.extra_parallel_names=emb",
@@ -329,6 +340,10 @@ def test_clip_grad_norm_fsdp2_ep4(cpu_offload: bool):
 @pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])
 def test_clip_grad_norm_fsdp2_ep8(cpu_offload: bool):
     _run_clip_grad_norm_fsdp2_test(ep_size=8, emb_size=1, cpu_offload=cpu_offload)
+
+
+def test_clip_grad_norm_fsdp2_ep4_outside():
+    _run_clip_grad_norm_fsdp2_test(ep_size=4, emb_size=1, cpu_offload=False, ep_outside=True)
 
 
 @pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -33,6 +33,24 @@ from veomni.utils.device import (
 logger = helper.create_logger(__name__)
 
 
+def _expected_outer_extra_parallel_group_ranks(
+    rank: int,
+    world_size: int,
+    dp_replicate_size: int,
+    ep_size: int,
+) -> tuple[list[int], list[int]]:
+    """Return EP and EP-FSDP ranks for the row-major outside layout."""
+
+    replica_domain_size = world_size // dp_replicate_size
+    ep_fsdp_size = replica_domain_size // ep_size
+    replica_offset = rank // replica_domain_size * replica_domain_size
+    rank_in_replica = rank % replica_domain_size
+    ep_group = [replica_offset + rank_in_replica % ep_fsdp_size + index * ep_fsdp_size for index in range(ep_size)]
+    ep_fsdp_start = replica_offset + rank_in_replica // ep_fsdp_size * ep_fsdp_size
+    ep_fsdp_group = list(range(ep_fsdp_start, ep_fsdp_start + ep_fsdp_size))
+    return ep_group, ep_fsdp_group
+
+
 def _torch_npu_version() -> str:
     """Return the version of torch_npu if installed, otherwise return "0.0.0"."""
     if importlib.util.find_spec("torch_npu") is None:
@@ -170,10 +188,13 @@ def main():
     if ps.extra_parallel_group("emb") and ps.extra_parallel_fsdp_device_mesh["emb"] is not None:
         emb_fsdp_group = ps.extra_parallel_fsdp_device_mesh["emb"]["emb_fsdp"].get_group()
 
-    if args.train.accelerator.ep_outside:
-        rank = dist.get_rank()
-        expected_ep_group = list(range(rank % 2, dist.get_world_size(), 2))
-        expected_ep_fsdp_group = list(range(rank // 2 * 2, rank // 2 * 2 + 2))
+    if args.train.accelerator.ep_outside and ps.extra_parallel_enabled("ep"):
+        expected_ep_group, expected_ep_fsdp_group = _expected_outer_extra_parallel_group_ranks(
+            dist.get_rank(),
+            dist.get_world_size(),
+            ps.dp_replicate_size,
+            ps.ep_size,
+        )
         assert dist.get_process_group_ranks(ep_group) == expected_ep_group
         assert dist.get_process_group_ranks(ep_fsdp_group) == expected_ep_fsdp_group
 
@@ -325,6 +346,23 @@ def _run_clip_grad_norm_fsdp2_test(
         command.append("--train.accelerator.fsdp_config.offload=True")
     result = subprocess.run(command, check=True)
     assert result.returncode == 0
+
+
+@pytest.mark.parametrize(
+    ("rank", "world_size", "dp_replicate_size", "ep_size", "expected_ep", "expected_ep_fsdp"),
+    [
+        (3, 8, 1, 4, [1, 3, 5, 7], [2, 3]),
+        (5, 8, 2, 2, [5, 7], [4, 5]),
+        (13, 16, 2, 4, [9, 11, 13, 15], [12, 13]),
+    ],
+)
+def test_expected_outer_extra_parallel_group_ranks(
+    rank, world_size, dp_replicate_size, ep_size, expected_ep, expected_ep_fsdp
+):
+    assert _expected_outer_extra_parallel_group_ranks(rank, world_size, dp_replicate_size, ep_size) == (
+        expected_ep,
+        expected_ep_fsdp,
+    )
 
 
 @pytest.mark.parametrize("cpu_offload", [False, True], ids=["no_offload", "cpu_offload"])

--- a/tests/utils/test_save_safetensor_utils.py
+++ b/tests/utils/test_save_safetensor_utils.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -339,6 +340,53 @@ class TestExecutionOrdering(unittest.TestCase):
         idx_get = call_order.index("get_state")
         idx_writer = call_order.index("writer_init")
         self.assertLess(idx_get, idx_writer, f"Wrong order: {call_order}")
+
+
+class TestLoraExtraParallelCheckpointPlacement(unittest.TestCase):
+    def test_forwards_spec_shard_dimensions_to_checkpoint_restore(self):
+        import tempfile
+
+        from torch.distributed._tensor import Shard
+
+        from veomni.utils.save_safetensor_utils import save_lora_adapter_with_dcp
+
+        full_mesh = MagicMock()
+        fsdp_mesh = MagicMock()
+        full_mesh.__getitem__.return_value = fsdp_mesh
+        spec = SimpleNamespace(
+            para_name="ep",
+            placement=Shard(0),
+            para_fsdp_mesh=full_mesh,
+            fsdp_shard_dim=0,
+        )
+        model = MagicMock()
+        model._fqn2spec_info = {"experts.lora_A.default.weight": spec}
+        model.get_lora_config.return_value = MagicMock()
+        restore = MagicMock(side_effect=lambda tensor, *args, **kwargs: tensor)
+        mock_dist = MagicMock()
+        mock_dist.is_initialized.return_value = True
+        mock_dist.get_rank.return_value = 1
+
+        with tempfile.TemporaryDirectory() as save_path:
+            with (
+                patch("veomni.lora.is_veomni_lora_model", return_value=True),
+                patch(
+                    "veomni.lora.state_dict.get_lora_state_dict",
+                    return_value={"experts.lora_A.weight": torch.ones(2, 2)},
+                ),
+                patch("veomni.checkpoint.dcp_checkpointer.restore_extra_parallel_dim", restore),
+                patch(f"{_MOD}.dist", mock_dist),
+                patch(f"{_MOD}.dcp"),
+                patch(f"{_MOD}.synchronize"),
+                patch(f"{_MOD}.gc"),
+                patch(f"{_MOD}.helper"),
+            ):
+                save_lora_adapter_with_dcp(model, save_path)
+
+        restore.assert_called_once()
+        self.assertEqual(restore.call_args.kwargs["extra_parallel_name"], "ep")
+        self.assertEqual(restore.call_args.kwargs["ep_shard_dim"], 0)
+        self.assertEqual(restore.call_args.kwargs["fsdp_shard_dim"], 0)
 
 
 class TestLegacySaveModelWeights(unittest.TestCase):

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -529,7 +529,7 @@ class AcceleratorConfig:
     )
     extra_parallel_placement_innermost: List[bool] = field(
         default_factory=list,
-        metadata={"help": "Extra parallelism outside in para-fsdp."},
+        metadata={"help": "Legacy placement flags; true places each extra-parallel dimension outside FSDP."},
     )
     extra_parallel_names: List[str] = field(
         default_factory=list,

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -85,9 +85,9 @@ def _validate_extra_parallel_meshes(parallel_state) -> None:
     """Fail-fast precondition for ExtraParallel state dict preprocessing.
 
     At least one ExtraParallel mesh must be non-None, and at least one
-    of those meshes must carry the ExtraParallel + FSDP composition:
-    2D ``(ep_fsdp, ep)`` for plain FSDP or 3D
-    ``(ep_replicate, ep_fsdp, ep)`` for HSDP.
+    of those meshes must carry the ExtraParallel + FSDP composition. The
+    ExtraParallel and FSDP dimensions may appear in either order, while an
+    HSDP replicate dimension remains outermost.
     """
     extra_parallel_mesh = {
         para: parallel_state.extra_parallel_fsdp_device_mesh[para][para]
@@ -103,8 +103,8 @@ def _validate_extra_parallel_meshes(parallel_state) -> None:
         and parallel_state.extra_parallel_fsdp_device_mesh[para].ndim in (2, 3)
         for para in parallel_state.extra_parallel_names
     ), (
-        "At least one extra_parallel fsdp_device_mesh must carry the ExtraParallel+FSDP "
-        "composition: 2D (ep_fsdp, ep) for plain FSDP or 3D (ep_replicate, ep_fsdp, ep) for HSDP"
+        "At least one extra_parallel fsdp_device_mesh must carry a 2D ExtraParallel+FSDP "
+        "or 3D ExtraParallel+HSDP composition"
     )
 
 
@@ -164,11 +164,14 @@ def _apply_extra_parallel_dim(
 
         assert spec_info.para_fsdp_mesh is not None, f"ExtraParallel spec {name} must have an ExtraParallel FSDP mesh"
 
-        # Drop the innermost ExtraParallel (e.g. ``ep``) dim and keep the FSDP
-        # sub-mesh: 1D ``(ep_fsdp,)`` for plain FSDP, or 2D
-        # ``(ep_replicate, ep_fsdp)`` for HSDP. Mirrors the mesh slicing used
-        # when sharding the module in ``torch_parallelize``.
-        fsdp_submesh = spec_info.para_fsdp_mesh[spec_info.para_fsdp_mesh.mesh_dim_names[:-1]]
+        # Drop the named ExtraParallel (e.g. ``ep``) dim and keep the FSDP
+        # sub-mesh. The ExtraParallel dim can be either inside or outside its
+        # FSDP dim, so selecting dimensions by position would choose the wrong
+        # process group for an outside layout.
+        fsdp_dim_names = tuple(
+            dim_name for dim_name in spec_info.para_fsdp_mesh.mesh_dim_names if dim_name != spec_info.para_name
+        )
+        fsdp_submesh = spec_info.para_fsdp_mesh[fsdp_dim_names]
         # The ExtraParallel (e.g. ``ep``) dim shards the tensor along
         # ``spec_info.placement.dim`` (dim 0 for experts), while FSDP shards it
         # along ``spec_info.fsdp_shard_dim`` (1 by default, 0 for Muon zero-comm).
@@ -177,10 +180,15 @@ def _apply_extra_parallel_dim(
         ep_shard_dim = spec_info.placement.dim
         fsdp_shard_dim = spec_info.fsdp_shard_dim
         if action == "drop":
-            tensor = drop_extra_parallel_dim(tensor, fsdp_submesh, fsdp_shard_dim)
+            tensor = drop_extra_parallel_dim(tensor, fsdp_submesh, fsdp_shard_dim, spec_info.para_name)
         else:
             tensor = restore_extra_parallel_dim(
-                tensor, spec_info.para_fsdp_mesh, fsdp_submesh, ep_shard_dim, fsdp_shard_dim
+                tensor,
+                spec_info.para_fsdp_mesh,
+                fsdp_submesh,
+                ep_shard_dim,
+                fsdp_shard_dim,
+                spec_info.para_name,
             )
         state_dict[name] = tensor
 
@@ -335,7 +343,34 @@ class OptimizerState(Stateful):
         )
 
 
-def drop_extra_parallel_dim(loaded_tensor: torch.Tensor, device_mesh: DeviceMesh, fsdp_shard_dim: int = 1):
+def _named_extra_parallel_placements(
+    mesh_dim_names: tuple[str, ...],
+    extra_parallel_name: str,
+    ep_shard_dim: int,
+    fsdp_shard_dim: int,
+) -> list[Union[Replicate, Shard]]:
+    """Map named ExtraParallel mesh dimensions to their DTensor placements."""
+
+    placement_by_dim_name = {
+        f"{extra_parallel_name}_replicate": Replicate(),
+        extra_parallel_name: Shard(ep_shard_dim),
+        f"{extra_parallel_name}_fsdp": Shard(fsdp_shard_dim),
+    }
+    unknown_dim_names = tuple(name for name in mesh_dim_names if name not in placement_by_dim_name)
+    if unknown_dim_names:
+        raise RuntimeError(
+            f"Unexpected dimensions {unknown_dim_names} in {extra_parallel_name!r} checkpoint mesh {mesh_dim_names}"
+        )
+
+    return [placement_by_dim_name[name] for name in mesh_dim_names]
+
+
+def drop_extra_parallel_dim(
+    loaded_tensor: torch.Tensor,
+    device_mesh: DeviceMesh,
+    fsdp_shard_dim: int = 1,
+    extra_parallel_name: str = "ep",
+):
     """
     Drop ExtraParallel dims after loading from DCP so that ExtraParallel-FSDP would not be confused.
 
@@ -343,25 +378,30 @@ def drop_extra_parallel_dim(loaded_tensor: torch.Tensor, device_mesh: DeviceMesh
     1D ``(ep_fsdp,)`` for plain FSDP, or 2D ``(ep_replicate, ep_fsdp)`` for HSDP.
     ``fsdp_shard_dim`` is the tensor dim FSDP shards along (1 by default, 0 for
     the Muon zero-comm layout). The number of placements on the loaded DTensor
-    reflects the full saved mesh:
+    reflects the full saved mesh. FSDP placements are rebuilt from the named
+    sub-mesh dimensions rather than from their positions:
 
     * 1 placement: pure ExtraParallel, no FSDP -> return the plain local tensor.
-    * 2 placements: ``(ep_fsdp, ep)`` -> keep FSDP ``Shard(fsdp_shard_dim)`` on
-      the 1D sub-mesh.
-    * 3 placements: ``(ep_replicate, ep_fsdp, ep)`` (HSDP) -> keep
-      ``[Replicate(), Shard(fsdp_shard_dim)]`` on the 2D sub-mesh.
+    * 2 placements: ExtraParallel+FSDP -> keep FSDP
+      ``Shard(fsdp_shard_dim)`` on the 1D sub-mesh.
+    * 3 placements: ExtraParallel+HSDP -> keep replicate and FSDP placements
+      on the 2D sub-mesh.
     """
 
     num_placements = len(loaded_tensor.placements)
     if num_placements == 1:
         tensor_to_put = loaded_tensor.to_local()
-    elif num_placements == 2:
-        tensor_to_put = DTensor.from_local(
-            loaded_tensor._local_tensor, device_mesh=device_mesh, placements=[Shard(fsdp_shard_dim)]
+    elif num_placements in (2, 3):
+        placements = _named_extra_parallel_placements(
+            device_mesh.mesh_dim_names,
+            extra_parallel_name,
+            ep_shard_dim=0,
+            fsdp_shard_dim=fsdp_shard_dim,
         )
-    elif num_placements == 3:
         tensor_to_put = DTensor.from_local(
-            loaded_tensor._local_tensor, device_mesh=device_mesh, placements=[Replicate(), Shard(fsdp_shard_dim)]
+            loaded_tensor._local_tensor,
+            device_mesh=device_mesh,
+            placements=placements,
         )
     else:
         raise RuntimeError(
@@ -378,6 +418,7 @@ def restore_extra_parallel_dim(
     extra_parallel_fsdp_mesh: DeviceMesh,
     ep_shard_dim: int = 0,
     fsdp_shard_dim: int = 1,
+    extra_parallel_name: str = "ep",
 ):
     """
     Restore ExtraParallel dim so that DCP can be aware about ExtraParallel ranks
@@ -389,35 +430,28 @@ def restore_extra_parallel_dim(
 
     args:
         orgin_tensor (torch.Tensor): The orgin tensor (FSDP-local shard).
-        fsdp_mesh (DeviceMesh): The full ExtraParallel mesh, i.e. 2D
-            ``(ep_fsdp, ep)`` for plain FSDP or 3D
-            ``(ep_replicate, ep_fsdp, ep)`` for HSDP.
+        fsdp_mesh (DeviceMesh): The full named ExtraParallel mesh. The
+            ExtraParallel and FSDP dimensions may appear in either order.
         extra_parallel_fsdp_mesh (DeviceMesh): The FSDP sub-mesh (ExtraParallel
             dim excluded), used for the pure-ExtraParallel (no FSDP) path.
         ep_shard_dim (int): Tensor dim the ExtraParallel dim shards along.
         fsdp_shard_dim (int): Tensor dim FSDP shards along.
+        extra_parallel_name (str): Name of the ExtraParallel mesh dimension.
 
     Note:
-        When ``ep_shard_dim == fsdp_shard_dim`` (e.g. the Muon zero-comm layout
-        shards experts on dim 0 just like EP), both mesh dims split the SAME
-        tensor dim. The mesh order ``(ep_fsdp, ep)`` then composes ``ep_fsdp``
-        OUTER of ``ep``, whereas the physical layout is EP-outer / FSDP-inner,
-        so the reconstructed GLOBAL tensor is block-transposed along that dim.
-        Save->load into the SAME parallel config still round-trips correctly
-        (drop is the exact inverse); only resharding / external reads of such a
-        checkpoint see the permuted layout. Fixing this needs the EP mesh dims
-        reordered so ``ep`` precedes ``ep_fsdp`` (a parallel_state change).
+        When ``ep_shard_dim == fsdp_shard_dim``, the named mesh order determines
+        how the two shards compose along that tensor dimension. Placements must
+        therefore follow ``fsdp_mesh.mesh_dim_names`` exactly.
     """
     assert fsdp_mesh.ndim in (2, 3), f"global_mesh.ndim must be 2 or 3, got {fsdp_mesh.ndim}"
 
     if isinstance(orgin_tensor, DTensor):
-        # ExtraParallel+FSDP2. mesh order is (ep_fsdp, ep) or, for HSDP,
-        # (ep_replicate, ep_fsdp, ep): ep_fsdp -> Shard(fsdp_shard_dim),
-        # ep -> Shard(ep_shard_dim), ep_replicate -> Replicate().
-        if fsdp_mesh.ndim == 3:
-            placements = [Replicate(), Shard(fsdp_shard_dim), Shard(ep_shard_dim)]
-        else:
-            placements = [Shard(fsdp_shard_dim), Shard(ep_shard_dim)]
+        placements = _named_extra_parallel_placements(
+            fsdp_mesh.mesh_dim_names,
+            extra_parallel_name,
+            ep_shard_dim,
+            fsdp_shard_dim,
+        )
         dtensor = DTensor.from_local(orgin_tensor._local_tensor, device_mesh=fsdp_mesh, placements=placements)
     elif torch.is_tensor(orgin_tensor):
         # If there is no FSDP but only ExtraParallel

--- a/veomni/distributed/mesh_topology.py
+++ b/veomni/distributed/mesh_topology.py
@@ -1,0 +1,68 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ExtraParallelMeshSpec:
+    """Shape and named dimensions for one extra-parallel parameter mesh."""
+
+    shape: tuple[int, ...]
+    dim_names: tuple[str, ...]
+    fsdp_dim_names: tuple[str, ...]
+
+
+def build_extra_parallel_mesh_spec(
+    *,
+    dp_replicate_size: int,
+    dp_shard_sp_size: int,
+    parallel_size: int,
+    parallel_name: str,
+    parallel_outside: bool,
+) -> ExtraParallelMeshSpec:
+    """Build the rank-ordering contract for an extra-parallel mesh.
+
+    DeviceMesh uses row-major rank order, so the rightmost dimension forms
+    contiguous groups. ``parallel_outside`` swaps the parallel and FSDP
+    dimensions without moving an outer HSDP replicate dimension.
+    """
+
+    if min(dp_replicate_size, dp_shard_sp_size, parallel_size) < 1:
+        raise ValueError("mesh dimensions must be positive")
+    if not parallel_name:
+        raise ValueError("parallel_name must not be empty")
+    if dp_shard_sp_size % parallel_size != 0:
+        raise ValueError(f"{parallel_name}_size({parallel_size}) must divide dp_shard_sp_size({dp_shard_sp_size})")
+
+    parallel_fsdp_size = dp_shard_sp_size // parallel_size
+    shape: list[int] = []
+    dim_names: list[str] = []
+
+    if dp_replicate_size > 1:
+        shape.append(dp_replicate_size)
+        dim_names.append(f"{parallel_name}_replicate")
+
+    if parallel_outside:
+        shape.extend((parallel_size, parallel_fsdp_size))
+        dim_names.extend((parallel_name, f"{parallel_name}_fsdp"))
+    else:
+        shape.extend((parallel_fsdp_size, parallel_size))
+        dim_names.extend((f"{parallel_name}_fsdp", parallel_name))
+
+    return ExtraParallelMeshSpec(
+        shape=tuple(shape),
+        dim_names=tuple(dim_names),
+        fsdp_dim_names=tuple(dim_name for dim_name in dim_names if dim_name != parallel_name),
+    )

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -26,6 +26,7 @@ from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
 from ..utils import logging
 from ..utils.device import get_device_type
+from .mesh_topology import build_extra_parallel_mesh_spec
 
 
 if TYPE_CHECKING:
@@ -324,7 +325,9 @@ class ParallelState:
 
     @requires_mesh
     def extra_parallel_fsdp_mesh(self, para_name) -> "DeviceMesh":
-        return self.extra_parallel_fsdp_device_mesh[para_name][para_name, f"{para_name}_fsdp"]
+        para_mesh = self.extra_parallel_fsdp_device_mesh[para_name]
+        fsdp_dim_names = tuple(name for name in para_mesh.mesh_dim_names if name != para_name)
+        return para_mesh[fsdp_dim_names]
 
     @requires_mesh
     def extra_parallel_group(self, para_name) -> "ProcessGroup":
@@ -599,31 +602,22 @@ def init_parallel_state(
         extra_parallel_sizes, extra_parallel_placement_innermost, extra_parallel_names
     ):
         if para_size > 1:
-            # TODO: drop para_outside?
-            assert not para_outside, f"{para_name} is not supported when para_outside is True."
-
             # NOTE: Support HSDP for extra parallel. For example, world_size=1024
             # - dense param device_mesh: (dp_replicate, dp_shard_sp)=(4, 256)
             # - ep_size=8, expert parallel device_mesh: (ep_replicate, ep_fsdp, ep)=(4, 32, 8)
-            # Note that ep_size should be a factor of dp_shard_sp_size.
-            param_mesh_shape, para_mesh_dim_names = [], []
-            if dp_replicate_size > 1:
-                param_mesh_shape.append(dp_replicate_size)
-                para_mesh_dim_names.append(f"{para_name}_replicate")
             dp_shard_sp_size = device_mesh["dp_shard_sp"].size()
-            assert dp_shard_sp_size % para_size == 0, (
-                f"{para_name}_size({para_size}) must be a factor of dp_shard_sp_size({dp_shard_sp_size})"
+            mesh_spec = build_extra_parallel_mesh_spec(
+                dp_replicate_size=dp_replicate_size,
+                dp_shard_sp_size=dp_shard_sp_size,
+                parallel_size=para_size,
+                parallel_name=para_name,
+                parallel_outside=para_outside,
             )
-            para_fsdp_size = dp_shard_sp_size // para_size
-            param_mesh_shape.append(para_fsdp_size)
-            param_mesh_shape.append(para_size)
-            para_mesh_dim_names.append(f"{para_name}_fsdp")
-            para_mesh_dim_names.append(para_name)
 
             extra_parallel_fsdp_device_mesh[f"{para_name}"] = init_device_mesh(
                 device_type=device_type,
-                mesh_shape=param_mesh_shape,
-                mesh_dim_names=para_mesh_dim_names,
+                mesh_shape=mesh_spec.shape,
+                mesh_dim_names=mesh_spec.dim_names,
             )
 
     logger.info_rank0(f"Device mesh: {device_mesh}")

--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -347,13 +347,8 @@ def parallelize_model_fsdp2(
     for para in parallel_state.extra_parallel_names:
         if parallel_state.extra_parallel_enabled(para):
             para_mesh = parallel_state.extra_parallel_fsdp_device_mesh[para]
-            para_mesh_dim_names = para_mesh.mesh_dim_names
-            # exclude para_size dimension:
-            # - (ep_fsdp, ep) -> (ep_fsdp,)
-            # - (ep_replicate, ep_fsdp, ep) -> (ep_replicate, ep_fsdp)
-            para_fsdp_mesh = para_mesh[para_mesh_dim_names[:-1]]
             para_fsdp_kwargs = dict(fsdp_kwargs)
-            para_fsdp_kwargs["mesh"] = para_fsdp_mesh
+            para_fsdp_kwargs["mesh"] = parallel_state.extra_parallel_fsdp_mesh(para)
             shard_dim_for_para = 1
             # Muon zero-comm needs whole experts per rank; otherwise keep the
             # default hidden-dim sharding.

--- a/veomni/utils/save_safetensor_utils.py
+++ b/veomni/utils/save_safetensor_utils.py
@@ -320,6 +320,9 @@ def save_lora_adapter_with_dcp(
                     lora_state[name],
                     spec.para_fsdp_mesh,
                     spec.para_fsdp_mesh[f"{spec.para_name}_fsdp"],
+                    ep_shard_dim=spec.placement.dim,
+                    fsdp_shard_dim=spec.fsdp_shard_dim,
+                    extra_parallel_name=spec.para_name,
                 )
 
     # ckpt_to_state_dict's DCP conversion path only recognizes keys starting with "model.".


### PR DESCRIPTION
### What does this PR do?

VeOmni exposes `ep_outside` and `extra_parallel_placement_innermost`, but `init_parallel_state()` currently rejects every true value. This PR implements the advertised alternate rank ordering for ExtraParallel + FSDP2 while preserving the existing default.

With 32 DP-shard ranks and EP8:

- default: `(ep_fsdp=4, ep=8)`, so EP8 groups are contiguous;
- outside: `(ep=8, ep_fsdp=4)`, so expert-FSDP4 groups are contiguous.

The HSDP replicate dimension remains outermost in both layouts.

The checkpoint path also follows the named mesh dimensions. Model, optimizer, DCP-to-HF, and LoRA state handling no longer assumes that ExtraParallel is the last mesh dimension.

### Checklist Before Starting

- Searched open issues and PRs for `ep_outside`, `extra_parallel_placement_innermost`, and outer ExtraParallel mesh placement; no duplicate implementation was found.
- PR title follows the enforced `[{modules}] {type}: {description}` format.

### Test

Fresh local tests at commit `ed6cc7124e847b626b09fa232b1c3d1271a7d1af`:

```text
pytest -q tests/distributed/test_extra_parallel_mesh_topology.py
4 passed

pytest -q tests/utils/test_extra_parallel_clip_grad_norm.py \
  -k 'inf_norm or expected_outer_extra_parallel_group_ranks'
6 passed, 19 deselected

pytest -q tests/checkpoints/test_dcp_checkpointer.py \
  -k 'not test_save_dtype_only_casts_floating_tensors'
37 passed, 1 deselected, 2 xfailed

pytest -q tests/utils/test_save_safetensor_utils.py
17 passed

make quality
All checks passed; 635 files already formatted
```

The checkpoint unit regressions cover both mesh orders, HSDP placement, named FSDP submesh selection, non-`ep` ExtraParallel names, and LoRA propagation of both EP and FSDP shard axes. The excluded DCP-to-HF dtype test reaches an unrelated existing `torch.cpu.empty_cache` failure on the local macOS CPU environment.

The existing 8-GPU checkpoint suite now includes two `ep_outside=True` end-to-end cases:

- EP4 + plain FSDP2;
- EP2 + HSDP with replicate degree 2.

Both cases train, save and reload model plus optimizer state, merge DCP to HF, and compare the restored states. The MoE-LoRA EP2 integration path also runs with the outside layout for both shared and independent adapters. These GPU cases are collected locally and are wired into the repository's 8-GPU CI; their CI result is intentionally not pre-claimed here.

Single-node 8-GPU FSDP2 training validation was previously run at commit `bbf2d9b19fbf61cc4cdb58159cae6c62e53d4421` on 8 NVIDIA B300 GPUs with PyTorch 2.10.0+cu129 and Transformers 5.9.0:

- `ep_outside=True` constructed `DeviceMesh((ep=4, ep_fsdp=2), stride=(2, 1))`; actual EP and expert-FSDP process-group membership assertions passed.
- `ep_outside=False` constructed the unchanged default `DeviceMesh((ep_fsdp=2, ep=4), stride=(4, 1))`.
- Both layouts completed three forward/backward/gradient-clipping steps; both distributed runs exited 0.

This is single-node correctness evidence, not a cross-node topology or performance benchmark.

### API and Usage Example

No new config field is added. The existing expert-parallel convenience flag now works:

```yaml
train:
  accelerator:
    ep_size: 8
    ep_outside: true
```

The flag changes rank ordering only. It is not an unconditional performance optimization; users should benchmark complete training steps on their target topology.

`extra_parallel_placement_innermost` is retained for compatibility, but its historical name is misleading: `True` selects the outside layout. The CLI help and argument reference now state this explicitly.

### Design & Code Changes

- Add a pure mesh-spec builder that keeps rank-ordering policy independent from process-group construction.
- Remove the unconditional rejection of outer ExtraParallel placement.
- Select FSDP submeshes and checkpoint DTensor placements by dimension name rather than position.
- Preserve the actual EP and FSDP shard axes in model, optimizer, and LoRA checkpoint paths.
- Add CPU topology/checkpoint contract coverage and 8-GPU FSDP2/HSDP/LoRA end-to-end cases.
- Document the legacy placement-field naming, topology tradeoff, and named-dimension invariant.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied repository quality checks.
- [x] Added/updated documentation and agent constraints.
- [x] Added focused CPU regressions and 8-GPU CI coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable extra-parallel mesh placement inside or outside FSDP dimensions.
  * Added named mesh-dimension handling, supporting flexible ExtraParallel/FSDP ordering.
  * Added validation for incompatible parallel sizes and clearer configuration guidance.

* **Bug Fixes**
  * Improved checkpoint save/load and LoRA tensor handling across alternate extra-parallel layouts.
  * Preserved HSDP replication behavior across supported mesh configurations.

* **Tests**
  * Expanded coverage for mesh topology, distributed training, gradient clipping, LoRA, and checkpoint round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->