### PR TITLE
[ckpt] feat: optional local staging for the DCP write

### DIFF
--- a/tests/checkpoints/test_checkpoint_callback.py
+++ b/tests/checkpoints/test_checkpoint_callback.py
@@ -27,6 +27,7 @@ def _make_mock_trainer(save_path="/tmp/test_ckpt", save_async=False):
         load_path=None,
         manager="dcp",
         dcp_save_to_lowest_rank=False,
+        stage_dir=None,
         save_hf_weights=True,
         hf_save_steps=5,
         hf_save_epochs=1,

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1120,14 +1120,27 @@ class TestPromoteStagedCheckpoint:
     """
 
     @pytest.fixture
-    def staged(self, tmp_path):
-        """A staged checkpoint (two data files plus `.metadata`) and its destination."""
-        stage_path = tmp_path / "stage"
-        final_path = tmp_path / "final"
-        stage_path.mkdir()
-        for name in ("__0_0.distcp", "__0_1.distcp", ".metadata"):
-            (stage_path / name).write_text(name)
-        return str(stage_path), str(final_path)
+    def make_staged(self, tmp_path):
+        """Build an independent staged checkpoint and destination on each call.
+
+        Promotion consumes the staged copy, so anything exercising it more than
+        once needs a fresh one per run rather than a shared directory.
+        """
+
+        def _make(name: str = "default"):
+            stage_path = tmp_path / name / "stage"
+            final_path = tmp_path / name / "final"
+            stage_path.mkdir(parents=True)
+            for entry in ("__0_0.distcp", "__0_1.distcp", ".metadata"):
+                (stage_path / entry).write_text(entry)
+            return str(stage_path), str(final_path)
+
+        return _make
+
+    @pytest.fixture
+    def staged(self, make_staged):
+        """A single staged checkpoint (two data files plus `.metadata`) and its destination."""
+        return make_staged()
 
     def test_copies_everything_and_removes_the_staged_copy(self, staged):
         """The happy path: the destination ends up complete and the scratch copy is gone."""
@@ -1209,20 +1222,24 @@ class TestPromoteStagedCheckpoint:
     # Rank 8 matters on its own: it leads its node but is not the coordinator, so
     # it copies data without ever touching `.metadata`.
     _ROLES = {"coordinator_leader": (0, 0), "leader_only": (8, 0), "participant": (1, 1)}
+    # The participant copies nothing, so it cannot be a copy-failure source.
+    _COPYING_ROLES = ["coordinator_leader", "leader_only"]
 
-    @pytest.mark.parametrize("failing_role", list(_ROLES))
-    def test_every_rank_runs_the_same_barriers_when_a_copy_fails(self, staged, failing_role):
+    @pytest.mark.parametrize("failing_role", _COPYING_ROLES)
+    def test_every_rank_runs_the_same_barriers_when_a_copy_fails(self, make_staged, failing_role):
         """Collective parity: barriers are untagged, so one rank skipping one hangs the job.
 
