### PR TITLE
[dist, parallel] fix: correct DDP gradient sync under Ulysses/CP sequence parallelism

### DIFF
--- a/veomni/distributed/torch_parallelize.py
+++ b/veomni/distributed/torch_parallelize.py
@@ -711,7 +711,14 @@ def build_parallelize_model(
         else:
             if compile_config.enable:
                 raise RuntimeError("train.torch_compile.enable requires fsdp_mode='fsdp2'; DDP is not supported.")
-            model = DDP(model, device_ids=[parallel_state.local_rank], process_group=parallel_state.dp_group)
+            # Use fsdp_group (the flattened dp_sp mesh group), not dp_group: Ulysses/CP sequence
+            # parallelism shrinks dp_group down to a single rank once it absorbs the whole world,
+            # making DDP's gradient all-reduce a silent no-op while each rank still only holds the
+            # gradient for its own local sequence shard. fsdp_group spans every rank sharing this
+            # sequence (same group FSDP2's reduce-scatter and every trainer's loss/grad-norm
+            # all-reduce already use — see e.g. train_omni_model.py, clip_grad_norm.py), so the
+            # mean-reduce here correctly recombines the sharded gradients.
+            model = DDP(model, device_ids=[parallel_state.local_rank], process_group=parallel_state.fsdp_group)
     elif compile_config.enable:
         raise RuntimeError("train.torch_compile.enable requires FSDP2; compile without FSDP is not supported.")
 


### PR DESCRIPTION
## Summary

Fixes #1059.

`build_parallelize_model`'s DDP branch wraps the whole model with `process_group=parallel_state.dp_group`. Once Ulysses (or CP) sequence parallelism is enabled, `dp_group` only covers the `dp_replicate x dp_shard` mesh dimension — the sequence dimension is a separate `ulysses` (and `cp`) dimension entirely excluded from it. When `dp_size` shrinks to 1 (e.g. `world_size == ulysses_size`, a common single-node SP config), `dp_group` becomes a trivial per-rank group of size 1, so DDP's gradient all-reduce is a **silent no-op**: each rank keeps only the gradient contribution from its own local sequence shard instead of the combined gradient, with no error or shape mismatch to surface it.

## Fix

`parallel_state.fsdp_group` already exists for exactly this — it resolves to the flattened `dp_sp` mesh group (`dp_replicate x dp_shard x ulysses x cp`), and is what FSDP2's reduce-scatter and *every other* loss/grad-norm all-reduce call site in the codebase already uses:

- `tasks/omni/train_omni_model.py`
- `veomni/distributed/fsdp2/clip_grad_norm.py`
- `veomni/trainer/callbacks/trace_callback.py`
- `veomni/utils/moe_monitor.py`

The single DDP call site was the one place still using the narrower `dp_group`. This change points it at `fsdp_group` too, so the gradient all-reduce actually spans every rank holding a shard of the sequence — consistent with how the rest of the codebase treats this group.

## Verification

On 4 GPUs, with `dp_mode="ddp"`, `dp_size=1`, `ulysses_size=4` (confirmed via the real `ParallelState`: `dp_group` size=1, `fsdp_group` size=4):

- A small linear-layer repro that shards a 4-token sequence one token per rank, wrapped with the real `torch.nn.parallel.DistributedDataParallel`:
  - **Before** (`process_group=dp_group`): resulting gradient diverges from the true full-sequence gradient by up to **1.44** (max abs error) — silently wrong, no error raised.
  - **After** (`process_group=fsdp_group`, this fix): matches the true full-sequence gradient exactly, **max abs error 0.0** on every rank.

## Test plan

- [x] Reproduced the bug mechanism against the real `ParallelState` (`dp_group` size 1 vs `fsdp_group` size 4 under `dp_mode="ddp"` + `ulysses_size=4`)
- [x] Verified with the real `torch.nn.parallel.DistributedDataParallel`, using the exact `process_group` argument this PR changes, that the fix reproduces the true gradient while the old code does not
- [x] `ruff check` passes on the touched file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed training behavior for sequence-parallel execution by ensuring gradients are synchronized across all participating processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->