### PR TITLE
[docker] fix: use UTF-8 for generator text I/O

### DIFF
--- a/docker/generate.py
+++ b/docker/generate.py
@@ -98,7 +98,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    matrix = yaml.safe_load(MATRIX_FILE.read_text())
+    matrix = yaml.safe_load(MATRIX_FILE.read_text(encoding="utf-8"))
     defaults = matrix.get("defaults", {}) or {}
     images = matrix.get("images", []) or []
     extras_presets = matrix.get("uv_extras_presets", {}) or {}
@@ -119,7 +119,7 @@ def main() -> int:
         rel = out_path.relative_to(REPO_ROOT)
 
         if args.check:
-            current = out_path.read_text() if out_path.exists() else ""
+            current = out_path.read_text(encoding="utf-8") if out_path.exists() else ""
             if current != rendered:
                 drift.append(rel)
                 print(f"drift: {rel}", file=sys.stderr)
@@ -127,7 +127,7 @@ def main() -> int:
                 print(f"ok:    {rel}")
         else:
             out_path.parent.mkdir(parents=True, exist_ok=True)
-            out_path.write_text(rendered)
+            out_path.write_text(rendered, encoding="utf-8")
             print(f"wrote: {rel}")
 
     if args.check and drift:


### PR DESCRIPTION
### What does this PR do?

Fixes #1116 by making the Docker generator read its matrix and generated outputs, and write generated outputs, with an explicit UTF-8 encoding. This prevents false Dockerfile drift on Windows systems whose default text encoding is not UTF-8.

### Checklist Before Starting

- Searched open and closed issues and pull requests for `docker/generate.py`, cp1252, Windows drift, and UTF-8 generator reports. #825 changes the generator for NPU templating but does not address encoding; merged #807 fixed the same class of problem in patchgen.
- PR title follows `[{modules}] {type}: {description}` format.

### Test

- `python docker/generate.py --check` on Windows with preferred encoding cp1252: passes after the change (failed with false drift before it).
- `python -X utf8 docker/generate.py --check`: passes.
- Python 3.12.13: `python docker/generate.py --check`: passes.
- Regeneration with `python docker/generate.py` completes and produces no Dockerfile diff.
- Ruff 0.13.2: `ruff check tasks tests veomni docs docker/generate.py`: passes.
- Ruff 0.13.2: `ruff format --check tasks tests veomni docs docker/generate.py`: passes (568 files).
- `git diff --check`: passes.

### API and Usage Example

N/A. The command and generated files are unchanged.

### Design & Code Changes

- Decode `docker/matrix.yaml` as UTF-8.
- Decode existing generated Dockerfiles as UTF-8 during `--check`.
- Encode regenerated Dockerfiles as UTF-8.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md).
- [x] Applied pre-commit checks. The Windows host does not provide `make`; the two Ruff commands behind `make quality` were run directly with the repository's locked Ruff 0.13.2.
- [x] Documentation is not affected; no update is required.
- [x] No `tasks/` scripts were moved or renamed.
- [x] A separate CI test is not feasible because reproducing this bug requires a non-UTF-8 process default encoding. The documented generator command itself is the focused regression check and was run in default and UTF-8 modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for non-ASCII characters when loading data, validating generated files, and writing rendered outputs.
  * Preserved existing control flow and output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->