### PR TITLE
[config, docs] fix: use stock Qwen3-MoE checkpoints

### DIFF
--- a/configs/text/qwen3-moe.yaml
+++ b/configs/text/qwen3-moe.yaml
@@ -1,5 +1,5 @@
 model:
-  model_path: Qwen3-30B-A3B-merge
+  model_path: Qwen3-30B-A3B
   ops_implementation:
     attn_implementation: flash_attention_2
     moe_implementation: fused_triton

--- a/configs/text/qwen3_moe_lora.yaml
+++ b/configs/text/qwen3_moe_lora.yaml
@@ -17,7 +17,7 @@
 # Switch to Mode 1 (independent LoRA per expert) by setting `share_expert_lora: false`.
 
 model:
-  model_path: Qwen3-30B-A3B-merge
+  model_path: Qwen3-30B-A3B
   ops_implementation:
     attn_implementation: flash_attention_2
     moe_implementation: eager

--- a/configs/text/qwen3_moe_muon.yaml
+++ b/configs/text/qwen3_moe_muon.yaml
@@ -4,7 +4,7 @@
 # embeddings, lm_head, norms and biases.
 
 model:
-  model_path: Qwen3-30B-A3B-merge
+  model_path: Qwen3-30B-A3B
   ops_implementation:
     attn_implementation: flash_attention_2
     moe_implementation: fused_triton

--- a/docs/key_features/lora.md
+++ b/docs/key_features/lora.md
@@ -556,7 +556,7 @@ Config: [`configs/text/qwen3_moe_lora.yaml`](../../configs/text/qwen3_moe_lora.y
 
 ```yaml
 model:
-  model_path: Qwen3-30B-A3B-merge
+  model_path: Qwen3-30B-A3B
   ops_implementation:
     attn_implementation: flash_attention_2
     moe_implementation: eager           # EP (ep_size > 1) REQUIRES fused_triton


### PR DESCRIPTION
### What does this PR do?

Updates the remaining Qwen3-MoE example configurations and LoRA documentation to use the stock
`Qwen3-30B-A3B` checkpoint instead of the obsolete offline-merged `Qwen3-30B-A3B-merge` path.

Current main already registers the Qwen3-MoE runtime checkpoint tensor converter, so offline expert
weight merging is no longer required. This supersedes the Qwen3-MoE path portion of #996.

### Checklist Before Starting

- Related PRs: #996 and merged #813.
- PR title follows `[{modules}] {type}: {description}` format.
- Swept `configs/` and `docs/` for the same obsolete checkpoint-path pattern.

### Test

- Python YAML parsing for all three changed configurations — passed.
- `python3 scripts/ci/check_doc_task_paths.py` — passed.
- `uvx --from ruff==0.13.2 ruff check tasks tests veomni docs` — passed.
- `uvx --from ruff==0.13.2 ruff format --check tasks tests veomni docs` — passed.
- `git diff --check origin/main` — passed.
- `rg -n 'Qwen3-30B-A3B-merge' configs docs` — no remaining matches.

No accelerator validation is required because this PR changes only example path literals; runtime
checkpoint conversion is unchanged and already covered by the existing converter tests.

### API and Usage Example

No API changes. The examples now load the stock checkpoint directly:

```yaml
model:
  model_path: Qwen3-30B-A3B
```

### Design & Code Changes

- Align the standard, Muon, and LoRA Qwen3-MoE configs with runtime checkpoint conversion.
- Keep the LoRA guide example synchronized with its referenced configuration.

### Checklist Before Submitting

- Read the Contribute Guide.
- Applied repository quality checks.
- Updated related documentation.
- No new CI or runtime tests are needed for path-only example corrections.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated Qwen3-MoE configurations to use the `Qwen3-30B-A3B` model.
  - Applied the same model selection to LoRA and Muon training setups.
- **Documentation**
  - Updated the Qwen3-MoE LoRA training example to reflect the current model configuration.
  - Ensures setup instructions and available training configurations remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->