### PR TITLE
[ckpt] fix: do not publish a staged checkpoint when another rank's copy failed

### DIFF
--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1240,22 +1240,25 @@ class TestPromoteStagedCheckpoint:
     _COPYING_ROLES = ["coordinator_leader", "leader_only"]
 
     @pytest.mark.parametrize("failing_role", _COPYING_ROLES)
-    def test_every_rank_runs_the_same_barriers_when_a_copy_fails(self, make_staged, failing_role):
-        """Collective parity: barriers are untagged, so one rank skipping one hangs the job.
+    def test_every_role_runs_the_same_collectives_and_all_raise_when_a_copy_fails(self, make_staged, failing_role):
+        """Collectives are untagged, so one rank skipping one desynchronises the job.
 
-        Whichever role fails, every role -- including the participant that copies
-        nothing -- must reach the same number of barriers, and the error must
-        surface only after the last one.
+        Each role is replayed with the reduction reporting the *cluster* outcome,
+        which is what production sees: once any rank's copy fails, every rank runs
+        the same collectives, and every rank raises.
         """
         from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
 
         counts = {}
         for role, (global_rank, local_rank) in self._ROLES.items():
             stage_path, final_path = make_staged(f"{failing_role}-{role}")
-            barrier = MagicMock()
+            reductions = []
             raised = False
             with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
-                with patch("veomni.checkpoint.dcp_checkpointer.dist.barrier", barrier):
+                with patch(
+                    "veomni.checkpoint.dcp_checkpointer._any_rank_failed",
+                    side_effect=lambda failed: reductions.append(failed) or True,
+                ):
                     with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=global_rank):
                         with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=local_rank):
                             with patch(
@@ -1264,30 +1267,58 @@ class TestPromoteStagedCheckpoint:
                             ):
                                 try:
                                     _promote_staged_checkpoint(stage_path, final_path)
-                                except OSError:
+                                except (OSError, RuntimeError):
                                     raised = True
-            counts[role] = barrier.call_count
-            assert raised == (role == failing_role), f"{role}: unexpected raise={raised}"
 
-        assert len(set(counts.values())) == 1, f"barrier count diverged across roles: {counts}"
-        # Three barriers plus the phase-3 all_reduce, which doubles as the
-        # barrier closing phase 2.
-        assert set(counts.values()) == {3}
+            assert raised, f"{role} must raise once a peer failed"
+            counts[role] = len(reductions)
 
-    def test_failure_is_raised_only_after_the_last_barrier(self, staged):
-        """Raising early would strand the other ranks on a collective that never completes."""
+        # One collective per phase, four phases, on every role including the one
+        # that failed and the one that does no work at all.
+        assert set(counts.values()) == {4}, f"collective count diverged: {counts}"
+
+    def test_cleanup_still_runs_after_an_earlier_phase_failed(self, staged):
+        """The staged copy is model-plus-optimizer sized; a failure must not strand it."""
         from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
 
         stage_path, final_path = staged
-        calls = []
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=False):
+            with patch(
+                "veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=OSError("destination is full")
+            ):
+                with pytest.raises(OSError, match="destination is full"):
+                    _promote_staged_checkpoint(stage_path, final_path)
+        assert not os.path.exists(stage_path)
+
+    def test_a_failed_metadata_copy_reaches_every_rank(self, staged):
+        """Publishing is part of the save, so its failure cannot stay with the coordinator."""
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        stage_path, final_path = staged
+        reductions = []
+
+        def copy_only_data(src, dst):
+            if dst.endswith(".metadata"):
+                raise OSError("marker write failed")
+            with open(src) as r, open(dst, "w") as w:
+                w.write(r.read())
+
         with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
-            with patch("veomni.checkpoint.dcp_checkpointer.dist.barrier", side_effect=lambda: calls.append("barrier")):
+            with patch(
+                "veomni.checkpoint.dcp_checkpointer._any_rank_failed",
+                side_effect=lambda failed: reductions.append(failed) or failed,
+            ):
                 with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=0):
                     with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
-                        with patch("veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=OSError("boom")):
-                            with pytest.raises(OSError, match="boom"):
+                        with patch("veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=copy_only_data):
+                            with pytest.raises(OSError, match="marker write failed"):
                                 _promote_staged_checkpoint(stage_path, final_path)
-        assert len(calls) == 3
+
+        # Phases 1 and 2 are clean; the publish phase is where it breaks, and its
+        # reduction is what carries that to the ranks that are not the coordinator.
+        assert reductions[:2] == [False, False]
+        assert reductions[2] is True
+        assert not os.path.exists(os.path.join(final_path, ".metadata")), "no partial marker may survive"
 
     def test_metadata_is_not_published_when_another_rank_failed(self, staged):
         """A completion marker over partly-copied data is worse than no checkpoint.
@@ -1298,16 +1329,24 @@ class TestPromoteStagedCheckpoint:
         from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
 
         stage_path, final_path = staged
+        calls = {"n": 0}
+
+        def peer_fails_during_the_copy_phase(failed):
+            # clean through phase 1, then a peer's copy fails
+            calls["n"] += 1
+            return calls["n"] >= 2
+
         with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
-            with patch("veomni.checkpoint.dcp_checkpointer.dist.barrier"):
+            with patch(
+                "veomni.checkpoint.dcp_checkpointer._any_rank_failed",
+                side_effect=peer_fails_during_the_copy_phase,
+            ):
                 with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=0):
                     with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
