### PR TITLE
[ckpt] fix: sweep stale staged checkpoints instead of only the current step's

### DIFF
--- a/tests/checkpoints/test_checkpoint_callback.py
+++ b/tests/checkpoints/test_checkpoint_callback.py
@@ -286,3 +286,49 @@ class TestCheckpointerCallbackTrainEndWait:
         cb.on_train_end(TrainerState(global_step=60))
 
         trainer.checkpointer.wait_for_pending_save.assert_called_once_with()
+
+
+@patch("veomni.trainer.callbacks.checkpoint_callback.build_checkpointer")
+@patch("veomni.trainer.callbacks.checkpoint_callback.dist")
+@patch("veomni.trainer.callbacks.checkpoint_callback.helper")
+class TestCheckpointerCallbackStagingPath:
+    """``stage_dir`` keys its staging directory on the ``path`` given to ``save``.
+
+    That path must name the run, not the step. A caller that folds the step in
+    gets a fresh staging directory per step, and a save killed part-way then
+    strands a model-plus-optimizer-sized copy that no later save clears.
+    """
+
+    def test_the_step_reaches_save_instead_of_being_folded_into_the_path(
+        self, mock_helper, mock_dist, mock_build_ckpt, tmp_path
+    ):
+        from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
+
+        trainer = _make_mock_trainer(save_path=str(tmp_path / "run"))
+        trainer.args.train.checkpoint.stage_dir = str(tmp_path / "stage")
+        mock_build_ckpt.return_value = trainer.checkpointer
+        cb = CheckpointerCallback(trainer)
+
+        staged = []
+        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
+            for step in (10, 20):
+                cb._save_checkpoint(TrainerState(global_step=step))
+                call = trainer.checkpointer.save.call_args
+                assert call.kwargs["global_steps"] == step
+                staged.append(_prepare_stage_dir(call.kwargs["stage_dir"], call.args[0]))
+
+        assert staged[0] == staged[1], "each step staged somewhere different"
+
+    def test_the_logged_destination_is_the_one_save_writes(self, mock_helper, mock_dist, mock_build_ckpt):
+        """The callback names the step directory for its log and its HF export, while
+        ``save`` builds the same directory from ``path`` and ``global_steps``."""
+        from veomni.checkpoint.dcp_checkpointer import _GLOBAL_STEP_PREFIX
+
+        trainer = _make_mock_trainer(save_path="/remote/run")
+        mock_build_ckpt.return_value = trainer.checkpointer
+        cb = CheckpointerCallback(trainer)
+
+        cb._save_checkpoint(TrainerState(global_step=10))
+
+        call = trainer.checkpointer.save.call_args
+        assert f"{call.args[0]}/{_GLOBAL_STEP_PREFIX}{call.kwargs['global_steps']}" == "/remote/run/global_step_10"

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1519,6 +1519,36 @@ class TestStageDirValidation:
                 with pytest.raises(OSError, match="No space left"):
                     _prepare_stage_dir(str(tmp_path), "/remote/ckpt")
 
+    def test_unset_stage_dir_writes_straight_to_the_destination(self, tmp_path):
+        """Staging is opt-in: unset, nothing about the write changes.
+
+        DCP is pointed at the destination itself, and neither the staging directory
+        nor the promotion is reached -- so no scratch disk is touched and no extra
+        collective is issued.
+        """
+        from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer
+
+        final = tmp_path / "ckpt"
+        with (
+            patch.object(DistributedCheckpointer, "execute_save") as execute_save,
+            patch.object(DistributedCheckpointer, "_create_storage_writer") as create_writer,
+            patch.object(DistributedCheckpointer, "_save_extra_state"),
+            patch("veomni.checkpoint.dcp_checkpointer.ModelState"),
+            patch("veomni.checkpoint.dcp_checkpointer._prepare_stage_dir") as prepare,
+            patch("veomni.checkpoint.dcp_checkpointer._promote_staged_checkpoint") as promote,
+        ):
+            DistributedCheckpointer.save(
+                path=str(final),
+                state={"model": MagicMock()},
+                save_async=False,
+                global_steps=10,
+            )
+
+        assert create_writer.call_args.args[0] == str(final / "global_step_10")
+        assert execute_save.call_args.kwargs["storage_writer"] is create_writer.return_value
+        prepare.assert_not_called()
+        promote.assert_not_called()
+
     def test_stage_dir_with_explicit_storage_writer_is_rejected(self, tmp_path):
         """Silently ignoring stage_dir would write to the slow destination it was avoiding."""
         from veomni.checkpoint.dcp_checkpointer import DistributedCheckpointer

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1420,25 +1420,26 @@ class TestPromoteStagedCheckpoint:
 
 
 class TestStageDirValidation:
