### PR TITLE
[model, ci] fix: Wan Ulysses SP sync-path attention correctness

### DIFF
--- a/tests/parallel/ulysses/test_wan_self_attn_padding_mask.py
+++ b/tests/parallel/ulysses/test_wan_self_attn_padding_mask.py
@@ -9,7 +9,7 @@ CPU with no distributed setup.
 
 import torch
 
-from veomni.models.transformers.wan.modeling_wan import eager_attention_forward
+from veomni.models.transformers.wan.modeling_wan import _trim_kv_tail_padding, eager_attention_forward
 
 
 class _Module:
@@ -69,7 +69,47 @@ def test_unmasked_padding_would_have_diverged():
     )
 
 
+def test_trim_kv_tail_padding_matches_unpadded_reference():
+    """`_trim_kv_tail_padding` backs `wrapped_flash_attention_3`/`wrapped_sageattention`,
+    neither of which take a mask argument. It must drop exactly the padded tail the
+    global mask marks, and re-report that count as `pad_size` so the caller can re-pad
+    the kernel's output back to the original (padded) length."""
+    torch.manual_seed(0)
+    batch, heads, real_len, head_dim = 2, 4, 37, 16
+    pad_size = 3
+    local_len = real_len + pad_size
+
+    query = torch.randn(batch, heads, local_len, head_dim)
+    key = torch.randn(batch, heads, local_len, head_dim)
+    value = torch.randn(batch, heads, local_len, head_dim)
+
+    mask = torch.zeros(1, 1, 1, local_len)
+    mask[..., local_len - pad_size :] = torch.finfo(torch.float32).min
+
+    trimmed_q, trimmed_k, trimmed_v, reported_pad = _trim_kv_tail_padding(query, key, value, mask)
+
+    assert reported_pad == pad_size
+    torch.testing.assert_close(trimmed_q, query[..., :real_len, :])
+    torch.testing.assert_close(trimmed_k, key[..., :real_len, :])
+    torch.testing.assert_close(trimmed_v, value[..., :real_len, :])
+
+
+def test_trim_kv_tail_padding_is_noop_without_mask():
+    query = torch.randn(2, 4, 37, 16)
+    key = torch.randn(2, 4, 37, 16)
+    value = torch.randn(2, 4, 37, 16)
+
+    trimmed_q, trimmed_k, trimmed_v, pad_size = _trim_kv_tail_padding(query, key, value, None)
+
+    assert pad_size == 0
+    assert trimmed_q is query
+    assert trimmed_k is key
+    assert trimmed_v is value
+
+
 if __name__ == "__main__":
     test_padding_mask_matches_unpadded_reference()
     test_unmasked_padding_would_have_diverged()
+    test_trim_kv_tail_padding_matches_unpadded_reference()
+    test_trim_kv_tail_padding_is_noop_without_mask()
     print("OK")