-                        # This rank copies fine; a different node's leader did not.
-                        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=True):
-                            with pytest.raises(RuntimeError, match="failed on another rank"):
-                                _promote_staged_checkpoint(stage_path, final_path)
+                        with pytest.raises(RuntimeError, match="failed on another rank"):
+                            _promote_staged_checkpoint(stage_path, final_path)
 
-        assert os.path.exists(os.path.join(final_path, "__0_0.distcp")), "data should still have been copied"
+        assert os.path.exists(os.path.join(final_path, "__0_0.distcp")), "this rank's shards still copied"
         assert not os.path.exists(os.path.join(final_path, ".metadata")), "must not publish a completion marker"
 
     def test_stale_metadata_stays_removed_when_promotion_fails(self, staged):

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1239,17 +1239,24 @@ class TestPromoteStagedCheckpoint:
     # The participant copies nothing, so it cannot be a copy-failure source.
     _COPYING_ROLES = ["coordinator_leader", "leader_only"]
 
-    def _replay_every_role(self, make_staged, label, *, fails_locally=None, peer_fails_from=None):
+    def _replay_every_role(self, make_staged, label, *, fails=None, peer_fails_from=None):
         """Run promotion once as each role and report what each one saw.
 
-        ``fails_locally`` names the role whose own ``copyfile`` raises.
+        Copies run for real unless ``fails(role, dst)`` says otherwise, so the
+        assertions look at files that were actually written or actually withheld.
+        A no-op copy mock would make "no marker was published" true for the wrong
+        reason.
+
         ``peer_fails_from`` is the 1-based reduction index from which the group
-        starts reporting failure -- i.e. which phase a *different* rank broke in.
-        Phase 1 closes reduction 1, so a copy failure is `2` and a publish
-        failure is `3`; reporting it earlier would skip the phase under test.
+        reports failure -- i.e. which phase a *different* rank broke in. Phase 1
+        closes reduction 1, so a copy failure is 2 and a publish failure is 3;
+        reporting earlier would skip the phase under test.
         """
+        import shutil as _shutil
+
         from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
 
+        real_copyfile = _shutil.copyfile
         results = {}
         for role, (global_rank, local_rank) in self._ROLES.items():
             stage_path, final_path = make_staged(f"{label}-{role}")
@@ -1261,15 +1268,21 @@ class TestPromoteStagedCheckpoint:
                     return True
                 return failed
 
+            def copyfile(src, dst, _role=role):
+                if fails is not None and fails(_role, dst):
+                    # Mirror shutil: the destination exists before the write fails,
+                    # which is what can leave a truncated file behind.
+                    with open(dst, "w") as f:
+                        f.write("partial")
+                    raise OSError("boom")
+                return real_copyfile(src, dst)
+
             raised = False
             with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
                 with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", side_effect=reduction):
                     with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=global_rank):
                         with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=local_rank):
