### PR TITLE
[model] fix: port Qwen3.5 linear-attn-mask override to transformers 5.9 Cache API

### DIFF
--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.diff
@@ -1138,12 +1138,9 @@
 
 
  class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
-@@ -1233,19 +1828,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1235,17 +1830,39 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1152,18 +1149,17 @@
 +        Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 +
 +        Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-+        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-+        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-+        / host-device sync on *every* forward, which serialises the host against the device in
-+        VeOmni's otherwise sync-free training step.
++        — when ``past_key_values.has_previous_state()`` is true (a cached forward) or
++        ``torch.all(attention_mask == 1)`` (the batch has no padding). The latter reads a 0-D GPU
++        tensor and forces an implicit ``.item()`` / host-device sync on *every* forward, which
++        serialises the host against the device in VeOmni's otherwise sync-free training step.
 +
 +        We keep the cached-forward branch — it is a correctness guard, not just an optimization:
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). ``has_previous_state()`` only reads host-side Cache metadata, so this
++        branch was never the sync source.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1179,8 +1175,8 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here. Metadata-only check, no sync.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +
@@ -1192,7 +1188,7 @@
 
 
  @auto_docstring
-@@ -1441,64 +2059,43 @@
+@@ -1441,64 +2058,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1282,7 +1278,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1564,13 +2161,18 @@
+@@ -1564,13 +2160,18 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1301,7 +1297,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1578,29 +2180,169 @@
+@@ -1578,29 +2179,169 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1481,7 +1477,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1610,6 +2352,18 @@
+@@ -1610,6 +2351,18 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1500,7 +1496,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1617,6 +2371,7 @@
+@@ -1617,6 +2370,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1508,7 +1504,7 @@
              **kwargs,
          )
 
-@@ -1624,6 +2379,12 @@
+@@ -1624,6 +2378,12 @@
              **outputs,
              rope_deltas=self.rope_deltas,
          )
@@ -1521,7 +1517,7 @@
 
 
  @auto_docstring
-@@ -1654,10 +2415,13 @@
+@@ -1654,10 +2414,13 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
@@ -1535,7 +1531,7 @@
          labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
              Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
              config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
-@@ -1686,21 +2450,50 @@
+@@ -1686,21 +2449,50 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -1590,7 +1586,7 @@
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
-@@ -1740,6 +2533,41 @@
+@@ -1740,6 +2532,41 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1632,7 +1628,7 @@
  class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1796,57 +2624,10 @@
+@@ -1796,57 +2623,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1692,7 +1688,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1857,27 +2638,54 @@
+@@ -1857,27 +2637,54 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1753,7 +1749,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2103,6 +2911,24 @@
+@@ -2103,6 +2910,24 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_gpu.py
@@ -1828,23 +1828,22 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
         Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-        / host-device sync on *every* forward, which serialises the host against the device in
-        VeOmni's otherwise sync-free training step.
+        — when ``past_key_values.has_previous_state()`` is true (a cached forward) or
+        ``torch.all(attention_mask == 1)`` (the batch has no padding). The latter reads a 0-D GPU
+        tensor and forces an implicit ``.item()`` / host-device sync on *every* forward, which
+        serialises the host against the device in VeOmni's otherwise sync-free training step.
 
         We keep the cached-forward branch — it is a correctness guard, not just an optimization:
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). ``has_previous_state()`` only reads host-side Cache metadata, so this
+        branch was never the sync source.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1854,8 +1853,8 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here. Metadata-only check, no sync.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.diff
@@ -1195,12 +1195,9 @@
 
          hidden_states = inputs_embeds
          position_embeddings = self.rotary_emb(hidden_states, position_ids)
-@@ -1233,19 +1827,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1235,17 +1829,39 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1209,18 +1206,17 @@
 +        Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 +
 +        Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-+        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-+        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-+        / host-device sync on *every* forward, which serialises the host against the device in