--- a/tests/parallel/ulysses/test_wan_self_attn_ulysses.py
+++ b/tests/parallel/ulysses/test_wan_self_attn_ulysses.py
@@ -1,0 +1,113 @@
+"""Multi-process regression test for Wan's sync-path Ulysses SP self-attention.
+
+Issue #1140 (part 2): `SelfAttention.forward`'s sync path (`sp_async=False`, the only
+path Wan actually uses) never redistributed Q/K/V via all-to-all before calling into
+`AttentionModule`. Every rank's backend attention call therefore only ever saw its own
+local SP shard as both query and key/value, instead of the true full sequence with a
+subset of heads -- so Ulysses SP was not numerically equivalent to non-SP attention for
+Wan on any of the three local backends (`eager`, `flash_attention_3`, `sageattention`).
+
+This drives `SelfAttention.forward` directly (bypassing `WanModel` and patchify/rope
+grid setup) with `ulysses_size=world_size` and no sequence padding (full_seq_len is a
+multiple of world_size), and checks that the SP-sharded forward -- gathered back across
+ranks -- exactly matches a single-process "full sequence, no SP" reference computed from
+the same synced weights.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as c10d
+
+from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
+
+
+if not c10d.is_available() or not c10d.is_backend_available(get_dist_comm_backend()):
+    print("c10d NCCL not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+import pytest
+from torch.testing._internal.common_utils import run_tests
+
+from veomni.distributed.parallel_state import clear_parallel_state, get_parallel_state, init_parallel_state
+from veomni.models.transformers.wan.modeling_wan import SelfAttention, precompute_freqs_cis
+
+from .utils import SequenceParallelTest
+
+
+class WanSelfAttentionUlyssesTest(SequenceParallelTest):
+    @property
+    def world_size(self):
+        return 4
+
+    @pytest.mark.skipif(get_torch_device().device_count() < 4, reason="device_count should be >= 4")
+    def test_sync_path_matches_non_sp_reference(self):
+        group = self._get_process_group()
+        try:
+            init_parallel_state(
+                dp_size=1,
+                ulysses_size=self.world_size,
+                device_type=get_device_type(),
+                name=None,
+            )
+            device = get_device_type()
+            dtype = torch.float32
+            dim, num_heads, full_seq_len, batch = 64, 4, 32, 2
+            head_dim = dim // num_heads
+            assert full_seq_len % self.world_size == 0  # no tail padding -- isolates the a2a fix
+
+            config = SimpleNamespace(_attn_implementation="eager")
+            self_attn = SelfAttention(config, dim, num_heads).to(device=device, dtype=dtype)
+            self._sync_model(self_attn.state_dict(), self.rank)
+            for p in self_attn.parameters():
+                c10d.broadcast(p.data, src=0, group=group)
+
+            torch.manual_seed(0)
+            x_full = torch.randn(batch, full_seq_len, dim, device=device, dtype=dtype)
+            c10d.broadcast(x_full, src=0, group=group)
+
+            freqs_full = precompute_freqs_cis(head_dim, end=full_seq_len).reshape(full_seq_len, 1, -1).to(device)
+
+            # Reference: exact sync-path math (norm -> rope -> eager attn -> out proj),
+            # run directly on the FULL sequence with no SP redistribution at all.
+            with torch.no_grad():
+                q = self_attn.norm_q(self_attn.q(x_full))
+                k = self_attn.norm_k(self_attn.k(x_full))
+                v = self_attn.v(x_full)
+                q = rope_apply_ref(q, freqs_full, head_dim)
+                k = rope_apply_ref(k, freqs_full, head_dim)
+                attn_out = self_attn.attn(q, k, v, last_loss=None, isSelfAttn=True, attention_mask=None)
+                reference = self_attn.o(attn_out)
+
+            # Actual: each rank runs the real SelfAttention.forward on its own local
+            # shard, with Ulysses SP enabled -- exercising the all-to-all fix.
+            unit = full_seq_len // self.world_size
+            x_local = x_full[:, unit * self.rank : unit * (self.rank + 1), :].contiguous()
+            freqs_local = freqs_full[unit * self.rank : unit * (self.rank + 1)].contiguous()
+
+            assert get_parallel_state().ulysses_enabled
+            with torch.no_grad():
+                local_out = self_attn(x_local, freqs_local, cos=None, sin=None, last_loss=None, self_attn_mask=None)
+
+            chunks = [torch.empty(batch, unit, dim, device=device, dtype=dtype) for _ in range(self.world_size)]
+            c10d.all_gather(chunks, local_out.contiguous(), group=group)
+            gathered = torch.cat(chunks, dim=1)
+
+            # GPU float32 attention/matmul reduction order differs slightly between
+            # "all heads, one process" (reference) and "subset of heads per rank,
+            # concatenated" (actual) even though they're mathematically identical --
+            # a couple ULPs of noise, not a correctness gap.
+            torch.testing.assert_close(gathered, reference, atol=2e-4, rtol=2e-3)
+        finally:
+            clear_parallel_state()
+
+
+def rope_apply_ref(x, freqs, head_dim):
+    from veomni.models.transformers.wan.modeling_wan import rope_apply
+
+    return rope_apply(x, freqs=freqs, cos=None, sin=None, head_dim=head_dim)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/parallel/ulysses/test_wan_self_attn_ulysses.py
+++ b/tests/parallel/ulysses/test_wan_self_attn_ulysses.py
@@ -14,20 +14,22 @@ ranks -- exactly matches a single-process "full sequence, no SP" reference compu
 the same synced weights.
 """
 
