### PR TITLE
[agent, ci] feat: add a test-wiring decision rule

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -53,6 +53,7 @@ The `knowledge/` directory contains domain-specific context loaded by agents on 
 - **architecture.md** — module map, trainer hierarchy, data flow
 - **constraints.md** — hard constraints checked before any code change
 - **multimodal_metadata.md** — canonical multimodal metadata keys and ownership
+- **testing.md** — how CI selects tests; whether a change needs one and where it goes
 - **uv.md** — dependency management architecture
 
 ## Keeping these docs honest

--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -222,7 +222,8 @@ Distributed tests (`tests/parallel/`, `tests/distributed/`, `tests/e2e/`) may re
 test files one by one. Only `tests/data` runs as a whole directory in both
 workflows; `tests/ops` runs wholesale on GPU only (the NPU job enumerates three
 named ops files). A new file anywhere else is invisible to CI until it is added
-to those workflows, usually both.
+to those workflows, usually both. See `.agents/knowledge/testing.md` before
+adding a test.
 
 ## Key Entry Points
 

--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -220,10 +220,11 @@ Distributed tests (`tests/parallel/`, `tests/distributed/`, `tests/e2e/`) may re
 **A passing local run does not mean CI runs it.**
 `.github/workflows/gpu_unit_tests.yml` and `npu_unit_tests.yml` enumerate most
 test files one by one. Only `tests/data` runs as a whole directory in both
-workflows; `tests/ops` runs wholesale on GPU only (the NPU job enumerates three
-named ops files). A new file anywhere else is invisible to CI until it is added
-to those workflows, usually both. See `.agents/knowledge/testing.md` before
-adding a test.
+workflows; `tests/ops` and `tests/parallel/context_parallel` run wholesale on
+GPU only (the NPU job enumerates three named ops files). The e2e paths belong
+to `gpu_e2e_test.yml` / `npu_e2e_test.yml` instead. A new file anywhere else is
+invisible to CI until it is added to the workflow that owns its path, usually
+both unit workflows. See `.agents/knowledge/testing.md` before adding a test.
 
 ## Key Entry Points
 

--- a/.agents/knowledge/testing.md
+++ b/.agents/knowledge/testing.md
@@ -30,8 +30,9 @@ Consequences that cut both ways:
 Check whether a file is wired — by name, and by the directory it sits in:
 
 ```bash
-rg -n "$(basename <path/to/test_file.py>)" .github/workflows/
-rg -n "$(dirname  <path/to/test_file.py>)" .github/workflows/
+TEST_PATH=tests/trainer/test_my_new_thing.py
+rg -n "$(basename "$TEST_PATH")" .github/workflows/
+rg -n "$(dirname  "$TEST_PATH")" .github/workflows/
 ```
 
 ## Decision rule

