### PR TITLE
[agent] refactor: move the review gate to PR time and drop agent-specific tooling

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -30,14 +30,8 @@ See the [Agent Skills specification](https://agentskills.io/specification) for t
 
 ## Skill Index
 
-| Skill | Description |
-|-------|-------------|
-| `veomni-develop` | Feature development and refactoring — VeOmni-specific impact analysis and safety checklist |
-| `veomni-debug` | Bug fix and debugging — quick path for simple fixes, full protocol for complex issues |
-| `veomni-review` | Pre-commit code review via subagent (mandatory gate) |
-| `veomni-new-model` | Adding a new model to VeOmni (patchgen, parallel plan, registry) |
-| `veomni-migrate-transformers-v5` | Add or refresh a model's patchgen path under `veomni/models/transformers/<model>/generated/` (text + MoE + Omni). Use when porting upstream changes or adding a new model to the v5 patchgen flow. |
-| `veomni-new-op` | Adding a new optimized kernel/operator to veomni/ops/ |
-| `veomni-uv-update` | Dependency management with uv (version bumps, torch, lockfile) |
-| `create-pr` | Create a pull request — handles uncommitted changes, generates CI-compliant title and description |
-| `veomni-profile` | Performance profiling — analyze traces/snapshots or generate profiles and optimize |
+The dispatch table in [`AGENTS.md`](../../AGENTS.md) is the single index — it maps
+a task to the skill to use, and every agent already loads it. Each skill's own
+`description` frontmatter is the authoritative statement of when it applies.
+
+Keeping a second copy of the index here only produced drift, so it is gone.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -33,5 +33,3 @@ See the [Agent Skills specification](https://agentskills.io/specification) for t
 The dispatch table in [`AGENTS.md`](../../AGENTS.md) is the single index — it maps
 a task to the skill to use, and every agent already loads it. Each skill's own
 `description` frontmatter is the authoritative statement of when it applies.
-
-Keeping a second copy of the index here only produced drift, so it is gone.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -92,6 +92,11 @@ description: "Create a pull request for the current branch. Handles uncommitted 
 
 ### Step 3: Generate Draft File and Push (automatic)
 
+0. **Run the review gate first.** Unless the branch diff is docs-only or a
+   revert, run `/veomni-review` over `<base>...HEAD` before pushing — this is
+   the point the gate exists for, and once here covers the whole branch. A
+   `risky` verdict stops the PR: report it and wait for the user.
+
 1. Draft PR title in `[{modules}] {type}: {description}` format:
    - Multiple modules separated by comma: `[model, data] feat: ...`
    - Description: concise, lowercase start, no period, under 60 chars

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -92,10 +92,12 @@ description: "Create a pull request for the current branch. Handles uncommitted 
 
 ### Step 3: Generate Draft File and Push (automatic)
 
-0. **Run the review gate first.** Unless the branch diff is docs-only or a
-   revert, run `/veomni-review` over `<base>...HEAD` before pushing — this is
-   the point the gate exists for, and once here covers the whole branch. A
-   `risky` verdict stops the PR: report it and wait for the user.
+0. **Apply `/veomni-review` before pushing.** Use its applicability rules for
+   `<base>...HEAD`, including the documentation self-check and the narrowly
+   defined exemption for clean, exact reverts or approved-diff reapplications.
+   Partial reverts, extra edits and conflict resolutions need the normal gate.
+   Review again before a substantive update to an open PR. A `risky` verdict
+   stops the PR: report it and wait for the user.
 
 1. Draft PR title in `[{modules}] {type}: {description}` format:
    - Multiple modules separated by comma: `[model, data] feat: ...`

--- a/.agents/skills/veomni-debug/SKILL.md
+++ b/.agents/skills/veomni-debug/SKILL.md
@@ -75,12 +75,30 @@ Phase 5: Knowledge capture           -> pending
    the main environment instead of the two you just created, which is the
    opposite of what this is for. (`UV_PROJECT_ENVIRONMENT` works too.)
 
-   Then run the same reproducer in both envs to confirm the version is the
-   root cause. **If the suspect package is transformers, use two worktrees
-   rather than two venvs**: `generated/` modeling lives in the checkout, not
-   the venv, so regenerating it for Env B silently changes what Env A runs.
-   It is produced against the pinned version, and a stale `generated/` is
-   itself a source of failures.
+   Then run the same reproducer in both envs, each with its own env
+   *activated* — the `VIRTUAL_ENV=` prefixes above apply only to the `uv sync`
+   lines they are attached to, not to whatever you run next:
+   ```bash
+   (source .venv-a/bin/activate && <reproducer>)
+   (source .venv-b/bin/activate && <reproducer>)
+   ```
+
+   **If the suspect package is transformers, you need two worktrees *and* two
+   venvs — one venv per worktree.** They isolate different things and neither
+   substitutes for the other: a venv isolates the installed packages, a
+   worktree isolates the checkout. `generated/` modeling lives in the
+   checkout, so two venvs in one worktree share a single `generated/` and
+   regenerating it for Env B silently changes what Env A runs. Two worktrees
+   without separate venvs share one transformers install, which defeats the
+   bisect outright.
+   ```bash
+   git worktree add ../bisect-a HEAD && (cd ../bisect-a && uv venv .venv && VIRTUAL_ENV=.venv uv sync --active --extra gpu --dev)
+   git worktree add ../bisect-b HEAD && (cd ../bisect-b && uv venv .venv && VIRTUAL_ENV=.venv uv sync --active --extra gpu --dev && VIRTUAL_ENV=.venv uv pip install "transformers==<other-version>")
+   ```
+   Regenerate `generated/` inside each worktree against its own pin
+   (`make patchgen`) before running the reproducer — it is produced against
+   the pinned version, and a stale `generated/` is itself a source of
+   failures.
 
 ### Phase 3: Hypothesis and Testing
 

--- a/.agents/skills/veomni-debug/SKILL.md
+++ b/.agents/skills/veomni-debug/SKILL.md
@@ -30,7 +30,7 @@ If not resolved in 15 min → switch to Full Protocol.
 
 ### Before You Start
 
-Use TodoWrite to track all phases:
+Track the phases with whatever todo/plan tool the running agent provides:
 
 ```
 Phase 1: Investigate <symptom>       -> in_progress
@@ -61,11 +61,16 @@ Phase 5: Knowledge capture           -> pending
 4. Check dependencies — different transformers version? Different PyTorch version?
 5. **If a package version upgrade is suspected**, create isolated uv environments to bisect:
    ```bash
-   # Create the default env on the default pin (`transformers-stable` → 5.9.0).
-   uv venv .venv-default
-   VIRTUAL_ENV=.venv-default uv sync --extra gpu --dev
+   # Env A: the current default pin (the `transformers-stable` group).
+   uv venv .venv-a
+   VIRTUAL_ENV=.venv-a uv sync --extra gpu --dev
+
+   # Env B: the same tree with exactly one package moved.
+   uv venv .venv-b
+   VIRTUAL_ENV=.venv-b uv sync --extra gpu --dev
+   VIRTUAL_ENV=.venv-b uv pip install "<package>==<other-version>"
    ```
-   Run the same reproducer in both envs to confirm the version is the root cause. This avoids polluting the main `.venv/`.
+   Run the same reproducer in both envs to confirm the version is the root cause. This avoids polluting the main `.venv/`. If the suspect package is transformers, remember the `generated/` modeling was produced against the pinned version — a mismatch is itself a source of failures, so regenerate before concluding.
 
 ### Phase 3: Hypothesis and Testing
 
@@ -73,11 +78,6 @@ Phase 5: Knowledge capture           -> pending
 2. Design a MINIMAL experiment (change one thing only).
 3. Run the experiment. Record the result.
 4. If wrong, update understanding and form new hypothesis. No random guess-and-check.
-
-**Red flags — STOP and restart from Phase 1:**
-- "Let me just try changing X and see what happens"
-- "Quick fix for now, clean up later"
-- "It probably works, let me move on"
 
 **Verification gate** — before acting on a conclusion, check:
 - Does the evidence actually support this cause, or just correlate?
@@ -109,13 +109,14 @@ If none apply, explicitly note "no new knowledge to capture."
 
 ---
 
-## Three-Strike Rule
+## Stop Conditions
 
-If 3 consecutive fix attempts fail:
-- **STOP fixing symptoms.**
-- Question whether the underlying approach/architecture is wrong.
-- Step back and re-examine: are you solving the right problem?
-- Report to user with analysis before continuing.
+Restart from Phase 1 if you catch yourself thinking "let me just try changing X
+and see", "quick fix for now, clean up later", or "it probably works, moving on".
+
+After **3 consecutive failed fix attempts**, stop fixing symptoms. Question
+whether the underlying approach is wrong, re-examine whether you are solving the
+right problem, and report the analysis to the user before continuing.
 
 ## Common Pitfalls
 

--- a/.agents/skills/veomni-debug/SKILL.md
+++ b/.agents/skills/veomni-debug/SKILL.md
@@ -63,14 +63,24 @@ Phase 5: Knowledge capture           -> pending
    ```bash
    # Env A: the current default pin (the `transformers-stable` group).
    uv venv .venv-a
-   VIRTUAL_ENV=.venv-a uv sync --extra gpu --dev
+   VIRTUAL_ENV=.venv-a uv sync --active --extra gpu --dev
 
    # Env B: the same tree with exactly one package moved.
    uv venv .venv-b
-   VIRTUAL_ENV=.venv-b uv sync --extra gpu --dev
+   VIRTUAL_ENV=.venv-b uv sync --active --extra gpu --dev
    VIRTUAL_ENV=.venv-b uv pip install "<package>==<other-version>"
    ```
-   Run the same reproducer in both envs to confirm the version is the root cause. This avoids polluting the main `.venv/`. If the suspect package is transformers, remember the `generated/` modeling was produced against the pinned version — a mismatch is itself a source of failures, so regenerate before concluding.
+   `--active` is load-bearing. Without it `uv sync` runs in project mode and
+   targets `.venv/`, ignoring `VIRTUAL_ENV` — so both commands would rebuild
+   the main environment instead of the two you just created, which is the
+   opposite of what this is for. (`UV_PROJECT_ENVIRONMENT` works too.)
+
+   Then run the same reproducer in both envs to confirm the version is the
+   root cause. **If the suspect package is transformers, use two worktrees
+   rather than two venvs**: `generated/` modeling lives in the checkout, not
+   the venv, so regenerating it for Env B silently changes what Env A runs.
+   It is produced against the pinned version, and a stale `generated/` is
+   itself a source of failures.
 
 ### Phase 3: Hypothesis and Testing
 

--- a/.agents/skills/veomni-debug/SKILL.md
+++ b/.agents/skills/veomni-debug/SKILL.md
@@ -20,7 +20,7 @@ description: "Use this skill for ANY bug, error, crash, wrong output, loss diver
 3. Write a reproducer test if feasible.
 4. Minimal fix — root cause only, don't touch surrounding code.
 5. Verify: reproducer passes, `pytest tests/<module>/` passes, no regressions across modalities.
-6. Run `/veomni-review`, `make quality`, commit.
+6. Run `make quality`, commit. (The subagent review is owed once before the PR, not per commit.)
 
 If not resolved in 15 min → switch to Full Protocol.
 
@@ -119,7 +119,7 @@ Phase 5: Knowledge capture           -> pending
 2. Implement a SINGLE targeted fix addressing the root cause.
 3. Verify: test passes, training runs correctly, no regressions.
 4. Check for collateral — did the fix break other modalities or trainers?
-5. Before committing: run `/veomni-review` skill.
+5. Before opening the PR: run `/veomni-review` over the branch diff.
 
 ### Phase 5: Knowledge Capture (mandatory)
 

--- a/.agents/skills/veomni-debug/SKILL.md
+++ b/.agents/skills/veomni-debug/SKILL.md
@@ -113,8 +113,11 @@ Phase 5: Knowledge capture           -> pending
 
    Compare the package sets here too, using `uv pip freeze --python` with
    `../bisect-a/.venv/bin/python` and `../bisect-b/.venv/bin/python`, and
-   reconcile every non-transformers difference as above. Run codegen and the
-   reproducer from each worktree with its own environment activated:
+   reconcile non-transformers dependency version differences as above. The
+   editable VeOmni and patchgen paths must point to their respective worktrees;
+   normalize those corresponding paths only when comparing the freeze output,
+   without changing either environment's editable installs. Run codegen and
+   the reproducer from each worktree with its own environment activated:
    ```bash
    (cd ../bisect-a && source .venv/bin/activate && make patchgen && <reproducer>)
    (cd ../bisect-b && source .venv/bin/activate && make patchgen && <reproducer>)

--- a/.agents/skills/veomni-debug/SKILL.md
+++ b/.agents/skills/veomni-debug/SKILL.md
@@ -20,7 +20,7 @@ description: "Use this skill for ANY bug, error, crash, wrong output, loss diver
 3. Write a reproducer test if feasible.
 4. Minimal fix — root cause only, don't touch surrounding code.
 5. Verify: reproducer passes, `pytest tests/<module>/` passes, no regressions across modalities.
-6. Run `make quality`, commit. (The subagent review is owed once before the PR, not per commit.)
+6. Run `make quality`, commit. Run `/veomni-review` before opening the PR or pushing a substantive update, not per commit.
 
 If not resolved in 15 min → switch to Full Protocol.
 
@@ -75,6 +75,17 @@ Phase 5: Knowledge capture           -> pending
    the main environment instead of the two you just created, which is the
    opposite of what this is for. (`UV_PROJECT_ENVIRONMENT` works too.)
 
+   Confirm that installing the alternate version did not change other packages:
+   ```bash
+   uv pip freeze --python .venv-a/bin/python > /tmp/veomni-bisect-a.freeze
+   uv pip freeze --python .venv-b/bin/python > /tmp/veomni-bisect-b.freeze
+   diff -u /tmp/veomni-bisect-a.freeze /tmp/veomni-bisect-b.freeze
+   ```
+   Only the target package may differ. Pin or restore every non-target
+   difference in Env B to Env A's version, then compare again before running
+   the reproducer. If the target cannot run with that dependency set, report
+   the compatibility conflict; a multi-package change is not a one-package bisect.
+
    Then run the same reproducer in both envs, each with its own env
    *activated* — the `VIRTUAL_ENV=` prefixes above apply only to the `uv sync`
    lines they are attached to, not to whatever you run next:
@@ -100,6 +111,15 @@ Phase 5: Knowledge capture           -> pending
    the pinned version, and a stale `generated/` is itself a source of
    failures.
 
+   Compare the package sets here too, using `uv pip freeze --python` with
+   `../bisect-a/.venv/bin/python` and `../bisect-b/.venv/bin/python`, and
+   reconcile every non-transformers difference as above. Run codegen and the
+   reproducer from each worktree with its own environment activated:
+   ```bash
+   (cd ../bisect-a && source .venv/bin/activate && make patchgen && <reproducer>)
+   (cd ../bisect-b && source .venv/bin/activate && make patchgen && <reproducer>)
+   ```
+
 ### Phase 3: Hypothesis and Testing
 
 1. Form ONE specific, falsifiable hypothesis.
@@ -119,7 +139,7 @@ Phase 5: Knowledge capture           -> pending
 2. Implement a SINGLE targeted fix addressing the root cause.
 3. Verify: test passes, training runs correctly, no regressions.
 4. Check for collateral — did the fix break other modalities or trainers?
-5. Before opening the PR: run `/veomni-review` over the branch diff.
+5. Before opening the PR or pushing a substantive update: run `/veomni-review` over the branch diff.
 
 ### Phase 5: Knowledge Capture (mandatory)
 
@@ -128,9 +148,10 @@ Phase 5: Knowledge capture           -> pending
 - [ ] **New hard constraint?** → add to `.agents/knowledge/constraints.md`
 - [ ] **Architecture insight?** → add to `.agents/knowledge/architecture.md`
 - [ ] **Regression guard needed?** → prefer adding a case to an existing
-      CI-enumerated test; see `.agents/knowledge/testing.md`. A new file outside
-      `tests/ops/` / `tests/data/` must be wired into the unit-test workflows or
-      it never runs.
+      CI-enumerated test; see `.agents/knowledge/testing.md`. Only paths not
+      already covered by a directory-level CI entry need a new workflow line.
+      Use the workflow that owns the path, including the e2e workflows for
+      end-to-end tests; account for the GPU/NPU differences in that table.
 - [ ] **Docs outdated?** → update `docs/` if the fix changes API behavior, config semantics, or usage patterns
 
 If none apply, explicitly note "no new knowledge to capture."

--- a/.agents/skills/veomni-migrate-transformers-v5/SKILL.md
+++ b/.agents/skills/veomni-migrate-transformers-v5/SKILL.md
@@ -147,9 +147,10 @@ already gitignored so it won't leak into the repo).
 
 ---
 
-## Before You Start: Create Todos
+## Before You Start: Create a Plan
 
-Use TodoWrite to track phases. Suggested plan:
+Track the phases with whatever todo/plan tool the running agent provides.
+Suggested plan:
 
 ```
 Phase 0: Verify venv + drop HF reference files       -> in_progress

--- a/.agents/skills/veomni-migrate-transformers-v5/SKILL.md
+++ b/.agents/skills/veomni-migrate-transformers-v5/SKILL.md
@@ -161,7 +161,7 @@ Phase 4: Wire __init__.py to expose generated classes -> pending
 Phase 5: Run patchgen + verify diff                   -> pending
 Phase 6: Add test cases                               -> pending
 Phase 7: Run tests (single-GPU + e2e)                 -> pending
-Phase 8: Docs + /veomni-review + commit               -> pending
+Phase 8: Docs + commit; /veomni-review before the PR  -> pending
 ```
 
 Drop phases that don't apply (e.g. Phase 3 for non-MoE models).
@@ -773,14 +773,15 @@ Extra e2e gotchas:
 2. **.agents knowledge**: if the work surfaced a new hard constraint
    (e.g. "model X requires `logits_to_keep` handled in ForCausalLM.forward"),
    add it to `.agents/knowledge/constraints.md`.
-3. **Run `/veomni-review`** (mandatory pre-commit gate).
-   - `safe` → commit.
-   - `risky` → report, wait for user.
-4. **Commit**:
+3. **Commit**:
    - Title: `[BREAKING]` only if the change alters checkpoint format
      expectations or public APIs. Follow `[{modules}] {type}: {description}`.
      Example: `[veomni] feat: add patchgen-generated modeling for <m>`.
    - Commit message **must not** mention Claude / AI / Co-Authored-By.
+4. **Before opening the PR**: run `/veomni-review` over the branch diff. This
+   work touches `veomni/`, so the gate applies.
+   - `safe` / `needs-attention` → open the PR.
+   - `risky` → report, wait for the user.
 
 ---
 

--- a/.agents/skills/veomni-new-model/SKILL.md
+++ b/.agents/skills/veomni-new-model/SKILL.md
@@ -3,9 +3,9 @@ name: veomni-new-model
 description: "Use this skill when adding support for a new model to VeOmni. Covers the full lifecycle: analyzing the HuggingFace model, creating model patches, defining parallel plans, writing configs, integrating with the trainer, and testing. Trigger: 'add model', 'support new model', 'integrate a model', 'new model support'."
 ---
 
-## Before You Start: Create Todos
+## Before You Start: Create a Plan
 
-Use TodoWrite to track all phases:
+Track the phases with whatever todo/plan tool the running agent provides:
 
 ```
 Phase 1: Analyze HF model             -> in_progress

--- a/.agents/skills/veomni-new-op/SKILL.md
+++ b/.agents/skills/veomni-new-op/SKILL.md
@@ -189,9 +189,9 @@ ships a `device_patch.py`.
 
 ## Phase 5: Finalize
 
-1. Run `/veomni-review` skill.
-2. Run `make quality`.
-3. Verify the new variant shows up in `KERNEL_REGISTRY.dump()` and that the relevant `OpSlot` is rebound after `build_foundation_model`.
+1. Run `make quality`.
+2. Verify the new variant shows up in `KERNEL_REGISTRY.dump()` and that the relevant `OpSlot` is rebound after `build_foundation_model`.
+3. Before opening the PR, run `/veomni-review` over the branch diff — a new kernel touches `veomni/`, so the gate applies.
 
 ## Common Pitfalls
 

--- a/.agents/skills/veomni-review/SKILL.md
+++ b/.agents/skills/veomni-review/SKILL.md
@@ -17,8 +17,16 @@ branch you took, so the reader knows a review happened or why it didn't.
 
 ## Steps
 
-1. Run `git diff HEAD` to capture the full diff — plain `git diff` omits
-   anything already staged, which is exactly what is about to be committed.
+1. Capture the full diff, including files git does not track yet:
+   ```bash
+   git add -N .    # intent-to-add: makes new files visible to diff, stages no content
+   git diff HEAD
+   ```
+   Both halves matter. Plain `git diff` omits anything already staged — which
+   is exactly what is about to be committed. `git diff HEAD` on its own still
+   omits untracked files, so a brand-new module or test would be reviewed as
+   if it did not exist, and "add a new file" is one of the most common changes
+   there is. `git add -N` respects `.gitignore`, so build artifacts stay out.
 2. Read `.agents/knowledge/constraints.md` for known constraints.
 3. **Launch a review subagent** with your agent's subagent/task mechanism (see
    the prompt below). The subagent receives only the diff + constraints — NOT

--- a/.agents/skills/veomni-review/SKILL.md
+++ b/.agents/skills/veomni-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: veomni-review
-description: "Pre-commit code review gate. Required before committing any change to Python under veomni/, tasks/ or tests/, and any change to CI workflows, pyproject.toml or configs/. Also trigger proactively when a change spans multiple files, touches shared infrastructure (BaseTrainer, distributed, model loading, data pipeline, ops dispatch), or you are unsure a fix is safe. The review launches a subagent that checks implementation quality, multi-file consistency, and known constraint violations, then rates the change as safe/needs-attention/risky."
+description: "Pre-commit code review gate. Required before committing any change to Python under veomni/, tasks/ or tests/, and any change to CI workflows, pyproject.toml, uv.lock, docker/ or configs/. Also trigger proactively when a change spans multiple files, touches shared infrastructure (BaseTrainer, distributed, model loading, data pipeline, ops dispatch), or you are unsure a fix is safe. The review launches a subagent that checks implementation quality, multi-file consistency, and known constraint violations, then rates the change as safe/needs-attention/risky."
 ---
 
 ## When this gate applies
@@ -17,7 +17,8 @@ branch you took, so the reader knows a review happened or why it didn't.
 
 ## Steps
 
-1. Run `git diff` (staged + unstaged) to capture the full diff.
+1. Run `git diff HEAD` to capture the full diff — plain `git diff` omits
+   anything already staged, which is exactly what is about to be committed.
 2. Read `.agents/knowledge/constraints.md` for known constraints.
 3. **Launch a review subagent** with your agent's subagent/task mechanism (see
    the prompt below). The subagent receives only the diff + constraints — NOT
@@ -74,7 +75,7 @@ For each changed file, check:
 - PR title format: `[{modules}] {type}: {description}`?
 - All comments and docstrings in English?
 - No auto-generated files (`veomni/models/transformers/*/generated/`) edited directly?
-- Tests: does the diff extend an existing CI-enumerated test, or add a new file that is actually wired into the unit-test workflows? A new test file outside `tests/data/` and `tests/ops/` that no workflow lists will never run. Conversely, a workflow line added for a file under `tests/data/` or `tests/ops/` is redundant. See `.agents/knowledge/testing.md`.
+- Tests: does the diff extend an existing CI-enumerated test, or add a new file that the workflow owning that path actually lists? Check the owning workflow rather than assuming — `tests/data/` runs wholesale in both unit workflows, `tests/ops/` only in the GPU one (NPU enumerates ops files by name, so an Ascend-relevant ops file still needs a line), the e2e paths belong to `{gpu,npu}_e2e_test.yml`, and everything else must be listed file by file or it never runs. See `.agents/knowledge/testing.md`.
 - Ruff-compliant (`make quality` passes)?
 
 ## Output

--- a/.agents/skills/veomni-review/SKILL.md
+++ b/.agents/skills/veomni-review/SKILL.md
@@ -1,13 +1,29 @@
 ---
 name: veomni-review
-description: "Use this skill before committing ANY code change — this is a mandatory gate in the commit flow. Also trigger proactively when: you've made changes across multiple files and want to check consistency, you're unsure if a fix is safe, a change touches shared infrastructure (BaseTrainer, distributed, model loading, data pipeline), or a change is larger than a few lines. The review launches a subagent that checks implementation quality, multi-file consistency, and known constraint violations, then rates the change as safe/needs-attention/risky."
+description: "Pre-commit code review gate. Required before committing any change to Python under veomni/, tasks/ or tests/, and any change to CI workflows, pyproject.toml or configs/. Also trigger proactively when a change spans multiple files, touches shared infrastructure (BaseTrainer, distributed, model loading, data pipeline, ops dispatch), or you are unsure a fix is safe. The review launches a subagent that checks implementation quality, multi-file consistency, and known constraint violations, then rates the change as safe/needs-attention/risky."
 ---
+
+## When this gate applies
+
+| Change | Review |
+|--------|--------|
+| Python under `veomni/`, `tasks/`, `tests/` | Required |
+| `.github/workflows/`, `pyproject.toml`, `uv.lock`, `docker/`, `configs/` | Required |
+| Docs, comments, or `.agents/` knowledge and skills only | Skip — self-check instead: verify every repo path, config key and version you assert actually exists |
+| A revert, or re-applying a diff a reviewer already approved | Skip |
+
+Skipping means skipping the subagent, not skipping verification. Say which
+branch you took, so the reader knows a review happened or why it didn't.
 
 ## Steps
 
 1. Run `git diff` (staged + unstaged) to capture the full diff.
 2. Read `.agents/knowledge/constraints.md` for known constraints.
-3. **Launch a review subagent** (see below). The subagent receives only the diff + constraints — NOT your reasoning — to avoid confirmation bias.
+3. **Launch a review subagent** with your agent's subagent/task mechanism (see
+   the prompt below). The subagent receives only the diff + constraints — NOT
+   your reasoning — to avoid confirmation bias. If the change is already
+   committed on a feature branch, point it at `git diff main...HEAD` instead of
+   pasting the diff.
 4. Act on the verdict.
 
 | Verdict | Action |
@@ -20,7 +36,9 @@ description: "Use this skill before committing ANY code change — this is a man
 
 ## Subagent Launch
 
-Use the Task tool with this prompt:
+Launch a subagent with this prompt. Use whatever the running agent calls it —
+`Task`, `spawn_agent`, or an equivalent — and give it read-only access to the
+repo so it can verify claims against the actual files.
 
 ```
 You are a code reviewer for VeOmni, a distributed multi-modality training framework. Your job is to find problems in the following diff. You are NOT validating the author's intent — you are looking for bugs, risks, and constraint violations.
@@ -45,7 +63,8 @@ For each changed file, check:
 - If a Trainer method changed, do all subclasses need matching changes?
 - If model loading changed, are configs and parallel plans updated?
 - If data collator changed, do all modalities still work?
-- If distributed code changed, are both FSDP and FSDP2 paths handled?
+- If distributed code changed, are the FSDP2, sequence-parallel and ExtraParallel/EP paths all handled? (FSDP1 no longer exists — a diff that adds an FSDP1 branch is itself a finding.)
+- If a trainer lifecycle hook changed, do the composed trainers that override `forward_backward_step()` (`TextDPOTrainer`, `DiTTrainer`) still get it?
 
 ### Constraint Violations
 - Does this violate any entry in the known-constraints list?
@@ -55,6 +74,7 @@ For each changed file, check:
 - PR title format: `[{modules}] {type}: {description}`?
 - All comments and docstrings in English?
 - No auto-generated files (`veomni/models/transformers/*/generated/`) edited directly?
+- Tests: does the diff extend an existing CI-enumerated test, or add a new file that is actually wired into the unit-test workflows? A new test file outside `tests/data/` and `tests/ops/` that no workflow lists will never run. Conversely, a workflow line added for a file under `tests/data/` or `tests/ops/` is redundant. See `.agents/knowledge/testing.md`.
 - Ruff-compliant (`make quality` passes)?
 
 ## Output

--- a/.agents/skills/veomni-review/SKILL.md
+++ b/.agents/skills/veomni-review/SKILL.md
@@ -1,11 +1,21 @@
 ---
 name: veomni-review
-description: "Pre-commit code review gate. Required before committing any change to Python under veomni/, tasks/ or tests/, and any change to CI workflows, pyproject.toml, uv.lock, docker/ or configs/. Also trigger proactively when a change spans multiple files, touches shared infrastructure (BaseTrainer, distributed, model loading, data pipeline, ops dispatch), or you are unsure a fix is safe. The review launches a subagent that checks implementation quality, multi-file consistency, and known constraint violations, then rates the change as safe/needs-attention/risky."
+description: "Pre-PR code review gate. Run once before opening a pull request, and again before pushing a substantive update to an open one — not per commit. Required when the PR's branch diff touches Python under veomni/, tasks/ or tests/, or CI workflows, pyproject.toml, uv.lock, docker/ or configs/. Also trigger proactively when a change spans multiple files, touches shared infrastructure (BaseTrainer, distributed, model loading, data pipeline, ops dispatch), or you are unsure a fix is safe. The review launches a subagent that checks implementation quality, multi-file consistency, and known constraint violations, then rates the change as safe/needs-attention/risky."
 ---
 
 ## When this gate applies
 
-| Change | Review |
+**Once per PR, not once per commit.** The unit that lands is the pull request,
+so that is the unit worth reviewing: the reviewer sees the whole change instead
+of a slice of it, and a branch of ten commits costs one review rather than ten.
+Run it again before pushing a substantive update to an open PR — not for a
+typo fix or a rebase.
+
+Commits stay cheap: `make quality` and your own verification still gate every
+commit, and nothing stops you invoking this mid-branch when a change worries
+you. It is the *obligation* that moved, not the option.
+
+| The PR's branch diff touches | Review |
 |--------|--------|
 | Python under `veomni/`, `tasks/`, `tests/` | Required |
 | `.github/workflows/`, `pyproject.toml`, `uv.lock`, `docker/`, `configs/` | Required |
@@ -17,31 +27,40 @@ branch you took, so the reader knows a review happened or why it didn't.
 
 ## Steps
 
-1. Capture the full diff, including files git does not track yet:
+1. Capture the diff the PR will actually contain — the whole branch against the
+   base it targets, not the working tree:
    ```bash
-   git add -N .    # intent-to-add: makes new files visible to diff, stages no content
+   git diff <base>...HEAD          # <base> is the branch the PR targets
+   ```
+   Use three dots: it diffs from the merge base, so commits that landed on
+   `<base>` after you branched do not show up as your changes. `<base>` is
+   usually `main`, but for a stacked PR it is the branch below yours — diffing
+   against `main` there would hand the reviewer every PR under you as well.
+
+   If you still have uncommitted work you want included, add it too, and note
+   that a plain `git diff` sees neither staged nor untracked files:
+   ```bash
+   git add -N .                    # intent-to-add: new files become visible, stages no content
    git diff HEAD
    ```
-   Both halves matter. Plain `git diff` omits anything already staged — which
-   is exactly what is about to be committed. `git diff HEAD` on its own still
-   omits untracked files, so a brand-new module or test would be reviewed as
-   if it did not exist, and "add a new file" is one of the most common changes
-   there is. `git add -N` respects `.gitignore`, so build artifacts stay out.
+   `git diff HEAD` covers staged and unstaged tracked files; `git add -N` is
+   what makes a brand-new module or test visible at all, and it respects
+   `.gitignore` so build artifacts stay out.
 2. Read `.agents/knowledge/constraints.md` for known constraints.
 3. **Launch a review subagent** with your agent's subagent/task mechanism (see
    the prompt below). The subagent receives only the diff + constraints — NOT
-   your reasoning — to avoid confirmation bias. If the change is already
-   committed on a feature branch, point it at `git diff main...HEAD` instead of
-   pasting the diff.
+   your reasoning — to avoid confirmation bias. Point it at the diff command
+   rather than pasting, so it reads the current state.
 4. Act on the verdict.
 
 | Verdict | Action |
 |---------|--------|
-| **safe** | Proceed to commit |
-| **needs-attention** | Address listed issues, then commit |
-| **risky** | Output the report, do NOT commit, wait for user |
+| **safe** | Open or update the PR |
+| **needs-attention** | Address the listed issues, then open or update the PR |
+| **risky** | Output the report, do NOT open the PR, wait for the user |
 
-5. Run `make quality` before the final commit.
+5. Run `make quality` before pushing. (It gates every commit anyway, but this
+   is the last chance before the diff is public.)
 
 ## Subagent Launch
 

--- a/.agents/skills/veomni-review/SKILL.md
+++ b/.agents/skills/veomni-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: veomni-review
-description: "Pre-PR code review gate. Run once before opening a pull request, and again before pushing a substantive update to an open one — not per commit. Required when the PR's branch diff touches Python under veomni/, tasks/ or tests/, or CI workflows, pyproject.toml, uv.lock, docker/ or configs/. Also trigger proactively when a change spans multiple files, touches shared infrastructure (BaseTrainer, distributed, model loading, data pipeline, ops dispatch), or you are unsure a fix is safe. The review launches a subagent that checks implementation quality, multi-file consistency, and known constraint violations, then rates the change as safe/needs-attention/risky."
+description: "Pre-PR code review gate. Run before opening a pull request, and again before pushing a substantive update to an open one — not per commit. Required when the PR's branch diff touches Python under veomni/, tasks/ or tests/, or CI workflows, pyproject.toml, uv.lock, docker/ or configs/. Also trigger proactively for runtime or configuration changes that span multiple files, touch shared infrastructure (BaseTrainer, distributed, model loading, data pipeline, ops dispatch), or have uncertain safety. Docs, comments and .agents/-only changes use the self-check below. The review launches a subagent that checks implementation quality, multi-file consistency, and known constraint violations, then rates the change as safe/needs-attention/risky."
 ---
 
 ## When this gate applies
@@ -20,7 +20,10 @@ you. It is the *obligation* that moved, not the option.
 | Python under `veomni/`, `tasks/`, `tests/` | Required |
 | `.github/workflows/`, `pyproject.toml`, `uv.lock`, `docker/`, `configs/` | Required |
 | Docs, comments, or `.agents/` knowledge and skills only | Skip — self-check instead: verify every repo path, config key and version you assert actually exists |
-| A revert, or re-applying a diff a reviewer already approved | Skip |
+| A clean, exact revert or reapplication of a previously approved diff, with no additional or conflict-resolved changes | Skip |
+
+Partial reverts and reapplications with extra edits or conflict resolutions
+must follow the normal review gate; prior approval does not cover those changes.
 
 Skipping means skipping the subagent, not skipping verification. Say which
 branch you took, so the reader knows a review happened or why it didn't.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Read on demand:
 - **Explain, Don't Assume**: Explain **why** (motivation, tradeoffs), not just what. Cite files and line numbers.
 - **Ask When Stuck**: 3+ approaches fail? Stop, summarize, ask user. No hacks.
 - **Search Before You Act**: On unexpected behavior, search codebase + check constraints + review `git log` before attempting fixes.
-- **Planning Discipline**: Complex tasks (multi-file, >30 min) -> TodoWrite. Plan must state which skills will be used (e.g. `/veomni-develop` + `/veomni-review`). Simple tasks -> just do them.
+- **Planning Discipline**: Complex tasks (multi-file, >30 min) -> write a plan with the agent's todo/plan tool. The plan must state which skills will be used (e.g. `/veomni-develop` + `/veomni-review`). Simple tasks -> just do them.
 - **Cross-modality Awareness**: Changes in shared code (`BaseTrainer`, `data_collator`, `distributed/`) affect all modalities.
 - **No Patchgen Edits**: Never edit files under `veomni/models/transformers/*/generated/`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ Title: `[{modules}] {type}: {description}`
 
 - Allowed modules and types are defined in `.github/workflows/check_pr_title.yml` (the CI source of truth).
 - Breaking: prepend `[BREAKING]`
+- **Run `/veomni-review` before opening the PR** (subagent code review over the branch diff), and again before pushing a substantive update to an open one. **safe** / **needs-attention** -> proceed. **risky** -> report to the user and wait. This is the review gate; it is per PR, not per commit.
 - GitHub PRs are also reviewed by CodeRabbit (`.coderabbit.yaml`). On an existing PR, comment `@coderabbitai review` or `@coderabbitai full review`.
 
 ---
@@ -80,12 +81,15 @@ Title: `[{modules}] {type}: {description}`
 
 1. Complete and verify the change.
 2. Update related documentation: `docs/`, `README.md`, `.agents/knowledge/`, config examples — if the change introduces, modifies, or removes any API, config field, or workflow.
-3. Run `/veomni-review` skill (subagent code review).
-4. **safe** -> commit. **risky** -> report to user, wait for approval.
-5. Each fix -> immediate commit. Do not batch unrelated changes.
-6. Run `make quality` before every commit.
-7. **Commit messages must NOT mention Claude/AI/Co-Authored-By.**
-8. **Skill gap check**: If the task didn't match any existing skill, briefly assess after completion: Was this a one-off, or a repeatable pattern? If repeatable, suggest creating a new skill to the user.
+3. Run `make quality` before every commit.
+4. Each fix -> immediate commit. Do not batch unrelated changes.
+5. **Commit messages must NOT mention Claude/AI/Co-Authored-By.**
+6. **Skill gap check**: If the task didn't match any existing skill, briefly assess after completion: Was this a one-off, or a repeatable pattern? If repeatable, suggest creating a new skill to the user.
+
+The subagent review gate is **per PR, not per commit** — see **PR Guidelines**.
+Commits are gated by `make quality` and your own verification. Nothing stops you
+invoking `/veomni-review` mid-branch when a change worries you; it just is not
+owed on every commit.
 
 ---
 
@@ -97,7 +101,7 @@ Skills follow the [Agent Skills](https://agentskills.io) open standard. Each ski
 |------|-------|
 | Feature / refactoring | `/veomni-develop` |
 | Bug fix / debugging | `/veomni-debug` |
-| Code review (pre-commit) | `/veomni-review` |
+| Code review (before opening a PR) | `/veomni-review` |
 | Add new model | `/veomni-new-model` |
 | Migrate existing model to transformers v5 | `/veomni-migrate-transformers-v5` |
 | Add new op/kernel | `/veomni-new-op` |

--- a/docs/usage/agent_workflow.md
+++ b/docs/usage/agent_workflow.md
@@ -27,7 +27,7 @@ If you are using Cursor or another AI coding tool on this project, the workflow 
 1. The agent reads `AGENTS.md` on session start.
 2. For each task, the agent selects the appropriate skill from the dispatch table (or auto-discovers it via the `description` frontmatter).
 3. The agent reads the skill's `SKILL.md` and follows its step-by-step instructions.
-4. Before committing, the agent runs the `/veomni-review` skill (a subagent code review).
+4. Before opening a pull request, the agent runs the `/veomni-review` skill (a subagent code review over the branch diff).
 
 **You don't need to do anything special** — just describe your task in natural language. You can also invoke a specific skill with `/skill-name` in chat (e.g., `/veomni-debug`).
 
@@ -54,7 +54,7 @@ Each skill is a folder containing a `SKILL.md` file with YAML frontmatter (`name
 .agents/skills/
 ├── veomni-develop/SKILL.md    # Feature development and refactoring
 ├── veomni-debug/SKILL.md      # Bug fix and debugging (quick path + full protocol)
-├── veomni-review/SKILL.md     # Pre-commit code review (mandatory)
+├── veomni-review/SKILL.md     # Pre-PR code review (mandatory)
 ├── veomni-new-model/SKILL.md  # Add a new model to VeOmni
 ├── veomni-migrate-transformers-v5/SKILL.md  # Migrate model patches to transformers v5
 ├── veomni-new-op/SKILL.md     # Add a new kernel/operator
@@ -107,19 +107,22 @@ See the [Agent Skills specification](https://agentskills.io/specification) for t
 2. Reference it from the Context Loading section in `AGENTS.md`.
 3. If the knowledge contains hard rules, add them to `constraints.md`.
 
-## Commit Flow
+## Commit and review flow
 
-The agent workflow enforces a structured commit flow:
+Commits stay cheap; the subagent review is owed once per pull request, over the
+whole branch diff, because the PR is the unit that lands:
 
 ```
-Code Change -> /veomni-review (subagent) -> Verdict
-                                             |
-                                     safe -> commit
-                              needs-attention -> fix, then commit
-                                     risky -> report to user, wait
+each commit    -> make quality + your own verification
+
+before the PR  -> /veomni-review (subagent) -> Verdict
+                                                |
+                                        safe -> open the PR
+                                 needs-attention -> fix, then open the PR
+                                        risky -> report to user, wait
 ```
 
 Additional gates:
-- `make quality` must pass (ruff check + format)
+- `make quality` must pass (ruff check + format) on every commit
 - Commit messages must not mention AI/Claude
 - PR title must follow `[{modules}] {type}: {description}` format

--- a/docs/usage/agent_workflow.md
+++ b/docs/usage/agent_workflow.md
@@ -6,7 +6,7 @@ VeOmni provides a skill-based workflow system that helps AI coding agents work o
 
 The workflow consists of three layers:
 
-```
+```text
 AGENTS.md                      <- Entry point: principles, skill dispatch, commit flow
 .agents/skills/                <- Skills: step-by-step workflows for common tasks
 .agents/knowledge/             <- Knowledge: constraints, architecture, dependency info
@@ -16,7 +16,7 @@ AGENTS.md                      <- Entry point: principles, skill dispatch, commi
 When an agent opens the project, it reads `AGENTS.md` (or its symlink `CLAUDE.md`) to understand:
 - **What constraints to follow** before making any change
 - **Which skill to use** for the task at hand
-- **How to commit** (mandatory code review gate)
+- **How to verify commits and review pull requests**
 
 ## Quick Start
 
@@ -27,7 +27,7 @@ If you are using Cursor or another AI coding tool on this project, the workflow 
 1. The agent reads `AGENTS.md` on session start.
 2. For each task, the agent selects the appropriate skill from the dispatch table (or auto-discovers it via the `description` frontmatter).
 3. The agent reads the skill's `SKILL.md` and follows its step-by-step instructions.
-4. Before opening a pull request, the agent runs the `/veomni-review` skill (a subagent code review over the branch diff).
+4. Before opening a pull request and before pushing a substantive update to an open one, the agent runs `/veomni-review` over the branch diff, following its applicability rules.
 
 **You don't need to do anything special** — just describe your task in natural language. You can also invoke a specific skill with `/skill-name` in chat (e.g., `/veomni-debug`).
 
@@ -50,7 +50,7 @@ If you are using Cursor or another AI coding tool on this project, the workflow 
 
 Each skill is a folder containing a `SKILL.md` file with YAML frontmatter (`name` and `description`):
 
-```
+```text
 .agents/skills/
 ├── veomni-develop/SKILL.md    # Feature development and refactoring
 ├── veomni-debug/SKILL.md      # Bug fix and debugging (quick path + full protocol)
@@ -109,16 +109,18 @@ See the [Agent Skills specification](https://agentskills.io/specification) for t
 
 ## Commit and review flow
 
-Commits stay cheap; the subagent review is owed once per pull request, over the
-whole branch diff, because the PR is the unit that lands:
+Run `/veomni-review` over the whole branch diff before opening a pull request
+and again before pushing a substantive update to an open one. Follow the
+skill's applicability rules, including self-checks for documentation-only changes:
 
-```
+```text
 each commit    -> make quality + your own verification
 
-before the PR  -> /veomni-review (subagent) -> Verdict
+before opening or substantively updating a PR
+               -> /veomni-review -> Verdict
                                                 |
-                                        safe -> open the PR
-                                 needs-attention -> fix, then open the PR
+                                        safe -> open or update the PR
+                                 needs-attention -> fix, then open or update the PR
                                         risky -> report to user, wait
 ```
 


### PR DESCRIPTION
> Remaining stack: #1137 → #1145 → #1147 → #1148. Each PR targets the branch below it; #1135 and #1136 are merged.

### What does this PR do?

Move the review gate from individual commits to the whole PR diff, before opening a PR and again before pushing a substantive update. Replace tool-specific instructions and duplicate skill indexes with the repository's shared dispatch and review rules.

### Checklist Before Starting

- Related work: #1136 defines test wiring; #1145, #1147 and #1148 continue the skill refactor.
- PR title follows the modules and types in `.github/workflows/check_pr_title.yml`.

### Test

No new runtime test needed: this PR changes only documentation and skill instructions. `make quality` with CI Ruff 0.13.2 and `make check-agent-docs` pass. The `uv pip freeze --python` command was checked against the installed CLI. Independent review passed.

### API and Usage Example

Commits require local verification and `make quality`. Apply `/veomni-review` before opening a PR or pushing a substantive update, using its documented applicability rules.

### Design & Code Changes

- Limit proactive review triggers to runtime/configuration changes; documentation-only edits use a self-check.
- Exempt only clean, exact reverts or reapplications of approved diffs without extra edits or conflict resolutions. `create-pr` delegates to the same rules.
- Compare package freezes during dependency bisects and reconcile every non-target difference. Transformers bisects use two worktrees with separate environments, codegen and reproducer commands.
- Align test-wiring guidance with directory-level CI coverage and the owning unit/e2e workflow.
- Remove the obsolete index explanation and make workflow diagrams and review cadence consistent.

### Checklist Before Submitting

- Applied lint, format and documentation-reference checks.
- Updated related skill and workflow documentation.
- No training scripts moved or renamed.
- No new runtime test needed; see Test.
