### PR TITLE
[agent] fix: correct stale facts in skills and knowledge docs

### DIFF
--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -208,7 +208,7 @@ tests/
 | `veomni/distributed/` | `pytest tests/parallel/ tests/distributed/` |
 | `veomni/checkpoint/` | `pytest tests/checkpoints/` |
 | `veomni/utils/` | `pytest tests/utils/` |
-| `veomni/trainer/` | `pytest tests/trainer/`, then `tests/e2e/` for loop changes |
+| `veomni/trainer/` | `pytest tests/trainer/`, then `pytest tests/e2e/` for loop changes |
 | `veomni/lora/` | `pytest tests/lora/` |
 | `veomni/optim/` | `pytest tests/optim/` |
 | Full regression | `pytest tests/` |

--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -45,23 +45,38 @@ veomni/
 │   │                   ep_fsdp mesh.
 │   └── lr_scheduler.py LR scheduler construction
 ├── ops/                Optimized kernels and dispatch
-│   ├── config/         Unified ops registry + singleton resolved config
-│   │   ├── registry.py OpSpec/BackendSpec/OpScope + register_op/apply_*
+│   ├── kernel_registry.py  KERNEL_REGISTRY: (op, variant, impl) -> KernelSpec.
+│   │                   The mechanism new kernels should use.
+│   ├── dispatch.py     OpSlot placeholders declared in patchgen-generated
+│   │                   modeling; bound by _bind_veomni_ops() in models/auto.py
+│   ├── config/         Legacy per-model / global dispatch, still live
+│   │   ├── registry.py OpSpec/BackendSpec/OpScope. apply_global_ops() resolves
+│   │   │               OpScope.GLOBAL ops for every run (called from
+│   │   │               apply_ops_config); apply_per_model_patches() resolves
+│   │   │               OpScope.PER_MODEL ops and is called only from the
+│   │   │               device_patch.py of wan, deepseek_v3 and deepseek_v4
 │   │   └── singleton.py  get_ops_config()/set_ops_config() for patch files
 │   ├── kernels/        Kernel implementations (one subdir per op)
+│   │   ├── deepseek_sparse_attention/  DSA indexer/top-k selection
 │   │   ├── deepseek_v4/  TileLang sparse attention/indexer + precision helpers
 │   │   ├── attention/  Flash attention v2/3/4 + SP-aware variants
 │   │   ├── cross_entropy/  eager/liger/npu-chunk loss variants
+│   │   ├── gated_delta_rule/  Qwen3.5 linear-attention kernels
 │   │   ├── load_balancing_loss/  eager + triton variants
 │   │   ├── mhc/        TileKernels DeepSeek V4 pre/post/head adapters
 │   │   ├── rms_norm/   Liger/NPU/batch-invariant Triton RMSNorm
 │   │   ├── rotary/     Liger/NPU + DeepSeek V3 deterministic + Wan Triton
-│   │   ├── swiglu_mlp/ Liger SwiGLU MLP
+│   │   ├── swiglu/     Liger SwiGLU MLP
 │   │   └── moe/        Fused MoE kernels + group_gemm sub-kernels
 │   ├── platform/       Platform-specific runtime patches
 │   │   └── npu/        HCCL pre-mul sum patch
+│   ├── liger/          Liger kernel adapters
 │   └── batch_invariant_ops/  Mode switch for deterministic ops
-├── patchgen/           Auto-generate model patches from HuggingFace models
+├── lora/               LoRA / PEFT injection: linear + MoE-expert adapters,
+│                       DCP + HF-adapter save/load, target mapping
+├── patchgen/           Patch specs + codegen driver consumed by the `patchgen`
+│                       CLI, which is a separate package under patchgen-pkg/
+│                       (installed via the `patchgen` dependency group)
 ├── schedulers/         LR scheduler implementations (flow matching)
 ├── trainer/            Training loop implementations
 │   ├── base.py         BaseTrainer (ABC): the composable training skeleton
@@ -169,10 +184,17 @@ tests/
 ├── data/           Data pipeline, collator, transform tests
 ├── ops/            Kernel operation tests
 ├── parallel/       Distributed parallelism tests (ulysses, data balance)
+├── distributed/    dummy forward, torch.compile, FSDP equivalence, grad ckpt
+├── trainer/        Callback / trainer-unit tests (channel loss, step sync, DPO)
+├── lora/           LoRA + MoE-LoRA unit, kernel-parity and trainer tests
+├── optim/          Muon / optimizer param-group tests
 ├── checkpoints/    Checkpoint save/load tests
 ├── utils/          Utility function tests
 ├── e2e/            End-to-end training tests (require GPU)
+├── special_sanity/ Standalone sanity scripts (e.g. device API usage check)
+├── testdata/       Fixture assets used by tests
 ├── toy_config/     Minimal model configs for fast testing
