### PR TITLE
[ops] feat: add the TileLang teacher-distribution kernel for the DeepSeek-V4 indexer

### DIFF
--- a/tests/ops/test_deepseek_v4_indexer_loss.py
+++ b/tests/ops/test_deepseek_v4_indexer_loss.py
@@ -252,7 +252,7 @@ def test_target_kernel_rejects_more_than_64_heads():
     lse = torch.zeros(1, 2, 128, device="cuda", dtype=torch.float32)
     # Matching on "64" alone would also be satisfied by the head-multiple assert
     # or by any message that happens to mention a shape of 64.
-    with pytest.raises(AssertionError, match="one block owns the head sum"):
+    with pytest.raises(RuntimeError, match="one block owns the head sum"):
         sparse_mqa_target_fwd_interface(q, kv, topk, lse)
 
 
@@ -267,7 +267,7 @@ def test_target_kernel_rejects_head_counts_the_interface_cannot_emit():
     _require_tilelang_cuda()
     from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target
 
-    with pytest.raises(AssertionError, match=r"padded to one of \(16, 32, 64\)"):
+    with pytest.raises(RuntimeError, match=r"padded to one of \(16, 32, 64\)"):
         sparse_mqa_target(48, 64, 64)
 
 
@@ -282,9 +282,9 @@ def test_target_kernel_rejects_non_bfloat16_inputs():
     topk = torch.zeros(1, 2, 64, device="cuda", dtype=torch.int32)
     lse = torch.zeros(1, 2, 16, device="cuda", dtype=torch.float32)
 
-    with pytest.raises(AssertionError, match="bfloat16-only, got q"):
+    with pytest.raises(RuntimeError, match="bfloat16-only, got q"):
         sparse_mqa_target_fwd_interface(q.to(torch.float16), kv, topk, lse)
-    with pytest.raises(AssertionError, match="bfloat16-only, got kv"):
+    with pytest.raises(RuntimeError, match="bfloat16-only, got kv"):
         sparse_mqa_target_fwd_interface(q, kv.to(torch.float16), topk, lse)
 
 

--- a/tests/ops/test_deepseek_v4_indexer_loss.py
+++ b/tests/ops/test_deepseek_v4_indexer_loss.py
@@ -1,0 +1,85 @@
+# Copyright 2026 ByteDance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+def reference_compressed_target(q, kv, attn_sink, topk_idxs, compressed_start, sm_scale):
+    """Paper-correct teacher for DeepSeek-V3.2 eq. (4), in fp32.
+
+    Deliberately written without reference to any LSE: the per-head denominator
+    comes from one softmax over ``[selected slots ‖ sink]``, so the window and
+    sink contributions are structurally present. This is the property Megatron's
+    teacher violates (NVIDIA/Megatron-LM#5776) and the reason this reference must
+    never be replaced by a call into the implementation.
+
+    Args:
+        q:               [B, S, H, D] any float dtype
+        kv:              [B, S_kv, D] any float dtype
+        attn_sink:       [H]
+        topk_idxs:       [B, S, W + C] int, -1 for misses
+        compressed_start: W, the index where the compressed slice begins
+        sm_scale:        float
+
+    Returns:
+        [B, S, C] fp32, L1-normalised over the compressed slice.
+    """
+    b, s, h, d = q.shape
+    valid = topk_idxs >= 0
+    batch_index = torch.arange(b, device=kv.device).view(b, 1, 1)
+    gathered = kv[batch_index, topk_idxs.clamp_min(0)]  # [B, S, W + C, D]
+    logits = torch.einsum("bshd,bskd->bshk", q.float(), gathered.float()) * sm_scale
+    logits = logits.masked_fill(~valid.unsqueeze(2), float("-inf"))
+    sink = attn_sink.float().view(1, 1, h, 1).expand(b, s, h, 1)
+    probs = torch.softmax(torch.cat([logits, sink], dim=-1), dim=-1)[..., :-1]
+    compressed = probs[..., compressed_start:].sum(dim=2)  # head sum -> [B, S, C]
+    return compressed / compressed.sum(-1, keepdim=True).clamp_min(1e-20)
+
+
+def test_reference_target_responds_to_sink_and_window():
+    """The two perturbations Megatron's compressed-only teacher is blind to.
+
+    A per-head softmax over the compressed entries alone would make both of
+    these no-ops, so this test is what distinguishes a correct teacher from a
+    plausible one. Two heads with opposing preferences are required: with one
+    head the outer normalisation cancels the denominator entirely.
+    """
+    torch.manual_seed(0)
+    b, s, h, d, w, c = 1, 3, 2, 16, 2, 4
+    q = torch.randn(b, s, h, d)
+    kv = torch.randn(b, w + c, d)
+    topk = torch.arange(w + c).view(1, 1, -1).expand(b, s, -1).contiguous().to(torch.int32)
+    sink = torch.zeros(h)
+    scale = d**-0.5
+
+    base = reference_compressed_target(q, kv, sink, topk, w, scale)
+
+    bumped_sink = sink.clone()
+    bumped_sink[0] = 5.0
+    assert not torch.allclose(base, reference_compressed_target(q, kv, bumped_sink, topk, w, scale), atol=1e-4)
+
+    bumped_kv = kv.clone()
+    bumped_kv[:, 0] *= 4.0  # a window row, not a compressed row
+    assert not torch.allclose(base, reference_compressed_target(q, bumped_kv, sink, topk, w, scale), atol=1e-4)
+
+
+def test_reference_target_is_normalised():
+    torch.manual_seed(1)
+    q = torch.randn(2, 5, 4, 16)
+    kv = torch.randn(2, 12, 16)
+    topk = torch.randint(0, 12, (2, 5, 8), dtype=torch.int32)
+    topk[0, 0, 0] = -1
+    target = reference_compressed_target(q, kv, torch.zeros(4), topk, 4, 16**-0.5)
+    assert torch.allclose(target.sum(-1), torch.ones(2, 5), atol=1e-5)
+    assert (target >= 0).all()

--- a/tests/ops/test_deepseek_v4_indexer_loss.py
+++ b/tests/ops/test_deepseek_v4_indexer_loss.py
@@ -319,3 +319,26 @@ def test_target_kernel_emits_no_unexpected_warnings():
         if not any(known in str(w.message) for known in _TOLERATED_WARNING_SUBSTRINGS)
     ]
     assert not unexpected, "unexpected warning(s):\n" + "\n".join(unexpected)
