### PR TITLE
[data] fix: preserve source timing in Qwen-VL video preprocessing

### DIFF
--- a/docs/usage/multimodal_data_processing.md
+++ b/docs/usage/multimodal_data_processing.md
@@ -55,6 +55,43 @@ Frame sampling flow:
 4. Uniformly sample `nframes` indices from the video
 5. Pad with last frame if `nframes > total_frames`
 
+### Video Timing Metadata
+
+`fps` in `mm_configs` is a **target sampling rate**. Frame limits, alignment,
+rounding, and padding can change the actual intervals between selected frames.
+For example, limiting a 15-second video to 16 frames at a target of 2 FPS still
+selects frames across the whole video; it does not produce an 8-second clip.
+
+`smart_video_nframes`, `fetch_videos_metadata`, and the `load_video*` wrappers
+return metadata in the **source frame coordinate system**:
+
+| Field | Meaning |
+|-------|---------|
+| `fps` | Source frame rate, before sampling |
+| `total_num_frames` | Source frame count, before sampling |
+| `frames_indices` | Source index of each output frame; padding repeats the last selected index |
+
+Use `video.shape[0]` or `len(metadata["frames_indices"])` for the sampled frame
+count. Callers that previously treated metadata `fps` as the output sampling
+rate or `total_num_frames` as the sampled count must use these source semantics.
+`fetch_videos` retains its `(videos, audios)` return format.
+
+For paths/URLs and encoded video bytes, the decoder supplies the source FPS.
+Pre-decoded dicts use `video_fps`; for compatibility, a `video` array dict defaults
+to 30 FPS, while a `frames` bytes dict defaults to `mm_configs.fps` (2 FPS if
+omitted). Bare PIL/bytes frame lists also use `mm_configs.fps` as their input
+frame rate. To express a different source frame rate, wrap the frames in a dict
+with `video_fps`. A bare frame list cannot recover timing lost during earlier
+extraction, or represent irregular source timestamps.
+
+The Qwen-VL transform calls the video processor with `do_sample_frames=False`:
+VeOmni has already sampled the frames, and another sampling pass would overwrite
+their source indices. The processor still performs its spatial preprocessing
+and patch construction. Qwen3-VL/Qwen3.5 chat templates compute frame times as
+`frames_indices / fps` and average the first/last frame times within each temporal
+patch. This uses the source's average FPS; exact timing for variable-frame-rate
+containers would require retaining decoder presentation timestamps separately.
+
 ### Spatial Resize Parameters
 
 | Parameter | Description |

--- a/tests/data/multimodal/test_video_utils.py
+++ b/tests/data/multimodal/test_video_utils.py
@@ -1,6 +1,8 @@
 import os
+import sys
 import time
 from io import BytesIO
+from types import ModuleType, SimpleNamespace
 
 import av
 import numpy as np
@@ -8,6 +10,7 @@ import PIL.Image
 import pytest
 import torch
 
