### PR TITLE
[dist, ops, docs] feat: add NPU ring attention backend for USP

### DIFF
--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -17,7 +17,7 @@ veomni/
 │   ├── parallel_plan.py    ParallelPlan for ExtraParallel (EP, embedding shard)
 │   ├── fsdp2/          FSDP2 (composable fully_shard), gradient clipping
 │   ├── moe/            MoE expert parallelism: token routing, all-to-all, EPGroupGemm
-│   └── sequence_parallel/  Ulysses SP: all-to-all head/seq exchange, async variants
+│   └── sequence_parallel/  Ulysses + USP Ring Attention (CUDA FA2/FA4 and Ascend torch_npu)
 ├── models/             Model loading and patching
 │   ├── auto.py         High-level API: build_foundation_model, build_tokenizer, build_processor
 │   ├── loader.py       Registry-based model loading (MODELING_REGISTRY, MODEL_CONFIG_REGISTRY)
@@ -142,7 +142,12 @@ VeOmni uses FSDP2 exclusively.
    - `fully_shard()` on EP modules with `ep_fsdp` submesh (Shard(1) for hidden dim)
    - `fully_shard()` on each transformer block with `fsdp_mesh`
    - `fully_shard()` on root model
-4. SP is orthogonal to FSDP2 — models call Ulysses all-to-all (`gather_seq_scatter_heads` / `gather_heads_scatter_seq`) around attention; the FSDP shard mesh fuses with SP mesh (`dp_shard_sp`)
+4. SP is orthogonal to FSDP2 — models call Ulysses all-to-all
+   (`gather_seq_scatter_heads` / `gather_heads_scatter_seq`) around attention.
+   When CP is enabled, the Ulysses-local head shard runs zig-zag Ring Attention
+   over the CP group. CUDA uses FA2/FA4 low-level kernels and Ascend uses
+   `torch_npu.npu_fusion_attention`; the FSDP shard mesh fuses with SP mesh
+   (`dp_shard_sp`).
 5. EP token routing is in model MoE code + `moe_layer.py` using `ep_group` from `ParallelState`
 
 ## Config Structure

--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -17,7 +17,7 @@ veomni/
 │   ├── parallel_plan.py    ParallelPlan for ExtraParallel (EP, embedding shard)
 │   ├── fsdp2/          FSDP2 (composable fully_shard), gradient clipping
 │   ├── moe/            MoE expert parallelism: token routing, all-to-all, EPGroupGemm
-│   └── sequence_parallel/  Ulysses + USP Ring Attention (CUDA FA2/FA4 and Ascend torch_npu)
+│   └── sequence_parallel/  Ulysses plus the ring_attention/ package for USP (CUDA FA2/FA4 and Ascend torch_npu)
 ├── models/             Model loading and patching
 │   ├── auto.py         High-level API: build_foundation_model, build_tokenizer, build_processor
 │   ├── loader.py       Registry-based model loading (MODELING_REGISTRY, MODEL_CONFIG_REGISTRY)

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -60,6 +60,7 @@ Core entry points:
    - `gather_heads_scatter_seq(output)` — after attention: inverse exchange → **full heads, subset of sequence** per rank.
    - Underlying primitive: `_SeqAllToAll` (autograd-aware `all_to_all_tensor`).
    - Async variants in `async_ulysses*.py` for DiT and pipelined QKV/output projections.