-                            with patch(
-                                "veomni.checkpoint.dcp_checkpointer.shutil.copyfile",
-                                side_effect=OSError("boom") if role == fails_locally else None,
-                            ):
+                            with patch("veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=copyfile):
                                 try:
                                     _promote_staged_checkpoint(stage_path, final_path)
                                 except (OSError, RuntimeError):
@@ -1279,13 +1292,12 @@ class TestPromoteStagedCheckpoint:
 
     @pytest.mark.parametrize("failing_role", _COPYING_ROLES)
     def test_every_role_runs_the_same_collectives_and_all_raise_when_a_copy_fails(self, make_staged, failing_role):
-        """Collectives are untagged, so one rank skipping one desynchronises the job.
-
-        The group starts reporting failure at reduction 2, the one closing the
-        copy phase, so the copy really is where it breaks.
-        """
+        """Collectives are untagged, so one rank skipping one desynchronises the job."""
         results = self._replay_every_role(
-            make_staged, f"copyfail-{failing_role}", fails_locally=failing_role, peer_fails_from=2
+            make_staged,
+            f"copyfail-{failing_role}",
+            fails=lambda role, dst: role == failing_role and dst.endswith(".distcp"),
+            peer_fails_from=2,
         )
 
         for role, r in results.items():
@@ -1298,15 +1310,24 @@ class TestPromoteStagedCheckpoint:
     def test_every_role_sees_a_failed_metadata_copy(self, make_staged):
         """Publishing is part of the save, so its failure cannot stay with the coordinator.
 
-        Failure is reported from reduction 3 -- the one closing the publish phase --
-        so phases 1 and 2 complete normally and the break really is in publishing.
+        The coordinator's marker copy really is attempted and really does fail,
+        leaving a partial file behind, so this also covers that cleanup.
         """
-        results = self._replay_every_role(make_staged, "metafail", peer_fails_from=3)
+        results = self._replay_every_role(
+            make_staged,
+            "metafail",
+            fails=lambda role, dst: role == "coordinator_leader" and dst.endswith(".metadata"),
+            peer_fails_from=3,
+        )
 
         for role, r in results.items():
             assert r["raised"], f"{role} must raise after a failed publish"
             assert r["reductions"] == 4, f"{role} did not finish the cleanup reduction: {results}"
-            assert not os.path.exists(os.path.join(r["final"], ".metadata")), f"{role} published a marker"
+            assert not os.path.exists(os.path.join(r["final"], ".metadata")), f"{role} left a marker"
+
+        # The roles that copy data must still have copied it; only publishing broke.
+        for role in self._COPYING_ROLES:
+            assert os.listdir(results[role]["final"]), f"{role} copied nothing"
 
     def test_a_failing_publish_leaves_no_partial_marker(self, staged):
         """copyfile creates the destination before writing, so a half marker is possible."""

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1239,43 +1239,96 @@ class TestPromoteStagedCheckpoint:
     # The participant copies nothing, so it cannot be a copy-failure source.
     _COPYING_ROLES = ["coordinator_leader", "leader_only"]
 
-    @pytest.mark.parametrize("failing_role", _COPYING_ROLES)
-    def test_every_role_runs_the_same_collectives_and_all_raise_when_a_copy_fails(self, make_staged, failing_role):
-        """Collectives are untagged, so one rank skipping one desynchronises the job.
+    def _replay_every_role(self, make_staged, label, *, fails_locally=None, peer_fails_from=None):
+        """Run promotion once as each role and report what each one saw.
 
-        Each role is replayed with the reduction reporting the *cluster* outcome,
-        which is what production sees: once any rank's copy fails, every rank runs
-        the same collectives, and every rank raises.
+        ``fails_locally`` names the role whose own ``copyfile`` raises.
+        ``peer_fails_from`` is the 1-based reduction index from which the group
+        starts reporting failure -- i.e. which phase a *different* rank broke in.
+        Phase 1 closes reduction 1, so a copy failure is `2` and a publish
+        failure is `3`; reporting it earlier would skip the phase under test.
         """
         from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
 
-        counts = {}
+        results = {}
         for role, (global_rank, local_rank) in self._ROLES.items():
-            stage_path, final_path = make_staged(f"{failing_role}-{role}")
-            reductions = []
+            stage_path, final_path = make_staged(f"{label}-{role}")
+            seen = []
+
+            def reduction(failed, _seen=seen):
+                _seen.append(failed)
+                if peer_fails_from is not None and len(_seen) >= peer_fails_from:
+                    return True
+                return failed
+
             raised = False
             with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
-                with patch(
-                    "veomni.checkpoint.dcp_checkpointer._any_rank_failed",
-                    side_effect=lambda failed: reductions.append(failed) or True,
-                ):
+                with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", side_effect=reduction):
                     with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=global_rank):
                         with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=local_rank):
                             with patch(
                                 "veomni.checkpoint.dcp_checkpointer.shutil.copyfile",
-                                side_effect=OSError("boom") if role == failing_role else None,
+                                side_effect=OSError("boom") if role == fails_locally else None,
                             ):
                                 try:
                                     _promote_staged_checkpoint(stage_path, final_path)
                                 except (OSError, RuntimeError):
                                     raised = True
+            results[role] = {"reductions": len(seen), "raised": raised, "final": final_path}
+        return results
 
-            assert raised, f"{role} must raise once a peer failed"
-            counts[role] = len(reductions)
+    @pytest.mark.parametrize("failing_role", _COPYING_ROLES)
+    def test_every_role_runs_the_same_collectives_and_all_raise_when_a_copy_fails(self, make_staged, failing_role):
+        """Collectives are untagged, so one rank skipping one desynchronises the job.
 
-        # One collective per phase, four phases, on every role including the one
-        # that failed and the one that does no work at all.
-        assert set(counts.values()) == {4}, f"collective count diverged: {counts}"
+        The group starts reporting failure at reduction 2, the one closing the
+        copy phase, so the copy really is where it breaks.
+        """
+        results = self._replay_every_role(
+            make_staged, f"copyfail-{failing_role}", fails_locally=failing_role, peer_fails_from=2
+        )
+
+        for role, r in results.items():
+            assert r["raised"], f"{role} must raise once a peer failed"
+            # One collective per phase, four phases -- including on the role that
+            # does no work at all.
+            assert r["reductions"] == 4, f"{role} ran {r['reductions']} collectives: {results}"
+            assert not os.path.exists(os.path.join(r["final"], ".metadata")), f"{role} published a marker"
+
+    def test_every_role_sees_a_failed_metadata_copy(self, make_staged):
+        """Publishing is part of the save, so its failure cannot stay with the coordinator.
+
+        Failure is reported from reduction 3 -- the one closing the publish phase --
+        so phases 1 and 2 complete normally and the break really is in publishing.
+        """
+        results = self._replay_every_role(make_staged, "metafail", peer_fails_from=3)
+
+        for role, r in results.items():
+            assert r["raised"], f"{role} must raise after a failed publish"
+            assert r["reductions"] == 4, f"{role} did not finish the cleanup reduction: {results}"
+            assert not os.path.exists(os.path.join(r["final"], ".metadata")), f"{role} published a marker"
+
+    def test_a_failing_publish_leaves_no_partial_marker(self, staged):
+        """copyfile creates the destination before writing, so a half marker is possible."""
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        stage_path, final_path = staged
+
+        def copy_only_data(src, dst):
+            if dst.endswith(".metadata"):
+                with open(dst, "w") as f:
+                    f.write("half")  # the destination exists before the failure
+                raise OSError("marker write failed")
+            with open(src) as r, open(dst, "w") as w:
+                w.write(r.read())
+
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=False):
+            with patch("veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=copy_only_data):
+                with pytest.raises(OSError, match="marker write failed"):
+                    _promote_staged_checkpoint(stage_path, final_path)
+
+        assert os.path.exists(os.path.join(final_path, "__0_0.distcp")), "data should still be there"
+        assert not os.path.exists(os.path.join(final_path, ".metadata")), "no partial marker may survive"
 
     def test_cleanup_still_runs_after_an_earlier_phase_failed(self, staged):
         """The staged copy is model-plus-optimizer sized; a failure must not strand it."""
@@ -1289,65 +1342,6 @@ class TestPromoteStagedCheckpoint:
                 with pytest.raises(OSError, match="destination is full"):
                     _promote_staged_checkpoint(stage_path, final_path)
         assert not os.path.exists(stage_path)
-
-    def test_a_failed_metadata_copy_reaches_every_rank(self, staged):
-        """Publishing is part of the save, so its failure cannot stay with the coordinator."""
-        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
-
-        stage_path, final_path = staged
-        reductions = []
-
-        def copy_only_data(src, dst):
-            if dst.endswith(".metadata"):
-                raise OSError("marker write failed")
-            with open(src) as r, open(dst, "w") as w:
-                w.write(r.read())
-
-        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
-            with patch(
-                "veomni.checkpoint.dcp_checkpointer._any_rank_failed",
-                side_effect=lambda failed: reductions.append(failed) or failed,
-            ):
-                with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=0):
-                    with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
-                        with patch("veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=copy_only_data):
-                            with pytest.raises(OSError, match="marker write failed"):
-                                _promote_staged_checkpoint(stage_path, final_path)
-
-        # Phases 1 and 2 are clean; the publish phase is where it breaks, and its
-        # reduction is what carries that to the ranks that are not the coordinator.
-        assert reductions[:2] == [False, False]
-        assert reductions[2] is True
-        assert not os.path.exists(os.path.join(final_path, ".metadata")), "no partial marker may survive"
-
-    def test_metadata_is_not_published_when_another_rank_failed(self, staged):
-        """A completion marker over partly-copied data is worse than no checkpoint.
-
-        Promotion is split per node, so a copy failure is visible to one rank
-        only. The coordinator must learn about it before publishing `.metadata`.
-        """
-        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
-
-        stage_path, final_path = staged
-        calls = {"n": 0}
-
-        def peer_fails_during_the_copy_phase(failed):
-            # clean through phase 1, then a peer's copy fails
-            calls["n"] += 1
-            return calls["n"] >= 2
-
-        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
-            with patch(
-                "veomni.checkpoint.dcp_checkpointer._any_rank_failed",
-                side_effect=peer_fails_during_the_copy_phase,
-            ):
-                with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=0):
-                    with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
-                        with pytest.raises(RuntimeError, match="failed on another rank"):
-                            _promote_staged_checkpoint(stage_path, final_path)
-
-        assert os.path.exists(os.path.join(final_path, "__0_0.distcp")), "this rank's shards still copied"
-        assert not os.path.exists(os.path.join(final_path, ".metadata")), "must not publish a completion marker"
 
     def test_stale_metadata_stays_removed_when_promotion_fails(self, staged):
         """Half-replaced data must not keep the previous checkpoint's marker."""

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1420,6 +1420,39 @@ class TestPromoteStagedCheckpoint:
 
 
 class TestStageDirValidation:
+    def test_staging_dir_failure_is_agreed_across_ranks(self, tmp_path):
+        """A scratch disk fails per node, so ranks that could still stage must stop too.
+
+        Otherwise they go on into dcp.save and wait on a collective the failed
+        ranks never reach.
+        """
+        from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
+
+        # This rank prepares its directory fine; another node's did not.
+        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=True):
+            with pytest.raises(RuntimeError, match="another rank could not prepare"):
+                _prepare_stage_dir(str(tmp_path), "/remote/ckpt/step_1")
+
+    def test_staging_dir_is_emptied_and_returned(self, tmp_path):
+        from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
+
+        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
+            first = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/step_1")
+            with open(os.path.join(first, "leftover.distcp"), "w") as f:
+                f.write("from a crashed run")
+            second = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/step_1")
+        assert second == first
+        assert os.listdir(second) == []
+
+    def test_local_staging_failure_raises_its_own_error(self, tmp_path):
+        """The rank that actually failed reports what happened, not the peer message."""
+        from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
+
+        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", side_effect=lambda f: f):
+            with patch("veomni.checkpoint.dcp_checkpointer.os.makedirs", side_effect=OSError("No space left")):
+                with pytest.raises(OSError, match="No space left"):
+                    _prepare_stage_dir(str(tmp_path), "/remote/ckpt/step_1")
+
     def test_stage_dir_with_explicit_storage_writer_is_rejected(self, tmp_path):
         """Silently ignoring stage_dir would write to the slow destination it was avoiding."""
         from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1325,9 +1325,12 @@ class TestPromoteStagedCheckpoint:
             assert r["reductions"] == 4, f"{role} did not finish the cleanup reduction: {results}"
             assert not os.path.exists(os.path.join(r["final"], ".metadata")), f"{role} left a marker"
 
