### PR TITLE
[ops] feat: external ops-backend plugin loader via entry points

### DIFF
--- a/tests/ops/plugin_fixtures/__init__.py
+++ b/tests/ops/plugin_fixtures/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fake ops-backend plugin declarations for the loader tests.
+
+Importable as ``plugin_fixtures.*`` (``tests/ops`` is put on ``sys.path`` by
+``test_ops_plugin_loader.py``). Each module mimics one plugin scenario.
+"""
+
+from .kernels import FakeRMSNorm, fake_rms_norm
+
+
+__all__ = ["FakeRMSNorm", "fake_rms_norm"]

--- a/tests/ops/plugin_fixtures/backend_conflict.py
+++ b/tests/ops/plugin_fixtures/backend_conflict.py
@@ -1,0 +1,26 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Invalid plugin: backend name collides with a built-in (``liger_kernel``)."""
+
+VEOMNI_PLUGIN_API_VERSION = 1
+
+VEOMNI_OPS_BACKENDS = {
+    "ops": {
+        "rms_norm": {
+            "liger_kernel": {"entry": "plugin_fixtures.kernels:FakeRMSNorm"},
+        },
+    },
+    "kernels": [],
+}

--- a/tests/ops/plugin_fixtures/bad_version.py
+++ b/tests/ops/plugin_fixtures/bad_version.py
@@ -1,0 +1,26 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Invalid plugin: unsupported protocol version."""
+
+VEOMNI_PLUGIN_API_VERSION = 99
+
+VEOMNI_OPS_BACKENDS = {
+    "ops": {
+        "rms_norm": {
+            "futurekit": {"entry": "plugin_fixtures.kernels:FakeRMSNorm"},
+        },
+    },
+    "kernels": [],
+}

--- a/tests/ops/plugin_fixtures/boom.py
+++ b/tests/ops/plugin_fixtures/boom.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Broken plugin: the declaration module itself raises on import."""
+
+raise RuntimeError("simulated plugin import failure")

--- a/tests/ops/plugin_fixtures/good.py
+++ b/tests/ops/plugin_fixtures/good.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Valid plugin: adds an opt-in ``testkit`` backend to ``rms_norm``.
+
+``requires`` lists ``pytest`` because it is guaranteed installed in the test
+environment (exercises the generic package probe without extra deps).
+"""
+
+VEOMNI_PLUGIN_API_VERSION = 1
+
+VEOMNI_OPS_BACKENDS = {
+    "ops": {
+        "rms_norm": {
+            "testkit": {
+                "entry": "plugin_fixtures.kernels:FakeRMSNorm",
+                "requires": ["pytest"],
+            },
+        },
+    },
+    "kernels": [
+        {
+            "name": "testkit",
+            "op_name": "rms_norm",
+            "variant": "standard",
+            "factory": "plugin_fixtures.kernels:fake_rms_norm",
+            "device_type": "any",
+            "description": "fake test kernel",
+        },
+    ],
+}

--- a/tests/ops/plugin_fixtures/kernel_conflict.py
+++ b/tests/ops/plugin_fixtures/kernel_conflict.py
@@ -1,0 +1,34 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Invalid plugin: kernel name collides with an already-registered kernel.
+
+Loaded together with ``good`` (which registers kernel ``testkit`` for
+``rms_norm/standard`` first), this must be rejected atomically.
+"""
+
+VEOMNI_PLUGIN_API_VERSION = 1
+
+VEOMNI_OPS_BACKENDS = {
+    "ops": {},
+    "kernels": [
+        {
+            "name": "testkit",
+            "op_name": "rms_norm",
+            "variant": "standard",
+            "factory": "plugin_fixtures.kernels:fake_rms_norm",
+            "device_type": "any",
+        },
+    ],
+}

--- a/tests/ops/plugin_fixtures/kernels.py
+++ b/tests/ops/plugin_fixtures/kernels.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Entry targets for the fake plugin declarations (``module:attr`` endpoints)."""
+
+
+class FakeRMSNorm:
+    """BackendSpec.entry target: a stand-in PER_MODEL replacement class."""
+
+
+def fake_rms_norm(x, weight, eps=1e-6):  # pragma: no cover - never executed
+    """KernelSpec.factory target: a stand-in functional kernel."""
+    return x

--- a/tests/ops/plugin_fixtures/missing_payload.py
+++ b/tests/ops/plugin_fixtures/missing_payload.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Invalid plugin: missing the VEOMNI_OPS_BACKENDS payload attribute."""
+
+VEOMNI_PLUGIN_API_VERSION = 1

