### PR TITLE
[lora, perf] refactor: avoid one-hot routing in eager MoE LoRA

### DIFF
--- a/tests/lora/test_moe_lora_eager.py
+++ b/tests/lora/test_moe_lora_eager.py
@@ -65,6 +65,7 @@ Run:
 from __future__ import annotations
 
 import warnings
+from unittest import mock
 
 import pytest
 import torch
@@ -74,6 +75,7 @@ from veomni.lora.moe_layers import (
     _LORA_SPEC_KEYS,
     LoraIndependentExperts,
     LoraSharedExperts,
+    _group_routing_assignments,
     apply_independent_moe_lora,
     apply_shared_moe_lora,
 )
@@ -129,6 +131,32 @@ _MODE_CASES = [
     pytest.param("shared", id="shared"),
     pytest.param("independent", id="independent"),
 ]
+
+
+@pytest.mark.parametrize(
+    ("top_k_index", "num_experts"),
+    [
+        (torch.tensor([[3], [1], [3], [0]]), 5),
+        (torch.tensor([[2, 1], [2, 2], [0, 1], [2, 0]]), 4),
+        (torch.randint(0, 64, (257, 8), generator=torch.Generator().manual_seed(0)), 64),
+    ],
+)
+def test_group_routing_assignments_matches_one_hot_reference(top_k_index, num_experts):
+    expert_mask = torch.nn.functional.one_hot(top_k_index, num_classes=num_experts).permute(2, 1, 0)
+    expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+    expected = []
+    for expert_idx in expert_hit:
+        expert_idx = expert_idx[0]
+        top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+        expected.append((int(expert_idx), top_k_pos, token_idx))
+
+    actual = list(_group_routing_assignments(top_k_index))
+
+    assert len(actual) == len(expected)
+    for actual_group, expected_group in zip(actual, expected, strict=True):
+        assert actual_group[0] == expected_group[0]
+        assert torch.equal(actual_group[1], expected_group[1])
+        assert torch.equal(actual_group[2], expected_group[2])
 
 
 def _select_yaml_then_build(toy_dir: str):
@@ -294,6 +322,31 @@ def test_backward_isolates_to_lora_params(toy_dir: str, mode: str):
         f"{toy_dir}/{mode}: expected at least 3 lora_B params with grad "
         f"(gate + up + down halves), got {n_lora_with_grad}"
     )
