### PR TITLE
[model, ci] fix: pad Wan sequence before Ulysses SP slice to fix unpatchify mismatch

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -132,6 +132,7 @@ jobs:
           uv run --frozen pytest -s -x tests/parallel/ulysses/test_ulysses.py
           uv run --frozen pytest -s -x tests/parallel/ulysses/test_all_gather.py
           uv run --frozen pytest -s -x tests/parallel/ulysses/test_slice_input_tensor.py
+          uv run --frozen pytest -s -x tests/parallel/ulysses/test_wan_ulysses_padding.py
           uv run --frozen pytest -s -x tests/parallel/encoder_data_balance/test_balance_reverse.py
           uv run --frozen pytest -s -x tests/parallel/encoder_data_balance/test_balance_sorting_algo.py
           uv run --frozen pytest -s -x tests/parallel/test_ddp_sp_grad_sync.py

--- a/tests/parallel/ulysses/test_wan_self_attn_padding_mask.py
+++ b/tests/parallel/ulysses/test_wan_self_attn_padding_mask.py
@@ -1,0 +1,75 @@
+"""CPU-only correctness test for the Wan self-attention padding mask.
+
+Unlike `test_wan_ulysses_padding.py` (which needs NCCL/multi-process to exercise
+the actual Ulysses slice/gather), the mask itself is a single-process concern:
+does masking out the padded key positions with `eager_attention_forward`
+produce EXACTLY the same result as never having padded at all? This runs on
+CPU with no distributed setup.
+"""
+
+import torch
+
+from veomni.models.transformers.wan.modeling_wan import eager_attention_forward
+
+
+class _Module:
+    training = False
+
+
+def test_padding_mask_matches_unpadded_reference():
+    torch.manual_seed(0)
+    batch, heads, real_len, head_dim = 2, 4, 37, 16
+    pad_size = 3  # e.g. local_len=40, real_len=37 on the last SP rank
+
+    query = torch.randn(batch, heads, real_len, head_dim)
+    key_real = torch.randn(batch, heads, real_len, head_dim)
+    value_real = torch.randn(batch, heads, real_len, head_dim)
+
+    # Reference: no padding ever existed.
+    ref_output, _ = eager_attention_forward(_Module(), query, key_real, value_real, attention_mask=None)
+
+    # Padded: append zero keys/values (as `padding_tensor_for_seqeunce_parallel`
+    # does), mask them out exactly as WanModel.forward now does.
+    zeros = torch.zeros(batch, heads, pad_size, head_dim)
+    key_padded = torch.cat([key_real, zeros], dim=2)
+    value_padded = torch.cat([value_real, zeros], dim=2)
+
+    local_len = real_len + pad_size
+    mask = torch.zeros(1, 1, 1, local_len)
+    mask[..., local_len - pad_size :] = torch.finfo(torch.float32).min
+
+    padded_output, _ = eager_attention_forward(_Module(), query, key_padded, value_padded, attention_mask=mask)
+
+    torch.testing.assert_close(padded_output, ref_output, atol=1e-6, rtol=1e-5)
+
+
+def test_unmasked_padding_would_have_diverged():
+    """Sanity check that the test above is actually exercising something --
+    without the mask, padded zero-keys DO perturb the output, confirming the
+    fix is load-bearing rather than a no-op."""
+    torch.manual_seed(0)
+    batch, heads, real_len, head_dim = 2, 4, 37, 16
+    pad_size = 3
+
+    query = torch.randn(batch, heads, real_len, head_dim)
+    key_real = torch.randn(batch, heads, real_len, head_dim)
+    value_real = torch.randn(batch, heads, real_len, head_dim)
+
+    ref_output, _ = eager_attention_forward(_Module(), query, key_real, value_real, attention_mask=None)
+
+    zeros = torch.zeros(batch, heads, pad_size, head_dim)
+    key_padded = torch.cat([key_real, zeros], dim=2)
+    value_padded = torch.cat([value_real, zeros], dim=2)
+
+    unmasked_output, _ = eager_attention_forward(_Module(), query, key_padded, value_padded, attention_mask=None)
+
+    assert not torch.allclose(unmasked_output, ref_output, atol=1e-6, rtol=1e-5), (
+        "expected unmasked padding to perturb the output -- if this now passes, "
+        "the mask test above may not be exercising real behavior"
+    )
+
+
+if __name__ == "__main__":
+    test_padding_mask_matches_unpadded_reference()
+    test_unmasked_padding_would_have_diverged()
+    print("OK")