--- a/tests/ops/plugin_fixtures/partial_bad.py
+++ b/tests/ops/plugin_fixtures/partial_bad.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Invalid plugin: valid ``ops`` section but broken ``kernels`` entry.
+
+Guards atomicity — nothing from this plugin may be registered, not even the
+valid part.
+"""
+
+VEOMNI_PLUGIN_API_VERSION = 1
+
+VEOMNI_OPS_BACKENDS = {
+    "ops": {
+        "rms_norm": {
+            "partialkit": {"entry": "plugin_fixtures.kernels:FakeRMSNorm"},
+        },
+    },
+    "kernels": [
+        {
+            "name": "partialkit",
+            "op_name": "rms_norm",
+            "variant": "standard",
+            # "factory" deliberately missing -> invalid
+            "device_type": "any",
+        },
+    ],
+}

--- a/tests/ops/plugin_fixtures/unknown_key.py
+++ b/tests/ops/plugin_fixtures/unknown_key.py
@@ -1,0 +1,27 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Invalid plugin: unknown top-level payload key (plugins cannot set defaults)."""
+
+VEOMNI_PLUGIN_API_VERSION = 1
+
+VEOMNI_OPS_BACKENDS = {
+    "ops": {
+        "rms_norm": {
+            "defaultkit": {"entry": "plugin_fixtures.kernels:FakeRMSNorm"},
+        },
+    },
+    "kernels": [],
+    "defaults": {"rms_norm_implementation": "defaultkit"},
+}

