### PR TITLE
[agent, docs] refactor: rename the migrate skill to veomni-patchgen-model

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -11,15 +11,17 @@ Reusable skills and knowledge for AI coding agents working on VeOmni. Follows th
 │   ├── veomni-debug/
 │   ├── veomni-review/
 │   ├── veomni-new-model/
-│   ├── veomni-migrate-transformers-v5/
+│   ├── veomni-patchgen-model/
 │   ├── veomni-new-op/
 │   ├── veomni-uv-update/
 │   ├── veomni-profile/
 │   └── create-pr/
 ├── knowledge/           # Shared knowledge base
 │   ├── architecture.md
+│   ├── cloud_env.md
 │   ├── constraints.md
 │   ├── multimodal_metadata.md
+│   ├── testing.md
 │   └── uv.md
 ├── setup_agent.sh       # Bootstrap script (see below)
 └── README.md

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -61,7 +61,12 @@ The `knowledge/` directory contains domain-specific context loaded by agents on 
 ## Keeping these docs honest
 
 `make check-agent-docs` (run in CI by the **Check doc task paths** workflow)
-verifies that every repo path and skill name referenced from `AGENTS.md`,
-`.agents/**/*.md` and `.cursor/rules/*` actually exists. Use `<angle brackets>`
-for placeholders so they are skipped. It cannot check prose claims about
-behaviour — when you edit a skill, re-read the file it describes.
+resolves, in `AGENTS.md`, `.agents/**/*.md` and `.cursor/rules/*`: every
+repo-root-relative path, every bare `*.yml` workflow name, and every skill
+reference. Skill references are checked across the whole tracked tree, since a
+renamed skill also leaves dangling mentions in code comments. Use
+`<angle brackets>` for placeholders so they are skipped, and note that a bare
+`.py` name is deliberately not resolved — docs name upstream transformers
+modules and illustrative filenames that do not exist here. It cannot check
+prose claims about behaviour: when you edit a skill, re-read the file it
+describes.

--- a/.agents/skills/veomni-new-model/SKILL.md
+++ b/.agents/skills/veomni-new-model/SKILL.md
@@ -40,11 +40,17 @@ Phase 5: Test and document             -> pending
 1. **Create the model directory**: `veomni/models/transformers/<model_name>/`.
 
 2. **Switch to `/veomni-patchgen-model`.** It owns the whole modeling surface —
-   the `<model_name>_{gpu,npu}_patch_gen_config.py` files, `parallel_plan.py`
-   (FSDP wrapping plus EP for MoE), the MoE `checkpoint_tensor_converter.py`,
-   `__init__.py` registration, `make patchgen`, and the model-level test cases —
-   with the working examples and the pitfalls that cost the most time. Do not
-   re-derive it from this file.
+   the `<model_name>_{gpu,npu}_patch_gen_config.py` files, the MoE
+   `parallel_plan.py` and `checkpoint_tensor_converter.py`, `__init__.py`
+   registration, `make patchgen`, and the model-level test cases — with the
+   working examples and the pitfalls that cost the most time. Do not re-derive
+   it from this file.
+
+   Note that `parallel_plan.py` is **not** an FSDP wrapping policy: FSDP2 wraps
+   generically in `build_parallelize_model()`, and `ParallelPlan`
+   (`veomni/distributed/parallel_plan.py`) only describes ExtraParallel
+   EP/embedding sharding. Every `parallel_plan.py` in the repo belongs to a MoE
+   model; a dense model does not need one.
 
 3. **Exception — non-transformers architectures.** Diffusion models under
    `veomni/models/diffusers/<model_name>/`, and the `flux` / `movqgan` / `wan`

--- a/.agents/skills/veomni-new-model/SKILL.md
+++ b/.agents/skills/veomni-new-model/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: veomni-new-model
-description: "Use this skill when adding support for a new model to VeOmni. Covers the full lifecycle: analyzing the HuggingFace model, creating model patches, defining parallel plans, writing configs, integrating with the trainer, and testing. Trigger: 'add model', 'support new model', 'integrate a model', 'new model support'."
+description: "Use this skill when adding support for a new model to VeOmni. Owns the lifecycle around the modeling itself: analyzing the HuggingFace model, choosing the category, the training config, trainer and data-pipeline integration, tests and docs. The modeling patch itself is delegated to /veomni-patchgen-model. Trigger: 'add model', 'support new model', 'integrate a model', 'new model support'."
 ---
+
+> The hard part of a new transformers-family model — the patchgen config,
+> parallel plan, MoE weight conversion, `__init__.py` registration, codegen —
+> lives in `/veomni-patchgen-model`. This skill is the wrapper around it: it
+> decides *what* you are adding, then hands off, then does the config, trainer
+> and data work that patchgen does not cover.
 
 ## Before You Start: Create a Plan
 