--- a/tests/parallel/ulysses/test_wan_ulysses_padding.py
+++ b/tests/parallel/ulysses/test_wan_ulysses_padding.py
@@ -1,0 +1,96 @@
+import sys
+
+import torch
+import torch.distributed as c10d
+
+from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
+
+
+if not c10d.is_available() or not c10d.is_backend_available(get_dist_comm_backend()):
+    print("c10d NCCL not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+import pytest
+from torch.testing._internal.common_utils import run_tests
+
+from veomni.distributed.sequence_parallel.comm import get_ulysses_sequence_parallel_group
+from veomni.distributed.sequence_parallel.data import gather_outputs, slice_input_tensor_scale_grad
+from veomni.distributed.sequence_parallel.utils import padding_tensor_for_seqeunce_parallel
+
+from .utils import SequenceParallelTest
+
+
+class WanUlyssesUnpatchifyPaddingTest(SequenceParallelTest):
+    """Regression test for VeOmni issue #61.
+
+    `WanModel.forward` slices its patchified sequence for Ulysses SP with
+    `slice_input_tensor_scale_grad`, which floor-divides
+    (`dim_size // seq_world_size`) instead of padding first. When the patchified
+    token count isn't evenly divisible by the SP size -- e.g. a (f=21, h=60,
+    w=45) grid gives f*h*w=56700 tokens, and 56700 % 8 == 4 under sp_size=8 --
+    the remainder tokens are silently dropped: only 56696 of 56700 tokens ever
+    reach any rank, and `unpatchify`'s einops rearrange then fails on the
+    now-mismatched shape.
+
+    This exercises the exact pad -> slice -> (identity op) -> gather -> unpad
+    sequence `modeling_wan.py` now runs, and asserts the round trip is lossless
+    and gradient-correct against a non-SP reference -- independent of the Wan
+    model's weights, since the bug is in the SP primitives, not the model.
+    """
+
+    @property
+    def world_size(self):
+        return 4
+
+    @pytest.mark.skipif(get_torch_device().device_count() < 4, reason="device_count should be >= 4")
+    def test_non_divisible_seq_len_round_trips_losslessly(self):
+        self._get_process_group()
+        sp_group = get_ulysses_sequence_parallel_group()
+
+        # f*h*w for a (21, 60, 45) grid, sp_size=8, from issue #61 -- kept here at
+        # world_size=4 (56700 % 4 == 0 would hide the bug), so instead use a
+        # length with the same "not a clean multiple of sp_size" property at
+        # world_size=4: 56700 - 56700 % 4 + 3 tokens short of the next multiple.
+        seq_len = 56700 - (56700 % self.world_size) + (self.world_size - 1)
+        assert seq_len % self.world_size != 0
+
+        hidden_dim = 16
+        full_input = torch.randn(1, seq_len, hidden_dim, device=get_device_type())
+        c10d.broadcast(full_input, src=0)
+        full_input.requires_grad_(True)
+
+        # -- the exact sequence WanModel.forward now runs --
+        unpadded_seq_len = full_input.shape[1]
+        padded = padding_tensor_for_seqeunce_parallel(full_input, dim=1, group=sp_group)
+        local = slice_input_tensor_scale_grad(padded, dim=1, group=sp_group)
+
+        # A stand-in for the transformer blocks: any elementwise op so autograd
+        # has something to differentiate through.
+        local_out = local * 2.0
+
+        gathered = gather_outputs(
+            local_out,
+            gather_dim=1,
+            padding_dim=1,
+            unpad_dim_size=unpadded_seq_len,
+            scale_grad=False,
+            group=sp_group,
+        )
+
+        assert gathered.shape[1] == seq_len, (
+            f"expected the full {seq_len} tokens back, got {gathered.shape[1]} "
+            f"(this is the exact failure mode of issue #61: floor-division in "
+            f"slice_input_tensor_scale_grad silently drops the remainder)"
+        )
+
+        expected = full_input * 2.0
+        torch.testing.assert_close(gathered, expected, atol=1e-6, rtol=1e-5)
+
+        gathered.sum().backward()
+        full_input_grad = full_input.grad.detach().clone()
+        # every element's grad should be exactly 2.0 (d/dx of x*2, summed)
+        torch.testing.assert_close(full_input_grad, torch.full_like(full_input_grad, 2.0))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/parallel/ulysses/test_wan_ulysses_padding.py
+++ b/tests/parallel/ulysses/test_wan_ulysses_padding.py
@@ -59,7 +59,7 @@ class WanUlyssesUnpatchifyPaddingTest(SequenceParallelTest):
         c10d.broadcast(full_input, src=0)
         full_input.requires_grad_(True)
 
-        # -- the exact sequence WanModel.forward now runs --
+        # The exact sequence WanModel.forward now runs.
         unpadded_seq_len = full_input.shape[1]
         padded = padding_tensor_for_seqeunce_parallel(full_input, dim=1, group=sp_group)
         local = slice_input_tensor_scale_grad(padded, dim=1, group=sp_group)

--- a/veomni/models/transformers/wan/modeling_wan.py
+++ b/veomni/models/transformers/wan/modeling_wan.py
@@ -33,6 +33,7 @@ from veomni.distributed.sequence_parallel.async_ulysses_dit import (
     async_ulysses_output_projection,
     async_ulysses_qkv_projection,
 )
+from veomni.distributed.sequence_parallel.utils import padding_tensor_for_seqeunce_parallel
 
 from ....utils import logging
 from .config_wan import WanConfig
@@ -603,8 +604,18 @@ class WanModel(PreTrainedModel):
             .to(x.device)
         )
 