+├── train_scripts/  Python training entry scripts launched by tests/e2e/utils.py
 └── tools/          Test utilities (launch_utils, common_utils)
 ```
 
@@ -183,13 +205,22 @@ tests/
 | `veomni/models/` | `pytest tests/models/` |
 | `veomni/data/` | `pytest tests/data/` |
 | `veomni/ops/` | `pytest tests/ops/` |
-| `veomni/distributed/` | `pytest tests/parallel/` |
+| `veomni/distributed/` | `pytest tests/parallel/ tests/distributed/` |
 | `veomni/checkpoint/` | `pytest tests/checkpoints/` |
 | `veomni/utils/` | `pytest tests/utils/` |
-| `veomni/trainer/` | `pytest tests/e2e/` |
+| `veomni/trainer/` | `pytest tests/trainer/`, then `tests/e2e/` for loop changes |
+| `veomni/lora/` | `pytest tests/lora/` |
+| `veomni/optim/` | `pytest tests/optim/` |
 | Full regression | `pytest tests/` |
 
 Distributed tests (`tests/parallel/`, `tests/e2e/`) may require multiple GPUs and use `torchrun` or `tests/tools/launch_utils.py`.
+
+**A passing local run does not mean CI runs it.**
+`.github/workflows/gpu_unit_tests.yml` and `npu_unit_tests.yml` enumerate most
+test files one by one. Only `tests/data` runs as a whole directory in both
+workflows; `tests/ops` runs wholesale on GPU only (the NPU job enumerates three
+named ops files). A new file anywhere else is invisible to CI until it is added
+to those workflows, usually both.
 
 ## Key Entry Points
 

--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -45,8 +45,10 @@ veomni/
 │   │                   ep_fsdp mesh.
 │   └── lr_scheduler.py LR scheduler construction
 ├── ops/                Optimized kernels and dispatch
-│   ├── kernel_registry.py  KERNEL_REGISTRY: (op, variant, impl) -> KernelSpec.
-│   │                   The mechanism new kernels should use.
+│   ├── kernel_registry.py  KERNEL_REGISTRY: (op_name, variant) ->
+│   │                   {impl_name: KernelSpec}. register() takes one
+│   │                   KernelSpec; it is not a decorator. The mechanism
+│   │                   new kernels should use.
 │   ├── dispatch.py     OpSlot placeholders declared in patchgen-generated
 │   │                   modeling; bound by _bind_veomni_ops() in models/auto.py
 │   ├── config/         Legacy per-model / global dispatch, still live
@@ -213,7 +215,7 @@ tests/
 | `veomni/optim/` | `pytest tests/optim/` |
 | Full regression | `pytest tests/` |
 
-Distributed tests (`tests/parallel/`, `tests/e2e/`) may require multiple GPUs and use `torchrun` or `tests/tools/launch_utils.py`.
+Distributed tests (`tests/parallel/`, `tests/distributed/`, `tests/e2e/`) may require multiple GPUs and use `torchrun` or `tests/tools/launch_utils.py`.
 
 **A passing local run does not mean CI runs it.**
 `.github/workflows/gpu_unit_tests.yml` and `npu_unit_tests.yml` enumerate most

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -187,13 +187,14 @@ Core files:
 
 ## Hardware
 
-22. **NPU (Ascend) code paths require guards**
-    - NPU-specific code must be guarded with `is_torch_npu_available()` or `IS_NPU_AVAILABLE`.
-    - NPU kernels live in `veomni/ops/kernels/{rms_norm,rotary}/npu.py` and `veomni/ops/platform/npu/` — they must not be imported on GPU-only environments.
+22. **Non-CUDA accelerator code paths require guards**
+    - There are three backends today: CUDA, Ascend NPU and Cambricon MLU. Guard vendor-specific code with `is_torch_npu_available()` / `IS_NPU_AVAILABLE` or `is_torch_mlu_available()` / `IS_MLU_AVAILABLE` (`veomni/utils/import_utils.py`, `veomni/utils/device.py`).
+    - NPU kernels live in `veomni/ops/kernels/{rms_norm,rotary}/npu.py` and `veomni/ops/platform/npu/`; the MLU kernel is `veomni/ops/kernels/moe/mlu_group_gemm.py`. They must not be imported on a host without that vendor's runtime.
+    - Device-type sets, not `== "cuda"`, decide dispatch: `MOE_TRITON_DEVICE_TYPES` in `veomni/utils/device.py` is `("cuda", "mlu")` today. Adding a backend means auditing those sets, not just adding a branch.
 
 23. **Device-agnostic code must use `veomni.utils.device` helpers**
    - Use `get_device_type()`, `get_torch_device()`, `synchronize()`, `empty_cache()` instead of direct `torch.cuda.*` calls.
-   - Direct CUDA calls break NPU compatibility.
+   - Direct CUDA calls break NPU and MLU compatibility.
 
 ## Trainer Extensions
 

--- a/.agents/knowledge/multimodal_metadata.md
+++ b/.agents/knowledge/multimodal_metadata.md
@@ -17,6 +17,9 @@ eliminates the syncs entirely and lets the model forward consume CPU-int /
 CPU-tensor values that are batched up onto the device by the normal trainer
 `.to(device)` step.
 
+`tests/models/test_model_forward_no_implicit_sync.py` is the regression gate: it
+asserts the wired models' forwards stay sync-free.
+
 ## The derivation is model-owned, not framework-generic
 
 The ViT metadata formula is **Qwen-VL-family-specific**, not a framework-wide

--- a/.agents/knowledge/uv.md
+++ b/.agents/knowledge/uv.md
@@ -11,8 +11,19 @@ CI install a concrete pin and use `--locked` / `--frozen` for reproducibility.
 | Location | Format |
 |----------|--------|
 | `pyproject.toml` -> `[tool.uv]` -> `required-version` | range |
-| `docker/cuda/Dockerfile.cu130`, `docker/ascend/Dockerfile.*` | `COPY --from=ghcr.io/astral-sh/uv:X.Y.Z` |
+| `docker/**/Dockerfile.*` | concrete pin, per file: `COPY --from=ghcr.io/astral-sh/uv:X.Y.Z` |
 | `.github/workflows/check_patchgen.yml` | `setup-uv` `version: "X.Y.Z"` |
+
+Every Dockerfile is standalone and hand-maintained — the Jinja template
+generator and its matrix were dropped in #1133, so nothing fans a pin out for
+you. Only the uv-based images carry a pin at all; the pip-based ascend variants
+(`*.arm`, `*_a3`) install with `pip` and have none. Never assume one file's pin
+covers the rest; enumerate:
+
+```bash
+grep -rn "astral-sh/uv" docker/     # every uv pin
+grep -rnE "torch(-npu)?==" docker/  # same for torch; -npu is the ascend form
+```
 
 ## Dependency Layout
 
@@ -24,7 +35,7 @@ pyproject.toml
 │   │                  torch 2.11.0+cu130 + cu130 nvidia stack + cuda-python
 │   │                  + FA2 on x86_64 (cp311/cp312 wheels)
 │   │                  + FA3 / FlashMLA wheels on both architectures
-│   │                  + FA4 (PyPI) / FlashQLA (source-built from git)
+│   │                  + FA4 / FlashQLA (pure-Python PyPI wheels)
 │   │                  + liger-kernel + FLA + quack + TileLang/TileKernels + DLPack ext
 │   │                  + diffusers / av / librosa / soundfile / ftfy / peft
 │   │                  + megatron-energon (optional dataset format)
@@ -44,13 +55,13 @@ pyproject.toml
 │   ├── patchgen             patchgen (path source under patchgen-pkg/)
 │   └── transformers-stable  transformers==5.9.0 (default, in default-groups)
 ├── [tool.uv]
-│   ├── required-version     Pinned uv version
+│   ├── required-version     Allowed uv version range
 │   ├── override-dependencies  Per-extra torch/CUDA pins (markers scoped to gpu/npu/npu_aarch64)
 │   ├── conflicts            gpu/npu/npu_aarch64 mutual exclusion;
 │   │                        magi also conflicts with npu / npu_aarch64
 │   └── sources              Custom indexes, direct wheel URLs (av, torch,
 │                            FA2 cp311/cp312, FA3 sm90 abi3, FlashMLA);
-│                            git source (flash-qla)
+│                            git sources (MagiAttention and its three companions)
 └── uv.lock                  Lockfile (committed, used by Docker --locked)
 ```
 
@@ -69,7 +80,7 @@ uv sync --extra npu_aarch64 --dev              # Ascend NPU ARM
 
 A fresh `--extra gpu` installs architecture-specific torch, torchcodec, AV,
 FA3, and FlashMLA wheels. FA2 is installed from prebuilt wheels on x86_64 and
-omitted on aarch64. FA4 is a pure-Python wheel; only FlashQLA builds from git.
+omitted on aarch64. FA4 and FlashQLA are pure-Python PyPI wheels.
 The aarch64 FA3 wheel requires glibc 2.34 or newer. uv caches built wheels
 under `~/.cache/uv`. MagiAttention is not part of that default GPU set:
 `--extra magi` also pulls `gpu` and source-builds SM90/SM100 CUDA extensions.
