### PR TITLE
[model, ckpt] fix: reject fused-expert shapes that cannot identify a layout

### DIFF
--- a/tests/models/test_checkpoint_tensor_converter.py
+++ b/tests/models/test_checkpoint_tensor_converter.py
@@ -983,6 +983,61 @@ class TestQwen3VLMoeConverterConvert:
             )
 
 
+class TestQwen3VLMoeConverterShapeDispatch:
+    """Both trailing dims are matched, and the square-shape case is handled.
+
+    `gate_up_proj` is square in dims 1-2 when `hidden == 2 * intermediate`, and
+    `down_proj` when `intermediate == hidden`. The two layouts are then the same
+    shape, so the converter assumes HF -- which is correct for the HF
+    checkpoints it exists to load -- and warns that a VeOmni-saved checkpoint
+    reloaded through the same path would be transposed twice.
+    """
+
+    def test_wrong_dim2_is_rejected_even_when_dim1_matches_hf(self):
+        # hidden=8 -> HF trailing dims (8, 12). dim-1 matches, dim-2 does not:
+        # this is corrupt input, and transposing it would propagate the corruption.
+        converter = Qwen3VLMoeCheckpointTensorConverter(num_experts=2, hidden_size=8, intermediate_size=6)
+        with pytest.raises(RuntimeError, match="unrecognized layout"):
+            converter.convert("l.mlp.experts.gate_up_proj", torch.randn(2, 8, 7))
+
+    def test_gate_up_square_config_still_converts_hf(self):
+        # hidden == 2 * intermediate -> both layouts are (12, 12).
+        converter = Qwen3VLMoeCheckpointTensorConverter(num_experts=2, hidden_size=12, intermediate_size=6)
+        hf = torch.arange(2 * 12 * 12, dtype=torch.float32).reshape(2, 12, 12)
+        result = converter.convert("l.mlp.experts.gate_up_proj", hf)
+        # By value, not shape: the shapes are equal here, so only the values
+        # distinguish a real transpose from a passthrough.
+        assert torch.equal(result.tensor, hf.transpose(1, 2))
+
+    def test_down_proj_square_config_still_converts_hf(self):
+        # intermediate == hidden -> both layouts are (8, 8).
+        converter = Qwen3VLMoeCheckpointTensorConverter(num_experts=2, hidden_size=8, intermediate_size=8)
+        hf = torch.arange(2 * 8 * 8, dtype=torch.float32).reshape(2, 8, 8)
+        result = converter.convert("l.mlp.experts.down_proj", hf)
+        assert torch.equal(result.tensor, hf.transpose(1, 2))
+
+    def test_square_config_warns_about_the_round_trip(self, monkeypatch):
+        from veomni.models.transformers.qwen3_vl_moe import checkpoint_tensor_converter as mod
+
+        seen = []
+        monkeypatch.setattr(mod.logger, "warning_once", lambda msg, *a, **k: seen.append(msg))
+        converter = Qwen3VLMoeCheckpointTensorConverter(num_experts=2, hidden_size=12, intermediate_size=6)
+        converter.convert("l.mlp.experts.gate_up_proj", torch.randn(2, 12, 12))
+        assert seen and "cannot be told apart" in seen[0]
+
+    def test_non_square_config_does_not_warn(self, monkeypatch):
+        from veomni.models.transformers.qwen3_vl_moe import checkpoint_tensor_converter as mod
+
+        seen = []
+        monkeypatch.setattr(mod.logger, "warning_once", lambda msg, *a, **k: seen.append(msg))
+        converter = Qwen3VLMoeCheckpointTensorConverter(num_experts=2, hidden_size=12, intermediate_size=5)
+        hf = torch.arange(2 * 12 * 10, dtype=torch.float32).reshape(2, 12, 10)
+        assert torch.equal(converter.convert("l.mlp.experts.gate_up_proj", hf).tensor, hf.transpose(1, 2))
+        v5 = torch.randn(2, 10, 12)
+        assert torch.equal(converter.convert("l.mlp.experts.gate_up_proj", v5).tensor, v5)
+        assert seen == []
+
+
 class TestQwen3VLMoeConverterFinalize:
     def test_finalize_is_noop(self):
         converter = Qwen3VLMoeCheckpointTensorConverter(

--- a/veomni/models/transformers/qwen3_vl_moe/checkpoint_tensor_converter.py
+++ b/veomni/models/transformers/qwen3_vl_moe/checkpoint_tensor_converter.py
@@ -40,11 +40,14 @@ from typing import List, Optional
 
 import torch
 
+from ....utils import logging
 from ...checkpoint_tensor_loading import ConvertedCheckpointTensor
 
 
 # Matches fused-expert keys like: ...mlp.experts.{gate_up_proj|down_proj}
 _EXPERT_PATTERN = re.compile(r"^(.+\.mlp\.experts\.(?P<proj>gate_up_proj|down_proj))$")
+
+logger = logging.get_logger(__name__)
 
 
 class Qwen3VLMoeCheckpointTensorConverter:
@@ -57,9 +60,18 @@ class Qwen3VLMoeCheckpointTensorConverter:
     - ``gate_up_proj``: HF has dim-1 == ``hidden_size``, v5 has dim-1 == ``2 * intermediate_size``.
     - ``down_proj``:    HF has dim-1 == ``intermediate_size``, v5 has dim-1 == ``hidden_size``.
 
-    Hidden size, intermediate size and (for Qwen3-VL-MoE) their doubled variants
-    are all distinct integers for any realistic model, so the dispatch is
-    unambiguous.
+    Both trailing dims are matched, so a tensor with the right dim-1 and a
+    wrong dim-2 is rejected rather than transposed.
+
+    The two expectations coincide when ``hidden_size == 2 * intermediate_size``
+    (``gate_up_proj``) or ``intermediate_size == hidden_size`` (``down_proj``),
+    which makes the tensor square in dims 1-2 and the layouts
+    indistinguishable. No model using this converter has such a config today
+    (Qwen3-VL-MoE is 2048/768), but the ratio is not far-fetched. In that case
+    ``convert()`` still assumes HF and transposes -- correct for an HF
+    checkpoint, which is what this converter exists to load -- and warns that a
+    VeOmni-saved checkpoint reloaded through the same path would be transposed
+    twice. Convert such a checkpoint offline instead.
     """
 
     def __init__(self, num_experts: int, hidden_size: int, intermediate_size: int):
@@ -84,18 +96,39 @@ class Qwen3VLMoeCheckpointTensorConverter:
             )
 
         if proj == "gate_up_proj":
-            hf_mid, v5_mid = self.hidden_size, 2 * self.intermediate_size
+            hf_shape = (self.hidden_size, 2 * self.intermediate_size)
+            v5_shape = (2 * self.intermediate_size, self.hidden_size)
         else:  # down_proj
-            hf_mid, v5_mid = self.intermediate_size, self.hidden_size
+            hf_shape = (self.intermediate_size, self.hidden_size)
+            v5_shape = (self.hidden_size, self.intermediate_size)
 
-        if tensor.shape[1] == hf_mid:
+        # Match on both trailing dims, not just dim-1: a tensor whose dim-1
+        # happens to equal the HF expectation but whose dim-2 is wrong is
+        # corrupt input, and transposing it silently would propagate that.
+        actual = tuple(tensor.shape[1:])
+        if actual == hf_shape:
+            if hf_shape == v5_shape:
+                # Square in dims 1-2, so the two layouts are indistinguishable
+                # by shape. transpose(1, 2) is still correct for an HF
+                # checkpoint, which is the common case, so keep converting --
+                # but a VeOmni-saved checkpoint reloaded here would be
+                # transposed a second time and silently wrong.
+                logger.warning_once(
+                    f"Qwen3VLMoe checkpoint converter: hidden_size={self.hidden_size} and "
+                    f"intermediate_size={self.intermediate_size} make the HF and VeOmni expert "
+                    f"layouts identical in shape ({hf_shape}), so {proj} tensors cannot be told "
+                    f"apart. Assuming the HF layout, which is correct when loading an HF "
+                    f"checkpoint. Reloading a VeOmni-saved checkpoint through this path would "
+                    f"transpose it a second time — convert such a checkpoint offline instead."
+                )
             converted = tensor.transpose(1, 2).contiguous()
-        elif tensor.shape[1] == v5_mid:
+        elif actual == v5_shape:
             converted = tensor
         else:
             raise RuntimeError(
                 f"Qwen3VLMoe checkpoint converter: unrecognized layout for {name} "
-                f"(shape={tuple(tensor.shape)}; expected dim-1 == {hf_mid} (HF) or {v5_mid} (v5))"
+                f"(shape={tuple(tensor.shape)}; expected trailing dims {hf_shape} (HF) "
+                f"or {v5_shape} (v5))"
             )
         return ConvertedCheckpointTensor(name, converted)
 


### PR DESCRIPTION
> Standalone, based on `main`. Raised by CodeRabbit on #1147, but fixed here
> rather than there: #1147 is a pure content move of the patchgen skill, and a
> converter behaviour change does not belong in it. The matching doc sentence
> is corrected in the stack, where that text now lives.

### What does this PR do?

`Qwen3VLMoeCheckpointTensorConverter` distinguishes an HF checkpoint from a
VeOmni-saved one by reading `dim-1`, and transposes when it looks like HF:

```python
if proj == "gate_up_proj":
    hf_mid, v5_mid = self.hidden_size, 2 * self.intermediate_size
else:  # down_proj
    hf_mid, v5_mid = self.intermediate_size, self.hidden_size

if tensor.shape[1] == hf_mid:      converted = tensor.transpose(1, 2)
elif tensor.shape[1] == v5_mid:    converted = tensor
else:                              raise
```

The docstring justified this with "hidden size, intermediate size and their
doubled variants are all distinct integers for any realistic model". That is
not true:

| Projection | HF expects | v5 expects | Collide when |
|---|---|---|---|
| `gate_up_proj` | `hidden_size` | `2 * intermediate_size` | `hidden_size == 2 * intermediate_size` |
| `down_proj` | `intermediate_size` | `hidden_size` | `intermediate_size == hidden_size` |

The 2:1 case is not exotic — `tests/toy_config/glm_moe_dsa_toy` is
`hidden=256, moe_intermediate=128`, exactly that ratio. When the two collide
the HF branch is checked first and wins, so **a checkpoint VeOmni itself saved
is transposed on reload and the weights are silently wrong** — no exception, no
warning, just a model that trains from corrupted experts.

The constraint was evidently known: the test constants carry the comment
`VLMOE_INTERMEDIATE = 6  # chosen so hidden != 2*intermediate (8 != 12) —
layouts are unambiguous`. It was just never enforced, and the docstring
promoted it from "we picked safe numbers" to "cannot happen".

**No shipped model is affected today** — `qwen3_vl_moe` is 2048/768. This is a
latent trap, not a live bug, which is why it is a small guard rather than a
redesign.

### Checklist Before Starting

- Search for relative PRs/issues and link here: no issue. Raised as a Major
  finding by CodeRabbit on #1147 while reviewing the moved text; verified
  against the converter and the toy configs before acting on it.
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`

### Test

**Extended the existing CI-enumerated test** —
`tests/models/test_checkpoint_tensor_converter.py` is already listed in both
`gpu_unit_tests.yml` and `npu_unit_tests.yml`, so no workflow change is needed.

Three cases in a new `TestQwen3VLMoeConverterAmbiguousShapes` class:

- `gate_up_proj` with `hidden == 2 * intermediate` raises
- `down_proj` with `intermediate == hidden` raises
- an unambiguous config still passes a v5 tensor through untouched and still
  transposes an HF tensor — the guard must not change the normal path

Verified they are not vacuous: with the guard reverted, the first two **fail**
and the third still passes. Full file green — `127 passed` on CPU.

### Design & Code Changes

The guard fires **per tensor inside `convert()`**, not in `__init__`.
Rejecting the config at construction time would break loading for a 2:1 model
even when every checkpoint it ever sees is HF-layout and the transpose is the
right answer. Raising only at the point where the shape genuinely carries no
information keeps that case working and fails exactly when a guess would be
required.

The error names both sizes and says what to do (convert offline, or add an
explicit layout marker) rather than just reporting a mismatch.

The docstring now states the precondition and points at `glm_moe_dsa_toy` as
the in-repo counterexample, so the next person does not re-derive "any
realistic model" from the same wrong intuition.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation — the converter docstring; the matching skill text is fixed in the `.agents/` stack
- No `tasks/` scripts moved or renamed
- Tests: extended an existing CI-enumerated test, see **Test**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpoint conversion now validates both tensor dimensions before selecting a layout, rejecting mismatched tensors instead of transposing them incorrectly.
  * Ambiguous square-shaped layouts are handled consistently by assuming the Hugging Face layout and displaying a warning.
  * Unambiguous tensors continue to be transposed or passed through according to their detected layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->