@@ -9,11 +15,10 @@ Track the phases with whatever todo/plan tool the running agent provides:
 
 ```
 Phase 1: Analyze HF model             -> in_progress
-Phase 2: Create model patch            -> pending
-Phase 3: Define parallel plan          -> pending
-Phase 4: Write training config         -> pending
-Phase 5: Integrate with trainer        -> pending
-Phase 6: Test                          -> pending
+Phase 2: Modeling (/veomni-patchgen-model)  -> pending
+Phase 3: Write training config         -> pending
+Phase 4: Integrate with trainer        -> pending
+Phase 5: Test and document             -> pending
 ```
 
 ## Phase 1: Analyze HuggingFace Model
@@ -28,41 +33,28 @@ Phase 6: Test                          -> pending
 
 3. **Check existing similar models**: Find the closest existing model in `veomni/models/transformers/` and use it as a reference. E.g., if adding a new Qwen variant, reference `qwen3/` or `qwen3_vl/`.
 
-4. **Identify required patches**: VeOmni uses a patchgen system (`veomni/patchgen/`) to auto-generate model patches from HuggingFace models. Check if a patch spec already exists or if one needs to be created.
+4. **Identify required patches**: VeOmni uses a patchgen system (`veomni/patchgen/`) to generate model patches from the HuggingFace modeling. Check whether a sibling model already has a config you can extend via `name_map` — that is usually the difference between a 60-line config and a 1000-line one.
 
-## Phase 2: Create Model Patch
+## Phase 2: Modeling — hand off to `/veomni-patchgen-model`
 
-1. **Create the model directory**: `veomni/models/transformers/<model_name>/`
+1. **Create the model directory**: `veomni/models/transformers/<model_name>/`.
 
-2. **Required files**:
-   - `__init__.py` — model registration (`MODELING_REGISTRY` / `MODEL_CONFIG_REGISTRY` / `MODEL_PROCESSOR_REGISTRY`)
-   - `<model_name>_gpu_patch_gen_config.py` — declarative patchgen config (replace_class / override_method / replace_function / modify_init / add_post_import_block / drop_import_names) defining all VeOmni patches against the upstream HF modeling
-   - `<model_name>_npu_patch_gen_config.py` — NPU patchgen config (often just imports the GPU config and applies NPU-specific overrides via `name_map`)
-   - `parallel_plan.py` — FSDP / TP / EP sharding plan
-   - `generated/patched_modeling_<model_name>_{gpu,npu}.py` — patchgen output (do NOT edit manually)
+2. **Switch to `/veomni-patchgen-model`.** It owns the whole modeling surface —
+   the `<model_name>_{gpu,npu}_patch_gen_config.py` files, `parallel_plan.py`
+   (FSDP wrapping plus EP for MoE), the MoE `checkpoint_tensor_converter.py`,
+   `__init__.py` registration, `make patchgen`, and the model-level test cases —
+   with the working examples and the pitfalls that cost the most time. Do not
+   re-derive it from this file.
 
-3. **Patch patterns** — follow existing models:
-   - Sequence parallel: declare an `OpSlot` for attention/loss and override `forward` via patchgen
-   - MoE: stack per-expert weights (`gate_up_proj [E, 2*I, H]` / `down_proj [E, H, I]`) and add a `veomni_moe_experts_forward` `OpSlot`
-   - Cross-entropy: add a `veomni_causal_lm_loss` `OpSlot` and return `CausalLMOutputWithLogProbs`
-   - Register the model class in the model package `__init__.py` (no entry in `veomni/models/auto.py` is needed for transformers models — registration happens via the per-model `MODELING_REGISTRY` decorators)
+3. **Exception — non-transformers architectures.** Diffusion models under
+   `veomni/models/diffusers/<model_name>/`, and the `flux` / `movqgan` / `wan`
+   directories, have no `generated/` output and no patchgen config: they patch
+   through `device_patch.py` or direct modeling. Copy the closest existing one
+   and skip to Phase 3.
 
-4. **Run patchgen**: `make patchgen` regenerates every `generated/patched_modeling_*.py` from the matching `*_patch_gen_config.py`.
+Come back here once the model loads and its registry / patch tests pass.
 
-## Phase 3: Define Parallel Plan
-
-1. Create `parallel_plan.py` in the model directory.
-
-2. Define FSDP/FSDP2 sharding strategy:
-   - Which layers to wrap (typically transformer blocks)
-   - Activation checkpointing granularity
-   - Parameter dtype policies
-
-3. If the model is MoE, define expert parallelism plan in addition to FSDP.
-
-4. Reference existing parallel plans for guidance (e.g., `veomni/models/transformers/qwen3_moe/parallel_plan.py`).
-
-## Phase 4: Write Training Config
+## Phase 3: Write Training Config
 
 1. **Model config**: Create `configs/model_configs/<model_family>/<ModelName>.json` matching HuggingFace format.
 
@@ -75,7 +67,7 @@ Phase 6: Test                          -> pending
 
 4. **Verify against existing configs** — match the structure of similar model configs.
 
-## Phase 5: Integrate with Trainer
+## Phase 4: Integrate with Trainer
 
 1. Verify the model works with the appropriate trainer:
    - Text -> `TextTrainer` (`veomni/trainer/text_trainer.py`)
@@ -98,7 +90,7 @@ Phase 6: Test                          -> pending
    Model.forward → ViT.forward (with a runtime fallback), and the model added to
    `_MM_METADATA_WIRED_CASES` in the sync gate test.
 