-+        VeOmni's otherwise sync-free training step.
++        — when ``past_key_values.has_previous_state()`` is true (a cached forward) or
++        ``torch.all(attention_mask == 1)`` (the batch has no padding). The latter reads a 0-D GPU
++        tensor and forces an implicit ``.item()`` / host-device sync on *every* forward, which
++        serialises the host against the device in VeOmni's otherwise sync-free training step.
 +
 +        We keep the cached-forward branch — it is a correctness guard, not just an optimization:
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). ``has_previous_state()`` only reads host-side Cache metadata, so this
++        branch was never the sync source.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1236,8 +1232,8 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here. Metadata-only check, no sync.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +
@@ -1249,7 +1245,7 @@
 
 
  @auto_docstring
-@@ -1441,64 +2058,43 @@
+@@ -1441,64 +2057,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1339,7 +1335,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1564,13 +2160,18 @@
+@@ -1564,13 +2159,18 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1358,7 +1354,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1578,29 +2179,169 @@
+@@ -1578,29 +2178,169 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1538,7 +1534,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1610,6 +2351,18 @@
+@@ -1610,6 +2350,18 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1557,7 +1553,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1617,6 +2370,7 @@
+@@ -1617,6 +2369,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1565,7 +1561,7 @@
              **kwargs,
          )
 
-@@ -1624,6 +2378,12 @@
+@@ -1624,6 +2377,12 @@
              **outputs,
              rope_deltas=self.rope_deltas,
          )
@@ -1578,7 +1574,7 @@
 
 
  @auto_docstring
-@@ -1654,10 +2414,13 @@
+@@ -1654,10 +2413,13 @@
          inputs_embeds: torch.FloatTensor | None = None,
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
@@ -1592,7 +1588,7 @@
          labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
              Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
              config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
-@@ -1686,21 +2449,50 @@
+@@ -1686,21 +2448,50 @@
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
@@ -1647,7 +1643,7 @@
              past_key_values=outputs.past_key_values,
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
-@@ -1740,6 +2532,31 @@
+@@ -1740,6 +2531,31 @@
      rope_deltas: torch.LongTensor | None = None
 
 
@@ -1679,7 +1675,7 @@
  class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
      # Reference: fix gemma3 grad acc #37208
-@@ -1796,57 +2613,10 @@
+@@ -1796,57 +2612,10 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1739,7 +1735,7 @@
          outputs = self.model(
              input_ids=input_ids,
              pixel_values=pixel_values,
-@@ -1857,27 +2627,54 @@
+@@ -1857,27 +2626,54 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1800,7 +1796,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2103,6 +2900,24 @@
+@@ -2103,6 +2899,24 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
+++ b/veomni/models/transformers/qwen3_5/generated/patched_modeling_qwen3_5_npu.py
@@ -1827,23 +1827,22 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
         Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-        / host-device sync on *every* forward, which serialises the host against the device in
-        VeOmni's otherwise sync-free training step.
+        — when ``past_key_values.has_previous_state()`` is true (a cached forward) or
+        ``torch.all(attention_mask == 1)`` (the batch has no padding). The latter reads a 0-D GPU
+        tensor and forces an implicit ``.item()`` / host-device sync on *every* forward, which
+        serialises the host against the device in VeOmni's otherwise sync-free training step.
 
         We keep the cached-forward branch — it is a correctness guard, not just an optimization:
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). ``has_previous_state()`` only reads host-side Cache metadata, so this
+        branch was never the sync source.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1853,8 +1852,8 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here. Metadata-only check, no sync.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 

--- a/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
+++ b/veomni/models/transformers/qwen3_5/qwen3_5_gpu_patch_gen_config.py
@@ -518,23 +518,22 @@ def qwen3_5_gated_deltanet_forward_patched(
     "Qwen3_5TextModel._update_linear_attn_mask",
     description="Avoid host-device sync: decide linear-attention padding-mask zeroing without reading GPU scalars.",
 )