@@ -100,32 +111,35 @@ forced into a specific 5.x patch.
 | `flash-attn-3` (Hopper) | cp310-abi3 Luosuu wheel on x86_64; cp39-abi3 PyTorch cu130 wheel on aarch64 | abi3 covers supported Python versions; aarch64 requires glibc 2.34+ |
 | `flash-mla` | cp311/cp312 Luosuu cu130/torch2.11/sm90a+sm100f wheels | architecture-specific x86_64/aarch64 wheels |
 | `flash-attn-4` (cute) | PyPI `4.0.0b16` | pure-Python wheel |
-| `flash-qla` | git: QwenLM/FlashQLA | source-built; uv overrides its TileLang 0.1.8 metadata pin |
+| `flash-qla` | PyPI `0.1.2` | pure-Python wheel; static metadata already matches the TileLang / tvm-ffi pins, so no source build and no metadata override |
 | `tile-kernels` | PyPI `1.0.0` | DeepSeek V4 mHC forward/backward; requires TileLang 0.1.9 and SM90+ |
-| `magi-attention` | git: SandAI-org/MagiAttention | optional `--extra magi`; SM90/SM100 source build |
+| `magi-attention` + `create-block-mask-cuda`, `flash-attn-cute`, `magi-to-hstu-cuda` | git revs | optional `--extra magi`; SM90/SM100 source builds, omitted by the default GPU CI install |
 
-Two pyproject knobs make the remaining FlashQLA source build succeed:
+`flash-qla` and `tile-kernels` must agree on one TileLang version, so
+`[tool.uv].override-dependencies` pins the shared GPU environment to
+`tilelang==0.1.9`. DeepSeek V4 TileLang and TileKernels tests cover that
+resolved combination — bump the two packages and the override as a set.
 
-1. **`[[tool.uv.dependency-metadata]]`** with `version` for `flash-qla`.
-   It has no `pyproject.toml`; without static metadata uv runs its setup.py
-   on a fresh venv and crashes with `ModuleNotFoundError: No module named
-   'setuptools'`. The static `requires-dist` mirrors flash-qla's own
-   install_requires (`torch`, `tilelang==0.1.8`, `apache-tvm-ffi==0.1.9`)
-   — `flash_qla/__init__.py` top-level imports `tilelang`, so they have to
-   ship alongside, even though the `flash_qla` kernel itself only binds on
-   sm90 (gated by `KernelSpec(min_compute_capability=90)`).
+Two pyproject knobs make the remaining git source builds succeed:
 
-   The GPU extra also installs `tile-kernels==1.0.0`, which requires
-   `tilelang>=0.1.9`. `[tool.uv].override-dependencies` therefore pins the
-   shared GPU environment to `tilelang==0.1.9`; DeepSeek V4 TileLang and
-   TileKernels tests cover that resolved combination.
-
+1. **`[[tool.uv.dependency-metadata]]`** — these projects ship no usable
+   metadata, so without a static `requires-dist` uv runs their `setup.py` on a
+   fresh venv and crashes with `ModuleNotFoundError: No module named
+   'setuptools'`. All four blocks declare `requires-dist = []`: the three
+   companion extensions have no upstream runtime requirements, while
+   MagiAttention's are omitted from its metadata and kept in a separate CUDA 12
+   NVSHMEM requirements file. The CUDA 13 closure is supplied through the `gpu`
+   extra (torch, CUTLASS DSL, Quack) plus the `magi` extra (the three companion
+   packages and `debugpy`).
 2. **`[tool.uv.extra-build-dependencies]`** seeds `setuptools / wheel /
-   packaging / ninja` (+ `torch` where needed) — uv venvs are not seeded.
+   packaging / ninja` (+ `torch`, with `match-runtime = true` where the
+   extension links against it) — uv venvs are not seeded.
+   `[tool.uv.extra-build-variables]` carries `MAX_JOBS` / compute-capability
+   flags for the three that need them (not `flash-attn-cute`).
 
 `FLASH_ATTENTION_FORCE_BUILD=TRUE` and `[tool.uv.no-build-isolation-package]`
-are gone — no FA setup.py runs anywhere now (FA2/3 wheel, FA4 cute is a
-DSL package, flash-qla uses dependency-metadata).
+are gone — no FA setup.py runs anywhere now (FA2/3/MLA are wheels, FA4 and
+flash-qla are pure-Python PyPI releases).
 
 ## Common Commands
 

--- a/.agents/knowledge/uv.md
+++ b/.agents/knowledge/uv.md
@@ -111,7 +111,7 @@ forced into a specific 5.x patch.
 | `flash-attn-3` (Hopper) | cp310-abi3 Luosuu wheel on x86_64; cp39-abi3 PyTorch cu130 wheel on aarch64 | abi3 covers supported Python versions; aarch64 requires glibc 2.34+ |
 | `flash-mla` | cp311/cp312 Luosuu cu130/torch2.11/sm90a+sm100f wheels | architecture-specific x86_64/aarch64 wheels |
 | `flash-attn-4` (cute) | PyPI `4.0.0b16` | pure-Python wheel |
-| `flash-qla` | PyPI `0.1.2` | pure-Python wheel; static metadata already matches the TileLang / tvm-ffi pins, so no source build and no metadata override |
+| `flash-qla` | PyPI `0.1.2` | pure-Python wheel that publishes usable metadata (it declares only `apache-tvm-ffi`), so no source build and no `dependency-metadata` override |
 | `tile-kernels` | PyPI `1.0.0` | DeepSeek V4 mHC forward/backward; requires TileLang 0.1.9 and SM90+ |
 | `magi-attention` + `create-block-mask-cuda`, `flash-attn-cute`, `magi-to-hstu-cuda` | git revs | optional `--extra magi`; SM90/SM100 source builds, omitted by the default GPU CI install |
 
@@ -138,8 +138,11 @@ Two pyproject knobs make the remaining git source builds succeed:
    flags for the three that need them (not `flash-attn-cute`).
 
 `FLASH_ATTENTION_FORCE_BUILD=TRUE` and `[tool.uv.no-build-isolation-package]`
-are gone — no FA setup.py runs anywhere now (FA2/3/MLA are wheels, FA4 and
-flash-qla are pure-Python PyPI releases).
+are gone. FA2/3/MLA are wheels and FA4 and flash-qla are pure-Python PyPI
+releases, so nothing forces a build of mainline flash-attention. One FA-shaped
+source build remains: `flash-attn-cute` is the `flash_attn` subdirectory of the
+pinned `demonatic/flash-attention` fork, and it takes its toolchain from
+`[tool.uv.extra-build-dependencies]` rather than from `--no-build-isolation`.
 
 ## Common Commands
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -58,7 +58,7 @@ description: "Create a pull request for the current branch. Handles uncommitted 
    | `veomni/models/` | `model` |
    | `veomni/trainer/` | `trainer` |
    | `veomni/data/` | `data` |
-   | `veomni/distributed/` | `dist` |
+   | `veomni/distributed/` | `dist` (use `parallel` when the change is about a parallelism strategy rather than the plumbing) |
    | `veomni/ops/` | `ops` |
    | `veomni/checkpoint/` | `ckpt` |
    | `veomni/optim/` | `optim` |
@@ -69,16 +69,16 @@ description: "Create a pull request for the current branch. Handles uncommitted 
    | `docker/` | `docker` |
    | `tasks/` | `task` |
    | `.agents/` | `agent` |
+   | anything with a measurable speed/memory claim | add `perf` |
    | other / mixed | `misc` |
 
-   `parallel`, `logging`, `omni`, `perf` and `release` have no directory of
-   their own: use `parallel` when a `veomni/distributed/` change is about a
-   parallelism strategy rather than the plumbing, `perf` alongside another
-   module when the PR makes a measurable speed or memory claim, and `omni`,
-   `logging`, `release` for omni-model, log/telemetry-surface and
-   release-plumbing work respectively.
+   `omni`, `logging` and `release` have no directory of their own — use them
+   for omni-model, log/telemetry-surface and release-plumbing changes
+   respectively.
 
-   Allowed modules: `misc`, `ci`, `config`, `docs`, `data`, `dist`, `omni`, `logging`, `model`, `optim`, `ckpt`, `release`, `task`, `perf`, `ops`, `parallel`, `docker`, `trainer`, `agent`, `lora`
+   The authoritative module and type lists live in
+   `.github/workflows/check_pr_title.yml` (`allowedModules` / `allowedTypes`).
+   Read it rather than trusting this table if a name is rejected.
 
 3. Determine **change type**:
 
@@ -98,7 +98,9 @@ description: "Create a pull request for the current branch. Handles uncommitted 
    - Breaking changes: prepend `[BREAKING]`
    - Must pass the regex in `.github/workflows/check_pr_title.yml`
 
-2. Draft PR description following `.github/PULL_REQUEST_TEMPLATE.md`.
+2. Draft the PR description by **reading `.github/PULL_REQUEST_TEMPLATE.md`**
+   and filling in its sections. Do not reproduce the template from memory — it
+   changes, and a stale copy silently drops checklist items.
 
 3. **Write to `.pr-drafts/`** (already in `.gitignore`):
    ```bash
