### PR TITLE
[trainer] feat: make the default process group's collective timeout configurable

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -138,6 +138,7 @@ jobs:
           uv run --frozen pytest -s -x tests/models/test_models_patch.py
           uv run --frozen pytest -s -x tests/models/test_vlm_trainer.py
           uv run --frozen pytest -s -x tests/trainer/test_aux_metrics.py
+          uv run --frozen pytest -s -x tests/trainer/test_dist_timeout.py
           uv run --frozen pytest -s -x tests/lora/test_vlm_lora.py
           uv run --frozen pytest -s -x tests/models/test_padded_packed_loss.py
           uv run --frozen pytest -s -x tests/models/test_models_logits_equal_v5.py

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -162,6 +162,7 @@ jobs:
           uv run --frozen pytest -v -s -x tests/models/test_padded_packed_loss.py
           uv run --frozen pytest -v -s -x tests/models/test_vlm_trainer.py
           uv run --frozen pytest -v -s -x tests/trainer/test_aux_metrics.py
+          uv run --frozen pytest -v -s -x tests/trainer/test_dist_timeout.py
           uv run --frozen pytest -v -s -x tests/lora/test_vlm_lora.py
           uv run --frozen pytest -v -s -x tests/models/test_checkpoint_tensor_converter.py
       - name: Run fsdp2/extra_parallel+fsdp2 (e.g. ep+fsdp2, mb+fsdp2, ep+emb+fsdp2) clip grad norm test

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -373,6 +373,7 @@ group or learning rate is therefore a recipe choice beyond the reference, not a 
 | eval_steps | `int` | `0` | Steps between evaluations. `0` to disable. |
 | eval_epochs | `int` | `1` | Epochs between evaluations. `0` to disable. |
 | seed | `int` | `42` | Random seed. |
+| dist_timeout_seconds | `Optional[int]` | `None` | Collective timeout for the default process group. `None` keeps torch's per-backend default (10 min for NCCL). Raise it when a step legitimately blocks longer — a checkpoint written over a slow network filesystem — at the cost of taking that much longer to notice a real deadlock. Device-mesh subgroups keep torch's default. |
 | max_steps | `Optional[int]` | `None` | Max training steps per epoch (debug only). |
 | moe_load_balance_monitor_interval | `int` | `0` | Log a globally reduced MoE expert-load heatmap every N steps. `0` disables monitoring. |
 | optimizer | `OptimizerConfig` | — | Optimizer and learning-rate schedule. |

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -373,7 +373,7 @@ group or learning rate is therefore a recipe choice beyond the reference, not a 
 | eval_steps | `int` | `0` | Steps between evaluations. `0` to disable. |
 | eval_epochs | `int` | `1` | Epochs between evaluations. `0` to disable. |
 | seed | `int` | `42` | Random seed. |
-| dist_timeout_seconds | `Optional[int]` | `None` | Collective timeout for the default process group. `None` keeps torch's per-backend default (10 min for NCCL). Raise it when a step legitimately blocks longer — a checkpoint written over a slow network filesystem — at the cost of taking that much longer to notice a real deadlock. Device-mesh subgroups keep torch's default. |
+| dist_timeout_seconds | `Optional[int]` | `None` | Collective timeout in seconds for the default process group, a positive integer. `None` keeps torch's per-backend default (10 min for NCCL). Raise it when a step legitimately blocks longer — a checkpoint written over a slow network filesystem — at the cost of taking that much longer to notice a real deadlock. Device-mesh subgroups keep torch's default. |
 | max_steps | `Optional[int]` | `None` | Max training steps per epoch (debug only). |
 | moe_load_balance_monitor_interval | `int` | `0` | Log a globally reduced MoE expert-load heatmap every N steps. `0` disables monitoring. |
 | optimizer | `OptimizerConfig` | — | Optimizer and learning-rate schedule. |

