### PR TITLE
[model] refactor: declare context-parallel support in the model package

### DIFF
--- a/tests/parallel/context_parallel/test_dsv4_cp_gates.py
+++ b/tests/parallel/context_parallel/test_dsv4_cp_gates.py
@@ -59,3 +59,69 @@ def test_gate_rejects_context_parallel_on_npu(monkeypatch):
 
     with pytest.raises(NotImplementedError, match="GPU-only"):
         check_context_parallel_supported(SimpleNamespace(model_type="deepseek_v4"))
+
+
+@pytest.fixture
+def _cp_is_on(monkeypatch):
+    """Context parallelism enabled on a GPU, which is where the model gate is the
+    only thing left between a config and a run."""
+    monkeypatch.setattr(auto_module, "is_parallel_state_initialized", lambda: True)
+    monkeypatch.setattr(auto_module, "get_parallel_state", lambda: SimpleNamespace(cp_enabled=True))
+    monkeypatch.setattr(auto_module, "is_torch_npu_available", lambda: False)
+
+
+def test_the_declaring_model_is_admitted(_cp_is_on):
+    """The declaration in ``veomni/models/transformers/deepseek_v4/__init__.py`` has to
+    have been reached by the time the gate runs.
+
+    Not a tautology: the registry is populated as an import side effect of the model
+    package, and ``veomni/models/__init__.py`` imports ``transformers`` before
+    ``auto`` for that to hold. Were the order ever reversed, or the package import
+    made lazy, the model that *does* implement CP would be the one refused -- and
+    every other test here would still pass.
+    """
+    check_context_parallel_supported(SimpleNamespace(model_type="deepseek_v4"))
+
+
+@pytest.mark.parametrize("model_type", ["qwen3", "llama", None, "not_a_model_type"])
+def test_an_undeclared_model_is_refused(_cp_is_on, model_type):
+    """Absence has to mean refused, which is the whole safety property.
+
+    Parametrised over an unported model, a plausible one, ``None`` and a name that
+    was never a model type, because the query answers all four by the same path and a
+    registry lookup that raised on an unknown key would turn the last three into a
+    traceback about the registry rather than a message about CP.
+    """
+    with pytest.raises(NotImplementedError, match="Context parallelism is not implemented"):
+        check_context_parallel_supported(SimpleNamespace(model_type=model_type))
+
+
+def test_the_refusal_names_what_to_switch_to(_cp_is_on):
+    """A refusal that names only what failed leaves the user to search for the model
+    that would work. The enumeration is derived from the registry rather than
+    restated, so it cannot drift from the gate's own answer."""
+    with pytest.raises(NotImplementedError, match="only deepseek_v4 supports it"):
+        check_context_parallel_supported(SimpleNamespace(model_type="qwen3"))
+
+
+def test_a_capability_is_not_a_prefix_match(_cp_is_on):
+    """The query is set membership, not a substring test.
+
+    Cheap to pin and expensive to get wrong: a model declaring a longer capability
+    that happens to contain ``context_parallel`` would otherwise be granted CP it
+    never implemented.
+    """
+    from veomni.models.loader import MODEL_CAPABILITY_REGISTRY, model_supports
+
+    # Not ``monkeypatch.setitem``: it saves the old value with ``dict.get``, and
+    # ``Registry.__getitem__`` raises ``ValueError`` rather than ``KeyError`` on a
+    # missing key, so the inherited ``Mapping.get`` propagates instead of returning
+    # the default. Assigning writes the local override, which ``del`` undoes.
+    MODEL_CAPABILITY_REGISTRY["toy"] = frozenset({"context_parallel_planned"})
+    try:
+        assert model_supports("toy", "context_parallel") is False
+
+        with pytest.raises(NotImplementedError, match="Context parallelism is not implemented"):
+            check_context_parallel_supported(SimpleNamespace(model_type="toy"))
+    finally:
+        del MODEL_CAPABILITY_REGISTRY["toy"]

--- a/veomni/models/auto.py
+++ b/veomni/models/auto.py
@@ -29,7 +29,15 @@ from ..distributed.parallel_state import get_parallel_state, is_parallel_state_i
 from ..ops.dispatch import OpsConfigSlot, OpSlot
 from ..utils import logging
 from ..utils.device import is_torch_npu_available
-from .loader import BaseModelLoader, get_loader, get_model_config, get_model_processor
+from .loader import (
+    CONTEXT_PARALLEL,
+    BaseModelLoader,
+    get_loader,
+    get_model_config,
+    get_model_processor,
+    model_supports,
+    model_types_supporting,
+)
 
 
 if TYPE_CHECKING:
@@ -37,23 +45,28 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 
-# Models whose forward implements context parallelism. An allow-list rather than
-# a deny-list so that a model has to be ported deliberately: CP is enabled
-# model-agnostically (``ParallelState`` and ``TrainingArguments`` both admit
-# ``cp_size > 1`` for anything), and nothing downstream would notice a model that
-# has not been. ``SequenceParallelCollator`` shards the sequence on
-# ``sp_enabled``, which CP alone turns on, while every unported model gates its
-# sequence-parallel collectives on ``ulysses_enabled``, which CP alone leaves
-# false — so the shards are never gathered, each rank attends only within its own
-# 1/cp_size of the sequence, and the run trains to a plausible loss curve while
-# being silently wrong.
-CONTEXT_PARALLEL_MODEL_TYPES = frozenset({"deepseek_v4"})
-
 
 def check_context_parallel_supported(config: PretrainedConfig) -> None:
-    """Raise unless this model type implements context parallelism.
+    """Raise unless this model type declared that it implements context parallelism.
 
     A no-op when context parallelism is off, which is every other configuration.
+
+    An allow-list rather than a deny-list, so that a model has to be ported
+    deliberately. CP is enabled model-agnostically -- ``ParallelState`` and
+    ``TrainingArguments`` both admit ``cp_size > 1`` for anything -- and nothing
+    downstream would notice a model that has not been:
+    ``SequenceParallelCollator`` shards the sequence on ``sp_enabled``, which CP
+    alone turns on, while every unported model gates its sequence-parallel
+    collectives on ``ulysses_enabled``, which CP alone leaves false. The shards are
+    never gathered, each rank attends only within its own ``1/cp_size`` of the
+    sequence, and the run trains to a plausible loss curve while being silently
+    wrong. That is the failure this exists to convert into an error.
+
+    Which models qualify is read from ``MODEL_CAPABILITY_REGISTRY`` rather than
+    listed here, so the claim sits in the model package with the forward that backs
+    it. The registry direction is the one that matters: an unregistered model type
+    is refused, so forgetting to declare a capability costs a run that will not
+    start rather than one that is quietly incorrect.
     """
     # ``build_foundation_model`` runs this for every model, including in processes
     # that never installed a parallel state -- tests that spawn a multi-rank world
@@ -71,10 +84,10 @@ def check_context_parallel_supported(config: PretrainedConfig) -> None:
         raise NotImplementedError("Context parallelism is GPU-only in this release; set cp_size=1 on Ascend/NPU runs.")
 
     model_type = getattr(config, "model_type", None)
-    if model_type in CONTEXT_PARALLEL_MODEL_TYPES:
+    if model_supports(model_type, CONTEXT_PARALLEL):
         return
 
-    supported = ", ".join(sorted(CONTEXT_PARALLEL_MODEL_TYPES))
+    supported = ", ".join(model_types_supporting(CONTEXT_PARALLEL)) or "no model type"
     raise NotImplementedError(
         f"Context parallelism is not implemented for model type {model_type!r}; "
         f"only {supported} supports it. Set cp_size=1 to disable it, or use "

--- a/veomni/models/loader.py
+++ b/veomni/models/loader.py
@@ -16,6 +16,7 @@
 # Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/model_loader/loader.py
 
 from abc import ABC, abstractmethod
+from typing import List, Optional
 
 import torch
 from transformers import (
@@ -50,7 +51,49 @@ MODELING_REGISTRY = Registry("Modeling")
 MODEL_CONFIG_REGISTRY = Registry("ModelConfig")
 MODEL_PROCESSOR_REGISTRY = Registry("ModelProcessor")
 
+# What a model's VeOmni implementation can do beyond loading and a plain forward,
+# declared by the model package that implements it. Keyed by ``model_type`` and
+# holding a set of capability names.
+#
+# Registered rather than detected because the capabilities worth declaring here are
+# exactly the ones nothing downstream would notice the absence of -- see
+# ``check_context_parallel_supported``, whose whole reason for existing is that an
+# unported model under ``cp_size > 1`` trains to a plausible loss curve rather than
+# raising. A registry cannot be forgotten in the direction that matters: an
+# unregistered model is refused, so the failure mode of forgetting to declare a
+# capability is a run that will not start, not one that is silently wrong.
+MODEL_CAPABILITY_REGISTRY = Registry("ModelCapability")
+
+CONTEXT_PARALLEL = "context_parallel"
+
 logger = logging.get_logger(__name__)
+
+
+def model_supports(model_type: Optional[str], capability: str) -> bool:
+    """Whether *model_type* declared *capability*.
+
+    ``False`` for an unregistered model type, including ``None``. Callers gate on
+    this to refuse, so absence has to be the safe answer rather than an error --
+    ``Registry.__getitem__`` raises on an unknown key, which would turn every
+    unported model into a traceback about the registry instead of a message about
+    the feature the user asked for.
+    """
+    if model_type is None or model_type not in MODEL_CAPABILITY_REGISTRY.valid_keys():
+        return False
+    return capability in MODEL_CAPABILITY_REGISTRY[model_type]
+
+
+def model_types_supporting(capability: str) -> List[str]:
+    """Every registered model type declaring *capability*, sorted.
+
+    For error messages: a refusal that names what the user could switch to is worth
+    more than one that only names what failed.
+    """
+    return sorted(
+        model_type
+        for model_type in MODEL_CAPABILITY_REGISTRY.valid_keys()
+        if capability in MODEL_CAPABILITY_REGISTRY[model_type]
+    )
 
 
 def raise_unsupported_veomni_modeling(model_name: str) -> None:

--- a/veomni/models/transformers/deepseek_v4/__init__.py
+++ b/veomni/models/transformers/deepseek_v4/__init__.py
@@ -15,7 +15,14 @@
 from functools import partial
 
 from ....utils.device import IS_NPU_AVAILABLE
-from ...loader import MODELING_REGISTRY
+from ...loader import CONTEXT_PARALLEL, MODEL_CAPABILITY_REGISTRY, MODELING_REGISTRY
+
+
+# The generated modeling module shards the sequence and gathers it again around
+# attention, which is what ``cp_size > 1`` requires of a forward and what no other
+# model in the tree implements yet. Declared here rather than listed in
+# ``veomni/models/auto.py`` so that the claim sits with the code backing it.
+MODEL_CAPABILITY_REGISTRY.register("deepseek_v4", frozenset({CONTEXT_PARALLEL}))
 
 
 @MODELING_REGISTRY.register("deepseek_v4")


### PR DESCRIPTION
### What does this PR do?

Moves the context-parallel allow-list out of `veomni/models/auto.py` and into the model package that implements CP.

`CONTEXT_PARALLEL_MODEL_TYPES = frozenset({"deepseek_v4"})` put a model name in the generic model builder, where the next ported model has to be remembered into it. The claim now sits with the code backing it: `veomni/models/transformers/deepseek_v4/__init__.py` registers `CONTEXT_PARALLEL` in a new `MODEL_CAPABILITY_REGISTRY`, and `check_context_parallel_supported` asks the registry.

Behaviour is unchanged. No new capability is granted and none is withdrawn.

### Why a registry, and not the obvious alternatives

The safety property here runs the other way from most gates: this allow-list has to refuse models that are **absent** from it. An unported model under `cp_size > 1` shards the sequence via `SequenceParallelCollator` on `sp_enabled`, never gathers it (its collectives gate on `ulysses_enabled`, which CP alone leaves false), and trains to a plausible loss curve while being silently wrong. That is the failure this gate exists to convert into an error.

So:

- **A per-model hook on the config** — the shape used for `dsa_indexer_loss` in #1134 — would invert the property. A model implementing nothing declares nothing and would be granted CP.
- **A class attribute on the model config** would need a VeOmni-owned config class, and `deepseek_v4` has none on `main`.

Registration is the one direction where forgetting costs a run that will not start rather than one that is quietly incorrect.

### API and Usage Example

No user-facing change. For model authors, a model declares what its forward implements:

```python
MODEL_CAPABILITY_REGISTRY.register("deepseek_v4", frozenset({CONTEXT_PARALLEL}))
```

Two query helpers in `veomni/models/loader.py`: `model_supports(model_type, capability)`, which answers `False` for an unregistered or `None` model type rather than raising, and `model_types_supporting(capability)` for error messages. The refusal's list of what *does* support CP is now derived from the registry instead of restated, so it cannot drift from the gate's own answer.

### Test

`tests/parallel/context_parallel/test_dsv4_cp_gates.py`, 9 tests. Beyond the two that were already there:

- The declaring model is admitted. Not a tautology: the registry is populated as an import side effect of the model package, and `veomni/models/__init__.py` imports `transformers` before `auto` for that to hold. Were the order reversed or the package import made lazy, the model that *does* implement CP would be the one refused — and every other test here would still pass.
- An undeclared model is refused, parametrised over an unported model, a plausible one, `None`, and a name that was never a model type. All four go through the same query, and a lookup that raised on an unknown key would turn the last three into a traceback about the registry rather than a message about CP.
- The refusal names what to switch to.
- A capability is set membership, not a prefix match, so `context_parallel_planned` does not read as `context_parallel`.

Two tests in `tests/parallel/ulysses/test_async_ulysses.py` fail on this branch. I verified they fail identically on clean `main`, so they are not from this change.

One thing found on the way and deliberately not fixed here: `Registry.__getitem__` raises `ValueError` rather than `KeyError` for a missing key, so the inherited `Mapping.get` propagates instead of returning its default — which is why `model_supports` checks `valid_keys()` first, and why the last test assigns to the registry rather than using `monkeypatch.setitem`. Worth fixing separately; it affects every existing `Registry`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (`make quality`)
- [x] Added tests to CI workflow — `tests/parallel/context_parallel/test_dsv4_cp_gates.py`, covered by the existing `tests/parallel` step

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability-based support for context parallelism.
  * Enabled context parallelism for the DeepSeek V4 model.
  * Improved unsupported-model messages by listing models with the required capability.

* **Bug Fixes**
  * Prevented unsupported or undeclared model types from being incorrectly accepted based on partial name matches.
  * Added clearer handling for unknown model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->