-def qwen3_5_text_model_update_linear_attn_mask(self, attention_mask, cache_position):
+def qwen3_5_text_model_update_linear_attn_mask(self, attention_mask, past_key_values):
     """
     Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
     Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-    — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-    batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-    / host-device sync on *every* forward, which serialises the host against the device in
-    VeOmni's otherwise sync-free training step.
+    — when ``past_key_values.has_previous_state()`` is true (a cached forward) or
+    ``torch.all(attention_mask == 1)`` (the batch has no padding). The latter reads a 0-D GPU
+    tensor and forces an implicit ``.item()`` / host-device sync on *every* forward, which
+    serialises the host against the device in VeOmni's otherwise sync-free training step.
 
     We keep the cached-forward branch — it is a correctness guard, not just an optimization:
     ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
     cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
     only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-    a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-    ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-    than reading ``cache_position[0]``, so no sync.
+    a 1-token decode step). ``has_previous_state()`` only reads host-side Cache metadata, so this
+    branch was never the sync source.
 
     The all-ones short-circuit is the one we drop: returning the all-ones mask makes
     ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -544,8 +543,8 @@ def qwen3_5_text_model_update_linear_attn_mask(self, attention_mask, cache_posit
     if attention_mask is None:
         return None
     # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-    # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-    if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+    # apply_mask_to_padding_states, and upstream returns None here. Metadata-only check, no sync.
+    if past_key_values is not None and past_key_values.has_previous_state():
         return None
     return attention_mask
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.diff
@@ -1262,12 +1262,9 @@
 
 
  class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
-@@ -1353,19 +2023,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1355,17 +2025,39 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1276,18 +1273,17 @@
 +        Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 +
 +        Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-+        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-+        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-+        / host-device sync on *every* forward, which serialises the host against the device in
-+        VeOmni's otherwise sync-free training step.
++        — when ``past_key_values.has_previous_state()`` is true (a cached forward) or
++        ``torch.all(attention_mask == 1)`` (the batch has no padding). The latter reads a 0-D GPU
++        tensor and forces an implicit ``.item()`` / host-device sync on *every* forward, which
++        serialises the host against the device in VeOmni's otherwise sync-free training step.
 +
 +        We keep the cached-forward branch — it is a correctness guard, not just an optimization:
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). ``has_previous_state()`` only reads host-side Cache metadata, so this
++        branch was never the sync source.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1303,8 +1299,8 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here. Metadata-only check, no sync.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +
@@ -1316,7 +1312,7 @@
 
 
  @auto_docstring
-@@ -1376,7 +2069,19 @@
+@@ -1376,7 +2068,19 @@
      config: Qwen3_5MoeConfig
      _no_split_modules = ["Qwen3_5MoeDecoderLayer", "Qwen3_5MoeVisionBlock"]
 
@@ -1336,7 +1332,7 @@
          super().__init__(config)
          self.visual = Qwen3_5MoeVisionModel._from_config(config.vision_config)
          self.language_model = Qwen3_5MoeTextModel._from_config(config.text_config)
-@@ -1561,64 +2266,43 @@
+@@ -1561,64 +2265,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1426,7 +1422,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1684,6 +2368,7 @@
+@@ -1684,6 +2367,7 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1434,7 +1430,7 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5MoeModelOutputWithPast:
          r"""
-@@ -1691,6 +2376,10 @@
+@@ -1691,6 +2375,10 @@
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
@@ -1445,7 +1441,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1698,29 +2387,170 @@
+@@ -1698,29 +2386,170 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1626,7 +1622,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1730,6 +2560,17 @@
+@@ -1730,6 +2559,17 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1644,7 +1640,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1737,6 +2578,7 @@
+@@ -1737,6 +2577,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1652,7 +1648,7 @@
              **kwargs,
          )
 
-@@ -1828,6 +2670,12 @@
+@@ -1828,6 +2669,12 @@
      return overall_loss * num_experts
 
 
@@ -1665,7 +1661,7 @@
  @auto_docstring
  class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -1848,6 +2696,7 @@
+@@ -1848,6 +2695,7 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -1673,7 +1669,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1860,14 +2709,17 @@
+@@ -1860,14 +2708,17 @@
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
          output_router_logits: bool | None = None,
@@ -1692,7 +1688,7 @@
 
          Example:
 
-@@ -1899,30 +2751,70 @@
+@@ -1899,30 +2750,70 @@
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
              output_router_logits=output_router_logits,
@@ -1775,7 +1771,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1930,7 +2822,14 @@
+@@ -1930,7 +2821,14 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
@@ -1791,7 +1787,7 @@
 
 
  class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMixin):
-@@ -1977,6 +2876,7 @@
+@@ -1977,6 +2875,7 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1799,7 +1795,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1990,105 +2890,93 @@
+@@ -1990,105 +2889,93 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -1960,7 +1956,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2314,6 +3202,30 @@
+@@ -2314,6 +3201,30 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_gpu.py
@@ -2023,23 +2023,22 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
         Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-        / host-device sync on *every* forward, which serialises the host against the device in