--- a/.agents/knowledge/testing.md
+++ b/.agents/knowledge/testing.md
@@ -1,0 +1,98 @@
+# Test Wiring
+
+How to decide whether a change needs a test, where to put it, and whether CI
+will actually run it. Read this before adding a test file.
+
+## CI selects tests by explicit enumeration
+
+A test that passes locally is not necessarily a test CI runs.
+
+| Path | How CI picks it up |
+|------|--------------------|
+| `tests/data/` | whole directory, in both `gpu_unit_tests.yml` and `npu_unit_tests.yml` |
+| `tests/ops/` | whole directory in `gpu_unit_tests.yml`; NPU runs only a few named files |
+| `tests/parallel/context_parallel/` | whole directory, `gpu_unit_tests.yml` only |
+| everything else | **one `pytest` line per file**, listed in `gpu_unit_tests.yml`, and separately in `npu_unit_tests.yml` when it should run on Ascend |
+| `tests/e2e/test_e2e_parallel.py`, `tests/distributed/test_fsdp_equivalence.py` | `gpu_e2e_test.yml` / `npu_e2e_test.yml` |
+
+Consequences that cut both ways:
+
+- Adding a file under one of the directory-level entries above is already
+  covered. Adding a workflow line for it is redundant churn.
+- Adding a file anywhere else is **invisible to CI** until it is enumerated —
+  usually in two workflows. Roughly thirty existing files under
+  `tests/{trainer,utils,models,lora,distributed,parallel,e2e}` are in exactly
+  this state, so "a test file exists for X" does not mean X is guarded.
+- The GPU unit job runs on one self-hosted L20-8 fleet with a 120-minute budget
+  and `-x` fail-fast. Every new file pays process startup plus model build, and a
+  new flaky file blocks the whole suite for everyone.
+
+Check whether a file is wired — by name, and by the directory it sits in:
+
+```bash
+rg -n "$(basename <path/to/test_file.py>)" .github/workflows/
+rg -n "$(dirname  <path/to/test_file.py>)" .github/workflows/
+```
+
+## Decision rule
+
+Work down the list and stop at the first match.
+
+**1. The behaviour belongs to an already-enumerated test → add a case to it.**
+This is the default and needs no workflow change. Most of these files are driven
+by a `pytest.param` table, so a new case is a few lines:
+
+| Change | Extend |
+|--------|--------|
+| New/changed model registration | `tests/models/test_model_registry.py`, `tests/models/test_models_patch.py` (`TEST_CASES`) |
+| Patched-vs-upstream numerics | `tests/models/test_models_logits_equal_v5.py` (`CASES` / `_LOADER_CASES`) |
+| Host-device sync regressions | `tests/models/test_model_forward_no_implicit_sync.py` |
+| VLM trainer / freeze-ViT | `tests/models/test_vlm_trainer.py` |
+| MoE checkpoint conversion | `tests/models/test_checkpoint_tensor_converter.py` |
+| VLM / Omni dummy forward | `tests/distributed/test_dummy_forward.py` (`_vlm_cases` / `_omni_cases`) |
+| `torch.compile` support | `tests/distributed/test_torch_compile.py` |
+| Ulysses SP behaviour | `tests/parallel/ulysses/test_ulysses.py` and siblings |
+| Checkpoint callback / DCP round-trip | `tests/checkpoints/test_checkpoint_callback.py`, `test_trainer_saveload.py` |
+| Weight loading / broadcast / EP shard | `tests/utils/test_rank0_load_and_broadcast_weights.py`, `test_moe_ep_sharded_load_matrix.py` |
+| Grad clipping with ExtraParallel | `tests/utils/test_extra_parallel_clip_grad_norm.py` |
+| FLOPs / MFU accounting | `tests/utils/test_count_flops.py` |
+| Optimizer / Muon | `tests/optim/test_muon_*.py`, `test_optimizer_vlm_param_groups.py` |
+| LoRA / MoE-LoRA | the enumerated `tests/lora/test_*.py` set |
+| End-to-end parallel parity | `tests/e2e/test_e2e_parallel.py` (`text_test_cases` and friends) |
+
+**2. It is a self-contained kernel or data-pipeline unit test → new file under
+`tests/ops/` or `tests/data/`.** Covered automatically on GPU; do not touch
+`gpu_unit_tests.yml`. One exception: the NPU job runs `tests/data` wholesale but
+enumerates ops files by name, so a new `tests/ops/` file that should run on
+Ascend still needs a line in `npu_unit_tests.yml`.
+
+**3. It genuinely needs a new file elsewhere.** Prefer folding it into an
+enumerated file in the same directory first. If a separate file is warranted
+(different fixtures, different launcher, meaningfully different runtime), then
+add it to `gpu_unit_tests.yml`, and to `npu_unit_tests.yml` if the behaviour is
+not GPU-specific. Say in the PR what it costs in wall time.
+
+**4. Add no test.** Legitimate cases:
+
+- Pure refactor with the behaviour already covered by an existing test.
+- Docs, comments, config-example, or agent-knowledge changes.
+- Changes only observable on hardware CI does not have (multi-node, SM90+
+  kernels on the SM89 runners, NPU-only paths with no NPU coverage for that
+  area).
+- Changes whose only failure mode is a build/lint error that another gate
+  already catches (`check_patchgen`, `device_api_check`, `check_doc_task_paths`,
+  ruff via `check_pr_lint`).
+
+Say so explicitly in the PR's **Test** section, with the reason. "No test
+needed" without a reason is what the reviewer is looking for.
+
+## Guidance
+
+- Do not add a test whose only assertion is that the code imports, unless import
+  side effects are the thing that broke (model registration is a real example).
+- One new `pytest.param` on an existing table is worth more than a new file with
+  the same coverage: it runs in CI immediately and costs almost no wall time.
+- If you add a file and choose not to wire it, treat it as a local reproducer,
+  not as coverage, and do not claim it in the PR.
+- Prefer the cheapest tier that can fail for the right reason: CPU unit test over
+  single-GPU test over multi-GPU test over e2e training.

--- a/.agents/skills/veomni-debug/SKILL.md
+++ b/.agents/skills/veomni-debug/SKILL.md
@@ -99,7 +99,10 @@ Phase 5: Knowledge capture           -> pending
 
 - [ ] **New hard constraint?** → add to `.agents/knowledge/constraints.md`
 - [ ] **Architecture insight?** → add to `.agents/knowledge/architecture.md`
