### PR TITLE
[trainer, ci] feat: report model aux_metrics without folding them into the loss

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -142,6 +142,7 @@ jobs:
           uv run --frozen pytest -s -x tests/models/test_model_registry.py
           uv run --frozen pytest -s -x tests/models/test_models_patch.py
           uv run --frozen pytest -s -x tests/models/test_vlm_trainer.py
+          uv run --frozen pytest -s -x tests/trainer/test_aux_metrics.py
           uv run --frozen pytest -s -x tests/lora/test_vlm_lora.py
           uv run --frozen pytest -s -x tests/models/test_padded_packed_loss.py
           uv run --frozen pytest -s -x tests/models/test_models_logits_equal_v5.py

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -161,6 +161,7 @@ jobs:
           uv run --frozen pytest -v -s -x tests/models/test_models_patch.py
           uv run --frozen pytest -v -s -x tests/models/test_padded_packed_loss.py
           uv run --frozen pytest -v -s -x tests/models/test_vlm_trainer.py
+          uv run --frozen pytest -v -s -x tests/trainer/test_aux_metrics.py
           uv run --frozen pytest -v -s -x tests/lora/test_vlm_lora.py
           uv run --frozen pytest -v -s -x tests/models/test_checkpoint_tensor_converter.py
       - name: Run fsdp2/extra_parallel+fsdp2 (e.g. ep+fsdp2, mb+fsdp2, ep+emb+fsdp2) clip grad norm test

--- a/docs/usage/trainer.md
+++ b/docs/usage/trainer.md
@@ -72,8 +72,8 @@ def train_step(self, data_iterator):
 
     # Gradient Accumulation Loop
     for micro_step, micro_batch in enumerate(micro_batches):
-        loss, loss_dict = self.forward_backward_step(micro_batch)
-        # ... accumulation ...
+        loss, loss_dict, aux_metrics = self.forward_backward_step(micro_batch)
+        # ... losses summed, aux metrics averaged ...
 
     # Optimization
     grad_norm = veomni_clip_grad_norm(self.model, self.args.train.optimizer.max_grad_norm)
@@ -94,38 +94,46 @@ The `forward_backward_step` allows for customization of the forward and backward
 ### Auxiliary Metrics (`outputs.aux_metrics`)
 
 A forward can report diagnostics alongside the losses by returning an
-`aux_metrics` dict on its model output. `postforward` merges it into `loss_dict`
-*after* summing the backward scalar, so an auxiliary value is logged but never
-becomes part of the objective. `EnvironMeterCallback` then publishes each entry
-as `training/<key>`, which is the name that reaches wandb.
+`aux_metrics` dict on its model output. They travel in their own channel the whole
+way — `postforward` returns `(loss, loss_dict, aux_metrics)`, `train_step` reduces
+the two dicts differently, and `on_step_end` passes `aux_metrics` to callbacks
+beside `grad_norm` — so no summation of losses can reach a metric. It is
+`EnvironMeterCallback` that finally publishes both under the same prefix, as
+`training/<key>`, which is the name that reaches wandb.
+
+Keeping them out of `loss_dict` is the point: every entry there is pre-weighted by
+its share of the step's tokens, so summing the dict is meaningful, and anything
+that sums it — `postforward` building the backward scalar today, any other caller
+tomorrow — would train on a metric folded in.
 
 The contract:
 
 - **Values are detached scalar tensors.** `postforward` calls `.detach()` on the
-  way in, so a metric that still carries a graph does not keep it alive for the
+  way out, so a metric that still carries a graph does not keep it alive for the
   step. Anything reported must reduce to a scalar, since the reporting path only
   ever calls `.item()` on it.
-- **Reported as the mean over the step's micro batches.** Losses may be summed
-  across micro batches because `mean_global_loss` has already scaled each by its
-  share of the step's tokens; an auxiliary metric gets no such scaling, so
-  `postforward` divides by `num_micro_batches` instead. Emit a key on every micro
-  batch of a step, or on none — a key present in only some micro batches is
-  averaged over all of them.
-- **Names already reported under `training/` are reserved.** A colliding key
-  raises `ValueError`, because every consumer keys on the name alone and both
-  collision directions are silent. Two groups are reserved:
-    - Every key in `loss_dict`, i.e. the losses this step produced. Without the
-      check `dict.update` would shadow the loss entry and callbacks would report
-      the auxiliary value under `training/<loss name>`, while the backward scalar
-      stayed correct.
+- **Reported as the mean over the step's micro batches.** Losses are summed across
+  micro batches because `mean_global_loss` has already scaled each by its share of
+  the step's tokens; a metric carries no such scaling, so `train_step` averages it
+  via `mean_aux_metrics` instead. Emit a key on every micro batch of a step, or on
+  none — a key present in only some micro batches is averaged over all of them.
+  Values are also averaged across the FSDP group before they are logged.
+- **Names already reported under `training/` are reserved.** Separate dicts do not
+  separate the published namespace, where every consumer keys on the name alone
+  and both collision directions are silent, so a colliding key raises
+  `ValueError`. Two groups are reserved:
+    - Every key in `loss_dict`, i.e. the losses this step produced. Otherwise the
+      auxiliary value would surface as `training/<loss name>`, a loss curve
+      reading someone else's number, while the backward scalar stayed correct.
     - The names `EnvironMeterCallback` publishes itself, listed in
       `RESERVED_TRAINING_METRIC_NAMES`: `total_loss`, `avg_effective_len`, and
       `avg_sample_seq_len` are assigned before the merge, so an auxiliary metric
       would overwrite them; `grad_norm` and `lr` are assigned after it, so they
       would overwrite the auxiliary metric and drop it silently. Extend that set
       when adding a metric to the callback.
-- **No `*_loss` suffix is needed.** That convention is required only by
-  `mean_global_loss`, which runs before the merge and never sees an auxiliary key.
+- **Do not route metrics through `mean_global_loss`.** It applies token / FSDP /
+  SP scaling for gradients, which is not a logging semantic. That also means the
+  `*_loss` suffix convention it relies on is irrelevant here.
 
 Most model outputs have no such field; `postforward` reads it with `getattr`, so
 models that do not report metrics are unaffected.

--- a/docs/usage/trainer.md
+++ b/docs/usage/trainer.md
@@ -91,6 +91,36 @@ The `forward_backward_step` allows for customization of the forward and backward
 - `preforward`: Moves data to the correct device.
 - `postforward`: Computes the final loss from model outputs.
 
+### Auxiliary Metrics (`outputs.aux_metrics`)
+
+A forward can report diagnostics alongside the losses by returning an
+`aux_metrics` dict on its model output. `postforward` merges it into `loss_dict`
+*after* summing the backward scalar, so an auxiliary value is logged but never
+becomes part of the objective. `EnvironMeterCallback` then publishes each entry
+as `training/<key>`, which is the name that reaches wandb.
+
+The contract:
+
+- **Values are detached scalar tensors.** `postforward` calls `.detach()` on the
+  way in, so a metric that still carries a graph does not keep it alive for the
+  step. Anything reported must reduce to a scalar, since the reporting path only
+  ever calls `.item()` on it.
+- **Reported as the mean over the step's micro batches.** Losses may be summed
+  across micro batches because `mean_global_loss` has already scaled each by its
+  share of the step's tokens; an auxiliary metric gets no such scaling, so
+  `postforward` divides by `num_micro_batches` instead. Emit a key on every micro
+  batch of a step, or on none — a key present in only some micro batches is
+  averaged over all of them.
+- **Loss names are reserved.** A key that collides with one already in
+  `loss_dict` raises `ValueError`. Without that check `dict.update` would shadow
+  the loss entry, and callbacks would report the auxiliary value under
+  `training/<loss name>` while the backward scalar stayed correct.
+- **No `*_loss` suffix is needed.** That convention is required only by
+  `mean_global_loss`, which runs before the merge and never sees an auxiliary key.
+
+Most model outputs have no such field; `postforward` reads it with `getattr`, so
+models that do not report metrics are unaffected.
+
 ## Callbacks
 
 The Trainer uses a callback system to decouple logging, checkpointing, and evaluation from the core training loop.

--- a/docs/usage/trainer.md
+++ b/docs/usage/trainer.md
@@ -111,10 +111,19 @@ The contract:
   `postforward` divides by `num_micro_batches` instead. Emit a key on every micro
   batch of a step, or on none — a key present in only some micro batches is
   averaged over all of them.
-- **Loss names are reserved.** A key that collides with one already in
-  `loss_dict` raises `ValueError`. Without that check `dict.update` would shadow
-  the loss entry, and callbacks would report the auxiliary value under
-  `training/<loss name>` while the backward scalar stayed correct.
+- **Names already reported under `training/` are reserved.** A colliding key
+  raises `ValueError`, because every consumer keys on the name alone and both
+  collision directions are silent. Two groups are reserved:
+    - Every key in `loss_dict`, i.e. the losses this step produced. Without the
+      check `dict.update` would shadow the loss entry and callbacks would report
+      the auxiliary value under `training/<loss name>`, while the backward scalar
+      stayed correct.
+    - The names `EnvironMeterCallback` publishes itself, listed in
+      `RESERVED_TRAINING_METRIC_NAMES`: `total_loss`, `avg_effective_len`, and
+      `avg_sample_seq_len` are assigned before the merge, so an auxiliary metric
+      would overwrite them; `grad_norm` and `lr` are assigned after it, so they
+      would overwrite the auxiliary metric and drop it silently. Extend that set
+      when adding a metric to the callback.
 - **No `*_loss` suffix is needed.** That convention is required only by
   `mean_global_loss`, which runs before the merge and never sees an auxiliary key.
 

--- a/tests/distributed/test_torch_compile.py
+++ b/tests/distributed/test_torch_compile.py
@@ -438,7 +438,7 @@ def test_vlm_train_step_marks_each_compile_micro_batch(monkeypatch):
         model_reshard=lambda *_: None,
         _configure_hsdp_allreduce=lambda *_: None,
         sync_before_train_step=lambda: None,
-        forward_backward_step=lambda _: (torch.tensor(1.0), {}),
+        forward_backward_step=lambda _: (torch.tensor(1.0), {}, {}),
         optimizer=SimpleNamespace(step=lambda: None, zero_grad=lambda: None),
         lr_scheduler=SimpleNamespace(step=lambda: None),
         on_step_begin=lambda **_: None,

--- a/tests/models/test_models_patch.py
+++ b/tests/models/test_models_patch.py
@@ -312,7 +312,7 @@ class TrainerTest(BaseTrainer):
         if batch["position_ids"].dim() == 3 and batch["position_ids"].shape[1] == 3:
             batch["position_ids"] = batch["position_ids"].transpose(0, 1).contiguous()
 
-        loss, loss_dict = super().forward_backward_step(batch)
+        loss, loss_dict, _ = super().forward_backward_step(batch)
         grad_norm = veomni_clip_grad_norm(self.model, args.train.optimizer.max_grad_norm)
 
         _release_device_memory()

