### PR TITLE
[BREAKING][dist, trainer] refactor: build ParallelState from AcceleratorConfig

### DIFF
--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -12,7 +12,7 @@ veomni/
 │   ├── multimodal/     Vision, audio, video preprocessing and chat templates
 │   └── diffusion/      Diffusion model data loading
 ├── distributed/        All parallelism strategies
-│   ├── parallel_state.py   init_parallel_state(), ParallelState, device mesh setup
+│   ├── parallel_state.py   init_parallel_state_from_config(), ParallelState, mesh setup
 │   ├── torch_parallelize.py  build_parallelize_model(), parallelize_model_fsdp2()
 │   ├── parallel_plan.py    ParallelPlan for ExtraParallel (EP, embedding shard)
 │   ├── async_offload.py    Async activation offload (SwapTensor, OffloadManager, async_save_on_cpu)
@@ -113,7 +113,7 @@ BaseTrainer (ABC)
 
 Subclasses override specific methods (e.g., `compute_loss()`, custom data transforms) rather than the entire training loop.
 
-**Parallel-state scoping**: `_setup()` calls `init_parallel_state(name="base")` before seed/determinism; then each trainer builds under `use_parallel_state("base")`. Run time uses **per-op** wraps with `"base"` (forward / postforward / backward / clip). No `self.parallel_state` on trainers. See `.agents/knowledge/constraints.md` §7 and `docs/design/local_parallel_state.md`.
+**Parallel-state scoping**: `_setup()` calls `init_parallel_state_from_config(args.model.accelerator, name="base")` before seed/determinism; then each trainer builds under `use_parallel_state("base")`. Run time uses **per-op** wraps with `"base"` (forward / postforward / backward / clip). No `self.parallel_state` on trainers. See `.agents/knowledge/constraints.md` §7 and `docs/design/local_parallel_state.md`.
 
 ## Data Flow
 
@@ -152,7 +152,7 @@ YAML Config -> VeOmniArguments -> Trainer
 
 VeOmni uses FSDP2 exclusively.
 
-1. `init_parallel_state()` -> global `DeviceMesh` with named dims (`dp_shard`, `ulysses`, `cp`, etc.) + per-ExtraParallel submeshes (`[ep × ep_fsdp]`)
+1. `init_parallel_state_from_config()` -> global `DeviceMesh` with named dims (`dp_shard`, `ulysses`, `cp`, etc.) + per-ExtraParallel submeshes (`[ep × ep_fsdp]`)
 2. Model-specific `parallel_plan.py` -> define EP/embedding weight sharding via `ParallelPlan`
 3. `build_parallelize_model()` -> `parallelize_model_fsdp2()`:
    - `ParallelPlan.apply()` wraps EP/embedding params as DTensors on para mesh

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -35,7 +35,7 @@ Violating any of these causes silent bugs, crashes, or incorrect training result
 VeOmni uses FSDP2 exclusively. FSDP1 has been removed.
 
 Core entry points:
-- `veomni/distributed/parallel_state.py` — `init_parallel_state()`, `ParallelState` dataclass
+- `veomni/distributed/parallel_state.py` — `init_parallel_state_from_config()`, `ParallelState` dataclass
 - `veomni/distributed/torch_parallelize.py` — `build_parallelize_model()`, `parallelize_model_fsdp2()`
 - `veomni/distributed/parallel_plan.py` — `ParallelPlan`, `SpecInfo`
 
@@ -47,7 +47,7 @@ Core entry points:
    - When SP is enabled, the FSDP shard mesh fuses with the SP mesh (`dp_shard_sp`) so sequence-parallel ranks co-shard via FSDP.
    - Gradient clipping: `veomni/distributed/fsdp2/clip_grad_norm.py` — handles DTensor grads and ExtraParallel param groups.
 
-6. **Device mesh initialization (`init_parallel_state()`)**
+6. **Device mesh initialization (`init_parallel_state_from_config()`)**
    - Builds a global `DeviceMesh` with named dimensions: `pp`, `dp_replicate`, `dp_shard`, `ulysses`, `cp`, `tp` (each included only if size > 1).
    - Flattens subviews for common usage: `dp` (all data-parallel), `sp` (ulysses+cp), `dp_shard_sp` (FSDP shard × SP), `dp_sp` (for loss/grad sync across SP+DP).
    - For each ExtraParallel name (e.g. `ep`), builds a `[para_size × para_fsdp_size]` submesh via `init_para_mesh_matrix()`.