-- [ ] **New test needed?** → add to `tests/` for regression prevention
+- [ ] **Regression guard needed?** → prefer adding a case to an existing
+      CI-enumerated test; see `.agents/knowledge/testing.md`. A new file outside
+      `tests/ops/` / `tests/data/` must be wired into the unit-test workflows or
+      it never runs.
 - [ ] **Docs outdated?** → update `docs/` if the fix changes API behavior, config semantics, or usage patterns
 
 If none apply, explicitly note "no new knowledge to capture."

--- a/.agents/skills/veomni-develop/SKILL.md
+++ b/.agents/skills/veomni-develop/SKILL.md
@@ -43,6 +43,14 @@ Before committing, check if the change requires documentation updates:
 - **Architecture change** → update `.agents/knowledge/architecture.md`.
 - **New constraint discovered** → add to `.agents/knowledge/constraints.md`.
 
+## Tests
+
+Follow `.agents/knowledge/testing.md`. In short: extend an existing
+CI-enumerated test before creating a new file, and if you do create one outside
+`tests/ops/` / `tests/data/`, wire it into the unit-test workflows or it will
+not run. A pure refactor with existing coverage does not need a new test — say
+so in the PR instead of adding one.
+
 ## When to Use Other Skills
 
 - **New model** → `/veomni-new-model`

--- a/.agents/skills/veomni-develop/SKILL.md
+++ b/.agents/skills/veomni-develop/SKILL.md
@@ -46,9 +46,12 @@ Before committing, check if the change requires documentation updates:
 ## Tests
 
 Follow `.agents/knowledge/testing.md`. In short: extend an existing
-CI-enumerated test before creating a new file, and if you do create one outside
-`tests/ops/` / `tests/data/`, wire it into the unit-test workflows or it will
-not run. A pure refactor with existing coverage does not need a new test — say
+CI-enumerated test before creating a new file. If you do create one, check its
+path against the table there and wire it into the workflow that owns that path
+— the directory-level entries (`tests/data/`, `tests/ops/` on GPU,
+`tests/parallel/context_parallel/` on GPU) need no line, e2e paths belong to
+`{gpu,npu}_e2e_test.yml`, and everything else is invisible to CI until it is
+listed. A pure refactor with existing coverage does not need a new test — say
 so in the PR instead of adding one.
 
 ## When to Use Other Skills

--- a/.agents/skills/veomni-migrate-transformers-v5/SKILL.md
+++ b/.agents/skills/veomni-migrate-transformers-v5/SKILL.md
@@ -665,7 +665,11 @@ and regenerate. This is a hard rule called out in `AGENTS.md`.
 
 ## Phase 6: Add Test Cases
 
-Follow `docs/transformers_v5/testing_new_model.md`. Minimum coverage:
+Follow `docs/transformers_v5/testing_new_model.md`. Every file below is already
+enumerated in the unit-test workflows, so appending a case needs no workflow
+change — that is exactly why this phase extends tables instead of adding files.
+If you think you need a new test file, read `.agents/knowledge/testing.md` first.
+Minimum coverage:
 
 1. **Toy config**: create `tests/toy_config/<m>_toy/config.json` (few layers,
    small hidden/intermediate, tiny vocab). Add a `README.md` next to it noting

--- a/.agents/skills/veomni-new-model/SKILL.md
+++ b/.agents/skills/veomni-new-model/SKILL.md
@@ -102,12 +102,17 @@ Phase 6: Test                          -> pending
 
 1. **Create toy config**: Add `tests/toy_config/<model_name>_toy/config.json` with minimal parameters for fast testing.
 
-2. **Unit tests**: Add tests in `tests/models/` to verify:
-   - Model loads correctly via `veomni.models.auto`
-   - Forward pass produces correct output shape
-   - Model patch applies without errors
+2. **Unit tests**: add cases to the existing enumerated tables rather than new
+   files — `tests/models/test_model_registry.py` and
+   `tests/models/test_models_patch.py` (`TEST_CASES`) already cover loading via
+   `veomni.models.auto`, forward output shape, and patch application. See
+   `.agents/knowledge/testing.md` for the full landing-spot table and for why a
+   new file outside `tests/ops/` / `tests/data/` will not run in CI unless it is
+   wired into the unit-test workflows.
 
-3. **E2e tests** (if feasible): Test a short training run using the toy config.
+3. **E2e tests** (if feasible): add a `pytest.param` to
+   `tests/e2e/test_e2e_parallel.py` using the toy config, rather than a new
+   e2e file.
 
 4. Run `make quality` and `pytest tests/models/`.
 