--- a/tests/trainer/test_dist_timeout.py
+++ b/tests/trainer/test_dist_timeout.py
@@ -1,0 +1,29 @@
+"""Unit tests for `TrainingArguments.dist_timeout`.
+
+The value reaches `init_process_group` as the default group's collective timeout.
+Torch treats a collective that outlives it as a hang and the NCCL watchdog aborts
+the process, so an operation that legitimately blocks longer -- a checkpoint
+written over a slow network filesystem -- needs this raised to survive.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from veomni.arguments import TrainingArguments
+
+
+class TestDistTimeout:
+    def test_unset_defers_to_torch(self):
+        """None is not a value we can substitute: torch's default differs per backend."""
+        assert TrainingArguments().dist_timeout is None
+
+    def test_seconds_become_a_timedelta(self):
+        assert TrainingArguments(dist_timeout_seconds=1800).dist_timeout == timedelta(seconds=1800)
+
+    @pytest.mark.parametrize("seconds", [0, -1])
+    def test_non_positive_is_rejected_at_parse_time(self, seconds):
+        """Torch reads a non-positive timeout as "expire immediately", which aborts the
+        first collective. Rejecting it here fails the run before it reserves any GPU."""
+        with pytest.raises(ValueError, match="must be positive"):
+            TrainingArguments(dist_timeout_seconds=seconds)

--- a/tests/trainer/test_dist_timeout.py
+++ b/tests/trainer/test_dist_timeout.py
@@ -25,5 +25,15 @@ class TestDistTimeout:
     def test_non_positive_is_rejected_at_parse_time(self, seconds):
         """Torch reads a non-positive timeout as "expire immediately", which aborts the
         first collective. Rejecting it here fails the run before it reserves any GPU."""
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            TrainingArguments(dist_timeout_seconds=seconds)
+
+    @pytest.mark.parametrize("seconds", [True, 1800.5, "1800"])
+    def test_non_integer_is_rejected_at_parse_time(self, seconds):
+        """The parser hands YAML values through untouched, so anything can arrive here.
+
+        ``True`` is the one that has to be caught rather than tolerated: ``bool`` is an
+        ``int`` subclass and it survives a positive-value check as a one-second timeout.
+        """
+        with pytest.raises(ValueError, match="must be a positive integer"):
             TrainingArguments(dist_timeout_seconds=seconds)

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -16,6 +16,7 @@ import math
 import os
 import sys
 from dataclasses import MISSING, dataclass, field, fields
+from datetime import timedelta
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple
 
@@ -825,6 +826,22 @@ class TrainingArguments:
         default=42,
         metadata={"help": "Random seed."},
     )
+    dist_timeout_seconds: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Timeout for collective operations on the default process group. Unset "
+                "(default) keeps torch's own per-backend default, which is 10 minutes for "
+                "NCCL. A collective that outlives it is treated as a hang: the NCCL "
+                "watchdog aborts the process and the run restarts. Raise it when a step "
+                "legitimately blocks that long -- loading a model or writing a checkpoint "
+                "over a slow network filesystem -- at the cost of taking that much longer "
+                "to notice a real deadlock. Applies to the default group, which is what "
+                "checkpoint save and load collectives run on; device-mesh subgroups keep "
+                "torch's default."
+            )
+        },
+    )
     max_steps: Optional[int] = field(
         default=None,
         metadata={"help": "Max training steps per epoch. (for debug)"},
@@ -856,6 +873,9 @@ class TrainingArguments:
                 f"dyn_bsz_physical_overflow_ratio must be >= 1.0, got {self.dyn_bsz_physical_overflow_ratio}."
             )
 
+        if self.dist_timeout_seconds is not None and self.dist_timeout_seconds <= 0:
+            raise ValueError(f"dist_timeout_seconds must be positive, got {self.dist_timeout_seconds}.")
+
         self._train_steps = -1
         self.local_rank = int(os.getenv("LOCAL_RANK", 0))
         self.global_rank = int(os.getenv("RANK", 0))
@@ -865,6 +885,17 @@ class TrainingArguments:
         self._derive_batch_config()
         self._resolve_checkpoint_paths()
         self._resolve_profile()