--- a/tests/train_scripts/train_dit_test.py
+++ b/tests/train_scripts/train_dit_test.py
@@ -90,10 +90,14 @@ class TestDiTTrainer(DiTTrainer):
         super().on_train_end()
         self.base._log_callback.on_train_end(self.base.state)
 
-    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
-        super().on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
+    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None, aux_metrics=None):
+        super().on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm, aux_metrics=aux_metrics)
         self.base._log_callback.on_step_end(
-            self.base.state, loss=loss, loss_dict=loss_dict or {}, grad_norm=grad_norm or 0.0
+            self.base.state,
+            loss=loss,
+            loss_dict=loss_dict or {},
+            grad_norm=grad_norm or 0.0,
+            aux_metrics=aux_metrics,
         )
 
 

--- a/tests/trainer/test_aux_metrics.py
+++ b/tests/trainer/test_aux_metrics.py
@@ -14,12 +14,14 @@
 
 """Tests for ``outputs.aux_metrics`` on the trainer's reporting path.
 
-``BaseTrainer.postforward`` builds the backward scalar by summing ``loss_dict``,
-and ``train_step`` reports the *sum* of every micro batch's ``loss_dict``. Both
-summations are load-bearing for losses and both are wrong for a diagnostic: the
-first would fold the metric into the objective, the second would report it
-``gradient_accumulation_steps`` times too large. These tests pin both, plus the
-route from ``loss_dict`` to the ``training/<key>`` name that reaches wandb.
+``loss_dict`` carries a reduction contract a diagnostic does not share: every
+entry is pre-weighted by its share of the step's tokens, so ``postforward``
+summing it yields the backward scalar and ``train_step`` summing it across micro
+batches yields the step's mean loss. Both summations are wrong for a metric — the
+first would fold it into the objective, the second would report it
+``gradient_accumulation_steps`` times too large — so metrics travel in their own
+dict and are averaged instead. These tests pin that separation end to end, the
+averaging, and the route to the ``training/<key>`` name that reaches wandb.
 """
 
 import os
@@ -80,26 +82,29 @@ def _bare_trainer() -> BaseTrainer:
     return trainer
 
 
-def test_aux_metrics_are_reported_but_not_backpropagated(identity_loss):
-    """The metric is reported without joining the backward scalar.
+def test_aux_metrics_are_kept_out_of_the_losses(identity_loss):
+    """The metric is returned separately, so no summation of losses can reach it.
 
-    ``postforward`` sums ``loss_dict`` to build the scalar it hands to
-    ``backward()``, so a metric merged before that sum becomes part of the
-    objective. 1000.0 against a loss of 2.0 makes a leak unmistakable.
+    ``postforward`` sums ``loss_dict`` for the backward scalar, and it is not the
+    only consumer to do so, so the guarantee has to be structural rather than an
+    ordering invariant. 1000.0 against a loss of 2.0 makes a leak unmistakable.
     """
     trainer = _bare_trainer()
     lm_loss = torch.tensor(2.0, requires_grad=True)
     outputs = _Output(lm_loss, {"indexer_kl": torch.tensor(1000.0)})
 
-    loss, loss_dict = BaseTrainer.postforward(trainer, outputs, {})
+    loss, loss_dict, aux_metrics = BaseTrainer.postforward(trainer, outputs, {})
 
     assert loss.item() == pytest.approx(2.0), "aux metrics must not enter the backward scalar"
-    assert loss_dict["indexer_kl"].item() == pytest.approx(1000.0)
-    assert loss_dict["foundation_loss"].item() == pytest.approx(2.0)
+    assert aux_metrics["indexer_kl"].item() == pytest.approx(1000.0)
+    assert list(loss_dict) == ["foundation_loss"], "a metric in loss_dict would be summed as a loss"
+    # The invariant that makes the separation worth having: anything that sums the
+    # losses -- here or in a future caller -- cannot pick up a diagnostic.
+    assert torch.stack(list(loss_dict.values())).sum().item() == pytest.approx(2.0)
 
 
-def test_merged_aux_metric_carries_no_gradient(identity_loss):
-    """A metric that still had a graph must be detached on the way into ``loss_dict``.
+def test_reported_aux_metric_carries_no_gradient(identity_loss):
+    """A metric that still had a graph must be detached on the way out.
 
     ``train_step`` only ever calls ``.item()`` on it, but an attached tensor
     parked in a dict keeps its whole graph alive for the step.
@@ -109,10 +114,10 @@ def test_merged_aux_metric_carries_no_gradient(identity_loss):
     assert attached.requires_grad, "the fixture tensor must start out attached"
     outputs = _Output(torch.tensor(2.0, requires_grad=True), {"indexer_kl": attached})
 
-    _, loss_dict = BaseTrainer.postforward(trainer, outputs, {})
+    _, _, aux_metrics = BaseTrainer.postforward(trainer, outputs, {})
 
-    assert not loss_dict["indexer_kl"].requires_grad
-    assert loss_dict["indexer_kl"].grad_fn is None
+    assert not aux_metrics["indexer_kl"].requires_grad
+    assert aux_metrics["indexer_kl"].grad_fn is None
 
 
 def test_output_without_aux_metrics_attribute_is_unchanged(identity_loss):
@@ -120,30 +125,32 @@ def test_output_without_aux_metrics_attribute_is_unchanged(identity_loss):
     trainer = _bare_trainer()
     outputs = _PlainOutput(torch.tensor(2.0, requires_grad=True))
 
-    loss, loss_dict = BaseTrainer.postforward(trainer, outputs, {})
+    loss, loss_dict, aux_metrics = BaseTrainer.postforward(trainer, outputs, {})
 
     assert loss.item() == pytest.approx(2.0)
     assert list(loss_dict) == ["foundation_loss"]
+    assert aux_metrics == {}
 
 
-@pytest.mark.parametrize("aux_metrics", [None, {}], ids=["none", "empty"])
-def test_absent_aux_metrics_add_no_keys(identity_loss, aux_metrics):
+@pytest.mark.parametrize("reported", [None, {}], ids=["none", "empty"])
+def test_absent_aux_metrics_add_no_keys(identity_loss, reported):
     trainer = _bare_trainer()
-    outputs = _Output(torch.tensor(2.0, requires_grad=True), aux_metrics)
+    outputs = _Output(torch.tensor(2.0, requires_grad=True), reported)
 
-    loss, loss_dict = BaseTrainer.postforward(trainer, outputs, {})
+    loss, loss_dict, aux_metrics = BaseTrainer.postforward(trainer, outputs, {})
 
     assert loss.item() == pytest.approx(2.0)
     assert list(loss_dict) == ["foundation_loss"]
+    assert aux_metrics == {}
 
 
 def test_aux_metric_colliding_with_a_loss_key_is_rejected(identity_loss):
-    """A shadowed loss name is the one failure mode the merge cannot report honestly.
+    """Separate dicts do not separate the ``training/`` namespace they share.
 
-    ``dict.update`` would overwrite the loss entry. The backward scalar stays
-    correct — it is summed before the merge — so nothing diverges; the damage is
-    that callbacks then publish the auxiliary value as ``training/foundation_loss``,
-    a loss curve that silently reads someone else's number.
+    Nothing diverges — the metric never touches the objective — but
+    ``EnvironMeterCallback`` publishes both dicts under the same prefix, so the
+    auxiliary value would surface as ``training/foundation_loss``: a loss curve
+    silently reading someone else's number.
     """
     trainer = _bare_trainer()
     outputs = _Output(torch.tensor(2.0, requires_grad=True), {"foundation_loss": torch.tensor(1000.0)})
@@ -196,15 +203,15 @@ def _accumulating_trainer(outputs, recorded):
     trainer.forward_backward_step = lambda micro_batch: BaseTrainer.postforward(trainer, next(remaining), micro_batch)
     # ``TextTrainer`` / ``VLMTrainer`` route their ``on_step_end`` through the
     # base trainer, so patching it here captures the step totals for all three.