--- a/.agents/skills/veomni-new-op/SKILL.md
+++ b/.agents/skills/veomni-new-op/SKILL.md
@@ -162,10 +162,13 @@ ships a `device_patch.py`.
 
 ## Phase 3: Test
 
-1. **Add unit tests** to `tests/ops/`:
+1. **Add unit tests** to `tests/ops/` — this directory runs wholesale in CI, so a
+   new file needs no workflow change (see `.agents/knowledge/testing.md`):
    - Test correctness: compare output against a reference implementation (eager PyTorch)
    - Test numerical precision: verify tolerance for bf16/fp16
    - Test edge cases: empty inputs, single-element tensors, extreme shapes
+   If the kernel only binds on SM90+, guard it so the SM89 GPU runners skip
+   rather than fail.
 
 2. **Add benchmark** (optional but recommended for performance-critical ops):
    - Use `veomni/ops/kernels/moe/_kernels/utils/benchmark_utils.py` as reference

--- a/.agents/skills/veomni-new-op/SKILL.md
+++ b/.agents/skills/veomni-new-op/SKILL.md
@@ -162,8 +162,11 @@ ships a `device_patch.py`.
 
 ## Phase 3: Test
 
-1. **Add unit tests** to `tests/ops/` — this directory runs wholesale in CI, so a
-   new file needs no workflow change (see `.agents/knowledge/testing.md`):
+1. **Add unit tests** to `tests/ops/`. The GPU job runs this directory
+   wholesale, so a new file needs no `gpu_unit_tests.yml` change. The NPU job
+   does *not* — it enumerates ops files by name, so if the kernel must run on
+   Ascend, add a line to `npu_unit_tests.yml` (see
+   `.agents/knowledge/testing.md`):
    - Test correctness: compare output against a reference implementation (eager PyTorch)
    - Test numerical precision: verify tolerance for bf16/fp16
    - Test edge cases: empty inputs, single-element tensors, extreme shapes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@
 ### Test
 
 > Validation results (training curves, eval metrics) for changes not covered by CI.
+> State which of the three applies: extended an existing CI-enumerated test, added a new test and wired it into the unit-test workflows, or no test needed (with the reason).
 
 ### API and Usage Example
 
@@ -28,4 +29,4 @@
 - Applied pre-commit checks
 - Added/updated documentation
 - If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
