### PR TITLE
[dist, ci, docs] fix: release reentrant checkpoint input gradients

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -170,6 +170,7 @@ jobs:
         run: |
           uv run --frozen pytest -s -x tests/distributed/test_async_offload_unit.py
           uv run --frozen pytest -s -x tests/distributed/test_dummy_forward.py
+          uv run --frozen pytest -s -x tests/distributed/test_gradient_checkpointing.py
           uv run --frozen pytest -s -x tests/distributed/test_torch_compile.py
       - name: Run data tests
         run: |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,8 +62,9 @@ tests/
 │       ├── test_balance_reverse.py        # Balance/recovery precision (8 GPUs)
 │       └── test_balance_sorting_algo.py   # Post-MBS data sorting (CPU)
 │
-├── distributed/                    # Multi-GPU training correctness
+├── distributed/                    # Distributed training and runtime correctness
 │   ├── test_fsdp_equivalence.py         # Single-GPU vs FSDP2 grad equivalence
+│   ├── test_gradient_checkpointing.py   # Checkpoint kwargs and recomputed-input grad cleanup
 │   └── test_dummy_forward.py            # Asymmetric multimodal forward (NCCL hang prevention)
 │
 ├── e2e/                            # End-to-end training integration
@@ -107,7 +108,7 @@ tests/
 | **Ops / kernels** | `tests/ops/` | 0-1 GPU (SM90+ for Quack, DeepSeek-V4 TileLang, and mHC TileKernels) | pytest | Fused kernel guards, dispatch, correctness, and performance |
 | **Data pipeline** | `tests/data/` | 0-1 GPU | pytest | Data loading, collation, preprocessing |
 | **Parallelism** | `tests/parallel/` | 4-8 GPUs | torchrun / pytest | SP, EP, data-balance primitives |
-| **FSDP correctness** | `tests/distributed/` | 2+ GPUs | torchrun (subprocess + mp.spawn) | Single-GPU vs FSDP2 equivalence, dummy forward |
+| **Distributed runtime** | `tests/distributed/` | 0-2+ GPUs | pytest + torchrun | FSDP equivalence, dummy forward, gradient checkpointing |
 | **E2E parallel** | `tests/e2e/` | 4+ GPUs | torchrun (subprocess) | SP/EP alignment across full training runs |
 | **Checkpoints** | `tests/checkpoints/` | 0-8 GPUs | pytest + torchrun | Save/load, DCP→HF conversion |
 | **Utilities** | `tests/utils/` | 0-8 GPUs | pytest + torchrun | FLOPs, grad clipping, weight broadcast |

--- a/tests/distributed/test_gradient_checkpointing.py
+++ b/tests/distributed/test_gradient_checkpointing.py
@@ -1,10 +1,13 @@
 import types
+import weakref
 
 import pytest
+import torch
 import torch.nn as nn
 from torch.utils.checkpoint import noop_context_fn
 
 from veomni.arguments import GradientCheckpointingConfig, MixedPrecisionConfig
+from veomni.distributed.checkpoint import CheckpointFunction
 from veomni.distributed.torch_parallelize import build_parallelize_model
 
 
@@ -15,6 +18,20 @@ class _CheckpointingModel(nn.Module):
 
     def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs=None):
         self.gradient_checkpointing_kwargs = gradient_checkpointing_kwargs
+
+
+class _RetainingCheckpointModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.recomputed_output = None
+        self.recomputed_input_ref = None
+
+    def forward(self, value):
+        output = value.sin()
+        if torch.is_grad_enabled():
+            self.recomputed_output = output
+            self.recomputed_input_ref = weakref.ref(value)
+        return output * 2
 
 
 @pytest.mark.parametrize("early_stop", [True, False])
@@ -49,3 +66,16 @@ def test_build_parallelize_model_forwards_checkpoint_early_stop(monkeypatch, ear
 
 def test_gradient_checkpointing_config_enables_early_stop_by_default():
     assert GradientCheckpointingConfig().early_stop is True
+
+
+def test_reentrant_checkpoint_releases_recomputed_input_grad():
+    module = _RetainingCheckpointModule()
+    value = torch.randn(8, requires_grad=True)
+
+    output = CheckpointFunction.apply(module, False, value)
+    output.sum().backward()
+
+    recomputed_input = module.recomputed_input_ref()
+    assert recomputed_input is not None
+    assert recomputed_input.grad is None
+    torch.testing.assert_close(value.grad, 2 * value.detach().cos())

--- a/veomni/distributed/checkpoint.py
+++ b/veomni/distributed/checkpoint.py
@@ -130,6 +130,12 @@ class CheckpointFunction(torch.autograd.Function):
         torch.autograd.backward(outputs_with_grad, args_with_grad)
         grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else None for inp in detached_inputs)
 
+        # The detached recomputation leaves can outlive this call through saved-variable references.
+        # Their gradients have been captured above, so release the stale references before returning.
+        for inp in detached_inputs:
+            if isinstance(inp, torch.Tensor):
+                inp.grad = None
+
         # patch code, remove the extra allgather with use_reentrant + ckpt
         if handle:
             _post_backward_hook(state, handle, None)


### PR DESCRIPTION
### What does this PR do?

Release gradients attached to the detached input leaves created during reentrant activation-checkpoint recomputation.

The gradients are first captured for return to the outer autograd graph, then the temporary leaves have their `.grad` references cleared. This prevents retained recomputation graphs or saved-variable references from keeping an additional stale input-gradient buffer alive across iterations.

Related upstream reports:

- NVIDIA/Megatron-LM#6117
- NVIDIA/Megatron-LM#6339

### Checklist Before Starting

- Searched for related issues and PRs; the implementation follows the cleanup proposed in NVIDIA/Megatron-LM#6117 and #6339.
- PR title follows the `[{modules}] {type}: {description}` format.

### Test

- `pytest -q tests/distributed/test_gradient_checkpointing.py`: 6 passed.
- Ruff 0.13.2 lint and format checks: passed.
- Pre-commit hooks on all files changed by this PR: passed.
- Real NVIDIA H100 80GB test with an intentionally retained recomputation graph:
  - Before: each step retained a 32 MiB input-gradient buffer; allocated memory grew by 96 MiB per step.
  - After: recomputed-input `.grad` remained empty; allocated memory grew by 64 MiB per step.
  - Clearing the retained graph returned allocated memory to 0 GiB.

### API and Usage Example

No API or configuration changes.

### Design & Code Changes

- Capture recomputed-input gradients before returning from `CheckpointFunction.backward`.
- Clear `.grad` on the temporary detached input leaves after capture.
- Add a regression test that retains the recomputation graph, verifies the temporary gradient is released, and verifies the original input gradient remains numerically correct.
- Run the gradient-checkpointing test file in the GPU unit-test workflow.
- Update the test-suite overview with the distributed gradient-checkpointing coverage and execution requirements.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks
- [x] Updated the testing documentation for the GPU CI coverage change
- [x] Added the regression test to the GPU CI workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gradient checkpointing to release temporary gradients after backward passes, reducing stale references and memory retention.
  - Preserved expected gradients for original inputs during reentrant checkpointing.

- **Tests**
  - Added coverage validating gradient release behavior.
  - Included distributed checkpointing tests in GPU unit test runs.

- **Documentation**
  - Updated distributed testing documentation to cover runtime correctness and gradient checkpointing.
  - Clarified supported GPU ranges and test execution methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->