-        # The roles that copy data must still have copied it; only publishing broke.
+        # The roles that copy data must still have copied all of it; only
+        # publishing broke. Checking the exact set keeps this sensitive to a
+        # partial copy, which "something was written" would not catch.
         for role in self._COPYING_ROLES:
-            assert os.listdir(results[role]["final"]), f"{role} copied nothing"
+            copied = sorted(n for n in os.listdir(results[role]["final"]) if n.endswith(".distcp"))
+            assert copied == ["__0_0.distcp", "__0_1.distcp"], f"{role} copied {copied}"
 
     def test_a_failing_publish_leaves_no_partial_marker(self, staged):
         """copyfile creates the destination before writing, so a half marker is possible."""

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1119,6 +1119,20 @@ class TestPromoteStagedCheckpoint:
     staged copy behind.
     """
 
+    @pytest.fixture(autouse=True)
+    def _no_real_collectives(self):
+        """Keep `_any_rank_failed` off a real process group.
+
+        These tests fake `dist.is_initialized()`, so its all_reduce would other-
+        wise hit an uninitialised group. Leaving the tensor untouched makes the
+        reduction reflect this rank's own flag, which is what a single-rank test
+        means; cases about *another* rank failing patch `_any_rank_failed`
+        directly.
+        """
+        with patch("veomni.checkpoint.dcp_checkpointer.get_device_type", return_value="cpu"):
+            with patch("veomni.checkpoint.dcp_checkpointer.dist.all_reduce", side_effect=lambda t, op=None: None):
+                yield
+
     @pytest.fixture
     def make_staged(self, tmp_path):
         """Build an independent staged checkpoint and destination on each call.
