### PR TITLE
[misc] fix: require deterministic FLA on Blackwell

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ gpu = [
   # below, so it needs no source build and no dependency-metadata override.
   "flash-qla==0.1.2",
   "liger-kernel",
-  "flash-linear-attention",
+  # FLA 0.5.2 fixes nondeterministic Blackwell GDN forward configs during checkpoint recomputation.
+  "flash-linear-attention>=0.5.2,<0.6",
   "quack-kernels[cu13]==0.5.0",
   # Dao-AILab Gram Newton-Schulz (default muon_ns_implementation=gram_quack).
   # Pure-torch `gram` path does not need this; package ImportError falls back to gram.

--- a/uv.lock
+++ b/uv.lock
@@ -824,14 +824,14 @@ wheels = [
 
 [[package]]
 name = "fla-core"
-version = "0.4.1"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "einops" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/de/0d6bd5664ba2e711cabdde11ccb41ddcdd866c531e40900af3601bd7b8c6/fla_core-0.4.1.tar.gz", hash = "sha256:38ab28966eeadc2141b29e87c2bf72a8a4851e00af9d25bbbc3596b1fb53450d", size = 319608, upload-time = "2025-12-24T18:07:37.669Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/85/20bdc0fbbbaeec27b5b198e0dbbbc51161a267066a4aebd9e4b413637c6c/fla_core-0.5.2.tar.gz", hash = "sha256:9360fc412f784c1c8f05c320ec2902d5d968764178c9b8a92efc919e17a39680", size = 587835, upload-time = "2026-07-27T18:26:19.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/43/945ef69eb48a14c30fd7323d3e0b560c821ae71e6d3ef979e06a901bc3b9/fla_core-0.4.1-py3-none-any.whl", hash = "sha256:93c6afe4c80fc7bc705fa8aeea6a46d2cf2d77383f9619a41863c7114c801bab", size = 437282, upload-time = "2025-12-24T18:07:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ed/dfe19c4da779957eb6a42a26812f9b4e2280bf757a17a71933ff59ffcb98/fla_core-0.5.2-py3-none-any.whl", hash = "sha256:5e830c85bad3d0d34677f98ac7074d08687a3756f0f0499d95ceb96eb6920761", size = 819225, upload-time = "2026-07-27T18:26:16.147Z" },
 ]
 
 [[package]]
@@ -948,15 +948,15 @@ source = { git = "https://github.com/demonatic/flash-attention.git?subdirectory=
 
 [[package]]
 name = "flash-linear-attention"
-version = "0.4.1"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fla-core" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/83/7d8ec7ffb5229080b1c9b772338ff588cbd63282ac355ede2a12a6e174a8/flash_linear_attention-0.4.1.tar.gz", hash = "sha256:127ee7273ed15ac17f72bcf4c75e1051719d8fbe0a2d1d047e59406f36d81ee2", size = 158280, upload-time = "2025-12-24T18:07:38.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/76/c180949eae5161b9fcf4c928cab52f0c257ce84c1a59b4462b1d2b6e5883/flash_linear_attention-0.5.2.tar.gz", hash = "sha256:c053d3a75c8f5b725063f719ae6bce0f4d9dac6da32735be8ae7d485a6c9820f", size = 208110, upload-time = "2026-07-27T18:26:20.536Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/d5/6327559a9d5b9243b10c3984f1bcef256ed2ad06d105a3bb8f7b2979659c/flash_linear_attention-0.4.1-py3-none-any.whl", hash = "sha256:d18bdfe9d1f4b424676444eac9d50fb8433b70e5d4e0e0878b20bcbcdbea57ce", size = 287415, upload-time = "2025-12-24T18:07:35.815Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d2/2070e3cf2148c5cce99ca4876633c4b7b89ec085323600bd3d47aeacd306/flash_linear_attention-0.5.2-py3-none-any.whl", hash = "sha256:dcf405d81f5426393b59037097aa700d0f4a841465d5028d5aa543f4502f2400", size = 399590, upload-time = "2026-07-27T18:26:17.912Z" },
 ]
 
 [[package]]
