### PR TITLE
[lora, perf] refactor: accumulate independent MoE-LoRA gate and up projections

### DIFF
--- a/tests/lora/test_moe_lora_eager.py
+++ b/tests/lora/test_moe_lora_eager.py
@@ -276,13 +276,35 @@ def test_independent_eager_gate_up_accumulates_with_addmm(monkeypatch):
     assert all(call[3] == wrapper._lora_scale_value for call in calls)
 
 
-def test_gate_up_addmm_matches_nonzero_reference_and_gradients():
+@pytest.mark.parametrize(
+    ("device", "dtype", "rtol", "atol"),
+    [
+        pytest.param("cpu", torch.float64, 1e-12, 1e-12, id="cpu-fp64"),
+        pytest.param(
+            "cuda",
+            torch.float16,
+            2e-3,
+            2e-3,
+            id="cuda-fp16",
+            marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable"),
+        ),
+        pytest.param(
+            "cuda",
+            torch.bfloat16,
+            2e-2,
+            2e-2,
+            id="cuda-bf16",
+            marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable"),
+        ),
+    ],
+)
+def test_gate_up_addmm_matches_nonzero_reference_and_gradients(device, dtype, rtol, atol):
     """The accumulated form must preserve nonzero LoRA values and gradients."""
     torch.manual_seed(0)
     shapes = ((3, 7), (10, 7), (2, 7), (5, 2), (2, 7), (5, 2))
-    reference_inputs = [torch.randn(shape, dtype=torch.float64, requires_grad=True) for shape in shapes]
+    reference_inputs = [torch.randn(shape, dtype=dtype, device=device, requires_grad=True) for shape in shapes]
     candidate_inputs = [value.detach().clone().requires_grad_() for value in reference_inputs]
-    scale = 1.75
+    scale = 1 / 3
 
     x, weight, a_gate, b_gate, a_up, b_up = reference_inputs
     gate_delta = torch.nn.functional.linear(torch.nn.functional.linear(x, a_gate), b_gate) * scale
@@ -295,11 +317,12 @@ def test_gate_up_addmm_matches_nonzero_reference_and_gradients():
     up = torch.addmm(up, torch.nn.functional.linear(x, a_up), b_up.T, alpha=scale)
     candidate = torch.cat((gate, up), dim=-1)
 
-    reference_grads = torch.autograd.grad(reference.square().sum(), reference_inputs)
-    candidate_grads = torch.autograd.grad(candidate.square().sum(), candidate_inputs)
-    torch.testing.assert_close(candidate, reference, rtol=1e-12, atol=1e-12)
+    output_grad = torch.randn_like(reference)
+    reference_grads = torch.autograd.grad(reference, reference_inputs, output_grad)
+    candidate_grads = torch.autograd.grad(candidate, candidate_inputs, output_grad)
+    torch.testing.assert_close(candidate, reference, rtol=rtol, atol=atol)
     for candidate_grad, reference_grad in zip(candidate_grads, reference_grads, strict=True):
-        torch.testing.assert_close(candidate_grad, reference_grad, rtol=1e-12, atol=1e-12)
+        torch.testing.assert_close(candidate_grad, reference_grad, rtol=rtol, atol=atol)
 
 
 def test_independent_scale_cache_tracks_loaded_state():
@@ -317,10 +340,12 @@ def test_independent_scale_cache_tracks_loaded_state():
     )
     wrapper = model.get_submodule(sample_fqn)
     state_dict = wrapper.state_dict()
-    state_dict["lora_scaling"] = torch.tensor(1.75)
+    loaded_scaling = torch.tensor(1 / 3, dtype=torch.float64)
+    state_dict["lora_scaling"] = loaded_scaling
     wrapper.load_state_dict(state_dict)
 
-    assert wrapper._lora_scale_value == 1.75
+    assert wrapper._lora_scale_value == wrapper.lora_scaling.item()
+    assert wrapper._lora_scale_value != loaded_scaling.item()
 
 
 def test_independent_scale_cache_load_is_meta_safe():

--- a/tests/lora/test_moe_lora_eager.py
+++ b/tests/lora/test_moe_lora_eager.py
@@ -243,6 +243,108 @@ def test_eager_forward_no_op_at_init(toy_dir: str, mode: str):
     assert diff == 0.0, f"{toy_dir}/{mode}: LoRA must be no-op at init, got max|delta|={diff}"
 
 