-    trainer.on_step_end = lambda loss=None, loss_dict=None, grad_norm=None: recorded.update(
-        loss=loss, loss_dict=loss_dict
+    trainer.on_step_end = lambda loss=None, loss_dict=None, grad_norm=None, aux_metrics=None: recorded.update(
+        loss=loss, loss_dict=loss_dict, aux_metrics=aux_metrics
     )
     return trainer
 
 
 # ``TextTrainer`` and ``VLMTrainer`` do not reuse ``BaseTrainer.train_step``; each
-# keeps its own copy of the accumulation loop, so each has to publish
-# ``num_micro_batches`` for the shared ``postforward`` to normalize against.
+# keeps its own copy of the accumulation loop, and so has to reduce the metrics
+# itself. Running every case through all three is what keeps them from drifting.
 _TRAIN_STEP_OWNERS = {
     "base": (base_trainer_module, None),
     "text": (text_trainer_module, TextTrainer),
@@ -239,13 +246,12 @@ def run_train_step(request, monkeypatch):
 def test_reported_aux_metric_does_not_scale_with_gradient_accumulation(run_train_step, identity_loss):
     """The reported metric is the mean over the step's micro batches, not their sum.
 
-    ``train_step`` accumulates ``total_loss_dict[k] += v.item()`` over the micro
-    batches. That is right for losses, which ``mean_global_loss`` has already
-    weighted by their share of the step's tokens, and wrong for an aux metric
-    merged after that weighting: summed over N micro batches it would be
-    reported N times too large — plausible-looking, correctly signed, and off by
-    a configuration-dependent factor. Three micro batches, so the expectation
-    also separates the mean from a hard-coded halving.
+    The two dicts are reduced differently in the same loop: losses are summed,
+    because ``mean_global_loss`` has already weighted each by its share of the
+    step's tokens, while a metric carries no such weight and is averaged. Summing
+    it instead would report it N times too large — plausible-looking, correctly
+    signed, and off by a configuration-dependent factor. Three micro batches, so
+    the expectation also separates the mean from a hard-coded halving.
     """
     aux_values = [6.0, 9.0, 12.0]
     lm_losses = [1.0, 2.0, 3.0]
@@ -256,8 +262,9 @@ def test_reported_aux_metric_does_not_scale_with_gradient_accumulation(run_train
 
     run_train_step(trainer, micro_batches)
 
-    # mean(6, 9, 12) == 9.0; the unnormalized sum would report 27.0.
-    assert recorded["loss_dict"]["indexer_kl"] == pytest.approx(9.0)
+    # mean(6, 9, 12) == 9.0; the unreduced sum would report 27.0.
+    assert recorded["aux_metrics"]["indexer_kl"] == pytest.approx(9.0)
+    assert "indexer_kl" not in recorded["loss_dict"], "the metric must not reach the loss channel"
     # The loss terms, by contrast, must still be summed: each already carries
     # its token-share weight, so their sum is the step's mean loss.
     assert recorded["loss_dict"]["foundation_loss"] == pytest.approx(sum(lm_losses))
@@ -272,7 +279,38 @@ def test_single_micro_batch_reports_the_metric_unscaled(run_train_step, identity
 
     run_train_step(trainer, [{"labels": torch.tensor([[1, 2, -100, 4]])}])
 
-    assert recorded["loss_dict"]["indexer_kl"] == pytest.approx(6.0)
+    assert recorded["aux_metrics"]["indexer_kl"] == pytest.approx(6.0)
+
+
+def test_metric_emitted_by_some_micro_batches_is_averaged_over_all_of_them(run_train_step, identity_loss):
+    """The documented consequence of dividing by the step's micro-batch count.
+
+    A key only some micro batches emit is still divided by all of them, so a
+    partial emission reads low rather than being silently rescaled to look
+    complete. Callers are told to emit a key on every micro batch or none.
+    """
+    recorded = {}
+    outputs = [
+        _Output(torch.tensor(1.0), {"indexer_kl": torch.tensor(6.0)}),
+        _Output(torch.tensor(1.0), {}),
+    ]
+    trainer = _accumulating_trainer(outputs, recorded)
+    micro_batches = [{"labels": torch.tensor([[1, 2, -100, 4]])} for _ in outputs]
+
+    run_train_step(trainer, micro_batches)
+
+    assert recorded["aux_metrics"]["indexer_kl"] == pytest.approx(3.0)
+
+
+def test_a_step_without_aux_metrics_reports_an_empty_dict(run_train_step, identity_loss):
+    """Every other model in the repo takes this path; it must not report a stray key."""
+    recorded = {}
+    outputs = [_PlainOutput(torch.tensor(1.0))]
+    trainer = _accumulating_trainer(outputs, recorded)
+
+    run_train_step(trainer, [{"labels": torch.tensor([[1, 2, -100, 4]])}])
+
+    assert recorded["aux_metrics"] == {}
 
 
 def _environ_meter_callback(env_metrics=None, lr=None):
@@ -316,13 +354,13 @@ def test_reserved_names_match_what_the_callback_publishes_itself(monkeypatch):
     assert published - set(loss_dict) == set(RESERVED_TRAINING_METRIC_NAMES)
 
 
-def test_environ_meter_prefixes_aux_metric_without_a_loss_suffix(monkeypatch):
+def test_environ_meter_publishes_aux_metric_beside_the_losses(monkeypatch):
     """``training/indexer_kl`` is what reaches wandb, and no consumer needs ``*_loss``.
 
     ``EnvironMeterCallback.on_step_end`` — not the wandb callback — is what
-    prefixes ``loss_dict`` keys, and it treats them as opaque names. The
-    ``*_loss`` convention is required only by ``mean_global_loss``, which runs
-    before the merge and never sees an aux key.
+    prefixes the names, and it treats them as opaque, so a metric arriving in its
+    own dict still lands next to the losses. The ``*_loss`` convention is required
+    only by ``mean_global_loss``, which never sees an auxiliary key.
     """
     monkeypatch.setattr(trace_callback_module, "all_reduce", lambda value, group=None: value)
     callback = _environ_meter_callback()
@@ -330,10 +368,29 @@ def test_environ_meter_prefixes_aux_metric_without_a_loss_suffix(monkeypatch):
     callback.on_step_end(
         TrainerState(global_step=1),
         loss=2.0,
-        loss_dict={"foundation_loss": 2.0, "indexer_kl": 9.0},
+        loss_dict={"foundation_loss": 2.0},
         grad_norm=0.5,
+        aux_metrics={"indexer_kl": 9.0},
     )
 
     assert callback.trainer.step_train_metrics["training/indexer_kl"] == pytest.approx(9.0)
     assert callback.trainer.step_train_metrics["training/foundation_loss"] == pytest.approx(2.0)
     assert callback.trainer.step_env_metrics["training/indexer_kl"] == pytest.approx(9.0)
+
+
+@pytest.mark.parametrize("aux_metrics", [None, {}], ids=["none", "empty"])
+def test_environ_meter_tolerates_a_step_without_aux_metrics(monkeypatch, aux_metrics):
+    """Callbacks predate the parameter, and the trainers that never fill it still call it."""
+    monkeypatch.setattr(trace_callback_module, "all_reduce", lambda value, group=None: value)
+    callback = _environ_meter_callback()
+
+    callback.on_step_end(
+        TrainerState(global_step=1),
+        loss=2.0,
+        loss_dict={"foundation_loss": 2.0},
+        grad_norm=0.5,
+        aux_metrics=aux_metrics,
+    )
+
+    assert callback.trainer.step_train_metrics["training/foundation_loss"] == pytest.approx(2.0)
+    assert callback.trainer.step_train_metrics["training/grad_norm"] == pytest.approx(0.5)

--- a/tests/trainer/test_aux_metrics.py
+++ b/tests/trainer/test_aux_metrics.py
@@ -39,6 +39,7 @@ import veomni.trainer.text_trainer as text_trainer_module
 import veomni.trainer.vlm_trainer as vlm_trainer_module
 from veomni.trainer.base import BaseTrainer
 from veomni.trainer.callbacks.base import TrainerState
+from veomni.trainer.callbacks.trace_callback import RESERVED_TRAINING_METRIC_NAMES
 from veomni.trainer.text_trainer import TextTrainer
 from veomni.trainer.vlm_trainer import VLMTrainer
 
@@ -147,7 +148,21 @@ def test_aux_metric_colliding_with_a_loss_key_is_rejected(identity_loss):
     trainer = _bare_trainer()
     outputs = _Output(torch.tensor(2.0, requires_grad=True), {"foundation_loss": torch.tensor(1000.0)})
 
-    with pytest.raises(ValueError, match="collide with loss keys"):
+    with pytest.raises(ValueError, match="already reported under"):
+        BaseTrainer.postforward(trainer, outputs, {})
+
+
+@pytest.mark.parametrize("reserved", sorted(RESERVED_TRAINING_METRIC_NAMES))
+def test_aux_metric_colliding_with_a_callback_owned_name_is_rejected(identity_loss, reserved):
+    """These clash one layer later than a loss key, in the published namespace.
+
+    ``EnvironMeterCallback`` adds them to ``training/`` itself, so they are absent
+    from ``loss_dict`` and the loss-key check alone would let them through.
+    """
+    trainer = _bare_trainer()
+    outputs = _Output(torch.tensor(2.0, requires_grad=True), {reserved: torch.tensor(1000.0)})
+
+    with pytest.raises(ValueError, match="already reported under"):
         BaseTrainer.postforward(trainer, outputs, {})
 
 
@@ -260,6 +275,47 @@ def test_single_micro_batch_reports_the_metric_unscaled(run_train_step, identity
     assert recorded["loss_dict"]["indexer_kl"] == pytest.approx(6.0)
 
 
+def _environ_meter_callback(env_metrics=None, lr=None):
+    """``EnvironMeterCallback`` reduced to what ``on_step_end`` reads."""
+    callback = object.__new__(trace_callback_module.EnvironMeterCallback)
+    callback.parallel_state = SimpleNamespace(fsdp_group=None)
+    callback.start_time = time.time()
+    callback.lora_config = None
+    callback.freeze_vit = None
+    callback.trainer = SimpleNamespace(
+        environ_meter=SimpleNamespace(step=lambda delta_time, global_step, **kwargs: dict(env_metrics or {})),
+        lr_scheduler=None if lr is None else SimpleNamespace(get_last_lr=lambda: [lr]),
+    )
+    return callback
+
+
+def test_reserved_names_match_what_the_callback_publishes_itself(monkeypatch):
+    """Keeps the reserved set from going stale as the callback gains metrics.
+
+    Derives the callback-owned names rather than restating them: every
+    ``training/`` name that did not come from ``loss_dict`` was put there by the
+    callback or by the environ meter it merges, which is exactly the set an
+    auxiliary key must not collide with. Adding a metric to ``on_step_end``
+    without extending ``RESERVED_TRAINING_METRIC_NAMES`` fails here.
+    """
+    monkeypatch.setattr(trace_callback_module, "all_reduce", lambda value, group=None: value)
+    # Mirrors the ``training/``-prefixed keys of ``helper.EnvironMeter.step``. The
+    # unprefixed ones it also emits (mfu, flops, memory) land in another namespace
+    # and cannot collide, so one stands in for all of them.
+    env_metrics = {"training/avg_effective_len": 1.0, "training/avg_sample_seq_len": 2.0, "mfu": 0.5}
+    callback = _environ_meter_callback(env_metrics=env_metrics, lr=3.0)
+    loss_dict = {"foundation_loss": 2.0}
+
+    callback.on_step_end(TrainerState(global_step=1), loss=2.0, loss_dict=loss_dict, grad_norm=0.5)
+
+    published = {
+        key.removeprefix("training/")
+        for key in (*callback.trainer.step_train_metrics, *callback.trainer.step_env_metrics)
+        if key.startswith("training/")
+    }
+    assert published - set(loss_dict) == set(RESERVED_TRAINING_METRIC_NAMES)
+
+
 def test_environ_meter_prefixes_aux_metric_without_a_loss_suffix(monkeypatch):
     """``training/indexer_kl`` is what reaches wandb, and no consumer needs ``*_loss``.
 
@@ -269,15 +325,7 @@ def test_environ_meter_prefixes_aux_metric_without_a_loss_suffix(monkeypatch):
     before the merge and never sees an aux key.
     """
     monkeypatch.setattr(trace_callback_module, "all_reduce", lambda value, group=None: value)
-    callback = object.__new__(trace_callback_module.EnvironMeterCallback)
-    callback.parallel_state = SimpleNamespace(fsdp_group=None)
-    callback.start_time = time.time()
-    callback.lora_config = None
-    callback.freeze_vit = None
-    callback.trainer = SimpleNamespace(
-        environ_meter=SimpleNamespace(step=lambda delta_time, global_step, **kwargs: {}),
-        lr_scheduler=None,
-    )
+    callback = _environ_meter_callback()
 
     callback.on_step_end(
         TrainerState(global_step=1),

--- a/tests/trainer/test_aux_metrics.py
+++ b/tests/trainer/test_aux_metrics.py
@@ -35,8 +35,12 @@ import torch
 
 import veomni.trainer.base as base_trainer_module
 import veomni.trainer.callbacks.trace_callback as trace_callback_module
+import veomni.trainer.text_trainer as text_trainer_module
+import veomni.trainer.vlm_trainer as vlm_trainer_module
 from veomni.trainer.base import BaseTrainer
 from veomni.trainer.callbacks.base import TrainerState
+from veomni.trainer.text_trainer import TextTrainer
+from veomni.trainer.vlm_trainer import VLMTrainer
 
 
 class _Output:
@@ -132,18 +136,13 @@ def test_absent_aux_metrics_add_no_keys(identity_loss, aux_metrics):
     assert list(loss_dict) == ["foundation_loss"]
 
 
-def _accumulating_trainer(monkeypatch, outputs, recorded):
+def _accumulating_trainer(outputs, recorded):
     """A ``BaseTrainer`` reduced to the parts ``train_step`` touches.
 
     Everything stubbed here is off the reporting path — process groups, the
     optimizer, grad clipping, the model. The accumulation loop itself, and the
     ``postforward`` it calls, are the real ones.
     """
-    monkeypatch.setattr(base_trainer_module, "synchronize", lambda: None)
-    monkeypatch.setattr(base_trainer_module, "mark_compile_step_begin", lambda *args, **kwargs: None)
-    monkeypatch.setattr(base_trainer_module, "use_parallel_state", lambda name: nullcontext())
-    monkeypatch.setattr(base_trainer_module, "veomni_clip_grad_norm", lambda *args, **kwargs: 0.0)
-
     trainer = _bare_trainer()
     trainer.state = TrainerState(global_step=0)
     trainer.model = SimpleNamespace()
@@ -164,13 +163,45 @@ def _accumulating_trainer(monkeypatch, outputs, recorded):
     # Stands in for the forward + backward, so the real postforward runs on a
     # real per-micro-batch model output without a model or autograd.
     trainer.forward_backward_step = lambda micro_batch: BaseTrainer.postforward(trainer, next(remaining), micro_batch)
+    # ``TextTrainer`` / ``VLMTrainer`` route their ``on_step_end`` through the
+    # base trainer, so patching it here captures the step totals for all three.
     trainer.on_step_end = lambda loss=None, loss_dict=None, grad_norm=None: recorded.update(
         loss=loss, loss_dict=loss_dict
     )
     return trainer
 
 
-def test_reported_aux_metric_does_not_scale_with_gradient_accumulation(monkeypatch, identity_loss):
+# ``TextTrainer`` and ``VLMTrainer`` do not reuse ``BaseTrainer.train_step``; each
+# keeps its own copy of the accumulation loop, so each has to publish
+# ``num_micro_batches`` for the shared ``postforward`` to normalize against.
+_TRAIN_STEP_OWNERS = {
+    "base": (base_trainer_module, None),
+    "text": (text_trainer_module, TextTrainer),
+    "vlm": (vlm_trainer_module, VLMTrainer),
+}
+
+
+@pytest.fixture(params=sorted(_TRAIN_STEP_OWNERS))
+def run_train_step(request, monkeypatch):
+    """Runs one training step through whichever trainer owns the loop."""
+    module, wrapper_cls = _TRAIN_STEP_OWNERS[request.param]
+    monkeypatch.setattr(module, "synchronize", lambda: None)
+    monkeypatch.setattr(module, "use_parallel_state", lambda name: nullcontext())
+    monkeypatch.setattr(module, "veomni_clip_grad_norm", lambda *args, **kwargs: 0.0)
+    # VLMTrainer's loop does not mark compile steps.
+    monkeypatch.setattr(module, "mark_compile_step_begin", lambda *args, **kwargs: None, raising=False)
+
+    def run(trainer, micro_batches):
+        driver = trainer
+        if wrapper_cls is not None:
+            driver = object.__new__(wrapper_cls)
+            driver.base = trainer
+        type(driver).train_step(driver, iter([micro_batches]))
+
+    return run
+
+
+def test_reported_aux_metric_does_not_scale_with_gradient_accumulation(run_train_step, identity_loss):
     """The reported metric is the mean over the step's micro batches, not their sum.
 
     ``train_step`` accumulates ``total_loss_dict[k] += v.item()`` over the micro
@@ -185,10 +216,10 @@ def test_reported_aux_metric_does_not_scale_with_gradient_accumulation(monkeypat
     lm_losses = [1.0, 2.0, 3.0]
     outputs = [_Output(torch.tensor(lm), {"indexer_kl": torch.tensor(aux)}) for lm, aux in zip(lm_losses, aux_values)]
     recorded = {}
-    trainer = _accumulating_trainer(monkeypatch, outputs, recorded)
+    trainer = _accumulating_trainer(outputs, recorded)
     micro_batches = [{"labels": torch.tensor([[1, 2, -100, 4]])} for _ in aux_values]
 
-    BaseTrainer.train_step(trainer, iter([micro_batches]))
+    run_train_step(trainer, micro_batches)
 
     # mean(6, 9, 12) == 9.0; the unnormalized sum would report 27.0.
     assert recorded["loss_dict"]["indexer_kl"] == pytest.approx(9.0)
@@ -198,13 +229,13 @@ def test_reported_aux_metric_does_not_scale_with_gradient_accumulation(monkeypat
     assert recorded["loss"] == pytest.approx(sum(lm_losses))
 
 
-def test_single_micro_batch_reports_the_metric_unscaled(monkeypatch, identity_loss):
+def test_single_micro_batch_reports_the_metric_unscaled(run_train_step, identity_loss):
     """The N == 1 case, which the averaging must leave alone."""
     recorded = {}
     outputs = [_Output(torch.tensor(1.0), {"indexer_kl": torch.tensor(6.0)})]
-    trainer = _accumulating_trainer(monkeypatch, outputs, recorded)
+    trainer = _accumulating_trainer(outputs, recorded)
 
-    BaseTrainer.train_step(trainer, iter([[{"labels": torch.tensor([[1, 2, -100, 4]])}]]))
+    run_train_step(trainer, [{"labels": torch.tensor([[1, 2, -100, 4]])}])
 
     assert recorded["loss_dict"]["indexer_kl"] == pytest.approx(6.0)
 

--- a/tests/trainer/test_aux_metrics.py
+++ b/tests/trainer/test_aux_metrics.py
@@ -68,7 +68,7 @@ def identity_loss(monkeypatch):
     monkeypatch.setattr(
         base_trainer_module,
         "mean_global_loss",
-        lambda losses, micro_batch_token_len, micro_batches_token_len: {"foundation_loss": losses},
+        lambda losses, *token_len_args: {"foundation_loss": losses},
     )
 
 
@@ -155,6 +155,7 @@ def _accumulating_trainer(outputs, recorded):
                 dp_replicate_size=1,
                 fsdp_config=SimpleNamespace(fsdp_mode="fsdp2", reshard_after_backward=True),
             ),
+            sync_each_train_step=False,
         )
     )
     trainer._callbacks = []
@@ -188,6 +189,10 @@ def run_train_step(request, monkeypatch):
     monkeypatch.setattr(module, "synchronize", lambda: None)
     monkeypatch.setattr(module, "use_parallel_state", lambda name: nullcontext())
     monkeypatch.setattr(module, "veomni_clip_grad_norm", lambda *args, **kwargs: 0.0)
+    # Single process: the all-reduce over the step's token denominators is the identity.
+    monkeypatch.setattr(
+        module, "reduce_global_loss_token", lambda token_len: {key: value.item() for key, value in token_len.items()}
+    )
     # VLMTrainer's loop does not mark compile steps.
     monkeypatch.setattr(module, "mark_compile_step_begin", lambda *args, **kwargs: None, raising=False)
 
@@ -252,8 +257,10 @@ def test_environ_meter_prefixes_aux_metric_without_a_loss_suffix(monkeypatch):
     callback = object.__new__(trace_callback_module.EnvironMeterCallback)
     callback.parallel_state = SimpleNamespace(fsdp_group=None)
     callback.start_time = time.time()
+    callback.lora_config = None
+    callback.freeze_vit = None
     callback.trainer = SimpleNamespace(
-        environ_meter=SimpleNamespace(step=lambda delta_time, global_step: {}),
+        environ_meter=SimpleNamespace(step=lambda delta_time, global_step, **kwargs: {}),
         lr_scheduler=None,
     )
 

--- a/tests/trainer/test_aux_metrics.py
+++ b/tests/trainer/test_aux_metrics.py
@@ -136,6 +136,21 @@ def test_absent_aux_metrics_add_no_keys(identity_loss, aux_metrics):
     assert list(loss_dict) == ["foundation_loss"]
 
 
+def test_aux_metric_colliding_with_a_loss_key_is_rejected(identity_loss):
+    """A shadowed loss name is the one failure mode the merge cannot report honestly.
+
+    ``dict.update`` would overwrite the loss entry. The backward scalar stays
+    correct — it is summed before the merge — so nothing diverges; the damage is
+    that callbacks then publish the auxiliary value as ``training/foundation_loss``,
+    a loss curve that silently reads someone else's number.
+    """
+    trainer = _bare_trainer()
+    outputs = _Output(torch.tensor(2.0, requires_grad=True), {"foundation_loss": torch.tensor(1000.0)})
+
+    with pytest.raises(ValueError, match="collide with loss keys"):
+        BaseTrainer.postforward(trainer, outputs, {})
+
+
 def _accumulating_trainer(outputs, recorded):
     """A ``BaseTrainer`` reduced to the parts ``train_step`` touches.
 

--- a/tests/trainer/test_aux_metrics.py
+++ b/tests/trainer/test_aux_metrics.py
@@ -1,0 +1,238 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``outputs.aux_metrics`` on the trainer's reporting path.
+
+``BaseTrainer.postforward`` builds the backward scalar by summing ``loss_dict``,
+and ``train_step`` reports the *sum* of every micro batch's ``loss_dict``. Both
+summations are load-bearing for losses and both are wrong for a diagnostic: the
+first would fold the metric into the objective, the second would report it
+``gradient_accumulation_steps`` times too large. These tests pin both, plus the
+route from ``loss_dict`` to the ``training/<key>`` name that reaches wandb.
+"""
+
+import os
+import time
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+
+os.environ.setdefault("TORCH_DEVICE_BACKEND_AUTOLOAD", "0")
+
+import pytest
+import torch
+
+import veomni.trainer.base as base_trainer_module
+import veomni.trainer.callbacks.trace_callback as trace_callback_module
+from veomni.trainer.base import BaseTrainer
+from veomni.trainer.callbacks.base import TrainerState
+
+
+class _Output:
+    """A model output that carries aux metrics, as DeepSeek-V4's does."""
+
+    def __init__(self, loss, aux_metrics):
+        self.loss = loss
+        self.aux_metrics = aux_metrics
+
+
+class _PlainOutput:
+    """A model output with no ``aux_metrics`` attribute — every other model."""
+
+    def __init__(self, loss):
+        self.loss = loss
+
+
+@pytest.fixture
+def identity_loss(monkeypatch):
+    """Neutralize ``mean_global_loss``: it all-reduces, so it needs a process group.
+
+    The token weighting it applies is not under test here; what is under test is
+    what ``postforward`` does with the dict it returns.
+    """
+    monkeypatch.setattr(
+        base_trainer_module,
+        "mean_global_loss",
+        lambda losses, micro_batch_token_len, micro_batches_token_len: {"foundation_loss": losses},
+    )
+
+
+def _bare_trainer() -> BaseTrainer:
+    trainer = object.__new__(BaseTrainer)
+    trainer.micro_batch_token_len = {}
+    trainer.micro_batches_token_len = {}
+    return trainer
+
+
+def test_aux_metrics_are_reported_but_not_backpropagated(identity_loss):
+    """The metric is reported without joining the backward scalar.
+
+    ``postforward`` sums ``loss_dict`` to build the scalar it hands to
+    ``backward()``, so a metric merged before that sum becomes part of the
+    objective. 1000.0 against a loss of 2.0 makes a leak unmistakable.
+    """
+    trainer = _bare_trainer()
+    lm_loss = torch.tensor(2.0, requires_grad=True)
+    outputs = _Output(lm_loss, {"indexer_kl": torch.tensor(1000.0)})
+
+    loss, loss_dict = BaseTrainer.postforward(trainer, outputs, {})
+
+    assert loss.item() == pytest.approx(2.0), "aux metrics must not enter the backward scalar"
+    assert loss_dict["indexer_kl"].item() == pytest.approx(1000.0)
+    assert loss_dict["foundation_loss"].item() == pytest.approx(2.0)
+
+
+def test_merged_aux_metric_carries_no_gradient(identity_loss):
+    """A metric that still had a graph must be detached on the way into ``loss_dict``.
+
+    ``train_step`` only ever calls ``.item()`` on it, but an attached tensor
+    parked in a dict keeps its whole graph alive for the step.
+    """
+    trainer = _bare_trainer()
+    attached = (torch.tensor(3.0, requires_grad=True) * 2).sum()
+    assert attached.requires_grad, "the fixture tensor must start out attached"
+    outputs = _Output(torch.tensor(2.0, requires_grad=True), {"indexer_kl": attached})
+
+    _, loss_dict = BaseTrainer.postforward(trainer, outputs, {})
+
+    assert not loss_dict["indexer_kl"].requires_grad
+    assert loss_dict["indexer_kl"].grad_fn is None
+
+
+def test_output_without_aux_metrics_attribute_is_unchanged(identity_loss):
+    """The common case: ``postforward`` is shared by every model in the repo."""
+    trainer = _bare_trainer()
+    outputs = _PlainOutput(torch.tensor(2.0, requires_grad=True))
+
+    loss, loss_dict = BaseTrainer.postforward(trainer, outputs, {})
+
+    assert loss.item() == pytest.approx(2.0)
+    assert list(loss_dict) == ["foundation_loss"]
+
+
+@pytest.mark.parametrize("aux_metrics", [None, {}], ids=["none", "empty"])
+def test_absent_aux_metrics_add_no_keys(identity_loss, aux_metrics):
+    trainer = _bare_trainer()
+    outputs = _Output(torch.tensor(2.0, requires_grad=True), aux_metrics)
+
+    loss, loss_dict = BaseTrainer.postforward(trainer, outputs, {})
+
+    assert loss.item() == pytest.approx(2.0)
+    assert list(loss_dict) == ["foundation_loss"]
+
+
+def _accumulating_trainer(monkeypatch, outputs, recorded):
+    """A ``BaseTrainer`` reduced to the parts ``train_step`` touches.
+
+    Everything stubbed here is off the reporting path — process groups, the
+    optimizer, grad clipping, the model. The accumulation loop itself, and the
+    ``postforward`` it calls, are the real ones.
+    """
+    monkeypatch.setattr(base_trainer_module, "synchronize", lambda: None)
+    monkeypatch.setattr(base_trainer_module, "mark_compile_step_begin", lambda *args, **kwargs: None)
+    monkeypatch.setattr(base_trainer_module, "use_parallel_state", lambda name: nullcontext())
+    monkeypatch.setattr(base_trainer_module, "veomni_clip_grad_norm", lambda *args, **kwargs: 0.0)
+
+    trainer = _bare_trainer()
+    trainer.state = TrainerState(global_step=0)
+    trainer.model = SimpleNamespace()
+    trainer.optimizer = SimpleNamespace(step=lambda: None, zero_grad=lambda: None)
+    trainer.lr_scheduler = SimpleNamespace(step=lambda: None)
+    trainer.args = SimpleNamespace(
+        train=SimpleNamespace(
+            optimizer=SimpleNamespace(max_grad_norm=1.0),
+            accelerator=SimpleNamespace(
+                dp_replicate_size=1,
+                fsdp_config=SimpleNamespace(fsdp_mode="fsdp2", reshard_after_backward=True),
+            ),
+        )
+    )
+    trainer._callbacks = []
+
+    remaining = iter(outputs)
+    # Stands in for the forward + backward, so the real postforward runs on a
+    # real per-micro-batch model output without a model or autograd.
+    trainer.forward_backward_step = lambda micro_batch: BaseTrainer.postforward(trainer, next(remaining), micro_batch)
+    trainer.on_step_end = lambda loss=None, loss_dict=None, grad_norm=None: recorded.update(
+        loss=loss, loss_dict=loss_dict
+    )
+    return trainer
+
+
+def test_reported_aux_metric_does_not_scale_with_gradient_accumulation(monkeypatch, identity_loss):
+    """The reported metric is the mean over the step's micro batches, not their sum.
+
+    ``train_step`` accumulates ``total_loss_dict[k] += v.item()`` over the micro
+    batches. That is right for losses, which ``mean_global_loss`` has already
+    weighted by their share of the step's tokens, and wrong for an aux metric
+    merged after that weighting: summed over N micro batches it would be
+    reported N times too large — plausible-looking, correctly signed, and off by
+    a configuration-dependent factor. Three micro batches, so the expectation
+    also separates the mean from a hard-coded halving.
+    """
+    aux_values = [6.0, 9.0, 12.0]
+    lm_losses = [1.0, 2.0, 3.0]
+    outputs = [_Output(torch.tensor(lm), {"indexer_kl": torch.tensor(aux)}) for lm, aux in zip(lm_losses, aux_values)]
+    recorded = {}
+    trainer = _accumulating_trainer(monkeypatch, outputs, recorded)
+    micro_batches = [{"labels": torch.tensor([[1, 2, -100, 4]])} for _ in aux_values]
+
+    BaseTrainer.train_step(trainer, iter([micro_batches]))
+
+    # mean(6, 9, 12) == 9.0; the unnormalized sum would report 27.0.
+    assert recorded["loss_dict"]["indexer_kl"] == pytest.approx(9.0)
+    # The loss terms, by contrast, must still be summed: each already carries
+    # its token-share weight, so their sum is the step's mean loss.
+    assert recorded["loss_dict"]["foundation_loss"] == pytest.approx(sum(lm_losses))
+    assert recorded["loss"] == pytest.approx(sum(lm_losses))
+
+
+def test_single_micro_batch_reports_the_metric_unscaled(monkeypatch, identity_loss):
+    """The N == 1 case, which the averaging must leave alone."""
+    recorded = {}
+    outputs = [_Output(torch.tensor(1.0), {"indexer_kl": torch.tensor(6.0)})]
+    trainer = _accumulating_trainer(monkeypatch, outputs, recorded)
+
+    BaseTrainer.train_step(trainer, iter([[{"labels": torch.tensor([[1, 2, -100, 4]])}]]))
+
+    assert recorded["loss_dict"]["indexer_kl"] == pytest.approx(6.0)
+
+
+def test_environ_meter_prefixes_aux_metric_without_a_loss_suffix(monkeypatch):
+    """``training/indexer_kl`` is what reaches wandb, and no consumer needs ``*_loss``.
+
+    ``EnvironMeterCallback.on_step_end`` — not the wandb callback — is what
+    prefixes ``loss_dict`` keys, and it treats them as opaque names. The
+    ``*_loss`` convention is required only by ``mean_global_loss``, which runs
+    before the merge and never sees an aux key.
+    """
+    monkeypatch.setattr(trace_callback_module, "all_reduce", lambda value, group=None: value)
+    callback = object.__new__(trace_callback_module.EnvironMeterCallback)
+    callback.parallel_state = SimpleNamespace(fsdp_group=None)
+    callback.start_time = time.time()
+    callback.trainer = SimpleNamespace(
+        environ_meter=SimpleNamespace(step=lambda delta_time, global_step: {}),
+        lr_scheduler=None,
+    )
+
+    callback.on_step_end(
+        TrainerState(global_step=1),
+        loss=2.0,
+        loss_dict={"foundation_loss": 2.0, "indexer_kl": 9.0},
+        grad_norm=0.5,
+    )
+
+    assert callback.trainer.step_train_metrics["training/indexer_kl"] == pytest.approx(9.0)
+    assert callback.trainer.step_train_metrics["training/foundation_loss"] == pytest.approx(2.0)
+    assert callback.trainer.step_env_metrics["training/indexer_kl"] == pytest.approx(9.0)

--- a/tests/trainer/test_channel_loss_callback.py
+++ b/tests/trainer/test_channel_loss_callback.py
@@ -832,9 +832,9 @@ def test_base_forward_backward_allows_missing_channel_loss_callback(monkeypatch)
     trainer.micro_batch_token_len = 1
     trainer.micro_batches_token_len = 1
     trainer.LOG_SAMPLE = False
-    trainer.postforward = lambda outputs, micro_batch: (outputs.loss, {"loss": outputs.loss.detach()})
+    trainer.postforward = lambda outputs, micro_batch: (outputs.loss, {"loss": outputs.loss.detach()}, {})
 
-    loss, loss_dict = BaseTrainer.forward_backward_step(trainer, {"x": torch.tensor(2.0)})
+    loss, loss_dict, _ = BaseTrainer.forward_backward_step(trainer, {"x": torch.tensor(2.0)})
 
     assert loss.item() == 2.0
     assert loss_dict["loss"].item() == 2.0
@@ -860,7 +860,7 @@ def test_base_forward_backward_strips_channel_metadata_after_preforward(monkeypa
     trainer.micro_batch_token_len = 1
     trainer.micro_batches_token_len = 1
     trainer.LOG_SAMPLE = False
-    trainer.postforward = lambda outputs, micro_batch: (outputs.loss, {"loss": outputs.loss.detach()})
+    trainer.postforward = lambda outputs, micro_batch: (outputs.loss, {"loss": outputs.loss.detach()}, {})
     trainer.channel_loss_callback = ChannelLossCallback(trainer)
     preforward_seen = {}
 
@@ -877,7 +877,7 @@ def test_base_forward_backward_strips_channel_metadata_after_preforward(monkeypa
     }
 
     trainer.channel_loss_callback.on_step_begin(trainer.state, micro_batches=[micro_batch])
-    loss, loss_dict = BaseTrainer.forward_backward_step(trainer, micro_batch)
+    loss, loss_dict, _ = BaseTrainer.forward_backward_step(trainer, micro_batch)
 
     assert preforward_seen["has_source_metadata"]
     assert loss.item() == 2.0

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -208,6 +208,22 @@ class VeOmniIter:
         return {}
 
 
+def mean_aux_metrics(total_aux_metrics: Dict[str, float], num_micro_steps: int) -> Dict[str, float]:
+    """Reduce accumulated ``aux_metrics`` to the mean over a step's micro batches.
+
+    Losses may be summed across micro batches because ``mean_global_loss`` has
+    already weighted each by its share of the step's tokens. An auxiliary metric
+    carries no such weight, so it is averaged instead: for a per-token metric that
+    is the step's per-token mean when the micro batches hold equal token counts,
+    and unlike a token-share weighting it assumes nothing about which denominator
+    the metric used. Shared by the trainers that keep their own accumulation loop
+    so none of them can reduce it differently.
+    """
+    if not total_aux_metrics:
+        return {}
+    return {key: value / num_micro_steps for key, value in total_aux_metrics.items()}
+
+
 class BaseTrainer(Stateful, ABC):
     """
     Base trainer class for distributed model training.
@@ -653,19 +669,14 @@ class BaseTrainer(Stateful, ABC):
             callback.on_epoch_end(self.state)
 
     def on_step_begin(self, micro_batches=None, **kwargs):
-        # Every trainer funnels its step here, including the four that keep their
-        # own copy of the accumulation loop, so this is the one place that sees
-        # the step's micro-batch count for all of them. ``postforward`` needs it
-        # to normalize aux metrics; setting it per-loop instead would let the
-        # next trainer forget and silently report those metrics N times too high.
-        if micro_batches is not None:
-            self.num_micro_batches = len(micro_batches)
         for callback in self._callbacks:
             callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
 
-    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
+    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None, aux_metrics=None):
         for callback in self._callbacks:
-            callback.on_step_end(self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
+            callback.on_step_end(
+                self.state, loss=loss, loss_dict=loss_dict, grad_norm=grad_norm, aux_metrics=aux_metrics
+            )
 
     def preforward(self, micro_batch: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Preprocess micro batches before forward pass.
@@ -691,8 +702,17 @@ class BaseTrainer(Stateful, ABC):
 
     def postforward(
         self, outputs: ModelOutput, micro_batch: Dict[str, torch.Tensor]
-    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
-        """Postprocess model outputs after forward pass."""
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+        """Postprocess model outputs after forward pass.
+
+        Returns the backward scalar, the losses behind it, and any diagnostics the
+        forward asked to have logged. The diagnostics travel in their own dict
+        because ``loss_dict`` carries a reduction contract they do not share:
+        ``mean_global_loss`` has already scaled each loss by its share of the
+        step's tokens, so summing that dict is the last step of a global token
+        mean. A metric folded in would inherit that summation, and anything later
+        taking ``sum(loss_dict.values())`` would train on it.
+        """
         loss_dict: Dict[str, torch.Tensor] = mean_global_loss(
             outputs.loss,
             self.micro_batch_token_len,
@@ -700,35 +720,18 @@ class BaseTrainer(Stateful, ABC):
             getattr(self, "global_micro_batches_token_len", None),
         )
         loss = torch.stack(list(loss_dict.values())).sum()
-        # Diagnostics a forward wants logged next to the losses. Merged *after* the
-        # sum above, because everything in ``loss_dict`` up to that line is the
-        # backward scalar; a metric merged earlier would silently join the objective.
+        aux_metrics: Dict[str, torch.Tensor] = {}
         # ``getattr`` rather than attribute access: most model outputs in the repo
         # have no such field.
-        aux_metrics = getattr(outputs, "aux_metrics", None)
-        if aux_metrics:
-            # ``train_step`` reports the *sum* of the micro-batches' ``loss_dict``
-            # values. The losses may be summed because ``mean_global_loss`` has
-            # already scaled each one by its share of the step's tokens; an aux
-            # metric gets no such scaling, so without the 1/N here it would be
-            # reported ``gradient_accumulation_steps`` times too large. 1/N makes the
-            # reported number the mean of the micro-batch values -- for a per-token
-            # metric such as ``indexer_kl`` that is the step's per-token mean when the
-            # micro-batches carry equal token counts, and unlike a token-share
-            # weighting it assumes nothing about which denominator a metric used.
-            # ``on_step_begin`` sets the count; the default covers callers that reach
-            # a single forward without a step, such as tests.
-            num_micro_batches = getattr(self, "num_micro_batches", 1)
-            # Everything downstream keys on the name alone, so a collision is
-            # silent in both directions. A bare ``update`` would let an aux key
-            # shadow a loss of the same name: the backward scalar is already summed
-            # above so it would stay correct, but callbacks read ``loss_dict`` and
-            # would report the auxiliary value under ``training/<loss name>``. The
-            # reserved names are the same hazard one layer later, in the
-            # ``training/`` namespace that ``EnvironMeterCallback`` publishes into,
-            # where a clash either overwrites a real metric or drops the auxiliary
-            # one -- see ``RESERVED_TRAINING_METRIC_NAMES``.
-            collisions = sorted(aux_metrics.keys() & (loss_dict.keys() | RESERVED_TRAINING_METRIC_NAMES))
+        reported = getattr(outputs, "aux_metrics", None)
+        if reported:
+            # Separate dicts keep a metric out of the objective, but not out of the
+            # ``training/`` namespace that ``EnvironMeterCallback`` publishes both
+            # of them into, where every consumer keys on the name alone. A clash
+            # there is silent in either direction: it overwrites the loss or
+            # callback-owned metric it shadows, or is itself overwritten and never
+            # reported -- see ``RESERVED_TRAINING_METRIC_NAMES``.
+            collisions = sorted(reported.keys() & (loss_dict.keys() | RESERVED_TRAINING_METRIC_NAMES))
             if collisions:
                 raise ValueError(
                     f"aux_metrics keys {collisions} are already reported under "
@@ -736,12 +739,15 @@ class BaseTrainer(Stateful, ABC):
                     f"callbacks own {sorted(RESERVED_TRAINING_METRIC_NAMES)} are "
                     "reserved: rename the auxiliary metric."
                 )
-            loss_dict.update({key: value.detach() / num_micro_batches for key, value in aux_metrics.items()})
-        return loss, loss_dict
+            # Detach here so a metric that still carries a graph cannot keep it
+            # alive for the step; ``train_step`` reduces the values across micro
+            # batches.
+            aux_metrics = {key: value.detach() for key, value in reported.items()}
+        return loss, loss_dict, aux_metrics
 
     def forward_backward_step(
         self, micro_batch: dict[str, torch.Tensor]
-    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor], dict[str, torch.Tensor]]:
         channel_loss_callback = getattr(self, "channel_loss_callback", None)
         micro_step_context = (
             channel_loss_callback.micro_step_context(self.state, micro_batch)
@@ -765,7 +771,7 @@ class BaseTrainer(Stateful, ABC):
                 outputs: ModelOutput = self.model(**micro_batch, use_cache=False)
 
             with use_parallel_state("base"):
-                loss, loss_dict = self.postforward(outputs, micro_batch)
+                loss, loss_dict, aux_metrics = self.postforward(outputs, micro_batch)
 
             with (
                 use_parallel_state("base"),
@@ -775,7 +781,7 @@ class BaseTrainer(Stateful, ABC):
                 loss.backward()
 
             del micro_batch
-            return loss, loss_dict
+            return loss, loss_dict, aux_metrics
 
     def model_reshard(self, micro_step: int, num_micro_steps: int):
         """Reshard model after backward pass."""
@@ -822,6 +828,7 @@ class BaseTrainer(Stateful, ABC):
 
         total_loss = 0.0
         total_loss_dict = defaultdict(int)
+        total_aux_metrics = defaultdict(float)
 
         # token num for fixed_ce_loss in postforward
         self.micro_batches_token_len = count_loss_token(micro_batches)
@@ -834,13 +841,16 @@ class BaseTrainer(Stateful, ABC):
             self._configure_hsdp_allreduce(micro_step, num_micro_steps)
             loss: torch.Tensor
             loss_dict: Dict[str, torch.Tensor]
+            aux_metrics: Dict[str, torch.Tensor]
             # token num for fixed_ce_loss in postforward
             self.micro_batch_token_len = count_loss_token(micro_batch)
-            loss, loss_dict = self.forward_backward_step(micro_batch)
+            loss, loss_dict, aux_metrics = self.forward_backward_step(micro_batch)
 
             total_loss += loss.item()
             for k, v in loss_dict.items():
                 total_loss_dict[k] += v.item()
+            for k, v in aux_metrics.items():
+                total_aux_metrics[k] += v.item()
 
         # Gradient clipping (reads FSDP/EP groups from current ParallelState)
         with use_parallel_state("base"):
@@ -851,7 +861,12 @@ class BaseTrainer(Stateful, ABC):
         self.lr_scheduler.step()
         self.optimizer.zero_grad()
 
-        self.on_step_end(loss=total_loss, loss_dict=total_loss_dict, grad_norm=grad_norm)
+        self.on_step_end(
+            loss=total_loss,
+            loss_dict=total_loss_dict,
+            grad_norm=grad_norm,
+            aux_metrics=mean_aux_metrics(total_aux_metrics, num_micro_steps),
+        )
 
     def destroy_distributed(self):
         if not dist.is_available() or not dist.is_initialized():

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -652,6 +652,13 @@ class BaseTrainer(Stateful, ABC):
             callback.on_epoch_end(self.state)
 
     def on_step_begin(self, micro_batches=None, **kwargs):
+        # Every trainer funnels its step here, including the four that keep their
+        # own copy of the accumulation loop, so this is the one place that sees
+        # the step's micro-batch count for all of them. ``postforward`` needs it
+        # to normalize aux metrics; setting it per-loop instead would let the
+        # next trainer forget and silently report those metrics N times too high.
+        if micro_batches is not None:
+            self.num_micro_batches = len(micro_batches)
         for callback in self._callbacks:
             callback.on_step_begin(self.state, micro_batches=micro_batches, **kwargs)
 
@@ -708,9 +715,8 @@ class BaseTrainer(Stateful, ABC):
             # metric such as ``indexer_kl`` that is the step's per-token mean when the
             # micro-batches carry equal token counts, and unlike a token-share
             # weighting it assumes nothing about which denominator a metric used.
-            # The value is rank-local; ``EnvironMeterCallback.on_step_end`` already
-            # averages it over the FSDP group, and a per-micro-batch collective is
-            # not worth it for a diagnostic.
+            # ``on_step_begin`` sets the count; the default covers callers that reach
+            # a single forward without a step, such as tests.
             num_micro_batches = getattr(self, "num_micro_batches", 1)
             loss_dict.update({key: value.detach() / num_micro_batches for key, value in aux_metrics.items()})
         return loss, loss_dict
@@ -803,8 +809,6 @@ class BaseTrainer(Stateful, ABC):
         self.micro_batches_token_len = count_loss_token(micro_batches)
         self.global_micro_batches_token_len = reduce_global_loss_token(self.micro_batches_token_len)
         num_micro_steps = len(micro_batches)
-        # Read by postforward to average aux metrics over the step's micro batches.
-        self.num_micro_batches = num_micro_steps
         # forward and backward pass with gradient_accumulationsteps
         for micro_step, micro_batch in enumerate(micro_batches):
             mark_compile_step_begin(getattr(self.model, "_veomni_compile_uses_cuda_graphs", False))

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -76,6 +76,7 @@ from ..utils.device import (
 from ..utils.loss_utils import count_loss_token, mean_global_loss, reduce_global_loss_token
 from ..utils.model_utils import pretty_print_trainable_parameters
 from .callbacks import (
+    RESERVED_TRAINING_METRIC_NAMES,
     ChannelLossCallback,
     CheckpointerCallback,
     EnvironMeterCallback,
@@ -718,16 +719,22 @@ class BaseTrainer(Stateful, ABC):
             # ``on_step_begin`` sets the count; the default covers callers that reach
             # a single forward without a step, such as tests.
             num_micro_batches = getattr(self, "num_micro_batches", 1)
-            # A bare ``update`` would let an aux key shadow a loss of the same name.
-            # The backward scalar is already summed above so it would stay correct,
-            # but callbacks read ``loss_dict``, so they would report the auxiliary
-            # value under ``training/<loss name>`` -- a silently wrong loss curve.
-            collisions = sorted(aux_metrics.keys() & loss_dict.keys())
+            # Everything downstream keys on the name alone, so a collision is
+            # silent in both directions. A bare ``update`` would let an aux key
+            # shadow a loss of the same name: the backward scalar is already summed
+            # above so it would stay correct, but callbacks read ``loss_dict`` and
+            # would report the auxiliary value under ``training/<loss name>``. The
+            # reserved names are the same hazard one layer later, in the
+            # ``training/`` namespace that ``EnvironMeterCallback`` publishes into,
+            # where a clash either overwrites a real metric or drops the auxiliary
+            # one -- see ``RESERVED_TRAINING_METRIC_NAMES``.
+            collisions = sorted(aux_metrics.keys() & (loss_dict.keys() | RESERVED_TRAINING_METRIC_NAMES))
             if collisions:
                 raise ValueError(
-                    f"aux_metrics keys {collisions} collide with loss keys "
-                    f"{sorted(loss_dict.keys())}. Loss names are reserved: rename the "
-                    "auxiliary metric so callbacks cannot report it as a loss."
+                    f"aux_metrics keys {collisions} are already reported under "
+                    f"training/. Loss keys {sorted(loss_dict.keys())} and the names "
+                    f"callbacks own {sorted(RESERVED_TRAINING_METRIC_NAMES)} are "
+                    "reserved: rename the auxiliary metric."
                 )
             loss_dict.update({key: value.detach() / num_micro_batches for key, value in aux_metrics.items()})
         return loss, loss_dict

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -692,6 +692,27 @@ class BaseTrainer(Stateful, ABC):
             getattr(self, "global_micro_batches_token_len", None),
         )
         loss = torch.stack(list(loss_dict.values())).sum()
+        # Diagnostics a forward wants logged next to the losses. Merged *after* the
+        # sum above, because everything in ``loss_dict`` up to that line is the
+        # backward scalar; a metric merged earlier would silently join the objective.
+        # ``getattr`` rather than attribute access: most model outputs in the repo
+        # have no such field.
+        aux_metrics = getattr(outputs, "aux_metrics", None)
+        if aux_metrics:
+            # ``train_step`` reports the *sum* of the micro-batches' ``loss_dict``
+            # values. The losses may be summed because ``mean_global_loss`` has
+            # already scaled each one by its share of the step's tokens; an aux
+            # metric gets no such scaling, so without the 1/N here it would be
+            # reported ``gradient_accumulation_steps`` times too large. 1/N makes the
+            # reported number the mean of the micro-batch values -- for a per-token
+            # metric such as ``indexer_kl`` that is the step's per-token mean when the
+            # micro-batches carry equal token counts, and unlike a token-share
+            # weighting it assumes nothing about which denominator a metric used.
+            # The value is rank-local; ``EnvironMeterCallback.on_step_end`` already
+            # averages it over the FSDP group, and a per-micro-batch collective is
+            # not worth it for a diagnostic.
+            num_micro_batches = getattr(self, "num_micro_batches", 1)
+            loss_dict.update({key: value.detach() / num_micro_batches for key, value in aux_metrics.items()})
         return loss, loss_dict
 
     def forward_backward_step(
@@ -782,6 +803,8 @@ class BaseTrainer(Stateful, ABC):
         self.micro_batches_token_len = count_loss_token(micro_batches)
         self.global_micro_batches_token_len = reduce_global_loss_token(self.micro_batches_token_len)
         num_micro_steps = len(micro_batches)
+        # Read by postforward to average aux metrics over the step's micro batches.
+        self.num_micro_batches = num_micro_steps
         # forward and backward pass with gradient_accumulationsteps
         for micro_step, micro_batch in enumerate(micro_batches):
             mark_compile_step_begin(getattr(self.model, "_veomni_compile_uses_cuda_graphs", False))

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -718,6 +718,17 @@ class BaseTrainer(Stateful, ABC):
             # ``on_step_begin`` sets the count; the default covers callers that reach
             # a single forward without a step, such as tests.
             num_micro_batches = getattr(self, "num_micro_batches", 1)
+            # A bare ``update`` would let an aux key shadow a loss of the same name.
+            # The backward scalar is already summed above so it would stay correct,
+            # but callbacks read ``loss_dict``, so they would report the auxiliary
+            # value under ``training/<loss name>`` -- a silently wrong loss curve.
+            collisions = sorted(aux_metrics.keys() & loss_dict.keys())
+            if collisions:
+                raise ValueError(
+                    f"aux_metrics keys {collisions} collide with loss keys "
+                    f"{sorted(loss_dict.keys())}. Loss names are reserved: rename the "
+                    "auxiliary metric so callbacks cannot report it as a loss."
+                )
             loss_dict.update({key: value.detach() / num_micro_batches for key, value in aux_metrics.items()})
         return loss, loss_dict
 

--- a/veomni/trainer/callbacks/__init__.py
+++ b/veomni/trainer/callbacks/__init__.py
@@ -23,6 +23,7 @@ from .channel_loss_callback import ChannelLossCallback, ChannelLossComputer
 from .checkpoint_callback import CheckpointerCallback, HFLoraCkptCallback, HuggingfaceCkptCallback
 from .evaluate_callback import EvaluateCallback
 from .trace_callback import (
+    RESERVED_TRAINING_METRIC_NAMES,
     EnvironMeterCallback,
     MoERouterMonitorCallback,
     ProfileTraceCallback,
@@ -45,4 +46,5 @@ __all__ = [
     "EnvironMeterCallback",
     "MoERouterMonitorCallback",
     "TqdmCallback",
+    "RESERVED_TRAINING_METRIC_NAMES",
 ]

--- a/veomni/trainer/callbacks/base.py
+++ b/veomni/trainer/callbacks/base.py
@@ -37,7 +37,13 @@ class Callback:
         pass
 
     def on_step_end(
-        self, state: TrainerState, loss: float, loss_dict: Dict[str, float], grad_norm: float, **kwargs
+        self,
+        state: TrainerState,
+        loss: float,
+        loss_dict: Dict[str, float],
+        grad_norm: float,
+        aux_metrics: Dict[str, float] = None,
+        **kwargs,
     ) -> None:
         pass
 

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -190,7 +190,7 @@ class ProfileTraceCallback(Callback):
 # is updated next to the code that decides the names.
 #
 # Both collision directions are silent, which is why they are worth a guard:
-# ``total_loss`` is assigned *before* ``loss_dict`` is merged, so an auxiliary
+# ``total_loss`` is assigned *before* the metrics are merged, so an auxiliary
 # metric replaces it and ``training/total_loss`` then reports the metric. So do
 # ``avg_effective_len`` and ``avg_sample_seq_len``, which ``EnvironMeter.step``
 # emits already prefixed and which the merge at the end of ``on_step_end`` lets
@@ -231,7 +231,13 @@ class EnvironMeterCallback(Callback):
         self.start_time = time.time()
 
     def on_step_end(
-        self, state: TrainerState, loss: float, loss_dict: Dict[str, float], grad_norm: float, **kwargs
+        self,
+        state: TrainerState,
+        loss: float,
+        loss_dict: Dict[str, float],
+        grad_norm: float,
+        aux_metrics: Dict[str, float] = None,
+        **kwargs,
     ) -> None:
         delta_time = time.time() - self.start_time
         step_env_metrics = self.trainer.environ_meter.step(
@@ -245,6 +251,12 @@ class EnvironMeterCallback(Callback):
             "total_loss": loss,
         }
         step_train_metrics.update(loss_dict)
+        # Auxiliary metrics arrive in their own dict -- they are diagnostics, not
+        # part of the objective -- but are published beside the losses, and merged
+        # before the reduction below so they are averaged over the FSDP group too.
+        # ``BaseTrainer.postforward`` has already rejected any name that would
+        # collide here.
+        step_train_metrics.update(aux_metrics or {})
         step_train_metrics["grad_norm"] = grad_norm
 
         # gather training_step_info from all ranks

--- a/veomni/trainer/callbacks/trace_callback.py
+++ b/veomni/trainer/callbacks/trace_callback.py
@@ -183,6 +183,30 @@ class ProfileTraceCallback(Callback):
                 self.profiler.stop()
 
 
+# Names ``on_step_end`` below publishes into the ``training/`` namespace itself,
+# rather than taking from ``loss_dict``. A model's ``aux_metrics`` key that matches
+# one of these collides in that namespace even though it does not collide with any
+# loss, so ``BaseTrainer.postforward`` rejects them; keeping the set here means it
+# is updated next to the code that decides the names.
+#
+# Both collision directions are silent, which is why they are worth a guard:
+# ``total_loss`` is assigned *before* ``loss_dict`` is merged, so an auxiliary
+# metric replaces it and ``training/total_loss`` then reports the metric. So do
+# ``avg_effective_len`` and ``avg_sample_seq_len``, which ``EnvironMeter.step``
+# emits already prefixed and which the merge at the end of ``on_step_end`` lets
+# ``training/`` values win over. ``grad_norm`` and ``lr`` are assigned *after* the
+# merge, so they win instead and the auxiliary metric is dropped without a trace.
+RESERVED_TRAINING_METRIC_NAMES = frozenset(
+    {
+        "total_loss",
+        "grad_norm",
+        "lr",
+        "avg_effective_len",
+        "avg_sample_seq_len",
+    }
+)
+
+
 class EnvironMeterCallback(Callback):
     def __init__(self, trainer: "BaseTrainer") -> None:
         super().__init__(trainer)

--- a/veomni/trainer/dit_trainer.py
+++ b/veomni/trainer/dit_trainer.py
@@ -431,8 +431,8 @@ class DiTTrainer:
     def on_step_begin(self, micro_batches=None):
         self.base.on_step_begin(micro_batches=micro_batches)
 
-    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
-        self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
+    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None, aux_metrics=None):
+        self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm, aux_metrics=aux_metrics)
 
     def preforward(self, micro_batch: Dict[str, Any]) -> Dict[str, Any]:
         """Preprocess micro batches before forward pass."""

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -402,8 +402,8 @@ class TextDPOTrainer:
         # segments (chosen, rejected) but carries one source metadata entry.
         self.base.on_step_begin(micro_batches=micro_batches, source_repeat=2)
 
-    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
-        self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
+    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None, aux_metrics=None):
+        self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm, aux_metrics=aux_metrics)
 
     def train_step(self, data_iterator: Any) -> Dict[str, float]:
         args: VeOmniDPOArguments = self.base.args

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -129,8 +129,6 @@ class TextTrainer:
         self.base.micro_batches_token_len = count_loss_token(micro_batches)
         self.base.global_micro_batches_token_len = reduce_global_loss_token(self.base.micro_batches_token_len)
         num_micro_steps = len(micro_batches)
-        # Read by BaseTrainer.postforward to average aux metrics over the step.
-        self.base.num_micro_batches = num_micro_steps
         # forward and backward pass with gradient_accumulationsteps
         for micro_step, micro_batch in enumerate(micro_batches):
             mark_compile_step_begin(getattr(self.base.model, "_veomni_compile_uses_cuda_graphs", False))

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -129,6 +129,8 @@ class TextTrainer:
         self.base.micro_batches_token_len = count_loss_token(micro_batches)
         self.base.global_micro_batches_token_len = reduce_global_loss_token(self.base.micro_batches_token_len)
         num_micro_steps = len(micro_batches)
+        # Read by BaseTrainer.postforward to average aux metrics over the step.
+        self.base.num_micro_batches = num_micro_steps
         # forward and backward pass with gradient_accumulationsteps
         for micro_step, micro_batch in enumerate(micro_batches):
             mark_compile_step_begin(getattr(self.base.model, "_veomni_compile_uses_cuda_graphs", False))

--- a/veomni/trainer/text_trainer.py
+++ b/veomni/trainer/text_trainer.py
@@ -29,7 +29,7 @@ from ..models import build_tokenizer
 from ..utils import helper
 from ..utils.device import synchronize
 from ..utils.loss_utils import count_loss_token, reduce_global_loss_token
-from .base import BaseTrainer, VeOmniIter
+from .base import BaseTrainer, VeOmniIter, mean_aux_metrics
 
 
 logger = helper.create_logger(__name__)
@@ -105,8 +105,8 @@ class TextTrainer:
     def on_step_begin(self, micro_batches=None):
         self.base.on_step_begin(micro_batches=micro_batches)
 
-    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
-        self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
+    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None, aux_metrics=None):
+        self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm, aux_metrics=aux_metrics)
 
     def train_step(
         self,
@@ -124,6 +124,7 @@ class TextTrainer:
 
         total_loss = 0.0
         total_loss_dict = defaultdict(int)
+        total_aux_metrics = defaultdict(float)
 
         # token num for fixed_ce_loss in postforward
         self.base.micro_batches_token_len = count_loss_token(micro_batches)
@@ -136,13 +137,16 @@ class TextTrainer:
             self.base._configure_hsdp_allreduce(micro_step, num_micro_steps)
             loss: torch.Tensor
             loss_dict: Dict[str, torch.Tensor]
+            aux_metrics: Dict[str, torch.Tensor]
             # token num for fixed_ce_loss in postforward
             self.base.micro_batch_token_len = count_loss_token(micro_batch)
-            loss, loss_dict = self.base.forward_backward_step(micro_batch)
+            loss, loss_dict, aux_metrics = self.base.forward_backward_step(micro_batch)
 
             total_loss += loss.item()
             for k, v in loss_dict.items():
                 total_loss_dict[k] += v.item()
+            for k, v in aux_metrics.items():
+                total_aux_metrics[k] += v.item()
 
         # Gradient clipping (reads FSDP/EP groups from current ParallelState)
         with use_parallel_state("base"):
@@ -153,7 +157,12 @@ class TextTrainer:
         self.base.lr_scheduler.step()
         self.base.optimizer.zero_grad()
 
-        self.on_step_end(loss=total_loss, loss_dict=total_loss_dict, grad_norm=grad_norm)
+        self.on_step_end(
+            loss=total_loss,
+            loss_dict=total_loss_dict,
+            grad_norm=grad_norm,
+            aux_metrics=mean_aux_metrics(total_aux_metrics, num_micro_steps),
+        )
 
     def train(self):
         args: VeOmniArguments = self.base.args

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -34,7 +34,7 @@ from ..utils import helper
 from ..utils.device import get_device_type, synchronize
 from ..utils.loss_utils import count_loss_token, reduce_global_loss_token
 from ..utils.model_utils import pretty_print_trainable_parameters
-from .base import BaseTrainer, VeOmniIter
+from .base import BaseTrainer, VeOmniIter, mean_aux_metrics
 
 
 logger = helper.create_logger(__name__)
@@ -330,8 +330,8 @@ class VLMTrainer:
     def on_step_begin(self, micro_batches=None):
         self.base.on_step_begin(micro_batches=micro_batches)
 
-    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None):
-        self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm)
+    def on_step_end(self, loss=None, loss_dict=None, grad_norm=None, aux_metrics=None):
+        self.base.on_step_end(loss=loss, loss_dict=loss_dict, grad_norm=grad_norm, aux_metrics=aux_metrics)
 
     def train_step(
         self,
@@ -349,6 +349,7 @@ class VLMTrainer:
 
         total_loss = 0.0
         total_loss_dict = defaultdict(int)
+        total_aux_metrics = defaultdict(float)
 
         # token num for fixed_ce_loss in postforward
         self.base.micro_batches_token_len = count_loss_token(micro_batches)
@@ -361,13 +362,16 @@ class VLMTrainer:
             self.base._configure_hsdp_allreduce(micro_step, num_micro_steps)
             loss: torch.Tensor
             loss_dict: Dict[str, torch.Tensor]
+            aux_metrics: Dict[str, torch.Tensor]
             # token num for fixed_ce_loss in postforward
             self.base.micro_batch_token_len = count_loss_token(micro_batch)
-            loss, loss_dict = self.base.forward_backward_step(micro_batch)
+            loss, loss_dict, aux_metrics = self.base.forward_backward_step(micro_batch)
 
             total_loss += loss.item()
             for k, v in loss_dict.items():
                 total_loss_dict[k] += v.item()
+            for k, v in aux_metrics.items():
+                total_aux_metrics[k] += v.item()
 
         # Gradient clipping (reads FSDP/EP groups from current ParallelState)
         with use_parallel_state("base"):
@@ -378,7 +382,12 @@ class VLMTrainer:
         self.base.lr_scheduler.step()
         self.base.optimizer.zero_grad()
 
-        self.on_step_end(loss=total_loss, loss_dict=total_loss_dict, grad_norm=grad_norm)
+        self.on_step_end(
+            loss=total_loss,
+            loss_dict=total_loss_dict,
+            grad_norm=grad_norm,
+            aux_metrics=mean_aux_metrics(total_aux_metrics, num_micro_steps),
+        )
 
     def train(self):
         args: VeOmniVLMArguments = self.base.args

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -354,6 +354,8 @@ class VLMTrainer:
         self.base.micro_batches_token_len = count_loss_token(micro_batches)
         self.base.global_micro_batches_token_len = reduce_global_loss_token(self.base.micro_batches_token_len)
         num_micro_steps = len(micro_batches)
+        # Read by BaseTrainer.postforward to average aux metrics over the step.
+        self.base.num_micro_batches = num_micro_steps
         # forward and backward pass with gradient_accumulationsteps
         for micro_step, micro_batch in enumerate(micro_batches):
             mark_compile_step_begin(getattr(self.base.model, "_veomni_compile_uses_cuda_graphs", False))

--- a/veomni/trainer/vlm_trainer.py
+++ b/veomni/trainer/vlm_trainer.py
@@ -354,8 +354,6 @@ class VLMTrainer:
         self.base.micro_batches_token_len = count_loss_token(micro_batches)
         self.base.global_micro_batches_token_len = reduce_global_loss_token(self.base.micro_batches_token_len)
         num_micro_steps = len(micro_batches)
-        # Read by BaseTrainer.postforward to average aux metrics over the step.
-        self.base.num_micro_batches = num_micro_steps
         # forward and backward pass with gradient_accumulationsteps
         for micro_step, micro_batch in enumerate(micro_batches):
             mark_compile_step_begin(getattr(self.base.model, "_veomni_compile_uses_cuda_graphs", False))


### PR DESCRIPTION
### What does this PR do?

Lets a model forward report scalar diagnostics next to the loss without those scalars joining
the backward objective. A forward populates `outputs.aux_metrics`; the trainer reports the
step's mean and never sums it into the scalar handed to `backward()`.

Generic trainer plumbing with no model-specific code. DeepSeek-V4's indexer KL is the first
intended consumer and arrives in a later PR.

### Checklist Before Starting

- Search for relative PRs/issues and link here: no overlapping open PR. Rebased onto the
  current trainer after #941, #938, #1026 and #1091.
- PR title follows `[{modules}] {type}: {description}` format

### Test

- `pytest tests/trainer/test_aux_metrics.py` — 12 passed.
- `make quality` — clean.
- Wired `tests/trainer/test_aux_metrics.py` into both `gpu_unit_tests.yml` and
  `npu_unit_tests.yml`; the tests are pure CPU.

### API and Usage Example

A forward returns detached 0-d tensors keyed by metric name:

```python
return MoeCausalLMOutputWithPast(loss=loss, ..., aux_metrics={"indexer_kl": kl.detach()})
```

They surface as `training/indexer_kl` in the step metrics. The trainer reads the attribute with
`getattr`, so any output object may carry it and outputs without it are unaffected.

The reported value is the **mean over the step's micro batches**, then averaged over the FSDP
group by `EnvironMeterCallback`. Populate it with a per-micro-batch mean, not a running total:
a metric with sum semantics would come out divided by the gradient-accumulation count. Emit a
key on every micro batch of a step, or on none of them.

### Design & Code Changes

`BaseTrainer.postforward` merges `aux_metrics` into `loss_dict` **after** the sum that builds
the backward scalar, and detaches on the way in — an attached tensor parked in a dict keeps its
whole graph alive for the step. A metric of 1000.0 against a loss of 2.0 is asserted in the
tests so that a leak into the objective cannot pass silently.

`TextTrainer` and `VLMTrainer` do not reuse `BaseTrainer.train_step`; each keeps its own copy of
the accumulation loop. Rather than have all three divide by their own micro-batch count, the
base trainer publishes the count once, so a future trainer cannot forget it. The accumulation
assertion is parameterized over all three loop owners.

The final commit realigns the test fixtures with the trainer as it stands today: the stubs
predated `reduce_global_loss_token`, the fourth `mean_global_loss` argument,
`sync_each_train_step`, and `EnvironMeterCallback.lora_config`.

### Checklist Before Submitting

- Applied pre-commit checks
- Added/updated documentation
- Added tests to CI workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Training reports now include optional auxiliary metrics, averaged across gradient accumulation and distributed workers.
  - Metrics are available under `training/<metric>` for base, text, and vision-language workflows.
  - DiT training now supports configurable data transforms and sample logging.

- **Bug Fixes**
  - Auxiliary metrics remain separate from loss calculations and are safely detached.
  - Conflicting metric names are rejected to prevent reporting ambiguity.

- **Documentation**
  - Added guidance for configuring, averaging, and monitoring auxiliary metrics.

- **Tests**
  - Expanded GPU and NPU coverage for training metrics, checkpointing, and parallel training behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->