@@ -114,35 +116,11 @@ description: "Create a pull request for the current branch. Handles uncommitted 
    ```markdown
    [model] feat: add support for Qwen4
 
-   ### What does this PR do?
-
-   > Summary here.
-
-   ### Checklist Before Starting
-
-   - Search for relative PRs/issues and link here: ...
-   - PR title follows `[{modules}] {type}: {description}` format
-
-   ### Test
-
-   > Test description here.
-
-   ### API and Usage Example
-
-   > N/A
-
-   ### Design & Code Changes
-
-   > - Change 1
-   > - Change 2
-
-   ### Checklist Before Submitting
-
-   - [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
-   - [ ] Applied pre-commit checks
-   - [ ] Added/updated documentation
-   - [ ] Added tests to CI workflow (or explained why not feasible)
+   <sections copied from .github/PULL_REQUEST_TEMPLATE.md, filled in>
    ```
+
+   Keep the template's own bullet/checkbox style. Fill every section: an empty
+   `### Test` section is the most common review blocker.
 
 4. Tell the user the draft file path (so they know where to find it if they want to review later).
 

--- a/.agents/skills/veomni-develop/SKILL.md
+++ b/.agents/skills/veomni-develop/SKILL.md
@@ -14,7 +14,7 @@ Before implementing, check which areas your change affects:
 | `veomni/distributed/` | FSDP2 + ExtraParallel/MoE/SP paths | Shared distributed code is used by many downstream modalities |
 | `veomni/models/auto.py`, `loader.py` | Model registry, import-time side effects | `MODELING_REGISTRY` is populated at import time; moving registrations breaks loading |
 | `configs/` | YAML config keys | Renaming config keys breaks existing training configs silently |
-| `veomni/models/transformers/*/` | `__init__.py` registration entry points | All models ship a patchgen-generated v5 path under `generated/`; never import or call legacy `modeling_<m>.py` or `apply_veomni_<m>_patch()` (these no longer exist) |
+| `veomni/models/transformers/*/` | `__init__.py` registration entry points | Every transformers-family LLM/VLM/Omni model ships a patchgen-generated path under `generated/`; never import or call legacy `modeling_<m>.py` or `apply_veomni_<m>_patch()` (these no longer exist). The non-transformers-architecture models (`flux`, `movqgan`, `wan`) have no `generated/` and patch through `device_patch.py` or direct modeling — check the directory before assuming |
 
 ## Refactoring Safety Rules
 

--- a/.agents/skills/veomni-migrate-transformers-v5/SKILL.md
+++ b/.agents/skills/veomni-migrate-transformers-v5/SKILL.md
@@ -79,19 +79,23 @@ source .venv/bin/activate
 patchgen config is the single biggest accelerator for catching subtle
 signature/contract drift while iterating.
 
-```bash
-mkdir -p .agents_workspace/hf_reference/<m>/v5_8_1
+Use the pinned version as the directory name so several pins can coexist:
 
-curl -sL -o .agents_workspace/hf_reference/<m>/v5_8_1/modeling_<m>.py \
-  "https://github.com/huggingface/transformers/raw/v5.9.0/src/transformers/models/<m>/modeling_<m>.py"
+```bash
+PIN=$(python -c "import transformers; print(transformers.__version__)")
+mkdir -p ".agents_workspace/hf_reference/<m>/v${PIN}"
+
+curl -sL -o ".agents_workspace/hf_reference/<m>/v${PIN}/modeling_<m>.py" \
+  "https://github.com/huggingface/transformers/raw/v${PIN}/src/transformers/models/<m>/modeling_<m>.py"
 ```
 
 For VLMs also grab `processing_<m>.py` / `image_processing_<m>.py` /
 `configuration_<m>.py` if you expect processor-side or config-shape work.
 
 If you are **refreshing** an existing patchgen-generated file across a
-transformers minor bump (e.g. the current pin `5.9.0 → 5.9.0`), pull both
-versions side-by-side and diff to spot contract drift — substitute the
+transformers minor bump (the pin the generated file was produced against → the
+new pin), pull both versions side-by-side and diff to spot contract drift —
+substitute the
 `<old_ver>` / `<new_ver>` tags with the actual versions you are migrating
 between:
 

--- a/.agents/skills/veomni-migrate-transformers-v5/SKILL.md
+++ b/.agents/skills/veomni-migrate-transformers-v5/SKILL.md
@@ -85,9 +85,13 @@ Use the pinned version as the directory name so several pins can coexist:
 PIN=$(python -c "import transformers; print(transformers.__version__)")
 mkdir -p ".agents_workspace/hf_reference/<m>/v${PIN}"
 
-curl -sL -o ".agents_workspace/hf_reference/<m>/v${PIN}/modeling_<m>.py" \
+curl -fsSL -o ".agents_workspace/hf_reference/<m>/v${PIN}/modeling_<m>.py" \
   "https://github.com/huggingface/transformers/raw/v${PIN}/src/transformers/models/<m>/modeling_<m>.py"
 ```