+def test_independent_eager_gate_up_accumulates_with_addmm(monkeypatch):
+    """Independent eager gate/up LoRA should accumulate into the split base outputs."""
+    model, lora_cfg = _select_yaml_then_build("qwen3_moe_toy")
+    patterns = lora_cfg["target_parameters"]
+    sample_fqn, exp = find_first_matching_module(model, experts_module_globs(patterns))
+    p0 = next(exp.parameters())
+    _apply(
+        "independent",
+        model,
+        target_parameter_patterns=patterns,
+        r=lora_cfg["rank"],
+        lora_alpha=lora_cfg["alpha"],
+        freeze_base_model=True,
+    )
+    wrapper = model.get_submodule(sample_fqn)
+    hidden_states = torch.randn(4, exp.hidden_dim, dtype=p0.dtype, device=p0.device)
+    top_k_index = torch.zeros(4, 1, dtype=torch.long, device=p0.device)
+    top_k_weights = torch.ones(4, 1, dtype=p0.dtype, device=p0.device)
+    calls = []
+    original_addmm = torch.addmm
+
+    def recording_addmm(input, mat1, mat2, *, beta=1, alpha=1, out=None):
+        calls.append((input.shape, mat1.shape, mat2.shape, alpha))
+        return original_addmm(input, mat1, mat2, beta=beta, alpha=alpha, out=out)
+
+    monkeypatch.setattr(torch, "addmm", recording_addmm)
+    wrapper(hidden_states, top_k_index, top_k_weights)
+
+    assert len(calls) == 2
+    assert all(call[0][-1] == exp.intermediate_dim for call in calls)
+    assert all(call[3] == wrapper._lora_scale_value for call in calls)
+
+
+def test_gate_up_addmm_matches_nonzero_reference_and_gradients():
+    """The accumulated form must preserve nonzero LoRA values and gradients."""
+    torch.manual_seed(0)
+    shapes = ((3, 7), (10, 7), (2, 7), (5, 2), (2, 7), (5, 2))
+    reference_inputs = [torch.randn(shape, dtype=torch.float64, requires_grad=True) for shape in shapes]
+    candidate_inputs = [value.detach().clone().requires_grad_() for value in reference_inputs]
+    scale = 1.75
+
+    x, weight, a_gate, b_gate, a_up, b_up = reference_inputs
+    gate_delta = torch.nn.functional.linear(torch.nn.functional.linear(x, a_gate), b_gate) * scale
+    up_delta = torch.nn.functional.linear(torch.nn.functional.linear(x, a_up), b_up) * scale
+    reference = torch.nn.functional.linear(x, weight) + torch.cat((gate_delta, up_delta), dim=-1)
+
+    x, weight, a_gate, b_gate, a_up, b_up = candidate_inputs
+    gate, up = torch.nn.functional.linear(x, weight).chunk(2, dim=-1)
+    gate = torch.addmm(gate, torch.nn.functional.linear(x, a_gate), b_gate.T, alpha=scale)
+    up = torch.addmm(up, torch.nn.functional.linear(x, a_up), b_up.T, alpha=scale)
+    candidate = torch.cat((gate, up), dim=-1)
+
+    reference_grads = torch.autograd.grad(reference.square().sum(), reference_inputs)
+    candidate_grads = torch.autograd.grad(candidate.square().sum(), candidate_inputs)
+    torch.testing.assert_close(candidate, reference, rtol=1e-12, atol=1e-12)
+    for candidate_grad, reference_grad in zip(candidate_grads, reference_grads, strict=True):
+        torch.testing.assert_close(candidate_grad, reference_grad, rtol=1e-12, atol=1e-12)
+
+
+def test_independent_scale_cache_tracks_loaded_state():
+    """Loading the persistent scale buffer must also update the hot-path float cache."""
+    model, lora_cfg = _select_yaml_then_build("qwen3_moe_toy")
+    patterns = lora_cfg["target_parameters"]
+    sample_fqn, _ = find_first_matching_module(model, experts_module_globs(patterns))
+    _apply(
+        "independent",
+        model,
+        target_parameter_patterns=patterns,
+        r=lora_cfg["rank"],
+        lora_alpha=lora_cfg["alpha"],
+        freeze_base_model=True,
+    )
+    wrapper = model.get_submodule(sample_fqn)
+    state_dict = wrapper.state_dict()
+    state_dict["lora_scaling"] = torch.tensor(1.75)
+    wrapper.load_state_dict(state_dict)
+
+    assert wrapper._lora_scale_value == 1.75
+
+
+def test_independent_scale_cache_load_is_meta_safe():
+    """Scale cache loading must not read from an unmaterialized destination buffer."""
+    model, lora_cfg = _select_yaml_then_build("qwen3_moe_toy")
+    patterns = lora_cfg["target_parameters"]
+    sample_fqn, _ = find_first_matching_module(model, experts_module_globs(patterns))
+    _apply(
+        "independent",
+        model,
+        target_parameter_patterns=patterns,
+        r=lora_cfg["rank"],
+        lora_alpha=lora_cfg["alpha"],
+        freeze_base_model=True,
+    )
+    wrapper = model.get_submodule(sample_fqn).to("meta")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        wrapper.load_state_dict({"lora_scaling": torch.tensor(1.75)}, strict=False)
+
+    assert wrapper.lora_scaling.is_meta
+    assert wrapper._lora_scale_value == 1.75
+
+
 @pytest.mark.parametrize("mode", _MODE_CASES)
 @pytest.mark.parametrize("toy_dir", _MODEL_CASES)
 def test_backward_isolates_to_lora_params(toy_dir: str, mode: str):