-        Whichever role fails, every role must reach the same number of barriers and
-        surface the error only after the last one.
+        Whichever role fails, every role -- including the participant that copies
+        nothing -- must reach the same number of barriers, and the error must
+        surface only after the last one.
         """
         from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
 
         counts = {}
         for role, (global_rank, local_rank) in self._ROLES.items():
-            stage_path, final_path = staged
+            stage_path, final_path = make_staged(f"{failing_role}-{role}")
             barrier = MagicMock()
+            raised = False
             with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
                 with patch("veomni.checkpoint.dcp_checkpointer.dist.barrier", barrier):
                     with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=global_rank):
@@ -1234,8 +1251,9 @@ class TestPromoteStagedCheckpoint:
                                 try:
                                     _promote_staged_checkpoint(stage_path, final_path)
                                 except OSError:
-                                    pass
+                                    raised = True
             counts[role] = barrier.call_count
+            assert raised == (role == failing_role), f"{role}: unexpected raise={raised}"
 
         assert len(set(counts.values())) == 1, f"barrier count diverged across roles: {counts}"
         assert set(counts.values()) == {4}
@@ -1292,8 +1310,8 @@ class TestStageDirValidation:
         assert _stage_key("/tmp/a_b/c") != _stage_key("/tmp/a/b_c")
         assert _stage_key("/tmp/run/step_1") == _stage_key("/tmp/run/step_1")
         assert _stage_key("/tmp/run/step_1") != _stage_key("/tmp/run/step_2")
-        # relative and absolute spellings of one destination stage together
-        assert _stage_key("/tmp/run/step_1") == _stage_key("/tmp/run/./step_1")
+        # a relative destination and its absolute spelling stage together
+        assert _stage_key("run/step_1") == _stage_key(os.path.join(os.getcwd(), "run", "step_1"))
 
     def test_stage_dir_with_save_async_is_rejected_before_any_side_effect(self, tmp_path):
         """The staged copy is dropped when save() returns, i.e. before an async write ends."""

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1205,38 +1205,40 @@ class TestPromoteStagedCheckpoint:
                     _promote_staged_checkpoint(stage_path, final_path)
         assert not os.path.exists(stage_path)
 
-    @pytest.mark.parametrize("failing_rank", [0, 1])
-    def test_every_rank_runs_the_same_barriers_when_a_copy_fails(self, staged, failing_rank):
+    # (global_rank, local_rank) for the three roles promotion distinguishes.
+    # Rank 8 matters on its own: it leads its node but is not the coordinator, so
+    # it copies data without ever touching `.metadata`.
+    _ROLES = {"coordinator_leader": (0, 0), "leader_only": (8, 0), "participant": (1, 1)}
+
+    @pytest.mark.parametrize("failing_role", list(_ROLES))
+    def test_every_rank_runs_the_same_barriers_when_a_copy_fails(self, staged, failing_role):
         """Collective parity: barriers are untagged, so one rank skipping one hangs the job.
 
