### PR TITLE
[ckpt] fix: await pending async save at train end

### DIFF
--- a/tests/checkpoints/test_checkpoint_callback.py
+++ b/tests/checkpoints/test_checkpoint_callback.py
@@ -244,3 +244,44 @@ class TestHuggingfaceCkptCallbackLastSavedStep:
         mock_save_hf.reset_mock()
         cb.on_train_end(state)
         mock_save_hf.assert_not_called()
+
+
+@patch("veomni.trainer.callbacks.checkpoint_callback.build_checkpointer")
+@patch("veomni.trainer.callbacks.checkpoint_callback.dist")
+@patch("veomni.trainer.callbacks.checkpoint_callback.helper")
+class TestCheckpointerCallbackTrainEndWait:
+    """CheckpointerCallback.on_train_end must consume a pending async save.
+
+    Without it, a run whose last save is also its only save (no load_path, no
+    save_hf_weights) exits without ever calling result() on the async future, so
+    a write that raised in the background thread is discarded and the process
+    still exits 0 with no checkpoint on disk.
+    """
+
+    def test_train_end_waits_for_pending_async_save(self, mock_helper, mock_dist, mock_build_ckpt):
+        trainer = _make_mock_trainer(save_async=True)
+        mock_build_ckpt.return_value = trainer.checkpointer
+        cb = CheckpointerCallback(trainer)
+
+        cb.on_train_end(TrainerState(global_step=60))
+
+        trainer.checkpointer.wait_for_pending_save.assert_called_once_with()
+
+    def test_train_end_propagates_async_save_failure(self, mock_helper, mock_dist, mock_build_ckpt):
+        trainer = _make_mock_trainer(save_async=True)
+        mock_build_ckpt.return_value = trainer.checkpointer
+        trainer.checkpointer.wait_for_pending_save.side_effect = RuntimeError("HDFS write failed")
+        cb = CheckpointerCallback(trainer)
+
+        with pytest.raises(RuntimeError, match="HDFS write failed"):
+            cb.on_train_end(TrainerState(global_step=60))
+
+    def test_train_end_waits_even_without_async(self, mock_helper, mock_dist, mock_build_ckpt):
+        """The call is unconditional; wait_for_pending_save is a no-op when nothing is pending."""
+        trainer = _make_mock_trainer(save_async=False)
+        mock_build_ckpt.return_value = trainer.checkpointer
+        cb = CheckpointerCallback(trainer)
+
+        cb.on_train_end(TrainerState(global_step=60))
+
+        trainer.checkpointer.wait_for_pending_save.assert_called_once_with()

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -60,6 +60,30 @@ class CheckpointerCallback(Callback):
     def on_train_begin(self, state: TrainerState, **kwargs) -> None:
         self._load_checkpoint()
 
+    def on_train_end(self, state: TrainerState, **kwargs) -> None:
+        """Block until an in-flight async save has finished before the run exits.
+
+        With ``save_async``, ``_save_checkpoint`` returns as soon as
+        ``dcp.async_save`` has been queued: the write runs on a background thread
+        and any exception it raises stays captured in the future.
+        ``wait_for_pending_save`` is the only place that future is consumed, and
+        until now it was reached only from ``_load_checkpoint`` (needs
+        ``load_path``), from ``HuggingfaceCkptCallback`` / ``HFLoraCkptCallback``
+        (need ``save_hf_weights``), or from the *next* async save. A run whose
+        last save is also its only save therefore exited without ever observing
+        the result: ``ThreadPoolExecutor``'s atexit join let the write finish,
+        but a write that raised was silently discarded and the process still
+        exited 0, leaving no checkpoint behind.
+
+        Waiting here makes that failure visible, and puts the tail of the write
+        in the log rather than in an invisible interpreter-shutdown join.
+
+        No-op when nothing is pending, and ``save_future`` is set on every rank
+        or on none, so the barrier inside ``wait_for_pending_save`` stays
+        balanced.
+        """
+        self.trainer.checkpointer.wait_for_pending_save()
+
     def _load_checkpoint(self):
         """Load checkpoint from path."""
         args: "VeOmniArguments" = self.trainer.args


### PR DESCRIPTION
`CheckpointerCallback` had no `on_train_end`, so a run whose last checkpoint is also its only checkpoint never consumed the `dcp.async_save` future.

`wait_for_pending_save()` is the only place that future is awaited, and it was reachable from just three paths, all conditional:

- `_load_checkpoint()`, which needs `load_path`
- `HuggingfaceCkptCallback` / `HFLoraCkptCallback._save_checkpoint()`, which need `save_hf_weights`
- `execute_save()`, before the *next* async save

A config with `save_async: true`, a single save, no `load_path` and `save_hf_weights: false` hits none of them. `ThreadPoolExecutor`'s atexit join still let a healthy write finish, but a write that raised had its exception discarded with the future, so the process exited 0 having written no checkpoint.

Await it in `CheckpointerCallback.on_train_end` instead. The call is unconditional and is a no-op when nothing is pending; `save_future` is set on every rank or on none, so the barrier inside `wait_for_pending_save` stays balanced. As a side effect the tail of the write now appears in the log rather than in an invisible interpreter-shutdown join.

Found while debugging a weekly CI job (27B dense VL, 16xH100) where the synchronous save blocked the training loop for 11m09s and hang detector killed the process; async save is the fix there, and this makes its failures observable.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Training runs now wait for any in-progress checkpoint saves to finish before exiting.
  * Errors from asynchronous checkpoint saves are surfaced instead of being silently discarded.
  * Finalization remains safe when asynchronous saving is disabled or no save is pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->