@@ -1256,7 +1270,9 @@ class TestPromoteStagedCheckpoint:
             assert raised == (role == failing_role), f"{role}: unexpected raise={raised}"
 
         assert len(set(counts.values())) == 1, f"barrier count diverged across roles: {counts}"
-        assert set(counts.values()) == {4}
+        # Three barriers plus the phase-3 all_reduce, which doubles as the
+        # barrier closing phase 2.
+        assert set(counts.values()) == {3}
 
     def test_failure_is_raised_only_after_the_last_barrier(self, staged):
         """Raising early would strand the other ranks on a collective that never completes."""
@@ -1271,7 +1287,66 @@ class TestPromoteStagedCheckpoint:
                         with patch("veomni.checkpoint.dcp_checkpointer.shutil.copyfile", side_effect=OSError("boom")):
                             with pytest.raises(OSError, match="boom"):
                                 _promote_staged_checkpoint(stage_path, final_path)
-        assert len(calls) == 4
+        assert len(calls) == 3
+
+    def test_metadata_is_not_published_when_another_rank_failed(self, staged):
+        """A completion marker over partly-copied data is worse than no checkpoint.
+
+        Promotion is split per node, so a copy failure is visible to one rank
+        only. The coordinator must learn about it before publishing `.metadata`.
+        """
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        stage_path, final_path = staged
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
+            with patch("veomni.checkpoint.dcp_checkpointer.dist.barrier"):
+                with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=0):
+                    with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
+                        # This rank copies fine; a different node's leader did not.
+                        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=True):
+                            with pytest.raises(RuntimeError, match="failed on another rank"):
+                                _promote_staged_checkpoint(stage_path, final_path)
+
+        assert os.path.exists(os.path.join(final_path, "__0_0.distcp")), "data should still have been copied"
+        assert not os.path.exists(os.path.join(final_path, ".metadata")), "must not publish a completion marker"
+
+    def test_stale_metadata_stays_removed_when_promotion_fails(self, staged):
+        """Half-replaced data must not keep the previous checkpoint's marker."""
+        from veomni.checkpoint.dcp_checkpointer import _promote_staged_checkpoint
+
+        stage_path, final_path = staged
+        os.makedirs(final_path)
+        with open(os.path.join(final_path, ".metadata"), "w") as f:
+            f.write("previous checkpoint")
+
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
+            with patch("veomni.checkpoint.dcp_checkpointer.dist.barrier"):
+                with patch("veomni.checkpoint.dcp_checkpointer.dist.get_rank", return_value=0):
+                    with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
+                        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=True):
+                            with pytest.raises(RuntimeError, match="failed on another rank"):
+                                _promote_staged_checkpoint(stage_path, final_path)
+
+        assert not os.path.exists(os.path.join(final_path, ".metadata"))
+
+    def test_any_rank_failed_is_a_max_reduction(self):
+        """One failing rank must make every rank see a failure."""
+        import torch as _torch
+
+        from veomni.checkpoint.dcp_checkpointer import _any_rank_failed
+
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=False):
+            assert _any_rank_failed(True) is True
+            assert _any_rank_failed(False) is False
+
+        def fake_all_reduce(tensor, op=None):
+            assert op is _torch.distributed.ReduceOp.MAX, "must be MAX; SUM would overflow on many ranks"
+            tensor.fill_(1)
+
+        with patch("veomni.checkpoint.dcp_checkpointer.dist.is_initialized", return_value=True):
+            with patch("veomni.checkpoint.dcp_checkpointer.get_device_type", return_value="cpu"):
+                with patch("veomni.checkpoint.dcp_checkpointer.dist.all_reduce", side_effect=fake_all_reduce):
+                    assert _any_rank_failed(False) is True
 
     def test_non_leader_non_coordinator_ranks_touch_nothing(self, staged):
         """Ranks other than the node leaders and the coordinator only participate in barriers."""

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -476,18 +476,51 @@ def _stage_key(checkpoint_dir: str) -> str:
     return f"{os.path.basename(absolute) or 'ckpt'}-{digest}"
 
 