-        Ranks 0 and 1 stand in for the two roles that do work -- rank 0 is both
-        coordinator and a node leader, rank 1 is a plain participant. Whatever
-        fails, both must reach the same number of barriers, and the error must
-        surface only after the last one.
+        Whichever role fails, every role must reach the same number of barriers and
+        surface the error only after the last one.
         """
         from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
 
         counts = {}
-        for rank in (0, 1):
+        for role, (global_rank, local_rank) in self._ROLES.items():
             stage_path, final_path = staged
             barrier = MagicMock()
-            local_rank = 0 if rank == 0 else 1
             with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
                 with patch("veomni.checkpoint.dcp_checkpointer.dist.barrier", barrier):
-                    with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=rank):
+                    with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=global_rank):
                         with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=local_rank):
                             with patch(
                                 "veomni.checkpoint.dcp_checkpointer.shutil.copyfile",
-                                side_effect=OSError("boom") if rank == failing_rank else None,
+                                side_effect=OSError("boom") if role == failing_role else None,
                             ):
                                 try:
                                     _promote_staged_checkpoint(stage_path, final_path)
                                 except OSError:
                                     pass
-            counts[rank] = barrier.call_count
+            counts[role] = barrier.call_count
 
-        assert counts[0] == counts[1], f"barrier count diverged across ranks: {counts}"
-        assert counts[0] == 4
+        assert len(set(counts.values())) == 1, f"barrier count diverged across roles: {counts}"
+        assert set(counts.values()) == {4}
 
     def test_failure_is_raised_only_after_the_last_barrier(self, staged):
         """Raising early would strand the other ranks on a collective that never completes."""
@@ -1268,6 +1270,31 @@ class TestPromoteStagedCheckpoint:
 
 
 class TestStageDirValidation:
+    def test_stage_dir_with_explicit_storage_writer_is_rejected(self, tmp_path):
+        """Silently ignoring stage_dir would write to the slow destination it was avoiding."""
+        from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
+
+        final = tmp_path / "ckpt"
+        with pytest.raises(ValueError, match="explicit storage_writer"):
+            DistributedCheckpointer.save(
+                path=str(final),
+                state={"model": MagicMock()},
+                save_async=False,
+                storage_writer=MagicMock(),
+                stage_dir=str(tmp_path / "stage"),
+            )
+        assert not final.exists()
+
+    def test_stage_key_does_not_collide_across_similar_paths(self):
+        """Separator substitution maps /tmp/a_b/c and /tmp/a/b_c onto one directory."""
+        from veomni.checkpoint.dcp_checkpointer import _stage_key
+
+        assert _stage_key("/tmp/a_b/c") != _stage_key("/tmp/a/b_c")
+        assert _stage_key("/tmp/run/step_1") == _stage_key("/tmp/run/step_1")
+        assert _stage_key("/tmp/run/step_1") != _stage_key("/tmp/run/step_2")
+        # relative and absolute spellings of one destination stage together
+        assert _stage_key("/tmp/run/step_1") == _stage_key("/tmp/run/./step_1")
+
     def test_stage_dir_with_save_async_is_rejected_before_any_side_effect(self, tmp_path):
         """The staged copy is dropped when save() returns, i.e. before an async write ends."""
         from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1108,3 +1108,176 @@ class TestExtraStateSaveLoad:
 
         state = {"model": MagicMock()}
         DistributedCheckpointer._load_extra_state(str(tmp_path), state)
+
+
+class TestPromoteStagedCheckpoint:
+    """`stage_dir` promotion: a staged checkpoint becomes visible only once complete.
+
+    Choosing a usable staging directory is the caller's job, so what is pinned
+    down here is what the checkpointer itself owns: ordering of the completion
+    marker, collective parity across success and failure, and never leaving the
+    staged copy behind.
+    """
+
+    @pytest.fixture
+    def staged(self, tmp_path):
+        """A staged checkpoint (two data files plus `.metadata`) and its destination."""
+        stage_path = tmp_path / "stage"
+        final_path = tmp_path / "final"
+        stage_path.mkdir()
+        for name in ("__0_0.distcp", "__0_1.distcp", ".metadata"):
+            (stage_path / name).write_text(name)
+        return str(stage_path), str(final_path)
+
+    def test_copies_everything_and_removes_the_staged_copy(self, staged):
+        """The happy path: the destination ends up complete and the scratch copy is gone."""
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        stage_path, final_path = staged
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=False):
+            _promote_staged_checkpoint(stage_path, final_path)
+        assert sorted(os.listdir(final_path)) == [".metadata", "__0_0.distcp", "__0_1.distcp"]
+        assert not os.path.exists(stage_path)
+
+    def test_metadata_lands_after_the_data_files(self, staged):
+        """DCP reads `.metadata` as "complete", so it must be copied last."""
+        import shutil as _shutil
+
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        stage_path, final_path = staged
+        order = []
+        real_copy = _shutil.copyfile
+
+        def spy(src, dst):
+            """Record each copied filename, then perform the real copy."""
+            order.append(os.path.basename(dst))
+            return real_copy(src, dst)
+
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=False):
+            with patch("veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=spy):
+                _promote_staged_checkpoint(stage_path, final_path)
+        assert order[-1] == ".metadata"
+
+    def test_stale_metadata_is_removed_before_any_data_is_copied(self, staged):
+        """Overwriting in place must not leave the old marker over half-new data."""
+        import shutil as _shutil
+
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        stage_path, final_path = staged
+        os.makedirs(final_path)
+        with open(os.path.join(final_path, ".metadata"), "w") as f:
+            f.write("previous checkpoint")
+
+        events = []
+        real_copy = _shutil.copyfile
+        real_remove = os.remove
+
+        def copy_spy(src, dst):
+            """Record a copy event, then perform the real copy."""
+            events.append(("copy", os.path.basename(dst)))
+            return real_copy(src, dst)
+
+        def remove_spy(path):
+            """Record a removal event, then perform the real removal."""
+            events.append(("remove", os.path.basename(path)))
+            return real_remove(path)
+
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=False):
+            with patch("veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=copy_spy):
+                with patch("veomni.checkpoint.dcp_checkpointer.os.remove", side_effect=remove_spy):
+                    _promote_staged_checkpoint(stage_path, final_path)
+
+        assert events[0] == ("remove", ".metadata")
+        assert events[-1] == ("copy", ".metadata")
+
+    def test_staged_copy_is_removed_even_when_promotion_fails(self, staged):
+        """A leftover staged copy is the size of the model plus its optimizer state."""
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        stage_path, final_path = staged
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=False):
+            with patch(
+                "veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=OSError("destination is full")
+            ):
+                with pytest.raises(OSError, match="destination is full"):
+                    _promote_staged_checkpoint(stage_path, final_path)
+        assert not os.path.exists(stage_path)
+
+    @pytest.mark.parametrize("failing_rank", [0, 1])
+    def test_every_rank_runs_the_same_barriers_when_a_copy_fails(self, staged, failing_rank):
+        """Collective parity: barriers are untagged, so one rank skipping one hangs the job.
+
+        Ranks 0 and 1 stand in for the two roles that do work -- rank 0 is both
+        coordinator and a node leader, rank 1 is a plain participant. Whatever
+        fails, both must reach the same number of barriers, and the error must
+        surface only after the last one.
+        """
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        counts = {}
+        for rank in (0, 1):
+            stage_path, final_path = staged
+            barrier = MagicMock()
+            local_rank = 0 if rank == 0 else 1
+            with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
+                with patch("veomni.checkpoint.dcp_checkpointer.dist.barrier", barrier):
+                    with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=rank):
+                        with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=local_rank):
+                            with patch(
+                                "veomni.checkpoint.dcp_checkpointer.shutil.copyfile",
+                                side_effect=OSError("boom") if rank == failing_rank else None,
+                            ):
+                                try:
+                                    _promote_staged_checkpoint(stage_path, final_path)
+                                except OSError:
+                                    pass
+            counts[rank] = barrier.call_count
+
+        assert counts[0] == counts[1], f"barrier count diverged across ranks: {counts}"
+        assert counts[0] == 4
+
+    def test_failure_is_raised_only_after_the_last_barrier(self, staged):
+        """Raising early would strand the other ranks on a collective that never completes."""
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        stage_path, final_path = staged
+        calls = []
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
+            with patch("veomni.checkpoint.dcp_checkpointer.dist.barrier", side_effect=lambda: calls.append("barrier")):
+                with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=0):
+                    with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
+                        with patch("veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=OSError("boom")):
+                            with pytest.raises(OSError, match="boom"):
+                                _promote_staged_checkpoint(stage_path, final_path)
+        assert len(calls) == 4
+
+    def test_non_leader_non_coordinator_ranks_touch_nothing(self, staged):
+        """Ranks other than the node leaders and the coordinator only participate in barriers."""
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        stage_path, final_path = staged
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
+            with patch("veomni.checkpoint.dcp_checkpointer.dist.barrier"):
+                with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=3):
+                    with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=3):
+                        _promote_staged_checkpoint(stage_path, final_path)
+        assert not os.path.exists(final_path)
+        assert os.path.exists(stage_path)
+
+
+class TestStageDirValidation:
+    def test_stage_dir_with_save_async_is_rejected_before_any_side_effect(self, tmp_path):
+        """The staged copy is dropped when save() returns, i.e. before an async write ends."""
+        from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
+
+        final = tmp_path / "ckpt"
+        with pytest.raises(ValueError, match="stage_dir cannot be combined with save_async"):
+            DistributedCheckpointer.save(
+                path=str(final),
+                state={"model": MagicMock()},
+                save_async=True,
+                stage_dir=str(tmp_path / "stage"),
+            )
+        assert not final.exists()

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -621,6 +621,21 @@ class CheckpointConfig:
         default=False,
         metadata={"help": "Whether to save checkpoint asynchronously."},
     )
+    stage_dir: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Write checkpoints under this directory and copy them to `output_dir` "
+                "afterwards, instead of writing straight to `output_dir`. Intended for a "
+                "destination far slower than local disk, where a direct write can block the "
+                "training loop long enough to trip the collective timeout. The caller owns "
+                "the choice of directory: nothing is probed and free space is not checked, "
+                "so point it at a node-local filesystem that can hold every rank on the node "
+                "writing the model plus its optimizer state at once. Unset (default) writes "
+                "directly. Cannot be combined with `save_async`."
+            )
+        },
+    )
     dcp_save_to_lowest_rank: bool = field(
         default=False,
         metadata={

--- a/veomni/checkpoint/checkpointer.py
+++ b/veomni/checkpoint/checkpointer.py
@@ -63,7 +63,24 @@ class CheckpointerBase(ABC):
         trainable_only: bool = False,
         save_to_lowest_rank: bool = False,
         parallel_state=None,
+        stage_dir: Optional[str] = None,
     ):
+        """Persist training state to ``path``.
+
+        Args:
+            path: Destination the checkpoint is written to.
+            state: Objects to persist; must contain ``model``.
+            save_async: Return before the write completes, leaving it to a
+                background thread. Backends without async support ignore this.
+            global_steps: Step number; when given, the checkpoint goes into a
+                per-step subdirectory of ``path``.
+            trainable_only: Persist only parameters with ``requires_grad``.
+            save_to_lowest_rank: Concentrate replicated shards on the lowest rank
+                that holds them instead of spreading the writes.
+            parallel_state: Parallelism layout the state was sharded under.
+            stage_dir: Write under this directory and copy to ``path`` afterwards,
+                for a destination far slower than local disk.
+        """
         return
 
     @abstractmethod

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -15,7 +15,9 @@
 
 import gc
 import os
+import shutil
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, Optional, Union
 
 import torch
@@ -450,6 +452,97 @@ def restore_extra_parallel_dim(
     return dtensor
 
 
+def _local_rank() -> int:
+    """This process's rank within its node, as set by the elastic launcher.
+
+    Used to elect one rank per node for the node-local staging work; defaults to
+    0 so single-process runs still take the leader path.
+    """
+    value = os.environ.get("LOCAL_RANK", "0")
+    return int(value) if value.isdigit() else 0
+
+
+def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
+    """Copy a staged checkpoint to its destination, then drop the staged copy.
+
+    The staging directory is node-local and shared by every rank on the node, so
+    one rank per node copies all of it rather than each rank working out which
+    files it wrote; that keeps this independent of DCP's file naming.
+
+    Runs as four barrier-separated phases, and every rank enters every barrier
+    whether or not its own phase did any work or raised. A rank that bailed out
+    early on failure would leave the others waiting on a collective that never
+    comes -- barriers are untagged, so one rank skipping a barrier makes every
+    later one pair up wrongly and the save hangs instead of failing. Failures are
+    therefore recorded and re-raised only once all collectives are done.
+
+    ``.metadata`` is what DCP reads as "this checkpoint is complete", so the
+    destination's old copy is removed before anything is written and the new one
+    is copied last. A reader arriving mid-promotion then sees no metadata rather
+    than the previous checkpoint's metadata over half-replaced data.
+    """
+    metadata_name = ".metadata"
+    is_node_leader = _local_rank() == 0
+    is_coordinator = (not dist.is_initialized()) or dist.get_rank() == 0
+    final_metadata = os.path.join(final_path, metadata_name)
+    error: Optional[BaseException] = None
+
+    def _barrier() -> None:
+        """Synchronise every rank between promotion phases.
+
+        A no-op outside distributed runs, so the same code path covers both.
+        """
+        if dist.is_initialized():
+            dist.barrier()
+
+    # Phase 1: invalidate the destination before it is touched.
+    if is_coordinator:
+        try:
+            os.makedirs(final_path, exist_ok=True)
+            if os.path.exists(final_metadata):
+                os.remove(final_metadata)
+        except BaseException as e:  # noqa: BLE001 - re-raised after the barriers
+            error = e
+    _barrier()
+
+    # Phase 2: one rank per node copies that node's staged files.
+    if is_node_leader and error is None:
+        try:
+            names = [n for n in sorted(os.listdir(stage_path)) if n != metadata_name]
+            os.makedirs(final_path, exist_ok=True)
+
+            def _copy(name: str) -> None:
+                """Copy one staged file to the destination, preserving its name."""
+                shutil.copyfile(os.path.join(stage_path, name), os.path.join(final_path, name))
+
+            if names:
+                with ThreadPoolExecutor(max_workers=min(16, len(names))) as pool:
+                    list(pool.map(_copy, names))
+        except BaseException as e:  # noqa: BLE001 - re-raised after the barriers
+            error = e
+    _barrier()
+
+    # Phase 3: the completion marker goes last, once every node's data has landed.
+    if is_coordinator and error is None:
+        try:
+            src = os.path.join(stage_path, metadata_name)
+            if os.path.exists(src):
+                shutil.copyfile(src, final_metadata)
+        except BaseException as e:  # noqa: BLE001 - re-raised after the barriers
+            error = e
+    _barrier()
+
+    # Phase 4: the staged copy is as large as the model plus its optimizer state,
+    # so drop it even when promotion failed rather than filling the scratch disk
+    # for every later run on this node.
+    if is_node_leader:
+        shutil.rmtree(stage_path, ignore_errors=True)
+    _barrier()
+
+    if error is not None:
+        raise error
+
+
 class DistributedCheckpointer(CheckpointerBase):
     """
     Distributed checkpointer for torch.distributed.checkpoint