-## Phase 6: Test
+## Phase 5: Test and Document
 
 1. **Create toy config**: Add `tests/toy_config/<model_name>_toy/config.json` with minimal parameters for fast testing.
 
@@ -124,6 +116,5 @@ Phase 6: Test                          -> pending
 ## Common Pitfalls
 
 - **Model registry**: Registration must happen at import time in `__init__.py`. If the model's `AutoConfig` type is not registered, `build_foundation_model()` will fail.
-- **Generated files**: Never edit files in `generated/` directories — they are overwritten by patchgen. Edit the matching `<model>_{gpu,npu}_patch_gen_config.py` and re-run `make patchgen` instead.
 - **Tokenizer compatibility**: Some models require specific tokenizer versions or custom chat templates — verify in `veomni/data/chat_template.py`.
-- **Transformers version**: All modeling targets `transformers==5.9.0` (pinned by the `transformers-stable` default dependency group). Models register through the patchgen-generated path under `generated/`; do not introduce legacy `modeling_<m>.py` files or `apply_veomni_<m>_patch()` helpers.
+- **Skipping the handoff**: the modeling pitfalls — never editing `generated/`, MoE expert layout, `name_map` reuse, Omni subtree exclusion — are in `/veomni-patchgen-model`, not here. This file deliberately does not restate them, so a summary read of Phase 2 is not enough to write a config.

--- a/.agents/skills/veomni-new-model/SKILL.md
+++ b/.agents/skills/veomni-new-model/SKILL.md
@@ -40,8 +40,8 @@ Phase 5: Test and document             -> pending
 1. **Create the model directory**: `veomni/models/transformers/<model_name>/`.
 
 2. **Switch to `/veomni-patchgen-model`.** It owns the whole modeling surface —
-   the `<model_name>_{gpu,npu}_patch_gen_config.py` files, the MoE
-   `parallel_plan.py` and `checkpoint_tensor_converter.py`, `__init__.py`
+   the `<model_name>_{gpu,npu}_patch_gen_config.py` files, ExtraParallel
+   `parallel_plan.py`, any required MoE `checkpoint_tensor_converter.py`, `__init__.py`
    registration, `make patchgen`, and the model-level test cases — with the
    working examples and the pitfalls that cost the most time. Do not re-derive
    it from this file.
@@ -49,8 +49,9 @@ Phase 5: Test and document             -> pending
    Note that `parallel_plan.py` is **not** an FSDP wrapping policy: FSDP2 wraps
    generically in `build_parallelize_model()`, and `ParallelPlan`
    (`veomni/distributed/parallel_plan.py`) only describes ExtraParallel
-   EP/embedding sharding. Every `parallel_plan.py` in the repo belongs to a MoE
-   model; a dense model does not need one.
+   sharding, such as expert parallelism or embedding sharding. Add a plan
+   whenever the model uses ExtraParallel, including dense models that shard
+   embeddings; a model without ExtraParallel does not need one.
 
 3. **Exception — non-transformers architectures.** Diffusion models under
    `veomni/models/diffusers/<model_name>/`, and the `flux` / `movqgan` / `wan`

--- a/.agents/skills/veomni-patchgen-model/SKILL.md
+++ b/.agents/skills/veomni-patchgen-model/SKILL.md
@@ -170,18 +170,19 @@ Drop phases that don't apply (e.g. Phase 3 for non-MoE models).
 
 ## Phase 1: Scope & Audit
 
-**Input**: model name `<M>` (e.g. `qwen3_5`, `glm4_moe`).
+**Input**: model name `<M>` (e.g. `qwen3_5`, `glm_moe_dsa`).
 
 **Operations:**
 
-1. Confirm model exists at `veomni/models/transformers/<M>/`. If not, the task is
-   "add new model" — use `/veomni-new-model` instead.
+1. Locate `veomni/models/transformers/<M>/`. If the directory does not exist yet
+   you are being called as the modeling step of `/veomni-new-model`: create it,
+   and read that skill's Phase 1 first so the category (text / VLM / Omni,
+   dense / MoE, GPU-only or GPU+NPU) is already decided when you get here.
 2. If a patchgen-generated file already exists under
    `veomni/models/transformers/<M>/generated/` you are **refreshing** an
    existing config (e.g. picking up upstream changes, adding NPU sibling,
-   fixing a bug). Otherwise you are adding patchgen support to a model whose
-   `__init__.py` previously imported HF classes directly. Either way, the rest
-   of this protocol applies identically.
+   fixing a bug). Otherwise you are writing the first config for this model.
+   Either way, the rest of this protocol applies identically.
 3. Decide backend coverage:
    - GPU only → one `<m>_gpu_patch_gen_config.py` + one
      `generated/patched_modeling_<m>_gpu.py`.
@@ -625,7 +626,9 @@ def register_<m>_modeling(architecture: str):
 
 ## Phase 5: Run Patchgen + Verify Diff
 