+class _Promotion:
+    """Failure state shared by the phases of one promotion.
+
+    ``error`` is what this rank saw; ``failed`` is what the whole group saw. They
+    differ because the work is split across ranks -- one leader per node copies
+    that node's files -- so a failure starts out visible to a single rank.
+    """
+
+    def __init__(self) -> None:
+        self.error: Optional[BaseException] = None
+        self.failed = False
+
+
 def _any_rank_failed(failed: bool) -> bool:
     """Whether *any* rank hit an error, so every rank can agree on what to do next.
 
-    Promotion is split across ranks -- each node leader copies its own node's
-    files -- so a failure is only ever visible to one of them. Without this the
-    others carry on believing the checkpoint is intact.
+    MAX rather than SUM: one failure is enough, and SUM would overflow int32 on a
+    large enough group.
     """
     if not dist.is_initialized():
         return failed
     flag = torch.tensor([1 if failed else 0], dtype=torch.int32, device=get_device_type())
     dist.all_reduce(flag, op=dist.ReduceOp.MAX)
     return bool(flag.item())
+
+
+def _promotion_phase(state: _Promotion, work, *, participates: bool, always: bool = False) -> None:
+    """Run one phase on the ranks that take part, then let every rank agree on the result.
+
+    The closing reduction is the phase's only collective and every rank reaches
+    it on every path, including the failing one. That is the whole point:
+    collectives are untagged, so a rank that returned early would leave the
+    others pairing up with the wrong one from then on, and the save would hang
+    instead of failing. Keeping exactly one collective per phase makes the count
+    equal by construction rather than by inspection.
+
+    ``always`` marks a phase that must run even after a failure -- cleanup.
+    """
+    if participates and (always or not state.failed):
+        try:
+            work()
+        except BaseException as e:  # noqa: BLE001 - raised once every phase is done
+            if state.error is None:
+                state.error = e
+    state.failed = _any_rank_failed(state.error is not None) or state.failed
 
 
 def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
@@ -497,87 +530,77 @@ def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
     one rank per node copies all of it rather than each rank working out which
     files it wrote; that keeps this independent of DCP's file naming.
 
-    Runs as barrier-separated phases, and every rank enters every barrier whether
-    or not its own phase did work or raised. A rank that bailed out early on
-    failure would leave the others waiting on a collective that never comes --
-    barriers are untagged, so one rank skipping a barrier makes every later one
-    pair up wrongly and the save hangs instead of failing. Failures are therefore
-    recorded, shared with every rank, and re-raised only once all collectives are
-    done.
+    Four phases, each ending in a single collective (see ``_promotion_phase``).
+    Errors are collected and re-raised only once every phase has run, on every
+    rank rather than only where the failure happened.
 
-    ``.metadata`` is what DCP reads as "this checkpoint is complete", so the
-    destination's old copy is removed before anything is written and the new one
-    is copied last -- and only if every rank's data landed. A reader arriving
-    mid-promotion, or after a partial failure, sees no metadata rather than a
-    completion marker over data that is only partly there.
+    ``.metadata`` is what DCP reads as "this checkpoint is complete". The
+    destination's old copy goes first, before anything is overwritten, and the
+    new one goes last and only if every rank's data landed -- so a reader
+    arriving at any point sees either the previous complete checkpoint, or none,
+    never a completion marker over data that is only partly there.
     """
     metadata_name = ".metadata"
     is_node_leader = _local_rank() == 0
     is_coordinator = (not dist.is_initialized()) or dist.get_rank() == 0
     final_metadata = os.path.join(final_path, metadata_name)
-    error: Optional[BaseException] = None
+    state = _Promotion()
 
-    def _barrier() -> None:
-        """Synchronise every rank between promotion phases.
+    def drop_stale_marker() -> None:
+        """Stop advertising the previous checkpoint before overwriting its shards."""
+        os.makedirs(final_path, exist_ok=True)
+        if os.path.exists(final_metadata):
+            os.remove(final_metadata)
 
-        A no-op outside distributed runs, so the same code path covers both.
+    def copy_this_nodes_files() -> None:
+        """Copy every staged file on this node, except the completion marker."""
+        names = [n for n in sorted(os.listdir(stage_path)) if n != metadata_name]
+        os.makedirs(final_path, exist_ok=True)
+
+        def _copy(name: str) -> None:
+            """Copy one staged file to the destination, preserving its name."""
+            shutil.copyfile(os.path.join(stage_path, name), os.path.join(final_path, name))
+
+        if names:
+            with ThreadPoolExecutor(max_workers=min(16, len(names))) as pool:
+                list(pool.map(_copy, names))
+
+    def publish_marker() -> None:
+        """Publish the completion marker, or leave nothing behind if that fails."""
+        src = os.path.join(stage_path, metadata_name)
+        if not os.path.exists(src):
+            return
+        try:
+            shutil.copyfile(src, final_metadata)
+        except BaseException:
+            # copyfile creates the destination before writing it, so a failure
+            # can leave a truncated marker -- worse than none, since DCP would
+            # read it as a complete checkpoint.
+            try:
+                if os.path.exists(final_metadata):
+                    os.remove(final_metadata)
+            except OSError:
+                logger.error(f"could not remove a partially written {final_metadata}", exc_info=True)
+            raise
+
+    def drop_staged_copy() -> None:
+        """Free the scratch disk.
+
+        The staged copy is as large as the model plus its optimizer state, so
+        keeping it after a failure would strand that space for every later run on
+        this node. Nothing is lost: without a marker the destination reads as
+        incomplete, which it is, and the next save overwrites it.
         """
