### PR TITLE
[ci, model] fix: update Qwen3.5 cached mask handling

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -144,6 +144,7 @@ jobs:
           uv run --frozen pytest -s -x tests/models/test_padded_packed_loss.py
           uv run --frozen pytest -s -x tests/models/test_models_logits_equal_v5.py
           uv run --frozen pytest -s -x tests/models/test_model_forward_no_implicit_sync.py
+          uv run --frozen pytest -s -x tests/models/test_qwen3_5_cache_mask.py
           uv run --frozen pytest -s -x tests/models/test_checkpoint_tensor_converter.py
           uv run --frozen pytest -s -x tests/models/test_return_log_probs_e2e.py
       - name: Run Qwen3.5 GatedDeltaNet Ulysses SP tests

--- a/tests/models/test_qwen3_5_cache_mask.py
+++ b/tests/models/test_qwen3_5_cache_mask.py
@@ -1,0 +1,31 @@
+import importlib
+
+import pytest
+import torch
+from transformers.cache_utils import DynamicCache
+from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
+
+
+_MODEL_CASES = (
+    (
+        "veomni.models.transformers.qwen3_5.generated.patched_modeling_qwen3_5_gpu",
+        "Qwen3_5TextModel",
+    ),
+    (
+        "veomni.models.transformers.qwen3_5_moe.generated.patched_modeling_qwen3_5_moe_gpu",
+        "Qwen3_5MoeTextModel",
+    ),
+)
+
+
+@pytest.mark.parametrize(("module_name", "class_name"), _MODEL_CASES)
+def test_linear_attention_mask_uses_cache_metadata(module_name, class_name):
+    model_class = getattr(importlib.import_module(module_name), class_name)
+    attention_mask = torch.ones(1, 3, dtype=torch.long)
+    config = Qwen3_5TextConfig(num_hidden_layers=1, layer_types=["linear_attention"])
+    cache = DynamicCache(config=config)
+
+    assert model_class._update_linear_attn_mask(None, attention_mask, cache) is attention_mask
+
+    cache.update_conv_state(torch.zeros(1, 1, config.linear_conv_kernel_dim), layer_idx=0)
+    assert model_class._update_linear_attn_mask(None, attention_mask, cache) is None

--- a/tests/models/test_qwen3_5_cache_mask.py
+++ b/tests/models/test_qwen3_5_cache_mask.py
@@ -20,6 +20,7 @@ _MODEL_CASES = (
 
 @pytest.mark.parametrize(("module_name", "class_name"), _MODEL_CASES)
 def test_linear_attention_mask_uses_cache_metadata(module_name, class_name):
+    """Use real linear-attention cache states for dense and MoE mask handling."""
     model_class = getattr(importlib.import_module(module_name), class_name)
     attention_mask = torch.ones(1, 3, dtype=torch.long)
     config = Qwen3_5TextConfig(num_hidden_layers=1, layer_types=["linear_attention"])

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
@@ -1138,12 +1138,9 @@
 
 
  class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
-@@ -1233,19 +1828,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1235,17 +1830,40 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1152,18 +1149,18 @@
 +        Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 +
 +        Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-+        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-+        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-+        / host-device sync on *every* forward, which serialises the host against the device in
-+        VeOmni's otherwise sync-free training step.
++        — for a cached forward or when ``torch.all(attention_mask == 1)`` (the batch has no padding).
++        The all-ones predicate reads a 0-D GPU tensor and forces an implicit ``.item()`` / host-device
++        sync on *every* forward, which serialises the host against the device in VeOmni's otherwise
++        sync-free training step.
 +
 +        We keep the cached-forward branch — it is a correctness guard, not just an optimization:
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). Transformers 5.9 exposes this state through
++        ``past_key_values.has_previous_state()``, which reads host-side cache metadata and causes no
++        device synchronization.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1179,8 +1176,8 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
@@ -1828,23 +1828,23 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
         Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-        / host-device sync on *every* forward, which serialises the host against the device in
-        VeOmni's otherwise sync-free training step.
+        — for a cached forward or when ``torch.all(attention_mask == 1)`` (the batch has no padding).
+        The all-ones predicate reads a 0-D GPU tensor and forces an implicit ``.item()`` / host-device
+        sync on *every* forward, which serialises the host against the device in VeOmni's otherwise
+        sync-free training step.
 
         We keep the cached-forward branch — it is a correctness guard, not just an optimization:
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). Transformers 5.9 exposes this state through
+        ``past_key_values.has_previous_state()``, which reads host-side cache metadata and causes no
+        device synchronization.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1854,8 +1854,8 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
@@ -1195,12 +1195,9 @@
 
          hidden_states = inputs_embeds
          position_embeddings = self.rotary_emb(hidden_states, position_ids)
