### PR TITLE
fix: use base model when building DPO reference

### DIFF
--- a/tests/trainer/test_text_dpo_trainer_reference_model.py
+++ b/tests/trainer/test_text_dpo_trainer_reference_model.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from veomni.trainer import text_dpo_trainer
+
+
+def _args():
+    fsdp_config = SimpleNamespace(
+        reshard_after_forward=False,
+        forward_prefetch=False,
+        offload=False,
+        offload_pin_memory=False,
+        max_load_broadcast_size=None,
+    )
+    accelerator = SimpleNamespace(init_device="cpu", fsdp_config=fsdp_config)
+    model = SimpleNamespace(
+        config_path="config",
+        model_path="weights",
+        accelerator=accelerator,
+        ops_implementation=SimpleNamespace(),
+        model_config={},
+        basic_modules=[],
+        broadcast_model_weights_from_rank0=False,
+    )
+    return SimpleNamespace(model=model, dpo_config=SimpleNamespace(refer_model_precision="float32"))
+
+
+def test_build_reference_model_reads_parallel_plan_from_base_model(monkeypatch):
+    trainer = text_dpo_trainer.TextDPOTrainer.__new__(text_dpo_trainer.TextDPOTrainer)
+    policy = Mock()
+    policy.get_parallel_plan.return_value.cpu_load_param_name = "policy_param"
+    trainer.base = SimpleNamespace(args=_args(), model=policy)
+
+    reference = Mock(_no_split_modules=[])
+    monkeypatch.setattr(text_dpo_trainer, "build_foundation_model", lambda **kwargs: reference)
+    parallelize = Mock(return_value=reference)
+    monkeypatch.setattr(text_dpo_trainer, "build_parallelize_model", parallelize)
+    monkeypatch.setattr(text_dpo_trainer.helper, "print_device_mem_info", lambda *args, **kwargs: None)
+
+    trainer._build_reference_model()
+
+    assert parallelize.call_args.kwargs["cpu_load_param_name"] == "policy_param"

--- a/veomni/trainer/text_dpo_trainer.py
+++ b/veomni/trainer/text_dpo_trainer.py
@@ -208,8 +208,8 @@ class TextDPOTrainer:
         self.reference_model.requires_grad_(False)
 
         cpu_load_param_name = None
-        if hasattr(self.model, "get_parallel_plan"):
-            cpu_load_param_name = getattr(self.model.get_parallel_plan(), "cpu_load_param_name", None)
+        if hasattr(self.base.model, "get_parallel_plan"):
+            cpu_load_param_name = getattr(self.base.model.get_parallel_plan(), "cpu_load_param_name", None)
 
         self.reference_model = build_parallelize_model(
             self.reference_model,


### PR DESCRIPTION
Fixes #1129.

TextDPOTrainer stores the policy model on `self.base.model`, but `_build_reference_model()` dereferenced the nonexistent `self.model` while reading the parallel plan. This caused DPO initialization to fail before reference-model parallelization.

Changes:
- read `get_parallel_plan()` from `self.base.model`;
- add a focused regression test.

Validation:
- pre-fix Modal run: reproduced `AttributeError: TextDPOTrainer has no attribute model`;
- patched Modal run: `1 passed`;
- `git diff --check`: passed.

The Modal test used the repository source mounted into a clean Python 3.12 environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected reference model setup to use the policy model’s parallel configuration.
  - Ensured the appropriate CPU-loaded parameter setting is preserved when building the reference model.

- **Tests**
  - Added coverage verifying that the reference model receives the expected parallelization setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->