+        # f*h*w is not guaranteed to be divisible by the Ulysses SP size (e.g. a
+        # 21x60x45 grid under sp_size=8 has 56700 tokens, and 56700 % 8 == 4).
+        # `slice_input_tensor_scale_grad` floor-divides internally
+        # (`dim_size // seq_world_size`), so an un-padded call silently drops the
+        # remainder tokens instead of distributing them to any rank. Pad both `x`
+        # and `freqs` up to a multiple of sp_size first, and strip the padding
+        # back off after the post-block gather using the true `f*h*w` length.
+        unpadded_seq_len = x.shape[1]
         if get_parallel_state().ulysses_enabled:
+            x = padding_tensor_for_seqeunce_parallel(x, dim=1)
             x = slice_input_tensor_scale_grad(x, dim=1)
+            freqs = padding_tensor_for_seqeunce_parallel(freqs, dim=0)
             freqs = slice_input_tensor_scale_grad(freqs, dim=0)
 
         cos = freqs.real.squeeze().contiguous()
@@ -628,7 +639,7 @@ class WanModel(PreTrainedModel):
         x = self.head(x, t)
 
         if get_parallel_state().ulysses_enabled:
-            x = gather_outputs(x, gather_dim=1)
+            x = gather_outputs(x, gather_dim=1, padding_dim=1, unpad_dim_size=unpadded_seq_len)
         x = self.unpatchify(x, (f, h, w))
         return x
 

