### PR TITLE
Replace deprecated v2.ToTensor() with v2.ToImage() + v2.ToDtype(scale=True)

### DIFF
--- a/veomni/data/diffusion/preprocess/origin_dataset.py
+++ b/veomni/data/diffusion/preprocess/origin_dataset.py
@@ -54,7 +54,8 @@ class TextVideoDataset(torch.utils.data.Dataset):
             [
                 v2.CenterCrop(size=(height, width)),
                 v2.Resize(size=(height, width), antialias=True),
-                v2.ToTensor(),
+                v2.ToImage(),
+                v2.ToDtype(torch.float32, scale=True),
                 v2.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
             ]
         )


### PR DESCRIPTION
Fix #1102

## Summary

Replaces the deprecated `v2.ToTensor()` in `veomni/data/diffusion/preprocess/origin_dataset.py` with the officially recommended `v2.ToImage()` + `v2.ToDtype(torch.float32, scale=True)`.

`v2.ToTensor()` has emitted a `UserWarning` on construction since torchvision 0.15 (first release of the v2 namespace); the warning text explicitly recommends this exact replacement:

> The transform `ToTensor()` is deprecated and will be removed in a future release. Instead, please use `v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])`. Output is equivalent up to float precision.

## Changes

- `veomni/data/diffusion/preprocess/origin_dataset.py`: `v2.ToTensor()` → `v2.ToImage()` + `v2.ToDtype(torch.float32, scale=True)` inside the existing `v2.Compose`.

## Validation

Verified with torchvision 0.26.0 (CPU): the replacement pipeline constructs cleanly under `-W error::UserWarning`, and its output is identical to the old pipeline up to float precision (max abs diff ≈ 1e-7, single last-bit rounding on uint8→float32 scaling).

## Note

仅替换 v2.ToTensor(消除警告的最小改动);issue 中提到的 v1 管线统一(行 160)为可选项,本 PR 未包含。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video frame preprocessing to ensure frames are converted to images and consistently represented as scaled 32-bit floating-point data.
  * Preserved existing normalization behavior for processed frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->