@@ -62,8 +62,8 @@ Core entry points:
    - Async variants in `async_ulysses*.py` for DiT and pipelined QKV/output projections.
    - Data slicing: `veomni/distributed/sequence_parallel/data.py` — `sp_pad_and_slice()`, `slice_input_tensor()`, `gather_outputs()`.
    - Loss reduction: `reduce_sequence_parallel_loss()` in `loss.py` aggregates across SP ranks (optional `group=` arg; defaults to the current state's unified SP group).
-   - Process groups: `comm.py` has NO group globals. Its getters (`get_ulysses_sequence_parallel_group`, `get_unified_sequence_parallel_group`, `get_context_parallel_group`, `get_data_parallel_group`) resolve from the *current* `ParallelState`'s device mesh (`get_parallel_state().{ulysses,sp,cp,dp}_group`) — exactly how `fsdp_group` already worked. `set_ulysses_sequence_parallel_group(group)` survives ONLY as a unit-test injection seam (`_ULYSSES_SP_GROUP_OVERRIDE`, `None` in production); no production code calls it. Meshless SP is unsupported — `ParallelState.__post_init__` raises if `sp_enabled and device_mesh is None`; always build via `init_parallel_state`.
-   - Local parallel state: `BaseTrainer._setup()` calls `init_parallel_state(name="base")` **before** seed/determinism env vars (`NCCL_DETERMINISTIC`, etc.). Initialization caches by topology and registers under `name`; duplicate name → warn and return existing. Trainers do not store the ParallelState object or name — use `use_parallel_state("base")` / `get_parallel_state_by_name("base")`. `clear_parallel_state()` after `destroy_process_group()`.
+   - Process groups: `comm.py` has NO group globals. Its getters (`get_ulysses_sequence_parallel_group`, `get_unified_sequence_parallel_group`, `get_context_parallel_group`, `get_data_parallel_group`) resolve from the *current* `ParallelState`'s device mesh (`get_parallel_state().{ulysses,sp,cp,dp}_group`) — exactly how `fsdp_group` already worked. `set_ulysses_sequence_parallel_group(group)` survives ONLY as a unit-test injection seam (`_ULYSSES_SP_GROUP_OVERRIDE`, `None` in production); no production code calls it. Meshless SP is unsupported — `ParallelState.__post_init__` raises if `sp_enabled and device_mesh is None`; always build via `init_parallel_state_from_config`.
+   - Local parallel state: `BaseTrainer._setup()` calls `init_parallel_state_from_config(args.model.accelerator, name="base")` **before** seed/determinism env vars (`NCCL_DETERMINISTIC`, etc.). Initialization caches by topology and registers under `name`; duplicate name → warn and return existing. Trainers do not store the ParallelState object or name — use `use_parallel_state("base")` / `get_parallel_state_by_name("base")`. `clear_parallel_state()` after `destroy_process_group()`. Tests that need a topology no job config can express call `_init_parallel_state` directly.
    - **Build scope**: `_setup()` (registers `"base"`) → one `with use_parallel_state("base"):` around the whole build sequence. Do NOT re-wrap individual build helpers.
    - **Run scope (per-op, not whole `train_step`)**: each ambient-dependent op gets its own wrap with `"base"` — `model` forward, `postforward`/`mean_global_loss`, `loss.backward()`, `veomni_clip_grad_norm`. When an API takes explicit `group=`, pass `get_parallel_state_by_name("base").sp_group` and skip ambient.
    - **Callbacks**: cache `Callback.parallel_state` at construction (ChannelLossComputer too). Hook dispatch must not depend on ambient ParallelState.
@@ -96,7 +96,7 @@ Core entry points:
    - Weight sharding: `ParallelPlan` in `parallel_plan.py` defines which expert parameters get `Shard(0)` on the EP mesh. `ParallelPlan.apply()` wraps matching params as DTensors and redistributes to local shards.
    - Token routing: `veomni/distributed/moe/moe_layer.py` — `preprocess()` computes dispatch counts, `token_pre_all2all()` / `tokens_post_all2all()` exchange tokens between EP ranks via `all_to_all` / `all_to_all_async` in `moe/comm.py`.
    - Expert computation: `EPGroupGemm` runs fused expert MLP on grouped tokens per rank.
-   - Device mesh: `init_parallel_state()` builds `[ep × ep_fsdp]` submesh; accessed via `ParallelState.extra_parallel_mesh("ep")`, `ep_group`, `ep_rank`.
+   - Device mesh: `init_parallel_state_from_config()` builds `[ep × ep_fsdp]` submesh; accessed via `ParallelState.extra_parallel_mesh("ep")`, `ep_group`, `ep_rank`.
    - In FSDP2: expert modules get `fully_shard()` on the `ep_fsdp` submesh with `Shard(1)` placement so hidden-dim sharding composes with EP's dim-0 sharding.
 
 ## Data Pipeline

--- a/docs/design/local_parallel_state.md
+++ b/docs/design/local_parallel_state.md
@@ -10,13 +10,13 @@ use different sequence-parallel groups while preserving the simple
 
 | API | Purpose |
 |-----|---------|
-| `init_parallel_state(..., name="base")` | Build a topology, register it under `name`, and establish the first state as the ambient default. |
+| `init_parallel_state_from_config(accelerator, name)` | Build the topology an `AcceleratorConfig` describes, register it under `name`, and establish the first state as the ambient default. |
 | `get_parallel_state_by_name(name)` | Retrieve a registered state without changing the ambient state. |
 | `use_parallel_state(name_or_state)` | Temporarily make a registered name or `ParallelState` object ambient, then restore the previous state on exit. |
 | `get_parallel_state()` | Return the current ambient state; before initialization it returns a single-process state and logs a warning. |
 | `clear_parallel_state()` | Clear the ambient state, topology cache, and named registry after distributed teardown. |
 
-`init_parallel_state` maintains two independent mappings:
+Registration maintains two independent mappings:
 
 - The **named registry** maps logical module names to states. Registering an
   existing name logs a warning and returns the existing state.
@@ -24,21 +24,24 @@ use different sequence-parallel groups while preserving the simple
   matches. Different names can therefore refer to the same state without
   creating duplicate process groups.
 
+Tests that need a topology no job config can express (a CPU mesh, or a rank
+layout unrelated to `WORLD_SIZE`) call `_init_parallel_state` directly.
+
 ## Basic usage
 
+Every parallelism knob already lives on `AcceleratorConfig`, so the topology is
+described there rather than restated at the call site:
+
 ```python
+from veomni.arguments import AcceleratorConfig
 from veomni.distributed.parallel_state import (
     get_parallel_state_by_name,
-    init_parallel_state,
+    init_parallel_state_from_config,
     use_parallel_state,
 )
 
-init_parallel_state(
-    dp_size=4,
-    dp_shard_size=4,
-    ulysses_size=2,
-    name="base",
-)
+accelerator = AcceleratorConfig(dp_shard_size=4, ulysses_size=2)  # needs WORLD_SIZE=8
+init_parallel_state_from_config(accelerator, name="base")
 
 base_state = get_parallel_state_by_name("base")
 
@@ -56,8 +59,8 @@ Register each logical module on every rank, in the same order, before its first
 scoped operation. For an eight-rank process group:
 
 ```python
-init_parallel_state(dp_size=4, dp_shard_size=4, ulysses_size=2, name="thinker")
-init_parallel_state(dp_size=8, dp_shard_size=8, ulysses_size=1, name="talker")
+init_parallel_state_from_config(thinker_args.accelerator, name="thinker")
+init_parallel_state_from_config(talker_args.accelerator, name="talker")
 
 with use_parallel_state("thinker"):
     thinker_output = thinker(batch)
@@ -66,15 +69,19 @@ with use_parallel_state("talker"):
     talker_output = talker(thinker_output)
 ```
 
+Each module carries its own `AcceleratorConfig`, which is what lets `thinker`
+run at `ulysses_size=2` while `talker` runs without sequence parallelism.
+
 Sequence-parallel communication helpers resolve their process groups from the
-current ambient state. A sequence-parallel state must therefore be created by
-`init_parallel_state`; constructing a meshless `ParallelState` with SP enabled
-raises an error.
+current ambient state. A sequence-parallel state must therefore be built with a
+device mesh; constructing a meshless `ParallelState` with SP enabled raises an
+error.
 
 ## Trainer lifecycle
 
 Current built-in trainers register the main topology as `"base"` during
-`BaseTrainer._setup()`. Model, dataloader, optimizer, and scheduler construction
+`BaseTrainer._setup()`, which calls `init_parallel_state_from_config` before
+any model is built. Model, dataloader, optimizer, and scheduler construction
 run inside one `use_parallel_state("base")` build scope. At run time, only
 operations that depend on ambient groups are scoped: model forward,
 post-forward loss handling, backward, and gradient clipping. Callbacks retain

--- a/docs/usage/basic_modules.md
+++ b/docs/usage/basic_modules.md
@@ -65,9 +65,10 @@ class Arguments(VeOmniArguments):
 
 ## Parallel State
 VeOmni uses PyTorch DeviceMesh to manage multidimensional parallel topologies.
-`init_parallel_state` registers a state under a logical name, while
-`use_parallel_state` scopes operations that need to resolve the current
-process groups. See [Local Parallel State Registry and Scoping](../design/local_parallel_state.md)
+`init_parallel_state_from_config` registers a state under a logical name from
+an `AcceleratorConfig`, while `use_parallel_state` scopes operations that need
+to resolve the current process groups. See
+[Local Parallel State Registry and Scoping](../design/local_parallel_state.md)
 for the registry, topology-cache, and teardown rules.
 
 More details about torch device mesh, you can refer to the [Getting Started with DeviceMesh](https://pytorch.org/tutorials/recipes/distributed_device_mesh.html).
@@ -78,25 +79,11 @@ More details about torch device mesh, you can refer to the [Getting Started with
 from veomni.distributed.parallel_state import (
     get_parallel_state,
     get_parallel_state_by_name,
-    init_parallel_state,
+    init_parallel_state_from_config,
     use_parallel_state,
 )
 
-init_parallel_state(
-    dp_size=args.model.accelerator.dp_size, # data parallel size
-    dp_replicate_size=args.model.accelerator.dp_replicate_size, # data parallel replicate size
-    dp_shard_size=args.model.accelerator.dp_shard_size, # data parallel shard degree
-    tp_size=args.model.accelerator.tp_size, # tensor parallel size
-    pp_size=args.model.accelerator.pp_size, # pipeline parallel size, not support now
-    cp_size=args.model.accelerator.cp_size, # context parallel size, not support now
-    ulysses_size=args.model.accelerator.ulysses_size, # ulysses parallel size
-    extra_parallel_sizes=args.model.accelerator.extra_parallel_sizes, # including expert parallel size
-    extra_parallel_placement_innermost=args.model.accelerator.extra_parallel_placement_innermost,
-    extra_parallel_names=args.model.accelerator.extra_parallel_names,
-    dp_mode=args.model.accelerator.fsdp_config.fsdp_mode, # data parallel mode, can be "ddp" or "fsdp2"
-    async_enabled=args.model.accelerator.enable_async, # async ulysses
-    name="base",
-)
+init_parallel_state_from_config(args.model.accelerator, name="base")
 
 parallel_state = get_parallel_state()
 assert parallel_state is get_parallel_state_by_name("base")

--- a/tests/checkpoints/test_dcp_checkpointer.py
+++ b/tests/checkpoints/test_dcp_checkpointer.py
@@ -21,7 +21,7 @@ import torch.nn as nn
 from torch.distributed.fsdp import fully_shard
 
 from veomni.distributed import torch_parallelize
-from veomni.distributed.parallel_state import get_parallel_state, init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state, get_parallel_state
 from veomni.distributed.torch_parallelize import (
     build_parallelize_model,
     parallelize_model_ddp,
@@ -48,7 +48,7 @@ def _fsdp2_multi_optimizer_worker(rank: int, world_size: int, tmp_path: Path):
     dist.init_process_group(backend, rank=rank, world_size=world_size)
 
     try:
-        init_parallel_state(dp_size=world_size, dp_mode="fsdp2")
+        _init_parallel_state(dp_size=world_size, dp_mode="fsdp2")
         mesh = get_parallel_state().dp_shard_mesh
 
         def build_model_and_optimizer():

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 from datasets import Dataset as HuggingFaceDataset
 from torch.utils.data import Dataset, IterableDataset
 
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state
 from veomni.trainer.callbacks import CheckpointerCallback, TrainerState
 from veomni.utils import helper
 from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
@@ -46,7 +46,7 @@ def setup_test_distributed(args):
             rank=int(os.environ["RANK"]),
         )
 
-    parallel_state = init_parallel_state(
+    parallel_state = _init_parallel_state(
         dp_size=args.model.accelerator.dp_size,
         dp_replicate_size=args.model.accelerator.dp_replicate_size,
         dp_shard_size=args.model.accelerator.dp_shard_size,

--- a/tests/distributed/test_async_offload_unit.py
+++ b/tests/distributed/test_async_offload_unit.py
@@ -509,11 +509,11 @@ def _run_async_offload_base_trainer_fsdp2_gc():
         OptimizerConfig,
         TorchCompileConfig,
     )
-    from veomni.distributed.parallel_state import init_parallel_state, use_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state, use_parallel_state
     from veomni.trainer.base import BaseTrainer
 
     world_size = dist.get_world_size()
-    init_parallel_state(
+    _init_parallel_state(
         dp_size=world_size,
         dp_shard_size=world_size,
         dp_mode="fsdp2",

--- a/tests/distributed/test_dummy_forward.py
+++ b/tests/distributed/test_dummy_forward.py
@@ -135,7 +135,7 @@ def _omni_batch(*, rank, device, dtype, patch_size, is_qwen3_omni=False):
 def _asymmetric_forward_worker(model_type, config_path, batch_fn):
     """Rank 0 gets multimodal data, other ranks get text-only. Verifies no NCCL hang."""
     from veomni import _apply_patches
-    from veomni.distributed.parallel_state import init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state
     from veomni.distributed.torch_parallelize import build_parallelize_model
     from veomni.models.auto import build_foundation_model
     from veomni.utils.device import get_device_type
@@ -148,7 +148,7 @@ def _asymmetric_forward_worker(model_type, config_path, batch_fn):
     os.environ["NCCL_TIMEOUT"] = "120"
 
     world_size = dist.get_world_size()
-    init_parallel_state(dp_size=world_size, dp_shard_size=world_size, dp_mode="fsdp2")
+    _init_parallel_state(dp_size=world_size, dp_shard_size=world_size, dp_mode="fsdp2")
 
     rank = dist.get_rank()
     device = torch.device(f"{get_device_type()}:{rank}")

--- a/tests/lora/test_moe_lora_trainer.py
+++ b/tests/lora/test_moe_lora_trainer.py
@@ -223,7 +223,7 @@ class _LogDictSaveCallback(Callback):
         Using the trainer's parallel state instead of a hand-rolled
         ``dp_group`` lookup so this stays correct under FSDP1/FSDP2 +
         SP combinations (``dp_group`` already excludes SP/EP/PP per
-        ``init_parallel_state``).
+        ``_init_parallel_state``).
         """
         if not (dist.is_available() and dist.is_initialized()):
             return value

--- a/tests/optim/test_muon_fsdp2_parity.py
+++ b/tests/optim/test_muon_fsdp2_parity.py
@@ -29,7 +29,7 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import fully_shard
 from torch.distributed.tensor import DTensor, Replicate, Shard
 
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state
 from veomni.optim.muon import DistributedMuon
 from veomni.utils.device import (
     get_device_type,
@@ -411,7 +411,7 @@ def _run_qwen3_moe(use_zero_comm: bool) -> None:
     rank = dist.get_rank()
     assert world_size == 4, f"this test expects exactly 4 ranks, got {world_size}"
 
-    init_parallel_state(
+    _init_parallel_state(
         dp_size=world_size,
         dp_shard_size=world_size,
         extra_parallel_sizes=(EP_SIZE,),

--- a/tests/optim/test_muon_fsdp2_smoke.py
+++ b/tests/optim/test_muon_fsdp2_smoke.py
@@ -26,7 +26,7 @@ import torch.distributed as dist
 from torch.distributed.tensor import DTensor, Shard
 
 from veomni.arguments.arguments_types import MixedPrecisionConfig
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.optim import build_optimizer
 from veomni.optim.optimizer import MultiOptimizer
@@ -51,7 +51,7 @@ def _distributed_smoke(use_zero_comm: bool) -> None:
     rank = dist.get_rank()
     assert world_size == 4, f"this test expects exactly 4 ranks, got {world_size}"
 
-    init_parallel_state(
+    _init_parallel_state(
         dp_size=world_size,
         dp_shard_size=world_size,
         extra_parallel_sizes=(EP_SIZE,),

--- a/tests/parallel/context_parallel/test_deepseek_v4_cp.py
+++ b/tests/parallel/context_parallel/test_deepseek_v4_cp.py
@@ -194,10 +194,10 @@ def _init_cp_attention(
 
     from transformers import AutoConfig
 
-    from veomni.distributed.parallel_state import init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state
     from veomni.models.transformers.deepseek_v4.generated import patched_modeling_deepseek_v4_gpu as dsv4
 
-    init_parallel_state(dp_size=1, cp_size=world_size, ulysses_size=1, device_type=device_type)
+    _init_parallel_state(dp_size=1, cp_size=world_size, ulysses_size=1, device_type=device_type)
 
     config = AutoConfig.from_pretrained("tests/toy_config/deepseek_v4_toy")
     torch.manual_seed(0)
@@ -445,7 +445,7 @@ def _run_compressor_cp(
     row all-gather, and running it is the only way to drive them. Its selection
     is then observable through ``block_bias``, which is scattered from it.
     """
-    from veomni.distributed.parallel_state import clear_parallel_state, init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state, clear_parallel_state
 
     device_type = get_device_type()
     get_torch_device().set_device(rank)
@@ -462,7 +462,7 @@ def _run_compressor_cp(
     from veomni.models.transformers.deepseek_v4.generated import patched_modeling_deepseek_v4_gpu as dsv4
     from veomni.models.transformers.deepseek_v4.packed_utils import build_packed_compression_metadata
 
-    init_parallel_state(dp_size=1, cp_size=world_size, ulysses_size=1, device_type=device_type)
+    _init_parallel_state(dp_size=1, cp_size=world_size, ulysses_size=1, device_type=device_type)
 
     config = AutoConfig.from_pretrained("tests/toy_config/deepseek_v4_toy")
     torch.manual_seed(0)
@@ -591,7 +591,7 @@ def _run_indexer_cp(rank: int, world_size: int, init_file: str, seq_len: int) ->
     local. The packed layout is what forces it to shard the compression metadata
     it is handed, which is global.
     """
-    from veomni.distributed.parallel_state import clear_parallel_state, init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state, clear_parallel_state
 
     device_type = get_device_type()
     get_torch_device().set_device(rank)
@@ -608,7 +608,7 @@ def _run_indexer_cp(rank: int, world_size: int, init_file: str, seq_len: int) ->
     from veomni.models.transformers.deepseek_v4.generated import patched_modeling_deepseek_v4_gpu as dsv4
     from veomni.models.transformers.deepseek_v4.packed_utils import build_packed_compression_metadata
 
-    init_parallel_state(dp_size=1, cp_size=world_size, ulysses_size=1, device_type=device_type)
+    _init_parallel_state(dp_size=1, cp_size=world_size, ulysses_size=1, device_type=device_type)
     # The TileLang kernel is the production scorer and the only one with a query
     # partitioning of its own; the eager scorer is covered by the CSA layer test.
     dsv4.veomni_dsa_indexer_implementation.bind(SimpleNamespace(dsa_indexer_implementation="tilelang"))
@@ -1180,7 +1180,7 @@ def _run_model_cp_packed(rank: int, world_size: int, init_file: str, dtype: torc
     ``test_deepseek_v4_cp_collator_shards_contiguously_by_cp_rank`` pins that the
     collator really produces these three things.
     """
-    from veomni.distributed.parallel_state import clear_parallel_state, init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state, clear_parallel_state
 
     device_type = get_device_type()
     get_torch_device().set_device(rank)
@@ -1196,7 +1196,7 @@ def _run_model_cp_packed(rank: int, world_size: int, init_file: str, dtype: torc
 
     from veomni.models.transformers.deepseek_v4.generated import patched_modeling_deepseek_v4_gpu as dsv4
 
-    init_parallel_state(dp_size=1, cp_size=world_size, ulysses_size=1, device_type=device_type)
+    _init_parallel_state(dp_size=1, cp_size=world_size, ulysses_size=1, device_type=device_type)
     if tilelang:
         # The model forward withholds the dense mask only for bf16 CUDA tensors
         # with the TileLang attention selected, so this is the arm that reaches
@@ -1291,7 +1291,7 @@ def _run_cp_collator_contract(rank: int, world_size: int, init_file: str) -> Non
     CP-only mesh flattens ``sp`` onto ``cp``.
     """
     from veomni.data.data_collator import SequenceParallelCollator
-    from veomni.distributed.parallel_state import clear_parallel_state, get_parallel_state, init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state, clear_parallel_state, get_parallel_state
 
     device_type = get_device_type()
     get_torch_device().set_device(rank)
@@ -1302,7 +1302,7 @@ def _run_cp_collator_contract(rank: int, world_size: int, init_file: str) -> Non
         rank=rank,
         world_size=world_size,
     )
-    init_parallel_state(dp_size=1, cp_size=world_size, ulysses_size=1, device_type=device_type)
+    _init_parallel_state(dp_size=1, cp_size=world_size, ulysses_size=1, device_type=device_type)
 
     state = get_parallel_state()
     assert (state.sp_size, state.sp_rank) == (state.cp_size, state.cp_rank), (

--- a/tests/parallel/encoder_data_balance/test_balance_reverse.py
+++ b/tests/parallel/encoder_data_balance/test_balance_reverse.py
@@ -6,7 +6,7 @@ import sys
 import torch
 import torch.distributed as dist
 
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state
 from veomni.utils.data_balance.data_balance import Qwen3VLEncoderDataBalance
 from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
 
@@ -59,7 +59,7 @@ def check_recover_precision(pixel_values, image_grid_thw):
 def main():
     get_torch_device().set_device(f"{get_device_type()}:{os.getenv('RANK')}")
     dist.init_process_group(backend=get_dist_comm_backend())
-    init_parallel_state(
+    _init_parallel_state(
         dp_size=int(os.getenv("WORLD_SIZE")),
         dp_mode="fsdp2",
     )

--- a/tests/parallel/test_ddp_sp_grad_sync.py
+++ b/tests/parallel/test_ddp_sp_grad_sync.py
@@ -80,7 +80,7 @@ def _token_loss(outputs: torch.Tensor) -> torch.Tensor:
 
 def main() -> None:
     from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
-    from veomni.distributed.parallel_state import clear_parallel_state, get_parallel_state, init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state, clear_parallel_state, get_parallel_state
     from veomni.distributed.sequence_parallel.loss import reduce_sequence_parallel_loss
     from veomni.distributed.torch_parallelize import build_parallelize_model
     from veomni.models.module_utils import init_empty_weights
@@ -102,7 +102,7 @@ def main() -> None:
     assert world_size % sp_size == 0, f"world_size {world_size} must be divisible by ulysses_size {sp_size}"
     dp_size = world_size // sp_size
 
-    init_parallel_state(dp_size=dp_size, ulysses_size=sp_size, dp_mode="ddp")
+    _init_parallel_state(dp_size=dp_size, ulysses_size=sp_size, dp_mode="ddp")
     parallel_state = get_parallel_state()
     assert parallel_state.sp_size == sp_size
     assert dist.get_world_size(parallel_state.dp_group) == dp_size

--- a/tests/parallel/test_parallel_state_registry.py
+++ b/tests/parallel/test_parallel_state_registry.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""``init_parallel_state`` registry behaviour, including ``name=None``.
+"""``_init_parallel_state`` registry behaviour, including ``name=None``.
 
 Single-rank gloo, so this runs anywhere. The registry, the topology cache and
 the ambient state are process globals, hence the teardown.
@@ -22,10 +22,10 @@ import pytest
 import torch.distributed as dist
 
 from veomni.distributed.parallel_state import (
+    _init_parallel_state,
     clear_parallel_state,
     get_parallel_state,
     get_parallel_state_by_name,
-    init_parallel_state,
 )
 
 
@@ -43,7 +43,7 @@ def single_rank_group(tmp_path):
 
 
 def test_name_none_claims_no_registry_key(single_rank_group):
-    state = init_parallel_state(dp_size=1, device_type="cpu", name=None)
+    state = _init_parallel_state(dp_size=1, device_type="cpu", name=None)
 
     with pytest.raises(ValueError, match="is not registered"):
         get_parallel_state_by_name("base")
@@ -53,17 +53,17 @@ def test_name_none_claims_no_registry_key(single_rank_group):
 
 
 def test_named_init_still_registers(single_rank_group):
-    state = init_parallel_state(dp_size=1, device_type="cpu", name="vision_tower")
+    state = _init_parallel_state(dp_size=1, device_type="cpu", name="vision_tower")
 
     assert get_parallel_state_by_name("vision_tower") is state
 
 
 def test_a_later_named_init_adopts_the_cached_anonymous_state(single_rank_group):
-    anonymous = init_parallel_state(dp_size=1, device_type="cpu", name=None)
+    anonymous = _init_parallel_state(dp_size=1, device_type="cpu", name=None)
 
     # Same topology, so the cache hits: name=None declines a key for itself, it
     # does not keep the state out of the registry forever.
-    named = init_parallel_state(dp_size=1, device_type="cpu", name="base")
+    named = _init_parallel_state(dp_size=1, device_type="cpu", name="base")
 
     assert named is anonymous
     assert get_parallel_state_by_name("base") is anonymous

--- a/tests/parallel/ulysses/test_deepseek_v4_ulysses.py
+++ b/tests/parallel/ulysses/test_deepseek_v4_ulysses.py
@@ -68,10 +68,10 @@ def _run_deepseek_v4_attention_sp_fw_bw(
 
     from transformers import AutoConfig
 
-    from veomni.distributed.parallel_state import clear_parallel_state, init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state, clear_parallel_state
     from veomni.models.transformers.deepseek_v4.generated import patched_modeling_deepseek_v4_gpu as dsv4
 
-    init_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
+    _init_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
 
     config = AutoConfig.from_pretrained("tests/toy_config/deepseek_v4_toy")
     torch.manual_seed(0)
@@ -209,11 +209,11 @@ def _run_deepseek_v4_indexer_sp_equivalence(rank: int, world_size: int, init_fil
 
     from transformers import AutoConfig
 
-    from veomni.distributed.parallel_state import clear_parallel_state, init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state, clear_parallel_state
     from veomni.models.transformers.deepseek_v4.generated import patched_modeling_deepseek_v4_gpu as dsv4
     from veomni.models.transformers.deepseek_v4.packed_utils import build_packed_compression_metadata
 
-    init_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
+    _init_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
     dsv4.veomni_dsa_indexer_implementation.bind(SimpleNamespace(dsa_indexer_implementation="tilelang"))
 
     config = AutoConfig.from_pretrained("tests/toy_config/deepseek_v4_toy")

--- a/tests/parallel/ulysses/test_qwen3_5_gated_deltanet_ulysses.py
+++ b/tests/parallel/ulysses/test_qwen3_5_gated_deltanet_ulysses.py
@@ -216,11 +216,11 @@ def _run_gated_deltanet_sp_fw_bw(rank: int, world_size: int, init_file: str, bsz
     import importlib
 
     from veomni.arguments.arguments_types import OpsImplementationConfig
-    from veomni.distributed.parallel_state import init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state
     from veomni.models.auto import _bind_veomni_ops
     from veomni.models.transformers.qwen3_5.generated.patched_modeling_qwen3_5_gpu import Qwen3_5GatedDeltaNet
 
-    init_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
+    _init_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
 
     # The module-level ``_bind_qwen3_5_op_slots`` fixture only binds OpSlots
     # in the parent test process; ``mp.spawn(start_method="spawn")`` here
@@ -348,11 +348,11 @@ def _run_gated_deltanet_sp_determinism(rank: int, world_size: int, init_file: st
     import importlib
 
     from veomni.arguments.arguments_types import OpsImplementationConfig
-    from veomni.distributed.parallel_state import init_parallel_state
+    from veomni.distributed.parallel_state import _init_parallel_state
     from veomni.models.auto import _bind_veomni_ops
     from veomni.models.transformers.qwen3_5.generated.patched_modeling_qwen3_5_gpu import Qwen3_5GatedDeltaNet
 
-    init_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
+    _init_parallel_state(dp_size=1, ulysses_size=world_size, device_type=device_type)
 
     # The module-level ``_bind_qwen3_5_op_slots`` fixture only binds OpSlots
     # in the parent test process; ``mp.spawn(start_method="spawn")`` here

--- a/tests/parallel/ulysses/test_wan_self_attn_ulysses.py
+++ b/tests/parallel/ulysses/test_wan_self_attn_ulysses.py
@@ -32,7 +32,7 @@ if not c10d.is_available() or not c10d.is_backend_available(get_dist_comm_backen
 
 from torch.testing._internal.common_utils import run_tests
 
-from veomni.distributed.parallel_state import clear_parallel_state, get_parallel_state, init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state, clear_parallel_state, get_parallel_state
 from veomni.models.transformers.wan.modeling_wan import SelfAttention, precompute_freqs_cis
 
 from .utils import SequenceParallelTest
@@ -47,7 +47,7 @@ class WanSelfAttentionUlyssesTest(SequenceParallelTest):
     def test_sync_path_matches_non_sp_reference(self):
         group = self._get_process_group()
         try:
-            init_parallel_state(
+            _init_parallel_state(
                 dp_size=1,
                 ulysses_size=self.world_size,
                 device_type=get_device_type(),

--- a/tests/utils/test_extra_parallel_clip_grad_norm.py
+++ b/tests/utils/test_extra_parallel_clip_grad_norm.py
@@ -16,7 +16,7 @@ from torch.distributed._tensor import DTensor, Shard
 from veomni.arguments import ModelArguments, TrainingArguments, parse_args
 from veomni.distributed.clip_grad_norm import veomni_clip_grad_norm
 from veomni.distributed.parallel_plan import ParallelPlan
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.optim import build_optimizer
 from veomni.utils import helper
@@ -127,7 +127,7 @@ def main():
     args = parse_args(Argument)
 
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
-    init_parallel_state(
+    _init_parallel_state(
         dp_size=args.model.accelerator.dp_size,
         dp_replicate_size=args.model.accelerator.dp_replicate_size,
         dp_shard_size=args.model.accelerator.dp_shard_size,

--- a/tests/utils/test_helper.py
+++ b/tests/utils/test_helper.py
@@ -10,7 +10,7 @@ import torch.distributed as dist
 from transformers import Qwen2Config
 
 from veomni.arguments import DataArguments, ModelArguments, TrainingArguments, VeOmniArguments, parse_args
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state
 from veomni.lora import VeOmniLoraConfig
 from veomni.utils import helper
 from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
@@ -102,7 +102,7 @@ def run_environ_meter(args):
     dist.init_process_group(backend=get_dist_comm_backend(), world_size=world_size, rank=rank)
 
     config = Qwen2Config()
-    init_parallel_state(
+    _init_parallel_state(
         dp_size=args.model.accelerator.dp_size,
         dp_replicate_size=args.model.accelerator.dp_replicate_size,
         dp_shard_size=args.model.accelerator.dp_shard_size,

--- a/tests/utils/test_model_loader.py
+++ b/tests/utils/test_model_loader.py
@@ -7,7 +7,7 @@ import pytest
 import torch.distributed as dist
 
 from veomni.arguments import DataArguments, ModelArguments, TrainingArguments, VeOmniArguments, parse_args
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state
 from veomni.models import build_foundation_model
 from veomni.utils import helper
 from veomni.utils.device import get_device_type, get_dist_comm_backend, get_torch_device
@@ -37,7 +37,7 @@ def run_environ_meter(args: Arguments):
     get_torch_device().set_device(f"{get_device_type()}:{args.train.local_rank}")
     dist.init_process_group(backend=get_dist_comm_backend(), world_size=world_size, rank=rank)
 
-    init_parallel_state(
+    _init_parallel_state(
         dp_size=args.model.accelerator.dp_size,
         dp_replicate_size=args.model.accelerator.dp_replicate_size,
         dp_shard_size=args.model.accelerator.dp_shard_size,

--- a/tests/utils/test_moe_ep_sharded_load_matrix.py
+++ b/tests/utils/test_moe_ep_sharded_load_matrix.py
@@ -56,7 +56,7 @@ from safetensors.torch import save_file
 from torch.distributed.tensor import DTensor, Shard
 
 from veomni.distributed.parallel_plan import ParallelPlan
-from veomni.distributed.parallel_state import get_parallel_state, init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state, get_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models.checkpoint_tensor_loading import ConvertedCheckpointTensor
 from veomni.utils import helper
@@ -225,7 +225,7 @@ def run_worker() -> None:
 
     dist.init_process_group(backend=get_dist_comm_backend())
     # world == ep: experts sharded across all ranks, dense FSDP-sharded.
-    init_parallel_state(dp_size=world, extra_parallel_sizes=(world,), extra_parallel_names=("ep",), dp_mode="fsdp2")
+    _init_parallel_state(dp_size=world, extra_parallel_sizes=(world,), extra_parallel_names=("ep",), dp_mode="fsdp2")
 
     tmp = Path(os.environ["MOE_MATRIX_TMP"])
     ref = _reference_state()

--- a/tests/utils/test_rank0_load_and_broadcast_weights.py
+++ b/tests/utils/test_rank0_load_and_broadcast_weights.py
@@ -12,7 +12,7 @@ from torch import nn
 
 from veomni.arguments import DataArguments, ModelArguments, TrainingArguments, parse_args
 from veomni.distributed.parallel_plan import ParallelPlan
-from veomni.distributed.parallel_state import init_parallel_state
+from veomni.distributed.parallel_state import _init_parallel_state
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models.module_utils import load_model_weights, rank0_load_and_broadcast_weights
 from veomni.utils import helper
@@ -218,7 +218,7 @@ def run_rank0_broadcast_test(args: Arguments) -> None:
     get_torch_device().set_device(args.train.local_rank)
     dist.init_process_group(backend=args.test.backend)
 
-    init_parallel_state(
+    _init_parallel_state(
         dp_size=args.model.accelerator.dp_size,
         dp_replicate_size=args.model.accelerator.dp_replicate_size,
         dp_shard_size=args.model.accelerator.dp_shard_size,
@@ -453,7 +453,7 @@ def run_load_weights_test(args: Arguments) -> None:
     get_torch_device().set_device(args.train.local_rank)
     dist.init_process_group(backend=args.test.backend)
 
-    init_parallel_state(
+    _init_parallel_state(
         dp_size=args.model.accelerator.dp_size,
         dp_replicate_size=args.model.accelerator.dp_replicate_size,
         dp_shard_size=args.model.accelerator.dp_shard_size,

--- a/veomni/distributed/parallel_state.py
+++ b/veomni/distributed/parallel_state.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
     from torch.distributed.device_mesh import DeviceMesh
 
+    from ..arguments import AcceleratorConfig
+
 
 logger = logging.get_logger(__name__)
 
@@ -112,7 +114,8 @@ class ParallelState:
         if self.sp_enabled and self.device_mesh is None:
             raise ValueError(
                 "A sequence-parallel ParallelState must be built with a device mesh "
-                "(use init_parallel_state); meshless sequence-parallel init is no longer supported."
+                "(use init_parallel_state_from_config); meshless sequence-parallel init "
+                "is no longer supported."
             )
 
     @property
@@ -436,7 +439,7 @@ def clear_parallel_state() -> None:
     Drop the ambient state, topology cache, and named registry.
 
     Call after ``destroy_process_group()`` (or in test teardown) so a later
-    ``init_parallel_state`` with the same topology cannot reuse DeviceMesh /
+    ``_init_parallel_state`` with the same topology cannot reuse DeviceMesh /
     process groups from a destroyed distributed session.
     """
     global _PARALLEL_STATE
@@ -453,7 +456,7 @@ def get_parallel_state_by_name(name: str) -> "ParallelState":
     return _PARALLEL_STATE_REGISTRY[name]
 
 
-def init_parallel_state(
+def _init_parallel_state(
     dp_size: int = 1,
     dp_replicate_size: int = 1,
     dp_shard_size: int = 1,
@@ -473,6 +476,13 @@ def init_parallel_state(
     """
     Initialize a parallel state, register it under ``name``, and set it as the
     global state when none is current yet.
+
+    Private: every parallelism knob here also lives on
+    :class:`~veomni.arguments.AcceleratorConfig`, so a second mapping restated
+    at a call site is a second place to keep in sync. Production code goes
+    through :func:`init_parallel_state_from_config`. Tests call this
+    directly to build a topology no job config can express — a CPU mesh, or a
+    rank layout unrelated to ``WORLD_SIZE``.
 
     If ``name`` is already registered, log a warning and return the existing
     state without building, caching, or overwriting anything.
@@ -675,6 +685,29 @@ def init_parallel_state(
     if name is not None:
         _PARALLEL_STATE_REGISTRY[name] = parallel_state
     return parallel_state
+
+
+def init_parallel_state_from_config(accelerator: "AcceleratorConfig", name: Optional[str]) -> "ParallelState":
+    """Build the mesh an :class:`AcceleratorConfig` describes and register it as ``name``.
+
+    Every parallelism knob already lives on the config, so a caller that has one
+    should not be restating the mapping.
+    """
+    return _init_parallel_state(
+        dp_size=accelerator.dp_size,
+        dp_replicate_size=accelerator.dp_replicate_size,
+        dp_shard_size=accelerator.dp_shard_size,
+        tp_size=accelerator.tp_size,
+        pp_size=accelerator.pp_size,
+        cp_size=accelerator.cp_size,
+        ulysses_size=accelerator.ulysses_size,
+        extra_parallel_sizes=accelerator.extra_parallel_sizes,
+        extra_parallel_placement_innermost=accelerator.extra_parallel_placement_innermost,
+        extra_parallel_names=accelerator.extra_parallel_names,
+        dp_mode=accelerator.fsdp_config.fsdp_mode,
+        async_enabled=accelerator.enable_async,
+        name=name,
+    )
 
 
 def set_parallel_state(parallel_state: "ParallelState") -> Optional["ParallelState"]:

--- a/veomni/distributed/sequence_parallel/comm.py
+++ b/veomni/distributed/sequence_parallel/comm.py
@@ -40,7 +40,7 @@ def _current_state():
     # UNINITIALIZED process resolves to ``None`` — i.e. "no groups" — instead of
     # constructing a default ``ParallelState`` that validates against the
     # distributed world size and raises. Production always initializes via
-    # ``init_parallel_state`` before any SP op runs; this ``None`` path only
+    # ``_init_parallel_state`` before any SP op runs; this ``None`` path only
     # covers pre-init / unit-test code (which drives SP via the override seam).
     from .. import parallel_state
 

--- a/veomni/trainer/base.py
+++ b/veomni/trainer/base.py
@@ -59,7 +59,7 @@ from ..data.data_transform import build_data_transform
 from ..distributed.async_offload import apply_async_activation_offload, reset_async_activation_offload
 from ..distributed.clip_grad_norm import veomni_clip_grad_norm
 from ..distributed.offloading import build_activation_offloading_context
-from ..distributed.parallel_state import clear_parallel_state, init_parallel_state, use_parallel_state
+from ..distributed.parallel_state import clear_parallel_state, init_parallel_state_from_config, use_parallel_state
 from ..distributed.torch_compile import CompileConfig, mark_compile_step_begin
 from ..distributed.torch_parallelize import build_parallelize_model
 from ..models import build_foundation_model, build_tokenizer
@@ -382,21 +382,7 @@ class BaseTrainer(Stateful, ABC):
 
     def register_parallel_state(self, name: str = "base"):
         """Register this trainer's ParallelState under ``name`` in the registry."""
-        init_parallel_state(
-            dp_size=self.args.model.accelerator.dp_size,
-            dp_replicate_size=self.args.model.accelerator.dp_replicate_size,
-            dp_shard_size=self.args.model.accelerator.dp_shard_size,
-            tp_size=self.args.model.accelerator.tp_size,
-            pp_size=self.args.model.accelerator.pp_size,
-            cp_size=self.args.model.accelerator.cp_size,
-            ulysses_size=self.args.model.accelerator.ulysses_size,
-            extra_parallel_sizes=self.args.model.accelerator.extra_parallel_sizes,
-            extra_parallel_placement_innermost=self.args.model.accelerator.extra_parallel_placement_innermost,
-            extra_parallel_names=self.args.model.accelerator.extra_parallel_names,
-            dp_mode=self.args.model.accelerator.fsdp_config.fsdp_mode,
-            async_enabled=self.args.model.accelerator.enable_async,
-            name=name,
-        )
+        init_parallel_state_from_config(self.args.model.accelerator, name=name)
 
     def _build_model(self):
         logger.info_rank0("Build model")


### PR DESCRIPTION
### What does this PR do?

Production mesh construction no longer restates every parallelism knob. `init_parallel_state_from_config(accelerator, name)` builds the topology an `AcceleratorConfig` already describes and registers it. The old knob-list entry point is `_init_parallel_state`, for tests that need a mesh no job config can express.

`BaseTrainer` still owns the mesh. `_setup()` / `register_parallel_state("base")` call `from_config(self.args.model.accelerator, name="base")`. This PR does **not** introduce `VeOmniModelRuntime` or DPO dual meshes.

Independent of the checkpoint-manager split. After both land, merge `main` into #1125 so that PR is runtime-only.

### Checklist Before Starting

- Search for relative PRs/issues and link here: split out of #1125; depends on #1090 (`AcceleratorConfig`, already on `main`). Companion: checkpoint-manager branch `szl.checkpoint-manager`.
- PR title follows `[{modules}] {type}: {description}` format (enforced by [check_pr_title.yml](.github/workflows/check_pr_title.yml))
  - **Allowed modules:** `agent`, `ci`, `ckpt`, `config`, `data`, `dist`, `docker`, `docs`, `logging`, `lora`, `misc`, `model`, `omni`, `optim`, `ops`, `parallel`, `perf`, `release`, `task`, `trainer`
  - **Allowed types:** `feat`, `fix`, `refactor`, `chore`, `test`
  - Breaking changes: prepend `[BREAKING]` — e.g. `[BREAKING][parallel, model] feat: dynamic batching`

### Test

Extended the existing CI-enumerated `tests/parallel/test_parallel_state_registry.py` callers (rename `init_parallel_state` → `_init_parallel_state`). Production call sites go through `from_config`. No new CI workflow line.

CPU: registry tests on this branch were already passing at commit time; `make quality` clean.

### API and Usage Example

**Before (breaking):**

```python
from veomni.distributed.parallel_state import init_parallel_state

init_parallel_state(
    dp_size=args.model.accelerator.dp_size,
    dp_shard_size=args.model.accelerator.dp_shard_size,
    ulysses_size=args.model.accelerator.ulysses_size,
    # ... every other knob ...
    name="base",
)
```

**After:**

```python
from veomni.distributed.parallel_state import init_parallel_state_from_config

init_parallel_state_from_config(args.model.accelerator, name="base")
```

Tests that need a topology a job config cannot express:

```python
from veomni.distributed.parallel_state import _init_parallel_state

_init_parallel_state(dp_size=1, cp_size=world_size, device_type=device_type)
```

### Design & Code Changes

- Public: `init_parallel_state_from_config(accelerator, name)` in `veomni/distributed/parallel_state.py`.
- Private: `init_parallel_state` → `_init_parallel_state` (tests / non-config topologies).
- Trainer: `register_parallel_state` is a one-liner over `from_config`; `_setup()` is not renamed.
- Callers under `tests/` mechanically renamed; docs (`local_parallel_state.md`, `basic_modules.md`) and `.agents/knowledge/{architecture,constraints}.md` updated.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/ByteDance-Seed/VeOmni/blob/main/CONTRIBUTING.md)
- Applied pre-commit checks
- Added/updated documentation
- If `tasks/` training scripts were moved or renamed: updated `docs/` examples and verified `python3 scripts/ci/check_doc_task_paths.py` passes (also enforced by the **Check doc task paths** CI workflow)
- Tests: extended an existing CI-enumerated test, **or** added a new test and wired it into `gpu_unit_tests.yml` (and `npu_unit_tests.yml` where applicable), **or** explained in **Test** why none is needed. Note that CI enumerates test files individually — a new file outside `tests/data/` and `tests/ops/` does not run until it is listed. See [.agents/knowledge/testing.md](.agents/knowledge/testing.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration-based parallel-state initialization using accelerator settings.
  * Updated trainer setup and usage examples to use the new configuration-based entry point.

* **Documentation**
  * Updated architecture, distributed-training, design, and usage documentation to reflect the new initialization workflow.

* **Tests**
  * Updated distributed and parallelism tests to use the internal initializer for direct, test-specific topology setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->