-import sys
 from types import SimpleNamespace
 
+import pytest
 import torch
 import torch.distributed as c10d
 
 from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
 
 
+# A module-level `sys.exit(0)` here would raise SystemExit during collection and abort
+# the whole pytest session (other test files included) on environments without the
+# distributed backend, rather than just skipping this file -- use pytest's own skip
+# mechanism instead.
 if not c10d.is_available() or not c10d.is_backend_available(get_dist_comm_backend()):
-    print("c10d NCCL not available, skipping tests", file=sys.stderr)
-    sys.exit(0)
+    pytest.skip("c10d NCCL not available, skipping tests", allow_module_level=True)
 
-import pytest
 from torch.testing._internal.common_utils import run_tests
 
 from veomni.distributed.parallel_state import clear_parallel_state, get_parallel_state, init_parallel_state

--- a/veomni/models/transformers/wan/modeling_wan.py
+++ b/veomni/models/transformers/wan/modeling_wan.py
@@ -24,9 +24,9 @@ from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 
 from veomni.distributed.parallel_state import get_parallel_state
 from veomni.distributed.sequence_parallel import (
+    gather_heads_scatter_seq,
     gather_outputs,
     gather_seq_scatter_heads,
-    get_ulysses_sequence_parallel_rank,
     get_ulysses_sequence_parallel_world_size,
     slice_input_tensor_scale_grad,
 )