-1. Regenerate:
+1. Regenerate. `make patchgen` (`patchgen --all --diff`) rebuilds every model's
+   generated file, which is the safe default because it cannot leave a GPU/NPU
+   sibling behind. Target a single module only when you want a fast loop:
    ```bash
    patchgen \
        veomni.models.transformers.<m>.<m>_gpu_patch_gen_config \
@@ -667,8 +670,13 @@ and regenerate. This is a hard rule called out in `AGENTS.md`.
 ## Phase 6: Add Test Cases
 
 Follow `docs/transformers_v5/testing_new_model.md`. Every file below is already
-enumerated in the unit-test workflows, so appending a case needs no workflow
-change — that is exactly why this phase extends tables instead of adding files.
+enumerated in a CI workflow — the unit-test ones, or `gpu_e2e_test.yml` /
+`npu_e2e_test.yml` for the e2e tables — so appending a case needs no workflow
+change. That is exactly why this phase extends tables instead of adding files.
+`tests/models/test_model_registry.py` and
+`tests/models/test_models_logits_equal_v5.py` are part of the minimum too:
+the first proves the registry returns the generated class, the second that it
+is numerically equal to upstream.
 If you think you need a new test file, read `.agents/knowledge/testing.md` first.
 Minimum coverage:
 

--- a/.agents/skills/veomni-patchgen-model/SKILL.md
+++ b/.agents/skills/veomni-patchgen-model/SKILL.md
@@ -152,7 +152,7 @@ already gitignored so it won't leak into the repo).
 Track the phases with whatever todo/plan tool the running agent provides.
 Suggested plan:
 
-```
+```text
 Phase 0: Verify venv + drop HF reference files       -> in_progress
 Phase 1: Scope & audit upstream surface              -> pending
 Phase 2: Draft <model>_gpu_patch_gen_config.py       -> pending
@@ -161,7 +161,7 @@ Phase 4: Wire __init__.py to expose generated classes -> pending
 Phase 5: Run patchgen + verify diff                   -> pending
 Phase 6: Add test cases                               -> pending
 Phase 7: Run tests (single-GPU + e2e)                 -> pending
-Phase 8: Docs + commit; /veomni-review before the PR  -> pending
+Phase 8: Docs + commit; review before PR or substantive update -> pending
 ```
 
 Drop phases that don't apply (e.g. Phase 3 for non-MoE models).
@@ -447,7 +447,7 @@ Guidelines:
 
 **Regen command** (put at top of file as docstring, mirror qwen3):
 
-```
+```bash
 patchgen \
     veomni.models.transformers.<m>.<m>_gpu_patch_gen_config \
     -o veomni/models/transformers/<m>/generated --diff
@@ -786,9 +786,10 @@ Extra e2e gotchas:
      expectations or public APIs. Follow `[{modules}] {type}: {description}`.
      Example: `[veomni] feat: add patchgen-generated modeling for <m>`.
    - Commit message **must not** mention Claude / AI / Co-Authored-By.
-4. **Before opening the PR**: run `/veomni-review` over the branch diff. This
-   work touches `veomni/`, so the gate applies.
-   - `safe` / `needs-attention` → open the PR.
+4. **Before opening the PR or pushing a substantive update**: run
+   `/veomni-review` over the branch diff. This work touches `veomni/`, so the
+   gate applies.
+   - `safe` / `needs-attention` → address findings, then open or update the PR.
    - `risky` → report, wait for the user.
 
 ---

--- a/.agents/skills/veomni-patchgen-model/SKILL.md
+++ b/.agents/skills/veomni-patchgen-model/SKILL.md
@@ -1,22 +1,22 @@
 ---
-name: veomni-migrate-transformers-v5
-description: "Use this skill when adding or refreshing a patchgen-generated modeling file for a VeOmni model under its generated directory — GPU-only or GPU+NPU, dense or MoE, text-only / VLM / Omni-thinker+talker. Covers: creating GPU and NPU patchgen configs, using patchgen decorators (replace_class/override_method/replace_function/modify_init/add_post_import_block/drop_import_names), reusing sibling-model patches via name_map, handling MoE weight-loading (CheckpointTensorConverter + fused gate_up_proj layout), multimodal/VLM forward with Ulysses SP, excluding speech/vocoder subtrees in Omni models (talker/token2wav/DiT/BigVGAN), wiring __init__.py for the patchgen-generated classes, running codegen, and adding test cases. Trigger: 'port a model to patchgen', 'add patchgen for a model', 'transformers v5 migration', 'add NPU patchgen'. Do NOT edit files under generated/ manually — always regenerate via patchgen."
+name: veomni-patchgen-model
+description: "Author or refresh a VeOmni model's patchgen-generated modeling under generated/ — GPU and/or NPU config, dense or MoE, text / VLM / Omni. Covers the patchgen decorators, sharing patches across sibling models via name_map, MoE fused-expert weight loading, Ulysses SP in multimodal forwards, __init__.py registration, running codegen, and the test cases. This is the modeling step of adding a new model, not only of refreshing an existing one. Trigger: 'add patchgen for a model', 'write a patch_gen_config', 'regenerate the generated modeling', 'add NPU patchgen', 'port a model to patchgen', 'transformers v5 migration'. Never hand-edit anything under generated/."
 ---
 