-        VeOmni's otherwise sync-free training step.
+        — when ``past_key_values.has_previous_state()`` is true (a cached forward) or
+        ``torch.all(attention_mask == 1)`` (the batch has no padding). The latter reads a 0-D GPU
+        tensor and forces an implicit ``.item()`` / host-device sync on *every* forward, which
+        serialises the host against the device in VeOmni's otherwise sync-free training step.
 
         We keep the cached-forward branch — it is a correctness guard, not just an optimization:
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). ``has_previous_state()`` only reads host-side Cache metadata, so this
+        branch was never the sync source.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -2049,8 +2048,8 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here. Metadata-only check, no sync.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.diff
@@ -1318,12 +1318,9 @@
 
          hidden_states = inputs_embeds
          position_embeddings = self.rotary_emb(hidden_states, position_ids)
-@@ -1353,19 +2029,42 @@
-             past_key_values=past_key_values,
-         )
+@@ -1355,17 +2031,39 @@
 
--    def _update_linear_attn_mask(self, attention_mask, past_key_values):
-+    def _update_linear_attn_mask(self, attention_mask, cache_position):
+     def _update_linear_attn_mask(self, attention_mask, past_key_values):
          """
 -        NOTE: Left-padding is used for linear attention mask.
 -        No need for zeroing states when
@@ -1332,18 +1329,17 @@
 +        Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 +
 +        Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-+        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-+        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-+        / host-device sync on *every* forward, which serialises the host against the device in
-+        VeOmni's otherwise sync-free training step.
++        — when ``past_key_values.has_previous_state()`` is true (a cached forward) or
++        ``torch.all(attention_mask == 1)`` (the batch has no padding). The latter reads a 0-D GPU
++        tensor and forces an implicit ``.item()`` / host-device sync on *every* forward, which
++        serialises the host against the device in VeOmni's otherwise sync-free training step.
 +
 +        We keep the cached-forward branch — it is a correctness guard, not just an optimization:
 +        ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
 +        cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
 +        only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-+        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-+        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-+        than reading ``cache_position[0]``, so no sync.
++        a 1-token decode step). ``has_previous_state()`` only reads host-side Cache metadata, so this
++        branch was never the sync source.
 +
 +        The all-ones short-circuit is the one we drop: returning the all-ones mask makes
 +        ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -1359,8 +1355,8 @@
 +        if attention_mask is None:
 +            return None
 +        # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-+        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-+        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
++        # apply_mask_to_padding_states, and upstream returns None here. Metadata-only check, no sync.
++        if past_key_values is not None and past_key_values.has_previous_state():
 +            return None
 +        return attention_mask
 +
@@ -1372,7 +1368,7 @@
 
 
  @auto_docstring
-@@ -1376,7 +2075,19 @@
+@@ -1376,7 +2074,19 @@
      config: Qwen3_5MoeConfig
      _no_split_modules = ["Qwen3_5MoeDecoderLayer", "Qwen3_5MoeVisionBlock"]
 
@@ -1392,7 +1388,7 @@
          super().__init__(config)
          self.visual = Qwen3_5MoeVisionModel._from_config(config.vision_config)
          self.language_model = Qwen3_5MoeTextModel._from_config(config.text_config)
-@@ -1561,64 +2272,43 @@
+@@ -1561,64 +2271,43 @@
          self,
          pixel_values: torch.FloatTensor,
          image_grid_thw: torch.LongTensor | None = None,
@@ -1482,7 +1478,7 @@
          return special_image_mask, special_video_mask
 
      def compute_3d_position_ids(
-@@ -1684,6 +2374,7 @@
+@@ -1684,6 +2373,7 @@
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
          mm_token_type_ids: torch.IntTensor | None = None,
@@ -1490,7 +1486,7 @@
          **kwargs: Unpack[TransformersKwargs],
      ) -> tuple | Qwen3_5MoeModelOutputWithPast:
          r"""
-@@ -1691,6 +2382,10 @@
+@@ -1691,6 +2381,10 @@
              The temporal, height and width of feature shape of each image in LLM.
          video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
              The temporal, height and width of feature shape of each video in LLM.