@@ -470,6 +563,7 @@ class DistributedCheckpointer(CheckpointerBase):
         trainable_only: bool = False,
         save_to_lowest_rank: bool = False,
         parallel_state=None,
+        stage_dir: Optional[str] = None,
     ) -> None:
         """
         save training state to distributed checkpoint
@@ -495,11 +589,23 @@ class DistributedCheckpointer(CheckpointerBase):
                 checkpoint. Note this only consolidates *replicated* data: unique shards from
                 expert/tensor/pipeline parallelism are never deduplicated and remain distributed.
                 See ``CheckpointConfig.dcp_save_to_lowest_rank``.
+            stage_dir: write the checkpoint under this directory and copy it to ``path``
+                afterwards, instead of writing straight to ``path``. Intended for a
+                destination far slower than local disk. The caller owns the choice: this
+                does not probe for a usable directory or check free space, and an
+                unusable ``stage_dir`` fails the save rather than silently writing
+                elsewhere. See ``CheckpointConfig.stage_dir``.
         return:
             None
         """
         if "model" not in state:
             raise ValueError("Model must be provided to save a distributed checkpoint.")
+
+        if stage_dir and save_async:
+            # The staged copy is deleted as soon as save() returns, which for an async
+            # save is before the write has finished. Reject the pair up front, before
+            # anything has been created on disk, rather than silently dropping one.
+            raise ValueError("stage_dir cannot be combined with save_async")
 
         checkpoint_dir = f"{path}/{_GLOBAL_STEP_PREFIX}{global_steps}" if global_steps else path
         cls._create_checkpoint_dir(checkpoint_dir)
