### PR TITLE
[docs] fix: clarify Ascend Docker page titles

### DIFF
--- a/docs/hardware_support/AscendDockerUsage/overview.md
+++ b/docs/hardware_support/AscendDockerUsage/overview.md
@@ -1,4 +1,4 @@
-## Quick Reference
+# Ascend Docker Overview
 
 - VeOmni is maintained by [ByteDance Seed](https://github.com/ByteDance-Seed/VeOmni).
 - Images are published at [quay.io/ascend/veomni](https://quay.io/repository/ascend/veomni).
@@ -16,6 +16,8 @@ The VeOmni Ascend images build on Huawei's [CANN (Compute Architecture for Neura
 ---
 
 ## Supported Images and Tag Naming Rules
+
+For the complete list of published image tags, see [Ascend Docker Supported Tags](supported_tags.md).
 
 ### Tag Naming Rules
 

--- a/docs/hardware_support/AscendDockerUsage/overview.md
+++ b/docs/hardware_support/AscendDockerUsage/overview.md
@@ -1,5 +1,7 @@
 # Ascend Docker Overview
 
+## Quick Reference
+
 - VeOmni is maintained by [ByteDance Seed](https://github.com/ByteDance-Seed/VeOmni).
 - Images are published at [quay.io/ascend/veomni](https://quay.io/repository/ascend/veomni).
 - Where to get help:
@@ -15,9 +17,7 @@ The VeOmni Ascend images build on Huawei's [CANN (Compute Architecture for Neura
 
 ---
 
-## Supported Images and Tag Naming Rules
-
-For the complete list of published image tags, see [Ascend Docker Supported Tags](supported_tags.md).
+## Tag Naming Rules and Supported Images
 
 ### Tag Naming Rules
 
@@ -45,6 +45,8 @@ All image tags follow this pattern:
 |---|---|---|---|
 | 910B (A2) | amd64 + arm64 | `v0.1.11-cann9.1.0-torch_npu2.10.0.post2-910b-ubuntu22.04-py3.12-veomni` | [x86](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.1.0_torch_npu2.10.0.post2_910b.x86) / [arm](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.1.0_torch_npu2.10.0.post2_910b.arm) |
 | A3 | arm64 | `v0.1.11-cann9.1.0-torch_npu2.10.0.post2-a3-ubuntu22.04-py3.12-veomni` | [a3](https://github.com/ByteDance-Seed/VeOmni/blob/main/docker/ascend/Dockerfile.ascend_9.1.0_torch_npu2.10.0.post2_a3) |
+
+For the complete list of published image tags, see [Ascend Docker Supported Tags](supported_tags.md).
 
 Notes:
 

--- a/docs/hardware_support/AscendDockerUsage/supported_tags.md
+++ b/docs/hardware_support/AscendDockerUsage/supported_tags.md
@@ -1,4 +1,4 @@
-# Supported Tags
+# Ascend Docker Supported Tags
 
 A full list of tags published at
 [quay.io/ascend/veomni](https://quay.io/repository/ascend/veomni?tab=tags).


### PR DESCRIPTION
[docs] fix: clarify Ascend Docker page titles

### What does this PR do?

> Give the Ascend Docker overview and tag inventory pages descriptive titles, retain the quick-reference section, and link the image list to the complete supported-tag list.

### Checklist Before Starting

- Search for relative PRs/issues and link here: N/A
- PR title follows `[{modules}] {type}: {description}` format

### Test

> - `git diff --check`
> - `python3 scripts/ci/check_doc_task_paths.py`
> - Independent VeOmni review: safe
>
> `make quality` reports an existing formatting issue in the unchanged `tests/parallel/ulysses/test_ulysses.py` file.

### API and Usage Example

> N/A. Documentation-only change.

### Design & Code Changes

> - Add `Ascend Docker Overview` as the page title while retaining `Quick Reference` as a second-level section.
> - Rename the rendered tag inventory title from `Supported Tags` to `Ascend Docker Supported Tags`.
> - Present tag naming before supported images and place a direct relative link after the image list table.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied relevant pre-commit checks
- [x] Updated documentation navigation and cross-links
- [x] No tests are required for this documentation-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Ascend Docker documentation headings for clearer navigation.
  * Added a quick reference section and improved the placement of the published image tags reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->