@@ -145,18 +145,58 @@ def eager_attention_forward(
     return attn_output, attn_weights
 
 
+def _trim_kv_tail_padding(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Drop the trailing pad rows an additive tail-padding mask marks, so kernels with no
+    mask argument of their own (flash_attn_func, sageattn) never attend to them.
+
+    ``attention_mask`` here is always the global tail-padding mask built in
+    ``WanModel.forward`` for Ulysses SP (0 for real tokens, ``finfo.min`` for the padded
+    suffix, broadcastable over batch/heads/query-positions) -- never an arbitrary
+    per-position mask -- so "first masked column" is a safe, cheap way to find the valid
+    length. Self-attention gives Q and K the same sequence length, so trimming both by the
+    same amount keeps them aligned. The caller re-pads the output back to the original
+    length with zeros.
+    """
+    if attention_mask is None:
+        return query_states, key_states, value_states, 0
+
+    seq_len = key_states.shape[-2]
+    valid_len = int((attention_mask.reshape(-1) == 0).sum().item())
+    pad_size = seq_len - valid_len
+    if pad_size <= 0:
+        return query_states, key_states, value_states, 0
+
+    return (
+        query_states[..., :valid_len, :],
+        key_states[..., :valid_len, :],
+        value_states[..., :valid_len, :],
+        pad_size,
+    )
+
+
 def wrapped_sageattention(
     module: nn.Module,
     query_states: torch.Tensor,
     key_states: torch.Tensor,
     value_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
     **kwargs,
 ):
     assert SAGE_ATTN_AVAILABLE
+    query_states, key_states, value_states, pad_size = _trim_kv_tail_padding(
+        query_states, key_states, value_states, attention_mask
+    )
     head_dim = query_states.shape[-1]
     rerange_type_head_seq = "b n s d -> b s n d"
     attn_output = sageattn(query_states, key_states, value_states)
     attn_output = rearrange(attn_output, rerange_type_head_seq, d=head_dim)
+    if pad_size > 0:
+        attn_output = nn.functional.pad(attn_output, (0, 0, 0, 0, 0, pad_size))
     return attn_output
 
 
@@ -165,11 +205,15 @@ def wrapped_flash_attention_3(
     query_states: torch.Tensor,
     key_states: torch.Tensor,
     value_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
     last_loss=None,
     isSelfAttn=False,
     **kwargs,
 ):
     assert FLASH_ATTN_3_AVAILABLE
+    query_states, key_states, value_states, pad_size = _trim_kv_tail_padding(
+        query_states, key_states, value_states, attention_mask
+    )
     head_dim = query_states.shape[-1]
     rerange_type_seq_head = "b n s d -> b s n d"
 
@@ -198,6 +242,9 @@ def wrapped_flash_attention_3(
             )
     else:
         attn_output = flash_attn_interface.flash_attn_func(q, k, v)
+
+    if pad_size > 0:
+        attn_output = nn.functional.pad(attn_output, (0, 0, 0, 0, 0, pad_size))
 
     return attn_output
 
@@ -315,15 +362,12 @@ class SelfAttention(nn.Module):
         self.sp_async = False
 
     def forward(self, x, freqs, cos, sin, last_loss, self_attn_mask=None):
-        if self_attn_mask is not None and not self.sp_async:
-            # The sync path attends only over this rank's local SP shard (see
-            # AttentionModule), so the global tail-padding mask built in
-            # WanModel.forward must be narrowed to this rank's own segment --
-            # every shard is equal-size since it was padded to a multiple of
-            # sp_size before slicing.
-            sp_rank = get_ulysses_sequence_parallel_rank()
-            local_len = x.shape[1]
-            self_attn_mask = self_attn_mask[..., sp_rank * local_len : (sp_rank + 1) * local_len]
+        # Ulysses SP redistribution for the sync path: async_ulysses_qkv_projection
+        # already all-to-alls K/V to their full global length internally, so only the
+        # sync (sp_async=False) path needs an explicit gather-seq/scatter-heads here --
+        # without it, each rank's backend attention call only ever sees its own local
+        # SP shard instead of the true full sequence.
+        ulysses_enabled = get_parallel_state().ulysses_enabled
 
         if not self.sp_async:
             q = self.norm_q(self.q(x))
@@ -348,7 +392,19 @@ class SelfAttention(nn.Module):
         q = rope_apply(q, freqs=freqs, cos=cos, sin=sin, head_dim=self.head_dim)
         k = rope_apply(k, freqs=freqs, cos=cos, sin=sin, head_dim=self.head_dim)
 
+        if not self.sp_async and ulysses_enabled:
+            batch_size, local_seq_len = q.shape[0], q.shape[1]
+            q, k, v = (t.view(batch_size, local_seq_len, -1, self.head_dim) for t in (q, k, v))
+            q, k, v = gather_seq_scatter_heads_qkv(q, k, v, seq_dim=1, head_dim=2)
+            q, k, v = (t.reshape(t.shape[0], t.shape[1], -1) for t in (q, k, v))
+
         x = self.attn(q, k, v, last_loss=last_loss, isSelfAttn=True, attention_mask=self_attn_mask)
+
+        if not self.sp_async and ulysses_enabled:
+            batch_size, full_seq_len = x.shape[0], x.shape[1]
+            x = x.view(batch_size, full_seq_len, -1, self.head_dim)
+            x = gather_heads_scatter_seq(x, seq_dim=1, head_dim=2)
+            x = x.reshape(x.shape[0], x.shape[1], -1)
 
         if not self.sp_async:
             x = self.o(x)
@@ -632,23 +688,17 @@ class WanModel(PreTrainedModel):
             x = padding_tensor_for_seqeunce_parallel(x, dim=1)
             freqs = padding_tensor_for_seqeunce_parallel(freqs, dim=0)
 
-            # Build one GLOBAL additive mask over the padded tail, identical on
-            # every rank, marking the pad positions so they can't influence real
-            # tokens' attention output. `SelfAttention.forward` adapts it to
-            # whichever shape its attention call actually needs:
-            #   - sync path (`sp_async=False`, the only path Wan uses today):
-            #     each attention backend here runs on the LOCAL SP shard only,
-            #     so only the LAST rank's shard ever contains padding --
-            #     `SelfAttention` slices this mask down to its own local segment.
-            #   - async path (`sp_async=True`): `async_ulysses_qkv_projection`
-            #     all-to-alls K/V to their full GLOBAL length on every rank (its
-            #     own unpad call is a no-op here since it's told the padded, not
-            #     true, length), so every rank needs the full mask as-is.
-            # Only `eager_attention_forward` reads this today -- the
-            # flash_attention_3/sageattention wrappers ignore `attention_mask`
-            # entirely, so this is a strict improvement where supported and a
-            # no-op (unchanged prior behavior) elsewhere. See PR #1139 for the
-            # scope of what remains unmasked.
+            # Build one GLOBAL additive mask over the padded tail, identical on every
+            # rank, marking the pad positions so they can't influence real tokens'
+            # attention output. Both self-attention paths now see the true full
+            # sequence before their backend attention call -- the sync path
+            # (`sp_async=False`) all-to-alls Q/K/V via `gather_seq_scatter_heads_qkv`
+            # in `SelfAttention.forward`, and the async path's
+            # `async_ulysses_qkv_projection` does its own internal all-to-all -- so
+            # every rank uses this mask as-is, unsliced. `eager_attention_forward`
+            # reads it directly; `wrapped_flash_attention_3`/`wrapped_sageattention`
+            # trim the K/V tail it marks before calling their kernel (neither takes a
+            # mask argument) and re-pad the output back to `padded_seq_len`.
             if pad_size > 0:
                 self_attn_mask = torch.zeros(1, 1, 1, padded_seq_len, dtype=x.dtype, device=x.device)
                 self_attn_mask[..., padded_seq_len - pad_size :] = torch.finfo(x.dtype).min


### PR DESCRIPTION
### What does this PR do?

Fixes the two gaps flagged in #1140 (opened as a follow-up from #1139's review):

1. **`attention_mask` was a no-op for `flash_attention_3`/`sageattention`.** `wrapped_flash_attention_3` and `wrapped_sageattention` in `veomni/models/transformers/wan/modeling_wan.py` accepted `attention_mask` only via `**kwargs` and never read it, so the Ulysses SP tail-padding mask built in `WanModel.forward` had no effect for either backend (only `eager_attention_forward` honored it). Added `_trim_kv_tail_padding`, which drops the padded K/V rows the mask marks before the kernel call (neither kernel takes a mask argument of its own) and re-pads the output back to the original length afterward.

2. **The sync self-attention path never did the Ulysses all-to-all.** `SelfAttention.forward`'s sync path (`sp_async=False`, the only path Wan currently uses -- nothing in the repo sets `sp_async=True`) never redistributed Q/K/V via all-to-all before calling into `AttentionModule`; `gather_seq_scatter_heads_qkv` was defined in this file but never called. Every rank's backend attention therefore ran only over its own local SP shard as both query and key/value, instead of the true full sequence with a subset of heads -- so Ulysses SP was not numerically equivalent to non-SP attention for Wan on any of the three backends. Added the missing `gather_seq_scatter_heads_qkv` / `gather_heads_scatter_seq` pair around the attention call, matching the pattern already used in `flux/modeling_flux.py`. The global tail-padding mask no longer needs the sync path's old per-rank slicing, since both paths now see the true full sequence.

### Checklist Before Starting

- Related: #1140 (follow-up from #1139's review, both gaps described there)

### Test

- `tests/parallel/ulysses/test_wan_self_attn_padding_mask.py` (CPU-only): extended with coverage of the new `_trim_kv_tail_padding` helper (correct trim length, and a no-op when there's no mask).
- `tests/parallel/ulysses/test_wan_self_attn_ulysses.py` (new, multi-process): drives `SelfAttention.forward` directly with `ulysses_size=world_size`, gathers the SP-sharded output back across ranks, and checks it against a single-process non-SP reference computed from the same synced weights -- exercising the all-to-all fix end to end.
- `tests/parallel/ulysses/test_wan_ulysses_padding.py`: existing regression test, still passes.

All three run on 4xA10G (Modal): 4 passed / 1 passed / 1 passed, `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Wan self-attention accuracy when using Ulysses sequence parallelism, including synchronized and padded sequences.
  - Corrected handling of trailing padding for supported optimized attention backends.
  - Ensured attention behavior remains consistent with non-parallel reference results across distributed devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->