+from veomni.data.multimodal import video_utils
 from veomni.data.multimodal.video_utils import (
     _apply_dynamic_video_max_pixels,
     calculate_frame_indices,
@@ -22,10 +25,12 @@ from veomni.utils.import_utils import is_ffmpeg_available
 
 
 # Make sure to place a sample.mp4 file in tests/data/assets
-VIDEO_PATH = os.path.join(os.environ["CI_SAMPLES_DIR"], "sample.mp4")
+VIDEO_PATH = os.path.join(os.environ.get("CI_SAMPLES_DIR", "tests/data/assets"), "sample.mp4")
 
-# Skip tests if the sample video file doesn't exist
-pytestmark = pytest.mark.skipif(not os.path.exists(VIDEO_PATH), reason=f"Test video not found at {VIDEO_PATH}")
+# Only tests that read the external sample require it; synthetic tests run independently.
+requires_sample_video = pytest.mark.skipif(
+    not os.path.exists(VIDEO_PATH), reason=f"Test video not found at {VIDEO_PATH}"
+)
 
 
 def assert_video_output_valid(video: torch.Tensor, audio: np.ndarray = None, **kwargs):
@@ -87,6 +92,7 @@ def assert_video_output_valid(video: torch.Tensor, audio: np.ndarray = None, **k
             )
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_fetch_videos_from_path():
     """
@@ -110,6 +116,7 @@ def test_fetch_videos_from_path():
     assert_video_output_valid(videos[0], audios[0], **kwargs)
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_fetch_videos_from_bytes():
     """
@@ -190,6 +197,7 @@ def test_fetch_videos_from_dict():
     assert_video_output_valid(videos[0], audios[0], **kwargs)
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_fetch_videos_without_audio():
     """
@@ -213,6 +221,7 @@ def test_fetch_videos_without_audio():
     assert_video_output_valid(videos[0], **kwargs)
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_fetch_videos_with_frame_constraints():
     """
@@ -244,6 +253,7 @@ def test_fetch_videos_with_frame_constraints():
     assert_video_output_valid(videos[0], audios[0], **kwargs)
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_fetch_videos_multiple_inputs():
     """
@@ -280,6 +290,7 @@ def test_fetch_videos_multiple_inputs():
         assert_video_output_valid(video, audio, **kwargs)
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_fetch_videos_from_bytes_list():
     """
@@ -319,6 +330,7 @@ def test_fetch_videos_from_bytes_list():
     assert_video_output_valid(videos[0], **kwargs)
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_fetch_videos_metadata():
     """
@@ -346,7 +358,10 @@ def test_fetch_videos_metadata():
     assert "fps" in video_meta[0], "Video metadata should contain 'fps'"
     assert "total_num_frames" in video_meta[0], "Video metadata should contain 'total_num_frames'"
     assert "frames_indices" in video_meta[0], "Video metadata should contain 'frames_indices'"
-    assert video_meta[0]["total_num_frames"] == videos[0].shape[0], "Metadata frame count should match tensor"
+    with av.open(VIDEO_PATH) as container:
+        stream = container.streams.video[0]
+        assert video_meta[0]["total_num_frames"] == stream.frames
+        assert video_meta[0]["fps"] == pytest.approx(float(stream.average_rate))
 
     # Check frames_indices
     frames_indices = video_meta[0]["frames_indices"]
@@ -376,6 +391,7 @@ def test_fetch_videos_metadata():
     )
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_smart_video_nframes_explicit_frames():
     """
@@ -392,10 +408,12 @@ def test_smart_video_nframes_explicit_frames():
     assert processed_video.shape[0] == target_frames, (
         f"Expected {target_frames} frames, got {processed_video.shape[0]}"
     )
-    assert processed_meta["total_num_frames"] == target_frames
+    assert processed_meta["total_num_frames"] == video.shape[0]
+    assert len(processed_meta["frames_indices"]) == target_frames
     assert "fps" in processed_meta, "Processed metadata should contain 'fps'"
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_smart_video_nframes_metadata():
     """
@@ -412,10 +430,12 @@ def test_smart_video_nframes_metadata():
     assert "total_num_frames" in processed_meta, "Metadata should contain 'total_num_frames'"
 
     # Check metadata accuracy
-    assert processed_meta["total_num_frames"] == processed_video.shape[0]
-    assert processed_meta["fps"] > 0, "FPS should be positive"
+    assert processed_meta["total_num_frames"] == video.shape[0]
+    assert len(processed_meta["frames_indices"]) == processed_video.shape[0]
+    assert processed_meta["fps"] == video_meta["fps"]
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_smart_audio_nframes_conditional_resample():
     """
@@ -441,6 +461,7 @@ def test_smart_audio_nframes_conditional_resample():
             assert len(processed_audio2) != len(audio), "Audio length should change after resampling"
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_smart_audio_nframes_metadata():
     """
@@ -469,6 +490,7 @@ def test_load_video_from_bytes_list_empty():
         load_video_from_bytes_list([], fps=2.0)
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_load_video_metadata_structure():
     """
@@ -482,7 +504,10 @@ def test_load_video_metadata_structure():
     assert "fps" in video_meta, "Video metadata should contain 'fps'"
     assert "total_num_frames" in video_meta, "Video metadata should contain 'total_num_frames'"
     assert "frames_indices" in video_meta, "Video metadata should contain 'frames_indices'"
-    assert video_meta["total_num_frames"] == video.shape[0], "Metadata frame count should match tensor"
+    with av.open(VIDEO_PATH) as container:
+        stream = container.streams.video[0]
+        assert video_meta["total_num_frames"] == stream.frames
+        assert video_meta["fps"] == pytest.approx(float(stream.average_rate))
 
     # Check frames_indices
     frames_indices = video_meta["frames_indices"]
@@ -500,6 +525,7 @@ def test_load_video_metadata_structure():
         assert "total_num_frames" in audio_meta, "Audio metadata should contain 'total_num_frames'"
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 def test_frames_indices_for_qwen3vl():
     """
@@ -533,7 +559,8 @@ def test_frames_indices_for_qwen3vl():
     assert frames_indices is not None, "frames_indices should not be None"
     assert isinstance(frames_indices, torch.Tensor), "frames_indices should be a torch.Tensor"
     assert frames_indices.dtype == torch.long, f"frames_indices should be torch.long, got {frames_indices.dtype}"
-    assert len(frames_indices) == total_frames, "frames_indices length should match total_num_frames"
+    assert len(frames_indices) == videos[0].shape[0], "Each output frame must have a source index"
+    assert frames_indices.max() < total_frames, "Frame indices must refer to the source video"
 
     # Validate frames_indices values
     assert frames_indices.min() >= 0, "All frame indices should be >= 0"
@@ -661,6 +688,7 @@ class TestCalculateFrameIndicesRemainder:
         assert pad1 == pad2
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 @pytest.mark.benchmark
 def test_benchmark_fetch_videos_from_path():
@@ -717,6 +745,7 @@ def test_benchmark_fetch_videos_from_path():
     print(f"{'=' * 60}")
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 @pytest.mark.benchmark
 def test_benchmark_fetch_videos_different_resolutions():
@@ -770,6 +799,7 @@ def test_benchmark_fetch_videos_different_resolutions():
     print(f"{'=' * 95}")
 
 
+@requires_sample_video
 @pytest.mark.skipif(not (is_ffmpeg_available()), reason="torchcodec or ffmpeg is not available")
 @pytest.mark.benchmark
 def test_benchmark_audio_processing():
@@ -914,3 +944,96 @@ class TestApplyDynamicVideoMaxPixels:
         result = _apply_dynamic_video_max_pixels(nframes=16, kwargs=kwargs)
         assert result["video_max_pixels"] < 602112
         assert result["video_max_pixels"] > 100352
+
+
+def _frames(count):
+    # Pixel values identify the original frame, independently of returned metadata.
+    return torch.arange(count, dtype=torch.uint8)[:, None, None, None].expand(-1, 3, 32, 32).clone()
+
+
+@pytest.mark.parametrize("max_frames, expected", [(None, [0, 17, 34, 51, 68, 85, 102, 119]), (4, [0, 40, 79, 119])])
+@pytest.mark.parametrize("container", ["video.mp4", b"video container"])
+def test_container_metadata_preserves_source_time(monkeypatch, max_frames, expected, container):
+    frames = _frames(120)
+
+    class Decoder:
+        def __init__(self, *args, **kwargs):
+            self.metadata = SimpleNamespace(average_fps=30.0, num_frames=120)
+
+        def get_frames_at(self, indices):
+            return SimpleNamespace(data=frames[indices])
+
+    decoders = ModuleType("torchcodec.decoders")
+    decoders.VideoDecoder = Decoder
+    monkeypatch.setitem(sys.modules, "torchcodec.decoders", decoders)
+    monkeypatch.setattr(video_utils, "is_ffmpeg_available", lambda: True)
+    kwargs = dict(fps=2.0, max_frames=max_frames, use_audio_in_video=False)
+    videos, metadata, audios, _ = video_utils.fetch_videos_metadata([container], **kwargs)
+    meta = metadata[0]
+    assert meta["fps"] == 30.0
+    assert meta["total_num_frames"] == 120
+    assert meta["frames_indices"].tolist() == expected
+    assert videos[0][:, 0, 0, 0].tolist() == expected
+    assert (meta["frames_indices"] / meta["fps"]).tolist() == pytest.approx(np.array(expected) / 30.0)
+    # Omni and DiT still receive the same two-value API and sampled frame data.
+    legacy_videos, legacy_audios = video_utils.fetch_videos([container], **kwargs)
+    assert torch.equal(legacy_videos[0], videos[0])
+    assert legacy_audios == audios == [None]
+
+
+@pytest.mark.parametrize("kind", ["array_dict", "bytes_dict", "pil_list", "bytes_list"])
+@pytest.mark.parametrize(
+    "sampling, expected", [({"max_frames": 4}, [0, 2, 3, 5]), ({"frames": 8}, [0, 1, 2, 3, 4, 5, 5, 5])]
+)
+def test_predecoded_timing_and_repeated_frame_padding(kind, sampling, expected):
+    frames = _frames(6)
+    images = [PIL.Image.fromarray(frame.permute(1, 2, 0).numpy()) for frame in frames]
+    encoded = []
+    for img in images:
+        buffer = BytesIO()
+        img.save(buffer, format="PNG")
+        encoded.append(buffer.getvalue())
+    video = {
+        "array_dict": {"video": frames.permute(0, 2, 3, 1).numpy(), "video_fps": 2.0},
+        "bytes_dict": {"frames": encoded, "video_fps": 2.0},
+        "pil_list": images,
+        "bytes_list": encoded,
+    }[kind]
+    videos, metadata, _, _ = video_utils.fetch_videos_metadata([video], fps=2.0, **sampling)
+    meta = metadata[0]
+    assert meta["fps"] == 2.0
+    assert meta["total_num_frames"] == 6
+    assert meta["frames_indices"].tolist() == expected
+    assert videos[0][:, 0, 0, 0].tolist() == expected
+
+
+def test_dict_source_fps_differs_from_target():
+    video = {"video": _frames(120).numpy(), "video_fps": 30.0}
+    videos, metadata, _, _ = video_utils.fetch_videos_metadata([video], fps=2.0, max_frames=4)
+    assert metadata[0]["fps"] == 30.0
+    assert metadata[0]["total_num_frames"] == 120
+    assert metadata[0]["frames_indices"].tolist() == [0, 40, 79, 119]
+    assert videos[0][:, 0, 0, 0].tolist() == [0, 40, 79, 119]
+
+
+def test_decoder_fallback_keeps_repeated_first_frame_time(monkeypatch):
+    class Decoder:
+        def __init__(self, *args, **kwargs):
+            self.metadata = SimpleNamespace(average_fps=30.0, num_frames=120)
+
+        def get_frames_at(self, indices):
+            if indices != [0]:
+                raise RuntimeError("End of stream")
+            return SimpleNamespace(data=_frames(1))
+
+    decoders = ModuleType("torchcodec.decoders")
+    decoders.VideoDecoder = Decoder
+    monkeypatch.setitem(sys.modules, "torchcodec.decoders", decoders)
+    monkeypatch.setattr(video_utils, "is_ffmpeg_available", lambda: True)
+    videos, metadata, _, _ = video_utils.fetch_videos_metadata(
+        ["video.mp4"], fps=2, min_frames=4, frame_factor=2, use_audio_in_video=False
+    )
+    assert metadata[0]["fps"] == 30.0
+    assert metadata[0]["total_num_frames"] == 120
+    assert metadata[0]["frames_indices"].tolist() == [0, 0, 0, 0]
+    assert videos[0].shape[0] == 4

--- a/tests/data/test_chat_template.py
+++ b/tests/data/test_chat_template.py
@@ -272,6 +272,51 @@ def _video_metadata(total_num_frames, fps=2.0, frames_indices=None):
     )
 
 
+@pytest.mark.parametrize("sample_fps,max_frames", [(2.0, 4), (2.0, None), (1.0, None)])
+def test_qwen_vl_transform_preserves_video_timestamps(sample_fps, max_frames):
+    import re
+
+    import torch
+    from transformers import Qwen3VLVideoProcessor
+
+    from veomni.data.data_transform import _process_sample_qwen_vl_base
+
+    # Five seconds at 30 FPS. Each frame's pixels identify its source index.
+    frames = torch.arange(150, dtype=torch.uint8)[:, None, None, None].expand(-1, 3, 32, 32).numpy()
+    processor = SimpleNamespace(
+        tokenizer=_SpecialTokenTokenizer(),
+        video_processor=Qwen3VLVideoProcessor(size={"shortest_edge": 32 * 32, "longest_edge": 32 * 32}),
+    )
+    template = build_chat_template("qwen3vl", processor)
+    sample = {
+        "source": "LLaVA-Video-178K",
+        "videos": [{"video": frames, "video_fps": 30.0}],
+        "conversations": [{"from": "human", "value": "<image>\nDescribe the video."}],
+    }
+
+    def position_ids(**kwargs):
+        return {"position_ids": torch.arange(kwargs["input_ids"].shape[-1]).view(1, 1, -1)}
+
+    result = _process_sample_qwen_vl_base(
+        sample, processor, template, position_ids, fps=sample_fps, max_frames=max_frames
+    )[0]
+    decoded = "".join(chr(i - 1000) for i in result["input_ids"].tolist() if i >= 1000)
+    timestamps = re.findall(r"<([\d.]+) seconds>", decoded)
+    # Recover the selected frames independently from processor pixel output.
+    # Constant-color patches preserve their source frame value through normalization.
+    pixels = result["pixel_values_videos"]
+    patch_size = processor.video_processor.patch_size
+    temporal = processor.video_processor.temporal_patch_size
+    selected = (pixels.reshape(-1, 3, temporal, patch_size, patch_size)[:, 0, :, 0, 0] * 0.5 + 0.5) * 255
+    selected = selected.round().reshape(-1).tolist()
+    # At 32x32 there are four spatial patches per time block; take one copy.
+    spatial_patches = int(result["video_grid_thw"][0, 1:].prod())
+    source_pairs = [selected[i : i + temporal] for i in range(0, len(selected), spatial_patches * temporal)]
+    expected = [f"{(pair[0] + pair[-1]) / (2 * 30):.1f}" for pair in source_pairs]
+    assert timestamps == expected
+    assert float(timestamps[-1]) > 4.0
+
+
 # Frame/token pairs read off the real Qwen3VLVideoProcessor (temporal_patch_size=2,
 # merge_size=2) at 128x128: the processor pads an odd frame count up, so 15 and 16
 # frames both yield grid_t=8 and 128 tokens.

--- a/veomni/data/data_transform.py
+++ b/veomni/data/data_transform.py
@@ -315,8 +315,13 @@ def _process_sample_qwen_vl_base(
 
     if "videos" in sample and sample["videos"]:
         videos, metadata, _, _ = fetch_videos_metadata(sample["videos"], **kwargs)
+        # Fetch already sampled the frames. Preserve its source indices/FPS for timestamps.
         video_inputs = processor.video_processor(
-            videos=videos, video_metadata=metadata, return_tensors="pt", return_metadata=True
+            videos=videos,
+            video_metadata=metadata,
+            do_sample_frames=False,
+            return_tensors="pt",
+            return_metadata=True,
         )
         video_grid_thw = video_inputs["video_grid_thw"]
         video_metadata = video_inputs.pop("video_metadata", None)

--- a/veomni/data/multimodal/video_utils.py
+++ b/veomni/data/multimodal/video_utils.py
@@ -153,7 +153,7 @@ def smart_video_nframes(
     min_frames: int = None,
     max_frames: int = None,
     **kwargs,
-) -> tuple[torch.Tensor, Dict[str, Union[float, int]]]:
+) -> tuple[torch.Tensor, Dict[str, Union[float, int, torch.Tensor]]]:
     """Sample video frames with fps and alignment constraints.
 
     Args:
@@ -166,7 +166,9 @@ def smart_video_nframes(
         **kwargs: Additional arguments (e.g., 'frames' for explicit count)
 
     Returns:
-        (video, metadata): Processed video and metadata dict with 'fps', 'total_num_frames'
+        (video, metadata): Sampled video and source metadata. 'fps' and
+        'total_num_frames' describe the input before sampling; 'frames_indices'
+        maps each output frame back to that input, including repeated padding.
     """
     total_frames = video.shape[0]
 
@@ -197,11 +199,13 @@ def smart_video_nframes(
     if pad_count > 0:
         last_frame = video[-1:].expand(pad_count, -1, -1, -1)
         video = torch.cat([video, last_frame], dim=0)
+        indices = indices + [indices[-1]] * pad_count
 
-    nframes = video.shape[0]
-    fps_out = video_fps * nframes / total_frames if total_frames > 0 else fps
-
-    return video, {"fps": fps_out, "total_num_frames": nframes}
+    return video, {
+        "fps": video_fps,
+        "total_num_frames": total_frames,
+        "frames_indices": torch.tensor(indices, dtype=torch.long),
+    }
 
 
 def smart_audio_nframes(
@@ -452,8 +456,8 @@ def _load_and_process_video_with_codec(video_input: VideoInput, use_audio_in_vid
     Supports: str (path/URL), bytes, List[PIL.Image], List[bytes], Dict[str, np.ndarray].
 
     Returns:
-        (video, audio, audio_fps, frames_indices): Processed video, audio array, audio FPS,
-        and sampled frame indices from original video
+        (video, audio, audio_fps, video_metadata): Processed video, audio array,
+        audio FPS, and source video metadata with sampled original frame indices.
     """
     if isinstance(video_input, list):
         if len(video_input) > 0 and isinstance(video_input[0], bytes):
@@ -475,9 +479,8 @@ def _load_and_process_video_with_codec(video_input: VideoInput, use_audio_in_vid
         # Pre-compute nframes for dynamic max_pixels before spatial resize
         indices, pad_count = calculate_frame_indices(total_frames=video.shape[0], video_fps=video_fps, **kwargs)
         resize_kwargs = _apply_dynamic_video_max_pixels(len(indices) + pad_count, kwargs)
-        video, _ = smart_video_nframes(smart_resize(video, **resize_kwargs), video_fps, **kwargs)
-        frames_indices = torch.arange(video.shape[0])
-        return video, audio, audio_fps, frames_indices
+        video, video_metadata = smart_video_nframes(smart_resize(video, **resize_kwargs), video_fps, **kwargs)
+        return video, audio, audio_fps, video_metadata
 
     elif isinstance(video_input, dict):
         video, video_fps, audio, audio_fps = _dict_to_video_audio(
@@ -486,9 +489,8 @@ def _load_and_process_video_with_codec(video_input: VideoInput, use_audio_in_vid
         # Pre-compute nframes for dynamic max_pixels before spatial resize
         indices, pad_count = calculate_frame_indices(total_frames=video.shape[0], video_fps=video_fps, **kwargs)
         resize_kwargs = _apply_dynamic_video_max_pixels(len(indices) + pad_count, kwargs)
-        video, _ = smart_video_nframes(smart_resize(video, **resize_kwargs), video_fps, **kwargs)
-        frames_indices = torch.arange(video.shape[0])
-        return video, audio, audio_fps, frames_indices
+        video, video_metadata = smart_video_nframes(smart_resize(video, **resize_kwargs), video_fps, **kwargs)
+        return video, audio, audio_fps, video_metadata
 
     # video_input is str (path/URL) or bytes — the only branch that needs the
     # ffmpeg / torchcodec stack. dict / List[bytes] / List[PIL.Image] inputs above
@@ -558,9 +560,13 @@ def _load_and_process_video_with_codec(video_input: VideoInput, use_audio_in_vid
         max_audio_duration = (metadata.duration_seconds or 60.0) + 1.0
         audio, audio_fps = extract_audio_from_video(video_input, max_duration_seconds=max_audio_duration)
 
-    frames_indices = torch.tensor(padded_indices, dtype=torch.long)
+    video_metadata = {
+        "fps": video_fps,
+        "total_num_frames": total_frames,
+        "frames_indices": torch.tensor(padded_indices, dtype=torch.long),
+    }
 
-    return final_frames, audio, audio_fps, frames_indices
+    return final_frames, audio, audio_fps, video_metadata
 
 
 def fetch_videos(videos: List[VideoInput], **kwargs):
@@ -598,7 +604,10 @@ def fetch_videos(videos: List[VideoInput], **kwargs):
 def fetch_videos_metadata(videos: List[VideoInput], **kwargs):
     """Fetch and process videos with full metadata.
 
-    IMPORTANT: For Qwen3-VL, this returns frames_indices needed for timestamp calculation.
+    The video metadata uses the source FPS and frame count, not the requested
+    sampling FPS or output frame count. 'frames_indices' maps output frames to
+    the source timeline, including repeated indices for padding. Consumers of
+    these already-sampled videos must disable further frame sampling.
 
     ffmpeg / torchcodec is only required for ``str`` / ``bytes`` (raw container)
     inputs — see ``fetch_videos`` for the same note.
@@ -617,13 +626,7 @@ def fetch_videos_metadata(videos: List[VideoInput], **kwargs):
 
     for i, video in enumerate(videos):
         try:
-            processed_video, audio, audio_fps, frames_indices = _load_and_process_video_with_codec(video, **kwargs)
-
-            video_meta = {
-                "fps": kwargs.get("fps", 2.0),
-                "total_num_frames": processed_video.shape[0],
-                "frames_indices": frames_indices,
-            }
+            processed_video, audio, audio_fps, video_meta = _load_and_process_video_with_codec(video, **kwargs)
 
             video_inputs.append(processed_video)
             video_metadata_list.append(video_meta)


### PR DESCRIPTION
### What does this PR do?

  Fix incorrect video timestamp tokens caused by inconsistent metadata and repeated frame sampling in the Qwen-VL training preprocessing pipeline.

  VeOmni samples frames in fetch_videos_metadata, but previously rebuilt the metadata using the requested sampling FPS and sampled frame count while retaining original frame indices for encoded videos. The chat template calculates timestamps from frames_indices / fps, so mixing source indices with the sampling FPS produces incorrect times. For example, source frame 300 in a 30 FPS video represents 10 seconds, but dividing it by a target sampling FPS of 2 produces 150 seconds. Predecoded inputs also lost their original selected frame indices.

  The already-sampled frames could then be sampled again by the video processor, changing the selected frames and their timing metadata. Frame limits make the problem more apparent: requesting 2 FPS does not guarantee half-second intervals when max_frames limits the number of frames selected across the full video.

  This directly affects timestamp text tokens in Qwen3-VL, Qwen3-VL-MoE, Qwen3.5, and Qwen3.5-MoE, which share the Qwen-VL transform and qwen3vl chat template.

  This PR preserves the source FPS, original frame count, and selected source indices, including repeated padding indices, and disables further frame sampling in the shared transform. Spatial preprocessing and patch construction remain enabled.

  Qwen2-VL and Qwen2.5-VL also share this transform, so they receive the preprocessing correction, but they do not use the same textual timestamp tokens. Qwen2.5-VL temporal position encoding and Qwen2.5-Omni/Qwen3-Omni audio/video timing require separate fixes and are outside this PR’s scope.


### Checklist Before Starting

- No issue is linked. No existing open PR was found for this head branch.
- PR title follows the required format: `[data] fix: preserve source video timing in Qwen-VL`.

### Test

Validated an isolated export of commit `23d374f87dfe236ff596b9df763aa8421600685f`, without the subsequent Qwen2.5-VL or Omni commits, using the `veomni` conda environment and transformers 5.9.0:

- `pytest tests/data/test_chat_template.py tests/data/multimodal/test_video_timing.py -q`: 64 passed.
- `make quality`: passed; 592 files already formatted.
- Tests cover decoded timestamp tokens through the shared training transform at target 1/2 FPS, frame limits, source indices, and repeated padding. Synthetic frames and mocked decoder metadata require no model weights or external media.
- GPU/NPU training was not run. A successful full-repository `make commit` run is not claimed; earlier full pre-commit checks found unrelated baseline formatting issues.

### API and Usage Example

`fetch_videos_metadata`, `smart_video_nframes`, and `load_video*` metadata now describe the source video: `fps` is the source FPS, `total_num_frames` is the original frame count, and `frames_indices` maps sampled frames to that source. Use the returned video length for the sampled count. `fetch_videos` retains its `(videos, audios)` interface.

Consumers of these already-sampled videos must use `do_sample_frames=False`. Predecoded input FPS conventions and the average-FPS limitation for variable-frame-rate containers are documented.

### Design & Code Changes

- Preserve metadata from decoding/sampling instead of rebuilding it with the target sampling FPS.
- Keep original indices for predecoded dict/list inputs and repeated padding.
- Disable a second frame-sampling pass in `_process_sample_qwen_vl_base`.
- Add source-timing and decoded timestamp regression tests and document the metadata semantics.

This PR contains only the first video preprocessing fix. Qwen2.5-VL temporal position encoding and Omni audio/video interleaving changes are outside its scope.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [x] Passed Ruff checks and formatting checks.
- [ ] Full-repository pre-commit checks pass (baseline issues noted above).
- [x] Updated documentation.
- [x] Added regression tests to existing test modules; no new CI workflow is needed.
- [x] No training scripts were moved or renamed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved video timestamp alignment across different source and target frame rates.
  - Preserved original video timing and frame references when videos are sampled, padded, or loaded from predecoded frames.
  - Maintained compatibility with the existing video-loading return format.

- **Documentation**
  - Added guidance explaining video timing metadata, source-frame coordinates, FPS defaults, sampling behavior, and timestamp handling across supported video inputs and vision-language workflows.

- **Tests**
  - Added coverage for synthetic videos, varied frame rates, padding, decoder fallbacks, and timestamp accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->