+
+
+def test_sparse_attn_returns_non_differentiable_lse():
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4 import sparse_attn_tilelang
+
+    torch.manual_seed(3)
+    b, s, heads, d = 1, 8, 16, 64
+    q = torch.randn(b, s, heads, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    kv = torch.randn(b, 128, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    sink = torch.randn(heads, device="cuda", dtype=torch.float32, requires_grad=True)
+    topk = torch.randint(0, 128, (b, s, 64), device="cuda", dtype=torch.int32)
+
+    out_only = sparse_attn_tilelang(q, kv, sink, topk, d**-0.5)
+    out, lse = sparse_attn_tilelang(q, kv, sink, topk, d**-0.5, return_lse=True)
+
+    torch.testing.assert_close(out_only, out)
+    assert lse.shape == (b, s, heads)
+    assert lse.dtype == torch.float32
+    assert not lse.requires_grad, "the LSE feeds a detached teacher and must not open a path back into attention"
+
+    out.sum().backward()
+    assert q.grad is not None and torch.isfinite(q.grad).all()

--- a/tests/ops/test_deepseek_v4_indexer_loss.py
+++ b/tests/ops/test_deepseek_v4_indexer_loss.py
@@ -290,6 +290,23 @@ def test_target_kernel_rejects_non_bfloat16_inputs():
         sparse_mqa_target_fwd_interface(q, kv.to(torch.float16), topk, lse)
 
 
+def test_target_kernel_rejects_empty_kv():
+    """The gather clamps candidate rows into ``[0, S_kv - 1]``, so an empty kv
+    would clamp to row 0 of a tensor with no rows -- an out-of-bounds device read
+    that the candidate mask cannot prevent, since it only zeroes the score after
+    the gather. ``sparse_mqa_fwd_interface`` guards this; mirror it here."""
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
+
+    q = torch.randn(1, 2, 16, 64, device=DEVICE, dtype=torch.bfloat16)
+    kv = torch.randn(1, 0, 64, device=DEVICE, dtype=torch.bfloat16)
+    topk = torch.zeros(1, 2, 64, device=DEVICE, dtype=torch.int32)
+    lse = torch.zeros(1, 2, 16, device=DEVICE, dtype=torch.float32)
+
+    with pytest.raises(RuntimeError, match="at least one row"):
+        sparse_mqa_target_fwd_interface(q, kv, topk, lse)
+
+
 def test_target_kernel_emits_no_unexpected_warnings():
     """Pin the warning set, so a newly introduced warning is a failure rather than
     an unexplained bump in pytest's summary count.

--- a/tests/ops/test_deepseek_v4_indexer_loss.py
+++ b/tests/ops/test_deepseek_v4_indexer_loss.py
@@ -12,10 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 import pytest
 import torch
 
 from veomni.utils.device import IS_CUDA_AVAILABLE, get_gpu_compute_capability
+
+
+# Warnings this module tolerates, matched as substrings of the warning message.
+# Everything else fails test_target_kernel_emits_no_unexpected_warnings, so a new
+# warning cannot slip into a run unnoticed. Only add an entry for a warning that
+# provably originates outside this repository; a warning raised by our own code is
+# a bug to fix, not an entry here.
+_TOLERATED_WARNING_SUBSTRINGS = (
+    # tilelang deprecating one of its own pass-config keys. Raised from
+    # tilelang/transform/pass_config.py::normalize_pass_configs on every
+    # JITKernel construction, for the `TL_DISABLE_TMA_LOWER` config that every
+    # DeepSeek-V4 tilelang kernel in this tree sets -- including the attention
+    # forward these tests call to produce the LSE.
+    "`tl.disable_tma_lower` is deprecated",
+)
 
 
 def reference_compressed_target(q, kv, attn_sink, topk_idxs, compressed_start, sm_scale):
@@ -88,6 +105,31 @@ def test_reference_target_is_normalised():
     assert (target >= 0).all()
 
 
+def test_reference_target_all_invalid_compressed_row_is_zero():
+    """A query whose *compressed* slots are all misses is not a distribution.
+
+    ``test_reference_target_is_normalised`` only masks a slot in the window slice,
+    where the compressed mass is unaffected. When the whole compressed slice
+    misses, the mass being normalised is exactly zero and the ``clamp_min(1e-20)``
+    divides it by a floor instead of by itself, so the row comes out as zeros
+    rather than as a uniform distribution or a NaN. A later task takes a KL
+    against this row and has to tolerate it, so the contract is pinned here and
+    in ``test_target_kernel_all_invalid_compressed_row_is_zero`` for the kernel.
+    """
+    torch.manual_seed(3)
+    b, s, h, d, w, c = 1, 2, 2, 16, 4, 4
+    q = torch.randn(b, s, h, d)
+    kv = torch.randn(b, w + c, d)
+    topk = torch.arange(w + c).view(1, 1, -1).expand(b, s, -1).contiguous().to(torch.int32)
+    topk[0, 0, w:] = -1  # query 0 keeps a valid window and loses every compressed slot
+
+    target = reference_compressed_target(q, kv, torch.zeros(h), topk, w, d**-0.5)
+    assert (target[0, 0] == 0).all()
+    assert not torch.isnan(target).any()
+    # The zero row is local: the untouched query is still normalised.
+    assert torch.allclose(target[0, 1].sum(), torch.ones(()), atol=1e-5)
+
+
 def _require_tilelang_cuda():
     pytest.importorskip("tilelang")
     if torch.version.hip is not None or not IS_CUDA_AVAILABLE:
@@ -97,30 +139,46 @@ def _require_tilelang_cuda():
 
 
 @pytest.mark.parametrize("heads", [8, 16, 64])
-def test_target_kernel_matches_reference(heads):
+@pytest.mark.parametrize("c", [64, 128, 100])
+def test_target_kernel_matches_reference(heads, c):
     """``heads=8`` pads to 16 inside the kernel; the padded heads must contribute
     nothing to the head sum. That is not automatic — a padded head has zero Q and
-    would contribute ``exp2(0 - lse_pad)`` unless its LSE is padded to +inf."""
+    would contribute ``exp2(0 - lse_pad)`` unless its LSE is padded to +inf.
+
+    The ``c`` axis is the number of ``block_I``-sized slot tiles the kernel's
+    ``T.Pipelined(NI)`` loop runs, which is the axis production actually stresses:
+    ``index_topk = 512`` at ``block_I = 64`` is ``NI = 8``, never the ``NI = 1``
+    that ``c = 64`` alone exercises. ``c = 128`` gives ``NI = 2``, so the loop body
+    runs more than once against a reused ``tgt`` fragment and a moving output
+    slice. ``c = 100`` gives ``NI = 2`` *and* is not a multiple of ``block_I``, so
+    it is the only case that runs the interface's ``-1``-sentinel padding and the
+    final ``[:, :, :topk]`` slice that has to hide it again.
+    """
     _require_tilelang_cuda()
     from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_fwd import sparse_mqa_fwd_interface
     from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
 
     torch.manual_seed(0)
-    b, s, d, w, c = 2, 8, 64, 64, 64
+    b, s, d, w = 2, 8, 64, 64
     device = "cuda"
     q = torch.randn(b, s, heads, d, device=device, dtype=torch.bfloat16)
     kv = torch.randn(b, 256, d, device=device, dtype=torch.bfloat16)
     sink = torch.randn(heads, device=device, dtype=torch.float32)
     topk = torch.randint(0, 256, (b, s, w + c), device=device, dtype=torch.int32)
-    topk[0, 0, w] = -1  # a compressed miss
+    topk[0, 0, w] = -1  # a compressed miss in the first slot tile
+    topk[1, 0, w + c - 1] = -1  # and one in the last, which only NI > 1 reaches
     scale = d**-0.5
 
     _, lse = sparse_mqa_fwd_interface(q, kv, sink, topk, sm_scale=scale)
     actual = sparse_mqa_target_fwd_interface(q, kv, topk[:, :, w:].contiguous(), lse, sm_scale=scale)
+    # The sentinel padding a non-multiple ``c`` needs must not survive into the
+    # returned shape.
+    assert actual.shape == (b, s, c)
     actual = actual / actual.sum(-1, keepdim=True).clamp_min(1e-20)
 
     expected = reference_compressed_target(q, kv, sink, topk, w, scale)
-    # A normalised entry is ~1/C ~ 0.015 here, so a tolerance of the order of
+    # A normalised entry is ~1/C, i.e. 0.008 to 0.016 across this
+    # parametrisation, so a tolerance of the order of
     # 1e-2 would exceed the values being compared and accept anything. It is not
     # a hypothetical: summing the wrong axis of the score tile yields a
     # per-head row sum whose normalised form sits 1.5e-2 from the truth, i.e.
@@ -151,6 +209,39 @@ def test_target_kernel_zeroes_invalid_slots():
     assert (target[:, :, 3] == 0).all()
 
 
+def test_target_kernel_all_invalid_compressed_row_is_zero():
+    """The kernel's half of the contract pinned in
+    ``test_reference_target_all_invalid_compressed_row_is_zero``: an all-miss
+    compressed row comes back as exact zeros, and the caller's ``clamp_min``
+    normalisation leaves it as zeros rather than turning it into a NaN or a
+    uniform distribution."""
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_fwd import sparse_mqa_fwd_interface
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
+
+    torch.manual_seed(4)
+    b, s, heads, d, w, c = 1, 4, 16, 64, 64, 64
+    q = torch.randn(b, s, heads, d, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(b, 256, d, device="cuda", dtype=torch.bfloat16)
+    sink = torch.zeros(heads, device="cuda", dtype=torch.float32)
+    topk = torch.randint(0, 256, (b, s, w + c), device="cuda", dtype=torch.int32)
+    topk[0, 0, w:] = -1  # query 0 keeps a valid window and loses every compressed slot
+    scale = d**-0.5
+
+    _, lse = sparse_mqa_fwd_interface(q, kv, sink, topk, sm_scale=scale)
+    raw = sparse_mqa_target_fwd_interface(q, kv, topk[:, :, w:].contiguous(), lse, sm_scale=scale)
+    assert (raw[0, 0] == 0).all()
+
+    normalised = raw / raw.sum(-1, keepdim=True).clamp_min(1e-20)
+    assert (normalised[0, 0] == 0).all()
+    assert not torch.isnan(normalised).any()
+    # Still local: the queries with valid compressed slots are unaffected.
+    assert (raw[0, 1:] > 0).any()
+    assert torch.allclose(normalised[0, 1:].sum(-1), torch.ones(s - 1, device="cuda"), atol=1e-5)
+    # And the reference agrees on the same input, so the contract is one contract.
+    assert (reference_compressed_target(q, kv, sink, topk, w, scale)[0, 0] == 0).all()
+
+
 def test_target_kernel_rejects_more_than_64_heads():
     _require_tilelang_cuda()
     from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
@@ -159,5 +250,72 @@ def test_target_kernel_rejects_more_than_64_heads():
     kv = torch.randn(1, 128, 64, device="cuda", dtype=torch.bfloat16)
     topk = torch.zeros(1, 2, 64, device="cuda", dtype=torch.int32)
     lse = torch.zeros(1, 2, 128, device="cuda", dtype=torch.float32)
-    with pytest.raises(AssertionError, match="64"):
+    # Matching on "64" alone would also be satisfied by the head-multiple assert
+    # or by any message that happens to mention a shape of 64.
+    with pytest.raises(AssertionError, match="one block owns the head sum"):
         sparse_mqa_target_fwd_interface(q, kv, topk, lse)
+
+
+def test_target_kernel_rejects_head_counts_the_interface_cannot_emit():
+    """``heads % 16 == 0`` on its own admits 48, which no interface call can
+    produce -- padding is ``max(next_power_of_2(heads), 16)``, so one of
+    {16, 32, 64} -- and which ``T.GemmWarpPolicy.FullRow`` cannot partition: with
+    the guard removed, lowering dies on ``Check failed: (m_warp * n_warp ==
+    num_warps) is false: m_warp: 3, n_warp: 2, num_warps: 8``. Only a caller that
+    bypasses the interface can reach this, which is exactly what this test does.
+    """
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target
+
+    with pytest.raises(AssertionError, match=r"padded to one of \(16, 32, 64\)"):
+        sparse_mqa_target(48, 64, 64)
+
+
+def test_target_kernel_rejects_non_bfloat16_inputs():
+    """The kernel hardcodes ``dtype = T.bfloat16``; the interface names that
+    constraint instead of letting an fp16 caller fall into tilelang's lowering."""
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
+
+    q = torch.randn(1, 2, 16, 64, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(1, 128, 64, device="cuda", dtype=torch.bfloat16)
+    topk = torch.zeros(1, 2, 64, device="cuda", dtype=torch.int32)
+    lse = torch.zeros(1, 2, 16, device="cuda", dtype=torch.float32)
+
+    with pytest.raises(AssertionError, match="bfloat16-only, got q"):
+        sparse_mqa_target_fwd_interface(q.to(torch.float16), kv, topk, lse)
+    with pytest.raises(AssertionError, match="bfloat16-only, got kv"):
+        sparse_mqa_target_fwd_interface(q, kv.to(torch.float16), topk, lse)
+
+
+def test_target_kernel_emits_no_unexpected_warnings():
+    """Pin the warning set, so a newly introduced warning is a failure rather than
+    an unexplained bump in pytest's summary count.
+
+    ``heads = 32`` is used by no other test in this module, so both kernels below
+    are constructed here rather than being served from tilelang's in-process
+    cache; that is what makes the construction-time warnings observable at all.
+    """
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_fwd import sparse_mqa_fwd_interface
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
+
+    torch.manual_seed(5)
+    b, s, heads, d, w, c = 1, 2, 32, 64, 64, 64
+    q = torch.randn(b, s, heads, d, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(b, 256, d, device="cuda", dtype=torch.bfloat16)
+    sink = torch.zeros(heads, device="cuda", dtype=torch.float32)
+    topk = torch.randint(0, 256, (b, s, w + c), device="cuda", dtype=torch.int32)
+    scale = d**-0.5
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _, lse = sparse_mqa_fwd_interface(q, kv, sink, topk, sm_scale=scale)
+        sparse_mqa_target_fwd_interface(q, kv, topk[:, :, w:].contiguous(), lse, sm_scale=scale)
+
+    unexpected = [
+        f"{w.category.__name__} at {w.filename}:{w.lineno}: {w.message}"
+        for w in caught
+        if not any(known in str(w.message) for known in _TOLERATED_WARNING_SUBSTRINGS)
+    ]
+    assert not unexpected, "unexpected warning(s):\n" + "\n".join(unexpected)

--- a/tests/ops/test_deepseek_v4_indexer_loss.py
+++ b/tests/ops/test_deepseek_v4_indexer_loss.py
@@ -17,8 +17,10 @@ import warnings
 import pytest
 import torch
 
-from veomni.utils.device import IS_CUDA_AVAILABLE, get_gpu_compute_capability
+from veomni.utils.device import IS_CUDA_AVAILABLE, get_device_type, get_gpu_compute_capability
 
+
+DEVICE = get_device_type()
 
 # Warnings this module tolerates, matched as substrings of the warning message.
 # Everything else fails test_target_kernel_emits_no_unexpected_warnings, so a new
@@ -160,7 +162,7 @@ def test_target_kernel_matches_reference(heads, c):
 
     torch.manual_seed(0)
     b, s, d, w = 2, 8, 64, 64
-    device = "cuda"
+    device = DEVICE
     q = torch.randn(b, s, heads, d, device=device, dtype=torch.bfloat16)
     kv = torch.randn(b, 256, d, device=device, dtype=torch.bfloat16)
     sink = torch.randn(heads, device=device, dtype=torch.float32)
@@ -197,10 +199,10 @@ def test_target_kernel_zeroes_invalid_slots():
 
     torch.manual_seed(2)
     b, s, heads, d, w, c = 1, 4, 16, 64, 64, 64
-    q = torch.randn(b, s, heads, d, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(b, 256, d, device="cuda", dtype=torch.bfloat16)
-    sink = torch.zeros(heads, device="cuda", dtype=torch.float32)
-    topk = torch.randint(0, 256, (b, s, w + c), device="cuda", dtype=torch.int32)
+    q = torch.randn(b, s, heads, d, device=DEVICE, dtype=torch.bfloat16)
+    kv = torch.randn(b, 256, d, device=DEVICE, dtype=torch.bfloat16)
+    sink = torch.zeros(heads, device=DEVICE, dtype=torch.float32)
+    topk = torch.randint(0, 256, (b, s, w + c), device=DEVICE, dtype=torch.int32)
     topk[:, :, w + 3] = -1
     scale = d**-0.5
 
@@ -221,10 +223,10 @@ def test_target_kernel_all_invalid_compressed_row_is_zero():
 
     torch.manual_seed(4)
     b, s, heads, d, w, c = 1, 4, 16, 64, 64, 64
-    q = torch.randn(b, s, heads, d, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(b, 256, d, device="cuda", dtype=torch.bfloat16)
-    sink = torch.zeros(heads, device="cuda", dtype=torch.float32)
-    topk = torch.randint(0, 256, (b, s, w + c), device="cuda", dtype=torch.int32)
+    q = torch.randn(b, s, heads, d, device=DEVICE, dtype=torch.bfloat16)
+    kv = torch.randn(b, 256, d, device=DEVICE, dtype=torch.bfloat16)
+    sink = torch.zeros(heads, device=DEVICE, dtype=torch.float32)
+    topk = torch.randint(0, 256, (b, s, w + c), device=DEVICE, dtype=torch.int32)
     topk[0, 0, w:] = -1  # query 0 keeps a valid window and loses every compressed slot
     scale = d**-0.5
 
@@ -237,7 +239,7 @@ def test_target_kernel_all_invalid_compressed_row_is_zero():
     assert not torch.isnan(normalised).any()
     # Still local: the queries with valid compressed slots are unaffected.
     assert (raw[0, 1:] > 0).any()
-    assert torch.allclose(normalised[0, 1:].sum(-1), torch.ones(s - 1, device="cuda"), atol=1e-5)
+    assert torch.allclose(normalised[0, 1:].sum(-1), torch.ones(s - 1, device=DEVICE), atol=1e-5)
     # And the reference agrees on the same input, so the contract is one contract.
     assert (reference_compressed_target(q, kv, sink, topk, w, scale)[0, 0] == 0).all()
 
@@ -246,10 +248,10 @@ def test_target_kernel_rejects_more_than_64_heads():
     _require_tilelang_cuda()
     from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
 
-    q = torch.randn(1, 2, 128, 64, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(1, 128, 64, device="cuda", dtype=torch.bfloat16)
-    topk = torch.zeros(1, 2, 64, device="cuda", dtype=torch.int32)
-    lse = torch.zeros(1, 2, 128, device="cuda", dtype=torch.float32)
+    q = torch.randn(1, 2, 128, 64, device=DEVICE, dtype=torch.bfloat16)
+    kv = torch.randn(1, 128, 64, device=DEVICE, dtype=torch.bfloat16)
+    topk = torch.zeros(1, 2, 64, device=DEVICE, dtype=torch.int32)
+    lse = torch.zeros(1, 2, 128, device=DEVICE, dtype=torch.float32)
     # Matching on "64" alone would also be satisfied by the head-multiple assert
     # or by any message that happens to mention a shape of 64.
     with pytest.raises(RuntimeError, match="one block owns the head sum"):
@@ -277,10 +279,10 @@ def test_target_kernel_rejects_non_bfloat16_inputs():
     _require_tilelang_cuda()
     from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
 
-    q = torch.randn(1, 2, 16, 64, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(1, 128, 64, device="cuda", dtype=torch.bfloat16)
-    topk = torch.zeros(1, 2, 64, device="cuda", dtype=torch.int32)
-    lse = torch.zeros(1, 2, 16, device="cuda", dtype=torch.float32)
+    q = torch.randn(1, 2, 16, 64, device=DEVICE, dtype=torch.bfloat16)
+    kv = torch.randn(1, 128, 64, device=DEVICE, dtype=torch.bfloat16)
+    topk = torch.zeros(1, 2, 64, device=DEVICE, dtype=torch.int32)
+    lse = torch.zeros(1, 2, 16, device=DEVICE, dtype=torch.float32)
 
     with pytest.raises(RuntimeError, match="bfloat16-only, got q"):
         sparse_mqa_target_fwd_interface(q.to(torch.float16), kv, topk, lse)
@@ -302,10 +304,10 @@ def test_target_kernel_emits_no_unexpected_warnings():
 
     torch.manual_seed(5)
     b, s, heads, d, w, c = 1, 2, 32, 64, 64, 64
-    q = torch.randn(b, s, heads, d, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(b, 256, d, device="cuda", dtype=torch.bfloat16)
-    sink = torch.zeros(heads, device="cuda", dtype=torch.float32)
-    topk = torch.randint(0, 256, (b, s, w + c), device="cuda", dtype=torch.int32)
+    q = torch.randn(b, s, heads, d, device=DEVICE, dtype=torch.bfloat16)
+    kv = torch.randn(b, 256, d, device=DEVICE, dtype=torch.bfloat16)
+    sink = torch.zeros(heads, device=DEVICE, dtype=torch.float32)
+    topk = torch.randint(0, 256, (b, s, w + c), device=DEVICE, dtype=torch.int32)
     scale = d**-0.5
 
     with warnings.catch_warnings(record=True) as caught:
@@ -327,10 +329,10 @@ def test_sparse_attn_returns_non_differentiable_lse():
 
     torch.manual_seed(3)
     b, s, heads, d = 1, 8, 16, 64
-    q = torch.randn(b, s, heads, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
-    kv = torch.randn(b, 128, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
-    sink = torch.randn(heads, device="cuda", dtype=torch.float32, requires_grad=True)
-    topk = torch.randint(0, 128, (b, s, 64), device="cuda", dtype=torch.int32)
+    q = torch.randn(b, s, heads, d, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+    kv = torch.randn(b, 128, d, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+    sink = torch.randn(heads, device=DEVICE, dtype=torch.float32, requires_grad=True)
+    topk = torch.randint(0, 128, (b, s, 64), device=DEVICE, dtype=torch.int32)
 
     out_only = sparse_attn_tilelang(q, kv, sink, topk, d**-0.5)
     out, lse = sparse_attn_tilelang(q, kv, sink, topk, d**-0.5, return_lse=True)

--- a/tests/ops/test_deepseek_v4_indexer_loss.py
+++ b/tests/ops/test_deepseek_v4_indexer_loss.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
+
+from veomni.utils.device import IS_CUDA_AVAILABLE, get_gpu_compute_capability
 
 
 def reference_compressed_target(q, kv, attn_sink, topk_idxs, compressed_start, sm_scale):
@@ -83,3 +86,78 @@ def test_reference_target_is_normalised():
     target = reference_compressed_target(q, kv, torch.zeros(4), topk, 4, 16**-0.5)
     assert torch.allclose(target.sum(-1), torch.ones(2, 5), atol=1e-5)
     assert (target >= 0).all()
+
+
+def _require_tilelang_cuda():
+    pytest.importorskip("tilelang")
+    if torch.version.hip is not None or not IS_CUDA_AVAILABLE:
+        pytest.skip("DeepSeek V4 TileLang kernels require an NVIDIA CUDA GPU")
+    if get_gpu_compute_capability() < 90:
+        pytest.skip("DeepSeek V4 TileLang kernels require SM90 or later")
+
+
+@pytest.mark.parametrize("heads", [8, 16, 64])
+def test_target_kernel_matches_reference(heads):
+    """``heads=8`` pads to 16 inside the kernel; the padded heads must contribute
+    nothing to the head sum. That is not automatic — a padded head has zero Q and
+    would contribute ``exp2(0 - lse_pad)`` unless its LSE is padded to +inf."""
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_fwd import sparse_mqa_fwd_interface
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
+
+    torch.manual_seed(0)
+    b, s, d, w, c = 2, 8, 64, 64, 64
+    device = "cuda"
+    q = torch.randn(b, s, heads, d, device=device, dtype=torch.bfloat16)
+    kv = torch.randn(b, 256, d, device=device, dtype=torch.bfloat16)
+    sink = torch.randn(heads, device=device, dtype=torch.float32)
+    topk = torch.randint(0, 256, (b, s, w + c), device=device, dtype=torch.int32)
+    topk[0, 0, w] = -1  # a compressed miss
+    scale = d**-0.5
+
+    _, lse = sparse_mqa_fwd_interface(q, kv, sink, topk, sm_scale=scale)
+    actual = sparse_mqa_target_fwd_interface(q, kv, topk[:, :, w:].contiguous(), lse, sm_scale=scale)
+    actual = actual / actual.sum(-1, keepdim=True).clamp_min(1e-20)
+
+    expected = reference_compressed_target(q, kv, sink, topk, w, scale)
+    # A normalised entry is ~1/C ~ 0.015 here, so a tolerance of the order of
+    # 1e-2 would exceed the values being compared and accept anything. It is not
+    # a hypothetical: summing the wrong axis of the score tile yields a
+    # per-head row sum whose normalised form sits 1.5e-2 from the truth, i.e.
+    # inside a 2e-2 tolerance. The kernel and this reference consume the same
+    # bf16 inputs and both accumulate in fp32, so they agree to 2e-8 absolute
+    # and 5e-7 relative as measured on GB200; the bounds below leave three
+    # orders of magnitude of headroom for a different GEMM summation order or a
+    # TF32 einsum, while still rejecting the wrong-axis sum by a factor of 60.
+    torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-2)
+
+
+def test_target_kernel_zeroes_invalid_slots():
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_fwd import sparse_mqa_fwd_interface
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
+
+    torch.manual_seed(2)
+    b, s, heads, d, w, c = 1, 4, 16, 64, 64, 64
+    q = torch.randn(b, s, heads, d, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(b, 256, d, device="cuda", dtype=torch.bfloat16)
+    sink = torch.zeros(heads, device="cuda", dtype=torch.float32)
+    topk = torch.randint(0, 256, (b, s, w + c), device="cuda", dtype=torch.int32)
+    topk[:, :, w + 3] = -1
+    scale = d**-0.5
+
+    _, lse = sparse_mqa_fwd_interface(q, kv, sink, topk, sm_scale=scale)
+    target = sparse_mqa_target_fwd_interface(q, kv, topk[:, :, w:].contiguous(), lse, sm_scale=scale)
+    assert (target[:, :, 3] == 0).all()
+
+
+def test_target_kernel_rejects_more_than_64_heads():
+    _require_tilelang_cuda()
+    from veomni.ops.kernels.deepseek_v4.tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
+
+    q = torch.randn(1, 2, 128, 64, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(1, 128, 64, device="cuda", dtype=torch.bfloat16)
+    topk = torch.zeros(1, 2, 64, device="cuda", dtype=torch.int32)
+    lse = torch.zeros(1, 2, 128, device="cuda", dtype=torch.float32)
+    with pytest.raises(AssertionError, match="64"):
+        sparse_mqa_target_fwd_interface(q, kv, topk, lse)

--- a/veomni/ops/kernels/deepseek_v4/__init__.py
+++ b/veomni/ops/kernels/deepseek_v4/__init__.py
@@ -40,11 +40,25 @@ def sparse_attn_tilelang(
     attn_sink: torch.Tensor,
     topk_idxs: torch.Tensor,
     sm_scale: float | None = None,
-) -> torch.Tensor:
+    return_lse: bool = False,
+) -> "torch.Tensor | tuple[torch.Tensor, torch.Tensor]":
     _require_tilelang_sm90()
     from .tilelang_sparse_mla import sparse_attn_tilelang as impl
 
-    return impl(q, kv, attn_sink, topk_idxs, sm_scale)
+    return impl(q, kv, attn_sink, topk_idxs, sm_scale, return_lse)
+
+
+def sparse_mqa_target_fwd(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    lse: torch.Tensor,
+    sm_scale: float | None = None,
+) -> torch.Tensor:
+    _require_tilelang_sm90()
+    from .tilelang_sparse_mla_target import sparse_mqa_target_fwd_interface
+
+    return sparse_mqa_target_fwd_interface(q, kv, topk_idxs, lse, sm_scale)
 
 
 def v4_lighting_indexer(
@@ -120,5 +134,6 @@ __all__ = [
     "fp8_weight_quant",
     "linear_bf16_fp32",
     "sparse_attn_tilelang",
+    "sparse_mqa_target_fwd",
     "v4_lighting_indexer",
 ]

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla.py
@@ -22,16 +22,24 @@ from . import tilelang_sparse_mla_fwd as sparse_mla_fwd
 
 class DeepSeekV4SparseAttention(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, q, kv, attn_sink, topk_idxs, sm_scale=None):
+    def forward(ctx, q, kv, attn_sink, topk_idxs, sm_scale=None, return_lse=False):
         o, lse = sparse_mla_fwd.sparse_mqa_fwd_interface(q, kv, attn_sink, topk_idxs, sm_scale=sm_scale)
 
         ctx.save_for_backward(q, kv, attn_sink, topk_idxs, o.clone(), lse)
         ctx.sm_scale = sm_scale
+        ctx.return_lse = return_lse
 
+        if return_lse:
+            # The LSE only ever feeds the detached indexer teacher. Marking it
+            # non-differentiable keeps that path from becoming a second route
+            # back into q/kv/sink, which would break the decoupling the indexer
+            # loss depends on.
+            ctx.mark_non_differentiable(lse)
+            return o, lse
         return o
 
     @staticmethod
-    def backward(ctx, do):
+    def backward(ctx, do, dlse=None):
         q, kv, attn_sink, topk_idxs, o, lse = ctx.saved_tensors
         sm_scale = ctx.sm_scale
 
@@ -39,21 +47,24 @@ class DeepSeekV4SparseAttention(torch.autograd.Function):
             q, kv, attn_sink, o, do.contiguous(), topk_idxs, lse, sm_scale=sm_scale
         )
 
-        return dq, dkv, d_attn_sink, None, None
+        return dq, dkv, d_attn_sink, None, None, None
 
 
-def sparse_attn_tilelang(q, kv, attn_sink, topk_idxs, sm_scale=None):
+def sparse_attn_tilelang(q, kv, attn_sink, topk_idxs, sm_scale=None, return_lse=False):
     """Sparse MQA over the top-k gathered KV entries.
 
     Args:
-        q:         [B, S, H, D] bf16
-        kv:        [B, S_kv, D] bf16
-        attn_sink: [H] fp32
-        topk_idxs: [B, S, topk] int32
-        sm_scale:  softmax scale, defaults to ``1/sqrt(D)``
+        q:          [B, S, H, D] bf16
+        kv:         [B, S_kv, D] bf16
+        attn_sink:  [H] fp32
+        topk_idxs:  [B, S, topk] int32
+        sm_scale:   softmax scale, defaults to ``1/sqrt(D)``
+        return_lse: also return the log-sum-exp the forward already computed.
+            The indexer's teacher distribution needs it to renormalize the
+            sparse scores, and the kernel writes it either way.
 
     Returns:
-        [B, S, H, D] bf16
+        [B, S, H, D] bf16, or that and the [B, S, H] fp32 LSE when ``return_lse``
     """
     # The kernels are compiled for bf16 operands. Callers run under autocast,
     # whose fp32 op policy (sum, rsqrt, ...) can silently promote an upstream
@@ -64,4 +75,4 @@ def sparse_attn_tilelang(q, kv, attn_sink, topk_idxs, sm_scale=None):
         )
     if attn_sink.dtype is not torch.float32:
         raise ValueError(f"DeepSeek V4 TileLang sparse attention requires a float32 sink, got {attn_sink.dtype}")
-    return DeepSeekV4SparseAttention.apply(q, kv, attn_sink, topk_idxs, sm_scale)
+    return DeepSeekV4SparseAttention.apply(q, kv, attn_sink, topk_idxs, sm_scale, return_lse)

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_target.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_target.py
@@ -47,10 +47,15 @@ def sparse_mqa_target(heads, dim, topk, sm_scale=None, block_I=64, threads=256):
     # across CTAs. The attention forward replicates over heads above 64; this
     # kernel refuses instead.
     assert heads <= 64, f"target kernel requires heads <= 64 so one block owns the head sum, got {heads}"
-    # T.gemm's warp partition needs M % 16 == 0; without this the failure is a
-    # bare TVM InternalError from deep inside lowering. The interface pads for
-    # callers, so only a direct caller can trip it.
-    assert heads % 16 == 0, f"heads must be a multiple of 16 for T.gemm, got {heads}"
+    # Admit exactly the set the interface can emit -- it pads to
+    # max(next_power_of_2(heads), 16), so {16, 32, 64} -- rather than the weaker
+    # `heads % 16 == 0`, which also admits 48. M = 48 is unsound under
+    # T.GemmWarpPolicy.FullRow: the partition it picks is 3 warp-rows x 2
+    # warp-cols, which does not cover the 8 warps of a 256-thread block, and
+    # lowering dies with `Check failed: (m_warp * n_warp == num_warps) is false:
+    # m_warp: 3, n_warp: 2, num_warps: 8`. Without this guard that bare TVM
+    # InternalError is what a direct caller bypassing the interface would see.
+    assert heads in (16, 32, 64), f"target kernel requires heads padded to one of (16, 32, 64), got {heads}"
     if sm_scale is None:
         sm_scale = (1.0 / dim) ** 0.5 * 1.44269504  # log2(e)
     else:
@@ -140,6 +145,13 @@ def sparse_mqa_target(heads, dim, topk, sm_scale=None, block_I=64, threads=256):
                 # transposed form is rejected outright when H != BI and, far
                 # worse, is silently accepted when H == BI -- where it yields the
                 # per-head row sum instead of the head sum.
+                #
+                # `tgt` is reused across the NI iterations, so this relies on
+                # T.reduce_sum's default clear=True zeroing it first (the forward
+                # passes clear=False explicitly when it wants accumulation). Both
+                # that and the moving output slice are covered by the c=128 and
+                # c=100 parametrisations of test_target_kernel_matches_reference;
+                # at NI == 1 neither can fail.
                 T.reduce_sum(acc_s, tgt, dim=0)
                 T.copy(tgt, Target[b_i, s_i, i_i * BI : (i_i + 1) * BI])
 
@@ -162,6 +174,11 @@ def sparse_mqa_target_fwd_interface(q, kv, topk_idxs, lse, sm_scale=None, block_
     """
     assert q.is_contiguous() and kv.is_contiguous() and topk_idxs.is_contiguous()
     assert lse.is_contiguous() and lse.dtype == torch.float32
+    # The kernel hardcodes `dtype = T.bfloat16` for both Q and KV, so an fp16 or
+    # fp32 caller would otherwise get a tilelang type error from inside lowering
+    # instead of a named constraint.
+    assert q.dtype == torch.bfloat16, f"target kernel is bfloat16-only, got q.dtype={q.dtype}"
+    assert kv.dtype == torch.bfloat16, f"target kernel is bfloat16-only, got kv.dtype={kv.dtype}"
     batch, seq_len, heads, dim = q.shape
     assert heads <= 64, f"target kernel requires heads <= 64 so one block owns the head sum, got {heads}"
     assert kv.shape[-1] == dim

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_target.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_target.py
@@ -196,6 +196,12 @@ def sparse_mqa_target_fwd_interface(q, kv, topk_idxs, lse, sm_scale=None, block_
         raise RuntimeError(f"target kernel requires heads <= 64 so one block owns the head sum, got {heads}")
     if kv.shape[-1] != dim:
         raise RuntimeError(f"kv head dim {kv.shape[-1]} does not match q head dim {dim}")
+    # The gather clamps candidate rows into [0, S_kv - 1], which needs a row to
+    # exist: with S_kv == 0 the clamp target becomes -1 and the outer max pulls it
+    # back to row 0 of an empty tensor, an out-of-bounds device read. The candidate
+    # mask only zeroes the score afterwards, so it cannot prevent the gather.
+    if kv.shape[1] == 0:
+        raise RuntimeError("target kernel requires kv to have at least one row")
     if lse.shape != (batch, seq_len, heads):
         raise RuntimeError(f"lse must be [B, S, H], got {tuple(lse.shape)}")
     topk = topk_idxs.shape[-1]

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_target.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_target.py
@@ -1,0 +1,191 @@
+# Copyright 2026 ByteDance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa
+"""Head-summed attention probability over the compressed slice, for the DSA
+indexer loss (DeepSeek-V3.2 eq. 4).
+
+This consumes the LSE that ``sparse_mqa_fwd_interface`` returns. That LSE is the
+*full* CSA denominator: ``sparse_mqa_fwd_interface`` folds the attention sink
+into ``sumexp`` before writing it (see ``tilelang_sparse_mla_fwd.py``, "attn_sink:
+add exp(attn_sink[h] - max_scaled) to softmax denominator"), and the ``Indices``
+it consumed spanned the sliding window as well as the compressed entries. That
+is what makes the teacher produced here paper-correct rather than the
+compressed-only approximation. If the sink ever moves out of ``sumexp``,
+attention stays correct and this silently does not.
+"""
+
+import tilelang
+import torch
+from tilelang import language as T
+
+from ....utils.device import get_torch_device
+
+
+@tilelang.jit(
+    out_idx=[-1],
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    },
+)
+def sparse_mqa_target(heads, dim, topk, sm_scale=None, block_I=64, threads=256):
+    assert dim == tilelang.math.next_power_of_2(dim), f"dim must be power of 2, got {dim}"
+    assert topk % block_I == 0, f"topk ({topk}) must be divisible by block_I ({block_I})"
+    # One CTA must own every head of a query, or the head sum would need atomics
+    # across CTAs. The attention forward replicates over heads above 64; this
+    # kernel refuses instead.
+    assert heads <= 64, f"target kernel requires heads <= 64 so one block owns the head sum, got {heads}"
+    # T.gemm's warp partition needs M % 16 == 0; without this the failure is a
+    # bare TVM InternalError from deep inside lowering. The interface pads for
+    # callers, so only a direct caller can trip it.
+    assert heads % 16 == 0, f"heads must be a multiple of 16 for T.gemm, got {heads}"
+    if sm_scale is None:
+        sm_scale = (1.0 / dim) ** 0.5 * 1.44269504  # log2(e)
+    else:
+        sm_scale = sm_scale * 1.44269504  # log2(e)
+
+    batch = T.dynamic("batch")
+    seq_len = T.dynamic("seq_len")
+    seq_len_kv = T.dynamic("seq_len_kv")
+
+    q_shape = [batch, seq_len, heads, dim]
+    kv_shape = [batch, seq_len_kv, dim]
+    indices_shape = [batch, seq_len, topk]
+    lse_shape = [batch, seq_len, heads]
+    target_shape = [batch, seq_len, topk]
+    indices_dtype = T.int32
+    dtype = T.bfloat16
+    accum_dtype = T.float32
+
+    H_per_block = heads
+    BI = block_I
+    NI = tilelang.cdiv(topk, block_I)
+    D = dim
+
+    smem_lower_bound = H_per_block * D * 2 + BI * D * 2
+    smem_limit = get_torch_device().get_device_properties(None).shared_memory_per_block_optin
+    assert smem_lower_bound <= smem_limit, (
+        f"block_I={block_I}, dim={dim}, heads={heads} needs at least {smem_lower_bound} B "
+        f"of shared memory per block, above this device's {smem_limit} B"
+    )
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor(q_shape, dtype),  # type: ignore
+        KV: T.Tensor(kv_shape, dtype),  # type: ignore
+        Indices: T.Tensor(indices_shape, indices_dtype),  # type: ignore
+        Lse: T.Tensor(lse_shape, accum_dtype),  # type: ignore
+        Target: T.Tensor(target_shape, accum_dtype),  # type: ignore
+    ):
+        with T.Kernel(seq_len, batch, threads=threads) as (bx, by):
+            Q_shared = T.alloc_shared([H_per_block, D], dtype)
+            KV_shared = T.alloc_shared([BI, D], dtype)
+            mask = T.alloc_fragment([BI], "bool")
+            acc_s = T.alloc_fragment([H_per_block, BI], accum_dtype)
+            tgt = T.alloc_fragment([BI], accum_dtype)
+
+            b_i = by
+            s_i = bx
+
+            T.copy(Q[b_i, s_i, 0:H_per_block, :D], Q_shared)
+
+            for i_i in T.Pipelined(NI, num_stages=0):
+                for bi_i in T.Parallel(BI):
+                    mask[bi_i] = (
+                        Indices[b_i, s_i, i_i * BI + bi_i] >= 0 and Indices[b_i, s_i, i_i * BI + bi_i] < seq_len_kv
+                    )
+
+                # Same clamped whole-CTA gather as the attention forward: read the
+                # row index straight from global memory so layout inference can
+                # coalesce the copy. Out-of-range rows are absorbed by the -inf
+                # score initialisation below.
+                for bi_i, d_i in T.Parallel(BI, D):
+                    KV_shared[bi_i, d_i] = KV[
+                        b_i, T.max(T.min(Indices[b_i, s_i, i_i * BI + bi_i], seq_len_kv - 1), 0), d_i
+                    ]
+
+                for h_i, bi_i in T.Parallel(H_per_block, BI):
+                    acc_s[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_s.dtype))
+                T.gemm(
+                    Q_shared,
+                    KV_shared,
+                    acc_s,
+                    transpose_B=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+
+                # P = exp2(scores * sm_scale_log2e - LSE). Mirrors the backward
+                # kernel, which is the one that consumes a *final* LSE; the
+                # forward's expression works against a running maximum instead.
+                # No online maximum is needed here because LSE >= max score by
+                # construction, so every exponent is non-positive.
+                for h_i, bi_i in T.Parallel(H_per_block, BI):
+                    acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - Lse[b_i, s_i, h_i])
+
+                # Sum over heads, the non-contiguous axis of acc_s. Routing this
+                # through a [BI, H] transpose buffer is not an option: T.copy
+                # matches shapes elementwise and never transposes, so the
+                # transposed form is rejected outright when H != BI and, far
+                # worse, is silently accepted when H == BI -- where it yields the
+                # per-head row sum instead of the head sum.
+                T.reduce_sum(acc_s, tgt, dim=0)
+                T.copy(tgt, Target[b_i, s_i, i_i * BI : (i_i + 1) * BI])
+
+    return main
+
+
+def sparse_mqa_target_fwd_interface(q, kv, topk_idxs, lse, sm_scale=None, block_I=64, threads=256):
+    """Head-summed, unnormalised attention probability over the compressed slice.
+
+    Args:
+        q:         [B, S, H, D] bf16
+        kv:        [B, S_kv, D] bf16
+        topk_idxs: [B, S, C] int32 -- the *compressed* slice only, -1 for misses
+        lse:       [B, S, H] fp32 -- from ``sparse_mqa_fwd_interface``
+        sm_scale:  float or None (defaults to 1/sqrt(D)); must match the value
+                   passed to the forward that produced ``lse``
+
+    Returns:
+        [B, S, C] fp32. L1-normalise in the caller.
+    """
+    assert q.is_contiguous() and kv.is_contiguous() and topk_idxs.is_contiguous()
+    assert lse.is_contiguous() and lse.dtype == torch.float32
+    batch, seq_len, heads, dim = q.shape
+    assert heads <= 64, f"target kernel requires heads <= 64 so one block owns the head sum, got {heads}"
+    assert kv.shape[-1] == dim
+    assert lse.shape == (batch, seq_len, heads), f"lse must be [B, S, H], got {tuple(lse.shape)}"
+    topk = topk_idxs.shape[-1]
+
+    padded_topk = (topk + block_I - 1) // block_I * block_I
+    if padded_topk != topk:
+        pad = torch.full((batch, seq_len, padded_topk - topk), -1, device=topk_idxs.device, dtype=topk_idxs.dtype)
+        topk_idxs = torch.cat([topk_idxs, pad], dim=-1).contiguous()
+
+    # T.gemm requires the M extent to be a multiple of 16, so head counts below
+    # that (or awkward multiples of it) have to be padded, exactly as the
+    # attention forward pads. Unlike the forward, the padding here lands *inside*
+    # a sum rather than in a slice that can be thrown away afterwards, so a
+    # padded head must be inert rather than merely ignorable: zero Q alone would
+    # still contribute exp2(0 - lse_pad). Padding the LSE with +inf is what makes
+    # the contribution exactly exp2(-inf) == 0. Every score is finite or -inf, so
+    # the exponent is never inf - inf and no NaN can enter the head sum.
+    padded_heads = max(tilelang.math.next_power_of_2(heads), 16)
+    if padded_heads != heads:
+        q = torch.cat([q, q.new_zeros(batch, seq_len, padded_heads - heads, dim)], dim=2).contiguous()
+        lse = torch.cat([lse, lse.new_full((batch, seq_len, padded_heads - heads), float("inf"))], dim=2).contiguous()
+
+    kernel = sparse_mqa_target(padded_heads, dim, padded_topk, sm_scale, block_I=block_I, threads=threads)
+    target = kernel(q, kv, topk_idxs, lse)
+    return target[:, :, :topk].contiguous()

--- a/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_target.py
+++ b/veomni/ops/kernels/deepseek_v4/tilelang_sparse_mla_target.py
@@ -41,12 +41,15 @@ from ....utils.device import get_torch_device
     },
 )
 def sparse_mqa_target(heads, dim, topk, sm_scale=None, block_I=64, threads=256):
-    assert dim == tilelang.math.next_power_of_2(dim), f"dim must be power of 2, got {dim}"
-    assert topk % block_I == 0, f"topk ({topk}) must be divisible by block_I ({block_I})"
+    if dim != tilelang.math.next_power_of_2(dim):
+        raise RuntimeError(f"dim must be power of 2, got {dim}")
+    if topk % block_I != 0:
+        raise RuntimeError(f"topk ({topk}) must be divisible by block_I ({block_I})")
     # One CTA must own every head of a query, or the head sum would need atomics
     # across CTAs. The attention forward replicates over heads above 64; this
     # kernel refuses instead.
-    assert heads <= 64, f"target kernel requires heads <= 64 so one block owns the head sum, got {heads}"
+    if heads > 64:
+        raise RuntimeError(f"target kernel requires heads <= 64 so one block owns the head sum, got {heads}")
     # Admit exactly the set the interface can emit -- it pads to
     # max(next_power_of_2(heads), 16), so {16, 32, 64} -- rather than the weaker
     # `heads % 16 == 0`, which also admits 48. M = 48 is unsound under
@@ -55,7 +58,8 @@ def sparse_mqa_target(heads, dim, topk, sm_scale=None, block_I=64, threads=256):
     # lowering dies with `Check failed: (m_warp * n_warp == num_warps) is false:
     # m_warp: 3, n_warp: 2, num_warps: 8`. Without this guard that bare TVM
     # InternalError is what a direct caller bypassing the interface would see.
-    assert heads in (16, 32, 64), f"target kernel requires heads padded to one of (16, 32, 64), got {heads}"
+    if heads not in (16, 32, 64):
+        raise RuntimeError(f"target kernel requires heads padded to one of (16, 32, 64), got {heads}")
     if sm_scale is None:
         sm_scale = (1.0 / dim) ** 0.5 * 1.44269504  # log2(e)
     else:
@@ -81,10 +85,11 @@ def sparse_mqa_target(heads, dim, topk, sm_scale=None, block_I=64, threads=256):
 
     smem_lower_bound = H_per_block * D * 2 + BI * D * 2
     smem_limit = get_torch_device().get_device_properties(None).shared_memory_per_block_optin
-    assert smem_lower_bound <= smem_limit, (
-        f"block_I={block_I}, dim={dim}, heads={heads} needs at least {smem_lower_bound} B "
-        f"of shared memory per block, above this device's {smem_limit} B"
-    )
+    if smem_lower_bound > smem_limit:
+        raise RuntimeError(
+            f"block_I={block_I}, dim={dim}, heads={heads} needs at least {smem_lower_bound} B "
+            f"of shared memory per block, above this device's {smem_limit} B"
+        )
 
     @T.prim_func
     def main(
@@ -172,17 +177,27 @@ def sparse_mqa_target_fwd_interface(q, kv, topk_idxs, lse, sm_scale=None, block_
     Returns:
         [B, S, C] fp32. L1-normalise in the caller.
     """
-    assert q.is_contiguous() and kv.is_contiguous() and topk_idxs.is_contiguous()
-    assert lse.is_contiguous() and lse.dtype == torch.float32
+    # These guard the teacher's numerical contract, so they raise rather than
+    # assert: `python -O` strips asserts, and a stripped `heads <= 64` would not
+    # fail, it would return a head sum silently missing every head past 64.
+    if not (q.is_contiguous() and kv.is_contiguous() and topk_idxs.is_contiguous()):
+        raise RuntimeError("target kernel requires q, kv and topk_idxs to be contiguous")
+    if not (lse.is_contiguous() and lse.dtype == torch.float32):
+        raise RuntimeError(f"target kernel requires a contiguous fp32 lse, got dtype={lse.dtype}")
     # The kernel hardcodes `dtype = T.bfloat16` for both Q and KV, so an fp16 or
     # fp32 caller would otherwise get a tilelang type error from inside lowering
     # instead of a named constraint.
-    assert q.dtype == torch.bfloat16, f"target kernel is bfloat16-only, got q.dtype={q.dtype}"
-    assert kv.dtype == torch.bfloat16, f"target kernel is bfloat16-only, got kv.dtype={kv.dtype}"
+    if q.dtype != torch.bfloat16:
+        raise RuntimeError(f"target kernel is bfloat16-only, got q.dtype={q.dtype}")
+    if kv.dtype != torch.bfloat16:
+        raise RuntimeError(f"target kernel is bfloat16-only, got kv.dtype={kv.dtype}")
     batch, seq_len, heads, dim = q.shape
-    assert heads <= 64, f"target kernel requires heads <= 64 so one block owns the head sum, got {heads}"
-    assert kv.shape[-1] == dim
-    assert lse.shape == (batch, seq_len, heads), f"lse must be [B, S, H], got {tuple(lse.shape)}"
+    if heads > 64:
+        raise RuntimeError(f"target kernel requires heads <= 64 so one block owns the head sum, got {heads}")
+    if kv.shape[-1] != dim:
+        raise RuntimeError(f"kv head dim {kv.shape[-1]} does not match q head dim {dim}")
+    if lse.shape != (batch, seq_len, heads):
+        raise RuntimeError(f"lse must be [B, S, H], got {tuple(lse.shape)}")
     topk = topk_idxs.shape[-1]
 
     padded_topk = (topk + block_I - 1) // block_I * block_I


### PR DESCRIPTION
### What does this PR do?

Adds the TileLang kernel that computes the DeepSeek-V4 Lightning Indexer's **teacher
distribution**, and lets the existing sparse attention forward hand back the log-sum-exp it
already computes.

Kernel and plumbing only. The KL objective that consumes this arrives in a later PR, so nothing
here changes training behaviour.

### Checklist Before Starting

- Search for relative PRs/issues and link here: builds on #1012 (sparse MLA kernel time),
  already merged.
- PR title follows `[{modules}] {type}: {description}` format

### Test

- `pytest tests/ops/test_deepseek_v4_indexer_loss.py` — 19 passed. The suite includes an
  independent PyTorch reference for the teacher distribution, `NI > 1` coverage, and the
  zero-row contract.
- `make quality` — clean.
- `tests/ops` already runs as a whole directory in `gpu_unit_tests.yml`, so no workflow change
  is needed.

### API and Usage Example

```python
from veomni.ops.kernels.deepseek_v4 import sparse_attn_tilelang, sparse_mqa_target_fwd

out, lse = sparse_attn_tilelang(q, kv, sink, topk_idxs, sm_scale, return_lse=True)
target = sparse_mqa_target_fwd(q, kv, topk_idxs, lse, sm_scale)
```

`return_lse` defaults to `False`, so every existing call site is unaffected.

### Design & Code Changes

**`sparse_mqa_target_fwd`** produces the per-candidate attention probabilities the indexer is
distilled against, renormalized with the LSE from the attention forward rather than recomputing
a softmax. Its guards `raise` rather than `assert` so they survive `python -O`.

**Optional LSE.** The forward kernel already writes the LSE; returning it costs nothing. It is
marked non-differentiable in the autograd `Function`: the LSE only ever feeds the detached
indexer teacher, and leaving it differentiable would open a second gradient route back into
`q`/`kv`/`sink` and break the decoupling the indexer objective depends on.

### Checklist Before Submitting

- Applied pre-commit checks
- Added/updated documentation
- Added tests to CI workflow (covered by the existing `tests/ops` directory run)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sparse attention can optionally return log-sum-exp (LSE) values alongside attention outputs.
  * Added target attention support for compressed sparse indices on compatible CUDA hardware.
  * Improved handling of invalid or padded sparse indices and zero-mass rows.
* **Bug Fixes**
  * Added validation for unsupported head counts, data types, shapes, and configurations.
  * Ensured returned LSE values are not differentiated during backpropagation while attention outputs remain trainable.
* **Tests**
  * Added comprehensive coverage for normalization, masking, warnings, gradients, and kernel correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->