### PR TITLE
[misc, ci, docs] fix: repair make build and lint scripts/

### DIFF
--- a/.agents/knowledge/cloud_env.md
+++ b/.agents/knowledge/cloud_env.md
@@ -34,7 +34,8 @@ Those require the self-hosted GPU CI runners.
 - To build a model on this box, force all-eager ops and `init_device="cpu"`
   (flash-attn/triton are unavailable). `tasks/infer/*.py` show the eager
   `OpsImplementationConfig` pattern (`is_flash_attn_2_available()` → `eager`).
-- `make build` is stale (its `setup.py` target doesn't exist); build the wheel
-  with `./build.sh` (which runs `python3 -m build`) instead.
+- `make build` runs `python3 -m build`, the same command `publish.yml` uses.
+  It needs the `build` package (`pip install build`); `./build.sh` installs it
+  first and then runs the same thing.
 - Re-running `uv sync` is cheap and idempotent (~1s when unchanged); prefer it
   over `pip install`.

--- a/.agents/knowledge/cloud_env.md
+++ b/.agents/knowledge/cloud_env.md
@@ -34,8 +34,10 @@ Those require the self-hosted GPU CI runners.
 - To build a model on this box, force all-eager ops and `init_device="cpu"`
   (flash-attn/triton are unavailable). `tasks/infer/*.py` show the eager
   `OpsImplementationConfig` pattern (`is_flash_attn_2_available()` → `eager`).
-- `make build` runs `python3 -m build`, the same command `publish.yml` uses.
-  It needs the `build` package (`pip install build`); `./build.sh` installs it
-  first and then runs the same thing.
+- `make build` runs `uv run --with build python -m build` — the same
+  `python -m build` that `publish.yml` uses, with the `build` package supplied
+  for the one command instead of installed into `.venv` (an exact `uv sync`
+  would drop it again — see constraints, "Environment Reproducibility").
+  `./build.sh` is the uv-free equivalent: `pip install build`, then the same.
 - Re-running `uv sync` is cheap and idempotent (~1s when unchanged); prefer it
   over `pip install`.

--- a/.github/workflows/check_pr_lint.yml
+++ b/.github/workflows/check_pr_lint.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Run ruff lint and format check
         run: |
           failed=0
-          ruff check tasks tests veomni docs || failed=1
-          ruff format --check tasks tests veomni docs || failed=1
+          ruff check tasks tests veomni docs scripts || failed=1
+          ruff format --check tasks tests veomni docs scripts || failed=1
           if [ "$failed" -eq 1 ]; then
             echo ""
             echo "=========================================="

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,8 @@ jobs:
       - run: pip install ruff
       - name: Ruff check & format
         run: |
-          ruff check tasks tests veomni docs
-          ruff format --check tasks tests veomni docs
+          ruff check tasks tests veomni docs scripts
+          ruff format --check tasks tests veomni docs scripts
 
   version-check:
     name: Verify tag matches package version

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 check_dirs := tasks tests veomni docs
 
 build:
-	python3 setup.py sdist bdist_wheel
+	python3 -m build
 
 commit:
 	pre-commit install

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 check_dirs := tasks tests veomni docs scripts
 
 build:
-	python3 -m build
+	uv run --with build python -m build
 
 commit:
 	pre-commit install

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build commit quality style test patchgen check-patchgen check-agent-docs
 
-check_dirs := tasks tests veomni docs
+check_dirs := tasks tests veomni docs scripts
 
 build:
 	python3 -m build


### PR DESCRIPTION
> Standalone, based on `main` — **not** part of the `.agents/` stack
> (#1144 → #1135 → #1136 → #1137 → #1145 → #1147 → #1148). The only overlap is
> one line in `.agents/knowledge/cloud_env.md`, which #1148 renames to
> `cpu_only_env.md`. A trial merge of this branch into the stack tip is clean —
> git carries the edit through the rename — so the two can land in either order.

### What does this PR do?

Two independent breakages in the build/lint plumbing, one commit each.

**1. `make build` has been broken since the project went pyproject-only.**

```make
build:
	python3 setup.py sdist bdist_wheel
```

There is no `setup.py` in the tree — the build is `[build-system]
setuptools.build_meta` driven from `pyproject.toml`. The target fails
immediately. It has no callers anywhere in the repo, which is why this went
unnoticed.

It now runs `python3 -m build`, which is exactly what `publish.yml` runs to
produce the artifacts that get published to PyPI. So the local target and the
release path build the same way instead of one of them being fiction.
`build.sh` keeps its role: `pip install build`, then the same command.

**2. Nothing lints `scripts/`.**

`Makefile`'s `check_dirs` and both CI ruff invocations
(`check_pr_lint.yml`, `publish.yml`) list `tasks tests veomni docs` and stop
there. That leaves 14 Python files unlinted — including the CI checkers under
`scripts/ci/` that *other* workflows execute on every PR.

Nothing in `[tool.ruff]` excludes the directory (`extend-exclude` names only
`veomni/ops/kernels/gated_delta_rule/_ascend`), so this is an omission in the
invocation rather than a deliberate policy. All 14 files already pass both
`ruff check` and `ruff format --check`, so this closes the hole without
changing a line of code.

### Checklist Before Starting

- Search for relative PRs/issues and link here: no existing issue. Both found
  while auditing `.agents/` — `cloud_env.md` documented the `make build`
  breakage as a known gotcha rather than anyone fixing it.
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`

### Test

**No test needed** — build tooling and lint configuration. Both changes are
verified by running the exact commands rather than by a new test file, and the
second one is itself a CI gate.

- `python3 -m build --outdir <tmp>` succeeds and produces both artifacts:
  `veomni-0.1.11.tar.gz` and `veomni-0.1.11-py3-none-any.whl`. Built to a temp
  directory so nothing lands in the worktree.
- `ruff check tasks tests veomni docs scripts` and
  `ruff format --check tasks tests veomni docs scripts` both pass at
  `RUFF_VERSION` 0.13.2 — i.e. the new CI invocation is green *before* it is
  enforced, so this cannot break anyone's PR.
- Trial-merged into the `.agents/` stack tip to confirm the doc edit survives
  the `cloud_env.md` → `cpu_only_env.md` rename with no conflict.

### Design & Code Changes

- `Makefile` — `build` target now `python3 -m build`; `check_dirs` gains
  `scripts`.
- `.github/workflows/check_pr_lint.yml`, `.github/workflows/publish.yml` — the
  same directory added to both ruff invocations, so `make quality` and CI stay
  in agreement. Having the Makefile disagree with CI is how the gap appeared in
  the first place.
- `.agents/knowledge/cloud_env.md` — the gotcha said "`make build` is stale
  (its `setup.py` target doesn't exist); build the wheel with `./build.sh`".
  Now that the target works, it says what each of the two does.

I left `build.sh` alone. It overlaps with `make build`, but it also installs
the `build` package first, which is genuinely useful on a fresh environment,
and consolidating them is a separate call.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation — the `cloud_env.md` gotcha that described the bug
- No `tasks/` scripts moved or renamed
- Tests: no test needed, see **Test**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Updated the package build process to use the modern Python build workflow.
  * Improved the build setup so required tooling is installed before packaging.

* **Quality Improvements**
  * Expanded automated linting and formatting checks to cover utility scripts.
  * Added a validation command for agent documentation paths.

* **Documentation**
  * Clarified the recommended build commands and required tooling in the development documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->