-        if dist.is_initialized():
-            dist.barrier()
-
-    # Phase 1: invalidate the destination before it is touched. Removing the old
-    # marker cannot be deferred: leaving it in place would expose the previous
-    # checkpoint's metadata over shard files that are already being replaced.
-    if is_coordinator:
-        try:
-            os.makedirs(final_path, exist_ok=True)
-            if os.path.exists(final_metadata):
-                os.remove(final_metadata)
-        except BaseException as e:  # noqa: BLE001 - re-raised after the barriers
-            error = e
-    _barrier()
-
-    # Phase 2: one rank per node copies that node's staged files.
-    if is_node_leader and error is None:
-        try:
-            names = [n for n in sorted(os.listdir(stage_path)) if n != metadata_name]
-            os.makedirs(final_path, exist_ok=True)
-
-            def _copy(name: str) -> None:
-                """Copy one staged file to the destination, preserving its name."""
-                shutil.copyfile(os.path.join(stage_path, name), os.path.join(final_path, name))
-
-            if names:
-                with ThreadPoolExecutor(max_workers=min(16, len(names))) as pool:
-                    list(pool.map(_copy, names))
-        except BaseException as e:  # noqa: BLE001 - re-raised after the barriers
-            error = e
-
-    # Phase 3: publish only if every node's data landed. This is a collective, so
-    # it also serves as the barrier closing phase 2.
-    anyone_failed = _any_rank_failed(error is not None)
-
-    if is_coordinator and not anyone_failed:
-        try:
-            src = os.path.join(stage_path, metadata_name)
-            if os.path.exists(src):
-                shutil.copyfile(src, final_metadata)
-        except BaseException as e:  # noqa: BLE001 - re-raised after the barriers
-            error = e
-    _barrier()
-
-    # Phase 4: the staged copy is as large as the model plus its optimizer state,
-    # so drop it even when promotion failed rather than filling the scratch disk
-    # for every later run on this node. Nothing is lost by doing so: without the
-    # completion marker the destination reads as incomplete, and the next save
-    # overwrites it.
-    if is_node_leader:
         shutil.rmtree(stage_path, ignore_errors=True)
-    _barrier()
 
-    if error is not None:
-        raise error
-    if anyone_failed:
+    _promotion_phase(state, drop_stale_marker, participates=is_coordinator)
+    _promotion_phase(state, copy_this_nodes_files, participates=is_node_leader)
+    _promotion_phase(state, publish_marker, participates=is_coordinator)
+    _promotion_phase(state, drop_staged_copy, participates=is_node_leader, always=True)
+
+    if state.error is not None:
+        raise state.error
+    if state.failed:
         raise RuntimeError("checkpoint promotion failed on another rank; no completion marker was written")
 
 

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -45,7 +45,7 @@ from ..distributed.parallel_state import get_parallel_state
 from ..optim.optimizer import restore_optimizer_param_group_defaults
 from ..utils import logging
 from ..utils.checkpoint_utils import _GLOBAL_STEP_PREFIX
-from ..utils.device import empty_cache, synchronize
+from ..utils.device import empty_cache, get_device_type, synchronize
 from .checkpointer import CheckpointerBase
 
 
@@ -476,6 +476,20 @@ def _stage_key(checkpoint_dir: str) -> str:
     return f"{os.path.basename(absolute) or 'ckpt'}-{digest}"
 
 
+def _any_rank_failed(failed: bool) -> bool:
+    """Whether *any* rank hit an error, so every rank can agree on what to do next.
+
+    Promotion is split across ranks -- each node leader copies its own node's
+    files -- so a failure is only ever visible to one of them. Without this the
+    others carry on believing the checkpoint is intact.
+    """
+    if not dist.is_initialized():
+        return failed
+    flag = torch.tensor([1 if failed else 0], dtype=torch.int32, device=get_device_type())
+    dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+    return bool(flag.item())
+
+
 def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
     """Copy a staged checkpoint to its destination, then drop the staged copy.
 
@@ -483,17 +497,19 @@ def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
     one rank per node copies all of it rather than each rank working out which
     files it wrote; that keeps this independent of DCP's file naming.
 
-    Runs as four barrier-separated phases, and every rank enters every barrier
-    whether or not its own phase did any work or raised. A rank that bailed out
-    early on failure would leave the others waiting on a collective that never
-    comes -- barriers are untagged, so one rank skipping a barrier makes every
-    later one pair up wrongly and the save hangs instead of failing. Failures are
-    therefore recorded and re-raised only once all collectives are done.
+    Runs as barrier-separated phases, and every rank enters every barrier whether
+    or not its own phase did work or raised. A rank that bailed out early on
+    failure would leave the others waiting on a collective that never comes --
+    barriers are untagged, so one rank skipping a barrier makes every later one
+    pair up wrongly and the save hangs instead of failing. Failures are therefore
+    recorded, shared with every rank, and re-raised only once all collectives are
+    done.
 
     ``.metadata`` is what DCP reads as "this checkpoint is complete", so the
     destination's old copy is removed before anything is written and the new one
-    is copied last. A reader arriving mid-promotion then sees no metadata rather
-    than the previous checkpoint's metadata over half-replaced data.
+    is copied last -- and only if every rank's data landed. A reader arriving
+    mid-promotion, or after a partial failure, sees no metadata rather than a
+    completion marker over data that is only partly there.
     """
     metadata_name = ".metadata"
     is_node_leader = _local_rank() == 0
@@ -509,7 +525,9 @@ def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
         if dist.is_initialized():
             dist.barrier()
 
