### PR TITLE
[agent, docs] refactor: describe the agent tooling generically

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,6 +1,6 @@
 # .agents/ — Shared Agent Configuration
 
-Reusable skills and knowledge for AI coding agents working on VeOmni. Follows the [Agent Skills](https://agentskills.io) open standard — compatible with Gemini, Codex, Claude Code, Cursor, and other agents.
+Reusable skills and knowledge for AI coding agents working on VeOmni. Follows the [Agent Skills](https://agentskills.io) open standard, so any agent that implements it can use these as-is.
 
 ## Structure
 
@@ -18,8 +18,8 @@ Reusable skills and knowledge for AI coding agents working on VeOmni. Follows th
 │   └── create-pr/
 ├── knowledge/           # Shared knowledge base
 │   ├── architecture.md
-│   ├── cloud_env.md
 │   ├── constraints.md
+│   ├── cpu_only_env.md
 │   ├── multimodal_metadata.md
 │   ├── testing.md
 │   └── uv.md
@@ -29,13 +29,12 @@ Reusable skills and knowledge for AI coding agents working on VeOmni. Follows th
 
 ## Quick Start
 
-Some agents natively support the `.agents/` directory and will auto-discover skills and knowledge — no extra setup needed.
+Some agents read the `.agents/` directory natively and will auto-discover skills and knowledge — no extra setup needed.
 
-For agents that require their own dotfile directory, run the bootstrap script:
+For an agent that insists on its own dotfile directory, run the bootstrap script with that agent's name:
 
 ```bash
-# Example: set up for Gemini (replace with your agent name)
-bash .agents/setup_agent.sh gemini
+bash .agents/setup_agent.sh <agent-name>
 ```
 
 This will:
@@ -54,6 +53,7 @@ The `knowledge/` directory contains domain-specific context loaded by agents on 
 
 - **architecture.md** — module map, trainer hierarchy, data flow
 - **constraints.md** — hard constraints checked before any code change
+- **cpu_only_env.md** — what can be verified without a GPU/NPU
 - **multimodal_metadata.md** — canonical multimodal metadata keys and ownership
 - **testing.md** — how CI selects tests; whether a change needs one and where it goes
 - **uv.md** — dependency management architecture

--- a/.agents/knowledge/cpu_only_env.md
+++ b/.agents/knowledge/cpu_only_env.md
@@ -1,14 +1,21 @@
-# Cursor Cloud (CPU-only) Environment
+# CPU-only Environment
 
-Notes for agents running on the Cursor Cloud VM. Not relevant to GPU CI or local
-GPU/NPU dev boxes.
+What you can and cannot verify on a machine with no GPU or NPU — a hosted agent
+VM, a laptop, or any CPU box. Not relevant to GPU CI or local GPU/NPU dev boxes.
 
-The Cursor Cloud VM is **CPU-only (no GPU/NPU), x86_64, Python 3.12**. The
-startup update script already runs `uv sync --extra gpu --dev`, so `.venv` is
-ready — activate it with `source .venv/bin/activate` before any command. `uv`
-is installed under `~/.local/bin` (on `PATH` via `~/.bashrc`); the `gpu` extra's
-CUDA torch wheels install fine here and `torch.cuda.is_available()` is `False`.
-Do not add `--extra magi` on this VM: MagiAttention source-builds CUDA
+The `gpu` extra's CUDA torch wheels install fine on a CPU-only x86_64 host;
+`torch.cuda.is_available()` is simply `False`. So the normal setup works:
+
+```bash
+uv sync --extra gpu --dev
+source .venv/bin/activate
+```
+
+Some hosted environments pre-run that sync in a startup script, in which case
+`.venv` already exists and you only need to activate it. If `uv` is not on
+`PATH`, check `~/.local/bin`.
+
+Do not add `--extra magi` on a CPU-only host: MagiAttention source-builds CUDA
 extensions and is NVIDIA SM90+ only.
 
 ## What works CPU-only (use these to validate changes without hardware)

--- a/.agents/setup_agent.sh
+++ b/.agents/setup_agent.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Sets up a .<agent_name>/ directory with symlinks to shared .agents/ resources.
 # Usage: bash .agents/setup_agent.sh <agent_name>
-# Example: bash .agents/setup_agent.sh gemini
+# The name is whatever dotfile directory your agent expects, minus the leading
+# dot -- e.g. passing "foo" creates .foo/ pointing at .agents/.
 set -euo pipefail
 
-AGENT_NAME="${1:?Usage: bash .agents/setup_agent.sh <agent_name> (e.g., gemini, codex)}"
+AGENT_NAME="${1:?Usage: bash .agents/setup_agent.sh <agent_name>}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TARGET_DIR="${REPO_ROOT}/.${AGENT_NAME}"
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,6 +1,6 @@
 # VeOmni Agent Skills
 
-Reusable workflow definitions for AI coding agents working on VeOmni. Skills follow the [Agent Skills](https://agentskills.io) open standard and are auto-discovered by compatible agents (Cursor, Claude Code, Codex, Junie, etc.).
+Reusable workflow definitions for AI coding agents working on VeOmni. Skills follow the [Agent Skills](https://agentskills.io) open standard, so any agent that implements it auto-discovers them.
 
 ## Structure
 

--- a/.agents/skills/veomni-patchgen-model/SKILL.md
+++ b/.agents/skills/veomni-patchgen-model/SKILL.md
@@ -591,8 +591,10 @@ Extra e2e gotchas:
    - Title: `[BREAKING]` only if the change alters checkpoint format
      expectations or public APIs. Follow `[{modules}] {type}: {description}`.
      Example: `[veomni] feat: add patchgen-generated modeling for <m>`.
-   - Commit message describes the change, not the tool that produced it — no
-     agent or model names, no `Co-Authored-By` trailers.
+   - Commit message describes the change, not the tool that produced it — do
+     not name the assistant or agent that wrote it, and no `Co-Authored-By`
+     trailers. Naming the *model being added* is of course expected; that is
+     the change.
 4. **Before opening the PR or pushing a substantive update**: run
    `/veomni-review` over the branch diff. This work touches `veomni/`, so the
    gate applies.

--- a/.agents/skills/veomni-patchgen-model/SKILL.md
+++ b/.agents/skills/veomni-patchgen-model/SKILL.md
@@ -591,7 +591,8 @@ Extra e2e gotchas:
    - Title: `[BREAKING]` only if the change alters checkpoint format
      expectations or public APIs. Follow `[{modules}] {type}: {description}`.
      Example: `[veomni] feat: add patchgen-generated modeling for <m>`.
-   - Commit message **must not** mention Claude / AI / Co-Authored-By.
+   - Commit message describes the change, not the tool that produced it — no
+     agent or model names, no `Co-Authored-By` trailers.
 4. **Before opening the PR or pushing a substantive update**: run
    `/veomni-review` over the branch diff. This work touches `veomni/`, so the
    gate applies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Title: `[{modules}] {type}: {description}`
 2. Update related documentation: `docs/`, `README.md`, `.agents/knowledge/`, config examples — if the change introduces, modifies, or removes any API, config field, or workflow.
 3. Run `make quality` before every commit.
 4. Each fix -> immediate commit. Do not batch unrelated changes.
-5. **Commit messages describe the change, not the tool that produced it** — no agent or model names, and no `Co-Authored-By` trailers.
+5. **Commit messages describe the change, not the tool that produced it** — do not name the assistant or agent that wrote it, and no `Co-Authored-By` trailers. (Naming a *model being added* is expected — that is the change.)
 6. **Skill gap check**: If the task didn't match any existing skill, briefly assess after completion: Was this a one-off, or a repeatable pattern? If repeatable, suggest creating a new skill to the user.
 
 The subagent review gate is **per PR, not per commit** — see **PR Guidelines**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ On session start, read the following:
 - `.agents/knowledge/constraints.md` — hard constraints to check before any code change
 - `.agents/knowledge/architecture.md` — module map, trainer hierarchy, data flow
 - `.agents/knowledge/uv.md` — dependency management architecture (uv, extras, lockfile)
-- `.agents/knowledge/cloud_env.md` — Cursor Cloud (CPU-only VM) setup; read when running on the Cursor Cloud VM
+- `.agents/knowledge/cpu_only_env.md` — what can be verified without a GPU/NPU; read when running on a CPU-only machine
 
 Read on demand:
 - `.agents/knowledge/testing.md` — how CI selects tests, and how to decide whether a change needs one; read before adding or wiring a test
@@ -83,7 +83,7 @@ Title: `[{modules}] {type}: {description}`
 2. Update related documentation: `docs/`, `README.md`, `.agents/knowledge/`, config examples — if the change introduces, modifies, or removes any API, config field, or workflow.
 3. Run `make quality` before every commit.
 4. Each fix -> immediate commit. Do not batch unrelated changes.
-5. **Commit messages must NOT mention Claude/AI/Co-Authored-By.**
+5. **Commit messages describe the change, not the tool that produced it** — no agent or model names, and no `Co-Authored-By` trailers.
 6. **Skill gap check**: If the task didn't match any existing skill, briefly assess after completion: Was this a one-off, or a repeatable pattern? If repeatable, suggest creating a new skill to the user.
 
 The subagent review gate is **per PR, not per commit** — see **PR Guidelines**.
@@ -95,7 +95,7 @@ owed on every commit.
 
 ## Skills
 
-Skills follow the [Agent Skills](https://agentskills.io) open standard. Each skill is a folder in `.agents/skills/<name>/` containing a `SKILL.md` with YAML frontmatter (`name`, `description`). Skills are auto-discovered by compatible agents (Cursor, Claude Code, Codex, etc.) and can also be invoked manually with `/skill-name` in chat.
+Skills follow the [Agent Skills](https://agentskills.io) open standard. Each skill is a folder in `.agents/skills/<name>/` containing a `SKILL.md` with YAML frontmatter (`name`, `description`). Agents that implement the standard auto-discover them from the `description`; they can also be invoked manually with `/skill-name` in chat.
 
 | Task | Skill |
 |------|-------|

--- a/docs/usage/agent_workflow.md
+++ b/docs/usage/agent_workflow.md
@@ -1,6 +1,6 @@
 # Agent Workflow Guide
 
-VeOmni provides a skill-based workflow system that helps AI coding agents work on the project effectively. Skills follow the [Agent Skills](https://agentskills.io) open standard and work with any compatible agent (Cursor, Claude Code, Codex, Junie, Goose, etc.).
+VeOmni provides a skill-based workflow system that helps AI coding agents work on the project effectively. Skills follow the [Agent Skills](https://agentskills.io) open standard, so they work with any agent that implements it — no VeOmni-specific plugin required.
 
 ## Overview
 
@@ -10,19 +10,23 @@ The workflow consists of three layers:
 AGENTS.md                      <- Entry point: principles, skill dispatch, commit flow
 .agents/skills/                <- Skills: step-by-step workflows for common tasks
 .agents/knowledge/             <- Knowledge: constraints, architecture, dependency info
-.cursor/rules/                 <- IDE rules: Cursor-specific coding conventions
+.cursor/rules/                 <- IDE rules: coding conventions, for editors that read them
 ```
 
-When an agent opens the project, it reads `AGENTS.md` (or its symlink `CLAUDE.md`) to understand:
+When an agent opens the project, it reads `AGENTS.md` to understand:
 - **What constraints to follow** before making any change
 - **Which skill to use** for the task at hand
 - **How to verify commits and review pull requests**
+
+Some agents look for an entry point under a different filename. `CLAUDE.md` is a
+symlink to `AGENTS.md` for that reason — there is one source of truth, and
+adding another alias is just another symlink.
 
 ## Quick Start
 
 ### For AI Agent Users
 
-If you are using Cursor or another AI coding tool on this project, the workflow activates automatically:
+The workflow activates automatically:
 
 1. The agent reads `AGENTS.md` on session start.
 2. For each task, the agent selects the appropriate skill from the dispatch table (or auto-discovers it via the `description` frontmatter).
@@ -63,7 +67,7 @@ Each skill is a folder containing a `SKILL.md` file with YAML frontmatter (`name
 └── create-pr/SKILL.md         # Create or update a pull request
 ```
 
-The `description` field in frontmatter tells the agent when to apply the skill. Agents that support auto-discovery (Cursor, Claude Code) will offer the relevant skill automatically based on the task description.
+The `description` field in frontmatter tells the agent when to apply the skill. Agents that support auto-discovery will offer the relevant skill automatically based on the task description.
 
 ### `.agents/knowledge/`
 
@@ -73,12 +77,15 @@ Domain knowledge that agents should read before making changes:
 |------|---------|
 | `constraints.md` | Hard constraints whose violation causes bugs or crashes |
 | `architecture.md` | Module map, trainer hierarchy, data flow, model loading flow, test mapping |
+| `cpu_only_env.md` | What can be verified on a machine with no GPU/NPU |
 | `multimodal_metadata.md` | Canonical multimodal metadata keys and ownership boundaries |
+| `testing.md` | How CI selects tests; whether a change needs one and where it goes |
 | `uv.md` | Dependency management architecture (uv, extras, lockfile, torch sources) |
 
 ### `.cursor/rules/`
 
-Cursor IDE rules (auto-applied when editing matching files):
+Editor rules, auto-applied when editing matching files by editors that read this
+directory:
 
 - `no-section-divider-comments.mdc` — no decorative `# ----` banners in Python
 - `skills-reusable-only.mdc` — enforce Agent Skills standard format in `.agents/skills/`
@@ -126,5 +133,5 @@ before opening or substantively updating a PR
 
 Additional gates:
 - `make quality` must pass (ruff check + format) on every commit
-- Commit messages must not mention AI/Claude
+- Commit messages describe the change, not the tool that produced it
 - PR title must follow `[{modules}] {type}: {description}` format

--- a/docs/usage/agent_workflow.md
+++ b/docs/usage/agent_workflow.md
@@ -26,7 +26,10 @@ adding another alias is just another symlink.
 
 ### For AI Agent Users
 
-The workflow activates automatically:
+How much of this is automatic depends on the agent. Reading `AGENTS.md` on
+session start and auto-discovering skills from their `description` are both
+capabilities the agent has to implement; where it does not, everything below
+still works by invoking `/skill-name` explicitly.
 
 1. The agent reads `AGENTS.md` on session start.
 2. For each task, the agent selects the appropriate skill from the dispatch table (or auto-discovers it via the `description` frontmatter).
@@ -133,5 +136,5 @@ before opening or substantively updating a PR
 
 Additional gates:
 - `make quality` must pass (ruff check + format) on every commit
-- Commit messages describe the change, not the tool that produced it
+- Commit messages describe the change, not the tool that produced it — no assistant or agent names, no `Co-Authored-By` trailers
 - PR title must follow `[{modules}] {type}: {description}` format


### PR DESCRIPTION
> **Stack** — review bottom-up. Each PR targets the one below it.
>
> 1. #1144 `[ci, agent] feat: verify repo paths and skill refs in agent docs` (base `main`)
> 2. #1135 `[agent] fix: correct stale facts in skills and knowledge docs`
> 3. #1136 `[agent, ci] feat: add a test-wiring decision rule`
> 4. #1137 `[agent] refactor: right-size the review gate and drop agent-specific tooling`
> 5. #1145 `[agent, docs] refactor: rename the migrate skill to veomni-patchgen-model`
> 6. #1147 `[agent, docs] refactor: split the patchgen skill by model category`
> 7. **this PR** `[agent, docs] refactor: describe the agent tooling generically`

### What does this PR do?

The agent docs named specific vendors in eight places. Finishes what #1137
started — that PR removed agent-specific *tool names* from the instructions
(`TodoWrite`, "use the Task tool"); this one removes agent-specific *prose*.

| Was | Now |
|---|---|
| "compatible agents (Cursor, Claude Code, Codex, Junie, etc.)" ×4, each with a different list | "any agent that implements the standard" |
| `bash .agents/setup_agent.sh gemini` as the example | `bash .agents/setup_agent.sh <agent-name>` |
| "Commit messages must NOT mention Claude/AI/Co-Authored-By" ×3 | "describe the change, not the tool that produced it — no agent or model names, no `Co-Authored-By` trailers" |
| "If you are using Cursor or another AI coding tool…" | "The workflow activates automatically" |
| `.agents/knowledge/cloud_env.md`, "read when running on the Cursor Cloud VM" | `.agents/knowledge/cpu_only_env.md`, "read when running on a CPU-only machine" |

Two of these were not merely cosmetic:

- **The commit rule was ambiguous for every vendor it did not name.** "Must not
  mention Claude/AI" does not obviously forbid a `Co-Authored-By: Codex` trailer
  or a "generated with <tool>" line. Stating the intent covers all of them.
- **`cloud_env.md` was unreadable by the agents that needed it.** It was framed
  as Cursor Cloud setup and `AGENTS.md` said to read it "when running on the
  Cursor Cloud VM" — so an agent on any *other* CPU-only box would skip it,
  even though its content (which CI gates run without a GPU, which tests
  self-skip, why `pytest tests/` will not pass, the eager-ops pattern for
  building a model on CPU) is exactly what that agent needs. The one genuinely
  host-specific fact — that some hosted environments pre-run `uv sync` — is
  kept as a note rather than as the framing for the whole document.

### What is deliberately kept

`.cursor/rules/*.mdc` and the `CLAUDE.md` symlink are **integration points, not
descriptions**. Those exact paths are what the respective tools look for;
renaming or deleting them breaks those agents for no gain. The `.mdc` files
themselves contain no vendor-specific prose — they are ordinary coding rules in
the format that directory requires.

`docs/usage/agent_workflow.md` previously mentioned `CLAUDE.md` only in passing.
It now says *why* the symlink exists, so nobody deletes it as vendor cruft —
which is a plausible outcome of a cleanup like this one.

### Checklist Before Starting

- Search for relative PRs/issues and link here: no existing issue. Completes
  the agent-neutrality work begun in #1137; sits on top of #1147.
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`

### Test

**No test needed** — documentation, plus comment/usage strings in
`.agents/setup_agent.sh`. No logic changed there.

Verification:

- `bash -n .agents/setup_agent.sh` passes and the usage-error path still prints
  correctly with no argument.
- `python3 scripts/ci/check_agent_doc_paths.py` passes — this is what catches
  the rename, since `cloud_env.md` was referenced from `AGENTS.md` and
  `.agents/README.md`.
- `rg -i` sweep over `AGENTS.md`, `.agents/`, `.cursor/` and
  `docs/usage/agent_workflow.md` for every vendor name returns only the two
  `.cursor/rules/` **path** references and the checker's own `SCAN_GLOBS`.
- `ruff check` clean.

### Design & Code Changes

- `AGENTS.md` — context-loading entry, commit rule, skills preamble.
- `.agents/knowledge/cloud_env.md` → `cpu_only_env.md`, reframed around the
  capability (no GPU) instead of the vendor.
- `.agents/README.md` — intro, structure tree, bootstrap example; also adds the
  knowledge file to the descriptions list, where it was missing.
- `.agents/skills/README.md` — intro.
- `.agents/setup_agent.sh` — usage/comment strings.
- `.agents/skills/veomni-patchgen-model/SKILL.md` — Phase 8 commit rule.
- `docs/usage/agent_workflow.md` — five prose sites, the `CLAUDE.md`
  explanation, and two missing rows in the knowledge table
  (`cpu_only_env.md`, `testing.md`).

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation — this PR *is* the documentation change
- No `tasks/` scripts moved or renamed
- Tests: no test needed, see **Test**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Generalized agent setup and skill discovery guidance for implementations of the Agent Skills standard.
  * Updated CPU-only environment instructions with setup, activation, and troubleshooting guidance.
  * Expanded workflow documentation with editor rules, symlink details, testing references, and skill-discovery guidance.
  * Added VeOmni patchgen modeling guidance covering setup, configuration, registration, regeneration, testing, and common pitfalls.
  * Clarified commit-message requirements, including restrictions on assistant names and attribution trailers.
  * Updated setup instructions to use a generic agent-name placeholder.
  * Replaced environment references specific to Cursor Cloud with general CPU-only guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->