+
+`-f` matters: without it a missing tag or renamed module returns 404 and curl
+writes the error page into `modeling_<m>.py` with exit status 0, so you would
+diff against an HTML page and not notice.
 
 For VLMs also grab `processing_<m>.py` / `image_processing_<m>.py` /
 `configuration_<m>.py` if you expect processor-side or config-shape work.
@@ -101,9 +105,9 @@ between:
 
 ```bash
 mkdir -p .agents_workspace/hf_reference/<m>/{old,new}
-curl -sL -o .agents_workspace/hf_reference/<m>/old/modeling_<m>.py \
+curl -fsSL -o .agents_workspace/hf_reference/<m>/old/modeling_<m>.py \
   "https://github.com/huggingface/transformers/raw/<old_ver>/src/transformers/models/<m>/modeling_<m>.py"
-curl -sL -o .agents_workspace/hf_reference/<m>/new/modeling_<m>.py \
+curl -fsSL -o .agents_workspace/hf_reference/<m>/new/modeling_<m>.py \
   "https://github.com/huggingface/transformers/raw/<new_ver>/src/transformers/models/<m>/modeling_<m>.py"
 diff -u .agents_workspace/hf_reference/<m>/{old,new}/modeling_<m>.py | less
 ```

--- a/.agents/skills/veomni-new-op/SKILL.md
+++ b/.agents/skills/veomni-new-op/SKILL.md
@@ -95,27 +95,61 @@ ships a `device_patch.py`.
 
 2. **Implement each kernel variant** in its own file (e.g. `triton_kernel.py`, `eager.py`, `npu_kernel.py`). Each variant declares a concrete function with the kernel's canonical signature.
 
-3. **Register the kernel** in `veomni/ops/kernels/<op_name>/__init__.py`:
+3. **Register the kernel** in `veomni/ops/kernels/<op_name>/__init__.py`. One
+   `KERNEL_REGISTRY.register(KernelSpec(...))` call per implementation —
+   `register()` takes a single `KernelSpec` and returns `None`, so it is not a
+   decorator:
    ```python
-   from veomni.ops.kernel_registry import KERNEL_REGISTRY
+   from veomni.ops.kernel_registry import KERNEL_REGISTRY, HardwareRequirement, KernelSpec
 
-   from .eager import my_op_eager
-   from .triton_kernel import my_op_triton
 
-   KERNEL_REGISTRY.register(slot="my_op", variant="eager")(my_op_eager)
-   KERNEL_REGISTRY.register(slot="my_op", variant="triton")(my_op_triton)
+   def _my_op_triton_factory():
+       from .triton_kernel import my_op_triton  # imported only when selected
+
+       return my_op_triton
+
+
+   KERNEL_REGISTRY.register(
+       KernelSpec(
+           name="triton",              # impl name the user selects in the config
+           op_name="my_op",            # the logical op — matches the OpSlot
+           variant="standard",         # op shape, when one op has several
+           factory=_my_op_triton_factory,
+           hardware=HardwareRequirement(device_type="gpu"),
+           description="Triton my_op",
+       )
+   )
    ```
 
-   Then declare a matching `OpSlot` in the patchgen config of every model that uses it:
+   `factory` is a **zero-argument callable returning the kernel**, not the
+   kernel itself. Keeping it lazy is what stops an optional dependency (Liger,
+   Triton, `torch_npu`) from being imported just because the module was loaded.
+   `hardware` is enforced at `resolve()` time, so an unavailable kernel fails
+   with a clear error instead of at first use.
+
+   Mind the two axes: `(op_name, variant)` identifies the *slot*, `name`
+   identifies the *implementation* within it. Kernels in different variants
+   never collide.
+
+   Then declare a matching `OpSlot` in the patchgen config of every model that
+   uses it — the arguments are `(op_name, variant)`, not an implementation:
    ```python
    from veomni.ops.dispatch import OpSlot
-   veomni_my_op = OpSlot("my_op", "eager")  # default variant
+   veomni_my_op = OpSlot("my_op", "standard")
    ```
-   `_bind_veomni_ops()` will swap this for the registry entry selected by `OpsImplementationConfig`.
+   `_bind_veomni_ops()` calls `slot.bind(impl_name)` with the implementation
+   selected by `OpsImplementationConfig`. See
+   `veomni/ops/kernels/rotary/__init__.py` for a live example, and
+   `veomni/ops/README.md` for the op/variant/impl table.
 
-4. **Wire the config field** (if the user needs to choose a variant):
+4. **Wire the config field** (if the user needs to choose an implementation):
    - Add a field to `OpsImplementationConfig` in `veomni/arguments/arguments_types.py`.
-   - In `veomni/ops/config/registry.py`, map the new config field to the `(slot, variant)` tuple consumed by `_bind_veomni_ops()`.
+   - Call `register_op(OpSpec(name=..., config_field=..., scope=..., default=..., backends={...}))`
+     from the same `veomni/ops/kernels/<op_name>/__init__.py` — the mapping
+     lives next to the kernel, not inside `veomni/ops/config/registry.py`,
+     which only defines `OpSpec` / `BackendSpec` / `register_op`. See
+     `veomni/ops/kernels/rms_norm/__init__.py`, which registers both an
+     `OpSpec` and its `KernelSpec`s.
 
 5. **For legacy global ops** (only when needed): add the public function to `veomni/ops/__init__.py` and rebind it from `apply_ops_config(ops_config)`.
 

--- a/.agents/skills/veomni-new-op/SKILL.md
+++ b/.agents/skills/veomni-new-op/SKILL.md
@@ -5,7 +5,9 @@ description: "Use this skill when adding a new optimized kernel or operator to v
 
 ## Before You Start
 