+
+
+@pytest.mark.parametrize("mode", _MODE_CASES)
+def test_eager_forward_does_not_materialize_one_hot_routing(mode: str):
+    model, lora_cfg = _select_yaml_then_build("qwen3_moe_toy")
+    patterns = lora_cfg["target_parameters"]
+    sample_fqn, experts = find_first_matching_module(model, experts_module_globs(patterns))
+    _apply(
+        mode,
+        model,
+        target_parameter_patterns=patterns,
+        r=lora_cfg["rank"],
+        lora_alpha=lora_cfg["alpha"],
+        freeze_base_model=True,
+    )
+    wrapper = model.get_submodule(sample_fqn)
+    parameter = next(wrapper.parameters())
+    hidden_states = torch.randn(8, experts.hidden_dim, dtype=parameter.dtype, device=parameter.device)
+    top_k_index = torch.randint(0, experts.num_experts, (8, 2), device=parameter.device)
+    top_k_weights = torch.softmax(torch.randn(8, 2, dtype=torch.float32, device=parameter.device), dim=-1).to(
+        parameter.dtype
+    )
+
+    with mock.patch.object(torch.nn.functional, "one_hot", side_effect=AssertionError("one-hot routing used")):
+        wrapper(hidden_states, top_k_index, top_k_weights)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/lora/test_moe_lora_eager.py
+++ b/tests/lora/test_moe_lora_eager.py
@@ -150,13 +150,21 @@ def test_group_routing_assignments_matches_one_hot_reference(top_k_index, num_ex
         top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
         expected.append((int(expert_idx), top_k_pos, token_idx))
 
-    actual = list(_group_routing_assignments(top_k_index))
+    actual = list(_group_routing_assignments(top_k_index, num_experts))
 
     assert len(actual) == len(expected)
     for actual_group, expected_group in zip(actual, expected, strict=True):
         assert actual_group[0] == expected_group[0]
         assert torch.equal(actual_group[1], expected_group[1])
         assert torch.equal(actual_group[2], expected_group[2])
+
+
+def test_group_routing_assignments_skips_padding_expert():
+    top_k_index = torch.tensor([[0, 3], [3, 1]])
+
+    actual = list(_group_routing_assignments(top_k_index, num_experts=3))
+
+    assert [expert_idx for expert_idx, _, _ in actual] == [0, 1]
 
 
 def _select_yaml_then_build(toy_dir: str):
@@ -347,6 +355,30 @@ def test_eager_forward_does_not_materialize_one_hot_routing(mode: str):
 
     with mock.patch.object(torch.nn.functional, "one_hot", side_effect=AssertionError("one-hot routing used")):
         wrapper(hidden_states, top_k_index, top_k_weights)
+
+
+@pytest.mark.parametrize("mode", _MODE_CASES)
+def test_eager_forward_skips_padding_expert(mode: str):
+    model, lora_cfg = _select_yaml_then_build("qwen3_moe_toy")
+    patterns = lora_cfg["target_parameters"]
+    sample_fqn, experts = find_first_matching_module(model, experts_module_globs(patterns))
+    _apply(
+        mode,
+        model,
+        target_parameter_patterns=patterns,
+        r=lora_cfg["rank"],
+        lora_alpha=lora_cfg["alpha"],
+        freeze_base_model=True,
+    )
+    wrapper = model.get_submodule(sample_fqn)
+    parameter = next(wrapper.parameters())
+    hidden_states = torch.randn(2, experts.hidden_dim, dtype=parameter.dtype, device=parameter.device)
+    top_k_index = torch.tensor([[0, experts.num_experts], [1, 0]], device=parameter.device)
+    top_k_weights = torch.softmax(torch.randn(2, 2, dtype=torch.float32, device=parameter.device), dim=-1).to(
+        parameter.dtype
+    )
+
+    wrapper(hidden_states, top_k_index, top_k_weights)
 
 
 # ---------------------------------------------------------------------------

--- a/veomni/lora/moe_layers.py
+++ b/veomni/lora/moe_layers.py
@@ -164,6 +164,20 @@ logger = logging.get_logger(__name__)
 _PEFT_PREFIX = "base_model.model."
 
 
+def _group_routing_assignments(top_k_index: torch.Tensor):
+    """Yield expert routing groups in the eager path's top-k-major order."""
+    num_tokens = top_k_index.shape[0]
+    flat_experts = top_k_index.T.reshape(-1)
+    sorted_experts, flat_positions = torch.sort(flat_experts, stable=True)
+    expert_ids, counts = torch.unique_consecutive(sorted_experts, return_counts=True)
+
+    offset = 0
+    for expert_idx, count in zip(expert_ids.tolist(), counts.tolist(), strict=True):
+        group_positions = flat_positions[offset : offset + count]
+        yield expert_idx, group_positions // num_tokens, group_positions % num_tokens
+        offset += count
+
+
 def _glob_to_regex(pattern: str) -> re.Pattern[str]:
     """Convert a PEFT-style glob (``*``) to a fully-anchored regex."""
     parts = [re.escape(piece) for piece in pattern.split("*")]
@@ -739,15 +753,7 @@ class LoraSharedExperts(nn.Module):
         lora_x_gate_up = torch.cat([gate_delta, up_delta], dim=-1)  # [N, 2I]
 
         final_hidden_states = torch.zeros_like(hidden_states)
-        with torch.no_grad():
-            expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts).permute(2, 1, 0)
-            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
-
-        for expert_idx in expert_hit:
-            expert_idx = expert_idx[0]
-            if expert_idx == self.num_experts:
-                continue
-            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+        for expert_idx, top_k_pos, token_idx in _group_routing_assignments(top_k_index):
             current_state = hidden_states[token_idx]
 
             gate_up = F.linear(current_state, gate_up_w[expert_idx]) + lora_x_gate_up[token_idx]