@@ -518,15 +624,29 @@ class DistributedCheckpointer(CheckpointerBase):
                 load=False,
             )
 
-        if storage_writer is None:
-            storage_writer = cls._create_storage_writer(checkpoint_dir)
+        stage_path = None
+        if stage_dir and storage_writer is None:
+            stage_path = os.path.join(stage_dir, os.path.abspath(checkpoint_dir).strip(os.sep).replace(os.sep, "_"))
+            shutil.rmtree(stage_path, ignore_errors=True)  # drop leftovers from a crashed run
+            os.makedirs(stage_path, exist_ok=True)
 
-        cls.execute_save(
-            save_state=save_state,
-            storage_writer=storage_writer,
-            save_async=save_async,
-            save_to_lowest_rank=save_to_lowest_rank,
-        )
+        if storage_writer is None:
+            storage_writer = cls._create_storage_writer(stage_path or checkpoint_dir)
+
+        try:
+            cls.execute_save(
+                save_state=save_state,
+                storage_writer=storage_writer,
+                save_async=save_async,
+                save_to_lowest_rank=save_to_lowest_rank,
+            )
+        except BaseException:
+            if stage_path is not None and _local_rank() == 0:
+                shutil.rmtree(stage_path, ignore_errors=True)
+            raise
+
+        if stage_path is not None:
+            _promote_staged_checkpoint(stage_path, checkpoint_dir)
 
         logger.info_rank0(f"Saved checkpoint to {checkpoint_dir}")
 

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -14,6 +14,7 @@
 
 
 import gc