-1. Read `.agents/knowledge/constraints.md` — especially rules about NPU guards (#19, #20).
+1. Read `.agents/knowledge/constraints.md` — especially the "Hardware" section
+   (NPU guards, device-agnostic helpers) and "Module-level OpSlots are shared by
+   every model instance" under "Trainer Extensions".
 2. Read `docs/design/kernel_selection.md` and `docs/design/unified_kernel_registry.md` — understand the kernel lifecycle, the `KERNEL_REGISTRY`, and `OpSlot` dispatch.
 3. Familiarize yourself with the ops architecture below.
 
@@ -22,11 +24,15 @@ veomni/ops/
 ├── __init__.py          # apply_ops_patch / apply_ops_config entry points
 ├── kernel_registry.py   # KERNEL_REGISTRY (the single source of truth)
 ├── dispatch.py          # OpSlot + binding helpers
-├── config/              # OpsImplementationConfig + per-op registry helpers
+├── config/              # legacy OpSpec/BackendSpec registry: apply_global_ops()
+│                        # + apply_per_model_patches() for device_patch.py models
 ├── kernels/             # all registry-driven kernels
 │   ├── attention/       # FA2/3/4 + sequence-parallel wrappers
 │   ├── cross_entropy/   # eager + liger fused CE
+│   ├── deepseek_sparse_attention/
+│   ├── deepseek_v4/     # TileLang sparse attention / indexer
 │   ├── load_balancing_loss/
+│   ├── mhc/             # TileKernels DeepSeek V4 adapters
 │   ├── moe/             # fused MoE (group_gemm / quack / npu_group_gemm)
 │   ├── rms_norm/        # eager / liger / batch-invariant
 │   ├── rotary/          # default / triton-deterministic
@@ -37,7 +43,8 @@ veomni/ops/
 └── platform/            # NPU-specific helpers
 ```
 
-**Two complementary mechanisms** coexist:
+**Three mechanisms coexist.** Pick the first one unless you have a concrete
+reason not to:
 
 1. **`KERNEL_REGISTRY` + `OpSlot`** (preferred for new ops). Each kernel
    registers itself under a `(slot_name, variant)` pair (e.g.
@@ -52,10 +59,18 @@ veomni/ops/
    that is rebound by `apply_ops_config()` so call sites in non-patchgen code
    (DeepSeek MLA inference paths, NPU custom forwards) can keep importing the
    public name without going through an `OpSlot`.
+3. **Per-model `device_patch.py`** via `OpSpec`/`BackendSpec` in
+   `ops/config/registry.py`. `apply_per_model_patches(hf_module, model_name,
+   targets={op: attr})` setattr-replaces attributes on an HF module. Used by the
+   models that have no patchgen-generated file (`wan`) or that need a runtime
+   device-specific swap after generation (`deepseek_v3`, `deepseek_v4`). Those
+   three `device_patch.py` files are its only callers. Do not extend this for
+   new kernels.
 
-Pick mechanism 1 for any kernel that lives inside a patchgen-generated
-modeling file. Use mechanism 2 only when the kernel must be callable from
-unpatched (or non-Transformers) Python code.
+Mechanism 1 covers any kernel living inside a patchgen-generated modeling file.
+Use 2 only when the kernel must be callable from unpatched (or
+non-Transformers) Python code, and 3 only when touching a model that already
+ships a `device_patch.py`.
 
 ## Phase 1: Design
 

--- a/.agents/skills/veomni-uv-update/SKILL.md
+++ b/.agents/skills/veomni-uv-update/SKILL.md
@@ -7,18 +7,40 @@ description: "Use this skill when updating dependencies managed by uv: bumping a
 
 Read `.agents/knowledge/uv.md` for the full dependency architecture. The key things that make VeOmni's uv setup non-trivial:
 
-- uv version is pinned in **three places** (must update together)
+- `[tool.uv].required-version` is a **range**; the concrete uv pins live
+  elsewhere and must stay inside it
+- every Dockerfile is standalone and hand-maintained; there is no generator or
+  matrix, so a version bump has to be applied file by file
 - torch uses **direct wheel URLs** (not just version bumps)
 - three mutually exclusive hardware extras (`gpu` / `npu` / `npu_aarch64`),
   each a complete superset, plus optional `--extra magi` (combine with `gpu`)
 
+`pyproject.toml` is the source of truth for every version claim below. Read the
+relevant block before editing — this file describes *where* things live, not
+which versions are current.
+
 ## Scenario 1: Update uv Version
 
-uv is pinned to a specific version. Update **all three locations** together:
+`pyproject.toml` -> `[tool.uv]` -> `required-version` is a **range**
+(e.g. `">=0.9.8,<0.13"`). Docker and CI install a **concrete** pin and run with
+`--locked` / `--frozen`. Every concrete pin must stay inside the range.
 
-1. `pyproject.toml` -> `[tool.uv]` -> `required-version = "==X.Y.Z"`
-2. `docker/cuda/Dockerfile.cu130` -> `COPY --from=ghcr.io/astral-sh/uv:X.Y.Z`
-3. `docker/ascend/Dockerfile.ascend_*` -> same pattern (if present)
+1. **Every Dockerfile that pins uv, one by one.** There is no generator; the
+   pin lives in a `COPY --from=ghcr.io/astral-sh/uv:X.Y.Z` line, and only the
+   uv-based images have one (the pip-based ascend `*.arm` / `*_a3` variants do
+   not). Enumerate rather than assume:
+
+   ```bash
+   grep -rn "astral-sh/uv" docker/
+   ```
+
+   Update every hit, and keep them on the same version — a per-image drift is
+   a debugging trap, not a feature.
+2. `.github/workflows/check_patchgen.yml` -> `astral-sh/setup-uv` `version:`.
+   This job runs outside the container image, so an unpinned uv would float
+   above the range ceiling.
+3. `pyproject.toml` -> `required-version` — only widen/move the range when the
+   new pin falls outside it.
 
 Then regenerate the lockfile:
 
@@ -50,7 +72,9 @@ This is the most complex update. torch versions are pinned in **multiple places*
 - `pyproject.toml` -> `[project.optional-dependencies]` -> `gpu` list
 - `pyproject.toml` -> `[tool.uv]` -> `override-dependencies` (the `extra == 'gpu'` entries)
 - `pyproject.toml` -> `[tool.uv.sources]` -> `torch` (direct wheel URL — must update to matching wheel)
-- Related packages: `torchvision`, `torchaudio`, `torchcodec`, `nvidia-cusparselt-cu13`, `nvidia-nccl-cu13`, `nvidia-cutlass-dsl`
+- Related packages that must move together: `torchvision`, `torchaudio`,
+  `torchcodec`, plus the `nvidia-*` runtime pins in the `gpu` extra. Grep the
+  `gpu` block rather than trusting this list — it grows.
 
 **For NPU (`npu` / `npu_aarch64` extras):**
 - Same pattern but with `+cpu` suffix or no suffix
@@ -58,9 +82,28 @@ This is the most complex update. torch versions are pinned in **multiple places*
 **Steps:**
 1. Identify the target torch version and matching wheel URLs from https://download.pytorch.org/whl/
 2. Update all pinned versions in `pyproject.toml` (extras, overrides, sources)
-3. Check FA / FlashQLA wheel/source compatibility:
-   - `flash-attn` (cp311 + cp312) and `flash-attn-3` are pinned to Luosuu prebuilt wheel URLs in `[tool.uv.sources]` (cu130/torch2.11/cxx11abi=true). Bumping torch / Python / cuda requires a matching Luosuu release — see https://github.com/Luosuu/flash-attention3-wheels/releases.
-   - `flash-attn-4` and `flash-qla` source-build from git pins; torch ABI bumps may need bumping the git revs. `flash-qla`'s `[[tool.uv.dependency-metadata]]` block mirrors its install_requires (`tilelang==0.1.8`, `apache-tvm-ffi==0.1.9`); refresh the pins if upstream bumps them.
+3. Check attention-kernel compatibility. Three groups behave differently —
+   confirm each against `[tool.uv.sources]` before editing:
+   - **Prebuilt wheel URLs** (`flash-attn` cp311/cp312 x86_64-only,
+     `flash-attn-3` abi3, `flash-mla`): pinned to torch+CUDA+ABI-specific
+     wheels. A torch / Python / CUDA bump requires a matching upstream release
+     — see https://github.com/Luosuu/flash-attention3-wheels/releases.
+   - **PyPI releases** (`flash-attn-4`, `flash-qla`): plain version pins in the
+     `gpu` extra. `flash-qla` is a pure-Python wheel whose static metadata
+     declares only `apache-tvm-ffi`, so it needs no
+     source build and no `dependency-metadata` override. `tilelang` is pinned
+     in `override-dependencies` because `tile-kernels` and `flash-qla` must
+     agree on one version — bump them as a set.
+   - **Source-built git pins** (`magi-attention`, `create-block-mask-cuda`,
+     `flash-attn-cute`, `magi-to-hstu-cuda`): each needs a
+     `[[tool.uv.dependency-metadata]]` block (upstream declares no usable
+     metadata) plus an `extra-build-dependencies` entry, and an
+     `extra-build-variables` entry where the build needs `MAX_JOBS` /
+     compute-capability flags (all but `flash-attn-cute` today).
+     A torch ABI bump may require bumping the git revs. These belong to the
+     optional `magi` extra and require SM90+; use `uv sync --extra gpu --extra magi`
+     to install them. GPU CI runs `uv sync --extra gpu` without `magi`, so
+     the SM89 L20 runners omit these source builds.
 4. Update `torchcodec` version if needed (compatibility note in pyproject.toml)
 5. Regenerate lockfile:
 
@@ -70,7 +113,16 @@ uv sync --extra gpu --dev
 ```
 
 6. Run tests: `pytest tests/`
-7. Update Docker images if torch version changed
+7. If the torch version changed, walk the Dockerfiles. Seven of them pin torch
+   directly — `docker/rocm/Dockerfile.ROCm7.14` a ROCm build, and the ascend
+   `*_torch_npu*` images a `torch-npu==X` matched to it by `fla_npu`'s
+   `check_npu_env`. The rest inherit torch from their base image
+   (`docker/cuda/Dockerfile.cu130` from the NGC PyTorch base), so there is no
+   single knob. Match `-npu` too, or you will find one pin out of seven:
+
+   ```bash
+   grep -rnE "torch(-npu)?==" docker/
+   ```
 
 ## Scenario 4: Update transformers Version
 
@@ -110,9 +162,10 @@ If `uv lock` fails due to version conflicts, check:
 
 ## Common Pitfalls
 
-- **Forgetting to update Docker**: uv version and torch version changes must be reflected in `docker/` Dockerfiles, otherwise CI builds will fail.
+- **Bumping one Dockerfile and calling it done**: there are a dozen-plus standalone Dockerfiles under `docker/` and no generator to fan a change out. `grep -rn` for the pin you are moving and update every hit.
 - **Partial torch updates**: updating `torch` but not `torchvision`/`torchaudio`/`torchcodec` to matching versions causes import errors.
 - **flash-attn wheel mismatch**: flash-attn wheels are built for specific torch+CUDA combinations. A torch version bump requires finding or building new wheels.
 - **Committing only pyproject.toml**: always commit `uv.lock` together. Docker builds use `--locked` which requires the lockfile to match.
 - **override-dependencies markers**: the `extra == 'gpu'` markers in overrides are critical. Removing them causes uv to download wrong torch variants from PyPI.
-- **no-build-isolation**: `flash-attn` and `flash-attn-3` are listed under `no-build-isolation-package`. They require torch to be installed first. If sync fails, try `uv sync` without these extras first, then add them.
+- **Assuming build isolation is disabled**: there is no `no-build-isolation-package` block any more. Source builds instead get their toolchain from `[tool.uv.extra-build-dependencies]` (uv venvs are not seeded), and `torch` is passed with `match-runtime = true` where the extension links against it. If a source build fails on a missing `setuptools`/`torch`, add it there rather than reaching for `--no-build-isolation`.
+- **Overlay reinstall**: an exact `uv sync` removes the MagiAttention SM90 CUTLASS overlay installed by `scripts/kernel/install_magi_sm90.sh`. Reinstall it afterwards (see constraints, "Environment Reproducibility").

--- a/.cursor/rules/no-section-divider-comments.mdc
+++ b/.cursor/rules/no-section-divider-comments.mdc
@@ -23,3 +23,19 @@ or
 ```
 
 These add visual noise without value. If code needs grouping, use module-level or class-level docstrings, or simply rely on class/function structure.
+
+## Exception: patchgen patch headers
+
+`veomni/models/transformers/*/**_patch_gen_config.py` and the
+`generated/patched_modeling_*.py` files they emit are exempt. There, the
+
+```python
+# ================================================================
+# Patch: <Class>.<method>
+# 1. <what changed> — <why>
+# ================================================================
+```
+
+headers plus inline `# --- Patch.N ---` markers are a required convention: they
+survive into the generated file and are what makes it reviewable against the
+upstream HuggingFace source. See `.agents/skills/veomni-migrate-transformers-v5/SKILL.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,9 @@ On session start, read the following:
 - `.agents/knowledge/uv.md` — dependency management architecture (uv, extras, lockfile)
 - `.agents/knowledge/cloud_env.md` — Cursor Cloud (CPU-only VM) setup; read when running on the Cursor Cloud VM
 
+Read on demand:
+- `.agents/knowledge/multimodal_metadata.md` — multimodal metadata precompute contract; read before touching VLM/Omni collators, ViT forwards, or the model metadata hooks
+
 ---
 
 ## Core Principles


### PR DESCRIPTION
> **Stack** — review bottom-up. Each PR targets the one below it.
>
> 1. #1144 `[ci, agent] feat: verify repo paths and skill refs in agent docs` (base `main`)
> 2. **this PR** `[agent] fix: correct stale facts in skills and knowledge docs`
> 3. #1136 `[agent, ci] feat: add a test-wiring decision rule`
> 4. #1137 `[agent] refactor: right-size the review gate and drop agent-specific tooling`
> 5. #1145 `[agent, docs] refactor: rename the migrate skill to veomni-patchgen-model`
> 6. #1147 `[agent, docs] refactor: split the patchgen skill by model category`
> 7. #1148 `[agent, docs] refactor: describe the agent tooling generically`
>
> Branch names still carry the original `p0`…`p4` drafting order, which no longer
> matches stack position. Renaming the branches would orphan the open PRs, so
> the numbers are left alone.

### What does this PR do?

The `.agents/` skills and knowledge docs hardcode repo facts — version pins,
directory trees, constraint numbers, an inlined copy of the PR template — and
until #1144 (below this in the stack) nothing verified them. Several have
drifted far enough that they now instruct agents to edit the wrong files. This
is a pure fact-correction pass; no workflow or policy changes, those are the
follow-ups above.

The most consequential fix is in `veomni-uv-update`, which was wrong about
where the uv pin lives *and* wrong about how many places carry one. It said
`[tool.uv].required-version` is an exact pin (it is a range) and that a uv bump
means hand-editing `docker/cuda/Dockerfile.cu130` (one file of several). It
also missed the pin in `check_patchgen.yml` entirely. Since #1133 removed the
Jinja template generator, every Dockerfile is standalone and hand-maintained —
there is no knob that fans a change out — so the skill now tells agents to
enumerate instead of assuming:

```bash
grep -rn "astral-sh/uv" docker/     # every uv pin
grep -rnE "torch(-npu)?==" docker/  # same for torch
```

That second pattern is not incidental. The obvious `grep -rn "torch==" docker/`
finds **one of the seven** torch pins, because the ascend images pin
`torch-npu==` — a spelling that does not contain `torch==`.

### Checklist Before Starting

- Search for relative PRs/issues and link here: no existing issue; found while
  auditing `.agents/` against the current tree. The `flash-qla` claims went
  stale in #1055, the docker guidance was invalidated by #1133 (template
  generator removed), and the `veomni-new-op` constraint numbers drifted as
  `constraints.md` grew.
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`

### Test

**No test needed** — documentation only, no runtime behaviour. The mechanical
half of this *is* now tested, by the check added in #1144 below.

Verification performed:

- Every claim added or modified here was checked against the file it describes
  (`pyproject.toml`, `docker/**/Dockerfile.*`,
  `.github/workflows/{check_patchgen,gpu_unit_tests,npu_unit_tests,check_pr_title}.yml`,
  `.github/PULL_REQUEST_TEMPLATE.md`, `veomni/ops/`,
  `veomni/models/transformers/*/`, `tests/`).
- `python3 scripts/ci/check_agent_doc_paths.py` passes.
- `ruff check` + `ruff format --check` on `tasks tests veomni docs scripts` pass
  (no Python touched; run as the standard gate).
- Three review passes over the diff (two read-only fact-check subagents, plus
  CodeRabbit). These were worth their cost. Between them they caught that
  `apply_per_model_patches()` has three callers and not two, that the
  `torch==` grep above misses `torch-npu==`, that only 7 of 14 Dockerfiles pin
  torch at all (the rest inherit from their base image), and that
  "`tests/ops/` runs wholesale in CI" is true only of the GPU job — the NPU job
  enumerates three named files.

The second commit fixes a further four, each verified against the tree rather
than taken on faith:

- "no FA `setup.py` runs anywhere now" was wrong in the direction that matters:
  `flash-attn-cute` is the `flash_attn` subdirectory of the pinned
  `demonatic/flash-attention` fork and is still a git source build.
- the `flash-qla` row credited its published metadata with matching the
  TileLang pin. `uv.lock` shows it declares only `apache-tvm-ffi`; the shared
  TileLang version comes from `override-dependencies`.
- a cell in the "Test command" table held a bare path rather than a command.
- `curl -sL` writes a 404 body to the output file and exits `0`, so a missing
  transformers tag would leave an HTML error page named `modeling_<m>.py` to
  diff against. Now `curl -fsSL`.

### API and Usage Example

N/A — no API surface.

### Design & Code Changes

- **`veomni-uv-update`**: `required-version` is a range; the concrete uv pins
  live in individual `docker/**/Dockerfile.*` files plus `check_patchgen.yml`,
  with no generator to fan them out. Reclassified the attention kernels into
  prebuilt wheels / PyPI releases / git source builds — `flash-attn-4` and
  `flash-qla` are PyPI releases, not source builds, and `flash-qla` needs no
  `dependency-metadata` override. Dropped the `no-build-isolation-package`
  pitfall: that block no longer exists, and source builds get their toolchain
  from `extra-build-dependencies` instead.
- **`knowledge/uv.md`**: same `flash-qla` correction; names the four packages
  that really build from git; notes that only the uv-based images carry a uv
  pin at all (the pip-based ascend variants have none).
- **`knowledge/architecture.md`**: documents the ops dispatch as it now works —
  `kernel_registry.py` (`KERNEL_REGISTRY`, the mechanism new kernels should
  use) and `dispatch.py` (`OpSlot`, bound by `_bind_veomni_ops()`), with
  `ops/config/` correctly labelled the legacy path and its
  `apply_per_model_patches()` scoped to its three real callers (`wan`,
  `deepseek_v3`, `deepseek_v4`). Also: `kernels/swiglu_mlp` → `swiglu`, added
  `deepseek_sparse_attention` and `gated_delta_rule`, added the missing
  `veomni/lora` module, and clarified that the patchgen CLI ships from
  `patchgen-pkg/`. The testing section now lists the directories that actually
  exist and notes that CI enumerates test files individually.
- **`veomni-new-op`**: replaced drifted `#19, #20` constraint references with
  section titles (numbers move whenever `constraints.md` grows), fixed the
  `kernels/` listing, and documented the third live dispatch mechanism
  (per-model `device_patch.py`) so the description matches the code.
- **`create-pr`**: stopped reproducing `PULL_REQUEST_TEMPLATE.md` inline — the
  embedded copy had already diverged, and a stale copy silently drops checklist
  items. It now says to read the template. Same for the module list, which is
  now pointed at `check_pr_title.yml` as the source of truth.
- **`veomni-develop`**: `flux`, `movqgan` and `wan` have no `generated/`
  directory and patch through `device_patch.py` or direct modeling — check the
  directory before assuming. (`janus` was in this list; it was deleted with the
  SeedOmni V1 stack in #1082.)
- **`veomni-migrate-transformers-v5`**: removed a `5.9.0 -> 5.9.0` artifact and
  derive the HF reference directory from the installed pin instead of a
  hardcoded `v5_8_1`. (#1145 renames this skill.)
- **`no-section-divider-comments` rule**: exempted patchgen configs and
  generated modeling, where the numbered patch headers are a required
  convention used by 51 files.
- **`AGENTS.md`**: added a "read on demand" tier and listed
  `multimodal_metadata.md` under it, so the session-start read stays short.
- **`knowledge/multimodal_metadata.md`**: names
  `tests/models/test_model_forward_no_implicit_sync.py` as the regression gate.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation — this PR *is* the documentation update
- No `tasks/` scripts moved or renamed
- Tests: no test needed, see **Test**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated architecture guidance for distributed processing, kernel registration, model patching, and hardware backends.
  - Expanded guidance for CUDA, Ascend NPU, and CambriMLU compatibility.
  - Clarified multimodal metadata synchronization requirements and regression coverage.
  - Updated dependency, Docker image, and attention-kernel maintenance instructions.
  - Improved pull request, development, migration, and new-operation workflow guidance.
  - Documented generated-model patch conventions and expanded test coverage references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->