--- a/veomni/models/transformers/wan/modeling_wan.py
+++ b/veomni/models/transformers/wan/modeling_wan.py
@@ -26,6 +26,7 @@ from veomni.distributed.parallel_state import get_parallel_state
 from veomni.distributed.sequence_parallel import (
     gather_outputs,
     gather_seq_scatter_heads,
+    get_ulysses_sequence_parallel_rank,
     get_ulysses_sequence_parallel_world_size,
     slice_input_tensor_scale_grad,
 )
@@ -313,7 +314,7 @@ class SelfAttention(nn.Module):
         self.attn = AttentionModule(config, self.num_heads, self.head_dim)
         self.sp_async = False
 
-    def forward(self, x, freqs, cos, sin, last_loss):
+    def forward(self, x, freqs, cos, sin, last_loss, self_attn_mask=None):
         if not self.sp_async:
             q = self.norm_q(self.q(x))
             k = self.norm_k(self.k(x))
@@ -337,7 +338,7 @@ class SelfAttention(nn.Module):
         q = rope_apply(q, freqs=freqs, cos=cos, sin=sin, head_dim=self.head_dim)
         k = rope_apply(k, freqs=freqs, cos=cos, sin=sin, head_dim=self.head_dim)
 
-        x = self.attn(q, k, v, last_loss=last_loss, isSelfAttn=True)
+        x = self.attn(q, k, v, last_loss=last_loss, isSelfAttn=True, attention_mask=self_attn_mask)
 
         if not self.sp_async:
             x = self.o(x)
@@ -437,12 +438,12 @@ class DiTBlock(nn.Module):
         self.modulation = nn.Parameter(torch.randn(1, 6, dim) / dim**0.5)
         self.gate = GateModule()
 
-    def forward(self, x, context, t_mod, freqs, cos, sin, last_loss):
+    def forward(self, x, context, t_mod, freqs, cos, sin, last_loss, self_attn_mask=None):
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
             self.modulation.to(dtype=t_mod.dtype, device=t_mod.device) + t_mod
         ).chunk(6, dim=1)
         input_x = modulate(self.norm1(x), shift_msa, scale_msa)
-        x = self.gate(x, gate_msa, self.self_attn(input_x, freqs, cos, sin, last_loss))
+        x = self.gate(x, gate_msa, self.self_attn(input_x, freqs, cos, sin, last_loss, self_attn_mask=self_attn_mask))
         x = x + self.cross_attn(self.norm3(x), context, skip_ulysses=True)
         input_x = modulate(self.norm2(x), shift_mlp, scale_mlp)
         x = self.gate(x, gate_mlp, self.ffn(input_x))
@@ -612,10 +613,33 @@ class WanModel(PreTrainedModel):
         # and `freqs` up to a multiple of sp_size first, and strip the padding
         # back off after the post-block gather using the true `f*h*w` length.
         unpadded_seq_len = x.shape[1]
+        self_attn_mask = None
         if get_parallel_state().ulysses_enabled:
+            sp_size = get_ulysses_sequence_parallel_world_size()
+            pad_size = (sp_size - unpadded_seq_len % sp_size) % sp_size
+            padded_seq_len = unpadded_seq_len + pad_size
+
             x = padding_tensor_for_seqeunce_parallel(x, dim=1)
-            x = slice_input_tensor_scale_grad(x, dim=1)
             freqs = padding_tensor_for_seqeunce_parallel(freqs, dim=0)
+
+            # Padding lands at the tail of the *global* sequence, and each rank
+            # gets an equal-size contiguous chunk after the slice below, so only
+            # the LAST rank's local shard can contain any padding. Build an
+            # additive self-attention mask over that rank's local key positions
+            # so the pad tokens (which the attention implementations here do not
+            # otherwise know about) can't influence real tokens' attention
+            # output. Only `eager_attention_forward` reads this today -- the
+            # flash_attention_3/sageattention wrappers below ignore
+            # `attention_mask` entirely, so this is a strict improvement where
+            # supported and a no-op (unchanged prior behavior) elsewhere. See PR
+            # discussion on #61 for the scope of what remains unmasked.
+            sp_rank = get_ulysses_sequence_parallel_rank()
+            if pad_size > 0 and sp_rank == sp_size - 1:
+                local_len = padded_seq_len // sp_size
+                self_attn_mask = torch.zeros(1, 1, 1, local_len, dtype=x.dtype, device=x.device)
+                self_attn_mask[..., local_len - pad_size :] = torch.finfo(x.dtype).min
+
+            x = slice_input_tensor_scale_grad(x, dim=1)
             freqs = slice_input_tensor_scale_grad(freqs, dim=0)
 
         cos = freqs.real.squeeze().contiguous()