-    # Phase 1: invalidate the destination before it is touched.
+    # Phase 1: invalidate the destination before it is touched. Removing the old
+    # marker cannot be deferred: leaving it in place would expose the previous
+    # checkpoint's metadata over shard files that are already being replaced.
     if is_coordinator:
         try:
             os.makedirs(final_path, exist_ok=True)
@@ -534,10 +552,12 @@ def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
                     list(pool.map(_copy, names))
         except BaseException as e:  # noqa: BLE001 - re-raised after the barriers
             error = e
-    _barrier()
 
-    # Phase 3: the completion marker goes last, once every node's data has landed.
-    if is_coordinator and error is None:
+    # Phase 3: publish only if every node's data landed. This is a collective, so
+    # it also serves as the barrier closing phase 2.
+    anyone_failed = _any_rank_failed(error is not None)
+
+    if is_coordinator and not anyone_failed:
         try:
             src = os.path.join(stage_path, metadata_name)
             if os.path.exists(src):
@@ -548,13 +568,17 @@ def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
 
     # Phase 4: the staged copy is as large as the model plus its optimizer state,
     # so drop it even when promotion failed rather than filling the scratch disk
-    # for every later run on this node.
+    # for every later run on this node. Nothing is lost by doing so: without the
+    # completion marker the destination reads as incomplete, and the next save
+    # overwrites it.
     if is_node_leader:
         shutil.rmtree(stage_path, ignore_errors=True)
     _barrier()
 
     if error is not None:
         raise error
+    if anyone_failed:
+        raise RuntimeError("checkpoint promotion failed on another rank; no completion marker was written")
 
 
 class DistributedCheckpointer(CheckpointerBase):

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -523,6 +523,26 @@ def _promotion_phase(state: _Promotion, work, *, participates: bool, always: boo
     state.failed = _any_rank_failed(state.error is not None) or state.failed
 
 
+def _prepare_stage_dir(stage_dir: str, checkpoint_dir: str) -> str:
+    """Create an empty staging directory for one checkpoint, agreed by every rank.
+
+    A scratch disk fills or goes read-only per node, so the ranks that could not
+    prepare one must not be the only ones to stop: the rest would go on into
+    ``dcp.save`` and wait on a collective that never arrives. Everyone agrees
+    here, before any of that starts.
+    """
+    stage_path = os.path.join(stage_dir, _stage_key(checkpoint_dir))
+    error: Optional[BaseException] = None
+    try:
+        shutil.rmtree(stage_path, ignore_errors=True)  # leftovers from a crashed run
+        os.makedirs(stage_path, exist_ok=True)
+    except BaseException as e:  # noqa: BLE001 - raised once every rank has agreed
+        error = e
+    if _any_rank_failed(error is not None):
+        raise error or RuntimeError(f"another rank could not prepare a staging directory under {stage_dir}")
+    return stage_path
+
+
 def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
     """Copy a staged checkpoint to its destination, then drop the staged copy.
 
@@ -691,11 +711,7 @@ class DistributedCheckpointer(CheckpointerBase):
                 load=False,
             )
 
-        stage_path = None
-        if stage_dir:
-            stage_path = os.path.join(stage_dir, _stage_key(checkpoint_dir))
-            shutil.rmtree(stage_path, ignore_errors=True)  # drop leftovers from a crashed run
-            os.makedirs(stage_path, exist_ok=True)
+        stage_path = _prepare_stage_dir(stage_dir, checkpoint_dir) if stage_dir else None
 
         if storage_writer is None:
             storage_writer = cls._create_storage_writer(stage_path or checkpoint_dir)


### PR DESCRIPTION
Follow-up to #1164.

## The defect

`_promote_staged_checkpoint` splits the copy per node — one rank per node moves that node's staged files — but tracks the outcome in a rank-local `error`. A node leader that fails in phase 2 is the only rank that knows. Every other rank, the coordinator included, still sees `error is None`, so phase 3 copies `.metadata` to the destination.

DCP reads `.metadata` as "this checkpoint is complete". The result on disk is a checkpoint advertised as complete with the failed node's shards missing. Phase 4 then drops the staged copy, and phase 1 has already removed the previous checkpoint's marker, so neither a good old checkpoint nor a good new one survives. The job does die once the failing rank re-raises, but a later `load_path` pointed at that directory would accept it.

## The fix

Reduce the failure flag across ranks (`MAX`, so one failure is enough) and skip the metadata copy unless every rank's data landed. The reduction doubles as the barrier closing phase 2, so the collective count stays equal on every rank — the property #1164 established. Ranks that succeeded now raise as well, so the save fails everywhere rather than only where the copy broke.

Leaving the destination without a marker is the right outcome: it reads as incomplete, which it is, and the next save overwrites it.

## Tests

- another rank failing leaves no `.metadata`, while this rank's shards are still copied
- a stale marker stays removed
- the reduction is `MAX`, not `SUM` (which would overflow across many ranks)
- an autouse fixture keeps `_any_rank_failed` off a real process group in the single-rank tests

## Evidence

The defect is established by reading the merged code, not by a reproduction. Reproducing it needs a multi-node run where one node's leader fails while the coordinator succeeds; no worker available to me could provide that. If you would rather see a repro before merging, say so and I will arrange a two-node run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpoint promotion failures are now reported consistently across all participating ranks.
  * Metadata is published only after promotion succeeds everywhere.
  * Partially written metadata is removed when metadata copying fails.
  * Metadata-copy failures now propagate consistently, ensuring all ranks observe the promotion failure.
  * Failed promotions clean up staged checkpoint data, preventing incomplete checkpoint state from being retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->