@@ -1501,7 +1497,7 @@
          """
          if (input_ids is None) ^ (inputs_embeds is not None):
              raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-@@ -1698,29 +2393,170 @@
+@@ -1698,29 +2392,170 @@
          if inputs_embeds is None:
              inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1682,7 +1678,7 @@
              position_ids = self.compute_3d_position_ids(
                  input_ids=input_ids,
                  image_grid_thw=image_grid_thw,
-@@ -1730,6 +2566,17 @@
+@@ -1730,6 +2565,17 @@
                  past_key_values=past_key_values,
                  mm_token_type_ids=mm_token_type_ids,
              )
@@ -1700,7 +1696,7 @@
 
          outputs = self.language_model(
              input_ids=None,
-@@ -1737,6 +2584,7 @@
+@@ -1737,6 +2583,7 @@
              attention_mask=attention_mask,
              past_key_values=past_key_values,
              inputs_embeds=inputs_embeds,
@@ -1708,7 +1704,7 @@
              **kwargs,
          )
 
-@@ -1828,6 +2676,12 @@
+@@ -1828,6 +2675,12 @@
      return overall_loss * num_experts
 
 
@@ -1721,7 +1717,7 @@
  @auto_docstring
  class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
      _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
-@@ -1848,6 +2702,7 @@
+@@ -1848,6 +2701,7 @@
          # Initialize weights and apply final processing
          self.post_init()
 
@@ -1729,7 +1725,7 @@
      @can_return_tuple
      @auto_docstring
      def forward(
-@@ -1860,14 +2715,17 @@
+@@ -1860,14 +2714,17 @@
          labels: torch.LongTensor | None = None,
          use_cache: bool | None = None,
          output_router_logits: bool | None = None,
@@ -1748,7 +1744,7 @@
 
          Example:
 
-@@ -1899,30 +2757,70 @@
+@@ -1899,30 +2756,70 @@
              inputs_embeds=inputs_embeds,
              use_cache=use_cache,
              output_router_logits=output_router_logits,
@@ -1831,7 +1827,7 @@
              loss=loss,
              aux_loss=aux_loss,
              logits=logits,
-@@ -1930,7 +2828,14 @@
+@@ -1930,7 +2827,14 @@
              hidden_states=outputs.hidden_states,
              attentions=outputs.attentions,
              router_logits=outputs.router_logits,
@@ -1847,7 +1843,7 @@
 
 
  class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMixin):
-@@ -1977,6 +2882,7 @@
+@@ -1977,6 +2881,7 @@
          """
          return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
@@ -1855,7 +1851,7 @@
      @can_return_tuple
      def forward(
          self,
-@@ -1990,105 +2896,93 @@
+@@ -1990,105 +2895,93 @@
          pixel_values_videos: torch.FloatTensor | None = None,
          image_grid_thw: torch.LongTensor | None = None,
          video_grid_thw: torch.LongTensor | None = None,
@@ -2016,7 +2012,7 @@
          )
 
      def prepare_inputs_for_generation(
-@@ -2314,6 +3208,30 @@
+@@ -2314,6 +3207,30 @@
 
          return input_ids, model_kwargs
 

--- a/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
+++ b/veomni/models/transformers/qwen3_5_moe/generated/patched_modeling_qwen3_5_moe_npu.py
@@ -2029,23 +2029,22 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
             past_key_values=past_key_values,
         )
 