-    def test_stale_staged_copies_from_earlier_steps_are_swept(self, tmp_path):
-        """A killed save strands a model-plus-optimizer-sized copy under its own key.
+    def test_every_checkpoint_of_a_run_reuses_one_emptied_directory(self, tmp_path):
+        """A killed save strands a model-plus-optimizer-sized copy on the scratch disk.
 
-        Clearing only the current key would leave it there, and the next save on
-        that node would ask for the same space again on a disk already short of it.
+        One directory per run, emptied before each save, is what reclaims it: the
+        next save on that node clears the copy instead of asking for the same space
+        again on a disk already short of it.
         """
         import os as _os
 
         from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
 
         with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
-            abandoned = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10")
+            abandoned = _prepare_stage_dir(str(tmp_path), "/remote/ckpt")
             with open(_os.path.join(abandoned, "big.distcp"), "w") as f:
                 f.write("a save that never finished")
 
-            current = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_20")
+            current = _prepare_stage_dir(str(tmp_path), "/remote/ckpt")
 
-        assert not _os.path.exists(abandoned), "the earlier step's copy must not survive"
-        assert _os.path.isdir(current)
+        assert current == abandoned
+        assert _os.listdir(current) == [], "the abandoned copy must not survive"
 
     def test_sweep_is_confined_to_veomni_own_directory(self, tmp_path):
         """stage_dir is the caller's, often /tmp; only our own subtree may be removed."""
@@ -1450,7 +1451,7 @@ class TestStageDirValidation:
         (someone_elses / "important.bin").write_text("not ours")
 
         with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
-            _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10")
+            _prepare_stage_dir(str(tmp_path), "/remote/ckpt")
 
         assert (someone_elses / "important.bin").exists(), "swept outside our own root"
 
@@ -1467,18 +1468,18 @@ class TestStageDirValidation:
 
         with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
             with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=3):
-                path = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10")
+                path = _prepare_stage_dir(str(tmp_path), "/remote/ckpt")
             assert not _os.path.exists(path), "a peer created the directory itself"
 
             with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
-                assert _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10") == path
+                assert _prepare_stage_dir(str(tmp_path), "/remote/ckpt") == path
             assert _os.path.isdir(path), "the leader must have created it"
 
             marker = _os.path.join(path, "written_by_the_leader")
             with open(marker, "w") as f:
                 f.write("x")
             with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=3):
-                _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10")
+                _prepare_stage_dir(str(tmp_path), "/remote/ckpt")
             assert _os.path.exists(marker), "a peer swept the leader's directory"
 
     def test_a_concurrent_run_sharing_stage_dir_is_not_swept(self, tmp_path):
@@ -1488,11 +1489,11 @@ class TestStageDirValidation:
         from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
 
         with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
-            other = _prepare_stage_dir(str(tmp_path), "/remote/other_run/global_step_10")
+            other = _prepare_stage_dir(str(tmp_path), "/remote/other_run")
             with open(_os.path.join(other, "in_flight.distcp"), "w") as f:
                 f.write("another job is using this")
 
-            _prepare_stage_dir(str(tmp_path), "/remote/this_run/global_step_10")
+            _prepare_stage_dir(str(tmp_path), "/remote/this_run")
 
         assert _os.path.exists(_os.path.join(other, "in_flight.distcp")), "swept another run's data"
 
@@ -1507,18 +1508,7 @@ class TestStageDirValidation:
         # This rank prepares its directory fine; another node's did not.
         with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=True):
             with pytest.raises(RuntimeError, match="another rank could not prepare"):
-                _prepare_stage_dir(str(tmp_path), "/remote/ckpt/step_1")
-
-    def test_staging_dir_is_emptied_and_returned(self, tmp_path):
-        from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
-
-        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
-            first = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/step_1")
-            with open(os.path.join(first, "leftover.distcp"), "w") as f:
-                f.write("from a crashed run")
-            second = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/step_1")
-        assert second == first
-        assert os.listdir(second) == []
+                _prepare_stage_dir(str(tmp_path), "/remote/ckpt")
 
     def test_local_staging_failure_raises_its_own_error(self, tmp_path):
         """The rank that actually failed reports what happened, not the peer message."""
@@ -1527,7 +1517,7 @@ class TestStageDirValidation:
         with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", side_effect=lambda f: f):
             with patch("veomni.checkpoint.dcp_checkpointer.os.makedirs", side_effect=OSError("No space left")):
                 with pytest.raises(OSError, match="No space left"):
-                    _prepare_stage_dir(str(tmp_path), "/remote/ckpt/step_1")
+                    _prepare_stage_dir(str(tmp_path), "/remote/ckpt")
 
     def test_stage_dir_with_explicit_storage_writer_is_rejected(self, tmp_path):
         """Silently ignoring stage_dir would write to the slow destination it was avoiding."""
@@ -1549,10 +1539,10 @@ class TestStageDirValidation:
         from veomni.checkpoint.dcp_checkpointer import _stage_key
 
         assert _stage_key("/tmp/a_b/c") != _stage_key("/tmp/a/b_c")