@@ -1084,15 +1090,7 @@ class LoraIndependentExperts(nn.Module):
         down_w = self.down_proj.base_layer.weight
 
         final_hidden_states = torch.zeros_like(hidden_states)
-        with torch.no_grad():
-            expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts).permute(2, 1, 0)
-            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
-
-        for expert_idx in expert_hit:
-            expert_idx = expert_idx[0]
-            if expert_idx == self.num_experts:
-                continue
-            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+        for expert_idx, top_k_pos, token_idx in _group_routing_assignments(top_k_index):
             current_state = hidden_states[token_idx]
 
             # Per-expert LoRA on gate and up halves — independent rank-r

--- a/veomni/lora/moe_layers.py
+++ b/veomni/lora/moe_layers.py
@@ -164,7 +164,7 @@ logger = logging.get_logger(__name__)
 _PEFT_PREFIX = "base_model.model."
 
 
-def _group_routing_assignments(top_k_index: torch.Tensor):
+def _group_routing_assignments(top_k_index: torch.Tensor, num_experts: int):
     """Yield expert routing groups in the eager path's top-k-major order."""
     num_tokens = top_k_index.shape[0]
     flat_experts = top_k_index.T.reshape(-1)
@@ -174,8 +174,10 @@ def _group_routing_assignments(top_k_index: torch.Tensor):
     offset = 0
     for expert_idx, count in zip(expert_ids.tolist(), counts.tolist(), strict=True):
         group_positions = flat_positions[offset : offset + count]
-        yield expert_idx, group_positions // num_tokens, group_positions % num_tokens
         offset += count
+        if expert_idx == num_experts:
+            continue
+        yield expert_idx, group_positions // num_tokens, group_positions % num_tokens
 
 
 def _glob_to_regex(pattern: str) -> re.Pattern[str]:
@@ -753,7 +755,7 @@ class LoraSharedExperts(nn.Module):
         lora_x_gate_up = torch.cat([gate_delta, up_delta], dim=-1)  # [N, 2I]
 
         final_hidden_states = torch.zeros_like(hidden_states)
-        for expert_idx, top_k_pos, token_idx in _group_routing_assignments(top_k_index):
+        for expert_idx, top_k_pos, token_idx in _group_routing_assignments(top_k_index, self.num_experts):
             current_state = hidden_states[token_idx]
 
             gate_up = F.linear(current_state, gate_up_w[expert_idx]) + lora_x_gate_up[token_idx]
@@ -1090,7 +1092,7 @@ class LoraIndependentExperts(nn.Module):
         down_w = self.down_proj.base_layer.weight
 
         final_hidden_states = torch.zeros_like(hidden_states)
-        for expert_idx, top_k_pos, token_idx in _group_routing_assignments(top_k_index):
+        for expert_idx, top_k_pos, token_idx in _group_routing_assignments(top_k_index, self.num_experts):
             current_state = hidden_states[token_idx]
 
             # Per-expert LoRA on gate and up halves — independent rank-r


### PR DESCRIPTION
### What does this PR do?

The eager shared and independent MoE-LoRA paths currently materialize a
`[num_tokens, top_k, num_experts]` one-hot tensor, reduce it to find active
experts, and then call `torch.where` for every active expert.

This PR groups the `[num_tokens, top_k]` routing assignments directly:

- transpose to preserve the original top-k-major traversal order;
- stable-sort the flattened assignments by expert ID;
- split consecutive assignments by expert;
- recover `(top_k_pos, token_idx)` from each flattened position.