-- Added tests to CI workflow (or explained why not feasible)
+- Tests: extended an existing CI-enumerated test, **or** added a new test and wired it into `gpu_unit_tests.yml` (and `npu_unit_tests.yml` where applicable), **or** explained in **Test** why none is needed. Note that CI enumerates test files individually — a new file outside `tests/data/` and `tests/ops/` does not run until it is listed. See [.agents/knowledge/testing.md](.agents/knowledge/testing.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 ### Test
 
 > Validation results (training curves, eval metrics) for changes not covered by CI.
-> State which of the three applies: extended an existing CI-enumerated test, added a new test and wired it into the unit-test workflows, or no test needed (with the reason).
+> State which of the three applies: extended an existing CI-enumerated test, added a new test and wired it into the CI workflow that owns its path (a unit-test workflow, or `gpu_e2e_test.yml` / `npu_e2e_test.yml` for e2e), or no test needed (with the reason).
 
 ### API and Usage Example
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ On session start, read the following:
 - `.agents/knowledge/cloud_env.md` — Cursor Cloud (CPU-only VM) setup; read when running on the Cursor Cloud VM
 
 Read on demand:
+- `.agents/knowledge/testing.md` — how CI selects tests, and how to decide whether a change needs one; read before adding or wiring a test
 - `.agents/knowledge/multimodal_metadata.md` — multimodal metadata precompute contract; read before touching VLM/Omni collators, ViT forwards, or the model metadata hooks
 
 ---


### PR DESCRIPTION
> **Stack** — review bottom-up. Each PR targets the one below it.
>
> 1. #1144 `[ci, agent] feat: verify repo paths and skill refs in agent docs` (base `main`)
> 2. #1135 `[agent] fix: correct stale facts in skills and knowledge docs`
> 3. **this PR** `[agent, ci] feat: add a test-wiring decision rule`
> 4. #1137 `[agent] refactor: right-size the review gate and drop agent-specific tooling`
> 5. #1145 `[agent, docs] refactor: rename the migrate skill to veomni-patchgen-model`
> 6. #1147 `[agent, docs] refactor: split the patchgen skill by model category`
> 7. #1148 `[agent, docs] refactor: describe the agent tooling generically`
>
> Branch names still carry the original `p0`…`p4` drafting order, which no longer
> matches stack position. Renaming the branches would orphan the open PRs, so
> the numbers are left alone.

### What does this PR do?

Agents add a CI test for essentially every change. The repo currently
encourages that: the PR template asks for one unconditionally, and every skill
says some variant of "add tests in `tests/<mod>/`" with no notion of cost or of
how CI actually selects tests.

Both failure modes show up in the tree today:

- **Redundant wiring.** `tests/data/` and `tests/ops/` already run as whole
  directories on GPU, so adding a workflow line for a new file there is pure
  churn.
- **Tests that never run.** Everywhere else, `gpu_unit_tests.yml` and
  `npu_unit_tests.yml` enumerate files one by one. 31 existing files under
  `tests/{trainer,utils,models,lora,distributed,parallel,e2e}` are not
  enumerated anywhere, so they are dead weight — including all of
  `tests/trainer/` and most of `tests/utils/`.

And the GPU unit job is one self-hosted L20-8 fleet with a 120-minute budget
and `-x`, so an unnecessary new file is a shared cost.

This PR gives agents (and humans) one ordered rule to follow instead of an
unconditional obligation. It deliberately does **not** wire up the 31 orphaned
files — that is a separate triage with its own runtime cost, and it should not
ride along with a policy change.

### Checklist Before Starting

- Search for relative PRs/issues and link here: no existing issue. Continues
  #1144 and #1135 in the same stack. The audit of the 31 currently-unwired test
  files is reported separately so it can be triaged on its own merits.
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`

### Test

**No test needed** — documentation and one PR-template checklist item, with no
runtime behaviour.

Verified by cross-checking every claim in `testing.md` against
`.github/workflows/{gpu,npu}_unit_tests.yml`, `{gpu,npu}_e2e_test.yml`, and the
`pytest.param` tables named in the landing-spot table.
`ruff check` / `ruff format --check` pass.

The second commit is a review-driven fix with a theme worth naming: the table
in `testing.md` has four cases, and **every place that restated it in one
sentence dropped some of them** — each omission pointing an agent at the wrong
workflow.

- `veomni-new-op` said a new `tests/ops/` file needs no workflow change. True
  on GPU, false on NPU, which enumerates ops files by name — so an
  Ascend-relevant kernel test would silently never run.
- `veomni-develop` and `architecture.md` forgot
  `tests/parallel/context_parallel/` (whole-directory, GPU only) and the
  separate e2e workflows.
- the PR template asked only about unit-test workflows, so a new e2e file could
  be reported as "wired" when nothing runs it.

They now derive from the table instead of paraphrasing it. Also fixed: the
wiring-check snippet used `<angle brackets>` inside `$(...)`, which the shell
parses as a redirect, so the command failed before `rg` ran. It now uses a
variable and has been executed as written.

### API and Usage Example

The rule, in short:

```
1. Extend an already-enumerated test          → nothing to wire
2. New file in tests/ops/ or tests/data/      → nothing to wire on GPU
                                                (NPU still enumerates ops by name)
3. New file elsewhere                         → must be listed, and say what it costs
4. No test                                    → allowed, with a stated reason
```

Check whether a file runs at all:

```bash
grep -rn "test_my_new_file" .github/workflows/
```

### Design & Code Changes

- **New `.agents/knowledge/testing.md`**: how the workflows select tests; the
  ordered decision rule above; a landing-spot table mapping a kind of change to
  the existing `pytest.param` table to extend; the cases where adding no test is
  correct; and the one-liner to check whether a file is wired.
- **`.github/PULL_REQUEST_TEMPLATE.md`**: the test checklist item becomes the
  three legitimate outcomes rather than an unconditional obligation, and states
  that a new file outside `tests/data/` and `tests/ops/` does not run until it
  is listed.
- **Skills** (`veomni-develop`, `veomni-debug`, `veomni-new-op`,
  `veomni-new-model`, `veomni-migrate-transformers-v5` — renamed in #1145) now
  defer to the shared rule. `veomni-new-model` names the tables to extend
  instead of "add tests in `tests/models/`"; `veomni-new-op` gets the GPU/NPU
  nuance plus an SM90+ skip-guard reminder for the SM89 runners.

The migrate skill already did the right thing — its Phase 6 extends existing
tables rather than adding files. This PR generalises that pattern.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation — this PR *is* the documentation change
- No `tasks/` scripts moved or renamed
- Tests: no test needed, see **Test**