+   - With USP (`cp_size > 1`), Ulysses runs first and zig-zag Ring Attention runs over the CP group. CUDA uses `ring_attention.py` (FA2/FA4); Ascend uses the guarded `ring_attention_npu.py` (`torch_npu.npu_fusion_attention`).
    - Data slicing: `veomni/distributed/sequence_parallel/data.py` — `sp_pad_and_slice()`, `slice_input_tensor()`, `gather_outputs()`.
    - Loss reduction: `reduce_sequence_parallel_loss()` in `loss.py` aggregates across SP ranks (optional `group=` arg; defaults to the current state's unified SP group).
    - Process groups: `comm.py` has NO group globals. Its getters (`get_ulysses_sequence_parallel_group`, `get_unified_sequence_parallel_group`, `get_context_parallel_group`, `get_data_parallel_group`) resolve from the *current* `ParallelState`'s device mesh (`get_parallel_state().{ulysses,sp,cp,dp}_group`) — exactly how `fsdp_group` already worked. `set_ulysses_sequence_parallel_group(group)` survives ONLY as a unit-test injection seam (`_ULYSSES_SP_GROUP_OVERRIDE`, `None` in production); no production code calls it. Meshless SP is unsupported — `ParallelState.__post_init__` raises if `sp_enabled and device_mesh is None`; always build via `init_parallel_state`.
@@ -167,7 +168,7 @@ Core files:
 
 22. **NPU (Ascend) code paths require guards**
     - NPU-specific code must be guarded with `is_torch_npu_available()` or `IS_NPU_AVAILABLE`.
-    - NPU kernels live in `veomni/ops/kernels/{rms_norm,rotary}/npu.py` and `veomni/ops/platform/npu/` — they must not be imported on GPU-only environments.
+    - NPU kernels generally live in `veomni/ops/kernels/*/npu.py` and `veomni/ops/platform/npu/`. Distributed NPU Ring Attention lives in `veomni/distributed/sequence_parallel/ring_attention_npu.py`; all such modules must remain importable on GPU-only environments without importing `torch_npu`.
 
 23. **Device-agnostic code must use `veomni.utils.device` helpers**
    - Use `get_device_type()`, `get_torch_device()`, `synchronize()`, `empty_cache()` instead of direct `torch.cuda.*` calls.

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -60,7 +60,7 @@ Core entry points:
    - `gather_heads_scatter_seq(output)` — after attention: inverse exchange → **full heads, subset of sequence** per rank.
    - Underlying primitive: `_SeqAllToAll` (autograd-aware `all_to_all_tensor`).
    - Async variants in `async_ulysses*.py` for DiT and pipelined QKV/output projections.
-   - With USP (`cp_size > 1`), Ulysses runs first and zig-zag Ring Attention runs over the CP group. CUDA uses `ring_attention.py` (FA2/FA4); Ascend uses the guarded `ring_attention_npu.py` (`torch_npu.npu_fusion_attention`).
+   - With USP (`cp_size > 1`), Ulysses runs first and zig-zag Ring Attention runs over the CP group. The unified entry and shared communication/layout helpers live under `sequence_parallel/ring_attention/`; CUDA uses `gpu.py` (FA2/FA4) and Ascend uses the guarded `npu.py` (`torch_npu.npu_fusion_attention`).
    - Data slicing: `veomni/distributed/sequence_parallel/data.py` — `sp_pad_and_slice()`, `slice_input_tensor()`, `gather_outputs()`.
    - Loss reduction: `reduce_sequence_parallel_loss()` in `loss.py` aggregates across SP ranks (optional `group=` arg; defaults to the current state's unified SP group).
    - Process groups: `comm.py` has NO group globals. Its getters (`get_ulysses_sequence_parallel_group`, `get_unified_sequence_parallel_group`, `get_context_parallel_group`, `get_data_parallel_group`) resolve from the *current* `ParallelState`'s device mesh (`get_parallel_state().{ulysses,sp,cp,dp}_group`) — exactly how `fsdp_group` already worked. `set_ulysses_sequence_parallel_group(group)` survives ONLY as a unit-test injection seam (`_ULYSSES_SP_GROUP_OVERRIDE`, `None` in production); no production code calls it. Meshless SP is unsupported — `ParallelState.__post_init__` raises if `sp_enabled and device_mesh is None`; always build via `init_parallel_state`.
@@ -168,7 +168,7 @@ Core files:
 
 22. **NPU (Ascend) code paths require guards**
     - NPU-specific code must be guarded with `is_torch_npu_available()` or `IS_NPU_AVAILABLE`.
-    - NPU kernels generally live in `veomni/ops/kernels/*/npu.py` and `veomni/ops/platform/npu/`. Distributed NPU Ring Attention lives in `veomni/distributed/sequence_parallel/ring_attention_npu.py`; all such modules must remain importable on GPU-only environments without importing `torch_npu`.
+    - NPU kernels generally live in `veomni/ops/kernels/*/npu.py` and `veomni/ops/platform/npu/`. Distributed NPU Ring Attention lives in `veomni/distributed/sequence_parallel/ring_attention/npu.py`; all such modules must remain importable on GPU-only environments without importing `torch_npu`.
 
 23. **Device-agnostic code must use `veomni.utils.device` helpers**
    - Use `get_device_type()`, `get_torch_device()`, `synchronize()`, `empty_cache()` instead of direct `torch.cuda.*` calls.

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -151,6 +151,8 @@ jobs:
           uv run --frozen pytest -v -s -x tests/parallel/ulysses/test_ulysses.py
           uv run --frozen pytest -v -s -x tests/parallel/ulysses/test_all_gather.py
           uv run --frozen pytest -v -s -x tests/parallel/ulysses/test_slice_input_tensor.py
+          uv run --frozen pytest -v -s -x tests/parallel/ring/test_usp_data.py
+          uv run --frozen pytest -v -s -x tests/parallel/ring/test_usp_ring_npu.py
           uv run --frozen pytest -v -s -x tests/parallel/encoder_data_balance/test_balance_reverse.py
           uv run --frozen pytest -v -s -x tests/parallel/encoder_data_balance/test_balance_sorting_algo.py
           uv run --frozen pytest -v -s -x tests/parallel/test_chunk_mbs.py

--- a/configs/text/qwen3_usp.yaml
+++ b/configs/text/qwen3_usp.yaml
@@ -9,8 +9,8 @@
 #
 # Constraints for the ``cp`` (ring) path:
 #   * causal attention only (no explicit attention masks under cp)
-#   * a flash-attn backend is required (FA2 on Ampere/Hopper, FA4 CuTe on
-#     Blackwell/GB200 — auto-selected at import time)
+#   * attention backend: FA2 on Ampere/Hopper, FA4 CuTe on Blackwell/GB200,
+#     or torch_npu fusion attention on Ascend (selected by device)
 #   * max_seq_len must be divisible by 2 * ulysses_size * cp_size
 #   * packed (varlen) sequences ARE supported: every packed document length
 #     must additionally be divisible by 2 * cp_size (balanced ring attention

--- a/docs/key_features/ulysses.md
+++ b/docs/key_features/ulysses.md
@@ -145,12 +145,12 @@ from veomni.distributed.sequence_parallel import (
 # now x is of shape [batch_size, seq_len/n, dim] on each sp rank
 
 # Step3 (part1): modify attention computation
-x = self.qkv(x) # [batch_size, seq_pad/n, dim]
-x = gather_seq_scatter_heads(x, seq_dim=1, head_dim=2) # [batch_size, seq_len, dim/n]
+x = self.qkv(x)  # [batch_size, seq_pad/n, dim]
+x = gather_seq_scatter_heads(x, seq_dim=1, head_dim=2)  # [batch_size, seq_len, dim/n]
 ...
 output = F.scaled_dot_product_attention(q, k, v, ...).reshape(...)
 ...
-output = gather_heads_scatter_seq(output, head_dim=2, seq_dim=1) # [batch_size, seq_pad/n, dim]
+output = gather_heads_scatter_seq(output, head_dim=2, seq_dim=1)  # [batch_size, seq_pad/n, dim]
 
 # Step3 (part2): reduce loss after model forward
 loss = loss_fct(logits, labels)
@@ -498,12 +498,12 @@ bash train.sh tasks/train_text.py configs/text/qwen3_usp.yaml \
   padding is coalesced into one aligned segment. The lower-level USP reorder
   helpers still validate the invariant and reject manually constructed
   unaligned batches.
-- **Flash-attention backend**: ring attention builds on a `flash_attn`
-  forward/backward pair, auto-selected at import time (see `FA_BACKEND` in
-  `ring_attention.py`): classic **FA2** (`flash_attn.flash_attn_interface`) on
-  Ampere/Hopper, or the **FA4** CuTe backend (`flash_attn.cute.interface`) on
-  Blackwell/GB200. FA3 is Hopper-only (no Blackwell kernel image) and is not
-  used by the ring path. Any one of these backends is sufficient.
+- **Attention backend**: CUDA uses a `flash_attn` forward/backward pair,
+  auto-selected at import time: classic **FA2** on Ampere/Hopper or the **FA4**
+  CuTe backend on Blackwell/GB200. Ascend uses
+  `torch_npu.npu_fusion_attention` / `npu_fusion_attention_grad`. Both dense
+  and packed paths select the backend from the active device. FA3 is not used
+  by Ring Attention.
 - **Divisibility**: `max_seq_len` must be divisible by `2 · ulysses_size · cp_size`
   (the collator pads up to this multiple automatically).
 - **Loss/data layout**: the `SequenceParallelCollator` lays sequences out
@@ -514,9 +514,13 @@ bash train.sh tasks/train_text.py configs/text/qwen3_usp.yaml \
 
 ### Implementation Map
 
-- Ring kernel: `veomni/distributed/sequence_parallel/ring_attention.py`
+- CUDA Ring kernel: `veomni/distributed/sequence_parallel/ring_attention.py`
   (`zigzag_ring_flash_attn_func` for dense, `zigzag_ring_flash_attn_varlen_func`
   for packed, online-softmax `update_out_and_lse`, `RingComm`).
+- Ascend Ring kernel:
+  `veomni/distributed/sequence_parallel/ring_attention_npu.py` (dense and
+  packed `torch_npu` fusion attention, softmax max/sum merge, explicit
+  forward/backward RNG state).
 - Data layout: `veomni/distributed/sequence_parallel/data.py`
   (`zigzag_reorder` / `zigzag_undo` for dense, `zigzag_reorder_varlen` /
   `local_cu_seqlens` for packed) and `SequenceParallelCollator._usp_slice`.

--- a/docs/key_features/ulysses.md
+++ b/docs/key_features/ulysses.md
@@ -514,16 +514,21 @@ bash train.sh tasks/train_text.py configs/text/qwen3_usp.yaml \
 
 ### Implementation Map
 
-- CUDA Ring kernel: `veomni/distributed/sequence_parallel/ring_attention.py`
+- Unified Ring entry and CUDA backend:
+  `veomni/distributed/sequence_parallel/ring_attention/__init__.py` and
+  `veomni/distributed/sequence_parallel/ring_attention/gpu.py`
   (`zigzag_ring_flash_attn_func` for dense, `zigzag_ring_flash_attn_varlen_func`
-  for packed, online-softmax `update_out_and_lse`, `RingComm`).
-- Ascend Ring kernel:
-  `veomni/distributed/sequence_parallel/ring_attention_npu.py` (dense and
+  for packed and online-softmax `update_out_and_lse`). Shared P2P communication
+  lives in `veomni/distributed/sequence_parallel/ring_attention/comm.py`.
+- Ascend Ring backend:
+  `veomni/distributed/sequence_parallel/ring_attention/npu.py` (fixed-shape and
   packed `torch_npu` fusion attention, softmax max/sum merge, explicit
-  forward/backward RNG state).
-- Data layout: `veomni/distributed/sequence_parallel/data.py`
-  (`zigzag_reorder` / `zigzag_undo` for dense, `zigzag_reorder_varlen` /
+  forward/backward RNG state). Packed APIs use standard leading-zero cumulative
+  offsets such as `[0, 6, 10]`; conversion to the endpoint list expected by
+  `torch_npu` happens only at the operator boundary.
+- Data layout: `veomni/distributed/sequence_parallel/ring_attention/layout.py`
+  (`zigzag_reorder` / `zigzag_undo` for fixed-shape inputs, `zigzag_reorder_packed` /
   `local_cu_seqlens` for packed) and `SequenceParallelCollator._usp_slice`.
-- Attention integration: the ring branch in
-  `veomni/ops/kernels/attention/__init__.py` runs after the Ulysses all-to-all.
+- Attention integration: `ring_attention(...)` runs after the Ulysses all-to-all;
+  `veomni/ops/kernels/attention/__init__.py` only delegates to that entry.
 - Mesh: `init_parallel_state()` builds `[ulysses, cp]` and flattens `sp`.

--- a/docs/usage/arguments.md
+++ b/docs/usage/arguments.md
@@ -427,7 +427,7 @@ validation instead of applying ChunkMBS to multiple stacks.
 | pp_size | `int` | `1` | Pipeline parallel size. |
 | ulysses_size | `int` | `1` | Ulysses sequence parallel size. |
 | enable_async | `bool` | `False` | Enable async Ulysses. |
-| cp_size | `int` | `1` | Ring-attention context-parallel size (USP). Composes with `ulysses_size`; effective SP size is `ulysses_size * cp_size`. Ring path is causal-only and needs a flash-attn backend (FA2 on Ampere/Hopper or FA4 CuTe on Blackwell/GB200, auto-selected); packed (varlen) sequences are supported when every document length is divisible by `2 * cp_size`. |
+| cp_size | `int` | `1` | Ring-attention context-parallel size (USP). Composes with `ulysses_size`; effective SP size is `ulysses_size * cp_size`. Ring path is causal-only and uses FA2/FA4 on CUDA or `torch_npu` fusion attention on Ascend; packed (varlen) sequences are supported when every document length is divisible by `2 * cp_size`. |
 | fsdp_config | `FSDPConfig` | — | FSDP sharding configuration. |
 | offload_config | `OffloadConfig` | — | Activation offload settings. |
 

--- a/tests/parallel/ring/test_ring_attention_dispatch.py
+++ b/tests/parallel/ring/test_ring_attention_dispatch.py
@@ -1,0 +1,95 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import veomni.distributed.sequence_parallel.ring_attention as ring_attention_module
+
+
+def test_ring_attention_routes_fixed_shape_input(monkeypatch):
+    calls = []
+
+    def forward(query, key, value, **kwargs):
+        calls.append((query, key, value, kwargs))
+        return query
+
+    backend = SimpleNamespace(forward=forward, packed_forward=None)
+    monkeypatch.setattr(ring_attention_module, "_load_backend", lambda device_type: backend)
+
+    query = torch.randn(1, 8, 2, 4)
+    output = ring_attention_module.ring_attention(
+        query,
+        query,
+        query,
+        group=object(),
+        cp_size=2,
+        device_type="cuda",
+    )
+
+    assert output is query
+    assert len(calls) == 1
+    assert calls[0][3]["dropout_p"] == 0.0
+
+
+def test_ring_attention_routes_packed_input_with_local_offsets(monkeypatch):
+    calls = []
+
+    def packed_forward(query, key, value, cu_seqlens, max_seqlen, **kwargs):
+        calls.append((query, key, value, cu_seqlens, max_seqlen, kwargs))
+        return query
+
+    backend = SimpleNamespace(forward=None, packed_forward=packed_forward)
+    monkeypatch.setattr(ring_attention_module, "_load_backend", lambda device_type: backend)
+
+    query = torch.randn(1, 8, 2, 4)
+    full_cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int64)
+    output = ring_attention_module.ring_attention(
+        query,
+        query,
+        query,
+        group=object(),
+        cp_size=2,
+        cu_seqlens=full_cu_seqlens,
+        device_type="cuda",
+    )
+
+    assert output.shape == query.shape
+    assert len(calls) == 1
+    assert torch.equal(calls[0][3], torch.tensor([0, 4, 8], dtype=torch.int32))
+    assert calls[0][4] == 4
+
+
+@pytest.mark.parametrize(
+    ("causal", "attention_mask", "match"),
+    [
+        (False, None, "requires causal attention"),
+        (True, torch.ones(1), "does not support explicit attention masks"),
+    ],
+)
+def test_ring_attention_validates_supported_inputs(causal, attention_mask, match):
+    query = torch.randn(1, 8, 2, 4)
+    with pytest.raises(NotImplementedError, match=match):
+        ring_attention_module.ring_attention(
+            query,
+            query,
+            query,
+            group=object(),
+            cp_size=2,
+            attention_mask=attention_mask,
+            causal=causal,
+            device_type="cuda",
+        )

--- a/tests/parallel/ring/test_usp_data.py
+++ b/tests/parallel/ring/test_usp_data.py
@@ -35,6 +35,10 @@ from veomni.distributed.sequence_parallel.data import (
     zigzag_reorder_varlen,
     zigzag_undo,
 )
+from veomni.distributed.sequence_parallel.ring_attention_npu import (
+    prepare_npu_cu_seqlens,
+    update_npu_out_and_softmax_stats,
+)
 from veomni.utils.constants import IGNORE_INDEX
 
 
@@ -99,6 +103,35 @@ def test_local_cu_seqlens_cp2():
     local = local_cu_seqlens(cu, cp_size=2)
     # each document length halved for cp=2
     assert local.tolist() == [0, 6, 10]
+
+
+def test_prepare_npu_cu_seqlens_uses_cpu_endpoints():
+    endpoints = prepare_npu_cu_seqlens(torch.tensor([0, 12, 20], dtype=torch.int32))
+    assert endpoints.device.type == "cpu"
+    assert endpoints.dtype == torch.long
+    assert endpoints.tolist() == [12, 20]
+
+
+def test_npu_softmax_stats_merge_tnd():
+    previous_out = torch.full((2, 3, 4), 2.0)
+    previous_max = torch.zeros((2, 3))
+    previous_sum = torch.ones((2, 3))
+    block_out = torch.full((2, 3, 4), 6.0)
+    block_max = torch.zeros((2, 3, 8))
+    block_sum = torch.full((2, 3, 8), 3.0)
+
+    out, softmax_max, softmax_sum = update_npu_out_and_softmax_stats(
+        previous_out,
+        previous_max,
+        previous_sum,
+        block_out,
+        block_max,
+        block_sum,
+    )
+
+    torch.testing.assert_close(out, torch.full_like(out, 5.0))
+    torch.testing.assert_close(softmax_max, torch.zeros_like(softmax_max))
+    torch.testing.assert_close(softmax_sum, torch.full_like(softmax_sum, 4.0))
 
 
 def test_reorder_varlen_cp1_is_noop():

--- a/tests/parallel/ring/test_usp_data.py
+++ b/tests/parallel/ring/test_usp_data.py
@@ -27,18 +27,16 @@ import pytest
 import torch
 
 import veomni.data.data_collator as dc
+import veomni.distributed.sequence_parallel.ring_attention.npu as ring_attention_npu
 from veomni.data.data_collator import MainCollator, PackingCollator, SequenceParallelCollator
-from veomni.distributed.sequence_parallel.data import (
+from veomni.distributed.sequence_parallel.ring_attention.layout import (
     local_cu_seqlens,
     zigzag_block_order,
     zigzag_reorder,
-    zigzag_reorder_varlen,
+    zigzag_reorder_packed,
     zigzag_undo,
 )
-from veomni.distributed.sequence_parallel.ring_attention_npu import (
-    prepare_npu_cu_seqlens,
-    update_npu_out_and_softmax_stats,
-)
+from veomni.distributed.sequence_parallel.ring_attention.npu import update_npu_out_and_softmax_stats
 from veomni.utils.constants import IGNORE_INDEX
 
 
@@ -88,7 +86,7 @@ def test_reorder_varlen_shards_each_document_cp2():
     doc_lens = [12, 8]
     cu = torch.tensor([0, 12, 20], dtype=torch.int32)
     x = torch.arange(sum(doc_lens)).view(-1, 1).float()
-    reordered = zigzag_reorder_varlen(x, cu, dim=0, cp_size=cp)
+    reordered = zigzag_reorder_packed(x, cu, dim=0, cp_size=cp)
     chunk = reordered.shape[0] // cp
     rank0 = reordered[:chunk].view(-1).int().tolist()
     rank1 = reordered[chunk:].view(-1).int().tolist()
@@ -105,11 +103,103 @@ def test_local_cu_seqlens_cp2():
     assert local.tolist() == [0, 6, 10]
 
 
-def test_prepare_npu_cu_seqlens_uses_cpu_endpoints():
-    endpoints = prepare_npu_cu_seqlens(torch.tensor([0, 12, 20], dtype=torch.int32))
-    assert endpoints.device.type == "cpu"
-    assert endpoints.dtype == torch.long
-    assert endpoints.tolist() == [12, 20]
+def test_normalize_npu_cu_seqlens_preserves_leading_zero():
+    offsets = ring_attention_npu._normalize_cu_seqlens(torch.tensor([0, 12, 20], dtype=torch.int32))
+    assert offsets.device.type == "cpu"
+    assert offsets.dtype == torch.long
+    assert offsets.tolist() == [0, 12, 20]
+
+    with pytest.raises(ValueError, match="must start with zero"):
+        ring_attention_npu._normalize_cu_seqlens(torch.tensor([12, 20], dtype=torch.int32))
+
+
+def test_npu_fusion_attention_uses_endpoint_lists(monkeypatch):
+    class FakeTorchNPU:
+        def npu_fusion_attention(self, q, k, v, **kwargs):
+            self.forward_kwargs = kwargs
+            stats = torch.zeros((*q.shape[:-1], 8), dtype=q.dtype)
+            return q.clone(), stats, stats + 1, None, 11, 22, 33
+
+        def npu_fusion_attention_grad(self, q, k, v, dout, **kwargs):
+            self.backward_kwargs = kwargs
+            return torch.zeros_like(q), torch.zeros_like(k), torch.zeros_like(v), None
+
+    fake_torch_npu = FakeTorchNPU()
+    monkeypatch.setattr(ring_attention_npu, "torch_npu", fake_torch_npu)
+    q = torch.randn(6, 2, 8)
+    cu_seqlens = torch.tensor([0, 2, 6], dtype=torch.int32)
+
+    out, softmax_max, softmax_sum, rng_state = ring_attention_npu._npu_fa_forward(
+        q,
+        q,
+        q,
+        input_layout="TND",
+        softmax_scale=0.5,
+        dropout_p=0.0,
+        causal=False,
+        actual_seq_qlen=cu_seqlens,
+        actual_seq_kvlen=cu_seqlens,
+        softmax_layout="TND",
+    )
+
+    assert fake_torch_npu.forward_kwargs["actual_seq_qlen"] == [2, 6]
+    assert fake_torch_npu.forward_kwargs["actual_seq_kvlen"] == [2, 6]
+    assert fake_torch_npu.forward_kwargs["softmax_layout"] == "TND"
+
+    ring_attention_npu._npu_fa_backward(
+        torch.ones_like(q),
+        q,
+        q,
+        q,
+        out,
+        softmax_max[..., 0],
+        softmax_sum[..., 0],
+        input_layout="TND",
+        softmax_scale=0.5,
+        dropout_p=0.0,
+        causal=False,
+        rng_state=rng_state,
+        actual_seq_qlen=cu_seqlens,
+        actual_seq_kvlen=cu_seqlens,
+        softmax_layout="TND",
+    )
+
+    assert fake_torch_npu.backward_kwargs["actual_seq_qlen"] == [2, 6]
+    assert fake_torch_npu.backward_kwargs["actual_seq_kvlen"] == [2, 6]
+    assert fake_torch_npu.backward_kwargs["softmax_layout"] == "TND"
+    assert fake_torch_npu.backward_kwargs["softmax_max"].shape == (6, 2, 8)
+    assert fake_torch_npu.backward_kwargs["softmax_sum"].shape == (6, 2, 8)
+
+
+def test_npu_fusion_attention_backward_expands_bsnd_stats(monkeypatch):
+    class FakeTorchNPU:
+        def npu_fusion_attention_grad(self, q, k, v, dout, **kwargs):
+            self.backward_kwargs = kwargs
+            return torch.zeros_like(q), torch.zeros_like(k), torch.zeros_like(v), None
+
+    fake_torch_npu = FakeTorchNPU()
+    monkeypatch.setattr(ring_attention_npu, "torch_npu", fake_torch_npu)
+    q = torch.randn(1, 4, 2, 8)
+    softmax_max = torch.zeros(1, 2, 4)
+    softmax_sum = torch.ones(1, 2, 4)
+
+    ring_attention_npu._npu_fa_backward(
+        torch.ones_like(q),
+        q,
+        q,
+        q,
+        q,
+        softmax_max,
+        softmax_sum,
+        input_layout="BSND",
+        softmax_scale=0.5,
+        dropout_p=0.0,
+        causal=False,
+        rng_state=(11, 22, 33),
+    )
+
+    assert fake_torch_npu.backward_kwargs["softmax_max"].shape == (1, 2, 4, 8)
+    assert fake_torch_npu.backward_kwargs["softmax_sum"].shape == (1, 2, 4, 8)
 
 
 def test_npu_softmax_stats_merge_tnd():
@@ -137,7 +227,7 @@ def test_npu_softmax_stats_merge_tnd():
 def test_reorder_varlen_cp1_is_noop():
     cu = torch.tensor([0, 6, 10], dtype=torch.int32)
     x = torch.randn(10, 2)
-    assert torch.equal(zigzag_reorder_varlen(x, cu, dim=0, cp_size=1), x)
+    assert torch.equal(zigzag_reorder_packed(x, cu, dim=0, cp_size=1), x)
     assert torch.equal(local_cu_seqlens(cu, cp_size=1), cu)
 
 
@@ -146,7 +236,7 @@ def test_reorder_varlen_requires_divisible_document():
     cu = torch.tensor([0, 10], dtype=torch.int32)
     x = torch.randn(10, 1)
     with pytest.raises(AssertionError):
-        zigzag_reorder_varlen(x, cu, dim=0, cp_size=2)
+        zigzag_reorder_packed(x, cu, dim=0, cp_size=2)
     with pytest.raises(AssertionError):
         local_cu_seqlens(cu, cp_size=2)
 
@@ -252,10 +342,10 @@ def test_varlen_slices_reassemble_full_sequence(monkeypatch):
 
     # Reconstruct per cp-region: for each cp_rank concat ulysses-inner pieces,
     # then the cp regions form the per-document zig-zag reorder of the sequence.
-    from veomni.distributed.sequence_parallel.data import zigzag_reorder_varlen
+    from veomni.distributed.sequence_parallel.ring_attention.layout import zigzag_reorder_packed
 
     cu = torch.tensor([0, doc_lens[0], seq], dtype=torch.int32)
-    expected_reordered = zigzag_reorder_varlen(tokens, cu, dim=1, cp_size=cp).view(-1).tolist()
+    expected_reordered = zigzag_reorder_packed(tokens, cu, dim=1, cp_size=cp).view(-1).tolist()
 
     # cp is OUTER, ulysses is INNER: rebuild in that order.
     cp_chunk = seq // cp

--- a/tests/parallel/ring/test_usp_ring_gpu.py
+++ b/tests/parallel/ring/test_usp_ring_gpu.py
@@ -48,14 +48,14 @@ from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import run_tests
 
 from veomni.distributed import parallel_state as PS
-from veomni.distributed.sequence_parallel.data import (
-    local_cu_seqlens,
-    zigzag_reorder,
-    zigzag_reorder_varlen,
-)
 from veomni.distributed.sequence_parallel.ring_attention import (
     zigzag_ring_flash_attn_func,
     zigzag_ring_flash_attn_varlen_func,
+)
+from veomni.distributed.sequence_parallel.ring_attention.layout import (
+    local_cu_seqlens,
+    zigzag_reorder,
+    zigzag_reorder_packed,
 )
 
 from ..ulysses.utils import SequenceParallelTest
@@ -167,7 +167,7 @@ class _ZigzagRingVarlenTest(MultiProcessTestCase):
         ref.backward(g)
 
         def shard(t):
-            tr = zigzag_reorder_varlen(t.detach(), cu, dim=0, cp_size=world)
+            tr = zigzag_reorder_packed(t.detach(), cu, dim=0, cp_size=world)
             chunk = tr.shape[0] // world
             return tr[self.rank * chunk : (self.rank + 1) * chunk].clone()
 
@@ -315,7 +315,7 @@ class USPAttentionE2ETest(MultiProcessTestCase):
         """Per-document zig-zag cp-outer + ulysses-inner slice (varlen layout)."""
         uly_rank = mesh.get_local_rank("ulysses")
         cp_rank = mesh.get_local_rank("cp")
-        reordered = zigzag_reorder_varlen(full.detach(), cu, dim=1, cp_size=CP)
+        reordered = zigzag_reorder_packed(full.detach(), cu, dim=1, cp_size=CP)
         cp_chunk = reordered.shape[1] // CP
         cp_region = reordered[:, cp_rank * cp_chunk : (cp_rank + 1) * cp_chunk]
         uly_chunk = cp_region.shape[1] // ULYSSES

--- a/tests/parallel/ring/test_usp_ring_npu.py
+++ b/tests/parallel/ring/test_usp_ring_npu.py
@@ -1,0 +1,287 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ascend numerical tests for NPU zig-zag Ring Attention and USP routing."""
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import run_tests
+
+from veomni.distributed import parallel_state as PS
+from veomni.distributed.sequence_parallel.data import (
+    local_cu_seqlens,
+    zigzag_reorder,
+    zigzag_reorder_varlen,
+)
+from veomni.distributed.sequence_parallel.ring_attention_npu import (
+    zigzag_ring_npu_flash_attn_func,
+    zigzag_ring_npu_flash_attn_varlen_func,
+)
+from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
+from veomni.utils.import_utils import is_torch_npu_available
+
+
+pytestmark = pytest.mark.skipif(not is_torch_npu_available(), reason="torch_npu is required")
+
+_ATOL = 8e-2
+_RTOL = 6e-2
+
+
+def _dense_reference(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: float) -> torch.Tensor:
+    dtype = q.dtype
+    q = q.float().transpose(1, 2)
+    k = k.float().transpose(1, 2)
+    v = v.float().transpose(1, 2)
+    scores = torch.matmul(q, k.transpose(-1, -2)) * scale
+    seq = scores.shape[-1]
+    mask = torch.triu(torch.ones((seq, seq), dtype=torch.bool, device=scores.device), diagonal=1)
+    scores = scores.masked_fill(mask, float("-inf"))
+    return torch.matmul(torch.softmax(scores, dim=-1), v).transpose(1, 2).to(dtype).contiguous()
+
+
+def _varlen_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    outputs = []
+    cu = [int(value) for value in cu_seqlens.tolist()]
+    for start, end in zip(cu[:-1], cu[1:]):
+        outputs.append(
+            _dense_reference(
+                q[start:end].unsqueeze(0),
+                k[start:end].unsqueeze(0),
+                v[start:end].unsqueeze(0),
+                scale,
+            ).squeeze(0)
+        )
+    return torch.cat(outputs, dim=0)
+
+
+class NPUZigzagRingTest(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def _init(self):
+        store = dist.FileStore(self.file_name, self.world_size)
+        get_torch_device().set_device(self.rank)
+        dist.init_process_group(get_dist_comm_backend(), store=store, rank=self.rank, world_size=self.world_size)
+        return dist.distributed_c10d._get_default_group()
+
+    def _shard_dense(self, full: torch.Tensor) -> torch.Tensor:
+        reordered = zigzag_reorder(full.detach(), dim=1, cp_size=self.world_size)
+        chunk = reordered.shape[1] // self.world_size
+        return reordered[:, self.rank * chunk : (self.rank + 1) * chunk].clone()
+
+    def _shard_varlen(self, full: torch.Tensor, cu_seqlens: torch.Tensor) -> torch.Tensor:
+        reordered = zigzag_reorder_varlen(full.detach(), cu_seqlens, dim=0, cp_size=self.world_size)
+        chunk = reordered.shape[0] // self.world_size
+        return reordered[self.rank * chunk : (self.rank + 1) * chunk].clone()
+
+    @pytest.mark.skipif(get_torch_device().device_count() < 2, reason="device_count should be >= 2")
+    def test_dense_forward_backward_matches_full_attention(self):
+        group = self._init()
+        device = get_device_type()
+        batch, seq, heads, dim = 1, 128, 4, 128
+        scale = dim**-0.5
+        q = torch.randn(batch, seq, heads, dim, device=device, dtype=torch.bfloat16)
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        grad = torch.randn_like(q)
+        for tensor in (q, k, v, grad):
+            dist.broadcast(tensor, 0)
+
+        q_ref = q.clone().requires_grad_(True)
+        k_ref = k.clone().requires_grad_(True)
+        v_ref = v.clone().requires_grad_(True)
+        out_ref = _dense_reference(q_ref, k_ref, v_ref, scale)
+        out_ref.backward(grad)
+
+        q_local = self._shard_dense(q).requires_grad_(True)
+        k_local = self._shard_dense(k).requires_grad_(True)
+        v_local = self._shard_dense(v).requires_grad_(True)
+        grad_local = self._shard_dense(grad)
+        out = zigzag_ring_npu_flash_attn_func(q_local, k_local, v_local, softmax_scale=scale, causal=True, group=group)
+        out.backward(grad_local)
+
+        torch.testing.assert_close(out, self._shard_dense(out_ref), atol=_ATOL, rtol=_RTOL)
+        torch.testing.assert_close(q_local.grad, self._shard_dense(q_ref.grad), atol=_ATOL, rtol=_RTOL)
+        torch.testing.assert_close(k_local.grad, self._shard_dense(k_ref.grad), atol=_ATOL, rtol=_RTOL)
+        torch.testing.assert_close(v_local.grad, self._shard_dense(v_ref.grad), atol=_ATOL, rtol=_RTOL)
+
+    @pytest.mark.skipif(get_torch_device().device_count() < 2, reason="device_count should be >= 2")
+    def test_varlen_forward_backward_matches_full_attention(self):
+        group = self._init()
+        device = get_device_type()
+        doc_lens = [32, 64, 128]
+        total, heads, dim = sum(doc_lens), 4, 128
+        scale = dim**-0.5
+        cu = torch.tensor([0, 32, 96, total], dtype=torch.long, device=device)
+        q = torch.randn(total, heads, dim, device=device, dtype=torch.bfloat16)
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        grad = torch.randn_like(q)
+        for tensor in (q, k, v, grad):
+            dist.broadcast(tensor, 0)
+
+        q_ref = q.clone().requires_grad_(True)
+        k_ref = k.clone().requires_grad_(True)
+        v_ref = v.clone().requires_grad_(True)
+        out_ref = _varlen_reference(q_ref, k_ref, v_ref, cu, scale)
+        out_ref.backward(grad)
+
+        q_local = self._shard_varlen(q, cu).requires_grad_(True)
+        k_local = self._shard_varlen(k, cu).requires_grad_(True)
+        v_local = self._shard_varlen(v, cu).requires_grad_(True)
+        grad_local = self._shard_varlen(grad, cu)
+        local_cu = local_cu_seqlens(cu, self.world_size)
+        out = zigzag_ring_npu_flash_attn_varlen_func(
+            q_local,
+            k_local,
+            v_local,
+            local_cu,
+            max(doc_lens) // self.world_size,
+            softmax_scale=scale,
+            causal=True,
+            group=group,
+        )
+        out.backward(grad_local)
+
+        torch.testing.assert_close(out, self._shard_varlen(out_ref, cu), atol=_ATOL, rtol=_RTOL)
+        torch.testing.assert_close(q_local.grad, self._shard_varlen(q_ref.grad, cu), atol=_ATOL, rtol=_RTOL)
+        torch.testing.assert_close(k_local.grad, self._shard_varlen(k_ref.grad, cu), atol=_ATOL, rtol=_RTOL)
+        torch.testing.assert_close(v_local.grad, self._shard_varlen(v_ref.grad, cu), atol=_ATOL, rtol=_RTOL)
+
+
+class _AttentionModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.is_causal = True
+
+        class _Config:
+            _attn_implementation = "veomni_flash_attention_2_with_sp"
+
+        self.config = _Config()
+        self.layer_idx = 0
+
+
+class NPUUSPAttentionTest(MultiProcessTestCase):
+    ulysses_size = 2
+    cp_size = 2
+
+    @property
+    def world_size(self):
+        return self.ulysses_size * self.cp_size
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def _init(self):
+        store = dist.FileStore(self.file_name, self.world_size)
+        get_torch_device().set_device(self.rank)
+        dist.init_process_group(get_dist_comm_backend(), store=store, rank=self.rank, world_size=self.world_size)
+        mesh = init_device_mesh(
+            get_device_type(),
+            (self.ulysses_size, self.cp_size),
+            mesh_dim_names=("ulysses", "cp"),
+        )
+        mesh[("ulysses", "cp")]._flatten(mesh_dim_name="sp")
+        PS._PARALLEL_STATE = PS.ParallelState(
+            dp_size=1,
+            dp_replicate_size=1,
+            dp_shard_size=1,
+            cp_size=self.cp_size,
+            ulysses_size=self.ulysses_size,
+            device_type=get_device_type(),
+            device_mesh=mesh,
+        )
+        return mesh
+
+    def _usp_slice(self, full: torch.Tensor, mesh, cu_seqlens: torch.Tensor = None) -> torch.Tensor:
+        if cu_seqlens is None:
+            reordered = zigzag_reorder(full.detach(), dim=1, cp_size=self.cp_size)
+        else:
+            reordered = zigzag_reorder_varlen(full.detach(), cu_seqlens, dim=1, cp_size=self.cp_size)
+        cp_rank = mesh.get_local_rank("cp")
+        ulysses_rank = mesh.get_local_rank("ulysses")
+        cp_chunk = reordered.shape[1] // self.cp_size
+        cp_region = reordered[:, cp_rank * cp_chunk : (cp_rank + 1) * cp_chunk]
+        ulysses_chunk = cp_region.shape[1] // self.ulysses_size
+        return cp_region[:, ulysses_rank * ulysses_chunk : (ulysses_rank + 1) * ulysses_chunk].clone()
+
+    def _run_unified_attention_case(self, packed: bool):
+        from veomni.ops.kernels.attention import flash_attention_forward
+
+        mesh = self._init()
+        device = get_device_type()
+        heads, dim = 4, 128
+        doc_lens = [64, 32] if packed else [128]
+        seq = sum(doc_lens)
+        scale = dim**-0.5
+        cu = torch.tensor([0, *torch.tensor(doc_lens).cumsum(0).tolist()], dtype=torch.int32, device=device)
+        q = torch.randn(1, heads, seq, dim, device=device, dtype=torch.bfloat16)
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        for tensor in (q, k, v):
+            dist.broadcast(tensor, 0)
+
+        q_bshd = q.transpose(1, 2).contiguous()
+        k_bshd = k.transpose(1, 2).contiguous()
+        v_bshd = v.transpose(1, 2).contiguous()
+        if packed:
+            reference = _varlen_reference(
+                q_bshd.squeeze(0), k_bshd.squeeze(0), v_bshd.squeeze(0), cu, scale
+            ).unsqueeze(0)
+        else:
+            reference = _dense_reference(q_bshd, k_bshd, v_bshd, scale)
+
+        def shard_bhsd(full):
+            local = self._usp_slice(full.transpose(1, 2).contiguous(), mesh, cu if packed else None)
+            return local.transpose(1, 2).contiguous()
+
+        kwargs = {"cu_seq_lens_q": cu, "cu_seq_lens_k": cu} if packed else {}
+        out, _ = flash_attention_forward(
+            _AttentionModule().to(device),
+            shard_bhsd(q),
+            shard_bhsd(k),
+            shard_bhsd(v),
+            attention_mask=None,
+            scaling=scale,
+            **kwargs,
+        )
+        expected = self._usp_slice(reference, mesh, cu if packed else None)
+        torch.testing.assert_close(out, expected, atol=_ATOL, rtol=_RTOL)
+
+    @pytest.mark.skipif(get_torch_device().device_count() < 4, reason="device_count should be >= 4")
+    def test_unified_attention_dense_routes_to_npu_ring(self):
+        self._run_unified_attention_case(packed=False)
+
+    @pytest.mark.skipif(get_torch_device().device_count() < 4, reason="device_count should be >= 4")
+    def test_unified_attention_varlen_routes_to_npu_ring(self):
+        self._run_unified_attention_case(packed=True)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/parallel/ring/test_usp_ring_npu.py
+++ b/tests/parallel/ring/test_usp_ring_npu.py
@@ -22,12 +22,12 @@ from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import run_tests
 
 from veomni.distributed import parallel_state as PS
-from veomni.distributed.sequence_parallel.data import (
+from veomni.distributed.sequence_parallel.ring_attention.layout import (
     local_cu_seqlens,
     zigzag_reorder,
-    zigzag_reorder_varlen,
+    zigzag_reorder_packed,
 )
-from veomni.distributed.sequence_parallel.ring_attention_npu import (
+from veomni.distributed.sequence_parallel.ring_attention.npu import (
     zigzag_ring_npu_flash_attn_func,
     zigzag_ring_npu_flash_attn_varlen_func,
 )
@@ -95,7 +95,7 @@ class NPUZigzagRingTest(MultiProcessTestCase):
         return reordered[:, self.rank * chunk : (self.rank + 1) * chunk].clone()
 
     def _shard_varlen(self, full: torch.Tensor, cu_seqlens: torch.Tensor) -> torch.Tensor:
-        reordered = zigzag_reorder_varlen(full.detach(), cu_seqlens, dim=0, cp_size=self.world_size)
+        reordered = zigzag_reorder_packed(full.detach(), cu_seqlens, dim=0, cp_size=self.world_size)
         chunk = reordered.shape[0] // self.world_size
         return reordered[self.rank * chunk : (self.rank + 1) * chunk].clone()
 
@@ -223,7 +223,7 @@ class NPUUSPAttentionTest(MultiProcessTestCase):
         if cu_seqlens is None:
             reordered = zigzag_reorder(full.detach(), dim=1, cp_size=self.cp_size)
         else:
-            reordered = zigzag_reorder_varlen(full.detach(), cu_seqlens, dim=1, cp_size=self.cp_size)
+            reordered = zigzag_reorder_packed(full.detach(), cu_seqlens, dim=1, cp_size=self.cp_size)
         cp_rank = mesh.get_local_rank("cp")
         ulysses_rank = mesh.get_local_rank("ulysses")
         cp_chunk = reordered.shape[1] // self.cp_size

--- a/veomni/arguments/arguments_types.py
+++ b/veomni/arguments/arguments_types.py
@@ -781,8 +781,8 @@ class TrainingArguments:
         # Context parallel (Ring-Attention) is supported as the ``cp`` half of USP
         # (Unified Sequence Parallelism, https://arxiv.org/abs/2405.07719). It
         # composes with Ulysses: the effective SP size is ``ulysses_size * cp_size``.
-        # Ring attention currently requires the causal, non-varlen path (no packing
-        # / cu_seqlens under ``cp``) and FA2 (flash-attn).
+        # The ring path is causal-only and supports dense or packed/varlen inputs
+        # through CUDA FlashAttention or Ascend torch_npu fusion attention.
 
         acc.dp_size = self.world_size // (acc.pp_size * acc.ulysses_size * acc.cp_size * acc.tp_size)
 

--- a/veomni/data/data_collator.py
+++ b/veomni/data/data_collator.py
@@ -384,7 +384,7 @@ class SequenceParallelCollator(DataCollator):
         # sequence is split as: ``cp`` OUTER in zig-zag block order (for balanced
         # causal ring attention) and ``ulysses`` INNER as contiguous sub-chunks
         # (so the in-attention Ulysses all-to-all reassembles each cp region's
-        # full sequence). See ``sequence_parallel.data.zigzag_reorder`` and the
+        # full sequence). See ``sequence_parallel.ring_attention.layout`` and the
         # ring branch in ``veomni/ops/kernels/attention``.
         self.cp_size = ps.cp_size
         self.ulysses_size = ps.ulysses_size
@@ -420,11 +420,11 @@ class SequenceParallelCollator(DataCollator):
         attention stays balanced per document. Otherwise the whole sequence is
         treated as one document (dense zig-zag).
         """
-        from ..distributed.sequence_parallel.data import zigzag_reorder, zigzag_reorder_varlen
+        from ..distributed.sequence_parallel.ring_attention.layout import zigzag_reorder, zigzag_reorder_packed
 
         cu = self._cp_cu_seqlens
         if cu is not None and cu.numel() > 2:
-            reordered = zigzag_reorder_varlen(feature, cu, dim=dim, cp_size=self.cp_size)
+            reordered = zigzag_reorder_packed(feature, cu, dim=dim, cp_size=self.cp_size)
         else:
             reordered = zigzag_reorder(feature, dim=dim, cp_size=self.cp_size)
         cp_chunk = reordered.size(dim) // self.cp_size

--- a/veomni/distributed/sequence_parallel/__init__.py
+++ b/veomni/distributed/sequence_parallel/__init__.py
@@ -49,6 +49,10 @@ from .ring_attention import (
     ring_flash_attn_func,
     zigzag_ring_flash_attn_func,
 )
+from .ring_attention_npu import (
+    zigzag_ring_npu_flash_attn_func,
+    zigzag_ring_npu_flash_attn_varlen_func,
+)
 from .ulysses import (
     all_to_all_images,
     gather_heads_scatter_seq,
@@ -89,6 +93,8 @@ __all__ = [
     "reduce_sequence_parallel_loss",
     "ring_flash_attn_func",
     "zigzag_ring_flash_attn_func",
+    "zigzag_ring_npu_flash_attn_func",
+    "zigzag_ring_npu_flash_attn_varlen_func",
     "async_ulysses_qkv_projection",
     "async_ulysses_output_projection",
     "divide_qkv_linear_weight",

--- a/veomni/distributed/sequence_parallel/__init__.py
+++ b/veomni/distributed/sequence_parallel/__init__.py
@@ -41,17 +41,15 @@ from .data import (
     sp_pad,
     sp_pad_and_slice,
     sp_take_own_seq,
-    zigzag_reorder,
-    zigzag_undo,
 )
 from .loss import reduce_sequence_parallel_loss
 from .ring_attention import (
     ring_flash_attn_func,
+    zigzag_reorder,
     zigzag_ring_flash_attn_func,
-)
-from .ring_attention_npu import (
     zigzag_ring_npu_flash_attn_func,
     zigzag_ring_npu_flash_attn_varlen_func,
+    zigzag_undo,
 )
 from .ulysses import (
     all_to_all_images,

--- a/veomni/distributed/sequence_parallel/data.py
+++ b/veomni/distributed/sequence_parallel/data.py
@@ -7,6 +7,7 @@ from torch.distributed import ProcessGroup
 
 from ...distributed.parallel_state import get_parallel_state
 from .comm import get_ulysses_sequence_parallel_group, get_unified_sequence_parallel_group
+from .ring_attention import layout as _ring_layout
 from .ulysses import _Gather, _Slice
 from .utils import pad_tensor, unpadding_tensor_for_seqeunce_parallel
 
@@ -298,127 +299,9 @@ def sp_take_own_seq(full: Tensor, dim: int, seg_lengths: List[int], sp_rank: int
     return full.narrow(dim, offset, seg_lengths[sp_rank])
 
 
-# ── Zig-zag reordering for USP ring attention ──────────────────────────────
-#
-# Balanced causal ring attention (see ``ring_attention.zigzag_ring_flash_attn``)
-# requires the sequence to be laid out so that context-parallel rank ``r`` owns
-# blocks ``r`` and ``2*cp-1-r`` of a ``2*cp``-way split. ``zigzag_reorder``
-# permutes the FULL (pre-slice) sequence so that a subsequent CONTIGUOUS slice
-# into ``cp`` equal chunks hands each cp-rank exactly those two blocks (in the
-# ``[low_block, high_block]`` order the kernel expects). ``zigzag_undo`` is the
-# inverse permutation, applied to per-rank outputs after they are gathered.
-
-
-def zigzag_block_order(cp_size: int) -> List[int]:
-    """Return the block permutation that maps zig-zag block layout to rank order.
-
-    With ``2*cp_size`` blocks, cp-rank ``r`` owns blocks ``r`` and
-    ``2*cp_size-1-r``. Concatenating each rank's ``[r, 2*cp-1-r]`` blocks in rank
-    order yields the permutation ``[0, 2c-1, 1, 2c-2, ...]`` over the original
-    block indices.
-    """
-    order = []
-    for r in range(cp_size):
-        order.append(r)
-        order.append(2 * cp_size - 1 - r)
-    return order
-
-
-def zigzag_reorder(tensor: Tensor, dim: int, cp_size: int) -> Tensor:
-    """Permute ``tensor`` along ``dim`` into zig-zag block order.
-
-    ``tensor`` length along ``dim`` must be divisible by ``2 * cp_size``. After
-    reordering, a contiguous split into ``cp_size`` chunks gives cp-rank ``r``
-    its ``[block r, block 2*cp-1-r]`` pair.
-    """
-    if cp_size <= 1:
-        return tensor
-    n_blocks = 2 * cp_size
-    seq = tensor.size(dim)
-    assert seq % n_blocks == 0, f"seq len {seq} not divisible by 2*cp_size ({n_blocks})"
-    blocks = list(torch.tensor_split(tensor, n_blocks, dim=dim))
-    order = zigzag_block_order(cp_size)
-    return torch.cat([blocks[i].contiguous() for i in order], dim=dim)
-
-
-def zigzag_undo(tensor: Tensor, dim: int, cp_size: int) -> Tensor:
-    """Inverse of :func:`zigzag_reorder` — restore the original block order."""
-    if cp_size <= 1:
-        return tensor
-    n_blocks = 2 * cp_size
-    seq = tensor.size(dim)
-    assert seq % n_blocks == 0, f"seq len {seq} not divisible by 2*cp_size ({n_blocks})"
-    blocks = list(torch.tensor_split(tensor, n_blocks, dim=dim))
-    order = zigzag_block_order(cp_size)
-    inverse = [0] * n_blocks
-    for new_pos, orig in enumerate(order):
-        inverse[orig] = new_pos
-    return torch.cat([blocks[inverse[i]].contiguous() for i in range(n_blocks)], dim=dim)
-
-
-# ── Per-document zig-zag reordering for USP varlen (packed) ring attention ──
-#
-# Packed sequences hold several documents concatenated along the sequence dim.
-# For balanced causal ring attention over ``cp`` each document must be
-# INDEPENDENTLY zig-zag split across the ``cp`` group. ``zigzag_reorder_varlen``
-# permutes each document's tokens into zig-zag block order so a subsequent
-# CONTIGUOUS split into ``cp_size`` chunks hands cp-rank ``r`` its
-# ``[block r, block 2*cp-1-r]`` pair FOR EVERY DOCUMENT. Every document length
-# must be divisible by ``2 * cp_size``.
-
-
-def zigzag_reorder_varlen(tensor: Tensor, cu_seqlens: "torch.Tensor", dim: int, cp_size: int) -> Tensor:
-    """Zig-zag reorder packed documents for a subsequent contiguous ``cp`` split.
-
-    Each document is split into ``2*cp_size`` blocks; cp-rank ``r`` owns blocks
-    ``r`` and ``2*cp_size-1-r`` of EVERY document. The output is laid out
-    ``rank``-major / ``document``-minor so a plain contiguous split into
-    ``cp_size`` chunks hands rank ``r`` its per-document ``[block r,
-    block 2*cp-1-r]`` pairs concatenated across documents (matching
-    :func:`local_cu_seqlens`). Every document length must be divisible by
-    ``2 * cp_size``.
-    """
-    if cp_size <= 1:
-        return tensor
-    cu = [int(x) for x in cu_seqlens.tolist()]
-    n_blocks = 2 * cp_size
-    # doc_blocks[i] holds the 2*cp block slices for document i.
-    doc_blocks = []
-    for i in range(len(cu) - 1):
-        start, end = cu[i], cu[i + 1]
-        seg_len = end - start
-        assert seg_len % n_blocks == 0, (
-            f"document length {seg_len} not divisible by 2*cp_size ({n_blocks}); "
-            "packed varlen under context-parallel requires every document length "
-            "to be a multiple of 2*cp_size"
-        )
-        seg = tensor.narrow(dim, start, seg_len)
-        doc_blocks.append(list(torch.tensor_split(seg, n_blocks, dim=dim)))
-    pieces = []
-    for r in range(cp_size):
-        for blocks in doc_blocks:
-            pieces.append(blocks[r])
-            pieces.append(blocks[n_blocks - 1 - r])
-    return torch.cat([p.contiguous() for p in pieces], dim=dim)
-
-
-def local_cu_seqlens(cu_seqlens: "torch.Tensor", cp_size: int) -> "torch.Tensor":
-    """Per-rank LOCAL cu_seqlens after per-document zig-zag slicing.
-
-    Each document's local length is ``doc_len // cp_size`` (this rank owns 2 of
-    the ``2*cp_size`` blocks). Returns a tensor of the same dtype/device.
-    """
-    if cp_size <= 1:
-        return cu_seqlens
-    cu = [int(x) for x in cu_seqlens.tolist()]
-    n_blocks = 2 * cp_size
-    local = [0]
-    for i in range(len(cu) - 1):
-        seg_len = cu[i + 1] - cu[i]
-        assert seg_len % n_blocks == 0, (
-            f"document length {seg_len} not divisible by 2*cp_size ({n_blocks}); "
-            "packed varlen under context-parallel requires every document length "
-            "to be a multiple of 2*cp_size"
-        )
-        local.append(local[-1] + seg_len // cp_size)
-    return torch.tensor(local, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
+# Compatibility exports. Ring-specific implementations live in ring_attention.layout.
+local_cu_seqlens = _ring_layout.local_cu_seqlens
+zigzag_block_order = _ring_layout.zigzag_block_order
+zigzag_reorder = _ring_layout.zigzag_reorder
+zigzag_reorder_varlen = _ring_layout.zigzag_reorder_varlen
+zigzag_undo = _ring_layout.zigzag_undo

--- a/veomni/distributed/sequence_parallel/ring_attention/__init__.py
+++ b/veomni/distributed/sequence_parallel/ring_attention/__init__.py
@@ -1,0 +1,120 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+from ....utils.device import get_device_type
+from .comm import RingComm
+from .gpu import (
+    FA_BACKEND,
+    ring_flash_attn_func,
+    update_out_and_lse,
+    zigzag_ring_flash_attn_func,
+    zigzag_ring_flash_attn_varlen_func,
+)
+from .layout import (
+    local_cu_seqlens,
+    zigzag_block_order,
+    zigzag_reorder,
+    zigzag_reorder_packed,
+    zigzag_reorder_varlen,
+    zigzag_undo,
+)
+from .npu import zigzag_ring_npu_flash_attn_func, zigzag_ring_npu_flash_attn_varlen_func
+
+
+__all__ = [
+    "ring_attention",
+    "RingComm",
+    "FA_BACKEND",
+    "local_cu_seqlens",
+    "zigzag_block_order",
+    "zigzag_reorder",
+    "zigzag_reorder_packed",
+    "zigzag_reorder_varlen",
+    "zigzag_undo",
+    "ring_flash_attn_func",
+    "update_out_and_lse",
+    "zigzag_ring_flash_attn_func",
+    "zigzag_ring_flash_attn_varlen_func",
+    "zigzag_ring_npu_flash_attn_func",
+    "zigzag_ring_npu_flash_attn_varlen_func",
+]
+
+
+def _load_backend(device_type: str):
+    if device_type == "npu":
+        from . import npu
+
+        return npu
+
+    from . import gpu
+
+    return gpu
+
+
+def ring_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    *,
+    group: ProcessGroup,
+    cp_size: int,
+    cu_seqlens: Optional[Tensor] = None,
+    attention_mask: Optional[Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    dropout_p: float = 0.0,
+    causal: bool = True,
+    device_type: Optional[str] = None,
+) -> Tensor:
+    """Run the device-specific balanced causal Ring Attention implementation."""
+    if not causal:
+        raise NotImplementedError("context-parallel (cp_size>1) ring attention requires causal attention")
+    if attention_mask is not None:
+        raise NotImplementedError(
+            "context-parallel (cp_size>1) ring attention does not support explicit attention masks"
+        )
+
+    backend = _load_backend(get_device_type() if device_type is None else device_type)
+    is_packed = cu_seqlens is not None and cu_seqlens.numel() > 2
+    if not is_packed:
+        return backend.forward(
+            query,
+            key,
+            value,
+            softmax_scale=softmax_scale,
+            causal=True,
+            group=group,
+            dropout_p=dropout_p,
+        )
+
+    local_cu = local_cu_seqlens(cu_seqlens.to(torch.int32), cp_size)
+    local_lengths = local_cu[1:] - local_cu[:-1]
+    local_max_seqlen = int(local_lengths.max().item()) if local_lengths.numel() else 0
+    output = backend.packed_forward(
+        query.squeeze(0),
+        key.squeeze(0),
+        value.squeeze(0),
+        local_cu,
+        local_max_seqlen,
+        softmax_scale=softmax_scale,
+        causal=True,
+        group=group,
+        dropout_p=dropout_p,
+    )
+    return output.unsqueeze(0)

--- a/veomni/distributed/sequence_parallel/ring_attention/comm.py
+++ b/veomni/distributed/sequence_parallel/ring_attention/comm.py
@@ -1,0 +1,49 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+
+class RingComm:
+    """P2P ring communicator over a context-parallel process group."""
+
+    def __init__(self, group: ProcessGroup):
+        self.group = group
+        self.rank = dist.get_rank(group)
+        self.world_size = dist.get_world_size(group)
+        self.send_rank = dist.get_global_rank(group, (self.rank + 1) % self.world_size)
+        self.recv_rank = dist.get_global_rank(group, (self.rank - 1) % self.world_size)
+        self._ops = []
+        self._reqs = None
+
+    def send_recv(self, to_send: Tensor, recv_tensor: Optional[Tensor] = None) -> Tensor:
+        result = torch.empty_like(to_send) if recv_tensor is None else recv_tensor
+        self._ops.append(dist.P2POp(dist.isend, to_send.contiguous(), self.send_rank, group=self.group))
+        self._ops.append(dist.P2POp(dist.irecv, result, self.recv_rank, group=self.group))
+        return result
+
+    def commit(self) -> None:
+        self._reqs = dist.batch_isend_irecv(self._ops)
+
+    def wait(self) -> None:
+        if self._reqs is not None:
+            for request in self._reqs:
+                request.wait()
+        self._ops = []
+        self._reqs = None

--- a/veomni/distributed/sequence_parallel/ring_attention/gpu.py
+++ b/veomni/distributed/sequence_parallel/ring_attention/gpu.py
@@ -24,7 +24,7 @@ rank ever holding the whole sequence.
 Causal load balancing uses the zig-zag layout: the global sequence is split
 into ``2 * cp_size`` blocks and rank ``r`` owns blocks ``r`` and
 ``2*cp_size-1-r``. Every ring step then does a constant amount of work. The
-matching data reordering lives in ``.data.zigzag_reorder`` / ``.data.zigzag_
+matching data reordering lives in ``.layout.zigzag_reorder`` / ``.layout.zigzag_
 undo`` and is applied by the collator before slicing.
 
 The Ulysses half (all-to-all head/seq exchange) is orthogonal: USP first does
@@ -37,11 +37,11 @@ import inspect
 from typing import Optional, Tuple
 
 import torch
-import torch.distributed as dist
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
-from .comm import get_context_parallel_group
+from ..comm import get_context_parallel_group
+from .comm import RingComm
 
 
 # Flash-attention backend selection for the ring kernels.
@@ -108,7 +108,8 @@ __all__ = [
     "zigzag_ring_flash_attn_func",
     "zigzag_ring_flash_attn_varlen_func",
     "update_out_and_lse",
-    "RingComm",
+    "forward",
+    "packed_forward",
 ]
 
 
@@ -222,40 +223,6 @@ def update_out_and_lse(
         out[slice_], lse[slice_] = slice_out, slice_lse
         return out, lse
     return _update_out_and_lse(out, lse, block_out, block_lse)
-
-
-class RingComm:
-    """P2P ring communicator over a context-parallel process group.
-
-    ``send_recv`` posts an ``isend`` to the next rank and an ``irecv`` from the
-    previous rank; ``commit``/``wait`` drain the batch so a ring step can overlap
-    the K/V transfer with the local FlashAttention compute.
-    """
-
-    def __init__(self, group: ProcessGroup):
-        self.group = group
-        self.rank = dist.get_rank(group)
-        self.world_size = dist.get_world_size(group)
-        self.send_rank = dist.get_global_rank(group, (self.rank + 1) % self.world_size)
-        self.recv_rank = dist.get_global_rank(group, (self.rank - 1) % self.world_size)
-        self._ops = []
-        self._reqs = None
-
-    def send_recv(self, to_send: Tensor, recv_tensor: Optional[Tensor] = None) -> Tensor:
-        res = torch.empty_like(to_send) if recv_tensor is None else recv_tensor
-        self._ops.append(dist.P2POp(dist.isend, to_send.contiguous(), self.send_rank, group=self.group))
-        self._ops.append(dist.P2POp(dist.irecv, res, self.recv_rank, group=self.group))
-        return res
-
-    def commit(self):
-        self._reqs = dist.batch_isend_irecv(self._ops)
-
-    def wait(self):
-        if self._reqs is not None:
-            for req in self._reqs:
-                req.wait()
-        self._ops = []
-        self._reqs = None
 
 
 # --------------------------------------------------------------------------- #
@@ -551,7 +518,7 @@ def zigzag_ring_flash_attn_func(
     """Balanced (zig-zag) causal ring attention.
 
     ``q/k/v`` are ``(b, 2*local, h, d)`` laid out so that dim-1 concatenates the
-    two zig-zag blocks the rank owns (see ``.data.zigzag_reorder``).
+    two zig-zag blocks the rank owns (see ``.layout.zigzag_reorder``).
     """
     if not _FA_AVAILABLE:
         raise RuntimeError("zigzag_ring_flash_attn_func requires a flash-attn backend (FA2 or FA4) to be installed.")
@@ -565,7 +532,7 @@ def zigzag_ring_flash_attn_func(
 #                                                                              #
 # Packed sequences hold several documents back-to-back. Under USP each document #
 # is INDEPENDENTLY zig-zag split across the ``cp`` group (see                  #
-# ``.data.zigzag_reorder_varlen``): rank ``r`` holds, for every document, that  #
+# ``.layout.zigzag_reorder_packed``): rank ``r`` holds, for every document, that  #
 # document's blocks ``r`` and ``2*cp-1-r`` concatenated. The local packed shard #
 # therefore has, per document, a ``front half`` (block r) and a ``back half``  #
 # (block 2*cp-1-r). ``cu_seqlens`` here are the LOCAL per-rank document offsets #
@@ -930,10 +897,49 @@ def zigzag_ring_flash_attn_varlen_func(
     every document, this rank's two zig-zag block halves. ``cu_seqlens`` are the
     LOCAL per-rank document offsets and every document's local length must be
     even (its global length divisible by ``2 * cp_size``). See
-    ``.data.zigzag_reorder_varlen``.
+    ``.layout.zigzag_reorder_packed``.
     """
     if not _FA_AVAILABLE:
         raise RuntimeError("zigzag_ring_flash_attn_varlen_func requires a flash-attn backend (FA2 or FA4).")
     assert causal, "zigzag ring attention is only defined for causal attention"
     group = get_context_parallel_group() if group is None else group
     return _ZigzagRingVarlenFlashAttn.apply(group, q, k, v, cu_seqlens, max_seqlen, softmax_scale)
+
+
+def forward(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    softmax_scale: Optional[float] = None,
+    causal: bool = True,
+    group: Optional[ProcessGroup] = None,
+    dropout_p: float = 0.0,
+) -> Tensor:
+    """Run balanced causal Ring Attention on fixed-shape CUDA tensors."""
+    del dropout_p  # The CUDA Ring backend currently preserves its zero-dropout behavior.
+    return zigzag_ring_flash_attn_func(q, k, v, softmax_scale=softmax_scale, causal=causal, group=group)
+
+
+def packed_forward(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    cu_seqlens: Tensor,
+    max_seqlen: int,
+    softmax_scale: Optional[float] = None,
+    causal: bool = True,
+    group: Optional[ProcessGroup] = None,
+    dropout_p: float = 0.0,
+) -> Tensor:
+    """Run balanced causal Ring Attention on packed CUDA tensors."""
+    del dropout_p  # The CUDA Ring backend currently preserves its zero-dropout behavior.
+    return zigzag_ring_flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens,
+        max_seqlen,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        group=group,
+    )

--- a/veomni/distributed/sequence_parallel/ring_attention/layout.py
+++ b/veomni/distributed/sequence_parallel/ring_attention/layout.py
@@ -1,0 +1,99 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+import torch
+from torch import Tensor
+
+
+def zigzag_block_order(cp_size: int) -> List[int]:
+    """Return the balanced causal block order for context-parallel ranks."""
+    order = []
+    for rank in range(cp_size):
+        order.append(rank)
+        order.append(2 * cp_size - 1 - rank)
+    return order
+
+
+def zigzag_reorder(tensor: Tensor, dim: int, cp_size: int) -> Tensor:
+    """Arrange a sequence so each CP rank receives its low and high blocks."""
+    if cp_size <= 1:
+        return tensor
+    num_blocks = 2 * cp_size
+    seq_len = tensor.size(dim)
+    assert seq_len % num_blocks == 0, f"seq len {seq_len} not divisible by 2*cp_size ({num_blocks})"
+    blocks = list(torch.tensor_split(tensor, num_blocks, dim=dim))
+    return torch.cat([blocks[index].contiguous() for index in zigzag_block_order(cp_size)], dim=dim)
+
+
+def zigzag_undo(tensor: Tensor, dim: int, cp_size: int) -> Tensor:
+    """Restore a sequence from the context-parallel zig-zag block order."""
+    if cp_size <= 1:
+        return tensor
+    num_blocks = 2 * cp_size
+    seq_len = tensor.size(dim)
+    assert seq_len % num_blocks == 0, f"seq len {seq_len} not divisible by 2*cp_size ({num_blocks})"
+    blocks = list(torch.tensor_split(tensor, num_blocks, dim=dim))
+    inverse = [0] * num_blocks
+    for new_position, original_position in enumerate(zigzag_block_order(cp_size)):
+        inverse[original_position] = new_position
+    return torch.cat([blocks[inverse[index]].contiguous() for index in range(num_blocks)], dim=dim)
+
+
+def zigzag_reorder_packed(tensor: Tensor, cu_seqlens: Tensor, dim: int, cp_size: int) -> Tensor:
+    """Arrange every packed sequence independently in zig-zag block order."""
+    if cp_size <= 1:
+        return tensor
+    cumulative_lengths = [int(value) for value in cu_seqlens.tolist()]
+    num_blocks = 2 * cp_size
+    document_blocks = []
+    for start, end in zip(cumulative_lengths[:-1], cumulative_lengths[1:]):
+        seq_len = end - start
+        assert seq_len % num_blocks == 0, (
+            f"document length {seq_len} not divisible by 2*cp_size ({num_blocks}); "
+            "packed varlen under context-parallel requires every document length "
+            "to be a multiple of 2*cp_size"
+        )
+        document = tensor.narrow(dim, start, seq_len)
+        document_blocks.append(list(torch.tensor_split(document, num_blocks, dim=dim)))
+
+    pieces = []
+    for rank in range(cp_size):
+        for blocks in document_blocks:
+            pieces.append(blocks[rank])
+            pieces.append(blocks[num_blocks - 1 - rank])
+    return torch.cat([piece.contiguous() for piece in pieces], dim=dim)
+
+
+def local_cu_seqlens(cu_seqlens: Tensor, cp_size: int) -> Tensor:
+    """Build per-rank packed-sequence offsets after zig-zag slicing."""
+    if cp_size <= 1:
+        return cu_seqlens
+    cumulative_lengths = [int(value) for value in cu_seqlens.tolist()]
+    num_blocks = 2 * cp_size
+    local_lengths = [0]
+    for start, end in zip(cumulative_lengths[:-1], cumulative_lengths[1:]):
+        seq_len = end - start
+        assert seq_len % num_blocks == 0, (
+            f"document length {seq_len} not divisible by 2*cp_size ({num_blocks}); "
+            "packed varlen under context-parallel requires every document length "
+            "to be a multiple of 2*cp_size"
+        )
+        local_lengths.append(local_lengths[-1] + seq_len // cp_size)
+    return torch.tensor(local_lengths, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
+
+
+# Compatibility name for callers that use the FlashAttention terminology.
+zigzag_reorder_varlen = zigzag_reorder_packed

--- a/veomni/distributed/sequence_parallel/ring_attention/npu.py
+++ b/veomni/distributed/sequence_parallel/ring_attention/npu.py
@@ -27,9 +27,9 @@ import torch
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
-from ...utils.import_utils import is_torch_npu_available
-from .comm import get_context_parallel_group
-from .ring_attention import RingComm
+from ....utils.import_utils import is_torch_npu_available
+from ..comm import get_context_parallel_group
+from .comm import RingComm
 
 
 if is_torch_npu_available():
@@ -45,8 +45,9 @@ RNGState = Tuple[int, int, int]
 _CAUSAL_MASK_CACHE: dict[tuple[str, Optional[int]], Tensor] = {}
 
 __all__ = [
-    "prepare_npu_cu_seqlens",
     "update_npu_out_and_softmax_stats",
+    "forward",
+    "packed_forward",
     "zigzag_ring_npu_flash_attn_func",
     "zigzag_ring_npu_flash_attn_varlen_func",
 ]
@@ -57,19 +58,36 @@ def _require_torch_npu() -> None:
         raise RuntimeError("NPU ring attention requires torch_npu to be installed.")
 
 
-def prepare_npu_cu_seqlens(cu_seqlens: ActualSeqLen) -> Tensor:
-    """Convert leading-zero cumulative lengths to NPU CPU endpoint format."""
+def _normalize_cu_seqlens(cu_seqlens: ActualSeqLen) -> Tensor:
+    """Normalize packed sequence offsets while preserving the leading zero."""
     if isinstance(cu_seqlens, Tensor):
-        endpoints = cu_seqlens.detach().to(device="cpu", dtype=torch.long)
+        offsets = cu_seqlens.detach().to(device="cpu", dtype=torch.long)
     else:
-        endpoints = torch.as_tensor(cu_seqlens, dtype=torch.long, device="cpu")
-    if endpoints.ndim != 1 or endpoints.numel() == 0:
-        raise ValueError("cu_seqlens must be a non-empty 1-D tensor or sequence")
-    if endpoints[0].item() == 0:
-        endpoints = endpoints[1:]
-    if endpoints.numel() == 0 or (endpoints <= 0).any() or (endpoints[1:] < endpoints[:-1]).any():
-        raise ValueError("cu_seqlens must contain positive, non-decreasing cumulative endpoints")
-    return endpoints.contiguous()
+        offsets = torch.as_tensor(cu_seqlens, dtype=torch.long, device="cpu")
+    if offsets.ndim != 1 or offsets.numel() < 2:
+        raise ValueError("cu_seqlens must be a 1-D tensor or sequence with at least two offsets")
+    if offsets[0].item() != 0:
+        raise ValueError("cu_seqlens must start with zero")
+    if (offsets[1:] <= 0).any() or (offsets[1:] < offsets[:-1]).any():
+        raise ValueError("cu_seqlens must contain positive, non-decreasing cumulative offsets")
+    return offsets.contiguous()
+
+
+def _to_npu_actual_seq_len(actual_seq_len: Optional[ActualSeqLen]) -> Optional[list[int]]:
+    """Convert cumulative lengths to the endpoint list expected by torch_npu."""
+    if actual_seq_len is None:
+        return None
+    if isinstance(actual_seq_len, Tensor):
+        values = actual_seq_len.detach().to(device="cpu", dtype=torch.long)
+    else:
+        values = torch.as_tensor(actual_seq_len, dtype=torch.long, device="cpu")
+    if values.ndim != 1 or values.numel() == 0:
+        raise ValueError("actual_seq_len must be a non-empty 1-D sequence")
+    if values[0].item() == 0:
+        values = values[1:]
+    if values.numel() == 0 or (values <= 0).any() or (values[1:] < values[:-1]).any():
+        raise ValueError("actual_seq_len must contain positive, non-decreasing endpoints")
+    return [int(value) for value in values.tolist()]
 
 
 def _causal_mask(device: torch.device) -> Tensor:
@@ -87,6 +105,8 @@ def _head_num(q: Tensor, input_layout: str) -> int:
         return q.shape[1]
     if input_layout == "BSND":
         return q.shape[2]
+    if input_layout == "BNSD":
+        return q.shape[1]
     raise ValueError(f"Unsupported NPU attention input layout: {input_layout!r}")
 
 
@@ -99,13 +119,15 @@ def _npu_fa_forward(
     softmax_scale: float,
     dropout_p: float,
     causal: bool,
-    actual_seq_qlen: Optional[Tensor] = None,
-    actual_seq_kvlen: Optional[Tensor] = None,
+    actual_seq_qlen: Optional[ActualSeqLen] = None,
+    actual_seq_kvlen: Optional[ActualSeqLen] = None,
     softmax_layout: str = "",
 ) -> Tuple[Tensor, Tensor, Tensor, RNGState]:
     _require_torch_npu()
     attention_mask = _causal_mask(q.device) if causal else None
     sparse_mode = 2 if causal else 0
+    actual_seq_qlen = _to_npu_actual_seq_len(actual_seq_qlen)
+    actual_seq_kvlen = _to_npu_actual_seq_len(actual_seq_kvlen)
     block_out, block_max, block_sum, _, seed, offset, numels = torch_npu.npu_fusion_attention(
         q,
         k,
@@ -137,13 +159,18 @@ def _npu_fa_backward(
     dropout_p: float,
     causal: bool,
     rng_state: RNGState,
-    actual_seq_qlen: Optional[Tensor] = None,
-    actual_seq_kvlen: Optional[Tensor] = None,
+    actual_seq_qlen: Optional[ActualSeqLen] = None,
+    actual_seq_kvlen: Optional[ActualSeqLen] = None,
     softmax_layout: str = "",
 ) -> Tuple[Tensor, Tensor, Tensor]:
     _require_torch_npu()
     attention_mask = _causal_mask(q.device) if causal else None
+    actual_seq_qlen = _to_npu_actual_seq_len(actual_seq_qlen)
+    actual_seq_kvlen = _to_npu_actual_seq_len(actual_seq_kvlen)
     seed, offset, numels = rng_state
+    if softmax_max.ndim == q.ndim - 1:
+        softmax_max = softmax_max.unsqueeze(-1).expand(*softmax_max.shape, 8).contiguous()
+        softmax_sum = softmax_sum.unsqueeze(-1).expand(*softmax_sum.shape, 8).contiguous()
     dq, dk, dv, *_ = torch_npu.npu_fusion_attention_grad(
         q,
         k,
@@ -457,23 +484,22 @@ def _zigzag_npu_varlen_forward(
     q: Tensor,
     k: Tensor,
     v: Tensor,
-    endpoints: Tensor,
+    cu_seqlens: Tensor,
     half0: HalfIndex,
     half1: HalfIndex,
     softmax_scale: float,
     dropout_p: float,
 ) -> Tuple[Tensor, Tensor, Tensor, list[RNGState]]:
     comm = RingComm(group)
-    full_cu = torch.cat((torch.zeros(1, dtype=endpoints.dtype), endpoints))
-    half_endpoints = (full_cu // 2)[1:].contiguous()
+    half_cu_seqlens = (cu_seqlens // 2).contiguous()
     block = q.shape[0] // 2
     q1 = q[half1].contiguous()
     out = softmax_max = softmax_sum = None
     rng_states: list[RNGState] = [(0, 0, 0) for _ in range(comm.world_size)]
 
     def forward_block(block_q: Tensor, block_k: Tensor, block_v: Tensor, causal: bool):
-        q_endpoints = half_endpoints if block_q.shape[0] == block else endpoints
-        kv_endpoints = half_endpoints if block_k.shape[0] == block else endpoints
+        q_cu_seqlens = half_cu_seqlens if block_q.shape[0] == block else cu_seqlens
+        kv_cu_seqlens = half_cu_seqlens if block_k.shape[0] == block else cu_seqlens
         return _npu_fa_forward(
             block_q,
             block_k,
@@ -482,8 +508,8 @@ def _zigzag_npu_varlen_forward(
             softmax_scale=softmax_scale,
             dropout_p=dropout_p,
             causal=causal,
-            actual_seq_qlen=q_endpoints,
-            actual_seq_kvlen=kv_endpoints,
+            actual_seq_qlen=q_cu_seqlens,
+            actual_seq_kvlen=kv_cu_seqlens,
             softmax_layout="TND",
         )
 
@@ -526,7 +552,7 @@ def _zigzag_npu_varlen_backward(
     out: Tensor,
     softmax_max: Tensor,
     softmax_sum: Tensor,
-    endpoints: Tensor,
+    cu_seqlens: Tensor,
     half0: HalfIndex,
     half1: HalfIndex,
     rng_states: Sequence[RNGState],
@@ -535,8 +561,7 @@ def _zigzag_npu_varlen_backward(
 ) -> Tuple[Tensor, Tensor, Tensor]:
     kv_comm = RingComm(group)
     d_kv_comm = RingComm(group)
-    full_cu = torch.cat((torch.zeros(1, dtype=endpoints.dtype), endpoints))
-    half_endpoints = (full_cu // 2)[1:].contiguous()
+    half_cu_seqlens = (cu_seqlens // 2).contiguous()
     block = q.shape[0] // 2
     q1 = q[half1].contiguous()
     dout1 = dout[half1].contiguous()
@@ -557,8 +582,8 @@ def _zigzag_npu_varlen_backward(
         causal: bool,
         rng_state: RNGState,
     ):
-        q_endpoints = half_endpoints if block_q.shape[0] == block else endpoints
-        kv_endpoints = half_endpoints if block_k.shape[0] == block else endpoints
+        q_cu_seqlens = half_cu_seqlens if block_q.shape[0] == block else cu_seqlens
+        kv_cu_seqlens = half_cu_seqlens if block_k.shape[0] == block else cu_seqlens
         return _npu_fa_backward(
             block_dout,
             block_q,
@@ -572,8 +597,8 @@ def _zigzag_npu_varlen_backward(
             dropout_p=dropout_p,
             causal=causal,
             rng_state=rng_state,
-            actual_seq_qlen=q_endpoints,
-            actual_seq_kvlen=kv_endpoints,
+            actual_seq_qlen=q_cu_seqlens,
+            actual_seq_kvlen=kv_cu_seqlens,
             softmax_layout="TND",
         )
 
@@ -651,19 +676,18 @@ class _ZigzagRingNPUFlashAttentionVarlen(torch.autograd.Function):
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** -0.5
         q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
-        endpoints = prepare_npu_cu_seqlens(cu_seqlens)
-        full_cu = torch.cat((torch.zeros(1, dtype=endpoints.dtype), endpoints))
-        half0 = _varlen_half_index(full_cu, front=True)
-        half1 = _varlen_half_index(full_cu, front=False)
+        cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+        half0 = _varlen_half_index(cu_seqlens, front=True)
+        half1 = _varlen_half_index(cu_seqlens, front=False)
         if isinstance(half0, Tensor):
             half0 = half0.to(q.device)
             half1 = half1.to(q.device)
 
         out, softmax_max, softmax_sum, rng_states = _zigzag_npu_varlen_forward(
-            group, q, k, v, endpoints, half0, half1, softmax_scale, dropout_p
+            group, q, k, v, cu_seqlens, half0, half1, softmax_scale, dropout_p
         )
         ctx.half_indices_are_tensors = isinstance(half0, Tensor)
-        tensors = [q, k, v, out, softmax_max, softmax_sum, endpoints]
+        tensors = [q, k, v, out, softmax_max, softmax_sum, cu_seqlens]
         if ctx.half_indices_are_tensors:
             tensors.extend((half0, half1))
         else:
@@ -678,7 +702,7 @@ class _ZigzagRingNPUFlashAttentionVarlen(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dout):
         saved = ctx.saved_tensors
-        q, k, v, out, softmax_max, softmax_sum, endpoints = saved[:7]
+        q, k, v, out, softmax_max, softmax_sum, cu_seqlens = saved[:7]
         if ctx.half_indices_are_tensors:
             half0, half1 = saved[7:]
         else:
@@ -692,7 +716,7 @@ class _ZigzagRingNPUFlashAttentionVarlen(torch.autograd.Function):
             out,
             softmax_max,
             softmax_sum,
-            endpoints,
+            cu_seqlens,
             half0,
             half1,
             ctx.rng_states,
@@ -715,6 +739,52 @@ def zigzag_ring_npu_flash_attn_varlen_func(
 ) -> Tensor:
     """Balanced causal Ring Attention for packed NPU ``(T, N, D)`` tensors."""
     _require_torch_npu()
-    del max_seqlen  # NPU fusion attention uses endpoint-style actual sequence lengths.
+    del max_seqlen  # Compatibility with the shared CUDA/NPU varlen wrapper API.
     group = get_context_parallel_group() if group is None else group
     return _ZigzagRingNPUFlashAttentionVarlen.apply(group, q, k, v, cu_seqlens, dropout_p, softmax_scale, causal)
+
+
+def forward(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    softmax_scale: Optional[float] = None,
+    causal: bool = True,
+    group: Optional[ProcessGroup] = None,
+    dropout_p: float = 0.0,
+) -> Tensor:
+    """Run balanced causal Ring Attention on fixed-shape NPU tensors."""
+    return zigzag_ring_npu_flash_attn_func(
+        q,
+        k,
+        v,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        group=group,
+        dropout_p=dropout_p,
+    )
+
+
+def packed_forward(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    cu_seqlens: ActualSeqLen,
+    max_seqlen: Optional[int] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = True,
+    group: Optional[ProcessGroup] = None,
+    dropout_p: float = 0.0,
+) -> Tensor:
+    """Run balanced causal Ring Attention on packed NPU tensors."""
+    return zigzag_ring_npu_flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens,
+        max_seqlen,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        group=group,
+        dropout_p=dropout_p,
+    )

--- a/veomni/distributed/sequence_parallel/ring_attention_npu.py
+++ b/veomni/distributed/sequence_parallel/ring_attention_npu.py
@@ -1,0 +1,720 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ascend NPU zig-zag Ring Attention primitives for USP.
+
+The sequence and ring schedule match :mod:`ring_attention`. The local
+attention backend is ``torch_npu.npu_fusion_attention`` instead of a CUDA
+FlashAttention low-level kernel. NPU fusion attention exposes softmax maximum
+and sum tensors rather than log-sum-exp, so partial ring outputs are merged
+with those statistics and saved for the explicit backward operator.
+"""
+
+from typing import Optional, Sequence, Tuple, Union
+
+import torch
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+from ...utils.import_utils import is_torch_npu_available
+from .comm import get_context_parallel_group
+from .ring_attention import RingComm
+
+
+if is_torch_npu_available():
+    import torch_npu
+else:  # pragma: no cover - exercised only when an NPU function is called without torch_npu
+    torch_npu = None
+
+
+ActualSeqLen = Union[Tensor, Sequence[int]]
+HalfIndex = Union[slice, Tensor]
+RNGState = Tuple[int, int, int]
+
+_CAUSAL_MASK_CACHE: dict[tuple[str, Optional[int]], Tensor] = {}
+
+__all__ = [
+    "prepare_npu_cu_seqlens",
+    "update_npu_out_and_softmax_stats",
+    "zigzag_ring_npu_flash_attn_func",
+    "zigzag_ring_npu_flash_attn_varlen_func",
+]
+
+
+def _require_torch_npu() -> None:
+    if torch_npu is None:
+        raise RuntimeError("NPU ring attention requires torch_npu to be installed.")
+
+
+def prepare_npu_cu_seqlens(cu_seqlens: ActualSeqLen) -> Tensor:
+    """Convert leading-zero cumulative lengths to NPU CPU endpoint format."""
+    if isinstance(cu_seqlens, Tensor):
+        endpoints = cu_seqlens.detach().to(device="cpu", dtype=torch.long)
+    else:
+        endpoints = torch.as_tensor(cu_seqlens, dtype=torch.long, device="cpu")
+    if endpoints.ndim != 1 or endpoints.numel() == 0:
+        raise ValueError("cu_seqlens must be a non-empty 1-D tensor or sequence")
+    if endpoints[0].item() == 0:
+        endpoints = endpoints[1:]
+    if endpoints.numel() == 0 or (endpoints <= 0).any() or (endpoints[1:] < endpoints[:-1]).any():
+        raise ValueError("cu_seqlens must contain positive, non-decreasing cumulative endpoints")
+    return endpoints.contiguous()
+
+
+def _causal_mask(device: torch.device) -> Tensor:
+    key = (device.type, device.index)
+    mask = _CAUSAL_MASK_CACHE.get(key)
+    if mask is None:
+        # sparse_mode=2 accepts the fixed 2048x2048 compressed causal mask.
+        mask = torch.triu(torch.ones((2048, 2048), dtype=torch.bool, device=device), diagonal=1)
+        _CAUSAL_MASK_CACHE[key] = mask
+    return mask
+
+
+def _head_num(q: Tensor, input_layout: str) -> int:
+    if input_layout == "TND":
+        return q.shape[1]
+    if input_layout == "BSND":
+        return q.shape[2]
+    raise ValueError(f"Unsupported NPU attention input layout: {input_layout!r}")
+
+
+def _npu_fa_forward(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    *,
+    input_layout: str,
+    softmax_scale: float,
+    dropout_p: float,
+    causal: bool,
+    actual_seq_qlen: Optional[Tensor] = None,
+    actual_seq_kvlen: Optional[Tensor] = None,
+    softmax_layout: str = "",
+) -> Tuple[Tensor, Tensor, Tensor, RNGState]:
+    _require_torch_npu()
+    attention_mask = _causal_mask(q.device) if causal else None
+    sparse_mode = 2 if causal else 0
+    block_out, block_max, block_sum, _, seed, offset, numels = torch_npu.npu_fusion_attention(
+        q,
+        k,
+        v,
+        head_num=_head_num(q, input_layout),
+        input_layout=input_layout,
+        softmax_layout=softmax_layout,
+        atten_mask=attention_mask,
+        scale=softmax_scale,
+        keep_prob=1.0 - dropout_p,
+        actual_seq_qlen=actual_seq_qlen,
+        actual_seq_kvlen=actual_seq_kvlen,
+        sparse_mode=sparse_mode,
+    )
+    return block_out, block_max, block_sum, (seed, offset, numels)
+
+
+def _npu_fa_backward(
+    dout: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    *,
+    input_layout: str,
+    softmax_scale: float,
+    dropout_p: float,
+    causal: bool,
+    rng_state: RNGState,
+    actual_seq_qlen: Optional[Tensor] = None,
+    actual_seq_kvlen: Optional[Tensor] = None,
+    softmax_layout: str = "",
+) -> Tuple[Tensor, Tensor, Tensor]:
+    _require_torch_npu()
+    attention_mask = _causal_mask(q.device) if causal else None
+    seed, offset, numels = rng_state
+    dq, dk, dv, *_ = torch_npu.npu_fusion_attention_grad(
+        q,
+        k,
+        v,
+        dout,
+        head_num=_head_num(q, input_layout),
+        input_layout=input_layout,
+        atten_mask=attention_mask,
+        softmax_max=softmax_max,
+        softmax_sum=softmax_sum,
+        attention_in=out,
+        scale_value=softmax_scale,
+        keep_prob=1.0 - dropout_p,
+        seed=seed,
+        offset=offset,
+        numels=numels,
+        softmax_layout=softmax_layout,
+        actual_seq_qlen=actual_seq_qlen,
+        actual_seq_kvlen=actual_seq_kvlen,
+        sparse_mode=2 if causal else 0,
+    )
+    return dq, dk, dv
+
+
+def update_npu_out_and_softmax_stats(
+    out: Optional[Tensor],
+    softmax_max: Optional[Tensor],
+    softmax_sum: Optional[Tensor],
+    block_out: Tensor,
+    block_max: Tensor,
+    block_sum: Tensor,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Merge an NPU fusion-attention block into the running softmax state."""
+    current_max = block_max[..., 0]
+    current_sum = block_sum[..., 0]
+    if out is None:
+        return block_out.to(torch.float32), current_max, current_sum
+    if softmax_max is None or softmax_sum is None:
+        raise RuntimeError("Previous NPU softmax statistics are missing.")
+
+    merged_max = torch.maximum(softmax_max, current_max)
+    previous_sum = softmax_sum * torch.exp(softmax_max - merged_max)
+    current_sum = current_sum * torch.exp(current_max - merged_max)
+    merged_sum = previous_sum + current_sum
+
+    previous_weight = previous_sum / merged_sum
+    current_weight = current_sum / merged_sum
+    if block_out.ndim == 4:
+        # BSND output pairs with BNS softmax statistics.
+        previous_weight = previous_weight.transpose(1, 2)
+        current_weight = current_weight.transpose(1, 2)
+    merged_out = out * previous_weight.unsqueeze(-1) + block_out * current_weight.unsqueeze(-1)
+    return merged_out, merged_max, merged_sum
+
+
+def _expand_npu_softmax_stats(stats: Tensor) -> Tensor:
+    return stats.unsqueeze(-1).expand(*stats.shape, 8).contiguous()
+
+
+def _zigzag_npu_forward(
+    group: ProcessGroup,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    softmax_scale: float,
+    dropout_p: float,
+) -> Tuple[Tensor, Tensor, Tensor, list[RNGState]]:
+    comm = RingComm(group)
+    block = q.shape[1] // 2
+    q1 = q[:, block:].contiguous()
+    out = softmax_max = softmax_sum = None
+    rng_states: list[RNGState] = [(0, 0, 0) for _ in range(comm.world_size)]
+
+    k = k.contiguous()
+    v = v.contiguous()
+    for step in range(comm.world_size):
+        if step + 1 != comm.world_size:
+            next_k = comm.send_recv(k)
+            next_v = comm.send_recv(v)
+            comm.commit()
+
+        if step == 0:
+            block_out, block_max, block_sum, rng_state = _npu_fa_forward(
+                q,
+                k,
+                v,
+                input_layout="BSND",
+                softmax_scale=softmax_scale,
+                dropout_p=dropout_p,
+                causal=True,
+            )
+            out, softmax_max, softmax_sum = update_npu_out_and_softmax_stats(
+                out, softmax_max, softmax_sum, block_out, block_max, block_sum
+            )
+        elif step <= comm.rank:
+            block_out, block_max, block_sum, rng_state = _npu_fa_forward(
+                q,
+                k[:, :block],
+                v[:, :block],
+                input_layout="BSND",
+                softmax_scale=softmax_scale,
+                dropout_p=dropout_p,
+                causal=False,
+            )
+            out, softmax_max, softmax_sum = update_npu_out_and_softmax_stats(
+                out, softmax_max, softmax_sum, block_out, block_max, block_sum
+            )
+        else:
+            block_out, block_max, block_sum, rng_state = _npu_fa_forward(
+                q1,
+                k,
+                v,
+                input_layout="BSND",
+                softmax_scale=softmax_scale,
+                dropout_p=dropout_p,
+                causal=False,
+            )
+            out[:, block:], softmax_max[:, :, block:], softmax_sum[:, :, block:] = update_npu_out_and_softmax_stats(
+                out[:, block:],
+                softmax_max[:, :, block:],
+                softmax_sum[:, :, block:],
+                block_out,
+                block_max,
+                block_sum,
+            )
+        rng_states[step] = rng_state
+
+        if step + 1 != comm.world_size:
+            comm.wait()
+            k, v = next_k, next_v
+
+    return out.to(q.dtype), softmax_max, softmax_sum, rng_states
+
+
+def _zigzag_npu_backward(
+    group: ProcessGroup,
+    dout: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    rng_states: Sequence[RNGState],
+    softmax_scale: float,
+    dropout_p: float,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    kv_comm = RingComm(group)
+    d_kv_comm = RingComm(group)
+    block = q.shape[1] // 2
+    q1 = q[:, block:].contiguous()
+    dout1 = dout[:, block:].contiguous()
+    out1 = out[:, block:].contiguous()
+    softmax_max1 = _expand_npu_softmax_stats(softmax_max[:, :, block:])
+    softmax_sum1 = _expand_npu_softmax_stats(softmax_sum[:, :, block:])
+    softmax_max = _expand_npu_softmax_stats(softmax_max)
+    softmax_sum = _expand_npu_softmax_stats(softmax_sum)
+
+    dq = dk = dv = None
+    next_dk = next_dv = None
+    dk_buffer = dv_buffer = None
+    for step in range(kv_comm.world_size):
+        if step + 1 != kv_comm.world_size:
+            next_k = kv_comm.send_recv(k)
+            next_v = kv_comm.send_recv(v)
+            kv_comm.commit()
+
+        if step == 0:
+            block_dq, block_dk, block_dv = _npu_fa_backward(
+                dout.contiguous(),
+                q,
+                k,
+                v,
+                out,
+                softmax_max,
+                softmax_sum,
+                input_layout="BSND",
+                softmax_scale=softmax_scale,
+                dropout_p=dropout_p,
+                causal=True,
+                rng_state=rng_states[step],
+            )
+            dq = block_dq.float().clone()
+            dk = block_dk.float().clone()
+            dv = block_dv.float().clone()
+        else:
+            if step <= kv_comm.rank:
+                block_dq, block_dk, block_dv = _npu_fa_backward(
+                    dout.contiguous(),
+                    q,
+                    k[:, :block],
+                    v[:, :block],
+                    out,
+                    softmax_max,
+                    softmax_sum,
+                    input_layout="BSND",
+                    softmax_scale=softmax_scale,
+                    dropout_p=dropout_p,
+                    causal=False,
+                    rng_state=rng_states[step],
+                )
+                dq += block_dq.float()
+            else:
+                block_dq, block_dk, block_dv = _npu_fa_backward(
+                    dout1,
+                    q1,
+                    k,
+                    v,
+                    out1,
+                    softmax_max1,
+                    softmax_sum1,
+                    input_layout="BSND",
+                    softmax_scale=softmax_scale,
+                    dropout_p=dropout_p,
+                    causal=False,
+                    rng_state=rng_states[step],
+                )
+                dq[:, block:] += block_dq.float()
+
+            d_kv_comm.wait()
+            dk_buffer, dv_buffer = dk, dv
+            dk, dv = next_dk, next_dv
+            if step <= kv_comm.rank:
+                dk[:, :block] += block_dk.float()
+                dv[:, :block] += block_dv.float()
+            else:
+                dk += block_dk.float()
+                dv += block_dv.float()
+
+        if step + 1 != kv_comm.world_size:
+            kv_comm.wait()
+            k, v = next_k, next_v
+
+        next_dk = d_kv_comm.send_recv(dk, dk_buffer)
+        next_dv = d_kv_comm.send_recv(dv, dv_buffer)
+        d_kv_comm.commit()
+
+    d_kv_comm.wait()
+    return dq.to(q.dtype), next_dk.to(k.dtype), next_dv.to(v.dtype)
+
+
+class _ZigzagRingNPUFlashAttention(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, group, q, k, v, dropout_p, softmax_scale, causal):
+        if not causal:
+            raise ValueError("NPU zig-zag ring attention requires causal=True")
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** -0.5
+        q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
+        out, softmax_max, softmax_sum, rng_states = _zigzag_npu_forward(group, q, k, v, softmax_scale, dropout_p)
+        ctx.save_for_backward(q, k, v, out, softmax_max, softmax_sum)
+        ctx.group = group
+        ctx.dropout_p = dropout_p
+        ctx.softmax_scale = softmax_scale
+        ctx.rng_states = rng_states
+        return out
+
+    @staticmethod
+    def backward(ctx, dout):
+        q, k, v, out, softmax_max, softmax_sum = ctx.saved_tensors
+        dq, dk, dv = _zigzag_npu_backward(
+            ctx.group,
+            dout,
+            q,
+            k,
+            v,
+            out,
+            softmax_max,
+            softmax_sum,
+            ctx.rng_states,
+            ctx.softmax_scale,
+            ctx.dropout_p,
+        )
+        return None, dq, dk, dv, None, None, None
+
+
+def zigzag_ring_npu_flash_attn_func(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    softmax_scale: Optional[float] = None,
+    causal: bool = True,
+    group: Optional[ProcessGroup] = None,
+    dropout_p: float = 0.0,
+) -> Tensor:
+    """Balanced causal Ring Attention for dense NPU ``(B, S, N, D)`` tensors."""
+    _require_torch_npu()
+    group = get_context_parallel_group() if group is None else group
+    return _ZigzagRingNPUFlashAttention.apply(group, q, k, v, dropout_p, softmax_scale, causal)
+
+
+def _varlen_half_index(cu_seqlens: Tensor, *, front: bool) -> HalfIndex:
+    if cu_seqlens.numel() == 2:
+        midpoint = int(cu_seqlens[-1].item()) // 2
+        return slice(None, midpoint) if front else slice(midpoint, None)
+
+    total = int(cu_seqlens[-1].item())
+    index = torch.zeros((total,), dtype=torch.bool, device=cu_seqlens.device)
+    for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+        start_int, end_int = int(start.item()), int(end.item())
+        midpoint = (start_int + end_int) // 2
+        if front:
+            index[start_int:midpoint] = True
+        else:
+            index[midpoint:end_int] = True
+    return index
+
+
+def _zigzag_npu_varlen_forward(
+    group: ProcessGroup,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    endpoints: Tensor,
+    half0: HalfIndex,
+    half1: HalfIndex,
+    softmax_scale: float,
+    dropout_p: float,
+) -> Tuple[Tensor, Tensor, Tensor, list[RNGState]]:
+    comm = RingComm(group)
+    full_cu = torch.cat((torch.zeros(1, dtype=endpoints.dtype), endpoints))
+    half_endpoints = (full_cu // 2)[1:].contiguous()
+    block = q.shape[0] // 2
+    q1 = q[half1].contiguous()
+    out = softmax_max = softmax_sum = None
+    rng_states: list[RNGState] = [(0, 0, 0) for _ in range(comm.world_size)]
+
+    def forward_block(block_q: Tensor, block_k: Tensor, block_v: Tensor, causal: bool):
+        q_endpoints = half_endpoints if block_q.shape[0] == block else endpoints
+        kv_endpoints = half_endpoints if block_k.shape[0] == block else endpoints
+        return _npu_fa_forward(
+            block_q,
+            block_k,
+            block_v,
+            input_layout="TND",
+            softmax_scale=softmax_scale,
+            dropout_p=dropout_p,
+            causal=causal,
+            actual_seq_qlen=q_endpoints,
+            actual_seq_kvlen=kv_endpoints,
+            softmax_layout="TND",
+        )
+
+    for step in range(comm.world_size):
+        if step + 1 != comm.world_size:
+            next_k = comm.send_recv(k)
+            next_v = comm.send_recv(v)
+            comm.commit()
+
+        if step == 0:
+            block_out, block_max, block_sum, rng_state = forward_block(q, k, v, True)
+            out, softmax_max, softmax_sum = update_npu_out_and_softmax_stats(
+                out, softmax_max, softmax_sum, block_out, block_max, block_sum
+            )
+        elif step <= comm.rank:
+            block_out, block_max, block_sum, rng_state = forward_block(q, k[half0], v[half0], False)
+            out, softmax_max, softmax_sum = update_npu_out_and_softmax_stats(
+                out, softmax_max, softmax_sum, block_out, block_max, block_sum
+            )
+        else:
+            block_out, block_max, block_sum, rng_state = forward_block(q1, k, v, False)
+            out[half1], softmax_max[half1], softmax_sum[half1] = update_npu_out_and_softmax_stats(
+                out[half1], softmax_max[half1], softmax_sum[half1], block_out, block_max, block_sum
+            )
+        rng_states[step] = rng_state
+
+        if step + 1 != comm.world_size:
+            comm.wait()
+            k, v = next_k, next_v
+
+    return out.to(q.dtype), softmax_max, softmax_sum, rng_states
+
+
+def _zigzag_npu_varlen_backward(
+    group: ProcessGroup,
+    dout: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    softmax_max: Tensor,
+    softmax_sum: Tensor,
+    endpoints: Tensor,
+    half0: HalfIndex,
+    half1: HalfIndex,
+    rng_states: Sequence[RNGState],
+    softmax_scale: float,
+    dropout_p: float,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    kv_comm = RingComm(group)
+    d_kv_comm = RingComm(group)
+    full_cu = torch.cat((torch.zeros(1, dtype=endpoints.dtype), endpoints))
+    half_endpoints = (full_cu // 2)[1:].contiguous()
+    block = q.shape[0] // 2
+    q1 = q[half1].contiguous()
+    dout1 = dout[half1].contiguous()
+    out1 = out[half1].contiguous()
+    softmax_max1 = _expand_npu_softmax_stats(softmax_max[half1])
+    softmax_sum1 = _expand_npu_softmax_stats(softmax_sum[half1])
+    softmax_max = _expand_npu_softmax_stats(softmax_max)
+    softmax_sum = _expand_npu_softmax_stats(softmax_sum)
+
+    def backward_block(
+        block_dout: Tensor,
+        block_q: Tensor,
+        block_k: Tensor,
+        block_v: Tensor,
+        block_out: Tensor,
+        block_max: Tensor,
+        block_sum: Tensor,
+        causal: bool,
+        rng_state: RNGState,
+    ):
+        q_endpoints = half_endpoints if block_q.shape[0] == block else endpoints
+        kv_endpoints = half_endpoints if block_k.shape[0] == block else endpoints
+        return _npu_fa_backward(
+            block_dout,
+            block_q,
+            block_k,
+            block_v,
+            block_out,
+            block_max,
+            block_sum,
+            input_layout="TND",
+            softmax_scale=softmax_scale,
+            dropout_p=dropout_p,
+            causal=causal,
+            rng_state=rng_state,
+            actual_seq_qlen=q_endpoints,
+            actual_seq_kvlen=kv_endpoints,
+            softmax_layout="TND",
+        )
+
+    dq = dk = dv = None
+    next_dk = next_dv = None
+    dk_buffer = dv_buffer = None
+    for step in range(kv_comm.world_size):
+        if step + 1 != kv_comm.world_size:
+            next_k = kv_comm.send_recv(k)
+            next_v = kv_comm.send_recv(v)
+            kv_comm.commit()
+
+        if step == 0:
+            block_dq, block_dk, block_dv = backward_block(
+                dout.contiguous(), q, k, v, out, softmax_max, softmax_sum, True, rng_states[step]
+            )
+            dq = block_dq.float().clone()
+            dk = block_dk.float().clone()
+            dv = block_dv.float().clone()
+        else:
+            if step <= kv_comm.rank:
+                block_dq, block_dk, block_dv = backward_block(
+                    dout.contiguous(),
+                    q,
+                    k[half0],
+                    v[half0],
+                    out,
+                    softmax_max,
+                    softmax_sum,
+                    False,
+                    rng_states[step],
+                )
+                dq += block_dq.float()
+            else:
+                block_dq, block_dk, block_dv = backward_block(
+                    dout1,
+                    q1,
+                    k,
+                    v,
+                    out1,
+                    softmax_max1,
+                    softmax_sum1,
+                    False,
+                    rng_states[step],
+                )
+                dq[half1] += block_dq.float()
+
+            d_kv_comm.wait()
+            dk_buffer, dv_buffer = dk, dv
+            dk, dv = next_dk, next_dv
+            if step <= kv_comm.rank:
+                dk[half0] += block_dk.float()
+                dv[half0] += block_dv.float()
+            else:
+                dk += block_dk.float()
+                dv += block_dv.float()
+
+        if step + 1 != kv_comm.world_size:
+            kv_comm.wait()
+            k, v = next_k, next_v
+
+        next_dk = d_kv_comm.send_recv(dk, dk_buffer)
+        next_dv = d_kv_comm.send_recv(dv, dv_buffer)
+        d_kv_comm.commit()
+
+    d_kv_comm.wait()
+    return dq.to(q.dtype), next_dk.to(k.dtype), next_dv.to(v.dtype)
+
+
+class _ZigzagRingNPUFlashAttentionVarlen(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, group, q, k, v, cu_seqlens, dropout_p, softmax_scale, causal):
+        if not causal:
+            raise ValueError("NPU zig-zag ring attention requires causal=True")
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** -0.5
+        q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
+        endpoints = prepare_npu_cu_seqlens(cu_seqlens)
+        full_cu = torch.cat((torch.zeros(1, dtype=endpoints.dtype), endpoints))
+        half0 = _varlen_half_index(full_cu, front=True)
+        half1 = _varlen_half_index(full_cu, front=False)
+        if isinstance(half0, Tensor):
+            half0 = half0.to(q.device)
+            half1 = half1.to(q.device)
+
+        out, softmax_max, softmax_sum, rng_states = _zigzag_npu_varlen_forward(
+            group, q, k, v, endpoints, half0, half1, softmax_scale, dropout_p
+        )
+        ctx.half_indices_are_tensors = isinstance(half0, Tensor)
+        tensors = [q, k, v, out, softmax_max, softmax_sum, endpoints]
+        if ctx.half_indices_are_tensors:
+            tensors.extend((half0, half1))
+        else:
+            ctx.half0, ctx.half1 = half0, half1
+        ctx.save_for_backward(*tensors)
+        ctx.group = group
+        ctx.dropout_p = dropout_p
+        ctx.softmax_scale = softmax_scale
+        ctx.rng_states = rng_states
+        return out
+
+    @staticmethod
+    def backward(ctx, dout):
+        saved = ctx.saved_tensors
+        q, k, v, out, softmax_max, softmax_sum, endpoints = saved[:7]
+        if ctx.half_indices_are_tensors:
+            half0, half1 = saved[7:]
+        else:
+            half0, half1 = ctx.half0, ctx.half1
+        dq, dk, dv = _zigzag_npu_varlen_backward(
+            ctx.group,
+            dout,
+            q,
+            k,
+            v,
+            out,
+            softmax_max,
+            softmax_sum,
+            endpoints,
+            half0,
+            half1,
+            ctx.rng_states,
+            ctx.softmax_scale,
+            ctx.dropout_p,
+        )
+        return None, dq, dk, dv, None, None, None, None
+
+
+def zigzag_ring_npu_flash_attn_varlen_func(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    cu_seqlens: ActualSeqLen,
+    max_seqlen: Optional[int] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = True,
+    group: Optional[ProcessGroup] = None,
+    dropout_p: float = 0.0,
+) -> Tensor:
+    """Balanced causal Ring Attention for packed NPU ``(T, N, D)`` tensors."""
+    _require_torch_npu()
+    del max_seqlen  # NPU fusion attention uses endpoint-style actual sequence lengths.
+    group = get_context_parallel_group() if group is None else group
+    return _ZigzagRingNPUFlashAttentionVarlen.apply(group, q, k, v, cu_seqlens, dropout_p, softmax_scale, causal)

--- a/veomni/ops/kernels/attention/__init__.py
+++ b/veomni/ops/kernels/attention/__init__.py
@@ -26,6 +26,7 @@ from ....distributed.sequence_parallel import (
     gather_seq_scatter_heads,
 )
 from ....utils import logging
+from ....utils.device import get_device_type
 from ....utils.import_utils import is_transformers_version_greater_or_equal_to
 
 
@@ -316,18 +317,32 @@ def flash_attention_forward(
     # ring only needs to span the ``cp`` group. The data collator lays the
     # sequence out in zig-zag block order (see ``SequenceParallelCollator`` /
     # ``sequence_parallel.data.zigzag_reorder``), so causal attention is balanced
-    # across ``cp`` ranks. Requires a flash-attn backend (FA2 on Ampere/Hopper,
-    # FA4 CuTe on Blackwell/GB200 — auto-selected in ``ring_attention``) and
-    # causal attention. Both dense and packed (varlen) sequences are supported:
-    # packed documents take the ``zigzag_ring_flash_attn_varlen_func`` path with
-    # per-document LOCAL cu_seqlens derived from the FULL ``cu_seq_lens_q``.
+    # across ``cp`` ranks. CUDA uses FA2 on Ampere/Hopper or FA4 CuTe on
+    # Blackwell; Ascend uses torch_npu fusion attention. Both dense and packed
+    # (varlen) sequences are supported, and packed documents use per-document
+    # LOCAL cu_seqlens derived from the FULL ``cu_seq_lens_q``.
     cp_state = get_parallel_state()
     if cp_state.cp_enabled:
         from ....distributed.sequence_parallel.data import local_cu_seqlens
-        from ....distributed.sequence_parallel.ring_attention import (
-            zigzag_ring_flash_attn_func,
-            zigzag_ring_flash_attn_varlen_func,
-        )
+
+        if get_device_type() == "npu":
+            from ....distributed.sequence_parallel.ring_attention_npu import (
+                zigzag_ring_npu_flash_attn_func as zigzag_ring_attn_func,
+            )
+            from ....distributed.sequence_parallel.ring_attention_npu import (
+                zigzag_ring_npu_flash_attn_varlen_func as zigzag_ring_attn_varlen_func,
+            )
+
+            ring_backend_kwargs = {"dropout_p": dropout}
+        else:
+            from ....distributed.sequence_parallel.ring_attention import (
+                zigzag_ring_flash_attn_func as zigzag_ring_attn_func,
+            )
+            from ....distributed.sequence_parallel.ring_attention import (
+                zigzag_ring_flash_attn_varlen_func as zigzag_ring_attn_varlen_func,
+            )
+
+            ring_backend_kwargs = {}
 
         if not is_causal:
             raise NotImplementedError("context-parallel (cp_size>1) ring attention requires causal attention")
@@ -353,7 +368,7 @@ def flash_attention_forward(
             seqlens = local_cu[1:] - local_cu[:-1]
             local_max = int(seqlens.max().item()) if seqlens.numel() else 0
             q3, k3, v3 = query.squeeze(0), key.squeeze(0), value.squeeze(0)
-            attn_output = zigzag_ring_flash_attn_varlen_func(
+            attn_output = zigzag_ring_attn_varlen_func(
                 q3,
                 k3,
                 v3,
@@ -362,16 +377,18 @@ def flash_attention_forward(
                 softmax_scale=scaling,
                 causal=True,
                 group=cp_state.cp_group,
+                **ring_backend_kwargs,
             )
             attn_output = attn_output.unsqueeze(0)
         else:
-            attn_output = zigzag_ring_flash_attn_func(
+            attn_output = zigzag_ring_attn_func(
                 query,
                 key,
                 value,
                 softmax_scale=scaling,
                 causal=True,
                 group=cp_state.cp_group,
+                **ring_backend_kwargs,
             )
     else:
         attn_output = _flash_attention_forward(

--- a/veomni/ops/kernels/attention/__init__.py
+++ b/veomni/ops/kernels/attention/__init__.py
@@ -25,8 +25,8 @@ from ....distributed.sequence_parallel import (
     gather_heads_scatter_seq,
     gather_seq_scatter_heads,
 )
+from ....distributed.sequence_parallel.ring_attention import ring_attention
 from ....utils import logging
-from ....utils.device import get_device_type
 from ....utils.import_utils import is_transformers_version_greater_or_equal_to
 
 
@@ -308,88 +308,21 @@ def flash_attention_forward(
             f"unknown attn_implementation for veomni flash_attention with SP support: {module.config._attn_implementation}"
         )
 
-    # USP ring-attention (context-parallel) branch.
-    #
-    # When ``cp_size > 1`` the sequence is additionally split across the ``cp``
-    # mesh dimension and attention is computed with zig-zag ring attention over
-    # the ``cp`` group. This composes with Ulysses: the Ulysses all-to-all above
-    # already restored the full ``cp``-local sequence with a head subset, so the
-    # ring only needs to span the ``cp`` group. The data collator lays the
-    # sequence out in zig-zag block order (see ``SequenceParallelCollator`` /
-    # ``sequence_parallel.data.zigzag_reorder``), so causal attention is balanced
-    # across ``cp`` ranks. CUDA uses FA2 on Ampere/Hopper or FA4 CuTe on
-    # Blackwell; Ascend uses torch_npu fusion attention. Both dense and packed
-    # (varlen) sequences are supported, and packed documents use per-document
-    # LOCAL cu_seqlens derived from the FULL ``cu_seq_lens_q``.
     cp_state = get_parallel_state()
     if cp_state.cp_enabled:
-        from ....distributed.sequence_parallel.data import local_cu_seqlens
-
-        if get_device_type() == "npu":
-            from ....distributed.sequence_parallel.ring_attention_npu import (
-                zigzag_ring_npu_flash_attn_func as zigzag_ring_attn_func,
-            )
-            from ....distributed.sequence_parallel.ring_attention_npu import (
-                zigzag_ring_npu_flash_attn_varlen_func as zigzag_ring_attn_varlen_func,
-            )
-
-            ring_backend_kwargs = {"dropout_p": dropout}
-        else:
-            from ....distributed.sequence_parallel.ring_attention import (
-                zigzag_ring_flash_attn_func as zigzag_ring_attn_func,
-            )
-            from ....distributed.sequence_parallel.ring_attention import (
-                zigzag_ring_flash_attn_varlen_func as zigzag_ring_attn_varlen_func,
-            )
-
-            ring_backend_kwargs = {}
-
-        if not is_causal:
-            raise NotImplementedError("context-parallel (cp_size>1) ring attention requires causal attention")
-        if attention_mask is not None:
-            raise NotImplementedError(
-                "context-parallel (cp_size>1) ring attention does not support explicit attention masks"
-            )
-        # ``cu_seq_lens_q`` (when present) is computed by the collator on the FULL
-        # (pre-slice) packed position_ids, so it describes the whole sequence
-        # across the ``cp`` group. A single ``[0, S]`` segment is a plain
-        # (non-packed) sequence and takes the dense ring path; multiple segments
-        # are genuinely packed documents and take the varlen ring path, where
-        # each document is zig-zag split independently across ``cp`` (see
-        # ``SequenceParallelCollator`` / ``sequence_parallel.data``).
-        cu_seq_lens_q = kwargs.get("cu_seq_lens_q")
-        is_packed = cu_seq_lens_q is not None and cu_seq_lens_q.numel() > 2
-        # query/key/value are (b, s, h, d) here (already transposed for FA).
-        if is_packed:
-            # Derive the per-rank LOCAL document offsets for this cp-region: every
-            # document is split evenly across ``cp`` so each local document length
-            # is ``doc_len // cp_size``. ``varlen`` FA wants ``(total, h, d)``.
-            local_cu = local_cu_seqlens(cu_seq_lens_q.to(torch.int32), cp_state.cp_size)
-            seqlens = local_cu[1:] - local_cu[:-1]
-            local_max = int(seqlens.max().item()) if seqlens.numel() else 0
-            q3, k3, v3 = query.squeeze(0), key.squeeze(0), value.squeeze(0)
-            attn_output = zigzag_ring_attn_varlen_func(
-                q3,
-                k3,
-                v3,
-                local_cu,
-                local_max,
-                softmax_scale=scaling,
-                causal=True,
-                group=cp_state.cp_group,
-                **ring_backend_kwargs,
-            )
-            attn_output = attn_output.unsqueeze(0)
-        else:
-            attn_output = zigzag_ring_attn_func(
-                query,
-                key,
-                value,
-                softmax_scale=scaling,
-                causal=True,
-                group=cp_state.cp_group,
-                **ring_backend_kwargs,
-            )
+        attn_output = ring_attention(
+            query,
+            key,
+            value,
+            group=cp_state.cp_group,
+            cp_size=cp_state.cp_size,
+            device_type=cp_state.device_type,
+            cu_seqlens=kwargs.get("cu_seq_lens_q"),
+            attention_mask=attention_mask,
+            softmax_scale=scaling,
+            dropout_p=dropout,
+            causal=is_causal,
+        )
     else:
         attn_output = _flash_attention_forward(
             query,


### PR DESCRIPTION
### What does this PR do?

Adds an Ascend NPU backend for zig-zag Ring Attention, completing the USP (Ulysses × Ring) sequence parallelism support on Huawei Ascend NPUs. The existing CUDA path uses FlashAttention (FA2/FA4); the new NPU path uses `torch_npu.npu_fusion_attention` / `npu_fusion_attention_grad` as the local attention kernel, with the same zig-zag schedule, P2P ring communication, and online softmax merge — but operating on softmax max/sum statistics instead of log-sum-exp.

A unified `ring_attention()` entry point auto-selects the backend from the active device, so no config change is needed: existing USP training scripts work on NPU out of the box.


### Checklist Before Starting

- Search for relative PRs/issues and link here: builds on the `usp-support` branch (commit `a7f8086`) which introduced CUDA USP.
- PR title follows `[{modules}] {type}: {description}` format ✅

### Test

**Unit tests (NPU):**

- `tests/parallel/ring/test_usp_ring_npu.py` — distributed numerical tests for both dense and packed (varlen) zig-zag ring attention on NPU, plus end-to-end USP attention routing (ulysses=2 × cp=2, 4 devices). Tolerances: `atol=8e-2, rtol=6e-2` (bfloat16).
- `tests/parallel/ring/test_ring_attention_dispatch.py` — device-agnostic dispatch tests (monkeypatched, no hardware needed).
- `tests/parallel/ring/test_usp_data.py` — extended with NPU softmax-merge unit tests (`update_npu_out_and_softmax_stats`, cu_seqlens normalization, endpoint-list conversion, BSND stat expansion).
- All new tests are guarded with `is_torch_npu_available()` / `device_count >= N` and are added to `.github/workflows/npu_unit_tests.yml`.

**Training convergence (NPU vs GPU alignment):**

FineWeb dataset, Qwen3-8B, 500 steps, 8 cards per run, bfloat16.

**dp=4 group (NPU vs GPU precision alignment):**

| Config | DP | Ulysses | CP | Device | Last-100 mean loss | Abs diff | Rel diff |
|--------|----|---------|-----|--------|--------------------|----------|----------|
| dp=4 | 4 | 1 | 1 | NPU | 2.503754 | — | — |
| dp=4 | 4 | 1 | 1 | GPU | 2.504407 | 0.000653 | 0.026% |
| dp=4 + cp=2 | 4 | 1 | 2 | NPU | 2.504026 | — | — |
| dp=4 + cp=2 | 4 | 1 | 2 | GPU | 2.503796 | 0.000230 | 0.009% |

> Over all 500 steps: **mean relative loss diff ≤ 0.093%**, **max relative loss diff ≤ 1.8%** (the maxima occur only in the first few warm-up steps where loss itself is unstable). Grad norm spikes are similarly confined to early steps; from step ~30 onward NPU and GPU grad norms track within typical bfloat16 noise.

**dp=2 group (NPU-only, different SP decompositions):**

| Config | DP | Ulysses | CP | Device |
|--------|----|---------|-----|--------|
| dp=2 + cp=2 + ulysses=2 | 2 | 2 | 2 | NPU |
| dp=2 + cp=4 | 2 | 1 | 4 | NPU |
| dp=2 + ulysses=4 | 2 | 4 | 1 | NPU |

All three dp=2 configurations converge identically, confirming that different Ulysses × CP decompositions produce numerically equivalent results on NPU.

<details>
<summary><b>📊 Training curves — dp=4 group</b> (NPU vs GPU, with/without cp=2)</summary>

<img width="1430" height="1040" alt="dp=4 loss & grad norm" src="https://github.com/user-attachments/assets/a82a000e-2c89-4886-ba20-cb530ec7dfb1" />

NPU and GPU curves overlap across both dp=4 and dp=4+cp=2 configurations, confirming precision alignment between the new NPU ring attention backend and the existing CUDA backend.
</details>

<details>
<summary><b>📊 Training curves — dp=2 group</b> (3 NPU runs with different SP decompositions)</summary>
<img width="1430" height="1040" alt="dp=2 loss & grad norm" src="https://github.com/user-attachments/assets/b25abb26-a723-4025-afb7-a8720c363a56" />

All three dp=2 configurations converge identically, confirming that different Ulysses × CP decompositions (cp=2+ulysses=2, cp=4, ulysses=4) produce numerically equivalent results on NPU.
</details>


### API and Usage Example

No API change. The same USP config works on both CUDA and Ascend:

```yaml
# configs/text/qwen3_usp.yaml
parallel:
  ulysses_size: 2
  cp_size: 2        # enables ring attention; auto-selects FA2/FA4 on CUDA, torch_npu on Ascend
```

### Design & Code Changes

**Architecture — `ring_attention/` package (new):**

The monolithic `ring_attention.py` is refactored into a package with a device-dispatching `__init__.py`:

- `ring_attention/__init__.py` — unified `ring_attention()` entry that routes to the gpu or npu backend based on `device_type`; exposes all public symbols.
- `ring_attention/gpu.py` — existing CUDA FA2/FA4 implementation (moved from `ring_attention.py`), adds `forward()` / `packed_forward()` thin wrappers for the dispatch API.
- `ring_attention/npu.py` — **new** Ascend backend: `torch_npu.npu_fusion_attention` forward/backward, `update_npu_out_and_softmax_stats` (online softmax max/sum merge), dense and varlen zig-zag ring attention autograd functions (`_ZigzagRingNPUFlashAttention`, `_ZigzagRingNPUFlashAttentionVarlen`).
- `ring_attention/comm.py` — shared `RingComm` P2P ring communicator (extracted from gpu.py, used by both backends).
- `ring_attention/layout.py` — shared zig-zag data layout helpers (`zigzag_reorder`, `zigzag_undo`, `zigzag_reorder_packed`, `local_cu_seqlens`; extracted from `data.py`).

**Key NPU implementation differences from CUDA:**

- **Softmax merge**: CUDA FA2/FA4 return log-sum-exp (`lse`); NPU fusion attention returns softmax max and sum tensors. The `update_npu_out_and_softmax_stats` function performs the numerically equivalent online merge using these statistics.
- **RNG state**: NPU fusion attention returns explicit `(seed, offset, numels)` RNG state tuples; these are saved per ring step and replayed in the backward for dropout reproducibility.
- **cu_seqlens format**: Standard leading-zero cumulative offsets (e.g. `[0, 6, 10]`) are converted to endpoint lists (`[6, 10]`) only at the `torch_npu` operator boundary; all internal code uses the standard format.
- **BSND layout**: The dense NPU path uses `BSND` layout (matching `torch_npu` expectations) with corresponding BNS softmax stats; the varlen path uses `TND`.

**Attention integration:**

`veomni/ops/kernels/attention/__init__.py` — the cp-branch now delegates to `ring_attention()` instead of importing backend-specific functions directly. Input validation (causal-only, no explicit mask) moves into the shared entry point.

**Data module:**

`veomni/distributed/sequence_parallel/data.py` — zig-zag layout functions moved to `ring_attention/layout.py`; `data.py` re-exports them for backward compatibility. `zigzag_reorder_varlen` is aliased to `zigzag_reorder_packed`.

**Documentation & config:**

- `docs/key_features/ulysses.md` — updated Implementation Map and backend description.
- `docs/usage/arguments.md` — `cp_size` arg now mentions Ascend backend.
- `configs/text/qwen3_usp.yaml` — updated comment on backend selection.
- `veomni/arguments/arguments_types.py` — updated docstring.
- `.agents/knowledge/architecture.md` / `constraints.md` — updated module map and NPU guard constraints.

**Tests:**

- `tests/parallel/ring/test_usp_ring_npu.py` (new, 287 lines)
- `tests/parallel/ring/test_ring_attention_dispatch.py` (new, 95 lines)
- `tests/parallel/ring/test_usp_data.py` — extended with NPU-specific unit tests
- `tests/parallel/ring/test_usp_ring_gpu.py` — import paths updated
- `.github/workflows/npu_unit_tests.yml` — new test entries added

**Files changed:** 20 files, +1693 / −270

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- [x] Applied pre-commit checks (`make style && make quality`)
- [x] Added/updated documentation (`docs/`, `.agents/knowledge/`, config comments)
- [x] NPU ring attention code guarded with `is_torch_npu_available()` — importable on GPU-only environments
- [x] Added tests to CI workflow (npu_unit_tests.yml)
