### PR TITLE
[ops] Add opt-in `nabla` Triton backends for RMSNorm and SwiGLU MLP

### DIFF
--- a/tests/ops/test_nabla_kernels.py
+++ b/tests/ops/test_nabla_kernels.py
@@ -1,0 +1,234 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the opt-in ``nabla`` kernels (RMSNorm, SwiGLU SiLU-mul).
+
+Structure mirrors ``test_kernel_registry_numerical.py``: CPU-runnable parts
+(registry wiring, torch fallback) run everywhere; the Triton paths are gated
+on CUDA.  Because these are *training* kernels, the CUDA tests check the
+backward pass too (grad_x / grad_weight / grad_gate / grad_up) against an
+fp32 eager oracle, not just the forward output.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import veomni.ops  # noqa: F401 -- trigger KERNEL_REGISTRY registrations
+from veomni.ops.config.registry import get_op
+from veomni.ops.dispatch import OpSlot
+from veomni.ops.kernel_registry import KERNEL_REGISTRY
+from veomni.utils.device import IS_CUDA_AVAILABLE
+
+
+DEVICE = "cuda" if IS_CUDA_AVAILABLE else "cpu"
+
+# ---------------------------------------------------------------------------
+# Eager fp32 oracles
+# ---------------------------------------------------------------------------
+
+
+def _eager_rms_norm(x, weight, eps):
+    # fp32-accumulation oracle with a single cast at the end — the same
+    # rounding order as the nabla kernels. The cast-early HF-style oracle
+    # (normalize -> cast to bf16 -> multiply) injects ~1 bf16 ULP per element
+    # into the output and O(sqrt(M) * ULP) noise into grad_weight, which
+    # measures the oracle's rounding style, not the kernel's math.
+    x_f = x.to(torch.float32)
+    variance = x_f.pow(2).mean(-1, keepdim=True)
+    x_n = x_f * torch.rsqrt(variance + eps)
+    return (weight.to(torch.float32) * x_n).to(x.dtype)
+
+
+def _eager_silu_mul(gate, up):
+    dtype = gate.dtype
+    return (torch.nn.functional.silu(gate.to(torch.float32)) * up.to(torch.float32)).to(dtype)
+
+
+# ---------------------------------------------------------------------------
+# CPU-runnable: registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_registry_lists_nabla_kernels():
+    assert "nabla" in KERNEL_REGISTRY.list_available("rms_norm", "standard")
+    assert "nabla" in KERNEL_REGISTRY.list_available("swiglu_mlp", "standard")
+
+
+def test_opspec_has_nabla_backend_and_default_unchanged():
+    rms = get_op("rms_norm")
+    assert rms.default == "liger_kernel"
+    assert "nabla" in rms.backends
+    assert rms.backends["nabla"].requires == ("triton",)
+
+    swiglu = get_op("swiglu_mlp")
+    assert swiglu.default == "liger_kernel"
+    assert "nabla" in swiglu.backends
+    assert swiglu.backends["nabla"].requires == ("triton",)
+
+
+# ---------------------------------------------------------------------------
+# CPU-runnable: torch fallback correctness (fwd + bwd)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_rms_norm_fallback_matches_eager_fwd_bwd(dtype):
+    from veomni.ops.kernels.rms_norm.nabla import rms_norm
+
+    x = torch.randn(4, 8, 128, dtype=dtype, requires_grad=True)
+    w = torch.randn(128, dtype=dtype, requires_grad=True)
+    dout = torch.randn(4, 8, 128, dtype=dtype)
+
+    out = rms_norm(x, w, 1e-6)
+    gx, gw = torch.autograd.grad(out, (x, w), dout)
+
+    x_e = x.detach().clone().requires_grad_(True)
+    w_e = w.detach().clone().requires_grad_(True)
+    out_e = _eager_rms_norm(x_e, w_e, 1e-6)
+    gx_e, gw_e = torch.autograd.grad(out_e, (x_e, w_e), dout)
+
+    # Same rounding order on both sides (fp32 end-to-end, single final cast):
+    # only fp32 accumulation order differs.
+    assert torch.allclose(out, out_e, atol=2e-3, rtol=2e-3)
+    # grads accumulate over rows; bf16 rounding on the leaf cast dominates.
+    assert torch.allclose(gx, gx_e, atol=2e-2, rtol=2e-2)
+    assert torch.allclose(gw, gw_e, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_silu_mul_fallback_matches_eager_fwd_bwd(dtype):
+    from veomni.ops.kernels.swiglu.nabla import silu_mul
+
+    gate = torch.randn(4, 8, 96, dtype=dtype, requires_grad=True)
+    up = torch.randn(4, 8, 96, dtype=dtype, requires_grad=True)
+    dout = torch.randn(4, 8, 96, dtype=dtype)
+
+    out = silu_mul(gate, up)
+    gg, gu = torch.autograd.grad(out, (gate, up), dout)
+
+    gate_e = gate.detach().clone().requires_grad_(True)
+    up_e = up.detach().clone().requires_grad_(True)
+    out_e = _eager_silu_mul(gate_e, up_e)
+    gg_e, gu_e = torch.autograd.grad(out_e, (gate_e, up_e), dout)
+
+    assert torch.allclose(out, out_e, atol=2e-3, rtol=2e-3)
+    assert torch.allclose(gg, gg_e, atol=2e-2, rtol=2e-2)
+    assert torch.allclose(gu, gu_e, atol=2e-2, rtol=2e-2)
+
+
+def test_nabla_rmsnorm_module_matches_eager():
+    from veomni.ops.kernels.rms_norm.nabla import NablaRMSNorm
+
+    mod = NablaRMSNorm(64, eps=1e-6)
+    x = torch.randn(2, 8, 64, dtype=torch.float32)
+    assert torch.allclose(mod(x), _eager_rms_norm(x, mod.weight, 1e-6), atol=1e-5, rtol=1e-5)
+
+
+def test_nabla_swiglu_mlp_module_matches_eager():
+    from veomni.ops.kernels.swiglu.nabla import NablaSwiGLUMLP
+
+    config = SimpleNamespace(hidden_size=32, intermediate_size=64, hidden_act="silu")
+    mlp = NablaSwiGLUMLP(config)
+    eager = SimpleNamespace(gate_proj=mlp.gate_proj, up_proj=mlp.up_proj, down_proj=mlp.down_proj)
+    x = torch.randn(2, 4, 32, dtype=torch.float32)
+    out_kernel = mlp(x)
+    out_eager = eager.down_proj(torch.nn.functional.silu(eager.gate_proj(x)) * eager.up_proj(x))
+    assert torch.allclose(out_kernel, out_eager, atol=1e-5, rtol=1e-5)
+
+    with pytest.raises(ValueError, match="not supported"):
+        NablaSwiGLUMLP(SimpleNamespace(hidden_size=32, intermediate_size=64, hidden_act="gelu"))
+
+
+# ---------------------------------------------------------------------------
+# CUDA-gated: Triton paths through the OpSlot dispatch
+# ---------------------------------------------------------------------------
+
+pytestmark_cuda = pytest.mark.skipif(not IS_CUDA_AVAILABLE, reason="nabla Triton kernels require CUDA")
+
+
+@pytestmark_cuda
+def test_rms_norm_nabla_triton_matches_eager_fwd_bwd():
+    slot = OpSlot("rms_norm", "standard")
+    slot.bind("nabla")
+
+    # 3-D call shape used by the generated modeling code ((B, S, H)).
+    x = torch.randn(2, 16, 128, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+    w = torch.randn(128, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+    dout = torch.randn(2, 16, 128, device=DEVICE, dtype=torch.bfloat16)
+
+    out = slot(x, w, 1e-6)
+    gx, gw = torch.autograd.grad(out, (x, w), dout)
+
+    x_e = x.detach().clone().requires_grad_(True)
+    w_e = w.detach().clone().requires_grad_(True)
+    out_e = _eager_rms_norm(x_e, w_e, 1e-6)
+    gx_e, gw_e = torch.autograd.grad(out_e, (x_e, w_e), dout)
+
+    # Single-pass reduction + fp32 kept end-to-end with a single final cast,
+    # same rounding order as the oracle above.
+    assert torch.allclose(out, out_e, atol=2e-3, rtol=2e-3)
+    # grads: fp32 accumulation inside the kernel; bf16 rounding on the leaf
+    # cast and on the 2x16-row reduction for grad_weight dominate.
+    assert torch.allclose(gx, gx_e, atol=2e-2, rtol=2e-2)
+    assert torch.allclose(gw, gw_e, atol=2e-2, rtol=2e-2)
+
+
+@pytestmark_cuda
+def test_rms_norm_nabla_triton_2d_3d_consistent():
+    slot = OpSlot("rms_norm", "standard")
+    slot.bind("nabla")
+
+    x3 = torch.randn(4, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+    w = torch.randn(128, device=DEVICE, dtype=torch.bfloat16)
+    assert torch.allclose(slot(x3, w, 1e-6), slot(x3.reshape(-1, 128), w, 1e-6).view_as(x3), atol=0, rtol=0)
+
+
+@pytestmark_cuda
+def test_swiglu_nabla_triton_matches_eager_fwd_bwd():
+    slot = OpSlot("swiglu_mlp", "standard")
+    slot.bind("nabla")
+
+    class _MLP(torch.nn.Module):
+        def __init__(self, dim, hidden):
+            super().__init__()
+            self.gate_proj = torch.nn.Linear(dim, hidden, bias=False)
+            self.up_proj = torch.nn.Linear(dim, hidden, bias=False)
+            self.down_proj = torch.nn.Linear(hidden, dim, bias=False)
+            self.act_fn = torch.nn.SiLU()
+
+    torch.manual_seed(0)
+    mlp = _MLP(128, 256).to(DEVICE).to(torch.bfloat16)
+    x = torch.randn(2, 16, 128, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+    dout = torch.randn(2, 16, 128, device=DEVICE, dtype=torch.bfloat16)
+
+    out = slot(mlp, x)
+    (gx,) = torch.autograd.grad(out, (x,), dout, retain_graph=True)
+    gg = torch.autograd.grad(out, (mlp.gate_proj.weight, mlp.up_proj.weight), dout, allow_unused=True)
+
+    x_e = x.detach().clone().requires_grad_(True)
+    # Eager reference with the SAME activation rounding order as the kernel
+    # (fp32 silu, single cast). A bf16 nn.SiLU reference injects ~1 bf16 ULP
+    # into every intermediate element, which the token-summing weight grads
+    # amplify beyond the tolerance — measuring rounding style, not math.
+    out_e = mlp.down_proj(_eager_silu_mul(mlp.gate_proj(x_e), mlp.up_proj(x_e)))
+    (gx_e,) = torch.autograd.grad(out_e, (x_e,), dout, retain_graph=True)
+    gg_e = torch.autograd.grad(out_e, (mlp.gate_proj.weight, mlp.up_proj.weight), dout, allow_unused=True)
+
+    # Three bf16 matmuls stack rounding; 5e-3 as in the liger swiglu test.
+    assert torch.allclose(out, out_e, atol=5e-3, rtol=5e-3)
+    assert torch.allclose(gx, gx_e, atol=5e-3, rtol=5e-3)
+    for g_k, g_e in zip(gg, gg_e):
+        assert torch.allclose(g_k, g_e, atol=5e-3, rtol=5e-3)

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -1061,13 +1061,15 @@ class OpsImplementationConfig:
         default="liger_kernel",
         metadata={
             "help": "RMSNorm. 'liger_kernel' (default, GPU) | 'npu' | "
-            "'triton' (DeepSeek-V3 batch-invariant; GPU only) | 'eager'."
+            "'triton' (DeepSeek-V3 batch-invariant; GPU only) | "
+            "'nabla' (single-kernel Triton fwd+bwd; GPU only) | 'eager'."
         },
     )
     swiglu_mlp_implementation: str = field(
         default="liger_kernel",
         metadata={
-            "help": "SwiGLU MLP. 'liger_kernel' (default, GPU) | 'eager'. No NPU backend — NPU users must set 'eager'."
+            "help": "SwiGLU MLP. 'liger_kernel' (default, GPU) | "
+            "'nabla' (Triton fwd+bwd SiLU-mul core; GPU only) | 'eager'. No NPU backend — NPU users must set 'eager'."
         },
     )
     rotary_pos_emb_implementation: str = field(

--- a/veomni/ops/README.md
+++ b/veomni/ops/README.md
@@ -20,9 +20,9 @@ veomni/ops/
 │   ├── deepseek_v4/        TileLang sparse attention/indexer + precision helpers
 │   ├── load_balancing_loss/  eager + triton fused kernel
 │   ├── mhc/                TileKernels mHC pre/post/head adapters
-│   ├── rms_norm/           Liger / NPU / triton batch-invariant
+│   ├── rms_norm/           Liger / NPU / triton batch-invariant / nabla
 │   ├── rotary/             Liger / NPU / deterministic / Wan Triton
-│   ├── swiglu/             Liger SwiGLU MLP
+│   ├── swiglu/             Liger SwiGLU MLP / nabla
 │   └── moe/                Fused MoE + _kernels/ (group_gemm, quack_gemm)
 ├── platform/               Platform-specific runtime patches
 │   └── npu/                HCCL pre-mul sum patch
@@ -50,9 +50,9 @@ depending on when and where the kernel is bound:
 | Attention | `attn_implementation` | import-time | `flash_attention_2` | `eager`, `sdpa`, `flash_attention_2/3/4`, `flex_attention`, `magi_attention`, `native-sparse` |
 | Cross-entropy loss | `cross_entropy_loss_implementation` | LOSS_MAPPING | `eager` | `eager`, `liger_kernel`, `npu` (chunked loss) |
 | Load-balancing loss | `load_balancing_loss_implementation` | GLOBAL | `eager` | `eager`, `triton` |
-| RMSNorm | `rms_norm_implementation` | PER_MODEL | `eager` | `liger_kernel`, `npu`, `triton`\* |
+| RMSNorm | `rms_norm_implementation` | PER_MODEL | `eager` | `liger_kernel`, `npu`, `triton`\*, `nabla` |
 | Rotary pos emb | `rotary_pos_emb_implementation` | PER_MODEL | `eager` | `liger_kernel`, `npu`, `triton`\* |
-| SwiGLU MLP | `swiglu_mlp_implementation` | PER_MODEL | `eager` | `liger_kernel` |
+| SwiGLU MLP | `swiglu_mlp_implementation` | PER_MODEL | `eager` | `liger_kernel`, `nabla` |
 | mHC | `mhc_implementation` | build-time `OpSlot` | `eager` | `tilelang` (DeepSeek V4, SM90+; provided by `tile-kernels`) |
 | Fused MoE | `moe_implementation` | build-time | `eager` | `eager`, `fused_triton` (group-gemm, SM70+), `fused_quack` (CUTLASS/CuTe, SM90+), `fused_npu` (Ascend). Mismatches raise instead of falling back. |
 

--- a/veomni/ops/kernels/rms_norm/__init__.py
+++ b/veomni/ops/kernels/rms_norm/__init__.py
@@ -19,6 +19,10 @@ Default per-model backends:
     - ``npu``: ``torch_npu.npu_rms_norm`` via ``veomni.ops.kernels.rms_norm.npu``
 Models can register a ``triton`` backend via ``extra_backends`` in their
 ``device_patch.py`` (e.g. DeepSeek V3 batch-invariant kernel).
+
+Opt-in GPU backend:
+    - ``nabla``: single-kernel Triton fwd+bwd (grad_weight accumulated in one
+      fp32 buffer via atomics), validated on H100 against liger v0.7.0.
 """
 
 from ...config.registry import BackendSpec, OpScope, OpSpec, register_op
@@ -37,12 +41,36 @@ register_op(
                 entry="liger_kernel.transformers.rms_norm:LigerRMSNorm",
                 requires=("liger_kernel",),
             ),
+            "nabla": BackendSpec(
+                entry="veomni.ops.kernels.rms_norm.nabla:NablaRMSNorm",
+                requires=("triton",),
+            ),
             "npu": BackendSpec(
                 entry="veomni.ops.kernels.rms_norm.npu:rms_norm_forward_npu",
                 requires=("torch_npu",),
                 replace_forward=True,
             ),
         },
+    )
+)
+
+
+def _nabla_rms_norm_factory():
+    """Return the functional Nabla fused RMSNorm kernel (standard formulation)."""
+
+    from .nabla import rms_norm
+
+    return rms_norm
+
+
+KERNEL_REGISTRY.register(
+    KernelSpec(
+        name="nabla",
+        op_name="rms_norm",
+        variant="standard",
+        factory=_nabla_rms_norm_factory,
+        hardware=HardwareRequirement(device_type="gpu"),
+        description="Nabla fused RMSNorm (single-kernel Triton fwd+bwd)",
     )
 )
 

--- a/veomni/ops/kernels/rms_norm/nabla.py
+++ b/veomni/ops/kernels/rms_norm/nabla.py
@@ -1,0 +1,198 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Nabla fused RMSNorm (Triton forward + backward).
+
+Ported from the Nabla kernel-optimization project (Apache-2.0), where this
+kernel was validated on H100 against liger-kernel v0.7.0 with an fp32 oracle:
+output, grad_x and grad_weight all pass bf16 tolerances (atol=7e-2,
+rtol=2e-2), and fwd+bwd latency is 1.41-1.48x liger at training shapes
+(M in {2048, 4096, 8192}, hidden=2048, bf16) — the win comes from the
+single-kernel backward (grad_weight accumulated in-place via ``tl.atomic_add``
+into one fp32 buffer) instead of liger's partials + separate reduction pass.
+
+Formulation is the standard one (matches ``LigerRMSNorm`` with offset=0.0,
+casting_mode="llama"):
+
+    out = x / sqrt(mean(x^2, dim=-1) + eps) * weight
+
+The Triton path requires a 2-D contiguous CUDA input; N-D inputs are flattened
+per call. Anything the Triton path cannot handle (CPU tensors, missing Triton,
+non-contiguous weight) transparently falls back to an fp32-accumulation pure
+torch implementation.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+try:
+    import triton
+    import triton.language as tl
+
+    _HAS_TRITON = True
+except ImportError:
+    _HAS_TRITON = False
+
+
+def _torch_rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    orig_dtype = x.dtype
+    x_f = x.float()
+    variance = x_f.pow(2).mean(dim=-1, keepdim=True)
+    out = x_f * torch.rsqrt(variance + eps) * weight.float()
+    return out.to(orig_dtype)
+
+
+def _num_warps_for(block: int) -> int:
+    if block >= 8192:
+        return 16
+    if block >= 4096:
+        return 8
+    if block >= 2048:
+        return 4
+    return 2
+
+
+if _HAS_TRITON:
+
+    @triton.jit
+    def _rmsnorm_fwd_kernel(
+        X,
+        W,
+        Y,
+        Rstd,
+        stride_row,
+        N,
+        eps,
+        BLOCK: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        cols = tl.arange(0, BLOCK)
+        mask = cols < N
+        x = tl.load(X + row * stride_row + cols, mask=mask, other=0.0).to(tl.float32)
+        var = tl.sum(x * x, axis=0) / N
+        rstd = 1.0 / tl.sqrt(var + eps)
+        tl.store(Rstd + row, rstd)
+        w = tl.load(W + cols, mask=mask, other=0.0).to(tl.float32)
+        y = x * rstd * w
+        tl.store(Y + row * stride_row + cols, y.to(Y.dtype.element_ty), mask=mask)
+
+    @triton.jit
+    def _rmsnorm_bwd_kernel(
+        DY,
+        X,
+        W,
+        Rstd,
+        DX,
+        DW,
+        stride_row,
+        N,
+        BLOCK: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        cols = tl.arange(0, BLOCK)
+        mask = cols < N
+        x = tl.load(X + row * stride_row + cols, mask=mask, other=0.0).to(tl.float32)
+        dy = tl.load(DY + row * stride_row + cols, mask=mask, other=0.0).to(tl.float32)
+        w = tl.load(W + cols, mask=mask, other=0.0).to(tl.float32)
+        rstd = tl.load(Rstd + row)
+
+        xhat = x * rstd
+        wdy = w * dy
+        c = tl.sum(xhat * wdy, axis=0) / N
+        dx = (wdy - xhat * c) * rstd
+        tl.store(DX + row * stride_row + cols, dx.to(DX.dtype.element_ty), mask=mask)
+        # grad_weight_j = sum_over_rows(dy_j * xhat_j); fp32 accumulation.
+        tl.atomic_add(DW + cols, dy * xhat, mask=mask)
+
+
+def _rmsnorm_fwd_launch(x: torch.Tensor, weight: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
+    m, n = x.shape
+    y = torch.empty_like(x)
+    rstd = torch.empty((m,), dtype=torch.float32, device=x.device)
+    block = triton.next_power_of_2(n)
+    _rmsnorm_fwd_kernel[(m,)](x, weight, y, rstd, x.stride(0), n, eps, BLOCK=block, num_warps=_num_warps_for(block))
+    return y, rstd
+
+
+def _rmsnorm_bwd_launch(
+    dy: torch.Tensor, x: torch.Tensor, weight: torch.Tensor, rstd: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m, n = x.shape
+    dy = dy.contiguous()
+    dx = torch.empty_like(x)
+    dw_f32 = torch.zeros((n,), dtype=torch.float32, device=x.device)
+    block = triton.next_power_of_2(n)
+    _rmsnorm_bwd_kernel[(m,)](
+        dy, x, weight, rstd, dx, dw_f32, x.stride(0), n, BLOCK=block, num_warps=_num_warps_for(block)
+    )
+    return dx, dw_f32.to(weight.dtype)
+
+
+class NablaRMSNormFunction(torch.autograd.Function):
+    """Fused RMSNorm forward + backward (Triton)."""
+
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:  # type: ignore[override]
+        y, rstd = _rmsnorm_fwd_launch(x, weight, eps)
+        ctx.save_for_backward(x, weight, rstd)
+        return y
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):  # type: ignore[override]
+        x, weight, rstd = ctx.saved_tensors
+        dx, dw = _rmsnorm_bwd_launch(grad_output, x, weight, rstd)
+        return dx, dw, None
+
+
+def _can_use_triton(x: torch.Tensor, weight: torch.Tensor) -> bool:
+    return (
+        _HAS_TRITON
+        and x.is_cuda
+        and weight.is_cuda
+        and x.dim() >= 2
+        and x.is_contiguous()
+        and weight.is_contiguous()
+        and weight.numel() == x.shape[-1]
+    )
+
+
+def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """Functional fused RMSNorm, matching the OpSlot call shape ``(x, weight, eps)``.
+
+    Accepts ``(B, S, H)`` (flattened internally) or ``(BxS, H)`` inputs. Triton
+    fwd+bwd when possible, fp32-accumulation torch fallback otherwise.
+    """
+    if _can_use_triton(x, weight):
+        shape = x.shape
+        x2d = x.reshape(-1, shape[-1])  # contiguous guaranteed -> always a view
+        return NablaRMSNormFunction.apply(x2d, weight, eps).view(*shape)
+    return _torch_rms_norm(x, weight, eps)
+
+
+class NablaRMSNorm(torch.nn.Module):
+    """Drop-in RMSNorm module for the ``rms_norm_implementation="nabla"`` backend.
+
+    ABI-compatible with ``LigerRMSNorm`` / HF ``{Model}RMSNorm``: constructed as
+    ``NablaRMSNorm(hidden_size, eps=...)`` and called as ``module(hidden_states)``.
+    """
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return rms_norm(hidden_states, self.weight, self.variance_epsilon)

--- a/veomni/ops/kernels/swiglu/__init__.py
+++ b/veomni/ops/kernels/swiglu/__init__.py
@@ -16,9 +16,14 @@
 
 Default per-model backend:
     - ``liger_kernel``: ``liger_kernel.transformers.swiglu.LigerSwiGLUMLP``
+
+Opt-in GPU backend:
+    - ``nabla``: Triton fwd+bwd SiLU-mul activation core (projections stay on
+      cuBLAS), validated on H100 against liger v0.7.0.
 """
 
 from ...config.registry import BackendSpec, OpScope, OpSpec, register_op
+from ...kernel_registry import KERNEL_REGISTRY, HardwareRequirement, KernelSpec
 
 
 register_op(
@@ -33,6 +38,30 @@ register_op(
                 entry="liger_kernel.transformers.swiglu:LigerSwiGLUMLP",
                 requires=("liger_kernel",),
             ),
+            "nabla": BackendSpec(
+                entry="veomni.ops.kernels.swiglu.nabla:NablaSwiGLUMLP",
+                requires=("triton",),
+            ),
         },
+    )
+)
+
+
+def _nabla_swiglu_factory():
+    """Return the OpSlot-shaped Nabla SwiGLU forward (fused SiLU-mul core)."""
+
+    from .nabla import nabla_swiglu_forward
+
+    return nabla_swiglu_forward
+
+
+KERNEL_REGISTRY.register(
+    KernelSpec(
+        name="nabla",
+        op_name="swiglu_mlp",
+        variant="standard",
+        factory=_nabla_swiglu_factory,
+        hardware=HardwareRequirement(device_type="gpu"),
+        description="Nabla fused SwiGLU MLP (Triton SiLU-mul activation core)",
     )
 )

--- a/veomni/ops/kernels/swiglu/nabla.py
+++ b/veomni/ops/kernels/swiglu/nabla.py
@@ -1,0 +1,172 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Nabla fused SiLU-mul (Triton forward + backward) and SwiGLU MLP.
+
+Ported from the Nabla kernel-optimization project (Apache-2.0), where the
+activation core was validated on H100 against liger-kernel v0.7.0 with an
+fp32 oracle: output, grad_gate and grad_up all pass bf16 tolerances
+(atol=7e-2, rtol=2e-2); fwd+bwd latency is 1.10-1.13x liger at training
+shapes (M in {2048, 4096, 8192}, intermediate=768, bf16).
+
+Only the fusable activation core ``silu(gate) * up`` is fused; the
+gate/up/down projections stay on cuBLAS, exactly like
+``LigerSiLUMulFunction`` / ``LigerSwiGLUMLP``:
+
+    out = silu(gate) * up        # silu(x) = x * sigmoid(x)
+
+The Triton path requires contiguous CUDA tensors; anything else (CPU,
+missing Triton, non-contiguous / mismatched inputs) transparently falls back
+to an fp32 pure-torch implementation.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+try:
+    import triton
+    import triton.language as tl
+
+    _HAS_TRITON = True
+except ImportError:
+    _HAS_TRITON = False
+
+_BLOCK = 1024
+
+
+def _torch_silu_mul(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    orig_dtype = gate.dtype
+    return (F.silu(gate.float()) * up.float()).to(orig_dtype)
+
+
+if _HAS_TRITON:
+
+    @triton.jit
+    def _silu_mul_fwd_kernel(GATE, UP, OUT, n_elements, BLOCK: tl.constexpr):
+        pid = tl.program_id(0)
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < n_elements
+        g = tl.load(GATE + offs, mask=mask, other=0.0).to(tl.float32)
+        u = tl.load(UP + offs, mask=mask, other=0.0).to(tl.float32)
+        s = tl.sigmoid(g)
+        out = g * s * u
+        tl.store(OUT + offs, out.to(OUT.dtype.element_ty), mask=mask)
+
+    @triton.jit
+    def _silu_mul_bwd_kernel(GATE, UP, DOUT, DGATE, DUP, n_elements, BLOCK: tl.constexpr):
+        pid = tl.program_id(0)
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < n_elements
+        g = tl.load(GATE + offs, mask=mask, other=0.0).to(tl.float32)
+        u = tl.load(UP + offs, mask=mask, other=0.0).to(tl.float32)
+        do = tl.load(DOUT + offs, mask=mask, other=0.0).to(tl.float32)
+        s = tl.sigmoid(g)
+        silu = g * s
+        dsilu = s * (1.0 + g * (1.0 - s))
+        dgate = do * u * dsilu
+        dup = do * silu
+        tl.store(DGATE + offs, dgate.to(DGATE.dtype.element_ty), mask=mask)
+        tl.store(DUP + offs, dup.to(DUP.dtype.element_ty), mask=mask)
+
+
+def _grid(n_elements: int) -> tuple[int, ...]:
+    return (triton.cdiv(n_elements, _BLOCK),)
+
+
+def _silu_mul_fwd_launch(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(gate)
+    n = gate.numel()
+    _silu_mul_fwd_kernel[_grid(n)](gate, up, out, n, BLOCK=_BLOCK)
+    return out
+
+
+def _silu_mul_bwd_launch(
+    gate: torch.Tensor, up: torch.Tensor, grad_out: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    grad_out = grad_out.contiguous()
+    dgate = torch.empty_like(gate)
+    dup = torch.empty_like(up)
+    n = gate.numel()
+    _silu_mul_bwd_kernel[_grid(n)](gate, up, grad_out, dgate, dup, n, BLOCK=_BLOCK)
+    return dgate, dup
+
+
+class NablaSiLUMulFunction(torch.autograd.Function):
+    """Fused silu(gate) * up forward + backward (Triton)."""
+
+    @staticmethod
+    def forward(ctx, gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        out = _silu_mul_fwd_launch(gate, up)
+        ctx.save_for_backward(gate, up)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):  # type: ignore[override]
+        gate, up = ctx.saved_tensors
+        dgate, dup = _silu_mul_bwd_launch(gate, up, grad_output)
+        return dgate, dup
+
+
+def _can_use_triton(gate: torch.Tensor, up: torch.Tensor) -> bool:
+    return (
+        _HAS_TRITON
+        and gate.is_cuda
+        and up.is_cuda
+        and gate.is_contiguous()
+        and up.is_contiguous()
+        and gate.shape == up.shape
+    )
+
+
+def silu_mul(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    """Fused ``silu(gate) * up``. Triton fwd+bwd when possible, torch fallback otherwise."""
+    if _can_use_triton(gate, up):
+        return NablaSiLUMulFunction.apply(gate, up)
+    return _torch_silu_mul(gate, up)
+
+
+def nabla_swiglu_forward(module: torch.nn.Module, x: torch.Tensor) -> torch.Tensor:
+    """OpSlot-shaped SwiGLU MLP forward: replaces ``{Model}MLP.forward(self, x)``.
+
+    Same shape as the registered liger kernel: the module supplies
+    ``gate_proj`` / ``up_proj`` / ``down_proj``; only the activation core is
+    fused, the projections stay on cuBLAS.
+    """
+    return module.down_proj(silu_mul(module.gate_proj(x), module.up_proj(x)))
+
+
+class NablaSwiGLUMLP(torch.nn.Module):
+    """Drop-in SwiGLU MLP module for the ``swiglu_mlp_implementation="nabla"`` backend.
+
+    ABI-compatible with ``LigerSwiGLUMLP``: constructed as
+    ``NablaSwiGLUMLP(config)`` where ``config`` exposes ``hidden_size``,
+    ``intermediate_size`` and ``hidden_act``.
+    """
+
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = torch.nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = torch.nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = torch.nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        if config.hidden_act not in ["silu", "swish"]:
+            raise ValueError(f"Activation function {config.hidden_act} not supported.")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(silu_mul(self.gate_proj(x), self.up_proj(x)))


### PR DESCRIPTION
## Summary

This PR adds the **Nabla** fused Triton kernels as a new, **opt-in, default-off** backend (`"nabla"`) for the `rms_norm` and `swiglu_mlp` ops, selectable via the existing config-driven kernel-selection layer. Defaults are untouched (`liger_kernel` stays); nothing changes for existing users.

Both kernels are training kernels (forward **and** backward), ported from the [Nabla](https://github.com/zhangxin81/nabla) kernel-optimization project (Apache-2.0) where they were validated on H100 against liger-kernel **v0.7.0** with an fp32/fp64 oracle: output and **all gradients** (grad_x / grad_weight / grad_gate / grad_up) pass bf16 tolerances (atol=7e-2, rtol=2e-2).

**H100 benchmark vs liger-kernel v0.7.0** (fwd+bwd joint latency, bf16, geomean over production shapes):

| op | shapes (M×H / M×I) | geomean speedup | range |
|---|---|---|---|
| RMSNorm | 2048/4096/8192 × 2048 | **1.44x** | 1.41–1.48x |
| SwiGLU (SiLU-mul core) | 2048/4096/8192 × 768 | **1.12x** | 1.10–1.13x |

Attribution for the >1.2x RMSNorm result: at these shapes both sides are dominated by fixed per-call cost (fwd/bwd times are flat from M=1 to M=8192), and the win comes from the **single-kernel backward** — grad_weight is accumulated in one fp32 buffer via `tl.atomic_add` — instead of liger's backward chain (`zeros_like` memset for dX + kernel writing `_dW[sm_count, H]` fp32 partials + separate `.sum(dim=0)` reduction + dtype cast), plus a leaner host dispatch path. This is launch-overhead reduction, not an HBM-bandwidth win; the gap is expected to narrow at larger real training shapes.

## What's in the change

| file | change |
|---|---|
| `veomni/ops/kernels/rms_norm/nabla.py` | **new** — fused RMSNorm: single Triton fwd kernel + single Triton bwd kernel (atomic fp32 dW), fp32-accumulation torch fallback, functional `rms_norm(x, weight, eps)` for the OpSlot path, `NablaRMSNorm(hidden_size, eps=...)` module for the PER_MODEL path (HF `{Model}RMSNorm` ABI) |
| `veomni/ops/kernels/swiglu/nabla.py` | **new** — fused SiLU-mul activation core (Triton fwd+bwd, fp32 math; gate/up/down projections stay on cuBLAS), `nabla_swiglu_forward(module, x)` for OpSlot, `NablaSwiGLUMLP(config)` mirroring `LigerSwiGLUMLP` |
| `veomni/ops/kernels/rms_norm/__init__.py` | register `"nabla"` in `OpSpec.backends` (`requires=("triton",)`) and `KERNEL_REGISTRY` (`rms_norm`/`standard`); default unchanged |
| `veomni/ops/kernels/swiglu/__init__.py` | same for `swiglu_mlp`/`standard` |
| `veomni/arguments/arguments_types.py` | help strings document the new option |
| `veomni/ops/README.md` | backend tables updated |
| `tests/ops/test_nabla_kernels.py` | **new** — registry wiring (CPU), torch-fallback fwd+bwd correctness (CPU), CUDA-gated OpSlot tests: output + all grads vs fp32 oracles, 2D/3D consistency, MLP module path |

## Usage

```yaml
model:
  ops_implementation:
    rms_norm_implementation: nabla      # opt-in; default remains liger_kernel
    swiglu_mlp_implementation: nabla
```

Works through both dispatch paths: build-time `OpSlot` binding (generated modeling code, e.g. Qwen2/Qwen3-MoE/DeepSeek-V4 GPU patches) and `apply_per_model_patches` (device_patch models). NPU behavior is unchanged (the backend is GPU/Triton-only; selecting it on NPU fails validation as before).

## Test plan

- `tests/ops/test_nabla_kernels.py`: **11/11 passed on H100** (driver 535.129.03 / CUDA 12.9, torch 2.11.0+cu128, triton 3.6.0); CPU-runnable subset also green on a CPU-only host; `tests/ops/test_kernel_registry_sanity.py` 24/24 unaffected.
- `ruff check` + `ruff format --check` clean.
- Upstream validation (same kernels, nabla harness): full workload grid PASSED 6/6 per op with `input_mutation` empty on both sides; correctness gated on fp32 oracle (evidence: nabla repo `training/*/docs/results.md`, provenance row in `bench/results.jsonl`).

## Scope & honest limitations

- Validated at the **single-GPU kernel level** (correctness + fwd/bwd latency vs the upstream liger kernels). End-to-end training equivalence in a real VeOmni run (single-step loss/grad-norm parity, short convergence, 8-GPU A/B) is **not yet** done and is the required next step before any default change — none is proposed here.
- Benchmark workloads use Qwen3-30B-A3B dimensions (hidden=2048; intermediate=768 is an example placeholder pending a real MoE capture). Numbers should be re-measured on real captured shapes before being cited for production claims.
- Known upstream nuance (documented in the nabla campaign): liger v0.7.0's RMSNorm `grad_weight` itself deviates from an fp64 oracle by up to ~1 bf16 ULP at large |dW| under `casting_mode="llama"`; the nabla kernels are *more* accurate than upstream here (fp32 accumulation throughout), which is why the validation oracle is fp32/fp64 rather than liger output.

## Attribution

Kernels ported from the Nabla project (Apache-2.0), benchmark evidence and provenance recorded in that repo (`docs/results.md`, `docs/baseline_source.md`; liger baseline resolved at `7644a0f` = v0.7.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional GPU-accelerated `nabla` backends for RMSNorm and SwiGLU MLP operations.
  * Added Triton forward and backward execution with automatic fallback for unsupported inputs.
  * Added support for multidimensional RMSNorm inputs and validated activation configuration.
* **Documentation**
  * Updated kernel configuration guidance and operations documentation to describe `nabla` availability and requirements.
* **Tests**
  * Added comprehensive coverage for backend registration, CPU fallback behavior, gradients, and CUDA Triton execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->