+
+    @property
+    def dist_timeout(self) -> Optional[timedelta]:
+        """``dist_timeout_seconds`` as ``init_process_group`` wants it.
+
+        ``None`` means "leave it to torch", which is not the same as any number we
+        could substitute: the default differs per backend.
+        """
+        if self.dist_timeout_seconds is None:
+            return None
+        return timedelta(seconds=self.dist_timeout_seconds)
 
     # -- validation & derivation helpers (called by __post_init__) -----------------------
 

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -830,7 +830,8 @@ class TrainingArguments:
         default=None,
         metadata={
             "help": (
-                "Timeout for collective operations on the default process group. Unset "
+                "Timeout in seconds for collective operations on the default process group, a "
+                "positive integer. Unset "
                 "(default) keeps torch's own per-backend default, which is 10 minutes for "
                 "NCCL. A collective that outlives it is treated as a hang: the NCCL "
                 "watchdog aborts the process and the run restarts. Raise it when a step "
@@ -873,8 +874,14 @@ class TrainingArguments:
                 f"dyn_bsz_physical_overflow_ratio must be >= 1.0, got {self.dyn_bsz_physical_overflow_ratio}."
             )
 
-        if self.dist_timeout_seconds is not None and self.dist_timeout_seconds <= 0:
-            raise ValueError(f"dist_timeout_seconds must be positive, got {self.dist_timeout_seconds}.")
+        # The parser hands YAML values through untouched, so the type is checked here.
+        # ``bool`` is an ``int`` subclass: without this, ``dist_timeout_seconds: true``
+        # would pass as a one-second timeout, which aborts the first collective -- the
+        # opposite of what this setting is for.
+        if self.dist_timeout_seconds is not None and (
+            type(self.dist_timeout_seconds) is not int or self.dist_timeout_seconds <= 0
+        ):
+            raise ValueError(f"dist_timeout_seconds must be a positive integer, got {self.dist_timeout_seconds!r}.")
 
         self._train_steps = -1
         self.local_rank = int(os.getenv("LOCAL_RANK", 0))

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -353,9 +353,10 @@ class BaseTrainer(Stateful, ABC):
         get_torch_device().set_device(device_str)
         self.device = torch.device(device_str)
 
-        # Initialize distributed process group
+        # Initialize distributed process group. A ``None`` timeout leaves torch to
+        # apply its own per-backend default; see ``train.dist_timeout_seconds``.
         if not dist.is_initialized():
-            dist.init_process_group(backend=get_dist_comm_backend())
+            dist.init_process_group(backend=get_dist_comm_backend(), timeout=self.args.train.dist_timeout)
 
         logger.info(f"Process rank: {self.args.train.global_rank}, world size: {self.args.train.world_size}")
 


### PR DESCRIPTION
## What

Adds `train.dist_timeout_seconds`, forwarded to `dist.init_process_group(timeout=...)`.

## Why

torch gives NCCL a 10-minute collective timeout. A collective that outlives it is treated as a hang: the watchdog aborts the process and the run restarts from its last resume point.

Some steps legitimately block longer than that. Writing a checkpoint or loading a model across a slow network filesystem can hold every non-writing rank on a scalar collective for the whole duration — observed as `Timeout(ms)=600000` aborts on runs whose checkpoint write took ~11 minutes. Restarting is strictly worse than waiting.

## Behaviour

- Unset (default) keeps torch's own per-backend default — 10 minutes for NCCL, 30 for others. There is no single number to substitute for that, so `None` stays `None`.
- Non-positive values are rejected in `__post_init__`: torch reads them as "expire immediately", which aborts the first collective instead of doing what the operator meant. Failing at parse time avoids reserving GPUs first.
- Scope: the default group, which is what checkpoint save/load collectives run on. Device-mesh subgroups are created by `DeviceMesh._init_process_groups` with `timeout=None` and keep torch's default; covering those needs per-dim `backend_override` options and is left out deliberately.

The trade-off is on the operator: a longer budget also means taking that much longer to notice a real deadlock.

## Tests

`tests/trainer/test_dist_timeout.py`, registered in the GPU and NPU unit lanes. Verified the tests fail against an implementation that returns the raw int or drops the validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional distributed training timeout setting for collective operations.
  * Timeout values are validated and support backend defaults when left unset.
  * Increased timeouts can accommodate slower checkpoint writes while affecting deadlock detection speed.

* **Documentation**
  * Documented the new distributed timeout setting, defaults, and trade-offs.

* **Tests**
  * Added coverage for default, configured, and invalid timeout values across GPU and NPU test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->