This reduces the routing workspace from `O(T * K * E)` to `O(T * K)`, while
preserving the original per-expert assignment order and leaving the projection
and routing-weight math unchanged.

### Checklist Before Starting

- Search for relative PRs/issues and link here: no overlapping PR or issue was
  found. #758 introduced MoE-LoRA, but does not contain this optimization.
- This PR title follows the required format:
  `[lora, perf] refactor: avoid one-hot routing in eager MoE LoRA`.
- This change is scoped to the existing eager MoE-LoRA implementation.

### Test

#### Regression tests

```bash
PYTHONPATH=. python -m pytest -q tests/lora/test_moe_lora_eager.py
```

Result: `37 passed`.

The new tests:

- compare the grouped assignments against the previous one-hot implementation
  for top-k 1, top-k 2, repeated/unused experts, and a random top-k 8 case;
- exercise both shared and independent Qwen3-MoE LoRA wrappers;
- fail if either eager forward path calls `torch.nn.functional.one_hot`.

#### Lint and formatting

```bash
ruff format --check veomni/lora/moe_layers.py tests/lora/test_moe_lora_eager.py
ruff check veomni/lora/moe_layers.py tests/lora/test_moe_lora_eager.py
git diff --check HEAD^
```

All checks pass.

#### RTX 4090 microbenchmark

Environment: RTX 4090, CUDA 13.0, PyTorch 2.11.0+cu130. Measurements use CUDA
events after warmup. The routing-only benchmark covers 48 combinations of
tokens (`128` to `8192`), top-k (`1`, `2`, `4`, `8`), and experts (`8` to
`256`).

| Benchmark | Previous | This PR | Change |
| --- | ---: | ---: | ---: |
| Routing-only median across 48 cases | — | — | 48/48 faster; median `-58.3%` |
| Routing-only, T=8192, K=8, E=256 | 15.5867 ms | 5.7285 ms | `-63.2%` |
| Peak routing memory, T=8192, K=8, E=256 | 329.565 MiB | 13.619 MiB | `-95.9%` |
| Shared wrapper forward | 6.923 ms | 5.395 ms | `-22.1%` |
| Independent wrapper forward | 11.153 ms | 7.434 ms | `-33.3%` |
| Independent wrapper forward + backward | 45.479 ms | 41.324 ms | `-9.1%` |

The shared forward + backward result was clock-sensitive across separate
processes: one run measured `+0.9%` and a repeat measured `-8.8%`. The
same-process routing-only result is therefore the primary performance signal.

### API and Usage Example

No public API or configuration changes.

### Design & Code Changes

- Add `_group_routing_assignments` as the shared eager routing helper.
- Replace one-hot mask construction in `LoraSharedExperts` and
  `LoraIndependentExperts` with grouped assignment iteration.
- Add equivalence and no-one-hot regression coverage.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [x] Added regression coverage for both eager MoE-LoRA modes.
- [x] Ran focused formatting, lint, and test checks.
- [x] No documentation update is required because the public API is unchanged.
- [x] The tests live in the existing `tests/lora/test_moe_lora_eager.py` suite.

### Limitations

- The benchmark was run on a single RTX 4090.
- This only changes the eager MoE-LoRA paths; fused MoE kernels are unaffected.

### AI assistance

AI assistance was used to explore the optimization, implement the patch, and
draft tests and documentation. I reviewed the changes and validated them with
the tests and benchmarks above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed eager Mixture-of-Experts LoRA routing to ignore padded expert entries and process only valid experts.
  - Preserved correct routing behavior across shared- and independent-expert modes.

- **Performance**
  - Reduced temporary routing overhead by avoiding materialization of one-hot routing tensors during eager execution.

- **Tests**
  - Added coverage for routing assignments, padded expert handling, and eager forward execution across supported LoRA modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->