@@ -632,9 +656,10 @@ class WanModel(PreTrainedModel):
                     cos,
                     sin,
                     last_loss=last_loss,
+                    self_attn_mask=self_attn_mask,
                 )
             else:
-                x = block(x, context, t_mod, freqs, cos, sin, last_loss=last_loss)
+                x = block(x, context, t_mod, freqs, cos, sin, last_loss=last_loss, self_attn_mask=self_attn_mask)
 
         x = self.head(x, t)
 

--- a/veomni/models/transformers/wan/modeling_wan.py
+++ b/veomni/models/transformers/wan/modeling_wan.py
@@ -315,6 +315,16 @@ class SelfAttention(nn.Module):
         self.sp_async = False
 
     def forward(self, x, freqs, cos, sin, last_loss, self_attn_mask=None):
+        if self_attn_mask is not None and not self.sp_async:
+            # The sync path attends only over this rank's local SP shard (see
+            # AttentionModule), so the global tail-padding mask built in
+            # WanModel.forward must be narrowed to this rank's own segment --
+            # every shard is equal-size since it was padded to a multiple of
+            # sp_size before slicing.
+            sp_rank = get_ulysses_sequence_parallel_rank()
+            local_len = x.shape[1]
+            self_attn_mask = self_attn_mask[..., sp_rank * local_len : (sp_rank + 1) * local_len]
+
         if not self.sp_async:
             q = self.norm_q(self.q(x))
             k = self.norm_k(self.k(x))
@@ -622,22 +632,26 @@ class WanModel(PreTrainedModel):
             x = padding_tensor_for_seqeunce_parallel(x, dim=1)
             freqs = padding_tensor_for_seqeunce_parallel(freqs, dim=0)
 
-            # Padding lands at the tail of the *global* sequence, and each rank
-            # gets an equal-size contiguous chunk after the slice below, so only
-            # the LAST rank's local shard can contain any padding. Build an
-            # additive self-attention mask over that rank's local key positions
-            # so the pad tokens (which the attention implementations here do not
-            # otherwise know about) can't influence real tokens' attention
-            # output. Only `eager_attention_forward` reads this today -- the
-            # flash_attention_3/sageattention wrappers below ignore
-            # `attention_mask` entirely, so this is a strict improvement where
-            # supported and a no-op (unchanged prior behavior) elsewhere. See PR
-            # discussion on #61 for the scope of what remains unmasked.
-            sp_rank = get_ulysses_sequence_parallel_rank()
-            if pad_size > 0 and sp_rank == sp_size - 1:
-                local_len = padded_seq_len // sp_size
-                self_attn_mask = torch.zeros(1, 1, 1, local_len, dtype=x.dtype, device=x.device)
-                self_attn_mask[..., local_len - pad_size :] = torch.finfo(x.dtype).min
+            # Build one GLOBAL additive mask over the padded tail, identical on
+            # every rank, marking the pad positions so they can't influence real
+            # tokens' attention output. `SelfAttention.forward` adapts it to
+            # whichever shape its attention call actually needs:
+            #   - sync path (`sp_async=False`, the only path Wan uses today):
+            #     each attention backend here runs on the LOCAL SP shard only,
+            #     so only the LAST rank's shard ever contains padding --
+            #     `SelfAttention` slices this mask down to its own local segment.
+            #   - async path (`sp_async=True`): `async_ulysses_qkv_projection`
+            #     all-to-alls K/V to their full GLOBAL length on every rank (its
+            #     own unpad call is a no-op here since it's told the padded, not
+            #     true, length), so every rank needs the full mask as-is.
+            # Only `eager_attention_forward` reads this today -- the
+            # flash_attention_3/sageattention wrappers ignore `attention_mask`
+            # entirely, so this is a strict improvement where supported and a
+            # no-op (unchanged prior behavior) elsewhere. See PR #1139 for the
+            # scope of what remains unmasked.
+            if pad_size > 0:
+                self_attn_mask = torch.zeros(1, 1, 1, padded_seq_len, dtype=x.dtype, device=x.device)
+                self_attn_mask[..., padded_seq_len - pad_size :] = torch.finfo(x.dtype).min
 
             x = slice_input_tensor_scale_grad(x, dim=1)
             freqs = slice_input_tensor_scale_grad(freqs, dim=0)