-@@ -1233,19 +1827,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1235,17 +1829,40 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1209,18 +1206,18 @@
 +        Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 +
 +        Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-+        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-+        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-+        / host-device sync on *every* forward, which serialises the host against the device in
-+        VeOmni's otherwise sync-free training step.
++        — for a cached forward or when ``torch.all(attention_mask == 1)`` (the batch has no padding).
++        The all-ones predicate reads a 0-D GPU tensor and forces an implicit ``.item()`` / host-device
++        sync on *every* forward, which serialises the host against the device in VeOmni's otherwise
++        sync-free training step.
 +
 +        We keep the cached-forward branch — it is a correctness guard, not just an optimization:
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). Transformers 5.9 exposes this state through
++        ``past_key_values.has_previous_state()``, which reads host-side cache metadata and causes no
++        device synchronization.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1236,8 +1233,8 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
@@ -1827,23 +1827,23 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
         Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-        / host-device sync on *every* forward, which serialises the host against the device in
-        VeOmni's otherwise sync-free training step.
+        — for a cached forward or when ``torch.all(attention_mask == 1)`` (the batch has no padding).
+        The all-ones predicate reads a 0-D GPU tensor and forces an implicit ``.item()`` / host-device
+        sync on *every* forward, which serialises the host against the device in VeOmni's otherwise
+        sync-free training step.
 
         We keep the cached-forward branch — it is a correctness guard, not just an optimization:
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). Transformers 5.9 exposes this state through
+        ``past_key_values.has_previous_state()``, which reads host-side cache metadata and causes no
+        device synchronization.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1853,8 +1853,8 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 

--- a/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
@@ -518,23 +518,23 @@ def qwen3_5_gated_deltanet_forward_patched(
     "Qwen3_5TextModel._update_linear_attn_mask",
     description="Avoid host-device sync: decide linear-attention padding-mask zeroing without reading GPU scalars.",
 )