--- a/tests/lora/test_moe_lora_eager.py
+++ b/tests/lora/test_moe_lora_eager.py
@@ -77,6 +77,7 @@ from veomni.lora.moe_layers import (
     apply_independent_moe_lora,
     apply_shared_moe_lora,
 )
+from veomni.utils.device import IS_CUDA_AVAILABLE, get_device_type
 
 from .utils import (
     build_toy,
@@ -129,6 +130,8 @@ _MODE_CASES = [
     pytest.param("shared", id="shared"),
     pytest.param("independent", id="independent"),
 ]
+
+_GPU_DEVICE = get_device_type()
 
 
 def _select_yaml_then_build(toy_dir: str):
@@ -281,20 +284,20 @@ def test_independent_eager_gate_up_accumulates_with_addmm(monkeypatch):
     [
         pytest.param("cpu", torch.float64, 1e-12, 1e-12, id="cpu-fp64"),
         pytest.param(
-            "cuda",
+            _GPU_DEVICE,
             torch.float16,
             2e-3,
             2e-3,
-            id="cuda-fp16",
-            marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable"),
+            id="gpu-fp16",
+            marks=pytest.mark.skipif(not IS_CUDA_AVAILABLE, reason="GPU is unavailable"),
         ),
         pytest.param(
-            "cuda",
+            _GPU_DEVICE,
             torch.bfloat16,
             2e-2,
             2e-2,
-            id="cuda-bf16",
-            marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable"),
+            id="gpu-bf16",
+            marks=pytest.mark.skipif(not IS_CUDA_AVAILABLE, reason="GPU is unavailable"),
         ),
     ],
 )

--- a/veomni/lora/moe_layers.py
+++ b/veomni/lora/moe_layers.py
@@ -935,6 +935,29 @@ class LoraIndependentExperts(nn.Module):
         if not any(p.is_meta for n, p in self.named_parameters() if _is_lora_param_name(n)):
             self.reset_lora_parameters()
 
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ) -> None:
+        loaded_scaling = state_dict.get(prefix + "lora_scaling")
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+        if loaded_scaling is not None and loaded_scaling.numel() == 1 and not loaded_scaling.is_meta:
+            self._lora_scale_value = loaded_scaling.item()
+
     # ── PEFT-compatible accessors (same surface as LoraSharedExperts) ──────
 
     def _get_lora_container(self, role: str, param_name: str, adapter_name: str | None = None) -> _LoraParam3D:
@@ -1095,14 +1118,11 @@ class LoraIndependentExperts(nn.Module):
             top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
             current_state = hidden_states[token_idx]
 
-            # Per-expert LoRA on gate and up halves — independent rank-r
-            # adapters, both computed inside the per-expert loop. Cat the
-            # per-half deltas into [n_e, 2I] so the add lines up with the
-            # merged ``gate_up_proj`` output before chunk + SiLU.
-            gate_delta = F.linear(F.linear(current_state, a_gate[expert_idx]), b_gate[expert_idx]) * scale  # [n_e, I]
-            up_delta = F.linear(F.linear(current_state, a_up[expert_idx]), b_up[expert_idx]) * scale  # [n_e, I]
-            gate_up = F.linear(current_state, gate_up_w[expert_idx]) + torch.cat([gate_delta, up_delta], dim=-1)
-            gate, up = gate_up.chunk(2, dim=-1)
+            gate, up = F.linear(current_state, gate_up_w[expert_idx]).chunk(2, dim=-1)
+            gate_hidden = F.linear(current_state, a_gate[expert_idx])
+            up_hidden = F.linear(current_state, a_up[expert_idx])
+            gate = torch.addmm(gate, gate_hidden, b_gate[expert_idx].T, alpha=self._lora_scale_value)
+            up = torch.addmm(up, up_hidden, b_up[expert_idx].T, alpha=self._lora_scale_value)
             mid = self.act_fn(gate) * up
 
             lora_x_down = F.linear(F.linear(mid, a_dn[expert_idx]), b_dn[expert_idx]) * scale

--- a/veomni/lora/moe_layers.py
+++ b/veomni/lora/moe_layers.py
@@ -956,7 +956,7 @@ class LoraIndependentExperts(nn.Module):
             error_msgs,
         )
         if loaded_scaling is not None and loaded_scaling.numel() == 1 and not loaded_scaling.is_meta:
-            self._lora_scale_value = loaded_scaling.item()
+            self._lora_scale_value = loaded_scaling.to(dtype=self.lora_scaling.dtype).item()
 
     # ── PEFT-compatible accessors (same surface as LoraSharedExperts) ──────
 


### PR DESCRIPTION
## Purpose

The independent eager MoE-LoRA path currently materializes the gate and up
LoRA deltas, scales both full-width tensors, concatenates them, and launches
a separate add against the merged base projection.

This PR splits the base gate/up projection first and uses standard
`torch.addmm` to accumulate each rank-r LoRA projection directly into the
corresponding base output:

```text
before: {mm: 5, mul: 2, cat: 1, add: 1}
after:  {mm: 3, addmm: 2}
```

This removes the two full-width delta tensors, their separate scale kernels,
the concatenation, and the final residual add. The shared and fused MoE-LoRA
paths are unchanged.

The Python float scale cache is synchronized when loading the persistent
`lora_scaling` buffer. The load hook reads the source state-dict entry so it
also remains safe when the destination module is initialized on `meta`.

## Checklist Before Starting

- Searched existing issues and PRs; no duplicate gate/up eager accumulation
  change was found.
- The PR title follows VeOmni's required
  `[{modules}] {type}: {description}` format.

## Test Plan

### Regression tests

```bash
python -m pytest -q tests/lora/test_moe_lora_eager.py \
  -k "not qwen3_5_moe"
```

The tests cover:

- the real independent Qwen3-MoE wrapper selecting two gate/up `addmm`
  accumulations;
- nonzero A/B weights and a non-unit scale;
- forward and gradient equivalence against the pre-change formula;
- scale-cache synchronization after `load_state_dict`;
- loading into a meta-initialized destination.

Result:

```text
30 passed, 6 deselected
```

The six deselected Qwen3.5 cases require the optional `fla` dependency, which
was unavailable in the benchmark environment.

### Lint and formatting

```bash
make quality
git diff --check
```

Result:

```text
ruff check: passed
ruff format --check: 589 files already formatted
git diff --check: passed
```

### RTX 4090 microbenchmark

Hardware/software: NVIDIA RTX 4090 24 GB, CUDA 13.0,
PyTorch 2.12.1+cu130. BF16 inputs, hidden size 4096,
intermediate size 14336, LoRA rank 16, 20 warmups and 100 measured iterations.

| Expert tokens | Old/New forward (ms) | Forward speedup | Old/New forward+backward (ms) | F+B speedup | Old/New forward peak allocation (MiB) |
|---:|---:|---:|---:|---:|---:|
| 8 | 0.3625 / 0.3318 | 1.09x | 3.0879 / 2.9189 | 1.06x | 243.63 / 242.75 |
| 32 | 0.4035 / 0.3205 | 1.26x | 3.0746 / 2.9460 | 1.04x | 250.63 / 246.88 |
| 128 | 0.4721 / 0.3697 | 1.28x | 3.0756 / 2.8104 | 1.09x | 277.63 / 263.63 |

The benchmark matches LoRA training semantics: hidden states and adapter
weights require gradients, while the base expert weight remains frozen.

The FP32 reference produced identical outputs. The maximum absolute gradient
difference ranged from `7.6e-6` to `1.2e-4`, reflecting the changed GEMM
accumulation order.

## API and Usage Example

No public API or configuration changes are required. The optimization applies
only to `LoraIndependentExperts` when the eager fallback is selected.

## Design & Code Changes

- Split the merged base gate/up result into views before applying LoRA.
- Accumulate gate and up LoRA projections with two `torch.addmm` calls.
- Preserve the loaded `lora_scaling` semantics by synchronizing the hot-path
  float cache from the source state dict.
- Add operator-path, numerical, gradient, state-load, and meta-init coverage.

## Limitations

These are isolated gate/up subgraph measurements from one RTX 4090 run, not
end-to-end MoE training throughput.

The benchmark used PyTorch 2.12.1+cu130, while the repository currently locks
PyTorch 2.11.0+cu130. Other GPU architectures and the Ascend eager path were
not benchmarked. Upstream CI remains the cross-platform validation gate.

## Checklist Before Submitting

- [x] Read the contribution guide
- [x] Applied the repository's locked Ruff 0.13.2 checks
- [x] Added focused regression tests
- [x] No public API or documentation update is required

## AI assistance

AI assistance was used during implementation, testing, benchmarking, review,
and PR drafting. The human contributor reviewed and takes responsibility for
the change and evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved eager MoE-LoRA computations to preserve correct outputs and gradients across supported devices and data types.
  * Fixed restoration of LoRA scaling values when loading saved model state, including converted values and metadata-only device setups.

* **Tests**
  * Added coverage for output accumulation, scaling behavior, checkpoint loading, device handling, and gradient correctness.
  * Expanded validation across CPU and GPU configurations with multiple data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->