+import hashlib
 import os
 import shutil
 from collections import OrderedDict
@@ -462,6 +463,19 @@ def _local_rank() -> int:
     return int(value) if value.isdigit() else 0
 
 
+def _stage_key(checkpoint_dir: str) -> str:
+    """Directory name that isolates one destination's staged files from another's.
+
+    Two jobs writing different destinations can share a node, and the same job can
+    be retried, so the key must not collide. Separator substitution would: it maps
+    ``/tmp/a_b/c`` and ``/tmp/a/b_c`` onto the same name. A digest of the absolute
+    path cannot, and the readable prefix keeps the directory identifiable on disk.
+    """
+    absolute = os.path.abspath(checkpoint_dir)
+    digest = hashlib.sha256(absolute.encode("utf-8")).hexdigest()[:16]
+    return f"{os.path.basename(absolute) or 'ckpt'}-{digest}"
+
+
 def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
     """Copy a staged checkpoint to its destination, then drop the staged copy.
 
@@ -607,6 +621,12 @@ class DistributedCheckpointer(CheckpointerBase):
             # anything has been created on disk, rather than silently dropping one.
             raise ValueError("stage_dir cannot be combined with save_async")
 
+        if stage_dir and storage_writer is not None:
+            # A caller-supplied writer already points somewhere; redirecting it to the
+            # staging directory is not ours to do, and ignoring stage_dir would write
+            # straight to the slow destination the caller was trying to avoid.
+            raise ValueError("stage_dir cannot be combined with an explicit storage_writer")
+
         checkpoint_dir = f"{path}/{_GLOBAL_STEP_PREFIX}{global_steps}" if global_steps else path
         cls._create_checkpoint_dir(checkpoint_dir)
 
@@ -625,8 +645,8 @@ class DistributedCheckpointer(CheckpointerBase):
             )
 
         stage_path = None
-        if stage_dir and storage_writer is None:
-            stage_path = os.path.join(stage_dir, os.path.abspath(checkpoint_dir).strip(os.sep).replace(os.sep, "_"))
+        if stage_dir:
+            stage_path = os.path.join(stage_dir, _stage_key(checkpoint_dir))
             shutil.rmtree(stage_path, ignore_errors=True)  # drop leftovers from a crashed run
             os.makedirs(stage_path, exist_ok=True)
 

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -158,6 +158,7 @@ class CheckpointerCallback(Callback):
             trainable_only=bool(getattr(args.model, "lora_config", None)),
             save_to_lowest_rank=args.train.checkpoint.dcp_save_to_lowest_rank,
             parallel_state=self.parallel_state,
+            stage_dir=args.train.checkpoint.stage_dir,
         )
 
         # Empty cache and barrier


### PR DESCRIPTION
Add `train.checkpoint.stage_dir`. When set, the DCP write lands under that directory and is copied to `output_dir` afterwards, instead of streaming straight to a destination that may be far slower than local disk.

The motivating failure: a 16-GPU run whose `output_dir` is a FUSE-mounted network filesystem wrote a 302 GiB checkpoint at ~230 MB/s per node, so the save blocked the training loop for 11 minutes. The ranks that were not writing sat in a scalar collective, NCCL's default 600s watchdog fired, and the job was killed and restarted from step 0 -- repeatedly. Writing locally first keeps the blocking phase short enough to stay inside that budget.

The flag is a plain switch, not a policy engine: no directory is probed, no free space is checked, and nothing silently falls back to a direct write. Which scratch device a node exposes, and whether it can hold every local rank's share of the model plus optimizer state, is deployment-specific knowledge the caller already has -- guessing at it here would only hide misconfiguration.

What the checkpointer does own:

- Promotion is done by one rank per node over the whole staging directory, rather than each rank copying the files it believes it wrote, so it does not depend on DCP's file naming.
- `.metadata` is copied last, and only by the coordinator. DCP reads its presence as "this checkpoint is complete", so promoting it earlier would let a reader pick up a half-written checkpoint.
- The staged copy is removed in a `finally`, and a failed `execute_save` cleans up before re-raising: it is as large as the model plus its optimizer state, so leaving it behind would fill the scratch disk for later runs on that node.
- `stage_dir` together with `save_async` is rejected up front, before anything is created on disk. The staged copy is dropped when `save()` returns, which for an async save is before the write has finished.

Default is None, so behaviour is unchanged unless the flag is set.

### What does this PR do?

> Concise overview of the change. Reference related issues/PRs.

### Checklist Before Starting

- Search for relative PRs/issues and link here: ...
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

> Validation results (training curves, eval metrics) for changes not covered by CI.

### API and Usage Example

> Show API changes and usage examples if applicable.

### Design & Code Changes

> High-level design description and specific change list.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Added tests to CI workflow (or explained why not feasible)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional local staging directory for checkpoint saves before copying them to the final destination.
  * Staged checkpoint paths now use deterministic, collision-resistant identifiers.
  * Added validation preventing local staging from being combined with an explicit storage writer.
  * Documented that local staging is incompatible with asynchronous checkpoint saving.

* **Tests**
  * Expanded coverage for staging validation, path handling, cleanup, and distributed checkpoint coordination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->