-# VeOmni Transformers v5 Patchgen Protocol
+# VeOmni Patchgen Modeling Protocol
 
 Purpose: add or refresh a model's patchgen-generated modeling under
 `veomni/models/transformers/<model>/generated/`. VeOmni pins
 `transformers==5.9.0` and ships patchgen-generated modeling for every
-supported model; legacy v4 monkey-patches have been retired.
+supported transformers-family model. The non-transformers architectures
+(`flux`, `movqgan`, `wan`) have no `generated/` directory and are out of scope.
 
 **References (read first, load on demand):**
 
-- `docs/transformers_v5/index.md` — overview of what v5 migration covers
 - `docs/design/patchgen.md` — patchgen DSL, CLI, CI drift check
 - `docs/transformers_v5/transformers_v5_moe_weight_loading.md` — MoE fused-expert layout + runtime converter
 - `docs/transformers_v5/veomni_flash_attention_kernel_adapter.md` — FA custom-name adapter
-- `docs/transformers_v5/testing_new_model.md` — v5 test case SOP
+- `docs/transformers_v5/testing_new_model.md` — test case SOP for a new model
 
 **Working examples (copy the structure, do not edit `generated/`):**
 
@@ -1032,10 +1032,15 @@ Extra e2e gotchas:
 
 ## Scope Guard
 
-This skill adds or refreshes patchgen-generated modeling for an **existing**
-model directory under `veomni/models/transformers/`. For:
+This skill owns everything that produces `generated/patched_modeling_<m>_*.py`
+for a model under `veomni/models/transformers/` — for a brand-new model
+directory as much as for an existing one. For:
 
-- New model (does not yet exist under `veomni/models/transformers/`): use
+- The rest of onboarding a new model — deciding the model category, the
+  training config, trainer and data-pipeline integration, docs: use
+  `/veomni-new-model`, which hands the modeling step back here.
+- A diffusion or other non-transformers architecture (`veomni/models/diffusers/`,
+  or `flux` / `movqgan` / `wan`): patchgen does not apply — use
   `/veomni-new-model`.
 - New op / kernel: use `/veomni-new-op`.
 - uv / dependency bumps (e.g. upgrading the `transformers-stable` pin): use

--- a/.cursor/rules/no-section-divider-comments.mdc
+++ b/.cursor/rules/no-section-divider-comments.mdc
@@ -38,4 +38,4 @@ These add visual noise without value. If code needs grouping, use module-level o
 
 headers plus inline `# --- Patch.N ---` markers are a required convention: they
 survive into the generated file and are what makes it reviewable against the
-upstream HuggingFace source. See `.agents/skills/veomni-migrate-transformers-v5/SKILL.md`.
+upstream HuggingFace source. See `.agents/skills/veomni-patchgen-model/SKILL.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Skills follow the [Agent Skills](https://agentskills.io) open standard. Each ski
 | Bug fix / debugging | `/veomni-debug` |
 | Code review (before opening a PR) | `/veomni-review` |
 | Add new model | `/veomni-new-model` |
-| Migrate existing model to transformers v5 | `/veomni-migrate-transformers-v5` |
+| Write or refresh a model's patchgen modeling | `/veomni-patchgen-model` |
 | Add new op/kernel | `/veomni-new-op` |
 | Update dependencies (uv) | `/veomni-uv-update` |
 | Performance profiling | `/veomni-profile` |
@@ -112,7 +112,7 @@ Skills follow the [Agent Skills](https://agentskills.io) open standard. Each ski
 ### Quick Decision Guide
 
 - **"Add support for model X"** → `/veomni-new-model`
-- **"Migrate X to transformers v5" / "port X to patchgen" / "convert monkey patch to generated modeling"** → `/veomni-migrate-transformers-v5`
+- **"Write a patch_gen_config" / "regenerate the generated modeling" / "add NPU patchgen" / "port X to patchgen"** → `/veomni-patchgen-model` (also the modeling step inside `/veomni-new-model`)
 - **"Add a new kernel / fused op"** → `/veomni-new-op`
 - **"Fix this error" / "training hangs" / "wrong results"** → `/veomni-debug`
 - **"Add a new capability" / "refactor" / "clean up"** → `/veomni-develop`

--- a/docs/usage/agent_workflow.md
+++ b/docs/usage/agent_workflow.md
@@ -40,7 +40,7 @@ If you are using Cursor or another AI coding tool on this project, the workflow 
 | "Add a fused RoPE kernel" | `/veomni-new-op` |
 | "Refactor the data collator" | `/veomni-develop` |
 | "Update torch to 2.10" | `/veomni-uv-update` |
-| "Port Qwen3 to transformers v5 patchgen" | `/veomni-migrate-transformers-v5` |
+| "Write the patchgen config for Qwen3" | `/veomni-patchgen-model` |
 | "Analyze this Chrome trace" | `/veomni-profile` |
 | "Submit the current branch as a PR" | `/create-pr` |
 
@@ -56,7 +56,7 @@ Each skill is a folder containing a `SKILL.md` file with YAML frontmatter (`name
 ├── veomni-debug/SKILL.md      # Bug fix and debugging (quick path + full protocol)
 ├── veomni-review/SKILL.md     # Pre-PR code review (mandatory)
 ├── veomni-new-model/SKILL.md  # Add a new model to VeOmni