-    def _update_linear_attn_mask(self, attention_mask, cache_position):
+    def _update_linear_attn_mask(self, attention_mask, past_key_values):
         """
         Build the attention mask passed to the linear-attention (gated DeltaNet) layers.
 
         Upstream returns ``None`` — disabling the per-token zeroing in ``apply_mask_to_padding_states``
-        — when ``cache_position[0] > 0`` (a cached forward) or ``torch.all(attention_mask == 1)`` (the
-        batch has no padding). Both predicates read a 0-D GPU tensor and force an implicit ``.item()``
-        / host-device sync on *every* forward, which serialises the host against the device in
-        VeOmni's otherwise sync-free training step.
+        — when ``past_key_values.has_previous_state()`` is true (a cached forward) or
+        ``torch.all(attention_mask == 1)`` (the batch has no padding). The latter reads a 0-D GPU
+        tensor and forces an implicit ``.item()`` / host-device sync on *every* forward, which
+        serialises the host against the device in VeOmni's otherwise sync-free training step.
 
         We keep the cached-forward branch — it is a correctness guard, not just an optimization:
         ``apply_mask_to_padding_states`` does ``hidden_states * attention_mask[:, :, None]``, and in a
         cached forward the 2-D ``attention_mask`` spans ``past + current`` tokens while ``hidden_states``
         only covers the current chunk, so the shapes wouldn't broadcast (or would broadcast wrongly for
-        a 1-token decode step). But we detect it host-side from tensor shapes — ``attention_mask`` has
-        ``shape[-1] == past + current`` whereas ``cache_position`` has ``shape[-1] == current`` — rather
-        than reading ``cache_position[0]``, so no sync.
+        a 1-token decode step). ``has_previous_state()`` only reads host-side Cache metadata, so this
+        branch was never the sync source.
 
         The all-ones short-circuit is the one we drop: returning the all-ones mask makes
         ``apply_mask_to_padding_states`` a no-op multiply, so it is equivalent to upstream's ``None``
@@ -2055,8 +2054,8 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
         if attention_mask is None:
             return None
         # Cached forward (decode / continuation): see docstring — shapes wouldn't line up in
-        # apply_mask_to_padding_states, and upstream returns None here. Detected from shapes only.
-        if cache_position is not None and attention_mask.shape[-1] != cache_position.shape[-1]:
+        # apply_mask_to_padding_states, and upstream returns None here. Metadata-only check, no sync.
+        if past_key_values is not None and past_key_values.has_previous_state():
             return None
         return attention_mask
 


### PR DESCRIPTION
## Summary

Fixes #1007.

The transformers-5.9 regeneration updated the upstream call site of `_update_linear_attn_mask` to pass `past_key_values` (a `Cache`) instead of `cache_position` (a tensor), but the VeOmni `method_override` in `qwen3_5_gpu_patch_gen_config.py` still read the argument as a tensor and called `.shape` on it. Any cached forward — `generate()` with `use_cache=True`, including the prefill step — crashed with:

```
AttributeError: 'DynamicCache' object has no attribute 'shape'
```

Training itself was unaffected, since `past_key_values` is always `None` there — which is presumably why this went uncaught.

## Fix

Ports the override to the same Cache-metadata check upstream now uses (`past_key_values.has_previous_state()`), which is host-side only and preserves the original host-device-sync-avoidance the override exists for (see the updated docstring). `qwen3_5_moe` reuses this same function object (`qwen3_5_text_model_update_linear_attn_mask`), so fixing the one source function and regenerating fixes all 4 affected files (GPU/NPU × qwen3_5/qwen3_5_moe), matching the issue's own root-cause analysis.

## Verification

- Confirmed the exact crash on the pre-fix code with a direct call to the generated `_update_linear_attn_mask`, using a real `transformers.cache_utils.DynamicCache`:
  ```
  AttributeError: 'DynamicCache' object has no attribute 'shape'
  ```
- After the fix, verified correct behavior for all relevant cases (no `past_key_values`, fresh cache with no previous state, cache with previous state, `attention_mask=None`) — no crash, and return values match upstream's `has_previous_state()`-based semantics.
- `patchgen --check` passes (generated `.py`/`.diff` pairs match a fresh regen from the patched source, no drift).
- `ruff check` passes on all touched files.
- Regenerating all 29 patch configs (`patchgen --all --diff`) touches only the 4 files this bug affects — no incidental drift elsewhere.

## Test plan

- [x] Reproduced the exact `AttributeError` from #1007 against the unfixed override
- [x] Verified the fix resolves it and matches upstream `transformers==5.9.0` semantics for `_update_linear_attn_mask`
- [x] `patchgen --check` (drift/CI gate) passes
- [x] `ruff check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved cached text generation by detecting previous state through cache metadata.
  * Reduced unnecessary GPU synchronization during attention-mask preparation.

* **Bug Fixes**
  * Preserved non-cached attention masks without altering their contents.
  * Improved handling of attention masks during generation with cached states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->