@@ -4283,7 +4283,7 @@ requires-dist = [
     { name = "flash-attn-3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/Luosuu/flash-attention3-wheels/releases/download/v0.0.5/flash_attn_3-3.0.0+20260610.cu130torch2110cxx11abitrue.fb02fc.sm90-cp310-abi3-linux_x86_64.whl" },
     { name = "flash-attn-4", marker = "extra == 'gpu'", specifier = "==4.0.0b16" },
     { name = "flash-attn-cute", marker = "sys_platform == 'linux' and extra == 'gpu'", git = "https://github.com/demonatic/flash-attention.git?subdirectory=flash_attn&rev=ee1d15159cda6f3f97bfab9e487da146a8254970" },
-    { name = "flash-linear-attention", marker = "extra == 'gpu'" },
+    { name = "flash-linear-attention", marker = "extra == 'gpu'", specifier = ">=0.5.2,<0.6" },
     { name = "flash-mla", marker = "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/Luosuu/flash-mla-wheels/releases/download/v1.0.0-9241ae3-torch211cu130/flash_mla-1.0.0%2B9241ae3-1torch211cu130cuda130sm90asm100f-cp311-cp311-linux_aarch64.whl" },
     { name = "flash-mla", marker = "(python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu')" },
     { name = "flash-mla", marker = "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/Luosuu/flash-mla-wheels/releases/download/v1.0.0-9241ae3-torch211cu130/flash_mla-1.0.0%2B9241ae3-1torch211cu130cuda130sm90asm100f-cp312-cp312-linux_aarch64.whl" },


### PR DESCRIPTION
### What does this PR do?

> Require `flash-linear-attention>=0.5.2,<0.6` for the GPU extra and refresh the lockfile to `flash-linear-attention==0.5.2` / `fla-core==0.5.2`.
>
> This addresses the intermittent checkpoint recomputation failure in #979. The underlying Blackwell Gated DeltaNet nondeterminism was isolated in [FLA #945](https://github.com/fla-org/flash-linear-attention/issues/945), fixed by [FLA #953](https://github.com/fla-org/flash-linear-attention/pull/953), and released in [FLA v0.5.2](https://github.com/fla-org/flash-linear-attention/releases/tag/v0.5.2).

### Checklist Before Starting

- [x] Searched related issues and PRs: VeOmni #979; FLA #945 and #953
- [x] PR title follows `[{modules}] {type}: {description}` format

### Test

> - `uv lock --check`: passed (240 packages resolved)
> - `pre-commit run --all-files`: passed
> - `make quality`: passed (633 files already formatted)
> - `pytest -q tests/distributed/test_torch_compile.py`: 43 passed, 1 skipped
> - `pytest -q tests/distributed/test_fsdp_equivalence.py`: 5 skipped because the local host does not have the required two GPUs
> - Imported the published `flash-linear-attention==0.5.2` and `fla-core==0.5.2` artifacts successfully
> - Confirmed the published `fla-core==0.5.2` source restricts the affected Blackwell GDN forward kernel to `num_warps=[2]`
>
> The full EP + Ulysses + checkpoint reproduction was not run locally because this host has no Blackwell GPU. Dependency and host-side checks are not presented as a B300 runtime validation.

### API and Usage Example

> N/A. This changes only GPU dependency resolution.

### Design & Code Changes

> - Add a 0.5.2 minimum so GPU installs cannot resolve FLA releases predating the Blackwell determinism fix.
> - Keep an upper bound below 0.6 so non-lockfile installs do not cross into an unvalidated pre-1.0 minor release.
> - Refresh only the FLA and `fla-core` lock entries; no VeOmni router, checkpoint, or EP runtime code changes.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Added an inline dependency comment explaining the version floor
- [x] No CI test added: the failing Triton kernel is upstream and requires Blackwell hardware; the dependency range and lockfile are the local regression gates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the optional GPU dependency requirement to a supported version range for improved compatibility and installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->