-├── veomni-migrate-transformers-v5/SKILL.md  # Migrate model patches to transformers v5
+├── veomni-patchgen-model/SKILL.md  # Author a model's patchgen-generated modeling
 ├── veomni-new-op/SKILL.md     # Add a new kernel/operator
 ├── veomni-uv-update/SKILL.md  # Dependency management with uv
 ├── veomni-profile/SKILL.md    # Performance profiling and optimization

--- a/docs/usage/support_new_models/guide_and_checklist.md
+++ b/docs/usage/support_new_models/guide_and_checklist.md
@@ -14,7 +14,7 @@
 > happening in `<model>_gpu_patch_gen_config.py`. For step-by-step
 > instructions on the patchgen flow, see
 > [the patchgen design guide](../../design/patchgen.md) and
-> the `veomni-migrate-transformers-v5` agent skill.
+> the `veomni-patchgen-model` agent skill.
 
 ---
 

--- a/docs/usage/support_new_models/qwen3_omni_moe_example.md
+++ b/docs/usage/support_new_models/qwen3_omni_moe_example.md
@@ -13,7 +13,7 @@ This document provides in-depth implementation details for each patch applied in
 > (declarative patchgen config emitted into `generated/`) rather than applied
 > at import time. See
 > [the patchgen design guide](../../design/patchgen.md) and
-> the `veomni-migrate-transformers-v5` agent skill for the current flow.
+> the `veomni-patchgen-model` agent skill for the current flow.
 
 ---
 

--- a/docs/usage/support_new_models/qwen3_vl_example.md
+++ b/docs/usage/support_new_models/qwen3_vl_example.md
@@ -12,7 +12,7 @@ This document walks through the specific patches applied to integrate **Qwen3-VL
 > what has changed is *where* the patches are declared (in the patchgen config
 > and emitted into `generated/`) rather than applied at import time. See
 > [the patchgen design guide](../../design/patchgen.md) and
-> the `veomni-migrate-transformers-v5` agent skill for the current flow.
+> the `veomni-patchgen-model` agent skill for the current flow.
 
 ---
 

--- a/scripts/ci/check_agent_doc_paths.py
+++ b/scripts/ci/check_agent_doc_paths.py
@@ -51,8 +51,11 @@ SKIP_ROOTS = frozenset({".git", ".venv", ".pr-drafts", ".agents_workspace"})
 INLINE_CODE = re.compile(r"`([^`\n]+)`")
 # [label](target)
 LINK_TARGET = re.compile(r"\]\(([^)\s]+)\)")
-# /skill-name, as used in the dispatch tables and cross-references
-SKILL_REF = re.compile(r"(?<![\w/])/(veomni-[a-z0-9-]+|create-pr)\b")
+# /skill-name, as used in the dispatch tables and cross-references. The
+# lookbehind also rejects `.`, so a relative path to a sibling checkout
+# (`../veomni-a`) is not mistaken for a skill -- the repo is called VeOmni, so
+# those paths turn up in docs.
+SKILL_REF = re.compile(r"(?<![\w/.])/(veomni-[a-z0-9-]+|create-pr)\b")
 # "`<name>` skill" / "skill `<name>`" -- prose references to a skill
 SKILL_PROSE = re.compile(r"`([a-z][a-z0-9-]{2,})`\s+skill\b|\bskill\s+`([a-z][a-z0-9-]{2,})`")
 
@@ -196,9 +199,13 @@ def main() -> int:
         print(f"error: .agents directory not found under {repo_root}", file=sys.stderr)
         return 2
 
+    # scan() already checks skill refs inside the doc globs, so the repo-wide
+    # pass re-reports those. Deduplicate on the whole message: keying on the
+    # file alone would drop a genuine skill error just because that file
+    # happened to have an unrelated path error.
     errors = scan(repo_root)
-    doc_paths = {error.split(":", 1)[0] for error in errors}
-    errors += [error for error in scan_skill_refs(repo_root) if error.split(":", 1)[0] not in doc_paths]
+    seen = set(errors)
+    errors += [error for error in scan_skill_refs(repo_root) if error not in seen]
     if errors:
         print("Agent docs reference paths or skills that do not exist:\n", file=sys.stderr)
         for message in errors:

--- a/scripts/ci/check_agent_doc_paths.py
+++ b/scripts/ci/check_agent_doc_paths.py
@@ -12,8 +12,18 @@ What is checked, in ``AGENTS.md``, ``.agents/**/*.md`` and ``.cursor/rules/*``:
   i.e. whose first segment matches an entry that exists at the repo root -- must
   resolve to a real file or directory. A ``path.py::symbol`` reference is
   checked as ``path.py``.
+* A bare ``*.yml`` / ``*.yaml`` filename must match a tracked file's basename.
+  Docs name workflows this way far more often than by full path, and a deleted
+  workflow is exactly the rot this check exists to catch. Other slash-less
+  references are skipped: docs legitimately name upstream transformers modules
+  and illustrative filenames that do not exist here.
 * ``/skill-name`` references must resolve to ``.agents/skills/<name>/SKILL.md``.
-* So must a backticked name used as a skill, as in "see ``some-skill`` skill".
+* So must a backticked name used in prose skill form, as in "see the
+  ``<name>`` skill".
+
+Skill references are additionally checked across every tracked text file, not
+just the doc globs: a renamed skill leaves dangling ``/skill-name`` mentions in
+code comments and workflow files too.
 
 Anything containing a placeholder (``<m>``, ``*``, ``{a,b}``, ``$VAR``, ...) is
 skipped, as are relative fragments whose first segment is not a repo-root entry
@@ -26,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -42,22 +53,32 @@ INLINE_CODE = re.compile(r"`([^`\n]+)`")
 LINK_TARGET = re.compile(r"\]\(([^)\s]+)\)")
 # /skill-name, as used in the dispatch tables and cross-references
 SKILL_REF = re.compile(r"(?<![\w/])/(veomni-[a-z0-9-]+|create-pr)\b")
-# "`some-name` skill" / "skill `some-name`" -- prose references to a skill
+# "`<name>` skill" / "skill `<name>`" -- prose references to a skill
 SKILL_PROSE = re.compile(r"`([a-z][a-z0-9-]{2,})`\s+skill\b|\bskill\s+`([a-z][a-z0-9-]{2,})`")
 
 # Placeholders and shell syntax: not literal paths.
 PLACEHOLDER_CHARS = set("<>*?{}$()|\"' \t")
 
+# Slash-less references worth resolving by basename. Deliberately narrow: a bare
+# `.py` name is usually an upstream transformers module or an example filename.
+BARE_NAME_SUFFIXES = frozenset({".yml", ".yaml"})
+
+# Repo-wide skill-reference scan: skip anything that is not plausibly text.
+TEXT_SUFFIXES = frozenset(
+    {".py", ".md", ".mdc", ".yml", ".yaml", ".toml", ".cfg", ".ini", ".sh", ".txt", ".json", ".j2", ""}
+)
+MAX_SCAN_BYTES = 2 * 1024 * 1024
+
 
 def looks_like_path(candidate: str) -> bool:
-    if "/" not in candidate:
-        return False
     if candidate.startswith(("http://", "https://", "//")):
         return False
     if any(char in PLACEHOLDER_CHARS for char in candidate):
         return False
     if ".." in candidate:
         return False
+    if "/" not in candidate:
+        return Path(candidate).suffix in BARE_NAME_SUFFIXES
     return True
 
 
@@ -78,6 +99,7 @@ def collect(text: str) -> set[str]:
 
 def scan(repo_root: Path) -> list[str]:
     roots = repo_root_entries(repo_root)
+    basenames = {path.name for path in tracked_files(repo_root)}
     errors: list[str] = []
 
     files: list[Path] = []
@@ -93,6 +115,10 @@ def scan(repo_root: Path) -> list[str]:
         for raw in sorted(collect(text)):
             candidate = normalize(raw.strip())
             if not looks_like_path(candidate):
+                continue
+            if "/" not in candidate:
+                if candidate not in basenames:
+                    errors.append(f"{where}: references missing file `{candidate}`")
                 continue
             if candidate.split("/", 1)[0] not in roots:
                 continue
@@ -112,6 +138,49 @@ def scan(repo_root: Path) -> list[str]:
     return errors
 
 
+def tracked_files(repo_root: Path) -> list[Path]:
+    """Every git-tracked file, as absolute paths."""
+    try:
+        listing = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files", "-z"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    return [repo_root / name for name in listing.split("\0") if name]
+
+
+def tracked_text_files(repo_root: Path) -> list[Path]:
+    """Every git-tracked file that is plausibly text, for the skill-name scan."""
+    return [
+        path
+        for path in tracked_files(repo_root)
+        if path.suffix in TEXT_SUFFIXES and path.is_file() and path.stat().st_size <= MAX_SCAN_BYTES
+    ]
+
+
+def scan_skill_refs(repo_root: Path) -> list[str]:
+    """Flag `/skill-name` references anywhere in the tree that resolve to nothing."""
+    errors: list[str] = []
+    for path in tracked_text_files(repo_root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        # ``name`` is the reST convention in Python docstrings; fold it so the
+        # prose form ("see the ``<name>`` skill") matches the same way as in Markdown.
+        text = text.replace("``", "`")
+        named = set(SKILL_REF.findall(text))
+        for before, after in SKILL_PROSE.findall(text):
+            named.add(before or after)
+        for skill in sorted(named):
+            if not (repo_root / ".agents" / "skills" / skill / "SKILL.md").is_file():
+                errors.append(f"{path.relative_to(repo_root)}: references missing skill `/{skill}`")
+    return errors
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -128,6 +197,8 @@ def main() -> int:
         return 2
 
     errors = scan(repo_root)
+    doc_paths = {error.split(":", 1)[0] for error in errors}
+    errors += [error for error in scan_skill_refs(repo_root) if error.split(":", 1)[0] not in doc_paths]
     if errors:
         print("Agent docs reference paths or skills that do not exist:\n", file=sys.stderr)
         for message in errors:

--- a/scripts/ci/check_agent_doc_paths.py
+++ b/scripts/ci/check_agent_doc_paths.py
@@ -66,10 +66,7 @@ PLACEHOLDER_CHARS = set("<>*?{}$()|\"' \t")
 # `.py` name is usually an upstream transformers module or an example filename.
 BARE_NAME_SUFFIXES = frozenset({".yml", ".yaml"})
 
-# Repo-wide skill-reference scan: skip anything that is not plausibly text.
-TEXT_SUFFIXES = frozenset(
-    {".py", ".md", ".mdc", ".yml", ".yaml", ".toml", ".cfg", ".ini", ".sh", ".txt", ".json", ".j2", ""}
-)
+# Bound the repo-wide scan; UTF-8 decoding below skips binary files.
 MAX_SCAN_BYTES = 2 * 1024 * 1024
 
 
@@ -156,12 +153,8 @@ def tracked_files(repo_root: Path) -> list[Path]:
 
 
 def tracked_text_files(repo_root: Path) -> list[Path]:
-    """Every git-tracked file that is plausibly text, for the skill-name scan."""
-    return [
-        path
-        for path in tracked_files(repo_root)
-        if path.suffix in TEXT_SUFFIXES and path.is_file() and path.stat().st_size <= MAX_SCAN_BYTES
-    ]
+    """Bounded git-tracked candidates; the caller skips files that fail UTF-8 decoding."""
+    return [path for path in tracked_files(repo_root) if path.is_file() and path.stat().st_size <= MAX_SCAN_BYTES]
 
 
 def scan_skill_refs(repo_root: Path) -> list[str]:

--- a/tests/models/test_model_forward_no_implicit_sync.py
+++ b/tests/models/test_model_forward_no_implicit_sync.py
@@ -49,8 +49,8 @@ turning a 0-D GPU scalar into a Python int (``.item()`` / ``int(t)``),
 slicing with a GPU tensor, calling ``repeat_interleave(GPU_repeats)``,
 ``if gpu_tensor:``, etc. Invisible during compute-heavy steps; expensive
 under SP/EP and small micro-batches, and can cascade into NCCL watchdog
-timeouts. See the ``debug-cuda-sync`` skill for the manual investigation
-flow against real weights.
+timeouts. See ``/veomni-debug`` for the manual investigation flow against
+real weights.
 
 This test is the *unit-level ratchet*: it runs on toy configs (so only
 catches sync sites reachable from a tiny forward) and is cheap enough

--- a/tests/models/test_models_patch.py
+++ b/tests/models/test_models_patch.py
@@ -328,8 +328,8 @@ class TrainerTest(BaseTrainer):
 _DEFAULT_RTOL = 1e-2
 _DEFAULT_ATOL = 1e-2
 
-# Models without a patchgen path are not covered here. Migrate them via
-# ``/veomni-migrate-transformers-v5`` to bring them back into this list.
+# Models without a patchgen path are not covered here. Add one via
+# ``/veomni-patchgen-model`` to bring them back into this list.
 TEST_CASES = [
     pytest.param(
         "./tests/toy_config/llama31_toy/config.json",


### PR DESCRIPTION
> Remaining stack: #1137 → #1145 → #1147 → #1148. Each PR targets the branch below it; #1135 and #1136 are merged.

### What does this PR do?

Rename `veomni-migrate-transformers-v5` to `veomni-patchgen-model` and make `veomni-new-model` hand off modeling work to it. Extend the reference checker so a skill rename cannot silently leave stale references in tracked text files outside the agent documentation.

### Checklist Before Starting

- Related work: #1137 establishes the review workflow; #1147 splits the renamed skill into category references.
- PR title follows the modules and types in `.github/workflows/check_pr_title.yml`.

### Test

The existing CI documentation checker covers this behavior; no new test file or workflow entry is required. Temporary Git-repository regression fixtures demonstrated that `.rst`, `.mdx` and `.ipynb` references were missed before the fix and are detected afterward. Valid references, undecodable binary files, files above the size limit and untracked files were also checked.

`make check-agent-docs`, `make quality` with CI Ruff 0.13.2, and explicit lint/format checks of `scripts/ci/check_agent_doc_paths.py` pass. Independent review passed.

### API and Usage Example

Use `/veomni-patchgen-model` to author or refresh generated modeling; `/veomni-new-model` owns model selection, configs, trainer and data integration. Non-transformers architectures follow the existing direct-modeling workflow.

### Design & Code Changes

- Update skill names and references across docs, agent guidance and test docstrings.
- Scan bounded tracked files regardless of filename suffix; UTF-8 decoding filters binary files.
- Keep `parallel_plan.py` scoped to all models using ExtraParallel, including embedding sharding in dense models; it is not an FSDP wrapping policy.
- Preserve the codegen and registry-test handoff, and require review before substantive PR updates as well as creation.

### Checklist Before Submitting

- Applied lint, format and documentation-reference checks.
- Updated skill names, workflow documentation and model handoff guidance.
- No training scripts moved or renamed.
- Existing CI checker plus temporary regression fixtures used; see Test.