### PR DESCRIPTION
## What does this PR do?

Fixes #61. `WanModel.forward` slices its patchified sequence for Ulysses SP with `slice_input_tensor_scale_grad`, whose `_Slice.forward` does `local_input.split(dim_size // seq_world_size, dim=dim)[ctx.rank]` — a floor division. When `f*h*w` isn't evenly divisible by `sp_size`, `torch.split` produces a remainder chunk that is never read by any rank, so those tokens are silently dropped instead of reaching the SP group.

Issue #61's numbers: a `(f=21, h=60, w=45)` grid gives `f*h*w=56700` tokens. `56700 % 8 == 4` under `sp_size=8`, so `56700 // 8 = 7087` and `torch.split(x, 7087)` yields 8 chunks of 7087 (= 56696) plus a 9th 4-token remainder that's dropped. The post-block gather then comes back with 56696 tokens instead of 56700, and `unpatchify`'s einops rearrange fails with exactly the reported shape mismatch.

## Fix

Pad `x` and `freqs` to a multiple of `sp_size` before slicing (`padding_tensor_for_seqeunce_parallel`, already used elsewhere in this module) and strip the padding back off after the post-block gather using the true `f*h*w` length (`gather_outputs` already accepts `padding_dim`/`unpad_dim_size` for exactly this). Both helpers already exist in `veomni/distributed/sequence_parallel/`; `WanModel.forward` just wasn't calling them.

## Test

Added `tests/parallel/ulysses/test_wan_ulysses_padding.py`, exercising the exact pad → slice → (elementwise op) → gather → unpad sequence `WanModel.forward` now runs, at a sequence length deliberately not divisible by `sp_size`. Asserts:
- the round trip returns the full, un-truncated token count
- output values match a non-SP reference exactly
- gradients match a non-SP reference exactly

Wired into `gpu_unit_tests.yml` alongside the existing `tests/parallel/ulysses/` suite.

Also verified the root cause and fix numerically (CPU-only, `gloo` backend, no GPU) outside this repo before writing the patch — reproduced the exact `56700 → 56696` / `4 tokens lost` numbers from the issue with the current unpadded code path, then confirmed the padded version round-trips bit-for-bit to the original tensor.

### Checklist Before Starting

- Search for relative PRs/issues and link here: fixes #61, no other PR found addressing it
- PR title follows `[{modules}] {type}: {description}` format

### Checklist Before Submitting

- Read the Contribute Guide
- Applied pre-commit checks (`ruff check` / `ruff format --check` clean on changed files)
- Added tests to CI workflow

## AI Usage Disclaimer
- [x] AI assistance (Claude Code) was used for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Wan model reliability when processing sequence lengths that are not evenly divisible across parallel workers.
  - Preserved correct outputs and gradients during sequence-parallel processing.
  - Prevented padded tokens from affecting attention results.
  - Ensured outputs retain their original sequence length after processing.

- **Tests**
  - Added GPU coverage for non-divisible sequence lengths and sequence-parallel round trips.
  - Added CPU coverage validating attention behavior with padded sequence positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->