-def qwen3_5_text_model_update_linear_attn_mask(self, attention_mask, cache_position):
+def qwen3_5_text_model_update_linear_attn_mask(self, attention_mask, past_key_values):
     """
     Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
     Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-    — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-    batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-    / host-device sync on *every* forward, which serialises the host against the device in
-    VeOmni's otherwise sync-free training step.
+    — for a cached forward or when ``torch.all(attention_mask == 1)`` (the batch has no padding).
+    The all-ones predicate reads a 0-D GPU tensor and forces an implicit ``.item()`` / host-device
+    sync on *every* forward, which serialises the host against the device in VeOmni's otherwise
+    sync-free training step.
 
     We keep the cached-forward branch — it is a correctness guard, not just an optimization:
     ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
     cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
     only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-    a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-    ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-    than reading ``cache_position[0]``, so no sync.
+    a 1-token decode step). Transformers 5.9 exposes this state through
+    ``past_key_values.has_previous_state()``, which reads host-side cache metadata and causes no
+    device synchronization.
 
     The all-ones short-circuit is the one we drop: returning the all-ones mask makes
     ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -544,8 +544,8 @@ def qwen3_5_text_model_update_linear_attn_mask(self, attention_mask, cache_posit
     if attention_mask is None:
         return None
     # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-    # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-    if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+    # apply_mask_to_padding_states, and upstream returns None here.
+    if past_key_values is not None and past_key_values.has_previous_state():
         return None
     return attention_mask
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
@@ -1262,12 +1262,9 @@
 
 
  class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
-@@ -1353,19 +2023,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1355,17 +2025,40 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1276,18 +1273,18 @@
 +        Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 +
 +        Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-+        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-+        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-+        / host-device sync on *every* forward, which serialises the host against the device in
-+        VeOmni's otherwise sync-free training step.
++        — for a cached forward or when ``torch.all(attention_mask == 1)`` (the batch has no padding).
++        The all-ones predicate reads a 0-D GPU tensor and forces an implicit ``.item()`` / host-device
++        sync on *every* forward, which serialises the host against the device in VeOmni's otherwise
++        sync-free training step.
 +
 +        We keep the cached-forward branch — it is a correctness guard, not just an optimization:
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). Transformers 5.9 exposes this state through
++        ``past_key_values.has_previous_state()``, which reads host-side cache metadata and causes no
++        device synchronization.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1303,8 +1300,8 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -2023,23 +2023,23 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
         Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-        / host-device sync on *every* forward, which serialises the host against the device in
-        VeOmni's otherwise sync-free training step.
+        — for a cached forward or when ``torch.all(attention_mask == 1)`` (the batch has no padding).
+        The all-ones predicate reads a 0-D GPU tensor and forces an implicit ``.item()`` / host-device
+        sync on *every* forward, which serialises the host against the device in VeOmni's otherwise
+        sync-free training step.
 
         We keep the cached-forward branch — it is a correctness guard, not just an optimization:
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). Transformers 5.9 exposes this state through
+        ``past_key_values.has_previous_state()``, which reads host-side cache metadata and causes no
+        device synchronization.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -2049,8 +2049,8 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
@@ -1318,12 +1318,9 @@
 
          hidden_states = inputs_embeds
          position_embeddings = self.rotary_emb(hidden_states, position_ids)
-@@ -1353,19 +2029,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1355,17 +2031,40 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1332,18 +1329,18 @@
 +        Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 +
 +        Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-+        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-+        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-+        / host-device sync on *every* forward, which serialises the host against the device in
-+        VeOmni's otherwise sync-free training step.
++        — for a cached forward or when ``torch.all(attention_mask == 1)`` (the batch has no padding).
++        The all-ones predicate reads a 0-D GPU tensor and forces an implicit ``.item()`` / host-device
++        sync on *every* forward, which serialises the host against the device in VeOmni's otherwise
++        sync-free training step.
 +
 +        We keep the cached-forward branch — it is a correctness guard, not just an optimization:
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). Transformers 5.9 exposes this state through
++        ``past_key_values.has_previous_state()``, which reads host-side cache metadata and causes no
++        device synchronization.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1359,8 +1356,8 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -2029,23 +2029,23 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
         Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-        / host-device sync on *every* forward, which serialises the host against the device in
-        VeOmni's otherwise sync-free training step.
+        — for a cached forward or when ``torch.all(attention_mask == 1)`` (the batch has no padding).
+        The all-ones predicate reads a 0-D GPU tensor and forces an implicit ``.item()`` / host-device
+        sync on *every* forward, which serialises the host against the device in VeOmni's otherwise
+        sync-free training step.
 
         We keep the cached-forward branch — it is a correctness guard, not just an optimization:
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). Transformers 5.9 exposes this state through
+        ``past_key_values.has_previous_state()``, which reads host-side cache metadata and causes no
+        device synchronization.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -2055,8 +2055,8 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 


### PR DESCRIPTION
### What does this PR do?

Fixes #1007.

Qwen3.5 and Qwen3.5-MoE generated modeling now follow the Transformers 5.9 `_update_linear_attn_mask(attention_mask, past_key_values)` contract. The previous override treated the `Cache` as the old `cache_position` tensor and accessed `.shape`, so any cached forward failed with `AttributeError`.

### Checklist Before Starting

- Searched open PRs by issue number and `_update_linear_attn_mask`/`DynamicCache`; no duplicate PR was found.
- PR title follows the enforced `[{modules}] {type}: {description}` format.

### Test

- `pytest tests/models/test_qwen3_5_cache_mask.py -vv` — 2 passed (dense and MoE generated GPU classes; empty and populated linear-attention cache states).
- `pytest tests/models/test_qwen3_5_cache_mask.py tests/models/test_model_forward_no_implicit_sync.py -vv` — 3 passed, 17 existing CUDA-only cases skipped on the CPU development host.
- `make check-patchgen` — all 29 patch configurations are up to date.
- `make quality` — Ruff check and format check pass.
- The issue's tiny `generate(use_cache=True)` reproduction proceeds past `_update_linear_attn_mask`; on the CPU development host it then reaches VeOmni's existing `cu_seq_lens_q` assertion, so this is not reported as a complete generation E2E pass.

### API and Usage Example

N/A. This restores compatibility with the pinned Transformers 5.9 internal cache contract and changes no VeOmni public API or configuration.

### Design & Code Changes

- Replace the stale `cache_position` argument with `past_key_values` in the shared Qwen3.5 patchgen override.
- Use `past_key_values.has_previous_state()`, which reads host-side cache metadata and preserves VeOmni's sync-free training path.
- Regenerate dense/MoE GPU and NPU modeling outputs and their tracked patch diffs from the shared source.
- Add a real-`DynamicCache` regression for both generated model families and wire it into GPU model CI.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- Applied pre-commit checks.
- Documentation is unchanged because there is no public API or configuration change.
- Added the regression test to the GPU unit-test workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention-mask handling for Qwen3.5 and Qwen3.5-MoE models during cached generation.
  * Preserved attention masks for initial, non-cached inputs and correctly disabled them after convolutional cache state is initialized.

* **Tests**
  * Added GPU coverage for linear-attention mask behavior across Qwen3.5 model variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->