--- a/tests/ops/plugin_fixtures/unknown_op.py
+++ b/tests/ops/plugin_fixtures/unknown_op.py
@@ -1,0 +1,26 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Invalid plugin: targets an op that does not exist."""
+
+VEOMNI_PLUGIN_API_VERSION = 1
+
+VEOMNI_OPS_BACKENDS = {
+    "ops": {
+        "no_such_op": {
+            "testkit": {"entry": "plugin_fixtures.kernels:FakeRMSNorm"},
+        },
+    },
+    "kernels": [],
+}

--- a/tests/ops/test_ops_plugin_loader.py
+++ b/tests/ops/test_ops_plugin_loader.py
@@ -1,0 +1,193 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-runnable tests for the external ops-backend plugin loader.
+
+No accelerator and no real plugin package required: entry points are injected
+explicitly and point at the ``plugin_fixtures`` declarations next to this file.
+
+Run on any host with ``pytest tests/ops/test_ops_plugin_loader.py``.
+"""
+
+import sys
+from importlib.metadata import EntryPoint
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import veomni.ops  # noqa: F401 -- trigger built-in registrations + plugin mount
+from veomni.ops.config import registry as registry_mod
+from veomni.ops.config._plugin_loader import PLUGIN_GROUP, load_ops_backend_plugins
+from veomni.ops.config.registry import get_op
+from veomni.ops.config.singleton import get_ops_config, set_ops_config
+from veomni.ops.kernel_registry import KERNEL_REGISTRY
+
+
+# Make ``plugin_fixtures.*`` importable (tests/ops is not a package).
+_TEST_OPS_DIR = Path(__file__).resolve().parent
+if str(_TEST_OPS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TEST_OPS_DIR))
+
+
+def _ep(name: str, module: str) -> EntryPoint:
+    return EntryPoint(name=name, value=f"plugin_fixtures.{module}", group=PLUGIN_GROUP)
+
+
+@pytest.fixture
+def restore_registries():
+    """Snapshot and restore both registries + the ops-config singleton.
+
+    Plugin loading mutates global state by design; tests must not leak
+    ``testkit`` backends into other test modules.
+    """
+    ops_snapshot = dict(registry_mod._OPS_REGISTRY)
+    kernels_snapshot = {k: dict(v) for k, v in KERNEL_REGISTRY._specs.items()}
+    config_snapshot = get_ops_config()
+    yield
+    registry_mod._OPS_REGISTRY.clear()
+    registry_mod._OPS_REGISTRY.update(ops_snapshot)
+    KERNEL_REGISTRY._specs.clear()
+    KERNEL_REGISTRY._specs.update(kernels_snapshot)
+    set_ops_config(config_snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.usefixtures("restore_registries")
+    def test_plugin_registers_in_both_registries(self):
+        loaded = load_ops_backend_plugins([_ep("good", "good")])
+        assert loaded == ("good",)
+
+        op = get_op("rms_norm")
+        assert "testkit" in op.backends
+        assert op.backends["testkit"].entry == "plugin_fixtures.kernels:FakeRMSNorm"
+        assert op.default != "testkit"  # opt-in only
+
+        assert KERNEL_REGISTRY.resolve("rms_norm", "standard", "testkit") is not None
+
+    @pytest.mark.usefixtures("restore_registries")
+    def test_plugin_backend_listed_in_error_message(self):
+        load_ops_backend_plugins([_ep("good", "good")])
+        set_ops_config(SimpleNamespace(rms_norm_implementation="typo_backend"))
+
+        from veomni.ops.config.registry import apply_per_model_patches
+
+        with pytest.raises(ValueError, match="testkit"):
+            apply_per_model_patches(
+                SimpleNamespace(FakeRMSNorm=object), "TestModel", targets={"rms_norm": "FakeRMSNorm"}
+            )
+
+    @pytest.mark.usefixtures("restore_registries")
+    def test_per_model_end_to_end_bind_and_eager(self):
+        from plugin_fixtures.kernels import FakeRMSNorm
+
+        load_ops_backend_plugins([_ep("good", "good")])
+        from veomni.ops.config.registry import apply_per_model_patches
+
+        hf_module = SimpleNamespace(FakeRMSNorm="original-class")
+        set_ops_config(SimpleNamespace(rms_norm_implementation="testkit"))
+        apply_per_model_patches(hf_module, "TestModel", targets={"rms_norm": "FakeRMSNorm"})
+        assert hf_module.FakeRMSNorm is FakeRMSNorm
+
+        hf_module2 = SimpleNamespace(FakeRMSNorm="original-class")
+        set_ops_config(SimpleNamespace(rms_norm_implementation="eager"))
+        apply_per_model_patches(hf_module2, "TestModel", targets={"rms_norm": "FakeRMSNorm"})
+        assert hf_module2.FakeRMSNorm == "original-class"  # eager keeps the HF default
+
+
+# ---------------------------------------------------------------------------
+# Rejection matrix: every failure mode must leave zero registration behind
+# ---------------------------------------------------------------------------
+
+
+class TestRejections:
+    @pytest.mark.usefixtures("restore_registries")
+    @pytest.mark.parametrize("module", ["bad_version", "missing_payload", "unknown_key", "unknown_op"])
+    def test_malformed_payloads_rejected(self, module):
+        assert load_ops_backend_plugins([_ep(module, module)]) == ()
+        assert "testkit" not in get_op("rms_norm").backends
+
+    @pytest.mark.usefixtures("restore_registries")
+    def test_backend_name_conflict_rejected_builtin_untouched(self):
+        assert load_ops_backend_plugins([_ep("conflict", "backend_conflict")]) == ()
+        op = get_op("rms_norm")
+        assert "liger_kernel" in op.backends
+        assert op.backends["liger_kernel"].entry.startswith("liger_kernel")
+
+    @pytest.mark.usefixtures("restore_registries")
+    def test_kernel_name_conflict_rejected(self):
+        load_ops_backend_plugins([_ep("good", "good")])
+        assert load_ops_backend_plugins([_ep("conflict", "kernel_conflict")]) == ()
+        # First plugin's kernel still resolves; the duplicate did not land.
+        assert KERNEL_REGISTRY.resolve("rms_norm", "standard", "testkit") is not None
+
+    @pytest.mark.usefixtures("restore_registries")
+    def test_partial_payload_rejected_atomically(self):
+        assert load_ops_backend_plugins([_ep("partial", "partial_bad")]) == ()
+        assert "partialkit" not in get_op("rms_norm").backends
+        assert "partialkit" not in KERNEL_REGISTRY.list_available("rms_norm", "standard")
+
+    @pytest.mark.usefixtures("restore_registries")
+    def test_broken_import_isolated(self):
+        assert load_ops_backend_plugins([_ep("boom", "boom")]) == ()
+        assert "testkit" not in get_op("rms_norm").backends
+
+    @pytest.mark.usefixtures("restore_registries")
+    def test_broken_plugin_does_not_block_later_plugins(self):
+        loaded = load_ops_backend_plugins([_ep("a_boom", "boom"), _ep("b_good", "good")])
+        assert loaded == ("b_good",)
+
+
+# ---------------------------------------------------------------------------
+# Kill-switch and re-entry safety
+# ---------------------------------------------------------------------------
+
+
+class TestSwitchAndReentry:
+    @pytest.mark.usefixtures("restore_registries")
+    def test_kill_switch_skips_everything(self, monkeypatch):
+        monkeypatch.setenv("VEOMNI_OPS_PLUGINS", "0")
+        assert load_ops_backend_plugins([_ep("good", "good")]) == ()
+        assert "testkit" not in get_op("rms_norm").backends
+
+    @pytest.mark.usefixtures("restore_registries")
+    def test_repeated_load_is_safe(self):
+        assert load_ops_backend_plugins([_ep("good", "good")]) == ("good",)
+        # Second pass hits name-conflict rejection -> skipped, nothing duplicated.
+        assert load_ops_backend_plugins([_ep("good", "good")]) == ()
+        op = get_op("rms_norm")
+        assert "testkit" in op.backends
+
+
+# ---------------------------------------------------------------------------
+# ``requires`` generalization (generic package probe)
+# ---------------------------------------------------------------------------
+
+
+class TestRequiresGeneralization:
+    def test_missing_package_raises_runtime_error_naming_it(self):
+        from veomni.ops.config.registry import _check_requires
+
+        with pytest.raises(RuntimeError, match="definitely_not_installed_pkg_xyz"):
+            _check_requires(("definitely_not_installed_pkg_xyz",))
+
+    def test_installed_package_passes(self):
+        from veomni.ops.config.registry import _check_requires
+
+        _check_requires(("pytest",))

--- a/veomni/ops/README.md
+++ b/veomni/ops/README.md
@@ -10,6 +10,7 @@ the dispatch machinery that picks the right implementation based on
 ```
 veomni/ops/
 ├── config/                 Dispatch infrastructure (no kernels here)
+│   ├── _plugin_loader.py   External ops-backend plugin loader (entry points)
 │   ├── registry.py         OpSpec / BackendSpec / OpScope + register_op,
 │   │                       apply_global_ops, apply_per_model_patches
 │   └── singleton.py        get_ops_config / set_ops_config — bridges the
@@ -75,6 +76,61 @@ own Triton RMSNorm/rotary. See the per-model table below.
 | `moe_implementation=fused_quack` | `quack` package, SM90+ | `is_quack_gemm_available()` |
 | `moe_implementation=fused_npu` | `torch_npu` + Ascend NPU | `is_torch_npu_available()` |
 | `mhc_implementation=tilelang` | `tile-kernels==1.0.0`, BF16, NVIDIA SM90+ | `KernelSpec(HardwareRequirement(..., min_compute_capability=90))` |
+
+### External ops-backend plugins
+
+Third-party kernel packages can add **opt-in** backends to any registered op
+without modifying VeOmni, via the standard entry-point group
+`veomni.ops_backends`. After a one-time merge of this mechanism, a new
+external kernel package requires **zero VeOmni changes**: install the package
+and its backend names become valid values for the matching
+`*_implementation` config fields (still opt-in; defaults never change).
+
+A plugin declares one entry point pointing at a **pure-data declaration
+module** (no heavy imports, no side effects):
+
+```toml
+# in the plugin package's pyproject.toml
+[project.entry-points."veomni.ops_backends"]
+my_kernels = "my_kernels.veomni_plugin"
+```
+
+```python
+# my_kernels/veomni_plugin.py
+VEOMNI_PLUGIN_API_VERSION = 1
+
+VEOMNI_OPS_BACKENDS = {
+    "ops": {  # merged into OpSpec.backends (config-field dispatch)
+        "rms_norm": {
+            "my_backend": {"entry": "my_kernels:MyRMSNorm",       # "module:attr", lazy
+                            "requires": ["my_kernels"]},           # generic package probe
+        },
+    },
+    "kernels": [  # merged into KERNEL_REGISTRY (OpSlot dispatch)
+        {"name": "my_backend", "op_name": "rms_norm", "variant": "standard",
+         "factory": "my_kernels:rms_norm", "device_type": "gpu",
+         "description": "fused RMSNorm (Triton fwd+bwd)"},
+    ],
+}
+```
+
+Semantics (enforced by `config/_plugin_loader.py`):
+
+- **Opt-in only.** The payload schema has no default/fallback keys — plugins
+  can make a backend resolvable, never change any default.
+- **Atomic per plugin.** The payload is fully validated before anything is
+  registered; any invalid entry rejects the whole plugin.
+- **Never fatal.** Import errors, bad payloads, and name conflicts (with
+  built-ins or other plugins) degrade to a warning and the plugin is skipped,
+  exactly as if it were not installed.
+- **One-shot, ordered.** Discovery runs once per process at `import
+  veomni.ops`, after built-in ops register; results are independent of load
+  order. `VEOMNI_OPS_PLUGINS=0` disables the mechanism entirely.
+
+`requires` entries are package names: `liger_kernel` / `torch_npu` / `triton`
+keep their dedicated availability helpers; any other name is checked by plain
+importability at resolve time (clear `RuntimeError` naming the missing
+package).
 
 #### Installing MagiAttention
 

--- a/veomni/ops/__init__.py
+++ b/veomni/ops/__init__.py
@@ -22,12 +22,19 @@ from ..utils.env import get_env
 # Eagerly import kernel packages so that every op registers itself with the
 # registry.  Order does not matter; each ``register_op`` call is idempotent.
 from . import kernels, liger  # noqa: F401  triggers all register_op() calls
+from .config._plugin_loader import load_ops_backend_plugins
 from .config.registry import apply_global_ops
 from .config.singleton import set_ops_config
 from .dispatch import OpSlot
 from .kernels import attention, cross_entropy, load_balancing_loss, moe  # noqa: F401
 from .kernels.load_balancing_loss import load_balancing_loss_func
 from .kernels.moe import fused_moe_forward
+
+
+# Merge external ops-backend plugins (entry-point group ``veomni.ops_backends``)
+# once all built-in ops are registered. Opt-in additions only; no-op when no
+# plugin package is installed or VEOMNI_OPS_PLUGINS=0. See config/_plugin_loader.py.
+load_ops_backend_plugins()
 
 
 if TYPE_CHECKING:

--- a/veomni/ops/config/_plugin_loader.py
+++ b/veomni/ops/config/_plugin_loader.py
@@ -1,0 +1,289 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""External ops-backend plugin loader.
+
+Third-party kernel packages can add **opt-in** backends to VeOmni's
+config-driven kernel selection without modifying VeOmni, by declaring an
+entry point in the ``veomni.ops_backends`` group::
+
+    [project.entry-points."veomni.ops_backends"]
+    my_kernels = "my_kernels.veomni_plugin"
+
+The referenced module must be pure data (no heavy imports, no side effects)
+and expose two attributes:
+
+* ``VEOMNI_PLUGIN_API_VERSION`` — protocol version; must exactly equal the
+  version supported here, otherwise the plugin is rejected.
+* ``VEOMNI_OPS_BACKENDS`` — declaration payload::
+
+      VEOMNI_OPS_BACKENDS = {
+          "ops": {  # merged into OpSpec.backends (config-field dispatch)
+              "rms_norm": {
+                  "my_backend": {"entry": "my_kernels:MyRMSNorm",
+                                  "requires": ["my_kernels"]},
+              },
+          },
+          "kernels": [  # merged into KERNEL_REGISTRY (OpSlot dispatch)
+              {"name": "my_backend", "op_name": "rms_norm", "variant": "standard",
+               "factory": "my_kernels:rms_norm", "device_type": "gpu",
+               "description": "..."},
+          ],
+      }
+
+Properties guaranteed by the loader:
+
+* **Opt-in only.** The payload schema has no default/fallback keys; plugins
+  can make a backend name resolvable, never change any op's default.
+* **Atomic per plugin.** The whole payload is validated before anything is
+  registered; a plugin with any invalid entry registers nothing.
+* **Never fatal.** Any plugin failure (import error, bad payload, name
+  conflict) degrades to a warning and the plugin is skipped — exactly as if
+  it were not installed.
+* **One-shot.** Discovery runs once per process at ``veomni.ops`` import
+  time; ``VEOMNI_OPS_PLUGINS=0`` disables the mechanism entirely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from functools import lru_cache
+from importlib.metadata import EntryPoint, entry_points
+from typing import Any
+
+from ...utils import logging
+from ...utils.env import get_env
+from ..kernel_registry import KERNEL_REGISTRY, HardwareRequirement, KernelSpec
+from .registry import BackendSpec, OpScope, _import_entry, extend_op_backends, get_op
+
+
+logger = logging.get_logger(__name__)
+
+PLUGIN_GROUP = "veomni.ops_backends"
+SUPPORTED_PLUGIN_API_VERSION = 1
+
+_PAYLOAD_KEYS = frozenset({"ops", "kernels"})
+_BACKEND_KEYS = frozenset(
+    {"entry", "requires", "side_effect", "replace_forward", "entry_is_factory", "target_override"}
+)
+_PER_MODEL_ONLY_KEYS = ("replace_forward", "entry_is_factory", "target_override")
+_KERNEL_REQUIRED_KEYS = ("name", "op_name", "variant", "factory", "device_type")
+_KERNEL_KEYS = frozenset(_KERNEL_REQUIRED_KEYS + ("min_compute_capability", "max_compute_capability", "description"))
+_DEVICE_TYPES = frozenset({"gpu", "npu", "any"})
+
+
+class PluginRejected(Exception):
+    """A plugin declaration is invalid; the whole plugin is skipped."""
+
+
+# ---------------------------------------------------------------------------
+# Validation / translation (pure; no registry mutation)
+# ---------------------------------------------------------------------------
+
+
+def _check_entry_string(value: Any, what: str) -> None:
+    if not isinstance(value, str):
+        raise PluginRejected(f"{what} must be a 'module:attr' string, got {type(value).__name__}.")
+    module, sep, attr = value.partition(":")
+    if not (sep and module and attr):
+        raise PluginRejected(f"{what} must be of the form 'module:attr', got {value!r}.")
+
+
+def _build_backend_spec(op_name: str, backend_name: str, desc: Any) -> BackendSpec:
+    if not isinstance(desc, dict):
+        raise PluginRejected(f"ops.{op_name}.{backend_name} must be a mapping, got {type(desc).__name__}.")
+    unknown = desc.keys() - _BACKEND_KEYS
+    if unknown:
+        raise PluginRejected(f"ops.{op_name}.{backend_name} has unknown key(s) {sorted(unknown)}.")
+    if "entry" not in desc:
+        raise PluginRejected(f"ops.{op_name}.{backend_name} is missing required key 'entry'.")
+    _check_entry_string(desc["entry"], f"ops.{op_name}.{backend_name}.entry")
+
+    requires = desc.get("requires", ())
+    if not isinstance(requires, (list, tuple)) or not all(isinstance(p, str) for p in requires):
+        raise PluginRejected(f"ops.{op_name}.{backend_name}.requires must be a list of package names.")
+
+    side_effect = desc.get("side_effect")
+    if side_effect is not None:
+        _check_entry_string(side_effect, f"ops.{op_name}.{backend_name}.side_effect")
+    replace_forward = desc.get("replace_forward", False)
+    entry_is_factory = desc.get("entry_is_factory", False)
+    if not isinstance(replace_forward, bool) or not isinstance(entry_is_factory, bool):
+        raise PluginRejected(f"ops.{op_name}.{backend_name}.replace_forward/entry_is_factory must be booleans.")
+    target_override = desc.get("target_override")
+    if target_override is not None and not isinstance(target_override, str):
+        raise PluginRejected(f"ops.{op_name}.{backend_name}.target_override must be a string.")
+
+    return BackendSpec(
+        entry=desc["entry"],
+        requires=tuple(requires),
+        side_effect=side_effect,
+        replace_forward=replace_forward,
+        entry_is_factory=entry_is_factory,
+        target_override=target_override,
+    )
+
+
+def _check_scope_compatibility(op_name: str, backend_name: str, desc: dict[str, Any], scope: OpScope) -> None:
+    """Reject keys the dispatch engine would silently ignore for this scope."""
+    if scope is OpScope.GLOBAL:
+        used = [key for key in _PER_MODEL_ONLY_KEYS if desc.get(key)]
+        if used:
+            raise PluginRejected(f"ops.{op_name}.{backend_name}: key(s) {used} only apply to per-model ops.")
+    elif desc.get("side_effect"):
+        raise PluginRejected(f"ops.{op_name}.{backend_name}: 'side_effect' only applies to global ops.")
+
+
+def _build_kernel_spec(desc: Any) -> KernelSpec:
+    if not isinstance(desc, dict):
+        raise PluginRejected(f"kernels[] entries must be mappings, got {type(desc).__name__}.")
+    unknown = desc.keys() - _KERNEL_KEYS
+    if unknown:
+        raise PluginRejected(f"kernels[] entry has unknown key(s) {sorted(unknown)}.")
+    for key in _KERNEL_REQUIRED_KEYS:
+        if key not in desc:
+            raise PluginRejected(f"kernels[] entry is missing required key {key!r}.")
+        if not isinstance(desc[key], str):
+            raise PluginRejected(f"kernels[].{key} must be a string.")
+    _check_entry_string(desc["factory"], "kernels[].factory")
+
+    device_type = desc["device_type"]
+    if device_type not in _DEVICE_TYPES:
+        raise PluginRejected(f"kernels[].device_type must be one of {sorted(_DEVICE_TYPES)}, got {device_type!r}.")
+    min_cc = desc.get("min_compute_capability")
+    max_cc = desc.get("max_compute_capability")
+    for cc, key in ((min_cc, "min_compute_capability"), (max_cc, "max_compute_capability")):
+        if cc is not None and not isinstance(cc, int):
+            raise PluginRejected(f"kernels[].{key} must be an integer.")
+    hardware = HardwareRequirement(
+        device_type=device_type, min_compute_capability=min_cc, max_compute_capability=max_cc
+    )
+    factory_entry = desc["factory"]
+    return KernelSpec(
+        name=desc["name"],
+        op_name=desc["op_name"],
+        variant=desc["variant"],
+        factory=lambda: _import_entry(factory_entry),  # lazy: resolved on first use
+        hardware=hardware,
+        description=desc.get("description", ""),
+    )
+
+
+def _plan_from_module(module: Any) -> dict[str, Any]:
+    """Validate a declaration module and build the registration plan.
+
+    Pure function: raises :class:`PluginRejected` on any problem without
+    touching registry state.
+    """
+    api_version = getattr(module, "VEOMNI_PLUGIN_API_VERSION", None)
+    if api_version != SUPPORTED_PLUGIN_API_VERSION:
+        raise PluginRejected(
+            f"VEOMNI_PLUGIN_API_VERSION is {api_version!r}; this VeOmni supports exactly "
+            f"{SUPPORTED_PLUGIN_API_VERSION}."
+        )
+    payload = getattr(module, "VEOMNI_OPS_BACKENDS", None)
+    if payload is None:
+        raise PluginRejected("module does not define VEOMNI_OPS_BACKENDS.")
+    if not isinstance(payload, dict):
+        raise PluginRejected(f"VEOMNI_OPS_BACKENDS must be a mapping, got {type(payload).__name__}.")
+    unknown = payload.keys() - _PAYLOAD_KEYS
+    if unknown:
+        raise PluginRejected(
+            f"VEOMNI_OPS_BACKENDS has unknown key(s) {sorted(unknown)}; plugins can only declare "
+            "'ops' and 'kernels' (never defaults or fallbacks)."
+        )
+
+    ops_plan: dict[str, dict[str, BackendSpec]] = {}
+    for op_name, backends in payload.get("ops", {}).items():
+        try:
+            op = get_op(op_name)
+        except KeyError as e:
+            raise PluginRejected(f"unknown op {op_name!r}.") from e
+        if not isinstance(backends, dict):
+            raise PluginRejected(f"ops.{op_name} must map backend names to declarations.")
+        overlap = op.backends.keys() & backends.keys()
+        if overlap:
+            raise PluginRejected(f"backend name(s) {sorted(overlap)} already registered for op {op_name!r}.")
+        specs: dict[str, BackendSpec] = {}
+        for backend_name, desc in backends.items():
+            _check_scope_compatibility(op_name, backend_name, desc, op.scope)
+            specs[backend_name] = _build_backend_spec(op_name, backend_name, desc)
+        ops_plan[op_name] = specs
+
+    kernels_payload = payload.get("kernels", [])
+    if not isinstance(kernels_payload, list):
+        raise PluginRejected("'kernels' must be a list of declarations.")
+    kernels_plan: list[KernelSpec] = []
+    for desc in kernels_payload:
+        spec = _build_kernel_spec(desc)
+        if spec.name in KERNEL_REGISTRY.list_available(spec.op_name, spec.variant):
+            raise PluginRejected(
+                f"kernel name {spec.name!r} is already registered for op={spec.op_name!r}, variant={spec.variant!r}."
+            )
+        kernels_plan.append(spec)
+
+    return {"ops": ops_plan, "kernels": kernels_plan}
+
+
+def _summarize(plan: dict[str, Any]) -> str:
+    parts = [f"{op_name}: {', '.join(sorted(specs))}" for op_name, specs in plan["ops"].items()]
+    parts += [f"kernel {s.op_name}/{s.variant}: {s.name}" for s in plan["kernels"]]
+    return "; ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Registration + discovery
+# ---------------------------------------------------------------------------
+
+
+def _register_plan(plan: dict[str, Any]) -> None:
+    for op_name, specs in plan["ops"].items():
+        extend_op_backends(op_name, specs)
+    for spec in plan["kernels"]:
+        KERNEL_REGISTRY.register(spec)
+
+
+def _load_plugins(eps: Iterable[EntryPoint]) -> tuple[str, ...]:
+    if get_env("VEOMNI_OPS_PLUGINS") == "0":
+        return ()
+    loaded: list[str] = []
+    for ep in sorted(eps, key=lambda e: e.name):
+        try:
+            module = ep.load()
+            plan = _plan_from_module(module)
+            _register_plan(plan)
+        except Exception as e:  # noqa: BLE001 -- a broken plugin must never break VeOmni startup
+            logger.warning_rank0(f"Ops backend plugin {ep.name!r} skipped: {e}")
+            continue
+        logger.info_rank0(f"Loaded ops backend plugin {ep.name!r}: {_summarize(plan)}")
+        loaded.append(ep.name)
+    return tuple(loaded)
+
+
+@lru_cache(maxsize=1)
+def _load_discovered_plugins() -> tuple[str, ...]:
+    return _load_plugins(entry_points(group=PLUGIN_GROUP))
+
+
+def load_ops_backend_plugins(eps: Iterable[EntryPoint] | None = None) -> tuple[str, ...]:
+    """Discover and register external ops-backend plugins (opt-in additions).
+
+    Called once at ``veomni.ops`` import time, after all built-in ops are
+    registered; the discovery result is cached for the process. Returns the
+    names of successfully loaded plugins. ``eps`` lets tests inject explicit
+    entry points instead of scanning the environment.
+    """
+    if eps is None:
+        return _load_discovered_plugins()
+    return _load_plugins(eps)

--- a/veomni/ops/config/registry.py
+++ b/veomni/ops/config/registry.py
@@ -37,7 +37,7 @@ callback remains as an escape hatch for truly one-off behaviour.
 from __future__ import annotations
 
 import importlib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from types import ModuleType
 from typing import TYPE_CHECKING, Callable
@@ -69,7 +69,10 @@ class BackendSpec:
     Attributes:
         entry: ``"module:attr"`` - lazily imported to resolve the replacement.
         requires: Package names that must be available, checked before
-            resolution. Supported values: ``"liger_kernel"``, ``"torch_npu"``.
+            resolution. Supported values: ``"liger_kernel"``, ``"torch_npu"``,
+            ``"triton"``, or any other importable package name (generic
+            importability check — used by external ops-backend plugins, see
+            ``_plugin_loader.py``).
         side_effect: GLOBAL ops only. ``"module:callable"`` invoked after
             ``entry`` is bound to ``global_slot`` (e.g. installing additional
             ``LOSS_MAPPING`` entries).
@@ -140,6 +143,22 @@ def get_op(name: str) -> OpSpec:
     return _OPS_REGISTRY[name]
 
 
+def extend_op_backends(op_name: str, backends: dict[str, BackendSpec]) -> None:
+    """Merge external backends into an already-registered op.
+
+    Used by the ops-backend plugin loader (``_plugin_loader.py``) to make
+    third-party implementations resolvable without re-registering the whole
+    ``OpSpec`` (``register_op`` treats a differing spec for a known op as an
+    error). Raises ``ValueError`` if any backend name already exists for the
+    op; never changes the op's ``default``.
+    """
+    op = get_op(op_name)
+    overlap = op.backends.keys() & backends.keys()
+    if overlap:
+        raise ValueError(f"Backend(s) {sorted(overlap)} already registered for op {op_name!r}.")
+    _OPS_REGISTRY[op_name] = replace(op, backends={**op.backends, **backends})
+
+
 def list_ops(scope: OpScope | None = None) -> list[OpSpec]:
     """Return all registered ops, optionally filtered by ``scope``."""
     ops = list(_OPS_REGISTRY.values())
@@ -179,7 +198,13 @@ def _check_requires(requires: tuple[str, ...]) -> None:
                     "(or 'triton-ascend' on NPU). Install it or set the field to 'eager'."
                 )
         else:
-            raise ValueError(f"Unsupported 'requires' token: {pkg!r}")
+            # Generic third-party package (e.g. an external ops-backend plugin
+            # package). Same importability check as the special cases above.
+            if not is_package_available(pkg):
+                raise RuntimeError(
+                    f"Backend requested but the {pkg!r} package is not installed. "
+                    f"Install it or set the field to another backend / 'eager'."
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/veomni/utils/env.py
+++ b/veomni/utils/env.py
@@ -22,6 +22,9 @@ logger = logging.get_logger(__name__)
 
 ENV_DEFAULTS = {
     "MODELING_BACKEND": "veomni",
+    # Kill-switch for external ops-backend plugins (veomni.ops_backends entry
+    # points). "0" restores built-in-backends-only behavior exactly.
+    "VEOMNI_OPS_PLUGINS": "1",
 }
 
 


### PR DESCRIPTION
## Summary

Adds a **generic external ops-backend plugin mechanism**: third-party kernel packages can register **opt-in** backends for any existing op via the standard Python entry-point group `veomni.ops_backends`, with **zero VeOmni-side changes per package**. This generalizes the pattern VeOmni already uses for the external `liger_kernel` package (`BackendSpec.entry` + `requires`): after this one-time mechanism lands, shipping a new external kernel package needs no PR here — `pip install <pkg>` makes its backend names valid values for the matching `*_implementation` config fields (always opt-in; no default ever changes). External training-kernel projects (e.g. the nabla kernels sketched in #1105) could then integrate as versioned installable packages instead of source-tree copies, keeping kernel maintenance with the kernel authors.

This PR contains **no kernels and no reference to any specific third-party package** — only the mechanism, its docs, and CPU-runnable tests.

## What's in the change

| file | change |
|---|---|
| `veomni/ops/config/_plugin_loader.py` | **new** — discovers `veomni.ops_backends` entry points once at `veomni.ops` import (after built-in ops register); validates each plugin's **pure-data** declaration module (`VEOMNI_PLUGIN_API_VERSION` + `VEOMNI_OPS_BACKENDS` payload) fully before registering anything (**atomic per plugin**); translates the payload into `BackendSpec` / `KernelSpec`; any plugin failure (import error, bad payload, name conflict) degrades to a warning and the plugin is skipped |
| `veomni/ops/config/registry.py` | `extend_op_backends()`: merge external backends into a registered op (needed because `register_op` rejects a differing spec for a known op); `_check_requires()`: `requires` generalizes from a closed token whitelist (`liger_kernel`/`torch_npu`/`triton`) to any package name via plain importability — the three known tokens keep their dedicated availability helpers |
| `veomni/ops/__init__.py` | mount: one `load_ops_backend_plugins()` call after built-in registrations |
| `veomni/utils/env.py` | `VEOMNI_OPS_PLUGINS` env default (`0` = kill-switch, restores built-in-only behavior exactly) |
| `veomni/ops/README.md` | "External ops-backend plugins" section: protocol, guarantees, example |
| `tests/ops/test_ops_plugin_loader.py` + `tests/ops/plugin_fixtures/` | **new** — 16 CPU-runnable tests with injected entry points (no real plugin package needed) |

## Design guarantees

- **Opt-in only.** The payload schema has no default/fallback keys; a plugin can make a backend name resolvable but can never touch any op's default.
- **Pure-data declarations.** The declaration module needs no veomni import and no heavy deps; real entry targets are imported lazily at bind time (same as `liger_kernel` entries today).
- **Never fatal.** Plugin problems cannot affect users who didn't install the plugin; users who did get the existing clear errors (`ValueError: ... not a registered backend` / `RuntimeError: package '...' is not installed`).
- **Zero cost when unused.** No plugin installed → the entry-point scan finds nothing and behavior is identical to today. `VEOMNI_OPS_PLUGINS=0` skips even the scan.

## Usage (third-party package side)

```toml
# plugin package's pyproject.toml
[project.entry-points."veomni.ops_backends"]
my_kernels = "my_kernels.veomni_plugin"
```

```python
# my_kernels/veomni_plugin.py — pure data
VEOMNI_PLUGIN_API_VERSION = 1

VEOMNI_OPS_BACKENDS = {
    "ops": {  # merged into OpSpec.backends (config-field dispatch)
        "rms_norm": {
            "my_backend": {"entry": "my_kernels:MyRMSNorm",
                            "requires": ["my_kernels"]},
        },
    },
    "kernels": [  # merged into KERNEL_REGISTRY (OpSlot dispatch)
        {"name": "my_backend", "op_name": "rms_norm", "variant": "standard",
         "factory": "my_kernels:rms_norm", "device_type": "gpu",
         "description": "fused RMSNorm (Triton fwd+bwd)"},
    ],
}
```

```yaml
model:
  ops_implementation:
    rms_norm_implementation: my_backend   # opt-in; default unchanged
```

## Test plan

- `pytest tests/ops/test_ops_plugin_loader.py` — **16/16 passed** (macOS arm64, py3.12, torch 2.13 CPU; no accelerator needed). Covers: happy path (both registries + backend listed in misconfiguration errors + PER_MODEL end-to-end bind + eager untouched), rejection matrix (API-version mismatch, missing/unknown payload keys, unknown op, backend-name conflict with built-ins, kernel-name conflict, atomicity of partially-valid payloads, broken-import isolation, one bad plugin doesn't block others), kill-switch, re-entry safety, `requires` generalization.
- Regression: `tests/ops/test_kernel_registry_sanity.py` **24/24** and `tests/ops/test_eager_kernels_cpu.py` **10/10** unaffected.
- `ruff check` + `ruff format --check` clean.

## Scope & limitations

- Mechanism only — no concrete plugin package is added or referenced; per-package integration is up to those packages.
- Plugin declaration protocol is versioned (`VEOMNI_PLUGIN_API_VERSION`, exact match). Adding optional payload keys later can stay v1-compatible; semantic changes bump the version.
- GLOBAL-scope `side_effect` is supported per `BackendSpec` semantics; per-model-only keys (`replace_forward` / `entry_is_factory` / `target_override`) on a GLOBAL op are rejected at load time instead of being silently ignored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional external operation-backend plugins.
  * Plugins can contribute configuration backends and hardware-specific kernels.
  * Added validation, conflict detection, safe registration, package checks, and failure isolation.
  * Added an environment setting to disable plugin loading.

* **Documentation**
  * Documented plugin discovery, registration requirements, validation, and configuration.

* **Tests**
  * Added coverage for valid, invalid, conflicting, failing, and partially registered plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->