-        assert _stage_key("/tmp/run/step_1") == _stage_key("/tmp/run/step_1")
-        assert _stage_key("/tmp/run/step_1") != _stage_key("/tmp/run/step_2")
+        assert _stage_key("/remote/run") == _stage_key("/remote/run")
+        assert _stage_key("/remote/run_a") != _stage_key("/remote/run_b")
         # a relative destination and its absolute spelling stage together
-        assert _stage_key("run/step_1") == _stage_key(os.path.join(os.getcwd(), "run", "step_1"))
+        assert _stage_key("run") == _stage_key(os.path.join(os.getcwd(), "run"))
 
     def test_stage_dir_with_save_async_is_rejected_before_any_side_effect(self, tmp_path):
         """The staged copy is dropped when save() returns, i.e. before an async write ends."""

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1455,10 +1455,11 @@ class TestStageDirValidation:
         assert (someone_elses / "important.bin").exists(), "swept outside our own root"
 
     def test_only_the_node_leader_touches_the_filesystem(self, tmp_path):
-        """Peers sweeping and creating in the same place would race with the leader.
+        """Peers sweeping or creating in the same place would race with the leader.
 
         They do not need to: the reduction is a collective, so the leader's work
-        is done and visible by the time any rank leaves.
+        is done and visible by the time any rank leaves. Checks both halves --
+        a peer neither creates the directory nor removes what the leader made.
         """
         import os as _os
 
@@ -1472,6 +1473,13 @@ class TestStageDirValidation:
             with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
                 assert _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10") == path
             assert _os.path.isdir(path), "the leader must have created it"
+
+            marker = _os.path.join(path, "written_by_the_leader")
+            with open(marker, "w") as f:
+                f.write("x")
+            with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=3):
+                _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10")
+            assert _os.path.exists(marker), "a peer swept the leader's directory"
 
     def test_a_concurrent_run_sharing_stage_dir_is_not_swept(self, tmp_path):
         """stage_dir is often generic (/tmp); two runs on one node must not collide."""

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1420,6 +1420,57 @@ class TestPromoteStagedCheckpoint:
 
 
 class TestStageDirValidation:
+    def test_stale_staged_copies_from_earlier_steps_are_swept(self, tmp_path):
+        """A killed save strands a model-plus-optimizer-sized copy under its own key.
+
+        Clearing only the current key would leave it there, and the next save on
+        that node would ask for the same space again on a disk already short of it.
+        """
+        import os as _os
+
+        from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
+
+        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
+            abandoned = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10")
+            with open(_os.path.join(abandoned, "big.distcp"), "w") as f:
+                f.write("a save that never finished")
+
+            current = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_20")
+
+        assert not _os.path.exists(abandoned), "the earlier step's copy must not survive"
+        assert _os.path.isdir(current)
+
+    def test_sweep_is_confined_to_veomni_own_directory(self, tmp_path):
+        """stage_dir is the caller's, often /tmp; only our own subtree may be removed."""
+
+        from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
+
+        someone_elses = tmp_path / "someone_elses_data"
+        someone_elses.mkdir()
+        (someone_elses / "important.bin").write_text("not ours")
+
+        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
+            _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10")
+
+        assert (someone_elses / "important.bin").exists(), "swept outside our own root"
+
+    def test_only_the_node_leader_sweeps(self, tmp_path):
+        """Every rank on the node shares the directory; one sweep is enough."""
+        import os as _os
+
+        from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
+
+        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
+            with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
+                stale = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10")
+            with open(_os.path.join(stale, "leftover"), "w") as f:
+                f.write("x")
+            # A non-leader must not wipe what the leader already prepared.
+            with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=3):
+                _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_20")
+
+        assert _os.path.exists(_os.path.join(stale, "leftover"))
+
     def test_staging_dir_failure_is_agreed_across_ranks(self, tmp_path):
         """A scratch disk fails per node, so ranks that could still stage must stop too.
 

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -1454,22 +1454,39 @@ class TestStageDirValidation:
 
         assert (someone_elses / "important.bin").exists(), "swept outside our own root"
 
-    def test_only_the_node_leader_sweeps(self, tmp_path):
-        """Every rank on the node shares the directory; one sweep is enough."""
+    def test_only_the_node_leader_touches_the_filesystem(self, tmp_path):
+        """Peers sweeping and creating in the same place would race with the leader.
+
+        They do not need to: the reduction is a collective, so the leader's work
+        is done and visible by the time any rank leaves.
+        """
         import os as _os
 
         from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
 
         with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
-            with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
-                stale = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10")
-            with open(_os.path.join(stale, "leftover"), "w") as f:
-                f.write("x")
-            # A non-leader must not wipe what the leader already prepared.
             with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=3):
-                _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_20")
+                path = _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10")
+            assert not _os.path.exists(path), "a peer created the directory itself"
 
-        assert _os.path.exists(_os.path.join(stale, "leftover"))
+            with patch("veomni.checkpoint.dcp_checkpointer._local_rank", return_value=0):
+                assert _prepare_stage_dir(str(tmp_path), "/remote/ckpt/global_step_10") == path
+            assert _os.path.isdir(path), "the leader must have created it"
+
+    def test_a_concurrent_run_sharing_stage_dir_is_not_swept(self, tmp_path):
+        """stage_dir is often generic (/tmp); two runs on one node must not collide."""
+        import os as _os
+
+        from veomni.checkpoint.dcp_checkpointer import _prepare_stage_dir
+
+        with patch("veomni.checkpoint.dcp_checkpointer._any_rank_failed", return_value=False):
+            other = _prepare_stage_dir(str(tmp_path), "/remote/other_run/global_step_10")
+            with open(_os.path.join(other, "in_flight.distcp"), "w") as f:
+                f.write("another job is using this")
+
+            _prepare_stage_dir(str(tmp_path), "/remote/this_run/global_step_10")
+
+        assert _os.path.exists(_os.path.join(other, "in_flight.distcp")), "swept another run's data"
 
     def test_staging_dir_failure_is_agreed_across_ranks(self, tmp_path):
         """A scratch disk fails per node, so ranks that could still stage must stop too.

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -526,32 +526,45 @@ def _promotion_phase(state: _Promotion, work, *, participates: bool, always: boo
 _STAGE_ROOT = "veomni_ckpt_stage"
 
 
+def _stage_run_root(stage_dir: str, checkpoint_dir: str) -> str:
+    """Directory holding every staged checkpoint of one run, and nothing else.
+
+    Keyed on the destination the run writes to, so two runs sharing a node and a
+    ``stage_dir`` -- which is often something generic like /tmp -- never land in
+    the same place. That matters because this directory gets swept: keying it any
+    more coarsely would let one run delete another's staged data.
+    """
+    return os.path.join(stage_dir, _STAGE_ROOT, _stage_key(os.path.dirname(os.path.abspath(checkpoint_dir))))
+
+
 def _prepare_stage_dir(stage_dir: str, checkpoint_dir: str) -> str:
     """Create an empty staging directory for one checkpoint, agreed by every rank.
 
-    Every staged checkpoint this process has ever written lives under one root,
-    and all of them are cleared here, not just this checkpoint's own directory.
-    A save killed part-way -- by a hang detector, a failover, a preemption --
-    leaves behind a copy the size of the model plus its optimizer state, under a
-    key naming *its* step. Removing only the current key would strand it, and the
-    next save on that node then asks for the same space again on a disk that is
-    already short of it.
+    Clears the whole run root rather than just this checkpoint's directory. A
+    save killed part-way -- by a hang detector, a failover, a preemption --
+    leaves a copy the size of the model plus its optimizer state under a key
+    naming *its* step, and removing only the current key would strand it; the
+    next save on that node then asks for the same space again on a disk already
+    short of it.
 
-    A scratch disk fills or goes read-only per node, so the ranks that could not
-    prepare a directory must not be the only ones to stop: the rest would go on
-    into ``dcp.save`` and wait on a collective that never arrives. Everyone
-    agrees here, before any of that starts.
+    Only the node leader touches the filesystem. Sweeping under peers that are
+    creating directories in the same place would race, and there is no need for
+    them to: the reduction below is a collective, so by the time any rank leaves
+    this function the leader's work is done and visible.
+
+    That reduction is also what keeps a per-node failure -- a full or read-only
+    scratch disk -- from being seen by one rank alone, which would leave the rest
+    waiting in ``dcp.save`` on a collective that never arrives.
     """
-    stage_root = os.path.join(stage_dir, _STAGE_ROOT)
-    stage_path = os.path.join(stage_root, _stage_key(checkpoint_dir))
+    run_root = _stage_run_root(stage_dir, checkpoint_dir)
+    stage_path = os.path.join(run_root, _stage_key(checkpoint_dir))
     error: Optional[BaseException] = None
-    try:
-        # One process per node does the sweep; the rest only need the directory.
-        if _local_rank() == 0:
-            shutil.rmtree(stage_root, ignore_errors=True)
-        os.makedirs(stage_path, exist_ok=True)
-    except BaseException as e:  # noqa: BLE001 - raised once every rank has agreed
-        error = e
+    if _local_rank() == 0:
+        try:
+            shutil.rmtree(run_root, ignore_errors=True)
+            os.makedirs(stage_path, exist_ok=True)
+        except BaseException as e:  # noqa: BLE001 - raised once every rank has agreed
+            error = e
     if _any_rank_failed(error is not None):
         raise error or RuntimeError(f"another rank could not prepare a staging directory under {stage_dir}")
     return stage_path

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -663,7 +663,10 @@ class DistributedCheckpointer(CheckpointerBase):
             path: path to save checkpoint
             state: state to save
             save_async: whether to save asynchronously
-            global_steps: global steps
+            global_steps: step this checkpoint belongs to. Given, the checkpoint goes
+                into a per-step subdirectory of ``path`` and ``path`` identifies the run,
+                which is what ``stage_dir`` keys its staging directory on. Callers that
+                fold the step into ``path`` themselves get a staging directory per step.
             storage_writer: storage writer backend for dcp.save and dcp.async_save. If None, will use FileSystemWriter
             trainable_only: when True, only persist parameters with ``requires_grad=True``
                 (LoRA / PEFT path). Frozen base weights are skipped on save and must be
@@ -702,7 +705,9 @@ class DistributedCheckpointer(CheckpointerBase):
         if stage_dir and storage_writer is not None:
             raise ValueError("stage_dir cannot be combined with an explicit storage_writer")
 
-        checkpoint_dir = f"{path}/{_GLOBAL_STEP_PREFIX}{global_steps}" if global_steps else path
+        # ``is not None`` rather than truthiness: step 0 is a step like any other, and
+        # folding it onto ``path`` would write it over the run's own directory.
+        checkpoint_dir = f"{path}/{_GLOBAL_STEP_PREFIX}{global_steps}" if global_steps is not None else path
         cls._create_checkpoint_dir(checkpoint_dir)
 
         # saving extra_state first to gurantee that every saved model/optimizer ckpts have their extra_state saved before them

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -523,18 +523,32 @@ def _promotion_phase(state: _Promotion, work, *, participates: bool, always: boo
     state.failed = _any_rank_failed(state.error is not None) or state.failed
 
 
+_STAGE_ROOT = "veomni_ckpt_stage"
+
+
 def _prepare_stage_dir(stage_dir: str, checkpoint_dir: str) -> str:
     """Create an empty staging directory for one checkpoint, agreed by every rank.
 
+    Every staged checkpoint this process has ever written lives under one root,
+    and all of them are cleared here, not just this checkpoint's own directory.
+    A save killed part-way -- by a hang detector, a failover, a preemption --
+    leaves behind a copy the size of the model plus its optimizer state, under a
+    key naming *its* step. Removing only the current key would strand it, and the
+    next save on that node then asks for the same space again on a disk that is
+    already short of it.
+
     A scratch disk fills or goes read-only per node, so the ranks that could not
-    prepare one must not be the only ones to stop: the rest would go on into
-    ``dcp.save`` and wait on a collective that never arrives. Everyone agrees
-    here, before any of that starts.
+    prepare a directory must not be the only ones to stop: the rest would go on
+    into ``dcp.save`` and wait on a collective that never arrives. Everyone
+    agrees here, before any of that starts.
     """
-    stage_path = os.path.join(stage_dir, _stage_key(checkpoint_dir))
+    stage_root = os.path.join(stage_dir, _STAGE_ROOT)
+    stage_path = os.path.join(stage_root, _stage_key(checkpoint_dir))
     error: Optional[BaseException] = None
     try:
-        shutil.rmtree(stage_path, ignore_errors=True)  # leftovers from a crashed run
+        # One process per node does the sweep; the rest only need the directory.
+        if _local_rank() == 0:
+            shutil.rmtree(stage_root, ignore_errors=True)
         os.makedirs(stage_path, exist_ok=True)
     except BaseException as e:  # noqa: BLE001 - raised once every rank has agreed
         error = e

--- a/veomni/checkpoint/dcp_checkpointer.py
+++ b/veomni/checkpoint/dcp_checkpointer.py
@@ -456,22 +456,21 @@ def restore_extra_parallel_dim(
 def _local_rank() -> int:
     """This process's rank within its node, as set by the elastic launcher.
 
-    Used to elect one rank per node for the node-local staging work; defaults to
-    0 so single-process runs still take the leader path.
+    Elects one rank per node for the node-local staging work; defaults to 0 so
+    single-process runs still take the leader path.
     """
     value = os.environ.get("LOCAL_RANK", "0")
     return int(value) if value.isdigit() else 0
 
 
-def _stage_key(checkpoint_dir: str) -> str:
-    """Directory name that isolates one destination's staged files from another's.
+def _stage_key(path: str) -> str:
+    """Directory name that isolates one run's staged files from another's.
 
-    Two jobs writing different destinations can share a node, and the same job can
-    be retried, so the key must not collide. Separator substitution would: it maps
-    ``/tmp/a_b/c`` and ``/tmp/a/b_c`` onto the same name. A digest of the absolute
-    path cannot, and the readable prefix keeps the directory identifiable on disk.
+    Substituting separators would collide -- it maps ``/tmp/a_b/c`` and
+    ``/tmp/a/b_c`` onto one name -- so the name is a digest of the absolute path,
+    prefixed with the basename to stay identifiable on disk.
     """
-    absolute = os.path.abspath(checkpoint_dir)
+    absolute = os.path.abspath(path)
     digest = hashlib.sha256(absolute.encode("utf-8")).hexdigest()[:16]
     return f"{os.path.basename(absolute) or 'ckpt'}-{digest}"
 
@@ -479,9 +478,9 @@ def _stage_key(checkpoint_dir: str) -> str:
 class _Promotion:
     """Failure state shared by the phases of one promotion.
 
-    ``error`` is what this rank saw; ``failed`` is what the whole group saw. They
-    differ because the work is split across ranks -- one leader per node copies
-    that node's files -- so a failure starts out visible to a single rank.
+    ``error`` is what this rank saw, ``failed`` what the whole group saw: the work
+    is split across ranks -- one leader per node copies that node's files -- so a
+    failure starts out visible to a single rank.
     """
 
     def __init__(self) -> None:
@@ -505,12 +504,11 @@ def _any_rank_failed(failed: bool) -> bool:
 def _promotion_phase(state: _Promotion, work, *, participates: bool, always: bool = False) -> None:
     """Run one phase on the ranks that take part, then let every rank agree on the result.
 
-    The closing reduction is the phase's only collective and every rank reaches
-    it on every path, including the failing one. That is the whole point:
-    collectives are untagged, so a rank that returned early would leave the
-    others pairing up with the wrong one from then on, and the save would hang
-    instead of failing. Keeping exactly one collective per phase makes the count
-    equal by construction rather than by inspection.
+    The closing reduction is the phase's only collective and every rank reaches it
+    on every path, including the failing one. Collectives are untagged, so a rank
+    that returned early would leave the others pairing up with the wrong one from
+    then on and the save would hang instead of failing; one collective per phase
+    keeps the counts equal by construction rather than by inspection.
 
     ``always`` marks a phase that must run even after a failure -- cleanup.
     """
@@ -526,42 +524,29 @@ def _promotion_phase(state: _Promotion, work, *, participates: bool, always: boo
 _STAGE_ROOT = "veomni_ckpt_stage"
 
 
-def _stage_run_root(stage_dir: str, checkpoint_dir: str) -> str:
-    """Directory holding every staged checkpoint of one run, and nothing else.
+def _prepare_stage_dir(stage_dir: str, path: str) -> str:
+    """Create the empty staging directory for the run writing to ``path``.
 
-    Keyed on the destination the run writes to, so two runs sharing a node and a
-    ``stage_dir`` -- which is often something generic like /tmp -- never land in
-    the same place. That matters because this directory gets swept: keying it any
-    more coarsely would let one run delete another's staged data.
+    One directory per run, shared by every checkpoint it writes and emptied
+    first. That is also how a save killed part-way is cleaned up: its copy -- the
+    size of the model plus its optimizer state -- is left exactly where the next
+    save clears it, instead of stranded under a key naming its own step.
+
+    Keyed on ``path`` because ``stage_dir`` is often something generic like /tmp
+    and this directory gets swept: two runs sharing a node must not land in the
+    same place, or one would delete the other's staged data.
+
+    Only the node leader touches the filesystem; peers would race the sweep and
+    have no need to, since the reduction below is a collective. That reduction
+    also keeps a per-node failure -- a full or read-only scratch disk -- from
+    being seen by one rank alone, which would leave the rest waiting in
+    ``dcp.save`` on a collective that never arrives.
     """
-    return os.path.join(stage_dir, _STAGE_ROOT, _stage_key(os.path.dirname(os.path.abspath(checkpoint_dir))))
-
-
-def _prepare_stage_dir(stage_dir: str, checkpoint_dir: str) -> str:
-    """Create an empty staging directory for one checkpoint, agreed by every rank.
-
-    Clears the whole run root rather than just this checkpoint's directory. A
-    save killed part-way -- by a hang detector, a failover, a preemption --
-    leaves a copy the size of the model plus its optimizer state under a key
-    naming *its* step, and removing only the current key would strand it; the
-    next save on that node then asks for the same space again on a disk already
-    short of it.
-
-    Only the node leader touches the filesystem. Sweeping under peers that are
-    creating directories in the same place would race, and there is no need for
-    them to: the reduction below is a collective, so by the time any rank leaves
-    this function the leader's work is done and visible.
-
-    That reduction is also what keeps a per-node failure -- a full or read-only
-    scratch disk -- from being seen by one rank alone, which would leave the rest
-    waiting in ``dcp.save`` on a collective that never arrives.
-    """
-    run_root = _stage_run_root(stage_dir, checkpoint_dir)
-    stage_path = os.path.join(run_root, _stage_key(checkpoint_dir))
+    stage_path = os.path.join(stage_dir, _STAGE_ROOT, _stage_key(path))
     error: Optional[BaseException] = None
     if _local_rank() == 0:
         try:
-            shutil.rmtree(run_root, ignore_errors=True)
+            shutil.rmtree(stage_path, ignore_errors=True)
             os.makedirs(stage_path, exist_ok=True)
         except BaseException as e:  # noqa: BLE001 - raised once every rank has agreed
             error = e
@@ -573,19 +558,18 @@ def _prepare_stage_dir(stage_dir: str, checkpoint_dir: str) -> str:
 def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
     """Copy a staged checkpoint to its destination, then drop the staged copy.
 
-    The staging directory is node-local and shared by every rank on the node, so
-    one rank per node copies all of it rather than each rank working out which
-    files it wrote; that keeps this independent of DCP's file naming.
+    The staging directory is node-local, so one rank per node copies all of it
+    rather than each rank working out which files it wrote; that keeps this
+    independent of DCP's file naming.
 
-    Four phases, each ending in a single collective (see ``_promotion_phase``).
-    Errors are collected and re-raised only once every phase has run, on every
-    rank rather than only where the failure happened.
+    Four phases, each ending in a single collective (see ``_promotion_phase``),
+    with errors re-raised on every rank once every phase has run.
 
     ``.metadata`` is what DCP reads as "this checkpoint is complete". The
     destination's old copy goes first, before anything is overwritten, and the
-    new one goes last and only if every rank's data landed -- so a reader
-    arriving at any point sees either the previous complete checkpoint, or none,
-    never a completion marker over data that is only partly there.
+    new one goes last and only if every rank's data landed -- so a reader sees
+    either the previous complete checkpoint or none, never a completion marker
+    over data that is only partly there.
     """
     metadata_name = ".metadata"
     is_node_leader = _local_rank() == 0
@@ -633,10 +617,9 @@ def _promote_staged_checkpoint(stage_path: str, final_path: str) -> None:
     def drop_staged_copy() -> None:
         """Free the scratch disk.
 
-        The staged copy is as large as the model plus its optimizer state, so
-        keeping it after a failure would strand that space for every later run on
-        this node. Nothing is lost: without a marker the destination reads as
-        incomplete, which it is, and the next save overwrites it.
+        Runs after a failure too: the copy is as large as the model plus its
+        optimizer state, and nothing is lost by dropping it -- without a marker
+        the destination reads as incomplete, which it is.
         """
         shutil.rmtree(stage_path, ignore_errors=True)
 
@@ -697,28 +680,26 @@ class DistributedCheckpointer(CheckpointerBase):
                 checkpoint. Note this only consolidates *replicated* data: unique shards from
                 expert/tensor/pipeline parallelism are never deduplicated and remain distributed.
                 See ``CheckpointConfig.dcp_save_to_lowest_rank``.
-            stage_dir: write the checkpoint under this directory and copy it to ``path``
-                afterwards, instead of writing straight to ``path``. Intended for a
-                destination far slower than local disk. The caller owns the choice: this
-                does not probe for a usable directory or check free space, and an
-                unusable ``stage_dir`` fails the save rather than silently writing
-                elsewhere. See ``CheckpointConfig.stage_dir``.
+            stage_dir: write the checkpoint here and copy it to ``path`` afterwards,
+                instead of writing straight to ``path``. Intended for a destination far
+                slower than local disk. The caller owns the choice: this does not probe
+                for a usable directory or check free space, and an unusable ``stage_dir``
+                fails the save rather than silently writing elsewhere. See
+                ``CheckpointConfig.stage_dir``.
         return:
             None
         """
         if "model" not in state:
             raise ValueError("Model must be provided to save a distributed checkpoint.")
 
+        # Rejected up front, before anything reaches disk. An async write is still
+        # running when save() returns and drops the staged copy; a caller-supplied
+        # writer already points somewhere, and ignoring stage_dir would write straight
+        # to the slow destination it was meant to avoid.
         if stage_dir and save_async:
-            # The staged copy is deleted as soon as save() returns, which for an async
-            # save is before the write has finished. Reject the pair up front, before
-            # anything has been created on disk, rather than silently dropping one.
             raise ValueError("stage_dir cannot be combined with save_async")
 
         if stage_dir and storage_writer is not None:
-            # A caller-supplied writer already points somewhere; redirecting it to the
-            # staging directory is not ours to do, and ignoring stage_dir would write
-            # straight to the slow destination the caller was trying to avoid.
             raise ValueError("stage_dir cannot be combined with an explicit storage_writer")
 
         checkpoint_dir = f"{path}/{_GLOBAL_STEP_PREFIX}{global_steps}" if global_steps else path
@@ -738,7 +719,7 @@ class DistributedCheckpointer(CheckpointerBase):
                 load=False,
             )
 
-        stage_path = _prepare_stage_dir(stage_dir, checkpoint_dir) if stage_dir else None
+        stage_path = _prepare_stage_dir(stage_dir, path) if stage_dir else None
 
         if storage_writer is None:
             storage_writer = cls._create_storage_writer(stage_path or checkpoint_dir)

--- a/veomni/trainer/callbacks/checkpoint_callback.py
+++ b/veomni/trainer/callbacks/checkpoint_callback.py
@@ -21,6 +21,7 @@ import torch.distributed as dist
 from ...checkpoint import CheckpointerBase, build_checkpointer
 from ...models import save_model_assets
 from ...utils import helper
+from ...utils.checkpoint_utils import _GLOBAL_STEP_PREFIX
 from ...utils.save_safetensor_utils import save_hf_safetensor, save_lora_adapter_with_dcp
 from .base import Callback, TrainerState
 
@@ -141,7 +142,9 @@ class CheckpointerCallback(Callback):
         """Save distributed checkpoint and optimizer state at each save_steps."""
         args: "VeOmniArguments" = self.trainer.args
 
-        save_checkpoint_path = os.path.join(args.train.checkpoint.save_path, f"global_step_{state.global_step}")
+        save_checkpoint_path = os.path.join(
+            args.train.checkpoint.save_path, f"{_GLOBAL_STEP_PREFIX}{state.global_step}"
+        )
 
         if hasattr(self.trainer, "data_iterator") and hasattr(self.trainer.data_iterator, "state_dict"):
             train_dataloader_state = self.trainer.data_iterator.state_dict()
@@ -176,8 +179,9 @@ class CheckpointerCallback(Callback):
         helper.empty_cache()
 
         self.trainer.checkpointer.save(
-            save_checkpoint_path,
+            args.train.checkpoint.save_path,
             ckpt_state,
+            global_steps=state.global_step,
             save_async=args.train.checkpoint.save_async,
             trainable_only=bool(getattr(args.model, "lora_config", None)),
             save_to_lowest_rank=args.train.checkpoint.dcp_save_to_lowest_rank,
@@ -237,7 +241,9 @@ class HuggingfaceCkptCallback(CheckpointerCallback):
     def _save_checkpoint(self, state: TrainerState, stage: str = "step_end"):
         """Save model in HuggingFace format."""
         args: "VeOmniArguments" = self.trainer.args
-        save_checkpoint_path = os.path.join(args.train.checkpoint.save_path, f"global_step_{state.global_step}")
+        save_checkpoint_path = os.path.join(
+            args.train.checkpoint.save_path, f"{_GLOBAL_STEP_PREFIX}{state.global_step}"
+        )
         if not os.path.exists(save_checkpoint_path):
             dist.barrier()
             super()._save_checkpoint(state)
@@ -274,7 +280,9 @@ class HFLoraCkptCallback(HuggingfaceCkptCallback):
     def _save_checkpoint(self, state: TrainerState, stage: str = "step_end"):
         """Save LoRA checkpoint in HuggingFace format at train end."""
         args: "VeOmniArguments" = self.trainer.args
-        save_checkpoint_path = os.path.join(args.train.checkpoint.save_path, f"global_step_{state.global_step}")
+        save_checkpoint_path = os.path.join(
+            args.train.checkpoint.save_path, f"{_GLOBAL_STEP_PREFIX}{state.global_step}"
+        )
         if not os.path.exists(save_checkpoint_path):
             dist.barrier()
             CheckpointerCallback._save_checkpoint(self, state)


### PR DESCRIPTION
Follow-up to #1164 / #1172.

## The problem

`_prepare_stage_dir` cleared only the directory keyed on the checkpoint it was about to write. A save killed part-way — by a hang detector, a failover, a preemption — leaves a copy the size of the model plus its optimizer state under a key naming *its* step, and nothing ever removed it.

The next save on that node then asks for the same space again on a disk already short of it. Staging deliberately neither probes nor falls back, so it fails outright rather than degrading.

This lands where it hurts most: the jobs with the least headroom are the large ones, and those are also the ones that get restarted.

## The fix

Stage under a `veomni_ckpt_stage` root and clear the whole root at the start of each save.

The extra level is what makes the sweep safe — `stage_dir` belongs to the caller and is often something like `/tmp`, which must never be removed wholesale. One rank per node sweeps; the rest only ensure the directory exists, and everything still passes through the existing `_any_rank_failed` handshake.

## Tests

- an earlier step's abandoned copy is removed
- unrelated content sitting beside our root survives the sweep
- a non-leader rank does not wipe what the node leader prepared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint staging cleanup by reusing one emptied directory for each run.
  * Isolated staging data between runs and preserved data belonging to other runs.
  * Ensured staging directory creation and cleanup remain coordinated across nodes.
  * Corrected checkpoint step directory handling, including step 0.
  * Kept reported checkpoint destinations aligned with the locations actually saved.

* **Tests**
  * Added coverage for per-run directory reuse, stale-data cleanup, staging isolation, distinct run paths, and checkpoint destination consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->