### PR TITLE
[omni, model, config, docs] feat: OmniConfig / OmniModel / graph FSM / processing / mixins

### DIFF
--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -146,6 +146,9 @@ jobs:
           uv run --frozen pytest -s -x tests/models/test_model_forward_no_implicit_sync.py
           uv run --frozen pytest -s -x tests/models/test_checkpoint_tensor_converter.py
           uv run --frozen pytest -s -x tests/models/test_return_log_probs_e2e.py
+      - name: Run SeedOmni V2 unit tests
+        run: |
+          uv run --frozen pytest -s -x tests/seed_omni/
       - name: Run Qwen3.5 GatedDeltaNet Ulysses SP tests
         if: steps.changes.outputs.qwen3_5_ulysses == 'true'
         run: |

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -166,6 +166,9 @@ jobs:
           uv run --frozen pytest -v -s -x tests/trainer/test_aux_metrics.py
           uv run --frozen pytest -v -s -x tests/lora/test_vlm_lora.py
           uv run --frozen pytest -v -s -x tests/models/test_checkpoint_tensor_converter.py
+      - name: Run SeedOmni V2 unit tests
+        run: |
+          uv run --frozen pytest -v -s -x tests/seed_omni/
       - name: Run fsdp2/extra_parallel+fsdp2 (e.g. ep+fsdp2, mb+fsdp2, ep+emb+fsdp2) clip grad norm test
         run: |
           uv run --frozen pytest -v -s -x tests/utils/test_extra_parallel_clip_grad_norm.py

--- a/tests/seed_omni/test_conversation.py
+++ b/tests/seed_omni/test_conversation.py
@@ -1,0 +1,96 @@
+"""Unit tests for SeedOmni V2 conversation-list helpers."""
+
+from __future__ import annotations
+
+import torch
+
+from veomni.models.seed_omni.utils.conversation import (
+    ConversationItem,
+    build_conversation,
+    collect_desired_values,
+    get_tail_output_item,
+    iter_desired_items,
+    maybe_merge_outputs,
+    seal_outputs,
+)
+
+
+def test_build_conversation_text_only_yields_user_part():
+    parts = build_conversation(prompt="hello")
+    assert [(p.type, p.role, p.value) for p in parts] == [("text", "user", "hello")]
+
+
+def test_build_conversation_with_images_places_them_first():
+    img_a, img_b = object(), object()
+    parts = build_conversation(prompt="describe", images=[img_a, img_b])
+    assert [(p.type, p.role) for p in parts] == [
+        ("image", "user"),
+        ("image", "user"),
+        ("text", "user"),
+    ]
+    assert parts[0].value is img_a
+    assert parts[1].value is img_b
+    assert parts[2].value == "describe"
+
+
+def test_conversation_item_meta_defaults_empty():
+    p = ConversationItem(type="text", value="", role="user")
+    assert p.meta == {}
+
+
+def test_output_merge_and_seal():
+    a = ConversationItem(type="output", value=torch.zeros(1, 2, 4), meta={"phase": "text"})
+    b = ConversationItem(type="output", value=torch.ones(1, 1, 4), meta={"phase": "text"})
+    parts = [a, b]
+    assert maybe_merge_outputs(parts)
+    assert len(parts) == 1
+    assert parts[0].value.shape == (1, 3, 4)
+    seal_outputs(parts, new_type="text")
+    assert parts[0].type == "text"
+    assert "phase" in parts[0].meta
+
+
+def test_iter_desired_items_allows_multiple_images_per_sample():
+    img_a, img_b, img_c = object(), object(), object()
+    batch = [
+        [
+            ConversationItem(type="image", value=img_a, role="user"),
+            ConversationItem(type="image", value=img_b, role="user"),
+        ],
+        [ConversationItem(type="image", value=img_c, role="user")],
+    ]
+    items = list(iter_desired_items(batch, types=["image"], roles=["user"]))
+    assert [item.value for item in items] == [img_a, img_b, img_c]
+    assert collect_desired_values(batch, types=["image"], roles=["user"]) == [img_a, img_b, img_c]
+
+
+def test_iter_desired_items_filters_meta_keys():
+    batch = [
+        [
+            ConversationItem(type="output", value=torch.zeros(1), role="assistant", meta={}),
+            ConversationItem(
+                type="output",
+                value=torch.ones(1),
+                role="assistant",
+                meta={"flow_velocity_target": torch.zeros(1)},
+            ),
+        ]
+    ]
+
+    items = list(iter_desired_items(batch, types=["output"], meta_keys=["flow_velocity_target"]))
+
+    assert len(items) == 1
+    assert torch.equal(items[0].value, torch.ones(1))
+
+
+def test_get_tail_output_item_returns_latest_matching_output():
+    first = ConversationItem(type="output", value=torch.zeros(1), role="assistant", source="a")
+    middle = ConversationItem(type="text", value="done", role="assistant")
+    second = ConversationItem(type="output", value=torch.ones(1), role="assistant", source="b")
+    third = ConversationItem(type="output", value=torch.full((1,), 2.0), role="assistant", source="a")
+    conversation = [first, middle, second, third]
+
+    assert get_tail_output_item(conversation) is third
+    assert get_tail_output_item(conversation, sources=["a"]) is third
+    assert get_tail_output_item(conversation, sources=["b"]) is second
+    assert get_tail_output_item(conversation, sources=["missing"]) is None

--- a/tests/seed_omni/test_graph.py
+++ b/tests/seed_omni/test_graph.py
@@ -1,0 +1,419 @@
+"""Unit tests for the SeedOmni V2 graph layer (flat edge-list training subset)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import torch.nn as nn
+
+from veomni.models.seed_omni import EdgeDef, NodeDef
+from veomni.models.seed_omni.configuration_omni import OmniConfig
+from veomni.models.seed_omni.graphs.base import END
+from veomni.models.seed_omni.graphs.generation_graph import GenerationGraph
+from veomni.models.seed_omni.graphs.training_graph import TrainingGraph
+from veomni.models.seed_omni.mixins.base_mixin import BaseMixin
+from veomni.models.seed_omni.mixins.inference_module_mixin import InferenceModuleMixin
+from veomni.models.seed_omni.mixins.training_module_mixin import TrainingModuleMixin
+from veomni.models.seed_omni.modeling_omni import OmniModel
+from veomni.models.seed_omni.utils import graph_profiler
+from veomni.models.seed_omni.utils.graph_profiler import GraphProfiler
+
+
+# NOTE: graph-*execution* dispatch (``execute_train_node`` / ``execute_generation_node``)
+# and the FSDP-aware ``OmniModelRuntime`` live under ``seed_omni/accelerator/`` (ModuleRuntime),
+# which is scoped to a later sub-PR (#1064), not this one. Tests here cover only the graph
+# FSM/config/mixin primitives that ship in this PR.
+
+
+# ── NodeDef parsing ───────────────────────────────────────────────────────────
+
+
+def test_from_endpoint_default_method():
+    n = NodeDef.from_endpoint("ar_llm", default_method="forward")
+    assert n.module == "ar_llm" and n.method == "forward"
+    assert n.name == "ar_llm.forward"
+
+
+def test_from_endpoint_dotted_form():
+    n = NodeDef.from_endpoint("vq_decoder.encode", default_method="forward")
+    assert n.module == "vq_decoder" and n.method == "encode"
+    assert n.name == "vq_decoder.encode"
+
+
+def test_from_endpoint_generate_default():
+    n = NodeDef.from_endpoint("ar_llm", default_method="generate")
+    assert n.module == "ar_llm" and n.method == "generate"
+
+
+def test_from_endpoint_rejects_reserved_end():
+    with pytest.raises(ValueError, match=f"'{END}' is the virtual sink"):
+        NodeDef.from_endpoint(END, default_method="forward")
+
+
+def test_from_endpoint_rejects_empty():
+    with pytest.raises(ValueError, match="non-empty 'module"):
+        NodeDef.from_endpoint("   ", default_method="forward")
+
+
+# ── EdgeDef parsing ───────────────────────────────────────────────────────────
+
+
+def test_parse_edge():
+    e = EdgeDef.parse({"from": "vision_encoder", "to": "run_ar"}, default_method="forward")
+    assert e.from_ == "vision_encoder.forward" and e.to == "run_ar.forward"
+    assert e.from_node.module == "vision_encoder" and e.to_node.module == "run_ar"
+    assert not e.is_sink()
+
+
+def test_parse_edge_to_end_is_sink():
+    e = EdgeDef.parse({"from": "tok_decode", "to": "end"}, default_method="forward")
+    assert e.is_sink() and e.to == END and e.to_node is None
+    assert e.from_ == "tok_decode.forward"
+
+
+def test_parse_edge_rejects_from_end():
+    with pytest.raises(ValueError, match="`from: end` is forbidden"):
+        EdgeDef.parse({"from": "end", "to": "run_ar"}, default_method="forward")
+
+
+def test_parse_edge_rejects_node_fields():
+    with pytest.raises(ValueError, match="must not contain node fields"):
+        EdgeDef.parse({"from": "a", "to": "b", "module": "x"}, default_method="forward")
+
+
+def test_parse_edge_rejects_missing_endpoints():
+    with pytest.raises(ValueError, match="must declare both"):
+        EdgeDef.parse({"from": "a"}, default_method="forward")
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _janus_joint_edges() -> list[dict]:
+    """Janus joint training edges: vq_decoder appears under TWO methods.
+
+    Adds an explicit ``to: end`` sink for the leaf so every node is visible to
+    the active subset purely from the edge list.
+    """
+    return [
+        {"from": "vision_encoder", "to": "run_ar"},
+        {"from": "vq_decoder.encode", "to": "run_ar"},
+        {"from": "run_ar", "to": "vq_decoder.gen_loss"},
+        {"from": "vq_decoder.gen_loss", "to": "end"},
+    ]
+
+
+def _understanding_only_edges() -> list[dict]:
+    """Two encoders → ar_llm, simple DAG with end-sink."""
+    return [
+        {"from": "vision_encoder", "to": "run_ar"},
+        {"from": "vq_decoder", "to": "run_ar"},
+        {"from": "run_ar", "to": "end"},
+    ]
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+
+def test_missing_edges_raises():
+    with pytest.raises(ValueError, match="non-empty `training_graph`"):
+        TrainingGraph([])
+
+
+def test_duplicate_edge_raises():
+    with pytest.raises(ValueError, match="Duplicate edge"):
+        TrainingGraph(
+            [
+                {"from": "vision_encoder", "to": "run_ar"},
+                {"from": "vision_encoder", "to": "run_ar"},
+            ]
+        )
+
+
+def test_single_node_with_only_end_edge():
+    """``[{from: ar_llm, to: end}]`` derives exactly one real node."""
+    g = TrainingGraph([{"from": "ar_llm", "to": "end"}])
+    assert g.execution_order == ["ar_llm.forward"]
+    assert g.sources == ["ar_llm.forward"] and g.sinks == ["ar_llm.forward"]
+
+
+# ── Topological order ─────────────────────────────────────────────────────────
+
+
+def test_understanding_only_topological_order():
+    g = TrainingGraph(_understanding_only_edges())
+    assert g.execution_order[-1] == "run_ar.forward"
+    assert set(g.execution_order[:-1]) == {"vision_encoder.forward", "vq_decoder.forward"}
+
+
+def test_janus_joint_topological_order():
+    """vq_decoder appears as TWO nodes; topo must place them on either side of run_ar."""
+    g = TrainingGraph(_janus_joint_edges())
+    order = g.execution_order
+    assert order.index("vq_decoder.gen_loss") > order.index("run_ar.forward")
+    assert order.index("run_ar.forward") > order.index("vq_decoder.encode")
+    assert order.index("run_ar.forward") > order.index("vision_encoder.forward")
+
+
+def test_cycle_in_active_set_raises():
+    with pytest.raises(ValueError, match="Circular dependency"):
+        TrainingGraph(
+            [
+                {"from": "vq_decoder", "to": "ar_llm"},
+                {"from": "ar_llm", "to": "vq_decoder"},
+            ]
+        )
+
+
+# ── Sources / sinks ───────────────────────────────────────────────────────────
+
+
+def test_sources_and_sinks_understanding_only():
+    g = TrainingGraph(_understanding_only_edges())
+    assert set(g.sources) == {"vision_encoder.forward", "vq_decoder.forward"}
+    # run_ar's only outgoing edge targets `end`, so it's a sink.
+    assert g.sinks == ["run_ar.forward"]
+
+
+def test_sources_and_sinks_janus_joint():
+    g = TrainingGraph(_janus_joint_edges())
+    assert set(g.sources) == {"vision_encoder.forward", "vq_decoder.encode"}
+    # vq_decoder.gen_loss is the only sink (its only outgoing edge goes to `end`).
+    assert g.sinks == ["vq_decoder.gen_loss"]
+
+
+# ── module / method accessors ────────────────────────────────────────────────
+
+
+def test_module_and_method_lookup():
+    g = TrainingGraph(_janus_joint_edges())
+    assert g.module_of("vq_decoder.encode") == "vq_decoder"
+    assert g.method_of("vq_decoder.encode") == "encode"
+    assert g.module_of("vq_decoder.gen_loss") == "vq_decoder"
+    assert g.method_of("vq_decoder.gen_loss") == "gen_loss"
+    assert g.method_of("run_ar.forward") == "forward"
+
+
+def test_module_lookup_raises_for_unknown():
+    g = TrainingGraph(_janus_joint_edges())
+    with pytest.raises(KeyError):
+        g.module_of("not_a_node")
+
+
+# ── Execution lifecycle (cursor + step + maybe_transition) ────────────────────
+
+
+class _FakeOmniModule(nn.Module, TrainingModuleMixin, BaseMixin, InferenceModuleMixin):
+    """Minimal stand-in for an OmniModule: callable (→ forward) + pre/post hooks.
+
+    ``__call__`` delegates to ``self.forward`` so the non-``forward`` alias trick
+    (``raw.forward = encode``) works exactly as on a real ``nn.Module``.
+    """
+
+    def __init__(self, name: str):
+        super().__init__()
+        self.name = name
+
+    def pre_forward(self, method, **kwargs):
+        return kwargs
+
+    def post_forward(self, method, **outputs):
+        return outputs
+
+    def __call__(self, **kwargs):
+        return self.forward(**kwargs)
+
+    def forward(self, **kwargs):
+        cl = list(kwargs.get("conversation_list", []))
+        cl.append(f"{self.name}.forward")
+        return {"conversation_list": cl}
+
+    def encode(self, **kwargs):
+        cl = list(kwargs.get("conversation_list", []))
+        cl.append(f"{self.name}.encode")
+        return {"conversation_list": cl}
+
+    def generate(self, **kwargs):
+        cl = list(kwargs.get("conversation_list", []))
+        cl.append(f"{self.name}.generate")
+        return {"conversation_list": cl}
+
+    def generate_via_forward(self, **kwargs):
+        out = self.forward(**kwargs)
+        out["conversation_list"].append(f"{self.name}.generate_via_forward")
+        return out
+
+
+def _fake_modules(g: TrainingGraph) -> dict:
+    return {name: _FakeOmniModule(name) for name in {g.module_of(n) for n in g.execution_order}}
+
+
+def test_cursor_lifecycle():
+    g = TrainingGraph(_understanding_only_edges())
+    assert not g.is_done()
+    assert g.current_node_name == g.execution_order[0]
+    # Walk the cursor manually.
+    seen = []
+    while not g.is_done():
+        seen.append(g.current_node_name)
+        g.maybe_transition()
+    assert seen == g.execution_order
+    assert g.is_done()
+    with pytest.raises(RuntimeError, match="cursor past the last node"):
+        _ = g.current_node_name
+    g.reset()
+    assert not g.is_done() and g.current_node_name == g.execution_order[0]
+
+
+def _minimal_generation_graph(module: str = "run_ar") -> dict:
+    return {
+        "initial": "run",
+        "states": {
+            "run": {
+                "body": [{"from": module, "to": "end"}],
+                "transitions": [{"condition": {"type": "default"}, "next_state": "done"}],
+            }
+        },
+    }
+
+
+def _minimal_generation_graphs(module: str = "run_ar") -> dict:
+    return {"infer_gen": _minimal_generation_graph(module)}
+
+
+def test_graph_profiler_can_append_request_peak_memory(monkeypatch):
+    class _FakeDevice:
+        def __init__(self):
+            self.reset_calls = 0
+
+        def reset_peak_memory_stats(self):
+            self.reset_calls += 1
+
+        def max_memory_allocated(self):
+            return 2 * 1024**3
+
+        def max_memory_reserved(self):
+            return 3 * 1024**3
+
+    device = _FakeDevice()
+    monkeypatch.setattr(graph_profiler, "get_torch_device", lambda: device)
+
+    profiler = GraphProfiler(enable_memory=True)
+    with profiler.node("forward:run_ar.forward"):
+        pass
+
+    assert device.reset_calls == 1
+    assert profiler.save_records() == ["forward:run_ar.forward | peak_allocated_gb=2.000 | peak_reserved_gb=3.000"]
+
+
+# ── Mermaid visualisation ────────────────────────────────────────────────────
+
+
+def test_to_mermaid_janus_joint_contains_node_labels_and_end_sink():
+    g = TrainingGraph(_janus_joint_edges())
+    out = g.to_mermaid(title="Janus Joint Training")
+
+    # Frontmatter, ELK renderer hint, then LR flowchart.
+    assert out.startswith("---\ntitle: Janus Joint Training\n---\n")
+    assert "%%{init: {'flowchart': {'defaultRenderer': 'elk'}}}%%" in out
+    assert "flowchart LR" in out
+
+    # Node ids sanitise dots → underscores; labels keep the canonical name.
+    assert re.search(r'\bvision_encoder_forward\["<i>vision_encoder\.forward</i>"\]', out)
+    assert re.search(r'\bvq_decoder_encode\["<i>vq_decoder\.encode</i>"\]', out)
+    assert re.search(r'\brun_ar_forward\["<i>run_ar\.forward</i>"\]', out)
+    assert re.search(r'\bvq_decoder_gen_loss\["<i>vq_decoder\.gen_loss</i>"\]', out)
+
+    assert "vision_encoder_forward -->" in out and "run_ar_forward" in out
+    assert "vq_decoder_encode -->" in out
+    assert "run_ar_forward -->" in out and "vq_decoder_gen_loss" in out
+
+    # `end` rendered as the dashed terminal.
+    assert "end_sink" in out and "vq_decoder_gen_loss --> end_sink" in out
+
+    assert ":::source" in out and ":::sink" in out
+
+    # Per-rank invisible subgraphs (col0 = sources, col1 = middle, col2 = sinks).
+    assert "subgraph col0" in out and "subgraph col1" in out and "subgraph col2" in out
+    assert "style col0 fill:transparent,stroke:none" in out
+
+    assert "data -.-> vision_encoder_forward" in out
+    assert "data -.-> vq_decoder_encode" in out
+
+    # Single-loss protocol — no `losses` collector node.
+    assert "losses" not in out
+
+
+def test_to_mermaid_always_draws_data_pseudo_node():
+    g = TrainingGraph(_janus_joint_edges())
+    out = g.to_mermaid()
+    assert "data[(data)]" in out
+    assert "data -.-> vision_encoder_forward" in out
+    assert "losses" not in out
+    assert "end_sink" in out
+
+
+def test_generation_graph_mermaid_stacks_state_body_nodes():
+    g = GenerationGraph(
+        {
+            "initial": "prompt",
+            "states": {
+                "prompt": {
+                    "body": [{"from": "encoder.encode", "to": "decoder.decode"}],
+                    "transitions": [{"condition": {"type": "default"}, "next_state": "done"}],
+                }
+            },
+        }
+    )
+
+    out = g.to_mermaid(title="Compact FSM")
+
+    assert "flowchart LR" in out
+    assert "subgraph state_prompt [prompt]\n        direction TB" in out
+    assert "prompt__encoder_encode --> prompt__decoder_decode" in out
+
+
+class _DdpStyleWrapper(nn.Module):
+    """Minimal DDP-shaped wrapper: hooks live on ``.module``."""
+
+    def __init__(self, inner: nn.Module):
+        super().__init__()
+        self.module = inner
+
+    def forward(self, *args, **kwargs):
+        return self.module(*args, **kwargs)
+
+
+def test_named_omni_modules_yields_modules_as_attached():
+    """Bare :class:`OmniModel` yields sub-modules exactly as stored (no unwrap)."""
+    edges = _understanding_only_edges()
+    g = TrainingGraph(edges)
+    raw_modules = _fake_modules(g)
+    wrapped_modules = {name: _DdpStyleWrapper(mod) for name, mod in raw_modules.items()}
+    config = OmniConfig(
+        modules={name: {"subfolder": name} for name in raw_modules},
+        training_graph=edges,
+        generation_graphs=_minimal_generation_graphs(),
+    )
+    model = OmniModel(config, wrapped_modules)
+
+    resolved = dict(model.named_omni_modules())
+    assert set(resolved) == set(wrapped_modules)
+    for name, mod in resolved.items():
+        assert mod is wrapped_modules[name]
+
+
+def test_named_omni_modules_yields_all_graph_participants():
+    class _PlainModule(nn.Module):
+        def forward(self, x):
+            return x
+
+    plain = _PlainModule()
+    config = OmniConfig(
+        modules={"plain": {"subfolder": "plain"}},
+        training_graph=[{"from": "plain", "to": "end"}],
+        generation_graphs=_minimal_generation_graphs("plain"),
+    )
+    model = OmniModel(config, {"plain": plain})
+    assert list(model.named_omni_modules()) == [("plain", plain)]

--- a/tests/seed_omni/test_modeling_omni_load.py
+++ b/tests/seed_omni/test_modeling_omni_load.py
@@ -1,0 +1,358 @@
+"""Tests for HF-style OmniModel / OmniConfig checkpoint loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch.nn as nn
+import yaml
+from transformers import PretrainedConfig
+
+from veomni.models.seed_omni.configuration_omni import (
+    DEFAULT_GENERATION_GRAPH_FILE,
+    DEFAULT_TRAINING_GRAPH_FILE,
+    OmniConfig,
+)
+from veomni.models.seed_omni.modeling_omni import OmniModel, merge_generation_kwargs
+from veomni.models.seed_omni.utils.visualize import (
+    GRAPH_VIS_SUBDIR,
+    TRAINING_MMD_FILENAME,
+    generation_mmd_filename,
+)
+
+
+def _write_module_stub(module_dir: Path, *, model_type: str = "fake_omni_module") -> None:
+    module_dir.mkdir(parents=True, exist_ok=True)
+    (module_dir / "config.json").write_text(
+        json.dumps({"model_type": model_type, "hidden_size": 4}),
+        encoding="utf-8",
+    )
+
+
+def _write_omni_checkpoint(root: Path) -> None:
+    _write_module_stub(root / "encoder")
+    _write_module_stub(root / "decoder")
+
+    training_graph = [{"from": "encoder", "to": "decoder"}, {"from": "decoder", "to": "end"}]
+    generation_graphs = {
+        "infer_gen": {
+            "initial": "step",
+            "states": {
+                "step": {
+                    "body": [{"from": "encoder", "to": "end"}],
+                    "transitions": [{"condition": {"type": "default"}, "next_state": "done"}],
+                }
+            },
+        },
+        "infer_und": {
+            "initial": "understand",
+            "states": {
+                "understand": {
+                    "body": [{"from": "decoder", "to": "end"}],
+                    "transitions": [{"condition": {"type": "default"}, "next_state": "done"}],
+                }
+            },
+        },
+    }
+
+    yaml.safe_dump(
+        {"training_graph": training_graph},
+        (root / DEFAULT_TRAINING_GRAPH_FILE).open("w", encoding="utf-8"),
+        sort_keys=False,
+    )
+    yaml.safe_dump(
+        {"generation_graphs": generation_graphs},
+        (root / DEFAULT_GENERATION_GRAPH_FILE).open("w", encoding="utf-8"),
+        sort_keys=False,
+    )
+
+    config = {
+        "model_type": "omni",
+        "modules": {
+            "encoder": {"subfolder": "encoder"},
+            "decoder": {"subfolder": "decoder"},
+        },
+        "infer_type": "infer_gen",
+        "generation_kwargs": {"max_new_tokens": 16},
+    }
+    (root / "config.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
+
+
+class _FakeModuleConfig(PretrainedConfig):
+    model_type = "fake_omni_module"
+
+
+class _FakeModule(nn.Module):
+    config_class = _FakeModuleConfig
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+
+    @classmethod
+    def _from_config(cls, config, **kwargs):
+        """Mirrors ``PreTrainedModel._from_config`` — real modules have no public ``from_config``."""
+        return cls(config)
+
+    @classmethod
+    def from_pretrained(cls, module_path, **kwargs):
+        captured = getattr(cls, "_captured_kwargs", {})
+        captured[str(module_path)] = dict(kwargs)
+        cls._captured_kwargs = captured
+        cfg = _FakeModuleConfig.from_pretrained(module_path)
+        return cls(cfg)
+
+    def save_pretrained(self, save_directory, **kwargs):
+        Path(save_directory).mkdir(parents=True, exist_ok=True)
+        self.config.save_pretrained(save_directory)
+
+
+def test_omni_config_from_pretrained_hydrates_graph_sidecars(tmp_path):
+    _write_omni_checkpoint(tmp_path)
+
+    config = OmniConfig.from_pretrained(tmp_path)
+
+    assert config.training_graph == [
+        {"from": "encoder", "to": "decoder"},
+        {"from": "decoder", "to": "end"},
+    ]
+    assert config.infer_types == ["infer_gen", "infer_und"]
+    assert config.generation_graph["initial"] == "step"
+    assert config.generation_graphs["infer_und"]["initial"] == "understand"
+    assert config.module_subfolder("encoder") == "encoder"
+    assert config.resolve_module_path(tmp_path, "decoder") == str(tmp_path / "decoder")
+    assert isinstance(config.modules["encoder"], PretrainedConfig)
+    assert isinstance(config.modules["decoder"], PretrainedConfig)
+
+
+def test_omni_config_infer_type_selects_generation_graph(tmp_path):
+    _write_omni_checkpoint(tmp_path)
+
+    config = OmniConfig.from_pretrained(tmp_path)
+    assert config.generation_graph["initial"] == "step"
+
+    config.infer_type = "infer_und"
+    assert config.generation_graph["initial"] == "understand"
+
+    config.infer_type = "nope"
+    with pytest.raises(KeyError, match="Unknown infer_type"):
+        _ = config.generation_graph
+
+
+def test_omni_config_repr_survives_required_init_args(tmp_path):
+    """transformers probes `OmniConfig()` for defaults in to_diff_dict/__repr__."""
+    _write_omni_checkpoint(tmp_path)
+    config = OmniConfig.from_pretrained(tmp_path)
+    assert "omni" in repr(config)
+
+
+def test_omni_config_generation_graph_is_read_only():
+    config = OmniConfig(
+        modules={"encoder": {"subfolder": "encoder"}},
+        training_graph=[{"from": "encoder", "to": "end"}],
+        generation_graphs=_minimal_generation_graphs(),
+    )
+    with pytest.raises(AttributeError, match="read-only"):
+        config.generation_graph = {"initial": "x", "states": {}}
+
+
+def test_omni_config_without_scenarios_reports_clearly():
+    config = OmniConfig(
+        modules={"encoder": {"subfolder": "encoder"}},
+        training_graph=[{"from": "encoder", "to": "end"}],
+        generation_graphs={},
+    )
+    with pytest.raises(ValueError, match="No graph scenarios"):
+        _ = config.generation_graph
+
+
+def test_omni_config_from_dict_rejects_legacy_generation_graph_key():
+    with pytest.raises(ValueError, match="no longer a config field"):
+        OmniConfig.from_dict(
+            {
+                "modules": {"encoder": {"subfolder": "encoder"}},
+                "training_graph": [{"from": "encoder", "to": "end"}],
+                "generation_graph": _minimal_generation_graph(),
+            }
+        )
+
+
+def test_omni_config_rejects_legacy_single_graph_sidecar(tmp_path):
+    _write_omni_checkpoint(tmp_path)
+    yaml.safe_dump(
+        {"generation_graph": {"initial": "step", "states": {}}},
+        (tmp_path / DEFAULT_GENERATION_GRAPH_FILE).open("w", encoding="utf-8"),
+        sort_keys=False,
+    )
+
+    with pytest.raises(ValueError, match="no longer supported"):
+        OmniConfig.from_pretrained(tmp_path)
+
+
+@patch("veomni.models.seed_omni.modeling_omni.read_model_type", return_value="fake_omni_module")
+@patch("veomni.models.seed_omni.modeling_omni.OMNI_MODEL_REGISTRY")
+def test_omni_model_from_pretrained_forwards_kwargs_to_modules(registry_mock, _read_model_type, tmp_path):
+    _write_omni_checkpoint(tmp_path)
+
+    fake_cls = _FakeModule
+    fake_cls._captured_kwargs = {}
+    registry_mock.__getitem__.return_value = MagicMock(return_value=fake_cls)
+
+    model = OmniModel.from_pretrained(tmp_path, torch_dtype="bfloat16", device_map="auto")
+
+    assert isinstance(model, OmniModel)
+    assert set(model.modules_dict) == {"encoder", "decoder"}
+    assert fake_cls._captured_kwargs[str(tmp_path / "encoder")]["torch_dtype"] == "bfloat16"
+    assert fake_cls._captured_kwargs[str(tmp_path / "decoder")]["device_map"] == "auto"
+
+
+@patch("veomni.models.seed_omni.modeling_omni.read_model_type", return_value="fake_omni_module")
+@patch("veomni.models.seed_omni.modeling_omni.OMNI_MODEL_REGISTRY")
+def test_omni_model_from_config_builds_unweighted_modules(registry_mock, _read_model_type, tmp_path):
+    _write_omni_checkpoint(tmp_path)
+    config = OmniConfig.from_pretrained(tmp_path)
+
+    fake_cls = _FakeModule
+    registry_mock.__getitem__.return_value = MagicMock(return_value=fake_cls)
+
+    model = OmniModel.from_config(config, checkpoint_root=tmp_path)
+
+    assert set(model.modules_dict) == {"encoder", "decoder"}
+
+
+def _minimal_generation_graph(*, module: str = "encoder") -> dict:
+    return {
+        "initial": "run",
+        "states": {
+            "run": {
+                "body": [{"from": module, "to": "end"}],
+                "transitions": [{"condition": {"type": "default"}, "next_state": "done"}],
+            }
+        },
+    }
+
+
+def _minimal_generation_graphs(*, module: str = "encoder") -> dict:
+    return {"infer_gen": _minimal_generation_graph(module=module)}
+
+
+def test_omni_config_save_pretrained_writes_graph_sidecars(tmp_path):
+    config = OmniConfig(
+        modules={"encoder": {"subfolder": "encoder"}},
+        training_graph=[{"from": "encoder", "to": "end"}],
+        generation_graphs=_minimal_generation_graphs(),
+    )
+
+    config.save_pretrained(tmp_path)
+
+    saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert "training_graph" not in saved
+    assert saved["modules"] == {"encoder": {"subfolder": "encoder"}}
+    assert "generation_graphs" not in saved
+    assert (tmp_path / DEFAULT_GENERATION_GRAPH_FILE).exists()
+    assert yaml.safe_load((tmp_path / DEFAULT_TRAINING_GRAPH_FILE).read_text(encoding="utf-8"))["training_graph"] == [
+        {"from": "encoder", "to": "end"}
+    ]
+    sidecar = yaml.safe_load((tmp_path / DEFAULT_GENERATION_GRAPH_FILE).read_text(encoding="utf-8"))
+    assert list(sidecar["generation_graphs"]) == ["infer_gen"]
+    assert (tmp_path / GRAPH_VIS_SUBDIR / TRAINING_MMD_FILENAME).exists()
+    assert (tmp_path / GRAPH_VIS_SUBDIR / generation_mmd_filename("infer_gen")).exists()
+    training_mmd = (tmp_path / GRAPH_VIS_SUBDIR / TRAINING_MMD_FILENAME).read_text(encoding="utf-8")
+    assert "flowchart" in training_mmd
+
+
+@patch("veomni.models.seed_omni.modeling_omni.read_model_type", return_value="fake_omni_module")
+@patch("veomni.models.seed_omni.modeling_omni.OMNI_MODEL_REGISTRY")
+def test_omni_model_save_pretrained_roundtrip_layout(registry_mock, _read_model_type, tmp_path):
+    fake_cls = _FakeModule
+    registry_mock.__getitem__.return_value = MagicMock(return_value=fake_cls)
+
+    config = OmniConfig(
+        modules={
+            "encoder": {"subfolder": "encoder"},
+            "decoder": {"subfolder": "decoder"},
+        },
+        training_graph=[{"from": "encoder", "to": "decoder"}, {"from": "decoder", "to": "end"}],
+        generation_graphs=_minimal_generation_graphs(module="encoder"),
+    )
+    modules = {
+        "encoder": fake_cls(_FakeModuleConfig(hidden_size=4)),
+        "decoder": fake_cls(_FakeModuleConfig(hidden_size=4)),
+    }
+    model = OmniModel(config, modules)
+
+    save_root = tmp_path / "saved_omni"
+    model.save_pretrained(save_root, save_module_weights=False)
+
+    assert (save_root / "config.json").exists()
+    assert (save_root / DEFAULT_TRAINING_GRAPH_FILE).exists()
+    assert (save_root / DEFAULT_GENERATION_GRAPH_FILE).exists()
+    assert (save_root / GRAPH_VIS_SUBDIR / TRAINING_MMD_FILENAME).exists()
+    assert (save_root / GRAPH_VIS_SUBDIR / generation_mmd_filename("infer_gen")).exists()
+    assert (save_root / "encoder" / "config.json").exists()
+    assert (save_root / "decoder" / "config.json").exists()
+
+    reloaded = OmniConfig.from_pretrained(save_root)
+    assert reloaded.training_graph[0]["from"] == "encoder"
+    from transformers import PretrainedConfig
+
+    assert isinstance(reloaded.modules["encoder"], PretrainedConfig)
+    assert isinstance(reloaded.modules["decoder"], PretrainedConfig)
+
+
+def test_save_pretrained_roundtrips_every_generation_scenario(tmp_path):
+    """An exported checkpoint stays multi-scenario — it is not locked to the active one."""
+    config = OmniConfig(
+        modules={"encoder": {"subfolder": "encoder"}},
+        training_graph=[{"from": "encoder", "to": "end"}],
+        generation_graphs={
+            "infer_gen": _minimal_generation_graph(module="encoder"),
+            "infer_und": {
+                "initial": "understand",
+                "states": {
+                    "understand": {
+                        "body": [{"from": "encoder", "to": "end"}],
+                        "transitions": [{"condition": {"type": "default"}, "next_state": "done"}],
+                    }
+                },
+            },
+        },
+        infer_type="infer_und",
+    )
+
+    config.save_pretrained(tmp_path)
+    reloaded = OmniConfig.from_pretrained(tmp_path)
+
+    assert reloaded.infer_types == ["infer_gen", "infer_und"]
+    assert reloaded.infer_type == "infer_und"
+    assert reloaded.generation_graph["initial"] == "understand"
+    assert reloaded.generation_graphs["infer_gen"]["initial"] == "run"
+    for infer_type in reloaded.infer_types:
+        assert (tmp_path / GRAPH_VIS_SUBDIR / generation_mmd_filename(infer_type)).exists()
+
+
+def test_merge_generation_kwargs_overrides_defaults():
+    assert merge_generation_kwargs({"max_new_tokens": 32, "temperature": 1.0}, {"temperature": 0.5}) == {
+        "max_new_tokens": 32,
+        "temperature": 0.5,
+    }
+
+
+def test_omni_model_resolve_generation_kwargs_uses_config_defaults():
+    config = OmniConfig(
+        modules={"encoder": {"subfolder": "encoder"}},
+        training_graph=[{"from": "encoder", "to": "end"}],
+        generation_graphs=_minimal_generation_graphs(),
+        generation_kwargs={"max_new_tokens": 64},
+    )
+    model = OmniModel(config, {"encoder": _FakeModule(_FakeModuleConfig(hidden_size=4))})
+
+    assert model.resolve_generation_kwargs(None) == {"max_new_tokens": 64}
+    assert model.resolve_generation_kwargs({"temperature": 0.2}) == {
+        "max_new_tokens": 64,
+        "temperature": 0.2,
+    }
+    assert model.resolve_generation_kwargs({"max_new_tokens": 8}) == {"max_new_tokens": 8}

--- a/tests/seed_omni/test_offline_encoding_mixin.py
+++ b/tests/seed_omni/test_offline_encoding_mixin.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Collection
+
+import pytest
+import torch
+from transformers import PretrainedConfig
+
+from veomni.models.seed_omni import OfflineEncodingMixin
+from veomni.models.seed_omni.mixins.base_mixin import BaseMixin
+from veomni.models.seed_omni.mixins.training_module_mixin import TrainingModuleMixin, post_forward, pre_forward
+from veomni.models.seed_omni.utils.conversation import ConversationItem
+
+
+class DummyOfflineConfig(PretrainedConfig):
+    model_type = "dummy_offline_config"
+
+    def __init__(self, marker: str = "default", **kwargs: object) -> None:
+        self.marker = marker
+        super().__init__(**kwargs)
+
+
+class DummyOfflineModule(OfflineEncodingMixin, TrainingModuleMixin, BaseMixin):
+    def __init__(self, support_cache: bool = False, train_type: str = "train") -> None:
+        self.config = DummyOfflineConfig()
+        OfflineEncodingMixin.patch_config(self.config, support_cache=support_cache, train_type=train_type)
+        self.calls: list[str] = []
+        self._conversation_carrier: list[list[ConversationItem]] | None = None
+        super().__init__()
+
+    def offline_encode(self, **kwargs: torch.Tensor) -> dict[str, torch.Tensor]:
+        return {"encoded_cache": kwargs["pixel_values"]}
+
+    def online_process(self, **kwargs: torch.Tensor) -> dict[str, torch.Tensor]:
+        return {"latents": kwargs["encoded_cache"]}
+
+    @pre_forward("offline_encode")
+    def offline_encode_pre(
+        self,
+        conversation_list: list[list[ConversationItem]] | None = None,
+        **batch: object,
+    ) -> dict[str, torch.Tensor]:
+        del batch
+        self._conversation_carrier = conversation_list
+        self.calls.append("offline_encode_pre")
+        return {"pixel_values": torch.ones(1)}
+
+    @post_forward("offline_encode")
+    def offline_encode_post(self, **outputs: torch.Tensor) -> dict[str, list[list[ConversationItem]] | None]:
+        del outputs
+        self.calls.append("offline_encode_post")
+        return {"conversation_list": self._conversation_carrier}
+
+    @pre_forward("online_process")
+    def online_process_pre(
+        self,
+        conversation_list: list[list[ConversationItem]] | None = None,
+        **batch: object,
+    ) -> dict[str, torch.Tensor]:
+        del batch
+        self._conversation_carrier = conversation_list
+        self.calls.append("online_process_pre")
+        return {"encoded_cache": torch.ones(1)}
+
+    @post_forward("online_process")
+    def online_process_post(self, **outputs: torch.Tensor) -> dict[str, list[list[ConversationItem]] | None]:
+        del outputs
+        self.calls.append("online_process_post")
+        return {"conversation_list": self._conversation_carrier}
+
+
+@pytest.mark.parametrize(
+    ("support_cache", "train_type", "expected"),
+    [
+        (False, "offline_cache", "full"),
+        (True, "offline_cache", "encode_only"),
+        (True, "train_with_cache", "process_only"),
+        (True, "train", "full"),
+    ],
+)
+def test_cache_mode_is_derived_from_support_cache_and_train_type(
+    support_cache: bool, train_type: str, expected: str
+) -> None:
+    assert DummyOfflineModule(support_cache=support_cache, train_type=train_type).cache_mode == expected
+
+
+def test_patch_config_applies_runtime_overrides_without_config_mixin(tmp_path) -> None:
+    DummyOfflineConfig().save_pretrained(tmp_path)
+
+    config = DummyOfflineConfig.from_pretrained(tmp_path)
+    OfflineEncodingMixin.patch_config(config, support_cache=True, train_type="train_with_cache")
+
+    assert config.support_cache is True
+    assert config.train_type == "train_with_cache"
+    assert OfflineEncodingMixin.validated_cache_mode(config) == "process_only"
+
+
+def test_pre_forward_rejects_process_only_for_offline_encode() -> None:
+    module = DummyOfflineModule(support_cache=True, train_type="train_with_cache")
+
+    with pytest.raises(
+        ValueError, match="offline_encode requires cache_mode in .* current cache_mode is 'process_only'"
+    ):
+        module.pre_forward("offline_encode", conversation_list=[])
+
+
+def test_pre_forward_rejects_encode_only_for_online_process() -> None:
+    module = DummyOfflineModule(support_cache=True, train_type="offline_cache")
+
+    with pytest.raises(
+        ValueError, match="online_process requires cache_mode in .* current cache_mode is 'encode_only'"
+    ):
+        module.pre_forward("online_process", conversation_list=[])
+
+
+def test_default_partial_dcp_hooks_are_noop() -> None:
+    module = DummyOfflineModule(support_cache=True, train_type="train_with_cache")
+
+    assert module.load_partial_dcp_checkpoint("/tmp/load", trainer=object()) is None
+    assert module.save_partial_dcp_checkpoint("/tmp/save", trainer=object(), state=object()) is None
+
+
+def test_default_full_hf_checkpoint_hook_requires_module_implementation() -> None:
+    module = DummyOfflineModule(support_cache=True, train_type="train_with_cache")
+
+    with pytest.raises(NotImplementedError, match="save_full_hf_checkpoint"):
+        module.save_full_hf_checkpoint("/tmp/out", source_path="/tmp/source", trainer=object(), state=object())
+
+
+def test_offline_encoding_mixin_requires_tensor_endpoints() -> None:
+    source = inspect.getsource(OfflineEncodingMixin)
+    assert "@abstractmethod" in source
+    assert "def offline_encode" in source
+    assert "def online_process" in source
+
+
+def test_offline_encoding_mixin_is_not_module_mixin_subclass() -> None:
+    assert not issubclass(OfflineEncodingMixin, BaseMixin)
+
+
+def test_offline_encoding_mixin_does_not_implement_decorated_hooks() -> None:
+    source = inspect.getsource(OfflineEncodingMixin)
+    assert "@pre_forward" not in source
+    assert "@post_forward" not in source
+
+
+def test_decorated_hook_slots_can_bind_multiple_contexts() -> None:
+    class MultiContextModule(TrainingModuleMixin, BaseMixin):
+        @pre_forward("encode", "offline_encode")
+        def encode_pre(self, **kwargs: object) -> dict[str, object]:
+            return {"seen": kwargs["seen"]}
+
+        @post_forward("encode", "offline_encode")
+        def encode_post(self, **outputs: object) -> dict[str, object]:
+            return {"done": outputs["done"]}
+
+    module = MultiContextModule()
+
+    assert module.pre_forward("encode", seen=1) == {"seen": 1}
+    assert module.pre_forward("offline_encode", seen=2) == {"seen": 2}
+    assert module.post_forward("encode", done=3) == {"done": 3}
+    assert module.post_forward("offline_encode", done=4) == {"done": 4}
+
+
+def test_decorated_hook_slots_are_dispatched_by_module_mixin() -> None:
+    module = DummyOfflineModule()
+    conversation = [[ConversationItem(type="image", value=torch.ones(1), role="assistant")]]
+
+    assert module.pre_forward("offline_encode", conversation_list=conversation) == {"pixel_values": torch.ones(1)}
+    assert module.post_forward("offline_encode", encoded_cache=torch.ones(1)) == {"conversation_list": conversation}
+    assert module.pre_forward("online_process", conversation_list=conversation) == {"encoded_cache": torch.ones(1)}
+    assert module.post_forward("online_process", latents=torch.ones(1)) == {"conversation_list": conversation}
+    assert module.calls == [
+        "offline_encode_pre",
+        "offline_encode_post",
+        "online_process_pre",
+        "online_process_post",
+    ]
+
+
+def test_cache_mode_is_checked_once_per_offline_method() -> None:
+    module = DummyOfflineModule(support_cache=False)
+    conversation = [[ConversationItem(type="image", value=torch.ones(1), role="assistant")]]
+    calls: list[str] = []
+
+    original = module._check_cache_mode
+
+    def wrapped_check_cache_mode(*, method: str, allowed: Collection[str]) -> None:
+        calls.append(method)
+        return original(method=method, allowed=allowed)
+
+    module._check_cache_mode = wrapped_check_cache_mode  # type: ignore[method-assign]
+
+    module.pre_forward("offline_encode", conversation_list=conversation)
+    module.pre_forward("offline_encode", conversation_list=conversation)
+    module.pre_forward("online_process", conversation_list=conversation)
+    module.pre_forward("online_process", conversation_list=conversation)
+
+    assert calls == ["offline_encode", "online_process"]

--- a/tests/seed_omni/test_omni_config_paths.py
+++ b/tests/seed_omni/test_omni_config_paths.py
@@ -1,0 +1,42 @@
+"""Per-module checkpoint path resolution in ``_resolve_model_path``.
+
+A SeedOmni V2 checkpoint is a root folder with one subfolder per OmniModule, so
+a module's ``model_path`` is normally a bare name joined under that root. These
+tests pin down when the join must *not* happen.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from veomni.models.seed_omni.utils.model_path import resolve_model_path as _resolve_model_path
+
+
+def _resolved(root: str, module_path: str) -> str:
+    modules_config: dict[str, Any] = {"vision": {"model_path": module_path}}
+    return _resolve_model_path(root, modules_config)["vision"]["model_path"]
+
+
+def test_relative_module_path_joins_under_root() -> None:
+    assert _resolved("/local/root", "vision_encoder") == "/local/root/vision_encoder"
+
+
+def test_absolute_module_path_is_left_alone() -> None:
+    assert _resolved("/local/root", "/elsewhere/vision_encoder") == "/elsewhere/vision_encoder"
+
+
+def test_remote_module_path_is_left_alone() -> None:
+    """``os.path.isabs`` is False for a remote scheme, so without an explicit
+    check this would become ``/local/root/hdfs://ns/vision_encoder``."""
+    assert _resolved("/local/root", "hdfs://ns/vision_encoder") == "hdfs://ns/vision_encoder"
+
+
+def test_weights_path_seeds_the_resolved_model_path() -> None:
+    modules_config: dict[str, Any] = {"vision": {"weights_path": "vision_encoder"}}
+
+    assert _resolve_model_path("/local/root", modules_config)["vision"]["model_path"] == "/local/root/vision_encoder"
+
+
+def test_empty_modules_config_returns_empty_dict() -> None:
+    assert _resolve_model_path("/local/root", None) == {}
+    assert _resolve_model_path("/local/root", {}) == {}

--- a/tests/seed_omni/test_omni_processor.py
+++ b/tests/seed_omni/test_omni_processor.py
@@ -1,0 +1,117 @@
+from unittest.mock import MagicMock, patch
+
+from veomni.models.seed_omni.configuration_omni import OmniConfig
+from veomni.models.seed_omni.processing_omni import OmniProcessor
+from veomni.models.seed_omni.utils.conversation import ConversationItem
+
+
+class _RecordingPreprocessor:
+    def __init__(self, tag: str, store: list[str]) -> None:
+        self._tag = tag
+        self._store = store
+
+    def __call__(self, conversation_list, inference=False, **kwargs) -> None:
+        del inference, kwargs
+        self._store.append(self._tag)
+
+
+def test_omni_processor_builds_conversation_and_runs_preprocessors_in_order():
+    calls: list[str] = []
+    processor = OmniProcessor(
+        {
+            "a": _RecordingPreprocessor("first", calls),
+            "b": _RecordingPreprocessor("second", calls),
+        }
+    )
+
+    with patch("veomni.models.seed_omni.processing_omni.load_image", return_value="img"):
+        model_input = processor(text="hello", images=["/tmp/fake.png"])
+
+    assert calls == ["first", "second"]
+    assert "conversation_list" in model_input
+    conversation = model_input["conversation_list"]
+    assert len(conversation) == 2
+    assert conversation[0].type == "image"
+    assert conversation[1].type == "text"
+    assert conversation[1].value == "hello"
+
+
+def test_omni_processor_preprocess_mutates_existing_conversation():
+    calls: list[str] = []
+    processor = OmniProcessor({"a": _RecordingPreprocessor("only", calls)})
+    conversation = [ConversationItem(type="text", value="hi", role="user")]
+
+    out = processor.preprocess(conversation, inference=True)
+
+    assert calls == ["only"]
+    assert out["conversation_list"] is conversation
+
+
+def test_omni_processor_preprocess_batch_runs_with_inference_false():
+    calls: list[tuple[str, bool]] = []
+
+    class _FlagPreprocessor:
+        def __call__(self, conversation_list, inference=False, **kwargs) -> None:
+            del conversation_list, kwargs
+            calls.append(("batch", inference))
+
+    processor = OmniProcessor({"a": _FlagPreprocessor()})
+    batches = [[ConversationItem(type="text", value="hi", role="user")]]
+
+    processor.preprocess_batch(batches, inference=False)
+
+    assert calls == [("batch", False)]
+
+
+@patch("veomni.models.seed_omni.processing_omni.OMNI_MODEL_REGISTRY")
+@patch("veomni.models.seed_omni.processing_omni.read_model_type", return_value="encoder_type")
+@patch("veomni.models.seed_omni.processing_omni.OmniConfig.from_pretrained")
+def test_omni_processor_from_pretrained_collects_module_preprocessors(
+    mock_from_pretrained,
+    mock_read_model_type,
+    mock_registry,
+    tmp_path,
+):
+    del mock_read_model_type
+    mock_from_pretrained.return_value = OmniConfig(
+        modules={"encoder": {"subfolder": "encoder"}},
+        training_graph=[{"from": "encoder", "to": "end"}],
+        generation_graphs={"infer_gen": {"initial": "run", "states": {}}},
+    )
+    fake_mod_cls = MagicMock()
+    mock_registry.__getitem__.return_value = MagicMock(return_value=fake_mod_cls)
+
+    processor = OmniProcessor.from_pretrained(tmp_path, infer_type="infer_gen")
+
+    mock_from_pretrained.assert_called_once_with(tmp_path, infer_type="infer_gen")
+    fake_mod_cls.preprocessor_class.from_pretrained.assert_called_once()
+    assert len(processor._preprocessors) == 1
+
+
+@patch("veomni.models.seed_omni.processing_omni.OMNI_MODEL_REGISTRY")
+@patch("veomni.models.seed_omni.processing_omni.read_model_type", return_value="encoder_type")
+def test_omni_processor_from_config_forwards_module_model_config_overrides(mock_read_model_type, mock_registry):
+    """A module's YAML `model_config:` override (e.g. visual-instruction-tuning's
+    `enable_image: true` on `qwen3_text_encoder`) must reach the module's
+    `Preprocessor.from_pretrained` — regression: this used to only pass the
+    checkpoint path, silently dropping the override the live model itself receives.
+    """
+    del mock_read_model_type
+    fake_mod_cls = MagicMock()
+    mock_registry.__getitem__.return_value = MagicMock(return_value=fake_mod_cls)
+    config = OmniConfig(
+        modules={
+            "encoder": {
+                "subfolder": "encoder",
+                "model": {"model_config": {"enable_image": True}},
+            }
+        },
+        training_graph=[{"from": "encoder", "to": "end"}],
+        generation_graphs={"infer_gen": {"initial": "run", "states": {}}},
+    )
+
+    OmniProcessor.from_config(config, checkpoint_root="/tmp/checkpoint_root")
+
+    fake_mod_cls.preprocessor_class.from_pretrained.assert_called_once_with(
+        "/tmp/checkpoint_root/encoder", config_overrides={"enable_image": True}
+    )

--- a/veomni/models/loader.py
+++ b/veomni/models/loader.py
@@ -53,6 +53,34 @@ MODEL_PROCESSOR_REGISTRY = Registry("ModelProcessor")
 logger = logging.get_logger(__name__)
 
 
+def _omni_registries():
+    """Lazily fetch the SeedOmni V2 sub-module registries.
+
+    SeedOmni V2 splits a composite model (e.g. Janus) into self-contained
+    sub-modules — ``janus_siglip`` / ``janus_vqvae`` / ``janus_llama`` /
+    ``janus_text_encoder`` — whose ``model_type`` values are **not** in HF's
+    ``CONFIG_MAPPING`` and live in their own registries rather than
+    ``MODEL_CONFIG_REGISTRY`` / ``MODELING_REGISTRY`` / ``MODEL_PROCESSOR_REGISTRY``.
+
+    The ``get_model_*`` functions below consult these so the shared
+    :func:`veomni.models.build_foundation_model` / :func:`build_processor`
+    loader path works for an OmniModule sub-module exactly like a normal
+    single model (``OmniTrainer._build_model`` builds each sub-module this
+    way).  Imported lazily (inside the loader functions) to avoid a circular
+    import: ``veomni.models.seed_omni`` modeling imports back into
+    ``veomni.models``.
+
+    Returns ``(OMNI_CONFIG_REGISTRY, OMNI_MODEL_REGISTRY, OMNI_PROCESSOR_REGISTRY)``.
+    """
+    from .seed_omni.modules import (
+        OMNI_CONFIG_REGISTRY,
+        OMNI_MODEL_REGISTRY,
+        OMNI_PROCESSOR_REGISTRY,
+    )
+
+    return OMNI_CONFIG_REGISTRY, OMNI_MODEL_REGISTRY, OMNI_PROCESSOR_REGISTRY
+
+
 def raise_unsupported_veomni_modeling(model_name: str) -> None:
     # Gate for models whose VeOmni modeling path has NOT been ported to the
     # patchgen/generated flow. ``get_model_class`` in this module short-circuits
@@ -86,13 +114,19 @@ def get_model_config(config_path: str, **kwargs):
                     f"[CONFIG] Loading {model_type} from Huggingface as no customized config registered."
                 )
                 return config
-        except Exception:  # load from veomni
+        except Exception:  # load from veomni (custom / OmniModule model_type)
             config_dict, _ = PretrainedConfig.get_config_dict(config_path, **kwargs)
             model_type = (
                 config_dict["model_type"] if "model_type" in config_dict else config_dict["_class_name"]
             )  # diffusers use _class_name
-            logger.info_rank0(f"[CONFIG] Loading {model_type} from custom config.")
             kwargs.pop("trust_remote_code", None)
+            # SeedOmni V2 sub-module configs (janus_siglip / ...) live in the
+            # OMNI registry, not MODEL_CONFIG_REGISTRY.
+            omni_config_registry, _, _ = _omni_registries()
+            if model_type in set(omni_config_registry.valid_keys()):
+                logger.info_rank0(f"[CONFIG] Loading {model_type} from OMNI config registry.")
+                return omni_config_registry[model_type]().from_pretrained(config_path, **kwargs)
+            logger.info_rank0(f"[CONFIG] Loading {model_type} from custom config.")
             return MODEL_CONFIG_REGISTRY[model_type]().from_pretrained(config_path, **kwargs)
 
 
@@ -117,7 +151,21 @@ def get_model_processor(processor_path: str, **kwargs):
                     f"[PROCESSOR] Loading {processor_class_name} from Huggingface as no customized processor registered."
                 )
                 return processor
-        except Exception:  # load from veomni
+        except Exception:  # load from veomni (custom / OmniModule processor)
+            # SeedOmni V2 sub-module processors are keyed by ``model_type``
+            # (read from the module's ``config.json``), not by processor class
+            # name — consult the OMNI registry first.
+            try:
+                cfg_dict, _ = PretrainedConfig.get_config_dict(processor_path)
+                omni_model_type = cfg_dict.get("model_type")
+            except Exception:
+                omni_model_type = None
+            _, _, omni_processor_registry = _omni_registries()
+            if omni_model_type is not None and omni_model_type in set(omni_processor_registry.valid_keys()):
+                kwargs.pop("trust_remote_code", None)
+                logger.info_rank0(f"[PROCESSOR] Loading {omni_model_type} from OMNI processor registry.")
+                return omni_processor_registry[omni_model_type]().from_pretrained(processor_path, **kwargs)
+
             from transformers.processing_utils import ProcessorMixin
             from transformers.utils import PROCESSOR_NAME, cached_file
 
@@ -140,6 +188,13 @@ def get_model_class(model_config: PretrainedConfig):
     model_type = model_config.model_type
     modeling_backend = get_env("MODELING_BACKEND")
     if not modeling_backend == "hf":
+        # SeedOmni V2 sub-modules resolve to their OmniModule class via the
+        # OMNI registry (keyed by model_type; the factory takes no arch_name).
+        _, omni_model_registry, _ = _omni_registries()
+        if model_type in set(omni_model_registry.valid_keys()):
+            from .seed_omni.modules import OMNI_ACCELERATED_MODEL_REGISTRY
+
+            return OMNI_ACCELERATED_MODEL_REGISTRY[model_type]()
         return MODELING_REGISTRY[model_type](arch_name)
     if type(model_config) in AutoModelForImageTextToText._model_mapping.keys():  # assume built-in models
         load_class = AutoModelForImageTextToText

--- a/veomni/models/seed_omni/__init__.py
+++ b/veomni/models/seed_omni/__init__.py
@@ -1,0 +1,70 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ── SeedOmni V2 public API ──────────────────────────────────────────────────
+# Exports cluster around three concerns:
+#
+#   1. Core graph / runtime types (:class:`OmniConfig`, :class:`OmniModel`,
+#      :class:`BaseMixin`, :class:`TrainingGraph`, :class:`GenerationGraph`).
+#   2. Module registries — :data:`OMNI_CONFIG_REGISTRY`,
+#      :data:`OMNI_MODEL_REGISTRY`, :data:`OMNI_PROCESSOR_REGISTRY` — resolve
+#      ``model_type → class`` lazily at runtime.
+from .configuration_omni import OmniConfig
+from .graphs.base import END, EdgeDef, NodeDef
+from .graphs.generation_graph import GenerationGraph
+from .graphs.training_graph import TrainingGraph
+from .mixins.base_mixin import BaseMixin
+from .mixins.inference_module_mixin import InferenceModuleMixin
+from .mixins.metric_meter_mixin import MetricMeterMixin
+from .mixins.offline_encoding_mixin import OfflineEncodingMixin
+from .mixins.training_module_mixin import TrainingModuleMixin
+from .modeling_omni import OmniModel
+from .modules import (
+    OMNI_ACCELERATED_MODEL_REGISTRY,
+    OMNI_CONFIG_REGISTRY,
+    OMNI_MODEL_REGISTRY,
+    OMNI_PROCESSOR_REGISTRY,
+    read_hf_model_type,
+    read_model_type,
+)
+from .omni_pretrained_model import OmniPreTrainedModel
+from .processing_omni import OmniProcessor
+from .utils.conversation import build_conversation
+
+
+__all__ = [
+    # Core
+    "OmniConfig",
+    "OmniModel",
+    "OmniPreTrainedModel",
+    "OmniProcessor",
+    "BaseMixin",
+    "TrainingModuleMixin",
+    "InferenceModuleMixin",
+    "MetricMeterMixin",
+    "OfflineEncodingMixin",
+    "TrainingGraph",
+    "GenerationGraph",
+    "NodeDef",
+    "EdgeDef",
+    "END",
+    "build_conversation",
+    # Module registry
+    "OMNI_ACCELERATED_MODEL_REGISTRY",
+    "OMNI_CONFIG_REGISTRY",
+    "OMNI_MODEL_REGISTRY",
+    "OMNI_PROCESSOR_REGISTRY",
+    "read_hf_model_type",
+    "read_model_type",
+]

--- a/veomni/models/seed_omni/configuration_omni.py
+++ b/veomni/models/seed_omni/configuration_omni.py
@@ -1,0 +1,508 @@
+"""
+OmniConfig — central configuration for OmniModel V2.
+
+:class:`OmniConfig` describes **only** the composed model: module checkpoint layout,
+training DAG, and every generation FSM.  It is a plain ``PretrainedConfig`` — it reads
+and writes an on-disk checkpoint and knows nothing about the VeOmni launcher.
+
+A checkpoint carries **all** the generation scenarios it was exported with, keyed by
+``infer_type`` (``infer_gen`` / ``infer_edit`` / ``infer_und`` / …).  ``infer_type``
+selects which one is active; :attr:`OmniConfig.generation_graph` returns it.  Scenario
+choice is therefore a property of the config, not something baked in at YAML-load time.
+
+Building one from the launcher split-file layout is the runtime layer's job:
+:func:`~veomni.arguments.omni_arguments_types.resolve_omni_model` /
+:func:`~veomni.arguments.omni_arguments_types.build_omni_model_runtime`
+return :class:`~veomni.arguments.omni_arguments_types.OmniModelRuntimeArguments`
+(the full launcher view), and its ``.to_hf_config()`` projects that onto this
+checkpoint-shaped config.
+Per-module **runtime** args (FSDP, optimizer, dataloader, …) live on
+:class:`~veomni.arguments.omni_arguments_types.OmniModelRuntimeArguments.modules`.
+
+Launcher inputs consumed by that builder (see :class:`~veomni.arguments.OmniArguments`):
+
+  * ``model.model_path``   — split-checkpoint root folder (one subdir per module).
+  * ``model.model_config.modules`` — per-module YAML overrides (``modules_train.yaml``).
+  * ``model.model_config.train_graph`` — the training DAG (``graph_train.yaml``).
+  * ``model.model_config.modules`` — per-module YAML (``modules_train.yaml`` for
+    training; override with ``--model.model_config.modules …/modules_infer.yaml``
+    at inference time).
+  * ``model.model_config.infer_graph`` — scenario -> generation-graph file map.
+
+Stored ``modules`` entries look like:
+
+  janus_llama:
+    subfolder: janus_llama
+    model:
+      ops_implementation:
+        attn_implementation: flash_attention_2
+      model_config: {freeze: false}
+
+  # ── Active training subset.  A flat list of edges; each endpoint is a
+  #    self-describing `module[.method]` string (bare module → `.forward`).
+  #    Active nodes are derived from the endpoints.  `to: end` declares a leaf
+  #    node (virtual sink) — every node MUST appear on at least one edge.
+  training_graph:
+    - {from: siglip,            to: janus_llama}
+    - {from: vqvae.encode,      to: janus_llama}
+    - {from: wte_lm_head.encode, to: janus_llama}
+    - {from: janus_llama,       to: wte_lm_head.decode}
+    - {from: janus_llama,       to: vqvae.decode}
+    - {from: wte_lm_head.decode, to: end}
+    - {from: vqvae.decode,      to: end}
+
+  # ── Inference FSMs, one per scenario.  Each state.body is a list of inline
+  #    `{from, to}` edges (endpoints as `module[.method]` strings, bare module →
+  #    `.generate`); node order is derived (unique endpoints in declaration
+  #    order, excluding `end`).  The `done` state is auto-injected by the
+  #    framework — never declare it here, never set `done_state`.  Transitions
+  #    whose `next_state: done` land on the built-in terminal state which then
+  #    triggers each active module's `finalize` hook (text decode /
+  #    image save / etc).
+  #    States carry no iteration budget — a state body iterates until one of
+  #    its transitions fires, and modules decide when via signals (the AR
+  #    loop) or after a single pass via `default` (bridge/leaf states).
+  infer_type: infer_interleave
+  generation_graphs:
+    infer_interleave:
+      initial: text_ar
+      states:
+        text_ar:
+          body:
+            - {from: wte_lm_head, to: janus_llama}
+            - {from: janus_llama, to: wte_lm_head}
+            - {from: wte_lm_head, to: end}
+          transitions:
+            - {condition: {type: module_signal, key: start_image_gen}, next_state: image_vq}
+        image_vq:
+          body:
+            - {from: janus_llama, to: vqvae}
+            - {from: vqvae,       to: janus_llama}
+          transitions:
+            - {condition: {type: module_signal, key: image_complete}, next_state: text_ar}
+    infer_und:
+      initial: text_ar
+      states: {...}
+"""
+
+import json
+import os
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Union
+
+import yaml
+from transformers import PretrainedConfig
+
+
+DEFAULT_TRAINING_GRAPH_FILE = "training_graph.yaml"
+DEFAULT_GENERATION_GRAPH_FILE = "generation_graph.yaml"
+
+
+def select_graph(
+    graphs: Dict[str, Any],
+    scenario: Optional[str],
+    *,
+    empty_hint: str = "",
+    unknown_hint: str = "scenario",
+) -> Any:
+    """Pick the active graph out of a scenario map; unset ``scenario`` takes the first.
+
+    Shared by :class:`OmniConfig` and
+    :class:`~veomni.arguments.omni_arguments_types.OmniModelRuntimeArguments`
+    so both resolve training and generation scenarios identically.
+    """
+    if not graphs:
+        raise ValueError(f"No graph scenarios are declared. {empty_hint}".strip())
+    if scenario is None:
+        return next(iter(graphs.values()))
+    if scenario not in graphs:
+        known = ", ".join(graphs)
+        raise KeyError(f"Unknown {unknown_hint} {scenario!r}; expected one of: {known}.")
+    return graphs[scenario]
+
+
+class OmniConfig(PretrainedConfig):
+    """Configuration for OmniModel V2.
+
+    All nested dicts are stored as plain Python dicts for JSON serialisability.
+    Typed accessors (``module_model_config``, ``module_subfolder``,
+    ``training_edges``) provide a stable surface for the runtime / visualisation
+    tools.
+
+    Tokenizers and processors are per-module assets saved alongside each
+    module's checkpoint (e.g. ``janus_text_encoder/tokenizer.json``).
+    """
+
+    model_type = "omni"
+    # ``modules`` / ``training_graph`` / ``generation_graphs`` are required, so
+    # transformers must not probe defaults via a bare ``OmniConfig()`` — it does
+    # that in ``to_diff_dict`` (and therefore ``__repr__``) unless told otherwise.
+    has_no_defaults_at_init = True
+
+    def __init__(
+        self,
+        modules: Dict[str, Dict],
+        training_graph: List[Dict],
+        generation_graphs: Dict[str, Dict],
+        *,
+        infer_type: Optional[str] = None,
+        generation_kwargs: Optional[Dict] = None,
+        **kwargs,
+    ):
+        self.modules = modules
+        self.training_graph = training_graph
+        self.generation_graphs = generation_graphs
+        self.infer_type = infer_type
+        self.generation_kwargs = generation_kwargs
+
+        super().__init__(**kwargs)
+
+    @property
+    def training_edges(self) -> List[Dict]:
+        """Active training subset — the flat list of edge dicts."""
+        return list(self.training_graph)
+
+    @property
+    def infer_types(self) -> List[str]:
+        """Declared generation scenarios, in declaration order."""
+        return list(self.generation_graphs)
+
+    @property
+    def generation_graph(self) -> Dict:
+        """The generation FSM selected by :attr:`infer_type`.
+
+        A checkpoint carries every scenario it was exported with; ``infer_type``
+        picks which one :class:`~veomni.models.seed_omni.modeling_omni.OmniModel`
+        binds. Unset means the first declared scenario.
+        """
+        return select_graph(
+            self.generation_graphs,
+            self.infer_type,
+            empty_hint=(
+                "Populate `generation_graphs` (via `model.model_config.infer_graph`, or by loading a "
+                f"checkpoint whose `{DEFAULT_GENERATION_GRAPH_FILE}` sidecar has them)."
+            ),
+            unknown_hint="infer_type",
+        )
+
+    @generation_graph.setter
+    def generation_graph(self, value: Dict) -> None:
+        raise AttributeError(
+            "`generation_graph` is read-only — it is whichever entry of `generation_graphs` "
+            "`infer_type` names. Assign `generation_graphs` / `infer_type` instead."
+        )
+
+    @property
+    def module_names(self) -> List[str]:
+        # Config ``modules:`` declaration order (dict insertion order). This is the
+        # canonical, FIXED order that drives serial CPU-preprocessor execution in
+        # both training (SeedOmniCollator) and inference (OmniInferencer); declare
+        # modules so any order-dependent prep (e.g. vision patchify before the text
+        # chat-template) runs in the right sequence.
+        return list(self.modules.keys())
+
+    def module_subfolder(self, name: str) -> str:
+        """Return the resolved on-disk path segment for ``name`` (may be absolute)."""
+        entry = self.modules.get(name)
+        if entry is None:
+            raise KeyError(f"Module '{name}' not found in OmniConfig.modules")
+        if isinstance(entry, PretrainedConfig):
+            return self.module_checkpoint_subfolder(name)
+        if isinstance(entry, str):
+            return entry
+        if isinstance(entry, dict):
+            model_block = entry.get("model")
+            if isinstance(model_block, dict):
+                path = model_block.get("model_path") or model_block.get("weights_path")
+                if path:
+                    return path
+            subfolder = entry.get("subfolder")
+            if subfolder:
+                return str(subfolder)
+        return name
+
+    def module_checkpoint_subfolder(self, name: str) -> str:
+        """Relative subfolder under an omni checkpoint root for ``name``."""
+        if name not in self.modules:
+            raise KeyError(f"Module '{name}' not found in OmniConfig.modules")
+        return name
+
+    def normalize_modules_for_hf_export(self) -> Dict[str, Dict[str, Any]]:
+        """Slim ``modules`` block for HF ``config.json`` (subfolder + load options)."""
+        from transformers import PretrainedConfig
+
+        normalized: Dict[str, Dict[str, Any]] = {}
+        for name in self.module_names:
+            entry = self.modules.get(name)
+            if isinstance(entry, PretrainedConfig):
+                normalized[name] = {"subfolder": self.module_checkpoint_subfolder(name)}
+                ops = self.module_ops_implementation(name)
+                if ops:
+                    normalized[name]["model"] = {"ops_implementation": deepcopy(ops)}
+                continue
+            slim: Dict[str, Any] = {"subfolder": self.module_checkpoint_subfolder(name)}
+            model_block = self._module_export_model_block(name)
+            if model_block:
+                slim["model"] = model_block
+            normalized[name] = slim
+        return normalized
+
+    def _module_export_model_block(self, name: str) -> Dict[str, Any]:
+        model_block: Dict[str, Any] = {}
+        ops = self.module_ops_implementation(name)
+        if ops:
+            model_block["ops_implementation"] = deepcopy(ops)
+        model_config = self.module_model_config(name)
+        if model_config:
+            model_block["model_config"] = model_config
+        return model_block
+
+    def copy_for_hf_export(
+        self,
+        *,
+        training_graph: Optional[List[Dict]] = None,
+        generation_graphs: Optional[Dict[str, Dict]] = None,
+    ) -> "OmniConfig":
+        """Return a checkpoint-serializable copy with model-only module entries and graph sidecars."""
+        export_dict = self.to_dict()
+        export_dict["modules"] = self.normalize_modules_for_hf_export()
+        export_dict["training_graph"] = list(training_graph if training_graph is not None else self.training_graph)
+        export_dict["generation_graphs"] = deepcopy(
+            generation_graphs if generation_graphs is not None else self.generation_graphs
+        )
+        export_dict["infer_type"] = self.infer_type
+        accepted = {k: v for k, v in export_dict.items() if k in OmniConfig.__init__.__code__.co_varnames}
+        return OmniConfig.from_dict(accepted)
+
+    def module_model_config(self, name: str) -> Dict[str, Any]:
+        """Per-module ``from_pretrained`` overrides stored in the config."""
+        from transformers import PretrainedConfig
+
+        entry = self.modules.get(name)
+        if isinstance(entry, PretrainedConfig):
+            return {}
+        if not isinstance(entry, dict):
+            return {}
+        model_block = entry.get("model")
+        if not isinstance(model_block, dict):
+            return {}
+        overrides = model_block.get("model_config")
+        return dict(overrides or {})
+
+    def module_ops_implementation(self, name: str) -> Dict[str, Any]:
+        """Per-module VeOmni kernel options persisted in the checkpoint."""
+        cached = getattr(self, "_module_load_options", {}).get(name, {})
+        ops = cached.get("ops_implementation")
+        if ops:
+            return dict(ops)
+
+        entry = self.modules.get(name)
+        if not isinstance(entry, dict):
+            return {}
+        model_block = entry.get("model")
+        if not isinstance(model_block, dict):
+            return {}
+        ops = model_block.get("ops_implementation")
+        return dict(ops or {})
+
+    def _stash_module_load_options(self) -> None:
+        """Preserve ``model.ops_implementation`` before module configs are hydrated."""
+        options: Dict[str, Dict[str, Any]] = {}
+        for name in self.module_names:
+            ops = self.module_ops_implementation(name)
+            if ops:
+                options[name] = {"ops_implementation": deepcopy(ops)}
+        self._module_load_options = options
+
+    def resolve_module_path(self, checkpoint_root: Optional[Union[str, os.PathLike]], name: str) -> str:
+        """Resolve the on-disk path for module ``name`` under ``checkpoint_root``."""
+        subfolder = self.module_subfolder(name)
+        if os.path.isabs(subfolder):
+            return subfolder
+        if checkpoint_root is None:
+            return subfolder
+        return os.path.join(str(checkpoint_root), subfolder)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serializable dict; ``modules`` is slimmed to subfolder stubs."""
+        modules = self.modules
+        self.modules = self.normalize_modules_for_hf_export()
+        try:
+            return super().to_dict()
+        finally:
+            self.modules = modules
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+        """Load ``config.json``, graph sidecars, and per-module ``PretrainedConfig`` objects."""
+        config = super().from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
+        root = getattr(config, "_name_or_path", None) or str(pretrained_model_name_or_path)
+        config._stash_module_load_options()
+        config._hydrate_graphs_from_checkpoint(root)
+        config._hydrate_modules_from_checkpoint(root)
+        return config
+
+    def _hydrate_modules_from_checkpoint(self, checkpoint_root: Union[str, os.PathLike]) -> None:
+        """Load each module's ``config.json`` into :class:`PretrainedConfig` instances."""
+        root = str(checkpoint_root)
+        hydrated: Dict[str, Any] = {}
+        for name in self.module_names:
+            entry = self.modules.get(name)
+            if isinstance(entry, PretrainedConfig):
+                hydrated[name] = entry
+                continue
+            overrides = self.module_model_config(name)
+            subfolder = self.module_checkpoint_subfolder(name)
+            module_dir = os.path.join(root, subfolder)
+            config_path = os.path.join(module_dir, "config.json")
+            if not os.path.isfile(config_path):
+                hydrated[name] = entry if entry is not None else {"subfolder": subfolder}
+                continue
+            from .modules import OMNI_MODEL_REGISTRY, read_hf_model_type
+
+            model_type = read_hf_model_type(module_dir)
+            if model_type in OMNI_MODEL_REGISTRY.valid_keys():
+                mod_cls = OMNI_MODEL_REGISTRY[model_type]()
+                hf_config = mod_cls.config_class.from_pretrained(module_dir)
+            else:
+                with open(config_path, encoding="utf-8") as f:
+                    hf_config = PretrainedConfig.from_dict(json.load(f))
+            if overrides:
+                hf_config.update(deepcopy(overrides))
+            hydrated[name] = hf_config
+        self.modules = hydrated
+
+    def _hydrate_graphs_from_checkpoint(self, checkpoint_root: Union[str, os.PathLike]) -> None:
+        """Load ``training_graph`` and ``generation_graphs`` from their fixed-name YAML sidecars."""
+        root = str(checkpoint_root)
+
+        training_path = os.path.join(root, DEFAULT_TRAINING_GRAPH_FILE)
+        if not os.path.isfile(training_path):
+            raise FileNotFoundError(f"Omni checkpoint missing required graph sidecar: {training_path}")
+        self.training_graph = self._read_graph_file(training_path, "training_graph")
+
+        generation_path = os.path.join(root, DEFAULT_GENERATION_GRAPH_FILE)
+        if not os.path.isfile(generation_path):
+            raise FileNotFoundError(f"Omni checkpoint missing required graph sidecar: {generation_path}")
+        self.generation_graphs = self._read_generation_graphs(generation_path)
+
+    @staticmethod
+    def _read_generation_graphs(path: str) -> Dict[str, Dict]:
+        """Read the ``generation_graphs`` sidecar: ``{scenario_name: fsm_spec}``."""
+        with open(path, encoding="utf-8") as f:
+            payload = yaml.safe_load(f)
+        if not isinstance(payload, dict):
+            raise ValueError(f"Malformed generation-graph sidecar {path}: expected a mapping, got {type(payload)}.")
+        if "generation_graphs" not in payload:
+            if "generation_graph" in payload:
+                raise ValueError(
+                    f"{path} uses the single-graph `generation_graph:` layout, which is no longer supported. "
+                    "A checkpoint now stores every scenario under `generation_graphs: {<infer_type>: <fsm>}` "
+                    "and selects one via `infer_type`. Re-export the checkpoint with "
+                    "scripts/seed_omni/export_omni_checkpoint.py."
+                )
+            raise ValueError(f"Malformed generation-graph sidecar {path}: missing top-level `generation_graphs:` key.")
+        graphs = payload["generation_graphs"]
+        if not isinstance(graphs, dict):
+            raise ValueError(f"Malformed generation-graph sidecar {path}: `generation_graphs` must be a mapping.")
+        return graphs
+
+    def save_pretrained(self, save_directory: Union[str, os.PathLike], push_to_hub: bool = False, **kwargs):
+        """Write ``config.json`` plus graph YAML sidecars for HF-style reload."""
+        save_directory = str(save_directory)
+        os.makedirs(save_directory, exist_ok=True)
+
+        for name, entry in self.modules.items():
+            if isinstance(entry, PretrainedConfig):
+                module_dir = os.path.join(save_directory, self.module_checkpoint_subfolder(name))
+                os.makedirs(module_dir, exist_ok=True)
+                entry.save_pretrained(module_dir)
+
+        export_config = self.copy_for_hf_export()
+
+        self._write_graph_file(
+            os.path.join(save_directory, DEFAULT_TRAINING_GRAPH_FILE),
+            "training_graph",
+            export_config.training_graph,
+        )
+        self._write_graph_file(
+            os.path.join(save_directory, DEFAULT_GENERATION_GRAPH_FILE),
+            "generation_graphs",
+            export_config.generation_graphs,
+        )
+
+        # The sidecar files above are the sole source of truth for both graphs —
+        # `config.json` never carries them inline, so `from_pretrained` always
+        # re-hydrates via `_hydrate_graphs_from_checkpoint` (fixed filenames).
+        config_dict = export_config.to_dict()
+        config_dict.pop("training_graph", None)
+        config_dict.pop("generation_graphs", None)
+
+        config_path = os.path.join(save_directory, "config.json")
+        with open(config_path, "w", encoding="utf-8") as f:
+            # No sort_keys: ``modules`` declaration order is load-bearing (it drives
+            # serial CPU-preprocessor execution — see :meth:`module_names`), and JSON
+            # key sorting is recursive, so it would silently reorder the modules.
+            json.dump(config_dict, f, indent=2)
+            f.write("\n")
+
+        from .utils.visualize import save_graph_mermaid_diagrams
+
+        save_graph_mermaid_diagrams(export_config, save_directory)
+
+        if push_to_hub:
+            raise NotImplementedError("OmniConfig push_to_hub is not implemented yet.")
+
+    @staticmethod
+    def _write_graph_file(path: str, key: str, payload: Any) -> None:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump({key: payload}, f, sort_keys=False, allow_unicode=True)
+
+    @staticmethod
+    def _read_graph_file(path: str, key: str):
+        """Read a graph sidecar written by :meth:`_write_graph_file`.
+
+        Checkpoint sidecars are plain YAML documents; the launcher's ``inherit:``
+        composition is a build-time feature and never appears here.
+        """
+        with open(path, encoding="utf-8") as f:
+            payload = yaml.safe_load(f)
+        if isinstance(payload, dict) and key in payload:
+            return payload[key]
+        return payload
+
+    @classmethod
+    def from_dict(cls, config_dict: Dict, **kwargs) -> "OmniConfig":
+        """Build an :class:`OmniConfig` from a YAML-shaped dict.
+
+        Module blocks are kept verbatim; the split-checkpoint root and per-module
+        path resolution belong to the runtime layer
+        (:class:`~veomni.arguments.omni_arguments_types.OmniModelRuntimeArguments`)
+        and are not stored here. Unknown top-level keys are dropped silently so the
+        launcher YAML can carry training-only fields.
+
+        HF ``config.json`` stores graph payloads in YAML sidecars and leaves
+        placeholder ``training_graph`` / omits ``generation_graphs`` until
+        :meth:`from_pretrained` hydrates them.
+        """
+        config_dict = dict(config_dict)
+        # Unknown keys are dropped below, so the retired singular field would go
+        # silently inert — leaving a config whose FSM vanished. Reject it instead.
+        if "generation_graph" in config_dict:
+            raise ValueError(
+                "`generation_graph` (a single FSM) is no longer a config field. A config now "
+                "declares every scenario in `generation_graphs: {<infer_type>: <fsm>}` and "
+                "selects one via `infer_type`."
+            )
+        accepted = {k: v for k, v in config_dict.items() if k in cls.__init__.__code__.co_varnames}
+        if "generation_graphs" not in accepted:
+            accepted["generation_graphs"] = {}
+        if "training_graph" not in accepted:
+            accepted["training_graph"] = []
+        if "modules" not in accepted:
+            accepted["modules"] = {}
+        return cls(**{**accepted, **kwargs})
+
+
+__all__ = ["OmniConfig", "select_graph"]

--- a/veomni/models/seed_omni/graphs/__init__.py
+++ b/veomni/models/seed_omni/graphs/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SeedOmni V2 graph layer: shared edge/node types + training DAG + inference FSM."""
+
+from .base import END, EdgeDef, NodeDef, is_end
+from .generation_graph import FSM_SIGNAL_KEY, GenerationGraph
+from .training_graph import TrainingGraph
+
+
+__all__ = [
+    "END",
+    "EdgeDef",
+    "NodeDef",
+    "is_end",
+    "TrainingGraph",
+    "GenerationGraph",
+    "FSM_SIGNAL_KEY",
+]

--- a/veomni/models/seed_omni/graphs/base.py
+++ b/veomni/models/seed_omni/graphs/base.py
@@ -1,0 +1,160 @@
+"""
+Shared data types for the SeedOmni V2 graph.
+
+``OmniConfig`` no longer declares separate ``nodes`` / ``edges`` pools.  Both
+the training DAG (``training_graph``) and the inference FSM
+(``generation_graph``) are written as plain lists of **edges**, and each edge
+endpoint is a self-describing ``module[.method]`` string::
+
+    {from: janus_siglip,       to: janus_llama}        # bare → default method
+    {from: janus_vqvae.encode, to: janus_llama}        # explicit method
+    {from: janus_text_encoder.decode, to: end}         # leaf → virtual sink
+
+An endpoint string therefore *is* the node — there is no indirection through a
+named pool.  A node's identity is its canonical ``"<module>.<method>"`` form
+(see :meth:`NodeDef.from_endpoint`):
+
+- a **bare** endpoint (no ``.method``) takes the view's *default method* —
+  ``forward`` for the training DAG, ``generate`` for the inference FSM;
+- a **dotted** endpoint (``module.method``) uses that method verbatim in both
+  views.
+
+The same underlying ``nn.Module`` may appear under several methods — e.g. a VQ
+codec with both ``janus_vqvae.encode`` (pixels → embeds) and
+``janus_vqvae.decode`` (LLM hidden → CE loss).  These are independent nodes
+that happen to share weights.
+
+Data flows through the shared ``conversation_list`` carrier (training) or the
+FSM ``ctx`` dict (inference) — modules read/write keys directly on those shared
+objects; edges declare execution-order / topology only and do **not** route
+individual tensor fields.
+
+Reserved sink keyword
+---------------------
+The string ``"end"`` (exposed as the :data:`END` constant) is a virtual sink:
+``to: end`` declares that a node's output flows nowhere — it just makes the
+node visible to the active subset.  Every node MUST appear on at least one
+edge (no orphans); leaf nodes use ``to: end`` to satisfy that invariant.
+
+``end`` is reserved — it may only appear in an edge's ``to`` field, never as a
+``from`` endpoint or as a real module/method name.
+
+Two execution views consume these edge lists (see ``training_graph.py`` and
+``generation_graph.py``):
+
+- ``TrainingGraph``  — DAG view over ``OmniConfig.training_graph`` (a flat
+  list of edges).  Active nodes are derived from the endpoints (excluding the
+  virtual ``end`` node); a topological sort produces the forward order.
+- ``GenerationGraph`` — FSM view.  Each ``state.body`` is itself a list of
+  inline edge dicts; the unique nodes appearing as endpoints (excluding
+  ``end``) execute once per FSM step in declaration order.
+
+See the :class:`~veomni.models.seed_omni.graphs.training_graph.TrainingGraph` and
+:class:`~veomni.models.seed_omni.graphs.generation_graph.GenerationGraph` module
+docstrings for the full schema.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+END: str = "end"
+"""Reserved virtual sink node name.
+
+Used as ``to: end`` on edges whose source node has no real successor.  Treated
+as a sentinel in graph construction; never appears in execution orders.
+"""
+
+
+def is_end(name: Optional[str]) -> bool:
+    """Return True iff *name* refers to the virtual ``end`` sink."""
+    return name == END
+
+
+@dataclass
+class NodeDef:
+    """Parsed graph node — one ``module.method`` call-site.
+
+    Constructed from an edge endpoint string (:meth:`from_endpoint`).  ``name``
+    is the canonical ``"<module>.<method>"`` identity used to de-duplicate the
+    same call-site across edges.
+    """
+
+    name: str
+    module: str
+    method: str = "forward"
+
+    @classmethod
+    def from_endpoint(cls, endpoint: str, *, default_method: str) -> "NodeDef":
+        """Parse a ``module[.method]`` endpoint string into a :class:`NodeDef`.
+
+        A bare ``module`` takes *default_method* (``forward`` for the training
+        DAG, ``generate`` for the inference FSM); a dotted ``module.method``
+        uses that method verbatim.
+        """
+        if endpoint == END:
+            raise ValueError(f"'{END}' is the virtual sink, not a node — it may only appear in an edge's `to` field.")
+        if not isinstance(endpoint, str) or not endpoint.strip():
+            raise ValueError(f"Edge endpoint must be a non-empty 'module[.method]' string. Got: {endpoint!r}")
+
+        if "." in endpoint:
+            module, method = endpoint.split(".", 1)
+        else:
+            module, method = endpoint, default_method
+
+        if not module or not method:
+            raise ValueError(f"Edge endpoint '{endpoint}': module/method must be non-empty.")
+
+        return cls(name=f"{module}.{method}", module=module, method=method)
+
+
+@dataclass
+class EdgeDef:
+    """Parsed graph edge — declares ``from_`` must execute before ``to``.
+
+    Both endpoints are parsed from ``module[.method]`` strings into
+    :class:`NodeDef`; ``from_`` / ``to`` hold their canonical names.  ``to`` may
+    be the reserved keyword :data:`END` (``"end"``), in which case ``to_node``
+    is ``None`` and the edge is a virtual sink.
+
+    Data is **not** routed through edges — training modules share the
+    ``conversation_list`` carrier; inference modules merge outputs into ``ctx``.
+    """
+
+    from_: str
+    to: str
+    from_node: NodeDef
+    to_node: Optional[NodeDef] = None
+
+    @classmethod
+    def parse(cls, spec: Dict, *, default_method: str) -> "EdgeDef":
+        """Parse a ``{from, to}`` edge dict; endpoints resolve via *default_method*."""
+        if not isinstance(spec, dict):
+            raise ValueError(f"Edge spec must be a `{{from, to}}` dict. Got: {spec!r}")
+        if "module" in spec or "method" in spec:
+            raise ValueError(
+                f"Edge spec must not contain node fields (`module`/`method`) — write endpoints "
+                f"as `module[.method]` strings in `from`/`to`. Got: {spec!r}"
+            )
+        if "from" not in spec or "to" not in spec:
+            raise ValueError(f"Edge must declare both `from` and `to`. Got: {spec!r}")
+
+        from_ep = spec["from"]
+        to_ep = spec["to"]
+        if from_ep == END:
+            raise ValueError(f"`from: {END}` is forbidden — the virtual sink may only appear on `to`.")
+
+        from_node = NodeDef.from_endpoint(from_ep, default_method=default_method)
+        if to_ep == END:
+            return cls(from_=from_node.name, to=END, from_node=from_node, to_node=None)
+        to_node = NodeDef.from_endpoint(to_ep, default_method=default_method)
+        return cls(from_=from_node.name, to=to_node.name, from_node=from_node, to_node=to_node)
+
+    @property
+    def name(self) -> str:
+        """Synthetic diagnostic name (``"<from> -> <to>"``); edges are anonymous."""
+        return f"{self.from_} -> {self.to}"
+
+    def is_sink(self) -> bool:
+        """True iff this edge terminates at the virtual ``end`` sink."""
+        return self.to == END

--- a/veomni/models/seed_omni/graphs/generation_graph.py
+++ b/veomni/models/seed_omni/graphs/generation_graph.py
@@ -1,0 +1,574 @@
+"""
+GenerationGraph: FSM view over inline edge lists for inference.
+
+The FSM drives multi-modal generation by cycling through *named states*.
+Each state specifies:
+
+  body
+      An ordered list of inline **edges** (``{from, to}`` dicts whose endpoints
+      are ``module[.method]`` strings; a bare module defaults to ``.generate``).
+      Per FSM step the body is walked in **topological order**:
+
+      1. Pre-compute, per node ``X`` appearing in body, the count of
+         body edges with ``to: X`` (its in-body fan-in).
+      2. Walk the body edges in declaration order.  For each edge ``e``:
+
+         a. Ensure ``e.from_`` is executed.  If it has any unprocessed
+            in-body fan-in, that's a body-ordering bug — error.
+         b. Decrement ``e.to``'s pending fan-in.  When it hits zero
+            (i.e. all body edges into ``e.to`` have been processed),
+            execute ``e.to``.
+
+      Each executed node merges its return dict into ``ctx`` directly
+      (``ctx.update(out)``).  Edges declare execution order only — they
+      do not route individual fields.  Early FSM steps use
+      ``conversation_list``; later AR steps use ``input_ids`` /
+      ``past_key_values`` / ``hidden_states`` as modules write them.
+
+      This rule generalises "first-encounter execution":
+
+        * For purely linear bodies (e.g. ``text_ar`` =
+          ``tok_enc → llama → tok_dec``) it executes every node exactly
+          once, in declaration order.
+        * For multi-source nodes (e.g. understanding/I2T where
+          ``janus_llama`` consumes both ``inputs_embeds`` and
+          ``und_image_embeds``) the backbone executes only after the
+          last in-body fan-in edge has fired — both keys are already
+          in ``ctx`` from upstream ``ctx.update(out)`` calls.
+        * For self-feedback bodies (``image_vq`` =
+          ``ar_to_vae_dec, vae_dec_to_ar``) ``vae_decode`` writes
+          ``embed`` (or ``inputs_embeds``) into ``ctx``; the next
+          ``janus_llama`` step reads it directly — no edge renaming.
+
+      An edge with ``to: end`` is purely declarative — it pins the producing
+      node into the active set without routing anywhere.
+
+Default method
+--------------
+A bare endpoint (``module`` with no ``.method``) defaults to ``generate`` in the
+FSM view.  A dotted endpoint (``module.method`` — e.g. ``encode``, ``decode``,
+``emit_image_start``) is taken verbatim on the yielded :class:`NodeDef`.
+
+  transitions
+      Ordered list of ``{condition: ..., next_state: S}`` items checked after
+      every iteration of the state body.  First matching condition wins.
+
+      A state has **no iteration-count budget**: its body runs once and then
+      keeps iterating until one of its transitions fires.  Modules — not the
+      FSM — decide when a state ends, either by raising a signal (the AR
+      loop case) or implicitly after a single pass (the bridge/leaf case,
+      via a ``default`` transition).  Supported conditions:
+
+        ``{type: module_signal, key: K}``
+            Fires when ``context["module_signal"] == K``.  Modules write a
+            one-shot string signal into ``ctx["module_signal"]`` from inside
+            ``generate_step`` / ``decode`` — e.g. ``JanusTextEncoder.decode``
+            sets ``"start_image_gen"`` / ``"text_done"`` after sampling; a VQ
+            decoder sets ``"image_complete"`` on the final patch.  The
+            framework **auto-clears** ``ctx["module_signal"]`` once the
+            transition fires.  This is how an AR loop state (e.g. ``image_vq``)
+            keeps iterating until its module says "done".  The FSM never
+            inspects raw token ids — vocabulary semantics stay inside the
+            module.
+
+        ``{type: default}``
+            The catch-all (switch-``default``) branch — matches
+            unconditionally.  Because transitions are evaluated in order and
+            the first match wins, a ``default`` is the lowest-priority
+            **fallback**: it fires only when none of the conditions listed
+            *before* it matched.  It MUST therefore be the last transition in
+            a state (the FSM rejects a ``default`` that isn't, since any
+            transition after it would be dead code).  Two uses:
+
+            * sole transition on a deterministic single-pass bridge / leaf
+              state (prompt encode, ``<boi>`` / ``<eoi>`` emit) — run the
+              body once, then advance;
+            * the else-branch after one or more ``module_signal`` checks
+              (e.g. "sampled a normal text token → keep decoding").
+
+Usage
+-----
+  >>> fsm = GenerationGraph(config.generation_graph)
+  >>> fsm.reset()
+  >>> ctx = {"input_ids": ..., "attention_mask": ...}
+  >>> while not fsm.is_done():
+  ...     for node in fsm.iter_nodes(ctx):          # graph selects; caller runs
+  ...         run_node(modules, node, ctx)
+  ...     fsm.maybe_transition(ctx)
+
+See also
+--------
+``base.py``           — NodeDef / EdgeDef / END shared types.
+``training_graph.py``  — DAG view driven by ``OmniConfig.training_graph``.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Optional
+
+from .base import (
+    EdgeDef,
+    NodeDef,
+    is_end,
+)
+
+
+# Default method for a bare endpoint in the inference FSM (training uses
+# ``forward``).  Dotted endpoints (``module.method``) override this.
+_FSM_DEFAULT_METHOD: str = "generate"
+
+
+def _mermaid_id(name: str) -> str:
+    """Sanitise a canonical ``module.method`` node name into a Mermaid-safe id."""
+    return name.replace(".", "_").replace("-", "_")
+
+
+# Reserved name for the framework-injected terminal state.  Every FSM
+# automatically gains a ``done`` state with empty body and no transitions —
+# users must NOT declare it in their YAML.  All
+# transitions whose ``next_state`` is ``"done"`` therefore land on this
+# built-in state, and ``OmniModel.generate`` calls each active module's
+# :meth:`OmniModule.finalize` hook once the FSM enters it.
+DONE_STATE_NAME: str = "done"
+
+# Single ctx slot for module-driven FSM transitions.  Modules set
+# ``ctx[FSM_SIGNAL_KEY] = "<signal_name>"``; YAML ``module_signal.key``
+# matches that string value (not a separate boolean flag per signal).
+FSM_SIGNAL_KEY: str = "module_signal"
+
+
+# ── Condition helpers ─────────────────────────────────────────────────────────
+
+
+_KNOWN_CONDITION_TYPES = frozenset({"module_signal", "default"})
+
+
+@dataclass
+class _Condition:
+    type: str
+    key: Optional[str] = None  # required by `module_signal`, forbidden otherwise
+
+    def __post_init__(self) -> None:
+        # Catch malformed YAML at FSM build time, not at first transition
+        # check (which would otherwise silently never fire).
+        if self.type not in _KNOWN_CONDITION_TYPES:
+            raise ValueError(f"Unknown FSM condition type '{self.type}'. Supported: {sorted(_KNOWN_CONDITION_TYPES)}.")
+        if self.type == "module_signal" and not self.key:
+            raise ValueError("Condition `module_signal` requires a non-empty `key`.")
+        if self.type != "module_signal" and self.key is not None:
+            raise ValueError(f"Condition `{self.type}` does not accept `key`.")
+
+    def check(self, context: Dict[str, Any]) -> bool:
+        if self.type == "module_signal":
+            return context.get(FSM_SIGNAL_KEY) == self.key
+        if self.type == "default":
+            return True
+        return False
+
+    def describe(self) -> str:
+        if self.type == "module_signal":
+            return f"module_signal({self.key})"
+        return self.type
+
+
+@dataclass
+class _Transition:
+    condition: _Condition
+    next_state: str
+
+
+@dataclass
+class FiredTransition:
+    """A transition that just fired in :meth:`GenerationGraph.maybe_transition`.
+
+    Returned to the caller so it can format a transition trace if desired.
+    """
+
+    from_state: str
+    to_state: str
+    condition: str  # human-readable condition description, e.g. ``module_signal(text_done)``
+
+
+# ── State ─────────────────────────────────────────────────────────────────────
+
+
+class _State:
+    """Parsed FSM state.
+
+    ``body`` is a list of inline :class:`EdgeDef` parsed from ``{from, to}``
+    dicts (endpoints are ``module[.method]`` strings, bare → ``.generate``).
+    The *node sequence* — the unique nodes appearing as ``from``/``to``
+    endpoints in declaration order, excluding ``end`` — is precomputed for
+    stable iteration.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        spec: Dict,
+    ):
+        self.name = name
+        body_specs: List[Any] = list(spec.get("body", []))
+
+        body: List[EdgeDef] = []
+        for item in body_specs:
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"State '{name}' body items must be inline `{{from, to}}` edge dicts "
+                    f"(endpoints as `module[.method]` strings). Got: {item!r}"
+                )
+            body.append(EdgeDef.parse(item, default_method=_FSM_DEFAULT_METHOD))
+        self.body: List[EdgeDef] = body
+
+        # Derive node sequence: unique nodes by first appearance, skipping `end`.
+        seen: set = set()
+        sequence: List[str] = []
+        for e in body:
+            for node in (e.from_node, e.to_node):
+                if node is None or node.name in seen:
+                    continue
+                seen.add(node.name)
+                sequence.append(node.name)
+        self.node_sequence: List[str] = sequence
+
+        self.transitions: List[_Transition] = [
+            _Transition(
+                condition=_Condition(**t["condition"]),
+                next_state=t["next_state"],
+            )
+            for t in spec.get("transitions", [])
+        ]
+
+        # A `default` condition matches unconditionally, so with first-match
+        # ordering it is the lowest-priority fallback — anything after it is
+        # dead code.  Reject that at build time so the priority is explicit.
+        for i, trans in enumerate(self.transitions[:-1]):
+            if trans.condition.type == "default":
+                raise ValueError(
+                    f"State '{name}': a `default` transition must be last (it fires "
+                    f"unconditionally, so the {len(self.transitions) - i - 1} transition(s) after "
+                    f"it would never run). Move `default` to the end of `{name}.transitions`."
+                )
+
+
+# ── GenerationGraph ───────────────────────────────────────────────────────────
+
+
+class GenerationGraph:
+    """FSM view over the nodes / edges pools that drives multi-modal inference.
+
+    Parameters
+    ----------
+    fsm_config:
+        The ``generation_graph`` section of ``OmniConfig``.  Must have:
+        ``initial`` (str) and ``states`` (dict of state specs).  Each state's
+        ``body`` is a list of inline ``{from, to}`` edge dicts; the node pool
+        is derived from their endpoints.
+    """
+
+    def __init__(
+        self,
+        generation_graph: Dict,
+    ):
+        # `done` is reserved — auto-injected below.  Users must NOT redeclare
+        # it; doing so silently lets a custom body/transitions override the
+        # framework's terminal semantics, which is exactly the kind of magic
+        # we are trying to avoid.
+        if DONE_STATE_NAME in generation_graph["states"]:
+            raise ValueError(
+                f"State name '{DONE_STATE_NAME}' is reserved and auto-injected by the framework. "
+                f"Remove the explicit `{DONE_STATE_NAME}:` block from your generation_graph YAML — "
+                f"transitions targeting `next_state: {DONE_STATE_NAME}` will land on the built-in "
+                f"terminal state, which then triggers each active module's `finalize` hook."
+            )
+        # The pre-existing `done_state` config knob is gone — the framework
+        # always uses `DONE_STATE_NAME`.  If the user still has it lying
+        # around, reject loudly so they migrate cleanly.
+        if "done_state" in generation_graph:
+            raise ValueError(
+                "`generation_graph.done_state` is no longer configurable — the terminal state "
+                f"is hardcoded to '{DONE_STATE_NAME}'. Remove the `done_state:` line from your "
+                "generation_graph YAML."
+            )
+
+        self._initial: str = generation_graph["initial"]
+        self._states: Dict[str, _State] = {
+            name: _State(name, spec) for name, spec in generation_graph["states"].items()
+        }
+
+        # Inject the built-in terminal state.  Empty body, no outgoing
+        # transitions: the FSM "rests" here and the orchestrator picks up the
+        # post-processing baton via finalize hooks.
+        self._states[DONE_STATE_NAME] = _State(DONE_STATE_NAME, {"body": [], "transitions": []})
+
+        # Derive the node pool from every state's body edges (canonical names).
+        self._node_pool: Dict[str, NodeDef] = {}
+        for state in self._states.values():
+            for edge in state.body:
+                for node in (edge.from_node, edge.to_node):
+                    if node is not None and node.name not in self._node_pool:
+                        self._node_pool[node.name] = node
+
+        if self._initial not in self._states:
+            raise KeyError(
+                f"GenerationGraph initial state '{self._initial}' not in declared states {sorted(self._states)}."
+            )
+        for name, state in self._states.items():
+            for trans in state.transitions:
+                if trans.next_state not in self._states:
+                    raise KeyError(
+                        f"State '{name}' transitions to undeclared state "
+                        f"'{trans.next_state}' (known states: {sorted(self._states)})."
+                    )
+        self._done_sentinel: str = DONE_STATE_NAME
+
+        # Runtime state — reset before each generate call.
+        self._current: str = self._initial
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Reset FSM to the initial state for a new generation request."""
+        self._current = self._initial
+
+    def is_done(self) -> bool:
+        """Return True when the FSM has reached the framework-injected terminal state."""
+        return self._current == self._done_sentinel
+
+    # ── Step & Transition ─────────────────────────────────────────────────────
+
+    def iter_nodes(self, ctx: Dict[str, Any]) -> Iterator[NodeDef]:
+        """Yield the nodes to run for ONE iteration of the current state body.
+
+        Selection only — the graph never runs a model forward. The caller
+        executes each yielded ``NodeDef`` and mutates ``ctx`` in place; this
+        generator reads the mutated ``ctx`` *after* each yield to honour a
+        terminating ``module_signal`` (it stops yielding) and the body's
+        feed-forward fan-in gating. Mirror of
+        :meth:`TrainingGraph.iter_nodes` (which yields a whole training pass).
+
+        Algorithm (topological body execution, see module-doc §"body"):
+
+        1. Compute ``pending[X]`` = number of feed-forward body edges with
+           ``to: X`` for every node ``X`` in the body's node sequence. Nodes
+           with ``pending == 0`` are body sources — they run on first sight as
+           ``edge.from_``.
+        2. Walk ``state.body`` edges in declaration order. For each edge ``e``:
+
+           a. If ``e.from_`` hasn't run yet, yield it now. (If it still has
+              unprocessed in-body fan-in, that's a body-ordering bug — raise.)
+           b. If the just-run node raised a terminating ``module_signal``, stop.
+           c. Decrement ``pending[e.to]`` so a downstream node becomes runnable
+              once its later ``from_`` appearance is reached.
+
+        ``end`` is a virtual sink and is never yielded; an edge with ``to: end``
+        only pins its ``from_`` node into the active set. The same node never
+        re-runs within one body iteration.
+
+        Bare nodes default to ``generate``; dotted ``module.method`` nodes keep
+        the parsed method on :class:`NodeDef`.
+        """
+        state = self._current_state
+        executed: set = set()
+
+        # Per-node first appearance as `from_` in body — distinguishes
+        # **feed-forward** edges (with `to: X` *before* X's first `from_`
+        # position; these must complete before X runs) from
+        # **post-execution feedback** edges (after; they only update ctx
+        # for the next iteration / state).  Nodes that never appear as
+        # `from_` in body get ``len(body)`` so every incoming edge
+        # counts as feed-forward — this is the "to-only sink" case
+        # (e.g. ``janus_llama`` in ``image_vq_start`` whose body is
+        # ``[emit_start_to_janus_llama, janus_llama_sink]`` — the sink edge
+        # triggers ``janus_llama``).
+        first_from_idx: Dict[str, int] = {}
+        for i, e in enumerate(state.body):
+            if not is_end(e.from_) and e.from_ not in first_from_idx:
+                first_from_idx[e.from_] = i
+
+        # Feed-forward fan-in count per node (only edges before the
+        # node's first `from_` appearance).  Used to gate execution and
+        # to detect body-order bugs (a node about to run as `from_`
+        # whose pending > 0 means an upstream feed-forward edge appears
+        # later than expected).
+        pending: Dict[str, int] = dict.fromkeys(state.node_sequence, 0)
+        for i, e in enumerate(state.body):
+            if is_end(e.to):
+                continue
+            fi = first_from_idx.get(e.to, len(state.body))
+            if i < fi:
+                pending[e.to] += 1
+
+        for i, edge in enumerate(state.body):
+            # 1. Select the source node (idempotent for repeated `from_`).
+            name = edge.from_
+            if not is_end(name) and name not in executed:
+                if pending.get(name, 0) > 0:
+                    raise RuntimeError(
+                        f"FSM step (state '{state.name}'): node '{name}' is being "
+                        f"executed before all of its feed-forward in-body inputs have "
+                        f"been routed (pending={pending[name]}). Re-order the body "
+                        f"so every edge feeding '{name}' precedes its first "
+                        f"appearance as a source."
+                    )
+                executed.add(name)
+                yield self._node_pool[name]
+
+            # A terminating ``module_signal`` (e.g. ``text_done`` on ``</s>``),
+            # written by the node the caller just ran, means no further nodes in
+            # this body should run — the transition is evaluated in
+            # :meth:`maybe_transition` after this generator is exhausted.
+            if FSM_SIGNAL_KEY in ctx:
+                return
+
+            # 2. Decrement the destination's feed-forward pending count so it
+            #    becomes runnable once its later `from_` appearance is reached.
+            if not is_end(edge.to):
+                fi = first_from_idx.get(edge.to, len(state.body))
+                if i < fi:
+                    pending[edge.to] -= 1
+
+    def maybe_transition(self, context: Dict[str, Any]) -> Optional["FiredTransition"]:
+        """Check transitions for the current state.
+
+        Returns a :class:`FiredTransition` (``from_state`` / ``to_state`` /
+        ``condition`` description) if a transition fired and the state changed,
+        else ``None``. The caller may format a transition trace from the
+        returned value.
+
+        For ``module_signal`` transitions ``context["module_signal"]`` is popped
+        before the state switch.
+        """
+        state = self._current_state
+        for trans in state.transitions:
+            if trans.condition.check(context):
+                if trans.condition.type == "module_signal":
+                    context.pop(FSM_SIGNAL_KEY, None)
+                self._transition_to(trans.next_state, context)
+                return FiredTransition(
+                    from_state=state.name,
+                    to_state=trans.next_state,
+                    condition=trans.condition.describe(),
+                )
+        return None
+
+    # ── Accessors ─────────────────────────────────────────────────────────────
+
+    @property
+    def initial_state(self) -> str:
+        return self._initial
+
+    @property
+    def state_names(self) -> List[str]:
+        return list(self._states)
+
+    @property
+    def current_state_name(self) -> str:
+        return self._current
+
+    def state_node_sequence(self, state_name: str) -> List[str]:
+        """Return the derived node-execution sequence for a given state."""
+        return list(self._states[state_name].node_sequence)
+
+    # ── Visualization ─────────────────────────────────────────────────────────
+
+    def to_mermaid(self, title: Optional[str] = None) -> str:
+        """Render the FSM as a Mermaid ``flowchart LR`` with body subgraphs.
+
+        Visual conventions
+        ------------------
+        Each non-``done`` state is rendered as a labelled subgraph whose
+        interior is a mini-flow over the body's topology edges (``to: end`` sink
+        edges are filtered out since they don't carry data — they only
+        pin a node into the body).  The body's node names inside the
+        subgraph are namespaced as ``<state>__<node>`` so the same node
+        can appear in multiple states without ID collisions.
+
+        State transitions are thick arrows (``==>``) carrying the firing
+        condition (e.g. ``module_signal(start_image_gen)``, ``default``).
+        The line weight + simpler label distinguishes them visually from
+        the intra-body data edges.
+
+        A small ``▶`` node marks FSM entry; a small ``⏹`` terminal absorbs
+        every transition that targets the built-in ``done`` state.  The
+        ``done`` state itself is NOT drawn — its body is empty by
+        construction (framework-injected, not user-declared), and
+        rendering it would just add a redundant box.
+
+        Layout uses ``flowchart LR`` + the ELK renderer so major FSM states
+        read left-to-right. State bodies use ``direction TB`` so multi-step
+        states stay readable instead of stretching into a single wide strip.
+        """
+        lines: List[str] = []
+        if title:
+            lines += ["---", f"title: {title}", "---"]
+        lines.append("%%{init: {'flowchart': {'defaultRenderer': 'elk'}}}%%")
+        lines.append("flowchart LR")
+
+        done_name = self._done_sentinel
+
+        # ── Entry / terminal markers (small circles) ──────────────────────────
+        lines.append('    fsm_start(("▶")):::fsm_start')
+        has_done_target = done_name is not None and any(
+            trans.next_state == done_name for state in self._states.values() for trans in state.transitions
+        )
+        if has_done_target:
+            lines.append('    fsm_done(("⏹")):::fsm_terminal')
+
+        # ── Body subgraphs (skip the done state — empty body, no value) ───────
+        drawn: List[str] = []
+        for name, state in self._states.items():
+            if name == done_name:
+                continue
+            drawn.append(name)
+            lines.append(f"    subgraph state_{name} [{name}]")
+            lines.append("        direction TB")
+            for n_name in state.node_sequence:
+                n = self._node_pool[n_name]
+                node_label = f"<i>{n.module}.{n.method}</i>"
+                lines.append(f'        {name}__{_mermaid_id(n.name)}["{node_label}"]:::body_node')
+            for e in state.body:
+                if is_end(e.to):
+                    # `to: end` sinks are declarative pins — they don't carry
+                    # data, so they don't appear inside the body's mini-flow.
+                    continue
+                lines.append(f"        {name}__{_mermaid_id(e.from_)} --> {name}__{_mermaid_id(e.to)}")
+            lines.append("    end")
+
+        # ── Entry edge ────────────────────────────────────────────────────────
+        if self._initial in self._states and self._initial != done_name:
+            lines.append(f"    fsm_start ==> state_{self._initial}")
+
+        # ── State transitions (thick ==> arrows with quoted condition labels) ─
+        for name in drawn:
+            for trans in self._states[name].transitions:
+                if trans.next_state == done_name:
+                    target = "fsm_done"
+                else:
+                    target = f"state_{trans.next_state}"
+                cond = trans.condition.describe()
+                lines.append(f'    state_{name} ==>|"{cond}"| {target}')
+
+        # ── Class definitions / styling ──────────────────────────────────────
+        lines += [
+            "    classDef body_node fill:#fff,stroke:#666",
+            "    classDef fsm_start fill:#dff,stroke:#06c,stroke-width:2px",
+            "    classDef fsm_terminal fill:#eee,stroke:#333,stroke-width:1px,stroke-dasharray:3 3",
+        ]
+        if self._initial in self._states and self._initial != done_name:
+            # Highlight the initial state's subgraph background to mirror the
+            # training graph's source-node colouring (light blue accent).
+            lines.append(f"    style state_{self._initial} fill:#eef,stroke:#06c,stroke-width:2px")
+
+        return "\n".join(lines)
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    @property
+    def _current_state(self) -> _State:
+        return self._states[self._current]
+
+    def _transition_to(self, next_state: str, context: Dict[str, Any]) -> None:
+        self._current = next_state
+
+
+__all__ = ["GenerationGraph", "FiredTransition"]

--- a/veomni/models/seed_omni/graphs/generation_graph.py
+++ b/veomni/models/seed_omni/graphs/generation_graph.py
@@ -416,9 +416,17 @@ class GenerationGraph:
             # A terminating ``module_signal`` (e.g. ``text_done`` on ``</s>``),
             # written by the node the caller just ran, means no further nodes in
             # this body should run — the transition is evaluated in
-            # :meth:`maybe_transition` after this generator is exhausted.
-            if FSM_SIGNAL_KEY in ctx:
-                return
+            # :meth:`maybe_transition` after this generator is exhausted. An
+            # unknown or stale signal (no matching transition in this state)
+            # must not truncate the body — it is rejected and cleared instead.
+            signal = ctx.get(FSM_SIGNAL_KEY)
+            if signal is not None:
+                if any(
+                    trans.condition.type == "module_signal" and trans.condition.key == signal
+                    for trans in state.transitions
+                ):
+                    return
+                ctx.pop(FSM_SIGNAL_KEY, None)
 
             # 2. Decrement the destination's feed-forward pending count so it
             #    becomes runnable once its later `from_` appearance is reached.
@@ -426,6 +434,17 @@ class GenerationGraph:
                 fi = first_from_idx.get(edge.to, len(state.body))
                 if i < fi:
                     pending[edge.to] -= 1
+                    if edge.to not in first_from_idx and pending[edge.to] == 0 and edge.to not in executed:
+                        executed.add(edge.to)
+                        yield self._node_pool[edge.to]
+                        signal = ctx.get(FSM_SIGNAL_KEY)
+                        if signal is not None:
+                            if any(
+                                trans.condition.type == "module_signal" and trans.condition.key == signal
+                                for trans in state.transitions
+                            ):
+                                return
+                            ctx.pop(FSM_SIGNAL_KEY, None)
 
     def maybe_transition(self, context: Dict[str, Any]) -> Optional["FiredTransition"]:
         """Check transitions for the current state.

--- a/veomni/models/seed_omni/graphs/training_graph.py
+++ b/veomni/models/seed_omni/graphs/training_graph.py
@@ -1,0 +1,383 @@
+"""
+TrainingGraph: DAG view over a flat list of edges for training.
+
+Schema
+------
+``OmniConfig.training_graph`` is a *single list of edges*; each endpoint is a
+self-describing ``module[.method]`` string (a bare module defaults to
+``.forward``). A launcher ``graph_train.yaml`` *is* that list, at the file top
+level with no wrapper key::
+
+    - {from: janus_siglip,             to: janus_llama}
+    - {from: janus_vqvae.encode,       to: janus_llama}
+    - {from: janus_text_encoder.encode, to: janus_llama}
+    - {from: janus_llama,              to: janus_text_encoder.decode}
+    - {from: janus_llama,              to: janus_vqvae.decode}
+    - {from: janus_text_encoder.decode, to: end}   # leaf → end
+    - {from: janus_vqvae.decode,       to: end}    # leaf → end
+
+Active nodes are *derived* from the endpoints of those edges (excluding the
+virtual :data:`~.graph.END` keyword); a node's identity is its canonical
+``"<module>.<method>"`` form.
+
+Every node (real, non-``end``) MUST appear on at least one edge — either as a
+``from`` (data producer), as a ``to`` (data consumer), or as a leaf with
+``to: end``.  This guarantees no orphans and a single, well-formed forward
+queue.
+
+Each active node executes **exactly once** per forward pass.  Edges declare
+**topology only** (execution order) — there is no per-node input routing: every
+node receives the same shared ``batch`` and all cross-node state flows through
+the single ``conversation_list`` carrier, mutated/replaced in place as it goes.
+
+Single-loss protocol
+--------------------
+Each module's :meth:`OmniModule.forward` returns at most one ``_loss`` key
+(scalar, already token-mean-reduced across all micro-batches).  ``OmniModel``
+sums them — see ``modeling_omni.py``.
+
+Exposed surface
+---------------
+* ``execution_order``                   — node names in topological order.
+* ``active_nodes()`` / ``active_edges()`` — typed definitions, in topo / pool
+                                            order respectively.
+* ``sources`` / ``sinks``               — nodes with no incoming / no
+                                            non-``end`` outgoing active edge.
+* ``module_of(node)`` / ``method_of(node)`` — accessors.
+* ``reset()`` / ``is_done()`` / ``current_node_name`` — cursor lifecycle
+                                            (mirror of the generation FSM).
+* ``iter_nodes()``                      — generator that *selects* nodes in
+                                            execution order (no forward — the
+                                            caller runs each node's endpoint
+                                            against the shared batch);
+                                            ``maybe_transition()`` advances the
+                                            cursor.
+* ``to_mermaid(...)``                    — render the active DAG (``end`` is
+                                            drawn as a dashed terminal node).
+
+See also
+--------
+``base.py``           — NodeDef / EdgeDef / END shared types.
+``generation_graph.py`` — FSM view driven by ``OmniConfig.generation_graph``.
+"""
+
+from collections import defaultdict, deque
+from typing import Dict, Iterator, List, Optional
+
+from .base import EdgeDef, NodeDef, is_end
+
+
+def _mermaid_id(name: str) -> str:
+    """Sanitise a canonical ``module.method`` node name into a Mermaid-safe id."""
+    return name.replace(".", "_").replace("-", "_")
+
+
+class TrainingGraph:
+    """Active training DAG derived from a flat list of edges.
+
+    See module docstring for the full schema.
+    """
+
+    def __init__(
+        self,
+        training_graph: List[Dict],
+        *,
+        default_method: str = "forward",
+    ):
+        if not training_graph:
+            raise ValueError(
+                "TrainingGraph requires a non-empty `training_graph` list. "
+                "Even a single-node graph must use `to: end` to make the node visible."
+            )
+
+        # Parse edges; endpoints are self-describing `module[.method]` strings.
+        resolved_edges: List[EdgeDef] = []
+        seen_edges: set = set()
+        for spec in training_graph:
+            edge = EdgeDef.parse(spec, default_method=default_method)
+            key = (edge.from_, edge.to)
+            if key in seen_edges:
+                raise ValueError(f"Duplicate edge in training_graph: '{edge.name}'.")
+            seen_edges.add(key)
+            resolved_edges.append(edge)
+
+        # Derive the active node set (canonical names) in first-appearance order.
+        active_node_names: List[str] = []
+        self._node_by_name: Dict[str, NodeDef] = {}
+        for edge in resolved_edges:
+            for node in (edge.from_node, edge.to_node):
+                if node is None or node.name in self._node_by_name:
+                    continue
+                self._node_by_name[node.name] = node
+                active_node_names.append(node.name)
+
+        if not active_node_names:
+            raise ValueError("training_graph yielded zero real (non-`end`) nodes — every edge points to `end`.")
+
+        self._active_nodes: List[NodeDef] = [self._node_by_name[n] for n in active_node_names]
+        self._active_edges: List[EdgeDef] = resolved_edges
+
+        # Sanity: every active node has *some* outgoing edge (forbidding orphans
+        # is the whole point of the `to: end` keyword).  By construction every
+        # active node appears on at least one edge endpoint, so this is always
+        # satisfied — but assert defensively.
+        producers = {e.from_ for e in self._active_edges}
+        consumers = {e.to for e in self._active_edges if not is_end(e.to)}
+        touched = producers | consumers
+        for n in active_node_names:
+            assert n in touched, f"Internal: derived node '{n}' missing from any edge endpoint."
+
+        self._execution_order: List[str] = self._topological_sort()
+
+        # Runtime cursor into :attr:`_execution_order` — the training analogue of
+        # the FSM's ``_current`` state. ``step`` runs the node at the cursor;
+        # ``maybe_transition`` advances it. Reset before each forward pass.
+        self._cursor: int = 0
+
+    # ── public API ────────────────────────────────────────────────────────────
+
+    @property
+    def execution_order(self) -> List[str]:
+        """Active node names in dependency-safe execution order. Excludes ``end``."""
+        return list(self._execution_order)
+
+    @property
+    def sources(self) -> List[str]:
+        """Active nodes with no incoming active edge — they only see ``raw_batch``."""
+        targets = {e.to for e in self._active_edges if not is_end(e.to)}
+        return [n for n in self._execution_order if n not in targets]
+
+    @property
+    def sinks(self) -> List[str]:
+        """Active nodes whose only outgoing edges go to the virtual ``end``."""
+        producers_to_real = {e.from_ for e in self._active_edges if not is_end(e.to)}
+        return [n for n in self._execution_order if n not in producers_to_real]
+
+    def active_nodes(self) -> List[NodeDef]:
+        """Active node definitions in topological order."""
+        return [self._node_by_name[n] for n in self._execution_order]
+
+    def active_edges(self) -> List[EdgeDef]:
+        """Active edges in declaration order (``end``-targeted edges included)."""
+        return list(self._active_edges)
+
+    def module_of(self, node: str) -> str:
+        n = self._node_by_name.get(node)
+        if n is None:
+            raise KeyError(f"'{node}' is not an active node. Active: {sorted(self._node_by_name)}.")
+        return n.module
+
+    def method_of(self, node: str) -> str:
+        n = self._node_by_name.get(node)
+        if n is None:
+            raise KeyError(f"'{node}' is not an active node. Active: {sorted(self._node_by_name)}.")
+        return n.method
+
+    # ── Lifecycle (mirror of GenerationGraph) ───────────────────────────────────
+
+    def reset(self) -> None:
+        """Re-point the cursor at the first node for a fresh forward pass.
+
+        Training analogue of :meth:`GenerationGraph.reset` (FSM → initial state).
+        """
+        self._cursor = 0
+
+    def is_done(self) -> bool:
+        """True once every node in :attr:`execution_order` has been stepped.
+
+        Training analogue of :meth:`GenerationGraph.is_done` (FSM at ``done``).
+        """
+        return self._cursor >= len(self._execution_order)
+
+    @property
+    def current_node_name(self) -> str:
+        """The node the next :meth:`step` will run (the cursor position).
+
+        Analogue of :attr:`GenerationGraph.current_state_name`.
+        """
+        if self.is_done():
+            raise RuntimeError("TrainingGraph.current_node_name: cursor past the last node (graph is done).")
+        return self._execution_order[self._cursor]
+
+    # ── Step & Transition (mirror of GenerationGraph) ───────────────────────────
+
+    def iter_nodes(self) -> Iterator[NodeDef]:
+        """Yield each active node in execution order (selection only — no forward).
+
+        The graph only *chooses* what runs next; it never runs a model forward.
+        The caller executes each yielded ``NodeDef`` (``module`` + ``method``)
+        and mutates the shared ``conversation_list`` carrier in place. After the
+        caller consumes a node, this generator advances the cursor
+        (:meth:`maybe_transition`) and yields the next, until :meth:`is_done`.
+        Mirror of :meth:`GenerationGraph.iter_nodes` (one FSM body iteration).
+        """
+        while not self.is_done():
+            yield self._node_by_name[self.current_node_name]
+            self.maybe_transition()
+
+    def maybe_transition(self) -> bool:
+        """Advance the cursor to the next node (mirror of ``GenerationGraph.maybe_transition``).
+
+        Training's "transition" is unconditional: a static topological pass just
+        moves to the next node. Returns ``True`` while nodes remain, ``False``
+        once the cursor steps past the last one (``is_done()``).
+        """
+        self._cursor += 1
+        return not self.is_done()
+
+    # ── visualization ────────────────────────────────────────────────────────
+
+    def to_mermaid(
+        self,
+        title: Optional[str] = None,
+    ) -> str:
+        """Render the active training DAG as Mermaid flowchart syntax.
+
+        Each graph node is labelled ``<node_name><br/><module>.<method>`` so
+        multiple nodes of the same module are visually distinct.  Edges with
+        ``to: end`` render as dashed arrows into a single ``end`` terminal.
+
+        A dashed ``data`` pseudo-node fans out to every source node to mark
+        inputs that come from the shared batch dict.
+
+        Layout
+        ------
+        Direction is ``LR`` (left → right) and active nodes are bucketed into
+        invisible per-rank subgraphs by topological depth.  This forces the
+        renderer to lay out encoders / backbone / heads as parallel columns
+        rather than zig-zagging across the canvas.  The ELK renderer
+        (``defaultRenderer: elk``) is requested up-front so edges route
+        orthogonally with mostly straight segments — closer to what one
+        would draw by hand for a multi-modal training pipeline.
+
+        Single-loss protocol
+        --------------------
+        Each module collects its own scalar ``_loss`` (token-mean over its
+        own micro-batches); ``OmniModel`` sums them.  There is no central
+        ``losses`` collector, so the diagram only carries real data-flow
+        edges — no dashed fan-in to a pseudo loss node.
+
+        Parameters
+        ----------
+        title:
+            Optional Mermaid ``title:`` directive.
+        """
+        lines: List[str] = []
+        if title:
+            lines += ["---", f"title: {title}", "---"]
+        # Request the ELK renderer for orthogonal, mostly-straight edge routing.
+        lines.append("%%{init: {'flowchart': {'defaultRenderer': 'elk'}}}%%")
+        lines.append("flowchart LR")
+
+        sources = set(self.sources)
+        sinks = set(self.sinks)
+
+        # Topological depth per active node — the rank used for column banding.
+        # Sources sit at depth 0; every other node is one beyond its deepest
+        # active predecessor.  Edges into the virtual `end` don't count.
+        depth: Dict[str, int] = {}
+        active_predecessors: Dict[str, List[str]] = defaultdict(list)
+        for e in self._active_edges:
+            if not is_end(e.to):
+                active_predecessors[e.to].append(e.from_)
+        for n in self._execution_order:
+            preds = active_predecessors.get(n, [])
+            depth[n] = 0 if not preds else 1 + max(depth[p] for p in preds)
+
+        rank_to_nodes: Dict[int, List[str]] = defaultdict(list)
+        for n in self._execution_order:
+            rank_to_nodes[depth[n]].append(n)
+        ranks = sorted(rank_to_nodes)
+
+        if sources:
+            lines.append("    data[(data)]:::io")
+
+        # One invisible subgraph per topological rank — the renderer keeps each
+        # rank as a vertical stack, and the columns line up left-to-right.
+        for r in ranks:
+            lines.append(f"    subgraph col{r} [ ]")
+            lines.append("        direction TB")
+            for n_name in rank_to_nodes[r]:
+                n = self._node_by_name[n_name]
+                label = f"<i>{n.module}.{n.method}</i>"
+                cls = (
+                    "both"
+                    if n.name in sources and n.name in sinks
+                    else "source"
+                    if n.name in sources
+                    else "sink"
+                    if n.name in sinks
+                    else "middle"
+                )
+                lines.append(f'        {_mermaid_id(n.name)}["{label}"]:::{cls}')
+            lines.append("    end")
+
+        has_end = any(is_end(e.to) for e in self._active_edges)
+        if has_end:
+            lines.append('    end_sink(("end")):::end_sink')
+
+        if sources:
+            for n in sorted(sources):
+                lines.append(f"    data -.-> {_mermaid_id(n)}")
+
+        for e in self._active_edges:
+            label = self._edge_label(e)
+            arrow = f"-->|{label}|" if label else "-->"
+            target = "end_sink" if is_end(e.to) else _mermaid_id(e.to)
+            lines.append(f"    {_mermaid_id(e.from_)} {arrow} {target}")
+
+        # Hide the rank-banding subgraph borders — they only constrain layout.
+        for r in ranks:
+            lines.append(f"    style col{r} fill:transparent,stroke:none")
+
+        lines += [
+            "    classDef source fill:#dff,stroke:#06c,stroke-width:2px",
+            "    classDef sink fill:#fdd,stroke:#c06,stroke-width:2px",
+            "    classDef both fill:#efe,stroke:#693,stroke-width:2px",
+            "    classDef middle fill:#fff,stroke:#666",
+            "    classDef io fill:#eef,stroke:#669,stroke-dasharray:3 3",
+            "    classDef end_sink fill:#eee,stroke:#333,stroke-width:1px,stroke-dasharray:3 3",
+        ]
+        return "\n".join(lines)
+
+    # ── internal ─────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _edge_label(e: EdgeDef) -> str:
+        """Render a body edge label (topology-only — no field routing)."""
+        return ""
+
+    def _topological_sort(self) -> List[str]:
+        """Kahn's algorithm over the active-node dependency graph (excluding ``end``)."""
+        nodes: List[str] = [n.name for n in self._active_nodes]
+        deps: Dict[str, set] = defaultdict(set)
+        for e in self._active_edges:
+            if is_end(e.to):
+                continue
+            deps[e.to].add(e.from_)
+
+        in_degree: Dict[str, int] = {n: len(deps[n]) for n in nodes}
+        # Sort by user-declared order (active_nodes preserves first-appearance).
+        order_index = {n: i for i, n in enumerate(nodes)}
+        queue: deque = deque(sorted((n for n in nodes if in_degree[n] == 0), key=order_index.get))
+        order: List[str] = []
+
+        while queue:
+            n = queue.popleft()
+            order.append(n)
+            # Process in declaration order for stability.
+            for other in sorted(nodes, key=order_index.get):
+                if n in deps[other]:
+                    deps[other].discard(n)
+                    in_degree[other] -= 1
+                    if in_degree[other] == 0:
+                        queue.append(other)
+
+        if len(order) != len(nodes):
+            cycle = sorted(set(nodes) - set(order))
+            raise ValueError(
+                f"Circular dependency in active nodes: {cycle}. "
+                "The same module may back multiple nodes, but the active dependency graph must be acyclic."
+            )
+
+        return order

--- a/veomni/models/seed_omni/mixins/__init__.py
+++ b/veomni/models/seed_omni/mixins/__init__.py
@@ -1,0 +1,35 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SeedOmni V2 mixins: base lifecycle + training / inference graph hooks + metric meter."""
+
+from .base_mixin import BaseMixin
+from .inference_module_mixin import InferenceModuleMixin, post_generate, pre_generate
+from .metric_meter_mixin import MetricMeterMixin, MetricMeterResult
+from .offline_encoding_mixin import OfflineEncodingMixin
+from .training_module_mixin import TrainingModuleMixin, post_forward, pre_forward
+
+
+__all__ = [
+    "BaseMixin",
+    "InferenceModuleMixin",
+    "TrainingModuleMixin",
+    "pre_forward",
+    "post_forward",
+    "pre_generate",
+    "post_generate",
+    "MetricMeterMixin",
+    "MetricMeterResult",
+    "OfflineEncodingMixin",
+]

--- a/veomni/models/seed_omni/mixins/base_mixin.py
+++ b/veomni/models/seed_omni/mixins/base_mixin.py
@@ -1,0 +1,50 @@
+"""
+BaseMixin — minimal SeedOmni V2 lifecycle + shared graph-hook registry.
+
+Every module composes capability mixins (training / inference / meter / …) into a
+local ``VeOmniMixin``; ``modeling.py`` inherits only ``VeOmniMixin`` +
+``PreTrainedModel``.
+
+Layout
+------
+* ``omni_pretrained_model.py`` — :class:`OmniPreTrainedModel` (native HF sub-models)
+* ``base_mixin.py`` — :class:`BaseMixin` (runtime hook registry)
+* ``training_module_mixin.py`` — :class:`TrainingModuleMixin` (``pre_forward`` / ``post_forward``)
+* ``inference_module_mixin.py`` — :class:`InferenceModuleMixin` (runtime ``pre_generate`` / ``post_generate``)
+* ``modules/<family>/<sub>/modeling.py``::
+
+    class Xxx(OmniPreTrainedModel): ...
+
+* ``modules/<family>/<sub>/accelerated.py``::
+
+    class XxxAccelerated(VeOmniMixin, Xxx): ...
+"""
+
+from __future__ import annotations
+
+
+class BaseMixin:
+    """Accelerated SeedOmni base — shared graph-hook registry for runtime mixins."""
+
+    @classmethod
+    def _omni_hook_name(cls, marker: str, context: str) -> str | None:
+        """Resolve the method name tagged ``marker`` for call-site ``context``.
+
+        Shared by training (``@pre_forward`` / ``@post_forward``) and inference
+        (``@pre_generate`` / ``@post_generate``) dispatchers.
+        """
+        cache_attr = f"__omni_hooks_{marker}__"
+        registry: dict[str, str] | None = cls.__dict__.get(cache_attr)
+        if registry is None:
+            registry = {}
+            for klass in reversed(cls.__mro__):
+                for name, attr in vars(klass).items():
+                    contexts = getattr(attr, marker, None)
+                    if contexts is not None:
+                        for ctx in contexts:
+                            registry[ctx] = name
+            setattr(cls, cache_attr, registry)
+        return registry.get(context)
+
+
+__all__ = ["BaseMixin"]

--- a/veomni/models/seed_omni/mixins/emb_parallel_mixin.py
+++ b/veomni/models/seed_omni/mixins/emb_parallel_mixin.py
@@ -1,0 +1,96 @@
+"""Vocab-parallel (``emb`` extra-parallel) embedding lookup + tied projection.
+
+Shared by any module whose embedding table is ``Shard(0)``-split on dim-0 (vocab)
+over the ``emb`` extra-parallel group AND additionally FSDP-sharded on dim-1
+(hidden) over the ``emb_fsdp`` sub-mesh -- the base ``TextEncoder``'s
+``embed_tokens`` and Seedream 5.0's 258 GB over-encoding table both take this
+shape. The lookup / projection kernels (``AllToAllEmbedding`` /
+``VocabParallelLinear``) need this rank's *whole* emb chunk (all hidden), so the
+FSDP hidden shards are gathered back first (see :meth:`emb_local_weight`).
+
+All methods are ``@staticmethod`` so a top-level model (``TextEncoder``) or an
+inner ``nn.Module`` (Seedream's ``SHMOverEncodingEmbedding``) can call them
+regardless of ``self``; mix the class in for method-style access.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.tensor import DTensor
+
+from veomni.distributed.parallel_state import get_parallel_state
+from veomni.ops.kernels.embed import AllToAllEmbedding, VocabParallelLinear
+
+
+class EmbParallelMixin:
+    @staticmethod
+    def emb_parallel_active() -> bool:
+        """True when the ``emb`` extra-parallel group is present and size > 1."""
+        ps = get_parallel_state()
+        return "emb" in ps.extra_parallel_sizes and ps.extra_parallel_enabled("emb")
+
+    @staticmethod
+    def emb_local_weight(weight: torch.Tensor) -> torch.Tensor:
+        """Reconstruct this emb-rank's full ``[vocab/emb, hidden]`` slice.
+
+        The weight is ``Shard(0)`` (vocab) over ``emb`` and FSDP-sharded on the
+        hidden dim over ``emb_fsdp``; the kernels need this rank's whole emb chunk
+        across all hidden -- gathered WITHOUT mixing other emb ranks:
+
+        * ``emb_fsdp == 1`` (world == emb): the local shard already spans all
+          hidden, so ``to_local()`` returns it as a view -- no (tens-of-GB) copy.
+        * ``emb_fsdp  > 1``: ``full_tensor()`` all-gathers the hidden shards.
+          Detach under inference (``full_tensor``'s redistribute trips on an
+          in-place ``detach_`` of a grad-requiring DTensor); keep grad in training
+          so the kernel's backward reaches the sharded param.
+
+        With ``emb`` OFF the weight is still a DTensor -- a plain FSDP2 ``Shard(0)``
+        over ``dp_shard`` -- because a tied head reads ``embed_tokens.weight``
+        directly, bypassing the embedding's own FSDP2 unshard hook. There is no
+        ``emb`` group to consult, so ``full_tensor()`` all-gathers the whole
+        ``[vocab, hidden]`` table for the plain ``F.linear`` projection (grad kept
+        in training, detached in inference, as above).
+
+        Non-DTensor weights (single replica / eager) pass through unchanged.
+        """
+        if not isinstance(weight, DTensor):
+            return weight
+        if not EmbParallelMixin.emb_parallel_active():
+            return weight.full_tensor() if torch.is_grad_enabled() else weight.detach().full_tensor()
+        ps = get_parallel_state()
+        if ps.extra_parallel_fsdp_size("emb") == 1:
+            return weight.to_local()
+        return weight.full_tensor() if torch.is_grad_enabled() else weight.detach().full_tensor()
+
+    @staticmethod
+    def emb_parallel_lookup(embedding: nn.Module, ids: torch.Tensor) -> torch.Tensor:
+        """Embedding lookup: vocab-parallel when ``emb`` is on, else a plain call.
+
+        ``embedding`` is the row-owning module (an ``nn.Embedding`` or a lazy
+        table). Under ``emb`` its ``.weight`` is the ``Shard(0)`` DTensor and
+        ``AllToAllEmbedding`` all-to-all dispatches each global id to its owning
+        rank, so the result is bit-identical to a full-table lookup.
+        """
+        if not EmbParallelMixin.emb_parallel_active():
+            return embedding(ids)
+        ps = get_parallel_state()
+        weight = EmbParallelMixin.emb_local_weight(embedding.weight)
+        return AllToAllEmbedding.apply(ps.extra_parallel_group("emb"), ids, weight)
+
+    @staticmethod
+    def emb_parallel_project(hidden_states: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        """Project ``hidden -> vocab`` logits with a (possibly ``emb``-sharded) weight.
+
+        Dual of :meth:`emb_parallel_lookup` for a tied head: ``VocabParallelLinear``
+        all-gathers the vocab shards over ``emb`` to full-vocab logits; off ``emb``
+        it is a plain ``F.linear``. (``full_tensor()`` returns the fp32 master
+        param, so cast to the activation dtype before the matmul.)
+        """
+        weight = EmbParallelMixin.emb_local_weight(weight).to(hidden_states.dtype)
+        if EmbParallelMixin.emb_parallel_active():
+            ps = get_parallel_state()
+            return VocabParallelLinear.apply(ps.extra_parallel_group("emb"), hidden_states, weight)
+        return F.linear(hidden_states, weight)
+
+
+__all__ = ["EmbParallelMixin"]

--- a/veomni/models/seed_omni/mixins/inference_module_mixin.py
+++ b/veomni/models/seed_omni/mixins/inference_module_mixin.py
@@ -1,0 +1,105 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generation-FSM hooks shared by every SeedOmni V2 sub-model.
+
+Only :meth:`InferenceModuleMixin.reset_global_inference_state` and
+:meth:`InferenceModuleMixin.finalize` are wired in, on both inference paths —
+eager (``OmniModel.reset`` / ``OmniModel._invoke_module_finalize``) and
+distributed (``OmniModelRuntime``, ``accelerator/omni_model_runtime.py``).
+
+The ``pre_generate`` / ``post_generate`` / ``generate_step`` surface has NO
+call-site: both FSM drivers invoke each graph endpoint directly with no hooks
+(``accelerator/executor.py::execute_generation_node``,
+``OmniModel._run_generation_node``), so a module cannot opt in without new
+plumbing.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def pre_generate(*contexts: str) -> Callable[[Callable], Callable]:
+    """Decorator: register a **pre-hook** for one or more inference call-sites."""
+
+    if not contexts:
+        raise ValueError("@pre_generate requires at least one context.")
+
+    def decorator(fn: Callable) -> Callable:
+        fn._omni_pre_generate_context = tuple(contexts)
+        return fn
+
+    return decorator
+
+
+def post_generate(*contexts: str) -> Callable[[Callable], Callable]:
+    """Decorator: register a **post-hook** for one or more inference call-sites."""
+
+    if not contexts:
+        raise ValueError("@post_generate requires at least one context.")
+
+    def decorator(fn: Callable) -> Callable:
+        fn._omni_post_generate_context = tuple(contexts)
+        return fn
+
+    return decorator
+
+
+class InferenceModuleMixin:
+    """Inference-graph hooks — ``pre_generate`` / ``post_generate`` / ``generate*`` / reset.
+
+    Hook-name lookup lives on :class:`~veomni.models.seed_omni.mixins.base_mixin.BaseMixin`.
+
+    Module-local ``InferenceMixin`` subclasses should define ``__init__`` to set
+    inference-side runtime caches after ``super().__init__(...)``.
+    """
+
+    def pre_generate(self, method: str, **kwargs: Any) -> dict[str, Any]:
+        """Dispatch to the ``@pre_generate(method)``-decorated hook for this call-site."""
+        name = type(self)._omni_hook_name("_omni_pre_generate_context", method)
+        if name is None:
+            return kwargs
+        return getattr(self, name)(**kwargs)
+
+    def post_generate(self, method: str, **outputs: Any) -> dict[str, Any]:
+        """Dispatch to the ``@post_generate(method)``-decorated hook for this call-site."""
+        name = type(self)._omni_hook_name("_omni_post_generate_context", method)
+        if name is None:
+            return outputs
+        return getattr(self, name)(**outputs)
+
+    def generate_step(self, **kwargs: Any) -> dict[str, Any]:
+        """Single FSM-driven generation step.
+
+        Default: delegate to :meth:`forward`. Override when inference logic
+        differs from training.
+        """
+        return self.forward(**kwargs)
+
+    def reset_local_inference_state(self) -> None:
+        """Reset per-turn state inside an ongoing conversation."""
+        return None
+
+    def reset_global_inference_state(self) -> None:
+        """Reset the full conversation-level inference state."""
+        self.reset_local_inference_state()
+
+    def finalize(self, *, ctx: dict[str, Any]) -> dict[str, Any]:
+        """Flush module-private generation buffers into a one-shot ``generated`` payload."""
+        del ctx
+        return {}
+
+
+__all__ = ["InferenceModuleMixin", "post_generate", "pre_generate"]

--- a/veomni/models/seed_omni/mixins/metric_meter_mixin.py
+++ b/veomni/models/seed_omni/mixins/metric_meter_mixin.py
@@ -1,0 +1,167 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MetricMeterMixin — optional per-module training meter (tokens + theoretical FLOPs).
+
+Why per-module
+--------------
+A single-model trainer counts tokens and estimates FLOPs from one ``model_type``
+(see :class:`veomni.utils.helper.EnvironMeter`).  ``OmniModel`` is instead a
+*composition* of independent sub-modules with no single config to dispatch a
+FLOPs formula on — so each module must count its **own** tokens and estimate its
+**own** theoretical FLOPs (with its own config), and the orchestrator rolls them
+up into the overall throughput / MFU.
+
+What a module computes vs. what the trainer computes
+----------------------------------------------------
+A module only ever produces **time-independent** quantities:
+
+* :meth:`metric_meter_add` accumulates this module's token lengths — the per-module
+  analogue of ``EnvironMeter.add``.  The
+  :class:`~veomni.models.seed_omni.accelerator.module_runtime.ModuleRuntime` calls it right after
+  ``pre_forward`` (when the real input tensors are in hand), passing the node's
+  ``method`` + the forward ``data``.  A module reports its tokens by calling
+  :meth:`MetricMeterMixin.metric_meter_set_seqlens` inside its ``pre_forward``
+  **before any SP slice** (that setter lives on ``MetricMeterMixin`` so only
+  metered modules stash; token domains differ
+  — text seq len vs image patches vs VQ tokens — and some call-sites aren't
+  counted, e.g. a VQ codec counts on ``encode`` and stashes nothing on
+  ``decode``). The default :meth:`metric_meter_token_lengths` simply drains that
+  stash, so metering is identical with or without SP (measuring the
+  post-``pre_forward`` shard directly would under-count by ~``sp``).
+* :meth:`metric_meter_collect` returns ``(theoretical_flops, seqlens)`` — the total
+  theoretical TFLOPs for this module's compute over the step plus its raw token
+  lengths.  **No timing, no MFU, no cross-rank reduction here.**
+
+MFU / achieved-FLOPs / tokens-per-second are computed once, globally, by the
+orchestrator: a per-module wall-clock is meaningless because a module's
+``on_step_end`` only fires after the *whole* graph's forward+backward finishes,
+so the elapsed time it would see is the whole-step time, not its own. The trainer
+therefore times the whole graph once and divides the summed theoretical FLOPs by
+that single delta (see :class:`veomni.utils.omni_helper.OmniEnvironMeter`).
+
+A module has exactly **one** notion of sequence length — a token is a token,
+whatever its modality. Each module implements its own :meth:`estimate_flops`
+(its own FLOPs formula — there is no shared whole-model counter, which would
+mis-count at module granularity).
+
+Opt-in is by **multiple inheritance**, NOT by ``BaseMixin`` (``BaseMixin``
+does *not* inherit ``MetricMeterMixin``). A module that wants metering defines its own
+``XxxMetricMeterMixin(MetricMeterMixin)`` implementing just ``estimate_flops`` (token
+lengths come from :meth:`metric_meter_set_seqlens` via the default
+``metric_meter_token_lengths``), and its concrete model multi-inherits it, e.g.::
+
+    class TextEncoder(VeOmniMixin, PreTrainedModel): ...
+
+The orchestrator decides whether a module contributes metrics with
+``isinstance(model, MetricMeterMixin)``. Modules without a metric meter contribute
+nothing.
+"""
+
+from typing import Any, Dict, List, Tuple
+
+
+# What a metered module hands back each step: its total theoretical TFLOPs +
+# the raw (this-rank) per-sample token lengths it processed.
+MetricMeterResult = Tuple[float, List[int]]
+
+
+class MetricMeterMixin:
+    """Optional per-module token + theoretical-FLOPs meter for SeedOmni V2."""
+
+    def metric_meter_set_seqlens(self, method: str, seqlens: List[int]) -> None:
+        """Stash the FULL (pre-SP-slice) per-sample token lengths for call-site ``method``.
+
+        **Call this inside a ``pre_forward`` hook, BEFORE any SP gather/slice.**
+        Only modules that mix in ``MetricMeterMixin`` should call this; the default
+        :meth:`metric_meter_token_lengths` drains the stash at step end.
+
+        Why pre-slice / full-sample: under uniform SP the ``pre_forward`` hook
+        slices to this rank's ``1/sp_size`` shard, so a length read *after* the
+        slice would under-count by ~``sp``. Stash the FULL (pre-slice) per-sample
+        lengths here — before the slice branch — instead: ``OmniEnvironMeter`` sums
+        tokens+FLOPs over the ``dp_group`` (which excludes the SP ranks that all
+        hold the same replicated sample), so the full-sample value counted once per
+        DP shard reconstructs the true global total, matching the non-SP run.
+        """
+        if not hasattr(self, "_metric_full_seqlens"):
+            self._metric_full_seqlens: Dict[str, List[int]] = {}
+        self._metric_full_seqlens[method] = [int(s) for s in seqlens]
+
+    def _metric_meter_seqlen_buffer(self) -> List[int]:
+        # Lazily initialised so an implementing module never has to touch its own
+        # ``TrainingMixin.__init__`` / ``pre_forward``.
+        if not hasattr(self, "_metric_meter_seqlens"):
+            self._metric_meter_seqlens: List[int] = []
+        return self._metric_meter_seqlens
+
+    def estimate_flops(self, seqlens: List[int]) -> float:
+        """Total theoretical TFLOPs for this module's compute over ``seqlens``.
+
+        **Each metered module implements its own** — :class:`VeomniFlopsCounter`
+        is a *whole-model* estimator and is wrong at module granularity (e.g. an
+        AR backbone owns no ``wte`` / ``lm_head`` — those FLOPs belong to the
+        ``text_encoder`` module).  Return the total FLOPs in TFLOPs (forward +
+        backward), **time-independent**; the orchestrator divides the summed
+        FLOPs across modules + ranks by the single whole-graph wall-clock to get
+        achieved FLOPs / MFU.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} mixes in MetricMeterMixin but does not implement estimate_flops(seqlens)."
+        )
+
+    def metric_meter_token_lengths(self, method: str, data: Dict[str, Any]) -> List[int]:
+        """Per-sample token lengths this module processed for call-site ``method``.
+
+        Canonical path: drain the FULL, SP-invariant lengths a module stashed via
+        :meth:`metric_meter_set_seqlens` in its ``pre_forward``. A call-site that
+        ``decode``) returns ``[]`` and contributes nothing — so ``data`` is unused.
+
+        This unified stash replaces the old per-module readers that measured the
+        post-``pre_forward`` kwargs directly: under SP those kwargs are this rank's
+        shard, which under-counts tokens/FLOPs by ~``sp``. Stashing the full
+        pre-slice own-data length keeps metering identical across SP configs. A
+        module may still override this, but the stash is the intended mechanism.
+        """
+        del data
+        store = getattr(self, "_metric_full_seqlens", None)
+        if store is None:
+            return []
+        return store.pop(method, [])
+
+    def metric_meter_add(self, method: str, data: Dict[str, Any]) -> None:
+        """Accumulate this micro-batch's token lengths (per-module ``meter.add``).
+
+        Called once per micro-batch by the module-trainer right after
+        ``pre_forward`` (so ``data`` holds the real input tensors), with the
+        node's ``method``.  Sums correctly over a whole gradient-accumulation
+        step (a call that returns ``[]`` adds nothing).
+        """
+        self._metric_meter_seqlen_buffer().extend(self.metric_meter_token_lengths(method, data))
+
+    def metric_meter_collect(self) -> MetricMeterResult:
+        """Return ``(theoretical_flops, seqlens)`` for the step, then reset.
+
+        ``theoretical_flops`` is the module's own total theoretical TFLOPs
+        (time-independent) via :meth:`estimate_flops`; ``seqlens`` is this rank's
+        raw per-sample token lengths.  The orchestrator sums these across modules
+        + ranks and divides by the single whole-graph time for achieved FLOPs /
+        MFU.
+        """
+        seqlens = self._metric_meter_seqlen_buffer()
+        self._metric_meter_seqlens = []
+        return self.estimate_flops(seqlens), seqlens
+
+
+__all__ = ["MetricMeterMixin", "MetricMeterResult"]

--- a/veomni/models/seed_omni/mixins/offline_encoding_mixin.py
+++ b/veomni/models/seed_omni/mixins/offline_encoding_mixin.py
@@ -1,0 +1,148 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic offline-encoding surfaces for SeedOmni V2 modules."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Collection
+from typing import Any
+
+
+RUNTIME_CONFIG_KEYS = ("support_cache", "train_type")
+
+
+class OfflineEncodingMixin(ABC):
+    """Offline-cache capability for accelerated module mixins.
+
+    ``support_cache`` / ``train_type`` are launcher/runtime fields — not part of
+    the HF-native ``config.json``. :meth:`patch_config` applies them onto the
+    live config object; :meth:`__init__` does this automatically before the
+    native model body runs.
+
+    Modules that expose offline-cache graph endpoints must implement
+    :meth:`offline_encode` and :meth:`online_process` on a sibling ``*OfflineMixin``
+    placed **before** this mixin in ``VeOmniMixin`` bases so the concrete tensor
+    call-sites win MRO lookup.
+    """
+
+    DEFAULT_CACHE_MODE = "full"
+    VALID_CACHE_MODES = frozenset({"full", "encode_only", "process_only"})
+
+    config: Any
+
+    @classmethod
+    def derive_cache_mode(cls, *, support_cache: bool, train_type: str) -> str:
+        if not support_cache:
+            return cls.DEFAULT_CACHE_MODE
+        if train_type == "offline_cache":
+            return "encode_only"
+        if train_type == "train_with_cache":
+            return "process_only"
+        return cls.DEFAULT_CACHE_MODE
+
+    @classmethod
+    def patch_config(cls, config: Any, **overrides: Any) -> None:
+        """Apply launcher/runtime offline-cache fields onto a live config object."""
+        support_cache = overrides.get("support_cache", getattr(config, "support_cache", False))
+        train_type = overrides.get("train_type", getattr(config, "train_type", "train"))
+        config.support_cache = bool(support_cache)
+        config.train_type = str(train_type)
+
+    @classmethod
+    def validated_cache_mode(cls, config: Any) -> str:
+        mode = cls.derive_cache_mode(
+            support_cache=bool(getattr(config, "support_cache", False)),
+            train_type=str(getattr(config, "train_type", "train")),
+        )
+        if mode not in cls.VALID_CACHE_MODES:
+            valid = ", ".join(sorted(cls.VALID_CACHE_MODES))
+            raise ValueError(f"{type(config).__name__}.cache_mode must be one of {{{valid}}}; got {mode!r}.")
+        return mode
+
+    @property
+    def cache_mode(self) -> str:
+        return self.validated_cache_mode(self.config)
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        runtime_overrides = {key: kwargs.pop(key) for key in RUNTIME_CONFIG_KEYS if key in kwargs}
+        config = kwargs.get("config")
+        if config is None and args:
+            candidate = args[0]
+            if hasattr(candidate, "model_type"):
+                config = candidate
+        if config is not None:
+            self.patch_config(config, **runtime_overrides)
+        super().__init__(*args, **kwargs)
+        if config is None and hasattr(self, "config"):
+            self.patch_config(self.config, **runtime_overrides)
+
+    @abstractmethod
+    def offline_encode(self, **kwargs: Any) -> dict[str, Any]:
+        """Produce deterministic tensor cache artifacts from tensor inputs."""
+
+    @abstractmethod
+    def online_process(self, **kwargs: Any) -> dict[str, Any]:
+        """Materialize runtime tensors from offline encoded cache tensors."""
+
+    def pre_forward(self, method: str, **kwargs: Any) -> dict[str, Any]:
+        """Gate offline-cache call-sites before dispatching module hooks."""
+        if method == "offline_encode" and not getattr(self, f"_{method}_checked", False):
+            self._check_cache_mode(method=method, allowed={"full", "encode_only"})
+            setattr(self, f"_{method}_checked", True)
+        elif method == "online_process" and not getattr(self, f"_{method}_checked", False):
+            self._check_cache_mode(method=method, allowed={"full", "process_only"})
+            setattr(self, f"_{method}_checked", True)
+        return super().pre_forward(method=method, **kwargs)
+
+    def _check_cache_mode(self, *, method: str, allowed: Collection[str]) -> None:
+        mode = self.cache_mode
+        if mode not in allowed:
+            allowed_text = ", ".join(sorted(allowed))
+            raise ValueError(
+                f"{type(self).__name__}.{method} requires cache_mode in {{{allowed_text}}}; "
+                f"current cache_mode is {mode!r}."
+            )
+
+    def load_partial_dcp_checkpoint(self, load_dir: str, *, trainer: Any) -> None:
+        """Load runtime DCP state for a non-``full`` offline-cache module.
+
+        The default is a no-op for modules such as a VAE ``process_only`` stage
+        that has no online runtime state. Modules with trainable online
+        components can override this to restore a partial model/optimizer state.
+        """
+        del load_dir, trainer
+
+    def save_partial_dcp_checkpoint(self, save_dir: str, *, trainer: Any, state: Any) -> None:
+        """Save runtime DCP state for a non-``full`` offline-cache module.
+
+        The default is a no-op for modules with no online runtime state.
+        Modules with trainable online components can override this to persist a
+        partial model/optimizer state.
+        """
+        del save_dir, trainer, state
+
+    def save_full_hf_checkpoint(self, output_dir: str, *, source_path: str, trainer: Any, state: Any) -> None:
+        """Save a full HuggingFace artifact for a non-``full`` offline-cache module.
+
+        Concrete modules own the merge policy: a no-parameter process-only
+        module may copy the frozen source split, while a partial online module
+        may combine frozen source weights with trainable runtime weights.
+        """
+        del output_dir, source_path, trainer, state
+        raise NotImplementedError(f"{type(self).__name__}.save_full_hf_checkpoint is not implemented.")
+
+
+__all__ = ["OfflineEncodingMixin", "RUNTIME_CONFIG_KEYS"]

--- a/veomni/models/seed_omni/mixins/offline_encoding_mixin.py
+++ b/veomni/models/seed_omni/mixins/offline_encoding_mixin.py
@@ -51,7 +51,9 @@ class OfflineEncodingMixin(ABC):
             return "encode_only"
         if train_type == "train_with_cache":
             return "process_only"
-        return cls.DEFAULT_CACHE_MODE
+        if train_type == "train":
+            return cls.DEFAULT_CACHE_MODE
+        raise ValueError(f"Unsupported train_type: {train_type!r}")
 
     @classmethod
     def patch_config(cls, config: Any, **overrides: Any) -> None:

--- a/veomni/models/seed_omni/mixins/training_module_mixin.py
+++ b/veomni/models/seed_omni/mixins/training_module_mixin.py
@@ -1,0 +1,99 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Training-graph hooks shared by every SeedOmni V2 sub-model."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from torch.nn import Module
+
+
+def pre_forward(*contexts: str) -> Callable[[Callable], Callable]:
+    """Decorator: register a **pre-hook** for one or more training call-sites."""
+
+    if not contexts:
+        raise ValueError("@pre_forward requires at least one context.")
+
+    def decorator(fn: Callable) -> Callable:
+        fn._omni_pre_context = tuple(contexts)
+        return fn
+
+    return decorator
+
+
+def post_forward(*contexts: str) -> Callable[[Callable], Callable]:
+    """Decorator: register a **post-hook** for one or more training call-sites."""
+
+    if not contexts:
+        raise ValueError("@post_forward requires at least one context.")
+
+    def decorator(fn: Callable) -> Callable:
+        fn._omni_post_context = tuple(contexts)
+        return fn
+
+    return decorator
+
+
+class TrainingModuleMixin:
+    """Training-graph hooks — ``pre_forward`` / ``post_forward`` / ``forward`` / ``dummy_inputs``.
+
+    Hook-name lookup lives on :class:`~veomni.models.seed_omni.mixins.base_mixin.BaseMixin`.
+
+    Module-local ``TrainingMixin`` subclasses should define ``__init__`` to set
+    training-side runtime caches after ``super().__init__(...)``.
+    """
+
+    def pre_forward(self, method: str, **kwargs: Any) -> dict[str, Any]:
+        """Dispatch to the ``@pre_forward(method)``-decorated hook for this call-site."""
+        name = type(self)._omni_hook_name("_omni_pre_context", method)
+        if name is None:
+            return kwargs
+        return getattr(self, name)(**kwargs)
+
+    def post_forward(self, method: str, **outputs: Any) -> dict[str, Any]:
+        """Dispatch to the ``@post_forward(method)``-decorated hook for this call-site."""
+        name = type(self)._omni_hook_name("_omni_post_context", method)
+        if name is None:
+            return outputs
+        return getattr(self, name)(**outputs)
+
+    def forward(self, **kwargs: Any) -> dict[str, Any]:
+        """Training-graph ``forward`` endpoint.
+
+        Override on the module ``Accelerated`` class (or native ``modeling.py``)
+        when this module appears in the training graph. The default skips mixin
+        layers and delegates to the first concrete ``forward`` below this mixin
+        in MRO so a stub here does not shadow HF-native implementations.
+        """
+        for base in type(self).__mro__[1:]:
+            if base is TrainingModuleMixin or base is Module:
+                continue
+            impl = base.__dict__.get("forward")
+            if impl is None:
+                continue
+            return impl(self, **kwargs)
+        raise NotImplementedError(
+            f"{type(self).__name__}.forward(**kwargs) is not implemented. "
+            "Override it on the module Accelerated class if this module appears in the training graph."
+        )
+
+    def dummy_inputs(self, *, batch_size: int, device: Any, dtype: Any) -> dict[str, Any]:
+        """Zero-tensor placeholders for training-side dummy forward."""
+        del batch_size, device, dtype
+        return {}
+
+
+__all__ = ["TrainingModuleMixin", "post_forward", "pre_forward"]

--- a/veomni/models/seed_omni/modeling_omni.py
+++ b/veomni/models/seed_omni/modeling_omni.py
@@ -1,0 +1,498 @@
+"""
+OmniModel V2 — composable multi-modal model driven by config-specified graphs.
+
+This file holds the **clean modeling definition** — FSM inference via
+:meth:`OmniModel.generate` and checkpoint compose/load/save.  It is profiler-free
+and parallel-infra-free so it can be loaded with HF ``from_pretrained`` /
+``from_config`` and run eager single-process inference without VeOmni.
+
+Training and distributed execution belong in ``accelerator/``; this module
+imports nothing from there.
+
+Architecture
+------------
+``OmniModel`` carries:
+
+* sub-modules — each graph participant is a direct attribute from the registry.
+* ``generation_graph`` — :class:`GenerationGraph` (FSM).
+
+Inference
+---------
+``generate(request, generation_kwargs)`` loops the FSM.  Each node calls its
+endpoint directly (no pre/post hooks).  Stop when ``is_done()`` or
+``max_new_tokens`` is reached.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Iterator, Mapping
+
+import torch.distributed as dist
+import torch.nn as nn
+from transformers import PreTrainedModel
+
+from ...utils import helper
+from .configuration_omni import OmniConfig
+from .graphs.base import NodeDef
+from .graphs.generation_graph import GenerationGraph
+from .graphs.training_graph import TrainingGraph
+from .modules import OMNI_MODEL_REGISTRY, read_model_type
+
+
+logger = helper.create_logger(__name__)
+
+# HF hub kwargs forwarded to :meth:`OmniConfig.from_pretrained`.
+_CONFIG_LOAD_KWARG_NAMES = frozenset(
+    {
+        "cache_dir",
+        "force_download",
+        "local_files_only",
+        "proxies",
+        "resume_download",
+        "revision",
+        "subfolder",
+        "token",
+        "trust_remote_code",
+        "mirror",
+        "_from_pipeline",
+    }
+)
+
+# Top-level :class:`OmniConfig` fields overridable at ``OmniModel.from_pretrained`` time.
+_OMNI_CONFIG_OVERRIDE_KEYS = frozenset(
+    {
+        "infer_type",
+        "generation_kwargs",
+        "training_graph",
+        "generation_graphs",
+        "modules",
+    }
+)
+
+
+class OmniModel(PreTrainedModel):
+    """Pure SeedOmni modeling runtime over already-built sub-modules.
+
+    Parameters
+    ----------
+    config:
+        :class:`OmniConfig` with ``modules`` / ``training_graph`` /
+        ``generation_graphs`` populated. The FSM bound here is the one
+        ``config.infer_type`` selects, so switching scenario means rebuilding.
+    modules:
+        ``{module_name: nn.Module}`` — bare graph participants for the eager path.
+    """
+
+    config_class = OmniConfig
+    base_model_prefix = "omni"
+    main_input_name = "conversation_list"
+    supports_gradient_checkpointing = False
+
+    def __init__(self, config: OmniConfig, modules: Mapping[str, nn.Module]):
+        super().__init__(config)
+
+        self._module_names: list[str] = list(config.module_names)
+        for name in self._module_names:
+            self.add_module(name, modules[name])
+
+        self.training_graph = TrainingGraph(config.training_graph)
+        self.generation_graph = GenerationGraph(config.generation_graph)
+
+        self._last_printed_state: str | None = None
+        self._generated: list[dict[str, Any]] = []
+
+        self.reset()
+
+    def _init_weights(self, module: nn.Module) -> None:
+        """Sub-modules own weight init; the composed model has no standalone params."""
+        return
+
+    @classmethod
+    def from_config(cls, config: OmniConfig | dict[str, Any], **kwargs: Any) -> OmniModel:
+        """Build an :class:`OmniModel` from config only (sub-modules without weights)."""
+        if not isinstance(config, OmniConfig):
+            config = OmniConfig.from_dict(config)
+        checkpoint_root = kwargs.pop("checkpoint_root", None) or getattr(config, "_name_or_path", None)
+        modules = cls._load_modules(
+            config,
+            checkpoint_root=checkpoint_root,
+            pretrained=False,
+            **kwargs,
+        )
+        return cls(config, modules)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | os.PathLike,
+        *model_args: Any,
+        **kwargs: Any,
+    ) -> OmniModel:
+        """Load an :class:`OmniModel` and every declared sub-module from a split checkpoint.
+
+        ``pretrained_model_name_or_path`` is the omni root (``config.json`` +
+        graph YAML sidecars + one subfolder per module).
+
+        Remaining kwargs are forwarded to **every** sub-module's
+        ``from_pretrained`` as global load options (e.g. ``torch_dtype``,
+        ``device_map``).  Per-module ``model_config`` and ``ops_implementation``
+        persisted in the checkpoint are merged on top via
+        :meth:`_build_module_load_kwargs` — module-level ``attn_implementation``
+        wins over any global kwarg when both are set.
+
+        Pass ``config=`` to load the weights under an already-resolved
+        :class:`OmniConfig` instead of the root ``config.json`` — how
+        :class:`~veomni.trainer.omni.omni_inferencer.OmniInferencer` keeps its
+        launcher-YAML graph / ``model_config`` overrides on the eager path.
+
+        Top-level :class:`OmniConfig` fields (``infer_type``, ``generation_kwargs``,
+        …) may also be passed as kwargs and override the checkpoint defaults.
+        """
+        config = kwargs.pop("config", None)
+        config_kwargs = {key: kwargs.pop(key) for key in list(kwargs) if key in _CONFIG_LOAD_KWARG_NAMES}
+        config_overrides = {key: kwargs.pop(key) for key in list(kwargs) if key in _OMNI_CONFIG_OVERRIDE_KEYS}
+        if config is None:
+            config = OmniConfig.from_pretrained(
+                pretrained_model_name_or_path,
+                **config_kwargs,
+                **config_overrides,
+            )
+        elif not isinstance(config, OmniConfig):
+            config = OmniConfig.from_dict(config)
+            for key, value in config_overrides.items():
+                setattr(config, key, value)
+        elif config_overrides:
+            for key, value in config_overrides.items():
+                setattr(config, key, value)
+
+        checkpoint_root = getattr(config, "_name_or_path", None) or str(pretrained_model_name_or_path)
+        modules = cls._load_modules(
+            config,
+            checkpoint_root=checkpoint_root,
+            pretrained=True,
+            **kwargs,
+        )
+        return cls(config, modules)
+
+    @staticmethod
+    def _build_module_load_kwargs(
+        config: OmniConfig,
+        name: str,
+        base_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Merge checkpoint overrides and apply persisted ``ops_implementation``."""
+        from ...arguments import OpsImplementationConfig
+        from ...ops import apply_ops_config
+
+        load_kwargs = {**base_kwargs, **config.module_model_config(name)}
+        ops_dict = config.module_ops_implementation(name)
+        if not ops_dict:
+            return load_kwargs
+
+        ops = OpsImplementationConfig(**ops_dict)
+        apply_ops_config(ops)
+        if ops.attn_implementation is not None:
+            load_kwargs["attn_implementation"] = ops.attn_implementation
+        return load_kwargs
+
+    @classmethod
+    def _load_modules(
+        cls,
+        config: OmniConfig,
+        *,
+        checkpoint_root: str | os.PathLike | None,
+        pretrained: bool,
+        **kwargs: Any,
+    ) -> dict[str, nn.Module]:
+        import sys
+
+        from transformers import PretrainedConfig
+
+        from ...ops.config.singleton import get_ops_config
+        from ..auto import _bind_veomni_ops
+
+        modules: dict[str, nn.Module] = {}
+        for name in config.module_names:
+            module_path = config.resolve_module_path(checkpoint_root, name)
+            entry = config.modules.get(name)
+            load_kwargs = cls._build_module_load_kwargs(config, name, kwargs)
+            if isinstance(entry, PretrainedConfig):
+                model_type = entry.model_type
+                mod_cls = OMNI_MODEL_REGISTRY[model_type]()
+                modeling_module = sys.modules.get(mod_cls.__module__)
+                if modeling_module is not None and config.module_ops_implementation(name):
+                    _bind_veomni_ops(modeling_module, get_ops_config())
+                if pretrained:
+                    modules[name] = mod_cls.from_pretrained(module_path, config=entry, **load_kwargs)
+                else:
+                    modules[name] = mod_cls._from_config(entry, **load_kwargs)
+                continue
+            model_type = read_model_type(module_path)
+            mod_cls = OMNI_MODEL_REGISTRY[model_type]()
+            modeling_module = sys.modules.get(mod_cls.__module__)
+            if modeling_module is not None and config.module_ops_implementation(name):
+                _bind_veomni_ops(modeling_module, get_ops_config())
+            if pretrained:
+                modules[name] = mod_cls.from_pretrained(module_path, **load_kwargs)
+            else:
+                cfg_cls = mod_cls.config_class
+                sub_config = cfg_cls.from_pretrained(module_path)
+                modules[name] = mod_cls._from_config(sub_config, **config.module_model_config(name))
+        return modules
+
+    @staticmethod
+    def _save_module_assets(module: nn.Module, module_dir: str) -> None:
+        """Save config plus processor / tokenizer sidecars (no weights)."""
+        cfg = getattr(module, "config", None)
+        if cfg is not None and hasattr(cfg, "save_pretrained"):
+            cfg.save_pretrained(module_dir)
+        for attr in ("_processor", "_image_processor", "_video_processor", "_tokenizer"):
+            asset = getattr(module, attr, None)
+            if asset is not None and hasattr(asset, "save_pretrained"):
+                asset.save_pretrained(module_dir)
+
+    def _save_module_subdirectory(
+        self,
+        name: str,
+        module: nn.Module,
+        save_directory: str,
+        *,
+        save_module_weights: bool,
+        **kwargs: Any,
+    ) -> None:
+        subfolder = self.config.module_checkpoint_subfolder(name)
+        module_dir = os.path.join(save_directory, subfolder)
+        os.makedirs(module_dir, exist_ok=True)
+        # Processors / tokenizers are not part of a module's ``save_pretrained``, so
+        # they are written on both paths: a weights export without them reloads as a
+        # model that cannot preprocess its own inputs. Weights go last so the module
+        # has the final say over ``config.json``.
+        self._save_module_assets(module, module_dir)
+        if save_module_weights:
+            if not hasattr(module, "save_pretrained"):
+                raise TypeError(
+                    f"OmniModel.save_pretrained: sub-module '{name}' ({type(module).__name__}) "
+                    "has no save_pretrained()."
+                )
+            module.save_pretrained(module_dir, **kwargs)
+
+    def save_pretrained(
+        self,
+        save_directory: str | os.PathLike,
+        *,
+        save_module_weights: bool = True,
+        safe_serialization: bool = True,
+        max_shard_size: int | str = "5GB",
+        is_main_process: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Write an HF-style omni checkpoint (root config/graphs + module subfolders).
+
+        Parameters
+        ----------
+        save_directory:
+            Omni checkpoint root. Each module is written under
+            ``<root>/<subfolder>/`` where ``subfolder`` comes from
+            :meth:`OmniConfig.module_checkpoint_subfolder`.
+        save_module_weights:
+            When ``False``, only each module's ``config.json`` and attached
+            assets (processor / tokenizer) are written — used for the initial
+            ``model_assets`` export at train begin.
+        safe_serialization / max_shard_size:
+            Forwarded to each sub-module's ``save_pretrained`` when
+            ``save_module_weights=True``.
+        """
+        if is_main_process is None:
+            is_main_process = not dist.is_available() or not dist.is_initialized() or dist.get_rank() == 0
+        if not is_main_process:
+            return
+
+        save_directory = str(save_directory)
+        os.makedirs(save_directory, exist_ok=True)
+
+        module_save_kwargs = {
+            **kwargs,
+            "safe_serialization": safe_serialization,
+            "max_shard_size": max_shard_size,
+        }
+        for name in self._module_names:
+            module = getattr(self, name)
+            self._save_module_subdirectory(
+                name,
+                module,
+                save_directory,
+                save_module_weights=save_module_weights,
+                **module_save_kwargs,
+            )
+
+        self.config.save_pretrained(save_directory)
+
+    @property
+    def modules_dict(self) -> dict[str, nn.Module]:
+        """Back-compat dict view of the sub-modules."""
+        return {name: getattr(self, name) for name in self._module_names}
+
+    def forward(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Training is not supported on the bare :class:`OmniModel`."""
+        raise NotImplementedError(
+            "OmniModel.forward() is not available on the native eager model. "
+            "Training requires OmniModelRuntime (see OmniTrainer)."
+        )
+
+    # ── Inference ─────────────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Clear per-conversation inference runtime state."""
+        self.generation_graph.reset()
+        self._generated.clear()
+        for _, module in self.named_omni_modules():
+            reset_fn = getattr(module, "reset_global_inference_state", None)
+            if reset_fn is not None:
+                reset_fn()
+
+    @staticmethod
+    def _normalize_generated(item: Any) -> dict[str, Any] | None:
+        if item is None:
+            return None
+        if isinstance(item, dict) and "type" in item and "value" in item:
+            normalized: dict[str, Any] = {"type": item["type"], "value": item["value"]}
+            if item.get("meta") is not None:
+                normalized["meta"] = item["meta"]
+            return normalized
+        return None
+
+    def _append_generated(self, item: Any) -> None:
+        normalized = self._normalize_generated(item)
+        if normalized is not None:
+            self._generated.append(normalized)
+
+    def _collect_generated(self, ctx: dict[str, Any]) -> None:
+        """Drain ``ctx["generated"]`` into :attr:`_generated` (one-shot)."""
+        self._append_generated(ctx.pop("generated", None))
+
+    def _run_generation_node(
+        self,
+        module: nn.Module,
+        node: NodeDef,
+        ctx: dict[str, Any],
+        generation_kwargs: dict[str, Any] | None,
+    ) -> None:
+        """Run one generation node — eager endpoint call only."""
+        method = node.method
+        fn = getattr(module, method, None)
+        if fn is None:
+            raise AttributeError(f"Node method {type(module).__name__}.{method}() is not implemented.")
+        out = fn(**ctx, generation_kwargs=generation_kwargs)
+        if not isinstance(out, dict):
+            raise TypeError(f"FSM node '{node.name}'.{method} must return a dict; got {type(out).__name__}.")
+        ctx.update(out)
+
+    def _invoke_module_finalize(self, ctx: dict[str, Any]) -> None:
+        """Call ``finalize`` on every graph participant when the safety cap trips."""
+        for _, module in self.named_omni_modules():
+            finalize_fn = getattr(module, "finalize", None)
+            if finalize_fn is None:
+                continue
+            out = finalize_fn(ctx=ctx)
+            if not isinstance(out, dict):
+                raise TypeError(f"{type(module).__name__}.finalize must return a dict, got {type(out).__name__}.")
+            self._append_generated(out.pop("generated", None))
+
+    def _emit_progress(self, total_steps: int) -> None:
+        if total_steps == 0:
+            self._last_printed_state = None
+        current = self.generation_graph.current_state_name
+        if current != self._last_printed_state:
+            logger.info_rank0(f"[FSM] step {total_steps:>4}: {current}")
+            self._last_printed_state = current
+
+    def generate(
+        self,
+        request: dict[str, Any],
+        generation_kwargs: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Run inference using the FSM (profiler-free eager path).
+
+        Parameters
+        ----------
+        request:
+            Generation request dict — used directly as the initial ``ctx`` and
+            mutated in place as the FSM runs. Call :meth:`reset` before each
+            request to clear graph / module / artefact state.
+        generation_kwargs:
+            Per-request knobs merged on top of :attr:`~OmniConfig.generation_kwargs`
+            defaults (request keys win). Forwarded to every module's FSM step.
+            The framework only reads ``max_new_tokens`` (default 2048).
+
+        Returns
+        -------
+        list[dict]
+            Generated artefacts — ``{"type": ..., "value": ..., "meta": ...}``
+            entries collected from the FSM (text replies, images, …).
+        """
+        ctx: dict[str, Any] = request
+        generation_kwargs = self.resolve_generation_kwargs(generation_kwargs)
+
+        max_new_tokens = generation_kwargs.get("max_new_tokens", 2048)
+        total_steps = 0
+
+        while not self.generation_graph.is_done() and total_steps < max_new_tokens:
+            self._emit_progress(total_steps)
+            for node in self.generation_graph.iter_nodes(ctx):
+                module = getattr(self, node.module)
+                self._run_generation_node(module, node, ctx, generation_kwargs)
+            total_steps += 1
+            self._collect_generated(ctx)
+            self.generation_graph.maybe_transition(ctx)
+
+        self._emit_progress(total_steps)
+
+        if not self.generation_graph.is_done():
+            self._invoke_module_finalize(ctx)
+
+        return list(self._generated)
+
+    # ── Utilities ─────────────────────────────────────────────────────────────
+
+    def named_omni_modules(self) -> Iterator[tuple[str, nn.Module]]:
+        """Yield ``(name, module)`` for every graph participant."""
+        for name in self._module_names:
+            yield name, getattr(self, name)
+
+    def get_module(self, name: str) -> nn.Module:
+        if name not in self._module_names:
+            raise KeyError(f"Module '{name}' not found in OmniModel")
+        return getattr(self, name)
+
+    def resolve_generation_kwargs(
+        self,
+        generation_kwargs: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Merge :attr:`~OmniConfig.generation_kwargs` defaults with per-request overrides."""
+        return merge_generation_kwargs(self.config.generation_kwargs, generation_kwargs)
+
+    def collect_assets(self) -> list[Any]:
+        """Collect per-module assets (vision/audio processors, codebooks)."""
+        assets: list[Any] = []
+        for _, module in self.named_omni_modules():
+            get_assets = getattr(module, "get_assets", None)
+            if get_assets is not None:
+                assets.extend(get_assets())
+        return assets
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def merge_generation_kwargs(
+    defaults: Mapping[str, Any] | None,
+    overrides: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Return ``defaults`` updated with ``overrides`` (override keys win)."""
+    merged = dict(defaults or {})
+    merged.update(overrides or {})
+    return merged
+
+
+__all__ = ["OmniModel", "merge_generation_kwargs"]

--- a/veomni/models/seed_omni/modeling_omni.py
+++ b/veomni/models/seed_omni/modeling_omni.py
@@ -166,7 +166,7 @@ class OmniModel(PreTrainedModel):
             for key, value in config_overrides.items():
                 setattr(config, key, value)
 
-        checkpoint_root = getattr(config, "_name_or_path", None) or str(pretrained_model_name_or_path)
+        checkpoint_root = str(pretrained_model_name_or_path)
         modules = cls._load_modules(
             config,
             checkpoint_root=checkpoint_root,
@@ -340,8 +340,6 @@ class OmniModel(PreTrainedModel):
             "Training requires OmniModelRuntime (see OmniTrainer)."
         )
 
-    # ── Inference ─────────────────────────────────────────────────────────────
-
     def reset(self) -> None:
         """Clear per-conversation inference runtime state."""
         self.generation_graph.reset()
@@ -448,12 +446,9 @@ class OmniModel(PreTrainedModel):
 
         self._emit_progress(total_steps)
 
-        if not self.generation_graph.is_done():
-            self._invoke_module_finalize(ctx)
+        self._invoke_module_finalize(ctx)
 
         return list(self._generated)
-
-    # ── Utilities ─────────────────────────────────────────────────────────────
 
     def named_omni_modules(self) -> Iterator[tuple[str, nn.Module]]:
         """Yield ``(name, module)`` for every graph participant."""
@@ -480,9 +475,6 @@ class OmniModel(PreTrainedModel):
             if get_assets is not None:
                 assets.extend(get_assets())
         return assets
-
-
-# ── helpers ───────────────────────────────────────────────────────────────────
 
 
 def merge_generation_kwargs(

--- a/veomni/models/seed_omni/modules/__init__.py
+++ b/veomni/models/seed_omni/modules/__init__.py
@@ -1,0 +1,119 @@
+"""SeedOmni V2 module mixin registry.
+
+Each entry maps a HuggingFace ``model_type`` string (the ``model_type``
+field of each module's :class:`PretrainedConfig` subclass) to the
+:class:`~veomni.models.seed_omni.mixins.base_mixin.BaseMixin` subclass that backs it.  At trainer-build time the
+flow is::
+
+    model_type = read_model_type(<weights_path>)        # reads config.json
+    cfg_cls = OMNI_CONFIG_REGISTRY[model_type]()
+    cls     = OMNI_MODEL_REGISTRY[model_type]()
+    cfg     = cfg_cls.from_pretrained(<weights_path>)
+    module  = cls.from_pretrained(<weights_path>)       # HF PreTrainedModel API
+    # → FSDP-wrapped by build_parallelize_model inside OmniTrainer
+
+These modules are **not** registered with HuggingFace ``AutoConfig`` /
+``AutoModel`` — always resolve the class via ``OMNI_*_REGISTRY`` first,
+then call ``from_pretrained`` on that class.
+
+Factory functions registered on ``OMNI_*_REGISTRY`` lazy-import the
+concrete config / model / processor classes on first call — importing this
+package only wires up the registry table, it does not load modeling code.
+
+File layout
+-----------
+``modules/<family>/<sub_module>/(configuration.py, modeling.py[,
+processing.py])``.  Each sub-module gets its own folder; the folder name
+carries the namespace so the inner files use short names rather than
+re-spelling ``<family>_<sub_module>`` per file.  Cross-family
+lightweight modules live under ``modules/base/<sub_module>/``.
+"""
+
+from transformers import PretrainedConfig
+
+from ....utils.registry import Registry
+
+
+OMNI_CONFIG_REGISTRY = Registry("OmniConfig")
+OMNI_MODEL_REGISTRY = Registry("OmniModel")
+OMNI_ACCELERATED_MODEL_REGISTRY = Registry("OmniAcceleratedModel")
+OMNI_PROCESSOR_REGISTRY = Registry("OmniProcessor")
+
+
+def read_hf_model_type(model_path: str) -> str:
+    """Read the upstream ``model_type`` from a HuggingFace ``config.json``.
+
+    Generic reader (no registry validation): returns the raw ``model_type``
+    string. Shared by any caller that needs to dispatch on a checkpoint's
+    declared family — the SeedOmni convert pipeline
+    (:func:`~veomni.models.seed_omni.utils.convert_registry.convert_checkpoint`,
+    which dispatches on the *upstream* HF type) and as the primitive behind
+    :func:`read_model_type`.
+
+    Uses :meth:`PretrainedConfig.get_config_dict` rather than
+    :class:`AutoConfig.from_pretrained` because Janus / future split
+    checkpoints declare custom ``model_type`` values
+    (``janus_siglip`` / ``janus_text_encoder`` / ``janus_llama`` /
+    ``janus_vqvae``) that are NOT in HF's :data:`CONFIG_MAPPING`.
+    ``AutoConfig`` would raise on those families before we even get a chance
+    to consult the registries; reading the raw dict sidesteps that.  See
+    :mod:`veomni.models.loader` for the same pattern in the foundation-model
+    loader.
+    """
+    config_dict, _ = PretrainedConfig.get_config_dict(model_path)
+    model_type = config_dict.get("model_type")
+    if not model_type:
+        raise ValueError(f"Checkpoint at {model_path} has no `model_type` in config.json.")
+    return model_type
+
+
+# Side-effect only: attach @register factories under base/ (and any concrete
+# model family added by a later Wave-3 PR, e.g. bagel/, janus/, qwen3/,
+# qwen3_moe/, qwen3vl/). Imported after ``read_hf_model_type`` so the
+# convert_registry ↔ modules cycle resolves: each family's ``convert_model``
+# imports ``convert_registry``, whose ``convert_checkpoint`` reads
+# ``read_hf_model_type`` back from this module.
+from . import base  # noqa: F401  E402
+
+
+def read_model_type(model_path: str) -> str:
+    """Read ``model_type`` from a module's ``config.json`` and validate registration.
+
+    Shared helper for any caller that needs to dispatch from a
+    split-checkpoint subfolder to the matching module class —
+    today that's :class:`OmniInferencer` (eager ``from_pretrained``) and
+    :meth:`OmniTrainer._build_model` (meta-init via
+    :func:`build_foundation_model`).  Centralised here so both paths use
+    the same registration gate and emit identical error messages.
+
+    Builds on :func:`read_hf_model_type` (the raw ``config.json`` read) and
+    then gates the result on the SeedOmni registries.
+    """
+    model_type = read_hf_model_type(model_path)
+    # Note: :class:`Registry.__getitem__` raises ``ValueError`` (not
+    # ``KeyError``) on miss, so the default ``in`` test on a MutableMapping
+    # subclass would mis-route the exception.  Use ``valid_keys()`` to
+    # decide registration explicitly.
+    config_keys = set(OMNI_CONFIG_REGISTRY.valid_keys())
+    model_keys = set(OMNI_MODEL_REGISTRY.valid_keys())
+    if model_type in config_keys:
+        # Validate the config can be re-read by the registered subclass so
+        # downstream `from_pretrained` doesn't hit a surprise schema gap.
+        cfg_cls = OMNI_CONFIG_REGISTRY[model_type]()
+        cfg_cls.from_pretrained(model_path)
+    if model_type not in model_keys:
+        raise KeyError(
+            f"Module model_type {model_type!r} (from {model_path}) is not registered in "
+            f"OMNI_MODEL_REGISTRY. Known: {sorted(model_keys)}."
+        )
+    return model_type
+
+
+__all__ = [
+    "OMNI_ACCELERATED_MODEL_REGISTRY",
+    "OMNI_CONFIG_REGISTRY",
+    "OMNI_MODEL_REGISTRY",
+    "OMNI_PROCESSOR_REGISTRY",
+    "read_hf_model_type",
+    "read_model_type",
+]

--- a/veomni/models/seed_omni/modules/base/__init__.py
+++ b/veomni/models/seed_omni/modules/base/__init__.py
@@ -1,0 +1,23 @@
+"""Cross-family OmniModule mixins.
+
+Currently:
+* :class:`TextEncoder` — generic word-token embedding + LM head, reusable
+  across LLM families (model_type ``text_encoder``).
+* :mod:`llm_packing` — shared ``conversation_list`` ↔ AR backbone carrier helpers:
+  ``pack_llm_conversations_for_forward`` (1-D position backbones) and
+  ``scatter_llm_hidden_states`` (all AR families including Qwen3-VL).
+
+These modules don't depend on any specific HuggingFace family — they can be
+mixed into any backbone setup that needs the conventional vocab-bound
+encode/decode pair without re-deriving from a heavy HF base class.
+
+Layout
+------
+Each sub-module lives in its own folder named after the module
+(``text_encoder/``).  The folder contains short-named files —
+``configuration.py``, ``modeling.py`` — instead of repeating the module
+name in every filename.  See :mod:`veomni.models.seed_omni.modules`
+for the registry that wires them up.
+"""
+
+from . import text_encoder  # noqa: F401

--- a/veomni/models/seed_omni/modules/base/llm_packing.py
+++ b/veomni/models/seed_omni/modules/base/llm_packing.py
@@ -1,0 +1,170 @@
+"""Shared conversation packing for standard AR LLM backbones.
+
+Applies to backbones that consume pre-embedded ``conversation_list`` segments
+with flat 1-D ``position_ids`` and per-token ``attention_mask`` — e.g. Janus
+LLaMA and Qwen3 dense/MoE.  Vision-language backbones (Qwen3-VL M-RoPE) and
+packed MoT layouts (BAGEL Qwen2-MoT) keep family-specific packers in their own
+``modeling.py`` files.
+
+``scatter_llm_hidden_states`` is the inverse scatter step shared by all of the
+above families (including Qwen3-VL) after ``forward_post`` unflattens backbone
+outputs back onto ``conversation_list`` segments.
+
+``SimpleArGenerationMixin`` is the shared no-CFG, single-KV-cache
+``generate()`` used by the dense and MoE Qwen3 backbones (identical decode
+loop; only ``forward`` differs between the two). Janus LLaMA keeps its own
+CFG-aware ``generate()`` natively since it needs a second (unconditional)
+cache.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from veomni.utils.seqlen_pos_transform_utils import prepare_fa_kwargs_from_position_ids
+from veomni.utils.tensor_utils import naflatten
+
+from ...utils.conversation import ConversationItem, is_dummy
+
+
+def pack_llm_conversations_for_forward(
+    conversations: list[list[ConversationItem]],
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pack conversation embed segments for AR backbone forward (training + inference).
+
+    Returns ``(inputs_embeds, attention_mask, position_ids, inputs_embeds_shape)``
+    with batch dim 0 when the packed sample is a single varlen sequence.
+    """
+    inputs_embeds_list = []
+    attention_mask = []
+    position_ids = []
+    for sample in conversations:
+        sample_lengths = 0
+        for item in sample:
+            if item.role == "dummy":
+                continue
+            embeds = item.value
+            embeds_length = embeds.size(0)
+            chunk_attention_mask = item.meta.pop("attention_mask", None)
+            if chunk_attention_mask is None:
+                chunk_attention_mask = torch.ones(embeds_length, dtype=torch.long, device=device)
+            inputs_embeds_list.append(embeds.to(device))
+            attention_mask.append(chunk_attention_mask.to(device))
+            sample_lengths += embeds_length
+        sample_position_ids = torch.arange(sample_lengths, dtype=torch.long, device=device)
+        position_ids.append(sample_position_ids)
+    inputs_embeds, inputs_embeds_shape = naflatten(inputs_embeds_list)
+    position_ids = torch.cat(position_ids, dim=0)
+    attention_mask = torch.cat(attention_mask, dim=0)
+
+    if inputs_embeds.dim() == 2:
+        inputs_embeds = inputs_embeds.unsqueeze(0)
+    if attention_mask.dim() == 1:
+        attention_mask = attention_mask.unsqueeze(0)
+    if position_ids.dim() == 1:
+        position_ids = position_ids.unsqueeze(0)
+
+    return inputs_embeds, attention_mask, position_ids, inputs_embeds_shape
+
+
+def scatter_llm_hidden_states(
+    conversation_list: list[list[ConversationItem]],
+    hidden_states_list: list[torch.Tensor],
+) -> None:
+    """Write unflattened backbone hidden states back onto non-dummy conversation segments."""
+    hidden_states_list_iter = iter(hidden_states_list)
+    for sample in conversation_list:
+        for part in sample:
+            if is_dummy(part):
+                continue
+            part.value = next(hidden_states_list_iter)
+    if next(hidden_states_list_iter, None) is not None:
+        raise RuntimeError("scatter_llm_hidden_states: segment count exceeds non-dummy conversation items.")
+
+
+class SimpleArGenerationMixin:
+    """No-CFG, single-KV-cache ``generate()`` for Qwen3-style AR backbones.
+
+    Subclasses must call ``self._past_key_values = None`` in ``__init__`` and
+    provide ``self.forward(inputs_embeds=..., attention_mask=..., past_key_values=...,
+    use_cache=..., **kwargs)`` returning ``{"hidden_states": ..., "past_key_values": ...}``.
+    """
+
+    _past_key_values: Any
+
+    def reset_local_inference_state(self) -> None:
+        return
+
+    def reset_global_inference_state(self) -> None:
+        self.reset_local_inference_state()
+        self._past_key_values = None
+
+    def generate(
+        self,
+        conversation_list: list[ConversationItem] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        del kwargs
+        if self._past_key_values is None:
+            inputs_embeds, attention_mask, position_ids, _ = pack_llm_conversations_for_forward(
+                [conversation_list], self.device
+            )
+            (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(
+                position_ids
+            )
+
+            outputs = self.forward(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                past_key_values=self._past_key_values,
+                cu_seq_lens_q=cu_seq_lens_q,
+                cu_seq_lens_k=cu_seq_lens_k,
+                max_length_q=max_length_q,
+                max_length_k=max_length_k,
+                use_cache=True,
+            )
+            self._past_key_values = outputs["past_key_values"]
+
+            hidden_states = outputs["hidden_states"]
+            conversation_list.append(
+                ConversationItem(
+                    type="output",
+                    value=self._tail_hidden_from_forward(hidden_states),
+                    role="assistant",
+                )
+            )
+            return {"conversation_list": conversation_list}
+
+        tail_part = conversation_list[-1]
+        assert tail_part.type == "output"
+
+        inputs_embeds: torch.Tensor = tail_part.value[-1:].to(self.device)
+        inputs_embeds = inputs_embeds.unsqueeze(0)
+
+        outputs = self.forward(
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+            past_key_values=self._past_key_values,
+            use_cache=True,
+        )
+        self._past_key_values = outputs["past_key_values"]
+        hidden_states = outputs["hidden_states"]
+
+        conversation_list.append(
+            ConversationItem(
+                type="output",
+                value=self._tail_hidden_from_forward(hidden_states),
+                role="assistant",
+            )
+        )
+        return {"conversation_list": conversation_list}
+
+    @staticmethod
+    def _tail_hidden_from_forward(hidden_states: torch.Tensor) -> torch.Tensor:
+        if hidden_states.dim() == 3 and hidden_states.size(0) == 1:
+            hidden_states = hidden_states.squeeze(0)
+            return hidden_states[-1:].contiguous()
+        return hidden_states[:, -1:, :].contiguous()

--- a/veomni/models/seed_omni/modules/base/text_encoder/__init__.py
+++ b/veomni/models/seed_omni/modules/base/text_encoder/__init__.py
@@ -1,0 +1,31 @@
+"""Generic word-token embedding + LM head module.
+
+Sub-package layout (per :mod:`veomni.models.seed_omni.modules`):
+
+* :mod:`.configuration` — :class:`TextEncoderConfig`
+* :mod:`.modeling`      — :class:`TextEncoder`
+* :mod:`.processing`   — :class:`TextEncoderPreprocessor`
+"""
+
+from ... import OMNI_ACCELERATED_MODEL_REGISTRY, OMNI_CONFIG_REGISTRY, OMNI_MODEL_REGISTRY
+
+
+@OMNI_CONFIG_REGISTRY.register("text_encoder")
+def register_text_encoder_config():
+    from .configuration import TextEncoderConfig
+
+    return TextEncoderConfig
+
+
+@OMNI_MODEL_REGISTRY.register("text_encoder")
+def register_text_encoder_model():
+    from .modeling import TextEncoder
+
+    return TextEncoder
+
+
+@OMNI_ACCELERATED_MODEL_REGISTRY.register("text_encoder")
+def register_text_encoder_accelerated_model():
+    from .accelerated import TextEncoderAccelerated
+
+    return TextEncoderAccelerated

--- a/veomni/models/seed_omni/modules/base/text_encoder/accelerated.py
+++ b/veomni/models/seed_omni/modules/base/text_encoder/accelerated.py
@@ -1,0 +1,333 @@
+"""VeOmni-accelerated TextEncoder — training graph hooks.
+
+FSM ``generate`` + its sampling helpers now live natively on
+:class:`~.modeling.TextEncoder` (see its docstring) so pure HF usage of a
+family's native class works without this accelerated wrapper. Only the
+SP-aware training pre/forward/post hooks stay here.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn.functional as F
+
+from veomni.distributed.parallel_state import get_parallel_state
+from veomni.distributed.sequence_parallel import (
+    gather_outputs,
+    slice_input_tensor,
+    sp_pad,
+)
+from veomni.ops.kernels.cross_entropy import ForCausalLMLoss
+from veomni.ops.kernels.cross_entropy.eager import eager_cross_entropy
+from veomni.utils.tensor_utils import naflatten, unflatten
+
+from ....mixins.base_mixin import BaseMixin
+from ....mixins.emb_parallel_mixin import EmbParallelMixin
+from ....mixins.metric_meter_mixin import MetricMeterMixin
+from ....mixins.training_module_mixin import TrainingModuleMixin, post_forward, pre_forward
+from ....utils.conversation import ConversationItem, is_dummy
+from .chat_template import TextEncoderChatTemplate
+from .configuration import TextEncoderConfig
+from .modeling import TextEncoder, scatter_text_encoder_embeds
+
+
+class TrainingMixin(TrainingModuleMixin):
+    """Training-graph hooks shared by every text encoder."""
+
+    config: TextEncoderConfig
+    device: torch.device
+    _chat_template: TextEncoderChatTemplate
+    _encode_batch_shape: torch.LongTensor | None
+
+    @pre_forward("encode")
+    def encode_pre(
+        self,
+        conversation_list: Optional[list[list[ConversationItem]]] = None,
+    ) -> Dict[str, Any]:
+        self._conversation_carrier = conversation_list
+        input_ids = self._prepare_encode_inputs(self._conversation_carrier)
+
+        # Metering: this rank's OWN packed token count, stashed BEFORE the SP slice
+        # below. The meter sums over the DP group only, so each rank reports just its
+        # own tokens (not the SP peers that hold the same replicated sample) —
+        # identical to the non-SP run for both SP-disabled and uniform SP.
+        self.metric_meter_set_seqlens("encode", [int(input_ids.numel())])
+
+        if get_parallel_state().sp_size > 1:
+            # SP input-slice: hand this rank its ``1/sp_size`` slice of the packed
+            # token sequence (wte is a per-token lookup, so slicing is exact —
+            # mirrors VeOmni's whole-model SP where the embedding is
+            # sequence-sharded). Every SP rank already holds the same ``input_ids``
+            # (the dataloader replicates each shard); pad it to a multiple of
+            # ``sp_size`` and take this rank's contiguous chunk. ``encode_post``
+            # all-gathers the embeds back.
+            self._sp_own_len = input_ids.size(0)
+            input_ids = sp_pad(input_ids, dim=0, pad_value=0)
+            input_ids = slice_input_tensor(input_ids, dim=0, padding=False, group=get_parallel_state().sp_group)
+        return {"input_ids": input_ids}
+
+    @post_forward("encode")
+    def encode_post(self, inputs_embeds: torch.Tensor) -> Dict[str, Any]:
+        if get_parallel_state().sp_size > 1:
+            # SP output-gather: all-gather token shards back to the full sequence
+            # (autograd-aware; backward sums grads across the SP group), then drop
+            # the SP pad tail so the packed length matches its carrier below.
+            inputs_embeds = gather_outputs(inputs_embeds, gather_dim=0, group=get_parallel_state().sp_group)
+            inputs_embeds = inputs_embeds.narrow(0, 0, self._sp_own_len)
+        conversation = self._conversation_carrier
+        self._conversation_carrier = None
+        batch_shape = self._encode_batch_shape
+        self._encode_batch_shape = None
+        scatter_text_encoder_embeds(conversation, unflatten(inputs_embeds, batch_shape))
+        return {"conversation_list": conversation}
+
+    @pre_forward("decode")
+    def decode_pre(
+        self,
+        conversation_list: Optional[list[list[ConversationItem]]] = None,
+    ) -> Dict[str, Any]:
+        self._conversation_carrier = conversation_list
+        hidden_states, shift_labels = self._prepare_decode_inputs(self._conversation_carrier)
+        # No SP sharding here: the lm-head loss is a token-weighted mean over the whole
+        # ``dp_sp`` (``fsdp_group``) mesh (``modeling.decode`` →
+        # ``reduce_sequence_parallel_loss``), so each rank scoring only its OWN span
+        # yields the identical global loss + gradient regardless of the DP/SP split.
+        # Skipping the gather-concat keeps peak logits at this rank's own span.
+        return {"hidden_states": hidden_states, "shift_labels": shift_labels}
+
+    @post_forward("decode")
+    def decode_post(self, loss: torch.Tensor, logits: torch.Tensor) -> Dict[str, Any]:
+        conversation = self._conversation_carrier
+        self._conversation_carrier = None
+        # V2 single-loss protocol: drop logits, rename ``loss`` → ``_loss``.
+        if loss is not None:
+            return {"_loss": loss, "conversation_list": conversation}
+        # TODO: scatter logits for rl training
+        return {"conversation_list": conversation}
+
+    def _embed_tokens(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Vocab-parallel lookup when the ``emb`` extra-parallel group is active.
+
+        Overrides the native ``self.embed_tokens(input_ids)`` shortcut so every
+        family picks up ``AllToAllEmbedding`` under ``emb`` (mixed in via
+        :class:`~....mixins.emb_parallel_mixin.EmbParallelMixin`); off ``emb`` it
+        is exactly the native call.
+        """
+        return self.emb_parallel_lookup(self.embed_tokens, input_ids)
+
+    def _prepare_encode_inputs(
+        self,
+        conversation_list: Optional[list[list[ConversationItem]]],
+    ) -> torch.Tensor:
+        input_ids: list[torch.Tensor] = []
+        self._encode_batch_shape = None
+        for sample in conversation_list or []:
+            input_ids.extend(self._chat_template.pack_input_ids(sample))
+        # ``naflatten`` keeps the shape on CPU (avoids the post-forward D2H sync);
+        # the flat ids may be CPU (worker path) or device (fallback) — move once.
+        input_ids, self._encode_batch_shape = naflatten(input_ids)
+        input_ids = input_ids.to(self.device, non_blocking=True)
+        return input_ids
+
+    def _prepare_decode_inputs(
+        self,
+        conversation_list: Optional[list[list[ConversationItem]]],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states_chunks: list[torch.Tensor] = []
+        label_chunks: list[torch.Tensor] = []
+
+        for sample in conversation_list:
+            for part in sample:
+                if is_dummy(part):
+                    continue
+                hidden_states = part.value
+                if hidden_states.dim() == 3:
+                    hidden_states = hidden_states.squeeze(0)
+                if part.type == "text":
+                    labels = part.meta["labels"]
+                    assert labels.shape[0] == hidden_states.shape[0]
+                    hidden_states_chunks.append(hidden_states)
+                    label_chunks.append(labels)
+                elif part.type in ("image", "video"):
+                    # Vision segment carries projected patch embeds; keep one row
+                    # (no label) so the sequence stays aligned, like the backbone.
+                    hidden_states_chunks.append(hidden_states[-1:])
+                    label_chunks.append(torch.full((1,), -100, dtype=torch.long))
+
+        hidden_states = torch.cat(hidden_states_chunks, dim=0)
+        labels = torch.cat(label_chunks, dim=0)  # CPU
+
+        labels = labels[..., 1:].contiguous()
+        shift_labels = F.pad(labels, (0, 1), "constant", -100)
+        # Single H2D move (labels are tiny host-side bookkeeping); the loss forward
+        # orders after the backbone kernels on the GPU stream without a CPU stall.
+        shift_labels = shift_labels.to(device=hidden_states.device, non_blocking=True)
+        return hidden_states, shift_labels
+
+    def _project(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Tied-head projection that stays FSDP2-safe.
+
+        The native :meth:`~.modeling.TextEncoder._project` reads
+        ``embed_tokens.weight`` directly, which is only safe off-FSDP (pure HF
+        inference): under FSDP2 that read bypasses the embedding's own
+        unshard/reshard hook (``encode`` and ``decode`` are separate graph-node
+        forward calls, so there's no guarantee ``embed_tokens`` was unsharded by
+        this call), leaving a sharded ``DTensor`` that a plain ``F.linear``
+        can't multiply against the (unsharded) activation. ``emb_parallel_project``
+        (mixed in via :class:`~....mixins.emb_parallel_mixin.EmbParallelMixin`)
+        explicitly gathers the weight first — vocab-parallel when the ``emb``
+        extra-parallel group is active, otherwise a plain ``full_tensor()``
+        all-gather — so this override, not the native one, must run at train time.
+        """
+        if not self.config.tie_word_embeddings:
+            return self.lm_head(hidden_states)
+        return self.emb_parallel_project(hidden_states, self.embed_tokens.weight)
+
+    def decode(
+        self,
+        hidden_states: torch.Tensor | None = None,
+        labels: torch.LongTensor | None = None,
+        shift_labels: torch.LongTensor | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        """FSDP2/SP-safe counterpart of :meth:`~.modeling.TextEncoder.decode`.
+
+        Two departures from the native version, both runtime concerns the pure-HF
+        layer deliberately stays out of:
+
+        (a) The loss goes through the ops-selected cross-entropy backend rather
+        than a bare ``F.cross_entropy``, so an untied bias-free head gets the
+        fused linear+CE kernel (Liger / chunk_loss) and never materializes the
+        ``[T, V]`` logits. Passing ``logits=None`` + ``hidden_states`` + ``weights``
+        is what opts into that contract; a tied or biased head cannot (the fused
+        kernels take a weight tensor only, no bias, and the tied weight needs the
+        gather in :meth:`_project`), so it keeps an explicit projection and eager CE.
+
+        (b) ``loss_reduction_group=fsdp_group`` token-weights the loss mean across
+        the whole ``dp_sp`` mesh — required once SP is enabled, since each rank only
+        scores its own (unsliced, per :meth:`decode_pre`) span.
+        ``ForCausalLMLoss`` applies exactly the
+        :func:`~veomni.distributed.sequence_parallel.reduce_sequence_parallel_loss`
+        this method used to call inline.
+
+        (c) A span with no supervised token scores 0.0, matching the native
+        clamped denominator required by constraint 7b. Every fused backend
+        normalizes by its own supervised-token count with no way to clamp it
+        (Liger divides by ``n_non_ignore``, chunk_loss recounts the labels), so
+        such a span is routed to the eager branch and given an explicit
+        denominator instead of dividing 0 by 0.
+        """
+        loss: torch.Tensor | None = None
+        logits: torch.Tensor | None = None
+        target_labels = labels if labels is not None else shift_labels
+        fsdp_group = get_parallel_state().fsdp_group
+        num_supervised_tokens = None if target_labels is None else (target_labels != -100).sum()
+
+        if target_labels is None:
+            # Inference path: materialize logits because no loss is requested.
+            logits = self._project(hidden_states)
+        elif self.lm_head is not None and self.lm_head.bias is None and num_supervised_tokens > 0:
+            loss, logits, _ = self.loss_function(
+                logits=None,
+                labels=target_labels,
+                shift_labels=shift_labels,
+                vocab_size=self.config.vocab_size,
+                hidden_states=hidden_states,
+                weights=self.lm_head.weight,
+                loss_reduction_group=fsdp_group,
+            )
+        else:
+            logits = self._project(hidden_states)
+            loss, _, _ = ForCausalLMLoss(
+                logits=logits,
+                labels=target_labels,
+                shift_labels=shift_labels,
+                vocab_size=self.config.vocab_size,
+                num_items_in_batch=num_supervised_tokens.clamp(min=1),
+                loss_reduction_group=fsdp_group,
+                cross_entropy_fn=eager_cross_entropy,
+            )
+
+        return {
+            "loss": loss,
+            "logits": logits,
+        }
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._conversation_carrier: Any = None
+        self._encode_batch_shape: torch.LongTensor | None = None
+        # Active sample's packed token count. Under SP the encode output-gather hook
+        # (``encode_sp_post``) narrows the all-gathered (seq-padded) embeds to it.
+        self._sp_own_len: Optional[int] = None
+
+
+class MeterMixin(MetricMeterMixin):
+    """Per-module training meter for the text encoder (wte + lm_head)."""
+
+    config: TextEncoderConfig
+
+    def estimate_flops(self, seqlens: List[int]) -> float:
+        # This module owns wte (an embedding lookup ≈ 0 FLOPs) + the lm_head
+        # projection (hidden → vocab); the transformer layers belong to the
+        # backbone module. fwd+bwd ⇒ 6x; lm_head params = vocab * hidden.
+        lm_head_n = self.config.vocab_size * self.config.hidden_size
+        return 6 * lm_head_n * sum(seqlens) / 1e12
+
+    # Token lengths come from ``metric_meter_set_seqlens`` in ``encode_pre`` (the
+    # full pre-slice packed length); ``decode`` stashes nothing and contributes
+    # no tokens (its lm_head FLOPs are covered by the ``encode`` count). So the
+    # default ``metric_meter_token_lengths`` (drains the stash) is used as-is.
+
+
+class VeOmniMixin(BaseMixin, TrainingMixin, MeterMixin, EmbParallelMixin):
+    """Shared training / inference plumbing for every text encoder.
+
+    No ``InferenceMixin`` here: FSM ``generate`` and its sampling /
+    prompt-embedding helpers already live natively on
+    :class:`~.modeling.TextEncoder` via its own
+    :class:`~.modeling.InferenceMixin` (and each family's ``generate``
+    override) — every ``XxxTextEncoderAccelerated(VeOmniMixin, XxxTextEncoder)``
+    inherits that through its native base, so nothing needs to be re-declared
+    here. Concrete modules (janus / qwen3 / qwen3vl / bagel) subclass this and
+    define ``XxxTextEncoderPreprocessor`` in their ``processing.py`` by
+    subclassing
+    :class:`~veomni.models.seed_omni.modules.base.text_encoder.processing.TextEncoderPreprocessor`
+    and implementing :meth:`~veomni.models.seed_omni.modules.base.text_encoder.processing.TextEncoderPreprocessor.build_chat_template`
+    with the module-local chat template.  Register via ``preprocessor_class`` on
+    the family's HF-native ``modeling.py`` class (parallel to ``image_processor_class``
+    on vision/codec modules) — :class:`~veomni.models.seed_omni.processing_omni.OmniProcessor`
+    resolves it through ``OMNI_MODEL_REGISTRY`` (the native class), so it must live
+    there, not on this accelerated mixin. Each module's ``accelerated.py`` still owns
+    the ``encode_pre`` / ``encode_post`` / ``decode_pre`` / ``decode_post`` pass-through
+    hooks.
+    """
+
+    _chat_template: TextEncoderChatTemplate
+
+    def get_parallel_plan(self):
+        from .parallel_plan import get_parallel_plan as _get_parallel_plan
+
+        return _get_parallel_plan()
+
+    @property
+    def tokenizer(self) -> Any:
+        return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, tokenizer: Any) -> None:
+        self._tokenizer = tokenizer
+        self._chat_template = TextEncoderChatTemplate(tokenizer)
+
+
+class TextEncoderAccelerated(VeOmniMixin, TextEncoder):
+    """Training/runtime text encoder — vocab-parallel embed + SP-aware CE.
+
+    ``_embed_tokens`` / ``_project`` / ``decode`` overrides (FSDP2-/``emb``-safe)
+    live on :class:`TrainingMixin` above so every family's own accelerated
+    composition — which mixes in *its own* ``TrainingMixin(BaseTrainingMixin)``
+    rather than this class — inherits them too.
+    """
+
+
+__all__ = ["TextEncoderAccelerated", "scatter_text_encoder_embeds"]

--- a/veomni/models/seed_omni/modules/base/text_encoder/chat_template.py
+++ b/veomni/models/seed_omni/modules/base/text_encoder/chat_template.py
@@ -1,0 +1,140 @@
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from ....utils.conversation import ConversationItem, ItemRole, ItemType, ItemValue
+
+
+@dataclass(frozen=True)
+class ChatMarkers:
+    """Default wire-format markers shared by every text encoder (bos / eos only).
+
+    Per-model templates subclass-replace ``chat_markers`` with their own richer
+    dataclass (role markers, vision wrap tokens, …); these two are the universal
+    minimum resolved from the tokenizer in :meth:`TextEncoderChatTemplate.__init__`.
+    Either may be ``None`` (e.g. Qwen has no ``bos_token``).
+    """
+
+    bos_token: str | None
+    eos_token: str | None
+
+
+class TextEncoderChatTemplate:
+    chat_markers: ChatMarkers
+
+    def __init__(self, tokenizer: Any):
+        self.tokenizer = tokenizer
+        # Default markers (bos / eos). Resolved best-effort: a model whose tokenizer
+        # lacks one (e.g. Qwen has no bos) gets ``None`` rather than an error.
+        self.chat_markers = ChatMarkers(
+            bos_token=getattr(tokenizer, "bos_token", None),
+            eos_token=getattr(tokenizer, "eos_token", None),
+        )
+        self.bos_token_id = self._resolve_token_id(tokenizer, "bos_token_id")
+        self.eos_token_id = self._resolve_token_id(tokenizer, "eos_token_id")
+
+    @staticmethod
+    def _resolve_token_id(tokenizer: Any, attr: str) -> int | None:
+        token_id = getattr(tokenizer, attr, None)
+        return int(token_id) if token_id is not None else None
+
+    @abstractmethod
+    def apply_chat_template(self, sample: list[ConversationItem]) -> list[ConversationItem]:
+        """Apply the chat template only — produce ``str`` rows with ``meta['loss_mask']``.
+
+        Does NOT tokenize or merge. The full pipeline is
+        ``apply_chat_template`` → :meth:`tokenize` →
+        :meth:`merge_text_embeds`, bundled by :meth:`tokenize_conversation`.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply_generation_prompt(self, sample: list[ConversationItem]) -> list[ConversationItem]:
+        """Append the assistant generation prefix to a templated prompt (inference).
+
+        Used by a ChatML-style module ``generate``; each per-model template
+        implements it (Janus, whose inference is not ChatML, builds its assistant
+        prefix inline in ``generate`` instead).
+        """
+        raise NotImplementedError
+
+    def tokenize_conversation(
+        self,
+        sample: list[ConversationItem],
+        *,
+        add_generation_prompt: bool = False,
+    ) -> list[ConversationItem]:
+        """Full text pipeline: apply chat template → tokenize → merge tokenized text.
+
+        ``add_generation_prompt`` (inference) inserts the assistant generation
+        prefix (:meth:`apply_generation_prompt`) between templating and tokenizing,
+        so the request is left ready for the model to start decoding; training
+        leaves it off (the assistant turn is already in the data).
+        """
+        parts = self.apply_chat_template(sample)
+        if add_generation_prompt:
+            parts = self.apply_generation_prompt(parts)
+        self.tokenize(parts)
+        return self.merge_text_embeds(parts)
+
+    def _build_conversation_item(
+        self,
+        type: ItemType,
+        value: ItemValue,
+        role: ItemRole,  # for pretrain data, role is always "assistant"
+        loss_mask: int | None = None,
+        meta: dict | None = None,
+    ) -> ConversationItem:
+        """Build one conversation row; ``text`` rows always get ``meta["loss_mask"]``.
+
+        Only used for template-generated **text** marker rows. Media rows (image /
+        video) are passed through verbatim by the per-model ``apply_chat_template``
+        so they keep their ``value`` / ``source`` / ``meta`` (the per-module
+        encoders filter them by ``item.source``).
+        """
+        part_meta = dict(meta or {})
+        if type == "text":
+            part_meta["loss_mask"] = int(role == "assistant") if loss_mask is None else int(loss_mask)
+        return ConversationItem(type=type, value=value, role=role, meta=part_meta)
+
+    @staticmethod
+    def pack_input_ids(parts: list[ConversationItem]) -> list[torch.Tensor]:
+        """Collect ``type='text'`` token-id tensors (``value``); one tensor per text row."""
+        return [part.value for part in parts if part.type == "text"]
+
+    def tokenize(self, parts: list[ConversationItem]) -> None:
+        """Tokenize each ``text`` part in place: ``str`` value → token-id tensor.
+        Builds tensors on CPU. Sets ``meta['labels']`` (``-100`` where ``loss_mask`` is 0) and ``meta['attention_mask']``.
+        """
+        for part in parts:
+            if part.type == "text":
+                text = part.value
+                loss_mask = int(part.meta.pop("loss_mask"))
+                input_ids = self.tokenizer(text, add_special_tokens=False)["input_ids"]
+                labels = input_ids if loss_mask else [-100] * len(input_ids)
+                part.value = torch.tensor(input_ids, dtype=torch.long)
+                part.meta["labels"] = torch.tensor(labels, dtype=torch.long)
+                part.meta["attention_mask"] = torch.ones(len(input_ids), dtype=torch.long)
+
+    @staticmethod
+    def merge_text_embeds(parts: list[ConversationItem]) -> list[ConversationItem]:
+        """Merge adjacent same-role ``text`` parts (concat ids / labels / mask).
+
+        Run AFTER :meth:`tokenize`: it concatenates the per-segment token-id,
+        ``labels`` and ``attention_mask`` tensors. Because labels are already
+        computed per segment, distinct ``loss_mask`` spans under the same role
+        (e.g. the masked assistant prefix vs. the supervised response) keep their
+        own labels through the merge.
+        """
+        merged: list[ConversationItem] = []
+        for part in parts:
+            if merged and merged[-1].type == "text" and part.type == "text" and merged[-1].role == part.role:
+                prev = merged[-1]
+                prev.value = torch.cat([prev.value, part.value])
+                prev.meta["labels"] = torch.cat([prev.meta["labels"], part.meta["labels"]])
+                prev.meta["attention_mask"] = torch.cat([prev.meta["attention_mask"], part.meta["attention_mask"]])
+                continue
+            merged.append(part)
+        return merged

--- a/veomni/models/seed_omni/modules/base/text_encoder/configuration.py
+++ b/veomni/models/seed_omni/modules/base/text_encoder/configuration.py
@@ -1,0 +1,45 @@
+"""Configuration for :class:`TextEncoder`.
+
+The ``model_type`` string is the lookup key used by
+``OMNI_CONFIG_REGISTRY`` / ``OMNI_MODEL_REGISTRY`` (see
+``modules/__init__.py``).  Every other field is plumbed through to
+``TextEncoder.__init__``.
+"""
+
+from transformers import PretrainedConfig
+
+
+class TextEncoderConfig(PretrainedConfig):
+    """Config for the generic word-token embedding + LM head module.
+
+    Parameters
+    ----------
+    vocab_size:
+        Number of token IDs in the embedding / projection.
+    hidden_size:
+        LLM hidden-state dimension.  Must match the backbone model.
+    tie_word_embeddings:
+        If ``True``, ``decode`` projects via ``embed_tokens.weight`` (no
+        separate ``lm_head``).  If ``False``, an independent
+        ``nn.Linear`` is allocated.  Default: ``True``.
+    lm_head_bias:
+        Only meaningful when ``tie_word_embeddings`` is ``False``.  When
+        ``True`` the untied ``lm_head`` gains a bias term.  Default:
+        ``False``.
+    """
+
+    model_type = "text_encoder"
+
+    def __init__(
+        self,
+        vocab_size: int = 32000,
+        hidden_size: int = 4096,
+        tie_word_embeddings: bool = True,
+        lm_head_bias: bool = False,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.tie_word_embeddings = tie_word_embeddings
+        self.lm_head_bias = lm_head_bias

--- a/veomni/models/seed_omni/modules/base/text_encoder/modeling.py
+++ b/veomni/models/seed_omni/modules/base/text_encoder/modeling.py
@@ -1,0 +1,290 @@
+"""Generic word-token embedding (``wte``) + LM head as a graph node.
+
+``TextEncoder(InferenceMixin, OmniPreTrainedModel)`` — mirrors HF's own
+``PreTrainedModel`` + ``GenerationMixin`` split: ``OmniPreTrainedModel``
+owns weights / ``forward`` (here, ``encode`` / ``decode``, which mirror a
+VQ codec pre/post stage so the backbone stays vocab-agnostic), while
+``InferenceMixin`` owns the FSM ``generate`` sampling helpers shared by every
+text encoder (``_sample_token`` / ``_encode_prompt`` / ``_flush_text_generated``
+/ …). Each family's ``modeling.py`` subclasses ``TextEncoder`` and implements
+the concrete ``generate()`` (ChatML autoregression, T2I signal emission, …)
+plus its own chat template. VeOmni training-graph hooks (``encode_pre`` /
+``decode_post`` / SP-awareness) live in ``modules/<family>/text_encoder/accelerated.py``.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers import PreTrainedTokenizerBase
+
+from veomni.utils.tensor_utils import naflatten, unflatten
+
+from ....omni_pretrained_model import OmniPreTrainedModel
+from ....utils.conversation import ConversationItem, seal_outputs
+from .chat_template import TextEncoderChatTemplate
+from .configuration import TextEncoderConfig
+
+
+_SAMPLING_KWARGS = ("temperature", "top_p", "do_sample")
+
+
+def scatter_text_encoder_embeds(
+    conversation_list: list[list[ConversationItem]],
+    segment_embeds: list[torch.Tensor],
+) -> None:
+    """Write packed text embeds back onto conversation text segments."""
+    segment_embeds_iterator = iter(segment_embeds)
+    for sample in conversation_list:
+        for part in sample:
+            if part.type != "text":
+                continue
+            part.value = next(segment_embeds_iterator)
+    if next(segment_embeds_iterator, None) is not None:
+        raise RuntimeError("TextEncoder text segment count mismatch during embed scatter.")
+
+
+class InferenceMixin:
+    """FSM ``generate`` + shared sampling helpers — analogous to HF's ``GenerationMixin``.
+
+    Inference differs substantially across text encoders (Qwen ChatML
+    autoregression keyed on eos / ``<|im_end|>``; Janus T2I with ``<boi>`` /
+    ``<eoi>`` + classifier-free guidance), so each concrete module owns its
+    ``generate``. This mixin only provides the shared sampling / embedding
+    helpers below, plus the FSM inference state initialized in
+    :meth:`TextEncoder.__init__`.
+
+    Listed *before* :class:`~....omni_pretrained_model.OmniPreTrainedModel` in
+    :class:`TextEncoder`'s bases: ``OmniPreTrainedModel`` ships no-op
+    ``reset_local_inference_state`` / ``finalize`` defaults (kept so
+    inference-only modules that don't mix this in still satisfy the FSM
+    runtime's unconditional ``module.finalize(ctx=...)`` call), and MRO
+    resolves left-to-right — put second, those no-ops would shadow the real
+    implementations below.
+    """
+
+    def reset_local_inference_state(self) -> None:
+        self._text_token_cache.clear()
+
+    def reset_global_inference_state(self) -> None:
+        self.reset_local_inference_state()
+        self._bos_injected = False
+        self._prompt_encoded = False
+
+    def _encode_prompt(self, conversation_list: List[ConversationItem]) -> Dict[str, Any]:
+        """First FSM step: embed the already-prepared prompt + scatter back.
+
+        The inference CPU preprocessor (run before the FSM, mirroring training's
+        collator) has already applied the chat template, appended the generation
+        prompt and tokenized every text row, so this only packs the token ids,
+        embeds them through :meth:`~TextEncoder.encode`, and scatters the segment
+        embeds — the text-encoder twin of the per-step "pack → encode → scatter".
+        Subsequent ``generate`` calls autoregress (``_prompt_encoded`` guards
+        re-entry).
+        """
+        self._prompt_encoded = True
+        for part in conversation_list:
+            part.meta.pop("labels", None)
+        input_ids = self._chat_template.pack_input_ids(conversation_list)
+        input_ids, batch_shape = naflatten(input_ids)
+        input_ids = input_ids.to(self.device)
+        inputs_embeds = self.encode(input_ids)["inputs_embeds"]
+        scatter_text_encoder_embeds([conversation_list], unflatten(inputs_embeds, batch_shape))
+        return {"conversation_list": conversation_list}
+
+    def generate(
+        self,
+        conversation_list: Optional[List[ConversationItem]] = None,
+        generation_kwargs: Dict[str, Any] = dict,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """One FSM inference step — implemented per module (see class docstring)."""
+        del conversation_list, generation_kwargs, kwargs
+        raise NotImplementedError(f"{type(self).__name__} must implement generate().")
+
+    @staticmethod
+    def _top_p_filter(logits: torch.Tensor, top_p: float) -> torch.Tensor:
+        sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+        sorted_probs = torch.softmax(sorted_logits, dim=-1)
+        cumulative = torch.cumsum(sorted_probs, dim=-1)
+        sorted_indices_to_remove = cumulative - sorted_probs > top_p
+        sorted_logits[sorted_indices_to_remove] = float("-inf")
+        return logits.scatter(1, sorted_indices, sorted_logits)
+
+    def _sample_token(
+        self,
+        hidden_states: torch.Tensor,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        do_sample: bool = True,
+        **kwargs,
+    ) -> int:
+        del kwargs
+        hidden_states = hidden_states.to(self.device)
+        last = hidden_states[:, -1, :]
+        logits = self._project(last) if last.dim() == 2 else self._project(last.squeeze(0))
+        if not do_sample:
+            return int(logits.argmax(dim=-1).item())
+        if temperature != 1.0:
+            logits = logits / max(temperature, 1e-6)
+        if top_p < 1.0:
+            logits = self._top_p_filter(logits, top_p)
+        probs = F.softmax(logits, dim=-1)
+        token = torch.multinomial(probs, num_samples=1)
+        return token
+
+    def _token_id_tensor(self, token_id: int) -> torch.Tensor:
+        device = self.device
+        return torch.tensor([[token_id]], dtype=torch.long, device=device)
+
+    @staticmethod
+    def _extract_sampling_kwargs(
+        generation_kwargs: Optional[Dict[str, Any]],
+        temperature: float,
+        top_p: float,
+        kwargs: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        merged: Dict[str, Any] = {"temperature": temperature, "top_p": top_p, "do_sample": True}
+        if generation_kwargs:
+            for k in _SAMPLING_KWARGS:
+                if k in generation_kwargs:
+                    merged[k] = generation_kwargs[k]
+        for k in _SAMPLING_KWARGS:
+            if k in kwargs:
+                merged[k] = kwargs[k]
+        return merged
+
+    def finalize(self, *, ctx: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._text_token_cache:
+            return {}
+        flushed = self._flush_text_generated(ctx["conversation_list"])
+        if not flushed:
+            return {}
+        return {"generated": flushed}
+
+    def _flush_text_generated(self, conversation_list: List[ConversationItem]) -> Dict[str, Any]:
+        token_ids = list(self._text_token_cache)
+        self._text_token_cache.clear()
+        if not token_ids:
+            return {}
+        meta = {"token_ids": token_ids}
+        text = self._tokenizer.decode(token_ids, skip_special_tokens=True)
+        seal_outputs(conversation_list, new_type="text")
+        return {"type": "text", "value": text, "meta": meta}
+
+
+class TextEncoder(InferenceMixin, OmniPreTrainedModel):
+    """Word-token embedding + LM head, plus shared FSM ``generate`` sampling helpers."""
+
+    config_class = TextEncoderConfig
+    base_model_prefix = ""
+    _no_split_modules: list = ["Embedding"]
+    main_input_name = "input_ids"
+
+    def __init__(self, config: TextEncoderConfig):
+        super().__init__(config)
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        if config.tie_word_embeddings:
+            self.lm_head = None
+        else:
+            self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=config.lm_head_bias)
+        self._tokenizer: Optional[PreTrainedTokenizerBase] = None
+        self._chat_template: Optional[TextEncoderChatTemplate] = None
+        # FSM inference state (see ``InferenceMixin.generate`` / ``_encode_prompt``):
+        # first step embeds the whole (pre-templated, pre-tokenized) prompt; later
+        # steps autoregress.
+        self._prompt_encoded: bool = False
+        self._text_token_cache: list[int] = []
+        self._bos_injected: bool = False
+        self.post_init()
+
+    # ── Embedding accessors ────────────────────────────────────────────────────
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value: nn.Module) -> None:
+        self.embed_tokens = value
+
+    def get_output_embeddings(self) -> Optional[nn.Module]:
+        # When tied there is no separate ``lm_head`` — ``_project`` reuses
+        # ``embed_tokens.weight`` directly. Returning ``embed_tokens`` makes the
+        # generic load-time weight-tie a harmless self-assignment instead of
+        # crashing on a ``None`` output module.
+        if self.config.tie_word_embeddings:
+            return self.embed_tokens
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings: nn.Module) -> None:
+        if not self.config.tie_word_embeddings:
+            self.lm_head = new_embeddings
+
+    # ── Forward ────────────────────────────────────────────────────────────────
+
+    def forward(self, **kwargs) -> Dict[str, Any]:  # type: ignore[override]
+        return self.encode(**kwargs)
+
+    def encode(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        input_ids = input_ids.unsqueeze(0) if input_ids.dim() == 1 else input_ids
+        embeds = self._embed_tokens(input_ids)
+        return {
+            "inputs_embeds": embeds.squeeze(0) if embeds.size(0) == 1 else embeds,
+        }
+
+    def _embed_tokens(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def decode(
+        self,
+        hidden_states: Optional[torch.Tensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        shift_labels: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> dict:
+        del kwargs
+        logits = self._project(hidden_states)
+        loss: torch.Tensor | None = None
+
+        # Local, parallel-state-free CE: kernel selection and the DP+SP token
+        # weighting are the runtime's business, so ``accelerated.py`` overrides
+        # this with the fused ops dispatch (see ``TrainingMixin.decode``).
+        if shift_labels is not None:
+            flat_labels = shift_labels.view(-1)
+            ce_sum = F.cross_entropy(
+                logits.view(-1, logits.size(-1)),
+                flat_labels,
+                ignore_index=-100,
+                reduction="sum",
+            )
+            n_valid_local = (flat_labels != -100).sum().clamp(min=1)
+            loss = ce_sum / n_valid_local
+        elif labels is not None:
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_targets = labels[..., 1:].contiguous()
+            ce_sum = F.cross_entropy(
+                shift_logits.view(-1, shift_logits.size(-1)),
+                shift_targets.view(-1),
+                ignore_index=-100,
+                reduction="sum",
+            )
+            n_valid = (shift_targets != -100).sum().clamp(min=1)
+            loss = ce_sum / n_valid
+
+        return {
+            "loss": loss,
+            "logits": logits,
+        }
+
+    def _project(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if not self.config.tie_word_embeddings:
+            return self.lm_head(hidden_states)
+        return F.linear(hidden_states, self.embed_tokens.weight)
+
+
+__all__ = ["InferenceMixin", "TextEncoder", "scatter_text_encoder_embeds"]

--- a/veomni/models/seed_omni/modules/base/text_encoder/modeling.py
+++ b/veomni/models/seed_omni/modules/base/text_encoder/modeling.py
@@ -132,7 +132,7 @@ class InferenceMixin:
             logits = self._top_p_filter(logits, top_p)
         probs = F.softmax(logits, dim=-1)
         token = torch.multinomial(probs, num_samples=1)
-        return token
+        return int(token.item())
 
     def _token_id_tensor(self, token_id: int) -> torch.Tensor:
         device = self.device
@@ -200,8 +200,6 @@ class TextEncoder(InferenceMixin, OmniPreTrainedModel):
         self._bos_injected: bool = False
         self.post_init()
 
-    # ── Embedding accessors ────────────────────────────────────────────────────
-
     def get_input_embeddings(self) -> nn.Module:
         return self.embed_tokens
 
@@ -220,8 +218,6 @@ class TextEncoder(InferenceMixin, OmniPreTrainedModel):
     def set_output_embeddings(self, new_embeddings: nn.Module) -> None:
         if not self.config.tie_word_embeddings:
             self.lm_head = new_embeddings
-
-    # ── Forward ────────────────────────────────────────────────────────────────
 
     def forward(self, **kwargs) -> Dict[str, Any]:  # type: ignore[override]
         return self.encode(**kwargs)

--- a/veomni/models/seed_omni/modules/base/text_encoder/parallel_plan.py
+++ b/veomni/models/seed_omni/modules/base/text_encoder/parallel_plan.py
@@ -1,0 +1,15 @@
+from torch.distributed._tensor import Shard
+
+from ......distributed.parallel_plan import ParallelPlan
+
+
+def get_parallel_plan():
+    emb_plan = {
+        "embed_tokens.weight": Shard(0),
+    }
+    parallel_plan = ParallelPlan(
+        extra_parallel_plan={
+            "emb": emb_plan,
+        }
+    )
+    return parallel_plan

--- a/veomni/models/seed_omni/modules/base/text_encoder/processing.py
+++ b/veomni/models/seed_omni/modules/base/text_encoder/processing.py
@@ -1,0 +1,77 @@
+"""Shared CPU worker for every SeedOmni text encoder module.
+
+Each concrete text encoder keeps a thin ``processing.py`` that subclasses
+:class:`TextEncoderPreprocessor` and implements :meth:`build_chat_template`
+with its module-local :class:`~veomni.models.seed_omni.modules.base.text_encoder.chat_template.TextEncoderChatTemplate`
+subclass.  Tokenize / merge / pack live on the base chat template; this worker
+only runs ``tokenize_conversation`` inside DataLoader workers (training) or
+before the generation FSM (inference).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ....processing import ModulePreprocessorBase
+from ....utils.conversation import ConversationItem
+from .chat_template import TextEncoderChatTemplate
+
+
+class TextEncoderPreprocessor(ModulePreprocessorBase):
+    """Worker-side ``apply_chat_template`` → tokenize → merge for text encoders.
+
+    Holds only the (picklable) chat template — never the model — so it runs in
+    DataLoader workers and overlaps with GPU compute.  Builds CPU tensors; the
+    main process's thin ``encode_pre`` does the single ``.to(device)``.
+
+    :meth:`bind_module_assets` also copies ``_tokenizer`` onto the model —
+    :class:`~veomni.models.seed_omni.modules.base.text_encoder.modeling.TextEncoder`
+    decodes generated text via ``self._tokenizer``.
+    """
+
+    def __init__(self, chat_template: TextEncoderChatTemplate) -> None:
+        self._chat_template = chat_template
+        self._tokenizer = chat_template.tokenizer
+
+    @classmethod
+    def build_chat_template(
+        cls,
+        module_path: str,
+        *,
+        config_overrides: dict[str, Any] | None = None,
+    ) -> TextEncoderChatTemplate:
+        """Build this module's chat template from its checkpoint subfolder."""
+        del module_path, config_overrides
+        raise NotImplementedError(f"{cls.__name__} must implement build_chat_template()")
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        module_path: str,
+        *,
+        config_overrides: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ):
+        """Build straight from the checkpoint dir — no model instance needed."""
+        del kwargs
+        return cls(cls.build_chat_template(module_path, config_overrides=config_overrides))
+
+    def _tokenize_conversation_kwargs(self, inference: bool, **kwargs: Any) -> dict[str, Any]:
+        """Extra kwargs forwarded to :meth:`TextEncoderChatTemplate.tokenize_conversation`."""
+        del kwargs
+        return {"add_generation_prompt": inference}
+
+    def __call__(
+        self,
+        conversation_list: list[list[ConversationItem]],
+        inference: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        tc_kwargs = self._tokenize_conversation_kwargs(inference, **kwargs)
+        for sample in conversation_list or []:
+            parts = self._chat_template.tokenize_conversation(sample, **tc_kwargs)
+            sample.clear()
+            sample.extend(parts)
+
+
+__all__ = ["TextEncoderPreprocessor"]

--- a/veomni/models/seed_omni/omni_pretrained_model.py
+++ b/veomni/models/seed_omni/omni_pretrained_model.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HF-native SeedOmni sub-model base — extends :class:`PreTrainedModel` for eager inference."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from transformers import PreTrainedModel
+
+
+class OmniPreTrainedModel(PreTrainedModel):
+    """VeOmni HF-native base for every ``modules/*/modeling.py`` class.
+
+    Subclasses hold weights, ``forward``, and FSM ``generate`` endpoints only.
+    VeOmni training / distributed hooks live on ``accelerated.py`` mixins composed
+    at runtime (``OMNI_ACCELERATED_MODEL_REGISTRY``).
+    """
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: Any, *args: Any, **kwargs: Any):
+        """Load weights, then bind module-owned processor / tokenizer sidecars."""
+        from .processing.binding import bind_module_assets
+
+        model = super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        # ``kwargs`` may carry an HF ``config=<PretrainedConfig>`` (the loaded
+        # module config, forwarded by ``OmniModel._load_modules``) — that's a
+        # different "config" than the launcher/runtime overrides dict
+        # ``config_overrides`` represents (``support_cache`` / ``train_type`` /
+        # …). Some preprocessors' ``from_pretrained`` forward ``config_overrides``
+        # as ``**kwargs`` into helpers that also take a positional ``config``
+        # (e.g. ``OfflineEncodingMixin.patch_config``), so a passthrough ``config``
+        # key here would collide with it — strip it before binding.
+        config_overrides = {k: v for k, v in kwargs.items() if k != "config"}
+        bind_module_assets(
+            model,
+            checkpoint_path=str(pretrained_model_name_or_path),
+            config_overrides=config_overrides,
+        )
+        return model
+
+    def get_assets(self) -> list[Any]:
+        """Module-owned auxiliary artefacts to save alongside the weights."""
+        return []
+
+    def reset_local_inference_state(self) -> None:
+        """Reset per-turn state inside an ongoing conversation."""
+        return None
+
+    def reset_global_inference_state(self) -> None:
+        """Reset the full conversation-level inference state."""
+        self.reset_local_inference_state()
+
+    def finalize(self, *, ctx: dict[str, Any]) -> dict[str, Any]:
+        """Flush module-private generation buffers into a one-shot ``generated`` payload."""
+        del ctx
+        return {}
+
+
+__all__ = ["OmniPreTrainedModel"]

--- a/veomni/models/seed_omni/processing/__init__.py
+++ b/veomni/models/seed_omni/processing/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-module CPU preprocessing contracts and model asset binding."""
+
+from .base import ModulePreprocessorBase
+from .binding import MODULE_ASSET_ATTRS, bind_module_assets
+
+
+__all__ = [
+    "MODULE_ASSET_ATTRS",
+    "ModulePreprocessorBase",
+    "bind_module_assets",
+]

--- a/veomni/models/seed_omni/processing/base.py
+++ b/veomni/models/seed_omni/processing/base.py
@@ -1,0 +1,133 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base class for per-module CPU input preparation (DataLoader workers).
+
+Terminology (three different "processor" layers)
+------------------------------------------------
+* **HF asset — ``XxxProcessor``** (in each ``modules/*/processing.py``):
+  HuggingFace-style checkpoint sidecar — image processor, tokenizer, etc.
+  Saved/loaded via ``save_pretrained`` / ``from_pretrained`` on the asset itself
+  (e.g. ``JanusSiglipProcessor``, ``BagelVAEProcessor``).  Holds resize /
+  normalize constants; no ``nn.Module`` weights.
+
+* **Module CPU worker — ``XxxPreprocessor(ModulePreprocessorBase)``** (same file):
+  Picklable, weight-free object run inside DataLoader workers (training) or
+  once before the generation FSM (inference).  Usually *wraps* the HF asset
+  (``self._image_processor``, ``self._tokenizer``, …) and mutates
+  ``conversation_list`` in place via ``__call__``.
+
+* **Omni orchestrator — ``OmniProcessor``** (``processing_omni.py``):
+  Composes one ``XxxPreprocessor`` per active graph module — the SeedOmni
+  analogue of HuggingFace ``AutoProcessor``.
+
+This module defines only the **middle** layer's abstract base.  It is **not**
+a graph mixin; each module's native model class declares
+``preprocessor_class = XxxPreprocessor``
+as a registry pointer and optionally receives copied assets via
+:func:`~veomni.models.seed_omni.processing.binding.bind_module_assets`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ModulePreprocessorBase:
+    """Picklable, weight-free CPU input-prep run inside DataLoader workers.
+
+    Subclass as ``XxxPreprocessor`` in ``modules/<family>/<sub>/processing.py``.
+    The HF asset (``XxxProcessor`` / tokenizer) lives in the same file but is a
+    separate class — do not confuse the two.
+
+    Contract:
+
+    * **No model weights, no model instance.** It is pickled / fork-inherited into
+      worker processes, so it must hold only CPU-safe, picklable assets (tokenizer /
+      image processor / special-token ids / config ints) — never the ``nn.Module``.
+      :meth:`from_pretrained` builds it straight from a module's checkpoint
+      subfolder — mirroring HuggingFace's ``XxxProcessor.from_pretrained`` — with
+      **no dependency on any live/real model** (weight-free or otherwise).
+    * **CPU only.** Workers must not touch the training CUDA device; build CPU
+      tensors (no ``device=``).  The main process's thin ``pre_forward`` does the
+      single ``.to(device)``.
+    * **In-place mutation.** ``__call__`` receives the batched
+      ``conversation_list`` (``list[list[ConversationItem]]``) and mutates items'
+      ``value`` / ``meta`` in place, tagging the module ``source`` so the thin
+      ``pre_forward`` / ``generate`` reads the heavy work back uniformly.
+    * **Shared by training + inference.** Training runs it inside
+      :class:`~veomni.data.data_collator.SeedOmniCollator` (DataLoader worker);
+      inference runs it once over the request in
+      :meth:`~veomni.trainer.omni.omni_inferencer.OmniInferencer._preprocess_request`,
+      before the FSM. The ``inference`` flag flips the train/infer-only behaviour:
+      image modules **skip dummy injection** (no FSDP anchor at inference) and
+      text encoders **append the assistant generation prompt**. Extra request
+      options (e.g. ``generation_kwargs``) arrive via ``**kwargs`` so a module
+      *could* vary its input-prep by them (classifier-free guidance duplicating the
+      prompt, …); no current module needs them, but the hook is plumbed through.
+    * **Dummy inputs are optional and bound after construction.** A module whose
+      ``inference=False`` (training) branch injects an FSDP-anchor dummy item
+      (image modules only — text encoders never need one) computes that dummy's
+      shape from pure ``(config, dtype)`` — the preprocessor itself still never
+      touches a live model or the checkpoint disk to get that ``config``. The
+      *orchestrator* does, though: :meth:`~veomni.trainer.omni.omni_trainer.OmniTrainer._build_train_dataloader`
+      runs after the training model is already built, so it hands
+      :meth:`OmniProcessor.bind_dummy_inputs` each module's already-resolved
+      ``ModuleRuntime.model_config`` straight from memory (no disk re-read, no
+      config-override re-application) — see :meth:`bind_dummy_inputs`.
+      Inference never exercises the dummy branch, so an unbound dummy is harmless
+      there.
+    """
+
+    def __call__(self, conversation_list: list[list[Any]], inference: bool = False, **kwargs: Any) -> None:
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement "
+            "__call__(conversation_list, inference=False, **kwargs) and mutate it in place."
+        )
+
+    @classmethod
+    def from_pretrained(
+        cls, module_path: str, *, config_overrides: dict[str, Any] | None = None, **kwargs: Any
+    ) -> ModulePreprocessorBase | None:
+        """Build this module's CPU worker from its checkpoint subfolder alone.
+
+        No model instance (weight-free or otherwise) is built or required.
+        ``config_overrides`` mirrors the module's YAML ``model_config:`` block
+        (the same dict threaded into the live model's ``config_kwargs`` — see
+        ``ModuleRuntime._build_module_model``): a subclass that reads its own
+        ``config.json`` for a behavior-affecting field (e.g. ``enable_image``,
+        ``cache_mode``) must apply these on top of the on-disk defaults —
+        ``XxxConfig.from_pretrained(module_path, **(config_overrides or {}))`` —
+        so a preprocessor built independently of any model instance still
+        agrees with what the live model was actually configured with. Default:
+        this module contributes no preprocessor (e.g. a pure backbone with no
+        CPU-side input prep). Concrete modules override on their own
+        ``processing.py``-defined ``ModulePreprocessorBase`` subclass.
+        """
+        del module_path, config_overrides, kwargs
+        return None
+
+    def bind_dummy_inputs(self, config: Any, dtype: Any = None) -> None:
+        """Attach the FSDP-anchor dummy tensor(s) for training's ``inference=False``
+        branch — computed from ``config`` + ``dtype`` alone (no live model).
+
+        Called once by :meth:`~veomni.trainer.omni.omni_trainer.OmniTrainer._build_train_dataloader`
+        after the training collator's preprocessors are collected. Default: no-op
+        (text-encoder preprocessors and any module without a dummy branch).
+        """
+        del config, dtype
+        return None
+
+
+__all__ = ["ModulePreprocessorBase"]

--- a/veomni/models/seed_omni/processing/binding.py
+++ b/veomni/models/seed_omni/processing/binding.py
@@ -1,0 +1,66 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Copy HF asset handles from a CPU worker onto a live ``nn.Module`` instance."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import ModulePreprocessorBase
+
+
+# Attributes a ``XxxPreprocessor`` may hold that ``forward`` / ``generate`` read
+# directly on the model (``self._image_processor``, ``self.tokenizer``, …).
+MODULE_ASSET_ATTRS = ("_processor", "_image_processor", "_video_processor", "_tokenizer", "_chat_template")
+
+_BOUND_CHECK_ATTRS = ("_image_processor", "_video_processor", "_tokenizer")
+
+
+def bind_module_assets(
+    model: Any,
+    *,
+    checkpoint_path: str | None = None,
+    preprocessor: ModulePreprocessorBase | None = None,
+    config_overrides: dict[str, Any] | None = None,
+) -> None:
+    """Attach HF assets from a CPU worker onto ``model``.
+
+    Pass either a built ``preprocessor``, or ``checkpoint_path`` (reads
+    ``preprocessor_class`` off ``type(model)`` and calls
+    :meth:`ModulePreprocessorBase.from_pretrained`).  Copies well-known asset attributes
+    (``_image_processor``, ``_tokenizer``, …) onto the instance names that
+    ``forward`` / ``generate`` already read — no rebuild at bind time.
+
+    No-op when the module declares no ``preprocessor_class``, assets are already
+    bound, or ``from_pretrained`` returns ``None`` (modules with no CPU worker).
+    """
+    if any(getattr(model, attr, None) is not None for attr in _BOUND_CHECK_ATTRS):
+        return
+
+    if preprocessor is None:
+        preprocessor_cls = getattr(type(model), "preprocessor_class", None)
+        if preprocessor_cls is None or checkpoint_path is None:
+            return
+        preprocessor = preprocessor_cls.from_pretrained(checkpoint_path, config_overrides=config_overrides)
+
+    if preprocessor is None:
+        return
+
+    for attr in MODULE_ASSET_ATTRS:
+        if hasattr(preprocessor, attr):
+            setattr(model, attr, getattr(preprocessor, attr))
+
+
+__all__ = ["MODULE_ASSET_ATTRS", "bind_module_assets"]

--- a/veomni/models/seed_omni/processing/binding.py
+++ b/veomni/models/seed_omni/processing/binding.py
@@ -25,8 +25,6 @@ from .base import ModulePreprocessorBase
 # directly on the model (``self._image_processor``, ``self.tokenizer``, …).
 MODULE_ASSET_ATTRS = ("_processor", "_image_processor", "_video_processor", "_tokenizer", "_chat_template")
 
-_BOUND_CHECK_ATTRS = ("_image_processor", "_video_processor", "_tokenizer")
-
 
 def bind_module_assets(
     model: Any,
@@ -46,9 +44,6 @@ def bind_module_assets(
     No-op when the module declares no ``preprocessor_class``, assets are already
     bound, or ``from_pretrained`` returns ``None`` (modules with no CPU worker).
     """
-    if any(getattr(model, attr, None) is not None for attr in _BOUND_CHECK_ATTRS):
-        return
-
     if preprocessor is None:
         preprocessor_cls = getattr(type(model), "preprocessor_class", None)
         if preprocessor_cls is None or checkpoint_path is None:
@@ -59,7 +54,7 @@ def bind_module_assets(
         return
 
     for attr in MODULE_ASSET_ATTRS:
-        if hasattr(preprocessor, attr):
+        if hasattr(preprocessor, attr) and getattr(model, attr, None) is None:
             setattr(model, attr, getattr(preprocessor, attr))
 
 

--- a/veomni/models/seed_omni/processing_omni.py
+++ b/veomni/models/seed_omni/processing_omni.py
@@ -1,0 +1,206 @@
+"""OmniProcessor — composed request preprocessing for :class:`OmniModel`.
+
+Mirrors HuggingFace ``AutoProcessor``: collect each module's CPU preprocessor in
+``config.module_names`` order, build a ``conversation_list`` from user inputs,
+run the preprocessor chain, and return a generate-ready request dict.
+
+Every module's :class:`~veomni.models.seed_omni.processing.base.ModulePreprocessorBase`
+(defined in its own ``processing.py`` and pointed at by ``preprocessor_class`` on
+its native model class) builds straight off its checkpoint subfolder via
+:meth:`~veomni.models.seed_omni.processing.base.ModulePreprocessorBase.from_pretrained` —
+no model instance (weight-free, meta-device, or otherwise) is built or required.
+:meth:`OmniProcessor.from_config` reads each module's ``preprocessor_class`` off
+the class registered for its ``model_type`` and is the single code path backing
+both :meth:`OmniProcessor.from_pretrained` (checkpoint on disk) and callers that
+already hold a resolved config in memory (e.g. ``OmniTrainer`` builds its
+dataloader's collator this way, decoupled from ``self.model``). Callers that
+need a :class:`~veomni.data.data_collator.SeedOmniCollator` (e.g. ``OmniTrainer``)
+build one directly from a processor — that composition is theirs to own, not
+this module's.
+
+Usage::
+
+    processor = OmniProcessor.from_pretrained(checkpoint_root)
+    model = OmniModel.from_pretrained(checkpoint_root, device_map="auto")
+    inputs = processor(text="Describe this image.", images=["/path/to.jpg"])
+    model.reset()
+    generated = model.generate(inputs, generation_kwargs={"max_new_tokens": 128})
+
+Or, when the model is built first (e.g. from an already-resolved launcher-YAML
+config with per-module ``model_config:`` overrides — see ``OmniTrainer`` /
+``OmniInferencer``), reuse ``model.config`` instead of re-reading
+``checkpoint_root`` a second time — saves one redundant ``config.json`` load,
+and keeps the two builds looking at the exact same config::
+
+    model = OmniModel.from_pretrained(checkpoint_root, config=my_resolved_config, device_map="auto")
+    processor = OmniProcessor.from_config(model.config, checkpoint_root=checkpoint_root)
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from typing import Any, Union
+
+from PIL import Image
+
+from ...data.multimodal.image_utils import load_image
+from ...utils import logging
+from .configuration_omni import OmniConfig
+from .modules import OMNI_MODEL_REGISTRY, read_model_type
+from .processing import ModulePreprocessorBase
+from .utils.conversation import build_conversation
+
+
+logger = logging.get_logger(__name__)
+
+ImageInput = Union[str, Any]
+MediaInput = Union[ImageInput, Sequence[ImageInput]]
+
+
+def _normalize_images(images: MediaInput) -> list[Any]:
+    if isinstance(images, (str, bytes)) or isinstance(images, Image.Image):
+        images = [images]
+    normalized: list[Any] = []
+    for image in images:
+        if isinstance(image, Image.Image):
+            normalized.append(image)
+        else:
+            normalized.append(load_image(image))
+    return normalized
+
+
+class OmniProcessor:
+    """Composed SeedOmni request preprocessor (HF ``AutoProcessor``-style API)."""
+
+    def __init__(self, preprocessors: dict[str, ModulePreprocessorBase]) -> None:
+        self._preprocessors: dict[str, ModulePreprocessorBase] = dict(preprocessors)
+
+    def __len__(self) -> int:
+        """Number of worker-side preprocessors contributed by active graph modules."""
+        return len(self._preprocessors)
+
+    def bind_dummy_inputs(self, module_configs: Mapping[str, Any], *, dtype: Any = None) -> None:
+        """Training-only: attach each preprocessor's FSDP-anchor dummy tensor(s).
+
+        Computed from each module's own already-resolved config + ``dtype``
+        alone (see :meth:`ModulePreprocessorBase.bind_dummy_inputs`) — no disk re-read
+        here: ``module_configs`` is ``{module_name: config}`` taken straight
+        from the already-built live modules (e.g.
+        ``{name: module_runtime.model_config for name, module_runtime in
+        self.model.module_runtimes.items()}``), so it is already the exact
+        config the live model was built with, overrides included. Call once,
+        right after the training model finishes building
+        (:meth:`~veomni.trainer.omni.omni_trainer.OmniTrainer._build_train_dataloader`
+        runs after ``_build_model``). Unnecessary for pure inference
+        (``OmniInferencer``): the dummy branch is never exercised there.
+        """
+        for name, preprocessor in self._preprocessors.items():
+            config = module_configs.get(name)
+            if config is not None:
+                preprocessor.bind_dummy_inputs(config, dtype)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: OmniConfig,
+        *,
+        checkpoint_root: str | os.PathLike | None = None,
+    ) -> OmniProcessor:
+        """Build preprocessors straight off an already-resolved :class:`OmniConfig`.
+
+        No live/real module is built or required — see the module docstring. This is
+        the single builder both :meth:`from_pretrained` and any caller holding an
+        in-memory config (e.g. ``OmniTrainer`` / ``OmniInferencer`` launcher configs,
+        built before or independently of ``self.model``) should use.
+
+        Collects CPU preprocessors in ``config.module_names`` order: for each
+        module, reads its ``preprocessor_class`` off the class registered for its
+        ``model_type`` and calls :meth:`ModulePreprocessorBase.from_pretrained` directly on
+        its checkpoint subfolder — no model instance is built at all (not even a
+        ``meta``-device one). ``config.module_model_config(name)`` (the module's
+        YAML ``model_config:`` block) is forwarded as ``config_overrides`` so a
+        preprocessor that reads a behavior-affecting config field (e.g.
+        ``enable_image``, ``cache_mode``) agrees with what the live model is
+        actually configured with, instead of silently falling back to the
+        on-disk ``config.json`` default.
+        """
+        root = checkpoint_root if checkpoint_root is not None else getattr(config, "_name_or_path", None)
+        root = None if root is None else str(root)
+        preprocessors: dict[str, ModulePreprocessorBase] = {}
+        for name in config.module_names:
+            module_path = config.resolve_module_path(root, name)
+            model_type = read_model_type(module_path)
+            mod_cls = OMNI_MODEL_REGISTRY[model_type]()
+            preprocessor_cls = getattr(mod_cls, "preprocessor_class", None)
+            if preprocessor_cls is None:
+                continue
+            preprocessor = preprocessor_cls.from_pretrained(
+                module_path, config_overrides=config.module_model_config(name)
+            )
+            if preprocessor is not None:
+                preprocessors[name] = preprocessor
+                logger.info_rank0(f"OmniProcessor: module '{name}' contributes {type(preprocessor).__name__}.")
+        return cls(preprocessors)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | os.PathLike,
+        **config_kwargs: Any,
+    ) -> OmniProcessor:
+        """Load preprocessors from a split-checkpoint root (no module weights)."""
+        config = OmniConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
+        root = getattr(config, "_name_or_path", None) or str(pretrained_model_name_or_path)
+        return cls.from_config(config, checkpoint_root=root)
+
+    def __call__(
+        self,
+        text: str = "",
+        *,
+        images: MediaInput | None = None,
+        videos: MediaInput | None = None,
+        inference: bool = True,
+        **generation_kwargs: Any,
+    ) -> dict[str, Any]:
+        """Build and preprocess a single inference request.
+
+        Returns a dict suitable for :meth:`OmniModel.generate` — currently
+        ``{"conversation_list": [...]}``.
+        """
+        del videos  # video inputs follow the same path once callers pass PIL/VideoInputs
+
+        image_items = _normalize_images(images) if images is not None else []
+        conversation = build_conversation(prompt=text, images=image_items)
+        return self.preprocess(conversation, inference=inference, **generation_kwargs)
+
+    def preprocess(
+        self,
+        conversation: list[Any],
+        *,
+        inference: bool = True,
+        **generation_kwargs: Any,
+    ) -> dict[str, Any]:
+        """Run the module preprocessor chain on an existing ``conversation_list``."""
+        self.preprocess_batch([conversation], inference=inference, **generation_kwargs)
+        return {"conversation_list": conversation}
+
+    def preprocess_batch(
+        self,
+        conversation_batches: Sequence[list[Any]],
+        *,
+        inference: bool = False,
+        **generation_kwargs: Any,
+    ) -> None:
+        """Run the module preprocessor chain over a batched ``conversation_list``.
+
+        Training passes ``inference=False`` (default); single-request inference uses
+        :meth:`preprocess` / :meth:`__call__` with ``inference=True``.
+        """
+        for preprocessor in self._preprocessors.values():
+            preprocessor(conversation_batches, inference=inference, generation_kwargs=generation_kwargs or None)
+
+
+__all__ = [
+    "OmniProcessor",
+]

--- a/veomni/models/seed_omni/processing_omni.py
+++ b/veomni/models/seed_omni/processing_omni.py
@@ -168,7 +168,8 @@ class OmniProcessor:
         Returns a dict suitable for :meth:`OmniModel.generate` — currently
         ``{"conversation_list": [...]}``.
         """
-        del videos  # video inputs follow the same path once callers pass PIL/VideoInputs
+        if videos is not None:
+            raise NotImplementedError("Video preprocessing is not implemented.")
 
         image_items = _normalize_images(images) if images is not None else []
         conversation = build_conversation(prompt=text, images=image_items)

--- a/veomni/models/seed_omni/utils/__init__.py
+++ b/veomni/models/seed_omni/utils/__init__.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SeedOmni V2 utilities: conversation carrier + HF→split checkpoint conversion."""
+
+from .conversation import (
+    ConversationItem,
+    build_conversation,
+    collect_desired_values,
+    is_dummy,
+    iter_desired_items,
+    maybe_merge_outputs,
+    seal_outputs,
+)
+from .convert_registry import OMNI_CONVERT_REGISTRY, convert_checkpoint
+
+
+__all__ = [
+    "ConversationItem",
+    "build_conversation",
+    "is_dummy",
+    "maybe_merge_outputs",
+    "seal_outputs",
+    "iter_desired_items",
+    "collect_desired_values",
+    "OMNI_CONVERT_REGISTRY",
+    "convert_checkpoint",
+]

--- a/veomni/models/seed_omni/utils/checkpoint.py
+++ b/veomni/models/seed_omni/utils/checkpoint.py
@@ -1,0 +1,257 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-module checkpoint/resume for :class:`~veomni.models.seed_omni.accelerator.module_runtime.ModuleRuntime`."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import torch.distributed as dist
+
+from ....checkpoint import CheckpointerBase, build_checkpointer
+from ....utils import helper, logging
+from ....utils.save_safetensor_utils import save_hf_safetensor, save_lora_adapter_with_dcp
+from ..accelerator.dispatch import unwrap_module_chain
+from ..mixins.offline_encoding_mixin import OfflineEncodingMixin
+
+
+if TYPE_CHECKING:
+    from ....arguments.omni_arguments_types import OmniModuleRuntimeArguments
+    from ....trainer.callbacks import TrainerState
+    from ..accelerator.module_runtime import ModuleRuntime
+
+
+logger = logging.get_logger(__name__)
+
+
+class OmniModuleCheckpointManager:
+    """Own DCP / HF / LoRA save-load for one :class:`ModuleRuntime`.
+
+    On-disk layout::
+
+        <save_path>/global_step_{N}/
+        ├── <module_a>/        # DCP {model, optimizer, extra_state={lr_scheduler}} (+ hf export)
+        ├── <module_b>/        # …
+        └── trainer_state.pt   # global (orchestrator-owned)
+    """
+
+    def __init__(self, runtime: ModuleRuntime) -> None:
+        self.runtime = runtime
+        self.module_name = runtime.module_name
+        self.checkpoint_subfolder = runtime.module_name
+        args: OmniModuleRuntimeArguments = runtime.args
+        ckpt = runtime.train.checkpoint
+        self._last_saved_step: int = -1
+        self.checkpointer: CheckpointerBase = build_checkpointer(
+            dist_backend=args.accelerator.fsdp_config.fsdp_mode,
+            ckpt_manager=ckpt.manager,
+        )
+
+    @property
+    def last_saved_step(self) -> int:
+        return self._last_saved_step
+
+    @property
+    def args(self) -> OmniModuleRuntimeArguments:
+        return self.runtime.args
+
+    @property
+    def parallel_state(self):
+        return self.runtime.parallel_state
+
+    # ── Path helpers ──────────────────────────────────────────────────────────
+
+    def _global_step_root(self, state: TrainerState) -> str:
+        return os.path.join(self.runtime.train.checkpoint.save_path, f"global_step_{state.global_step}")
+
+    def _hf_export_dir(self, state: TrainerState) -> str:
+        return os.path.join(self._global_step_root(state), self.checkpoint_subfolder)
+
+    def _module_subdir(self, root: str, state: TrainerState) -> str:
+        return os.path.join(root, f"global_step_{state.global_step}", self.module_name)
+
+    def _save_dir(self, state: TrainerState) -> str:
+        return self._module_subdir(self.runtime.train.checkpoint.save_path, state)
+
+    def _output_dir(self, state: TrainerState) -> str:
+        return self._module_subdir(self.runtime.train.checkpoint.output_dir, state)
+
+    def _load_dir(self) -> str | None:
+        load_path = self.runtime.train.checkpoint.load_path
+        return None if load_path is None else os.path.join(load_path, self.module_name)
+
+    def _extra_state(self, state: TrainerState) -> dict[str, Any]:
+        lr_scheduler = self.runtime.lr_scheduler
+        return {"lr_scheduler": None if lr_scheduler is None else lr_scheduler.state_dict()}
+
+    def _load_extra_state(self, extra_state: dict[str, Any]) -> None:
+        lr_sd = extra_state.get("lr_scheduler")
+        lr_scheduler = self.runtime.lr_scheduler
+        if lr_sd is not None and lr_scheduler is not None:
+            lr_scheduler.load_state_dict(lr_sd)
+
+    def _offline_cache_model(self) -> OfflineEncodingMixin | None:
+        model = unwrap_module_chain(self.runtime.model)
+        if not isinstance(model, OfflineEncodingMixin) or model.cache_mode == "full":
+            return None
+        return model
+
+    # ── Load ──────────────────────────────────────────────────────────────────
+
+    def load(self) -> None:
+        model = self._offline_cache_model()
+        if model is not None:
+            self._load_partial_dcp(model)
+            return
+        self._load_dcp()
+
+    def _load_dcp(self) -> None:
+        load_dir = self._load_dir()
+        if load_dir is None:
+            return
+
+        state = {
+            "model": self.runtime.model,
+            "optimizer": self.runtime.optimizer,
+            "extra_state": {},
+        }
+        self.checkpointer.wait_for_pending_save()
+        self.checkpointer.load(
+            load_dir,
+            state,
+            trainable_only=bool(self.args.lora_config),
+            parallel_state=self.parallel_state,
+        )
+        self._load_extra_state(state["extra_state"])
+        dist.barrier()
+        logger.info_rank0(f"Load distributed checkpoint from {load_dir} successfully!")
+
+    def _load_partial_dcp(self, model: OfflineEncodingMixin) -> None:
+        load_dir = self._load_dir()
+        if load_dir is None:
+            return
+        self.checkpointer.wait_for_pending_save()
+        model.load_partial_dcp_checkpoint(load_dir, trainer=self.runtime)
+        if dist.is_initialized():
+            dist.barrier()
+        logger.info_rank0(f"Load partial offline-cache checkpoint from {load_dir} successfully!")
+
+    # ── Save (DCP / HF / LoRA) ────────────────────────────────────────────────
+
+    def save_dcp(self, state: TrainerState) -> None:
+        model = self._offline_cache_model()
+        if model is not None:
+            model.save_partial_dcp_checkpoint(self._save_dir(state), trainer=self.runtime, state=state)
+            self._last_saved_step = state.global_step
+            return
+
+        args = self.args
+        save_checkpoint_path = self._save_dir(state)
+        ckpt_state = {
+            "model": self.runtime.model,
+            "optimizer": self.runtime.optimizer,
+            "extra_state": self._extra_state(state),
+        }
+        helper.empty_cache()
+        self.checkpointer.save(
+            save_checkpoint_path,
+            ckpt_state,
+            save_async=self.runtime.train.checkpoint.save_async,
+            trainable_only=bool(args.lora_config),
+            save_to_lowest_rank=self.runtime.train.checkpoint.dcp_save_to_lowest_rank,
+            parallel_state=self.parallel_state,
+        )
+        helper.empty_cache()
+        dist.barrier()
+        self._last_saved_step = state.global_step
+        logger.info_rank0(f"Distributed checkpoint saved at {save_checkpoint_path} successfully!")
+
+    def save_hf(self, state: TrainerState) -> None:
+        model = self._offline_cache_model()
+        if model is not None:
+            self._save_full_hf_offline_cache(model, state)
+            return
+
+        args = self.args
+        save_checkpoint_path = self._save_dir(state)
+        if not os.path.exists(save_checkpoint_path):
+            dist.barrier()
+            self.save_dcp(state)
+
+        self.checkpointer.wait_for_pending_save()
+
+        if state.stage == "train_end":
+            self.runtime.optimizer = None
+            self.runtime.lr_scheduler = None
+
+        hf_weights_path = self._hf_export_dir(state)
+        save_hf_safetensor(
+            save_hf_safetensor_path=hf_weights_path,
+            model_assets=self.runtime.collect_hf_export_assets(),
+            ckpt_manager=self.runtime.train.checkpoint.manager,
+            output_dir=self.runtime.train.checkpoint.output_dir,
+            save_checkpoint_path=save_checkpoint_path,
+            model=self.runtime.model,
+            fqn_to_index_mapping=args.fqn_to_index_mapping,
+            is_rank_0=self.runtime.train.global_rank == 0,
+            parallel_state=self.parallel_state,
+        )
+        helper.empty_cache()
+        dist.barrier()
+        self._last_saved_step = state.global_step
+
+    def save_lora(self, state: TrainerState) -> None:
+        save_checkpoint_path = self._save_dir(state)
+        if not os.path.exists(save_checkpoint_path):
+            dist.barrier()
+            self.save_dcp(state)
+
+        self.checkpointer.wait_for_pending_save()
+
+        if state.stage == "train_end":
+            self.runtime.optimizer = None
+            self.runtime.lr_scheduler = None
+
+        save_lora_adapter_with_dcp(
+            model=self.runtime.model,
+            save_path=self._output_dir(state),
+            adapter_name="default",
+        )
+        helper.empty_cache()
+        dist.barrier()
+        self._last_saved_step = state.global_step
+
+    def _save_full_hf_offline_cache(self, model: OfflineEncodingMixin, state: TrainerState) -> None:
+        hf_weights_path = self._hf_export_dir(state)
+        if self.runtime.train.global_rank == 0:
+            model.save_full_hf_checkpoint(
+                hf_weights_path,
+                source_path=self.args.model_path,
+                trainer=self.runtime,
+                state=state,
+            )
+        if dist.is_initialized():
+            dist.barrier()
+        self._last_saved_step = state.global_step
+
+    def save_hf_or_lora(self, state: TrainerState) -> None:
+        if self.args.lora_config:
+            self.save_lora(state)
+        else:
+            self.save_hf(state)
+
+
+__all__ = ["OmniModuleCheckpointManager"]

--- a/veomni/models/seed_omni/utils/checkpoint.py
+++ b/veomni/models/seed_omni/utils/checkpoint.py
@@ -72,8 +72,6 @@ class OmniModuleCheckpointManager:
     def parallel_state(self):
         return self.runtime.parallel_state
 
-    # ── Path helpers ──────────────────────────────────────────────────────────
-
     def _global_step_root(self, state: TrainerState) -> str:
         return os.path.join(self.runtime.train.checkpoint.save_path, f"global_step_{state.global_step}")
 
@@ -108,8 +106,6 @@ class OmniModuleCheckpointManager:
         if not isinstance(model, OfflineEncodingMixin) or model.cache_mode == "full":
             return None
         return model
-
-    # ── Load ──────────────────────────────────────────────────────────────────
 
     def load(self) -> None:
         model = self._offline_cache_model()
@@ -148,8 +144,6 @@ class OmniModuleCheckpointManager:
         if dist.is_initialized():
             dist.barrier()
         logger.info_rank0(f"Load partial offline-cache checkpoint from {load_dir} successfully!")
-
-    # ── Save (DCP / HF / LoRA) ────────────────────────────────────────────────
 
     def save_dcp(self, state: TrainerState) -> None:
         model = self._offline_cache_model()

--- a/veomni/models/seed_omni/utils/conversation.py
+++ b/veomni/models/seed_omni/utils/conversation.py
@@ -1,0 +1,232 @@
+"""``ConversationItem`` — the single carrier object of SeedOmni V2.
+
+The whole pipeline (training and inference) operates on one batched
+``conversation_list`` (``list[list[ConversationItem]]`` for training, a flat
+``list[ConversationItem]`` for one inference request).  Modules read and
+**mutate ``item.value`` in place** — there are no per-field edge channels;
+``OmniModel`` writes the (possibly grown) list back into the shared batch /
+``ctx`` after every node.
+
+Item shape
+----------
+Each item is ``{type, value, role, meta}``:
+
+* ``type``  — ``"text"`` | ``"image"`` | ``"video"`` | ``"output"``.  ``"output"``
+  is the transient row a backbone appends while generating; :func:`seal_outputs`
+  renames it to its final modality once the span closes.  Janus interleaved
+  generation also accepts the legacy ``"image_output"`` on input, which
+  ``JanusSiglip.generate`` re-encodes and seals to ``"image"``.
+* ``value`` — polymorphic: raw content (``str`` / PIL image / pixel tensor)
+  before encoding, an ``(L, D)`` / ``(1, L, D)`` embedding tensor after.
+* ``role``  — ``"user"`` | ``"assistant"`` | ``"dummy"`` (``"dummy"`` rows are
+  zero-tensor FSDP placeholders appended by encoders on text-only
+  micro-batches; the backbone skips them and folds a zero-grad anchor).
+* ``meta``  — per-module baggage written during forward (``labels`` /
+  ``attention_mask`` / ``janus_vqvae_labels`` / ``source`` / …).
+
+Lifecycle
+---------
+1. An item is born with a raw ``value`` (text string, PIL image, pixels).
+2. An encoder (SigLIP / VQVAE / text wte) overwrites ``value`` with its
+   embedding tensor.
+3. The backbone overwrites ``value`` again with the per-segment hidden state.
+4. During inference, backbone steps append ``type="output"`` rows; when a
+   modality span finishes, :func:`seal_outputs` renames the trailing
+   ``output`` row to ``"text"`` / ``"image"``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterator, Union
+
+import torch
+from PIL import Image
+
+
+ItemType = str  # "text" | "image" | "video" | "output" (+ legacy "image_output")
+ItemRole = str  # "user" | "assistant" | "dummy"
+ItemValue = Union[str, torch.Tensor, Image.Image]
+
+# Sentinel so ``__value_repr__`` can distinguish "repr self.value" (no arg) from
+# "repr this explicit meta value" (which may legitimately be ``None``).
+_UNSET = object()
+
+# Per-image data-tag key written on ``meta`` by the data layer (preprocessors).
+# Image-only: text items do NOT carry it. Values: ``"und"`` | ``"gen"`` | ``"edit"``
+# — a model-agnostic declaration of the image's role in the sample. Model-side
+# routing reads it via ``iter_desired_items(..., meta={_IMG_TAG_KEY: [...]})`` or
+# ``item.meta.get(_IMG_TAG_KEY)``; this module only owns the key.
+_IMG_TAG_KEY = "_img_tag"
+
+
+@dataclass
+class ConversationItem:
+    """One element of a conversation list — ``{type, value, role, meta}``."""
+
+    type: ItemType
+    value: ItemValue
+    role: ItemRole = "user"
+    source: str | None = None
+    meta: dict = field(default_factory=dict)
+
+    def __value_repr__(self, value: Any = _UNSET) -> str:
+        # Repr ``self.value`` by default; ``__meta_repr__`` passes meta values.
+        if value is _UNSET:
+            value = self.value
+        if isinstance(value, str):
+            return f"[str]{repr(value)}"
+        elif isinstance(value, torch.Tensor):
+            return f"[torch.Tensor]{tuple(value.shape)}"
+        elif isinstance(value, Image.Image):
+            return f"[PIL.Image]{value.size}"
+        elif hasattr(value, "video") and hasattr(value, "video_fps"):
+            # VideoInputs bundle — duck-typed so core conversation.py doesn't
+            # import the optional video/audio (ffmpeg/torchcodec/librosa) stack.
+            v = value
+            shape = tuple(v.video.shape) if isinstance(v.video, torch.Tensor) else type(v.video).__name__
+            parts = [f"video.shape={shape}", f"fps={v.video_fps}"]
+            audio = getattr(v, "audio", None)
+            if audio is not None:
+                audio_shape = tuple(audio.shape) if isinstance(audio, torch.Tensor) else type(audio).__name__
+                parts.append(f"audio.shape={audio_shape}")
+                parts.append(f"audio_fps={getattr(v, 'audio_fps', None)}")
+            return f"[VideoInputs | {', '.join(parts)}]"
+        else:
+            return f"[UnknownType]{type(value).__name__}"
+
+    def __meta_repr__(self) -> str:
+        meta_items = [f"{key}={self.__value_repr__(value)}" for key, value in self.meta.items()]
+        return f"{{{','.join(meta_items)}}}"
+
+    def __repr__(self) -> str:
+        return f"ConversationItem(type={self.type}, value={self.__value_repr__()}, role={self.role}, source={self.source}, meta={self.__meta_repr__()}"
+
+
+def is_dummy(item: ConversationItem) -> bool:
+    return item.role == "dummy"
+
+
+def maybe_merge_outputs(parts: list[ConversationItem]) -> bool:
+    """Merge the last two ``output`` rows in the same AR phase (concat on seq dim)."""
+    if len(parts) < 2:
+        return False
+    a, b = parts[-2], parts[-1]
+    if a.type != "output" or b.type != "output":
+        return False
+    emb_a, emb_b = a.value, b.value
+    emb_b = emb_b.to(device=emb_a.device, dtype=emb_a.dtype)
+    a.value = torch.cat([emb_a, emb_b], dim=-2)
+    parts.pop()
+    return True
+
+
+def seal_outputs(parts: list[ConversationItem], new_type: ItemType) -> None:
+    """Rename completed ``output`` spans to a sealed type (``text`` / ``image``)."""
+    assert parts[-1].type == "output"
+    parts[-1].type = new_type
+
+
+def build_conversation(
+    *,
+    prompt: str,
+    images: list[Any] | None = None,
+) -> list[ConversationItem]:
+    """Build the canonical conversation list for a single inference request."""
+    parts: list[ConversationItem] = []
+    for img in images or []:
+        parts.append(ConversationItem(type="image", value=img, role="user"))
+    parts.append(ConversationItem(type="text", value=prompt, role="user"))
+    return parts
+
+
+# ── Training batch helpers (unified with inference ConversationItem) ────────
+
+
+def iter_desired_items(
+    conversation_list: list[list[ConversationItem]],
+    types: list[str] | None = None,
+    roles: list[str] | None = None,
+    sources: list[str] | None = None,
+    reverse_item: bool = False,
+    *,
+    meta_keys: list[str] | None = None,
+    meta: dict[str, list[Any]] | None = None,
+) -> Iterator[ConversationItem]:
+    """Yield matching items in micro-batch order (sample 0, then sample 1, …).
+
+    ``meta`` requires every configured key to exist and its value to match one
+    of the corresponding allowed values.
+    """
+
+    for sample in conversation_list:
+        items = reversed(sample) if reverse_item else sample
+        for item in items:
+            if types is not None and item.type not in types:
+                continue
+            if roles is not None and item.role not in roles:
+                continue
+            if sources is not None and item.source not in sources:
+                continue
+            if meta_keys is not None and any(key not in item.meta for key in meta_keys):
+                continue
+            if meta is not None and any(
+                key not in item.meta or item.meta[key] not in allowed_values for key, allowed_values in meta.items()
+            ):
+                continue
+            yield item
+
+
+def get_tail_output_item(
+    conversation_list: list[ConversationItem],
+    *,
+    sources: list[str] | None = None,
+    roles: list[str] | None = None,
+    meta_keys: list[str] | None = None,
+) -> ConversationItem | None:
+    """Return the latest matching output item in a single conversation."""
+    return next(
+        iter_desired_items(
+            [conversation_list],
+            types=["output"],
+            roles=roles,
+            sources=sources,
+            reverse_item=True,
+            meta_keys=meta_keys,
+        ),
+        None,
+    )
+
+
+def collect_desired_values(
+    conversation_list: list[list[ConversationItem]],
+    types: list[str] | None = None,
+    roles: list[str] | None = None,
+    sources: list[str] | None = None,
+    *,
+    meta_keys: list[str] | None = None,
+) -> list[Any]:
+    """Flat ``item.value`` list for matching items in micro-batch order."""
+    return [
+        item.value
+        for item in iter_desired_items(
+            conversation_list,
+            types,
+            roles,
+            sources,
+            meta_keys=meta_keys,
+        )
+    ]
+
+
+__all__ = [
+    "ConversationItem",
+    "build_conversation",
+    "is_dummy",
+    "maybe_merge_outputs",
+    "seal_outputs",
+    "get_tail_output_item",
+    "iter_desired_items",
+    "collect_desired_values",
+    "_IMG_TAG_KEY",
+]

--- a/veomni/models/seed_omni/utils/conversation.py
+++ b/veomni/models/seed_omni/utils/conversation.py
@@ -100,7 +100,7 @@ class ConversationItem:
         return f"{{{','.join(meta_items)}}}"
 
     def __repr__(self) -> str:
-        return f"ConversationItem(type={self.type}, value={self.__value_repr__()}, role={self.role}, source={self.source}, meta={self.__meta_repr__()}"
+        return f"ConversationItem(type={self.type}, value={self.__value_repr__()}, role={self.role}, source={self.source}, meta={self.__meta_repr__()})"
 
 
 def is_dummy(item: ConversationItem) -> bool:

--- a/veomni/models/seed_omni/utils/convert_registry.py
+++ b/veomni/models/seed_omni/utils/convert_registry.py
@@ -1,0 +1,31 @@
+"""Registry for monolithic HF checkpoint → SeedOmni V2 split checkpoints.
+
+Each model family registers a converter under its upstream HuggingFace
+``model_type`` (read from ``config.json`` at ``model_path``).  The unified
+entry point is :func:`convert_checkpoint` (CLI: ``scripts/convert_model.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from ....utils.registry import Registry
+
+
+OMNI_CONVERT_REGISTRY = Registry("OmniConvert")
+
+ConvertFn = Callable[..., None]
+
+
+def convert_checkpoint(model_path: str, output_dir: str, **kwargs) -> None:
+    """Dispatch to the registered converter for ``model_path``'s ``model_type``."""
+    # Lazy import to break the convert_registry ↔ modules cycle: every family's
+    # ``convert_model`` (imported by ``modules/__init__``) imports this module.
+    from ..modules import read_hf_model_type
+
+    model_type = read_hf_model_type(model_path)
+    converter: ConvertFn = OMNI_CONVERT_REGISTRY[model_type]()
+    converter(model_path, output_dir, **kwargs)
+
+
+__all__ = ["OMNI_CONVERT_REGISTRY", "convert_checkpoint"]

--- a/veomni/models/seed_omni/utils/graph_profiler.py
+++ b/veomni/models/seed_omni/utils/graph_profiler.py
@@ -1,0 +1,113 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GraphProfiler — request-local execution path and optional node timing.
+
+This is deliberately graph-owned, not a module mixin: the graph knows state,
+node, transition, and endpoint identity.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from time import perf_counter
+from typing import TYPE_CHECKING, Iterator
+
+from ....utils.device import IS_CUDA_AVAILABLE, IS_NPU_AVAILABLE, get_torch_device
+
+
+if TYPE_CHECKING:
+    from ....arguments import OmniGraphProfileArguments
+
+
+class GraphProfiler:
+    """Collect graph execution path lines and optional per-node timing."""
+
+    def __init__(
+        self,
+        *,
+        enable_wall_time: bool = False,
+        enable_cuda_events: bool = False,
+        enable_memory: bool = False,
+    ) -> None:
+        self.enable_wall_time = enable_wall_time
+        self.enable_cuda_events = enable_cuda_events
+        self.enable_memory = enable_memory
+        self._lines: list[str] = []
+        if self.enable_memory:
+            self._reset_peak_memory_stats()
+
+    @classmethod
+    def from_config(cls, config: OmniGraphProfileArguments) -> GraphProfiler:
+        """Build from ``train.graph_profile`` args (the ``enable_*`` detail switches).
+
+        Shared by the trainer and the inferencer so the field list lives in one
+        place; each caller keeps its own gating (train step window vs. always-on
+        per request).
+        """
+        return cls(
+            enable_wall_time=config.enable_wall_time,
+            enable_cuda_events=config.enable_cuda_events,
+            enable_memory=config.enable_memory,
+        )
+
+    @contextmanager
+    def node(self, line: str) -> Iterator[None]:
+        start_wall = perf_counter() if self.enable_wall_time else None
+        start_event = end_event = None
+        if self.enable_cuda_events and (IS_CUDA_AVAILABLE or IS_NPU_AVAILABLE):
+            device = get_torch_device()
+            start_event = device.Event(enable_timing=True)
+            end_event = device.Event(enable_timing=True)
+            start_event.record()
+
+        try:
+            yield
+        finally:
+            suffixes: list[str] = []
+            if start_wall is not None:
+                suffixes.append(f"wall_ms={(perf_counter() - start_wall) * 1000:.3f}")
+            if start_event is not None and end_event is not None:
+                end_event.record()
+                end_event.synchronize()
+                suffixes.append(f"cuda_ms={start_event.elapsed_time(end_event):.3f}")
+            if self.enable_memory:
+                suffixes.extend(self._memory_suffixes())
+            self._lines.append(line + (f" | {' | '.join(suffixes)}" if suffixes else ""))
+
+    def record(self, line: str) -> None:
+        self._lines.append(line)
+
+    def save_records(self) -> list[str]:
+        return list(self._lines)
+
+    def _reset_peak_memory_stats(self) -> None:
+        device = get_torch_device()
+        reset = getattr(device, "reset_peak_memory_stats", None)
+        if reset is not None:
+            reset()
+
+    def _memory_suffixes(self) -> list[str]:
+        device = get_torch_device()
+        max_allocated = getattr(device, "max_memory_allocated", None)
+        max_reserved = getattr(device, "max_memory_reserved", None)
+        if max_allocated is None or max_reserved is None:
+            return []
+        return [
+            f"peak_allocated_gb={max_allocated() / (1024**3):.3f}",
+            f"peak_reserved_gb={max_reserved() / (1024**3):.3f}",
+        ]
+
+
+__all__ = ["GraphProfiler"]

--- a/veomni/models/seed_omni/utils/model_path.py
+++ b/veomni/models/seed_omni/utils/model_path.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-module checkpoint path resolution for a SeedOmni V2 model.
+
+A SeedOmni V2 checkpoint is a root folder with one subfolder per OmniModule,
+so a module's ``model_path`` is normally a bare name joined under that root.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from ....utils.fs import is_non_local
+
+
+def resolve_model_path(
+    model_path: str | os.PathLike,
+    modules_config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Join a relative per-module ``model_path`` under the checkpoint root.
+
+    A remote-scheme path counts as absolute: ``os.path.isabs("hdfs://ns/x")`` is
+    ``False``, so without the extra check a fully-qualified remote path would be
+    silently joined under the root as ``/local/root/hdfs://ns/x``.
+    """
+    if not modules_config:
+        return {}
+    checkpoint_root = str(model_path)
+    for mod_cfg in modules_config.values():
+        if not isinstance(mod_cfg, dict):
+            continue
+        resolved = mod_cfg.get("model_path") or mod_cfg.get("weights_path")
+        if resolved is None:
+            continue
+        if not os.path.isabs(resolved) and not is_non_local(resolved):
+            resolved = os.path.join(checkpoint_root, resolved)
+        mod_cfg["model_path"] = resolved
+    return modules_config

--- a/veomni/models/seed_omni/utils/offline_cache.py
+++ b/veomni/models/seed_omni/utils/offline_cache.py
@@ -1,0 +1,114 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import pickle
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from datasets import Dataset
+
+from ....distributed.parallel_state import get_parallel_state
+from ....utils import logging
+from .conversation import ConversationItem
+
+
+logger = logging.get_logger(__name__)
+
+
+class SeedOmniOfflineCacheWriter:
+    """Write cached SeedOmni conversation-carrier samples as parquet shards."""
+
+    def __init__(self, save_path: str, *, max_rows_per_shard: int = 1000) -> None:
+        parallel_state = get_parallel_state()
+        self.rank = parallel_state.dp_rank if parallel_state.dp_rank >= 0 else int(os.getenv("RANK", 0))
+        self.world_size = parallel_state.dp_size if parallel_state.dp_size > 0 else int(os.getenv("WORLD_SIZE", 1))
+        self.save_path = save_path
+        self.max_rows_per_shard = max_rows_per_shard
+        self.shard_index = 0
+        self.buffer: list[dict[str, bytes]] = []
+        self.rows_written = 0
+        os.makedirs(save_path, exist_ok=True)
+        logger.info_rank0(f"SeedOmni offline cache writer saving parquet shards under {save_path}.")
+
+    @staticmethod
+    def _cpu_recursive(value: Any) -> Any:
+        if isinstance(value, ConversationItem):
+            return ConversationItem(
+                type=value.type,
+                value=SeedOmniOfflineCacheWriter._cpu_recursive(value.value),
+                role=value.role,
+                source=value.source,
+                meta=SeedOmniOfflineCacheWriter._cpu_recursive(value.meta),
+            )
+        if isinstance(value, dict):
+            return {k: SeedOmniOfflineCacheWriter._cpu_recursive(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [SeedOmniOfflineCacheWriter._cpu_recursive(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(SeedOmniOfflineCacheWriter._cpu_recursive(v) for v in value)
+        if isinstance(value, torch.Tensor):
+            return value.detach().cpu()
+        return value
+
+    def save_conversation_list(self, conversation_list: list[list[ConversationItem]]) -> None:
+        for sample in conversation_list:
+            persisted = [self._cpu_recursive(item) for item in sample]
+            if not persisted:
+                continue
+
+            self.buffer.append({"conversation_list": pickle.dumps(persisted)})
+            self.rows_written += 1
+            if len(self.buffer) >= self.max_rows_per_shard:
+                self.flush()
+
+    def flush(self) -> None:
+        if not self.buffer:
+            return
+
+        dataset = Dataset.from_list(self.buffer)
+        global_shard_index = self.shard_index * self.world_size + self.rank
+        path = os.path.join(self.save_path, f"shard_{global_shard_index:06d}.parquet")
+        dataset.to_parquet(path)
+        logger.info(f"Rank {self.rank} wrote {len(self.buffer)} cached SeedOmni sample(s) to {path}.")
+        self.buffer = []
+        self.shard_index += 1
+
+    def finalize(self) -> None:
+        self.flush()
+        distributed = dist.is_available() and dist.is_initialized()
+        if distributed:
+            dist.barrier()
+
+        if not distributed or self.rank == 0:
+            self._compact_shard_names()
+
+        if distributed:
+            dist.barrier()
+
+    def _compact_shard_names(self) -> None:
+        shard_names = sorted(
+            name for name in os.listdir(self.save_path) if name.startswith("shard_") and name.endswith(".parquet")
+        )
+        for next_index, name in enumerate(shard_names):
+            target_name = f"shard_{next_index:06d}.parquet"
+            if name == target_name:
+                continue
+            os.replace(os.path.join(self.save_path, name), os.path.join(self.save_path, target_name))
+
+
+__all__ = ["SeedOmniOfflineCacheWriter"]

--- a/veomni/models/seed_omni/utils/offline_cache.py
+++ b/veomni/models/seed_omni/utils/offline_cache.py
@@ -43,6 +43,16 @@ class SeedOmniOfflineCacheWriter:
         self.buffer: list[dict[str, bytes]] = []
         self.rows_written = 0
         os.makedirs(save_path, exist_ok=True)
+        existing_shards = [
+            name for name in os.listdir(save_path) if name.startswith("shard_") and name.endswith(".parquet")
+        ]
+        if existing_shards:
+            raise FileExistsError(
+                f"SeedOmni offline cache directory {save_path} already contains "
+                f"{len(existing_shards)} shard file(s) from a previous run. Remove them "
+                f"before starting a new offline-cache write to avoid mixing stale shards "
+                f"into the compacted output."
+            )
         logger.info_rank0(f"SeedOmni offline cache writer saving parquet shards under {save_path}.")
 
     @staticmethod

--- a/veomni/models/seed_omni/utils/visualize.py
+++ b/veomni/models/seed_omni/utils/visualize.py
@@ -1,0 +1,110 @@
+"""Mermaid export helpers for SeedOmni training / generation graphs."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Protocol
+
+from ..graphs.generation_graph import GenerationGraph
+from ..graphs.training_graph import TrainingGraph
+
+
+class GraphConfig(Protocol):
+    """The graph surface these helpers need.
+
+    Satisfied by both :class:`~veomni.models.seed_omni.configuration_omni.OmniConfig`
+    and the launcher-side
+    :class:`~veomni.arguments.omni_arguments_types.OmniModelRuntimeArguments`,
+    so diagrams can be drawn without projecting the runtime view onto a checkpoint.
+    """
+
+    training_graph: list[dict]
+    generation_graphs: dict
+
+    @property
+    def infer_types(self) -> list[str]: ...
+
+    @property
+    def generation_graph(self) -> dict: ...
+
+
+GRAPH_VIS_SUBDIR = "graphs"
+TRAINING_MMD_FILENAME = "training.mmd"
+
+_SAFE_INFER_TYPE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+def render_training_mermaid(config: GraphConfig, *, title: str = "Training graph") -> str:
+    """Return Mermaid source for ``config.training_graph``."""
+    return TrainingGraph(config.training_graph).to_mermaid(title=title)
+
+
+def render_generation_mermaid(
+    config: GraphConfig,
+    *,
+    title: str = "Generation graph",
+    infer_type: str | None = None,
+) -> str:
+    """Return Mermaid source for one generation scenario (default: the active one)."""
+    graph = config.generation_graphs[infer_type] if infer_type is not None else config.generation_graph
+    return GenerationGraph(graph).to_mermaid(title=title)
+
+
+def generation_mmd_filename(infer_type: str) -> str:
+    """Sidecar diagram filename for scenario ``infer_type``.
+
+    Scenario names come from launcher YAML and land in a path here, so anything
+    that is not a single plain path segment is rejected rather than escaping the
+    diagram directory.
+    """
+    if not _SAFE_INFER_TYPE.fullmatch(infer_type):
+        raise ValueError(
+            f"Invalid infer_type {infer_type!r}: scenario names must match {_SAFE_INFER_TYPE.pattern} "
+            "so they can be used as diagram filenames."
+        )
+    return f"generation_{infer_type}.mmd"
+
+
+def write_mermaid_file(path: str | os.PathLike, body: str) -> None:
+    """Write raw Mermaid (``.mmd``) text to *path*."""
+    path = str(path)
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(body)
+        if not body.endswith("\n"):
+            f.write("\n")
+
+
+def save_graph_mermaid_diagrams(
+    config: GraphConfig,
+    save_directory: str | os.PathLike,
+    *,
+    training_title: str = "Training graph",
+    generation_title: str = "Generation graph",
+) -> list[str]:
+    """Write ``graphs/training.mmd`` plus one ``graphs/generation_<infer_type>.mmd`` per scenario."""
+    vis_dir = os.path.join(str(save_directory), GRAPH_VIS_SUBDIR)
+    training_path = os.path.join(vis_dir, TRAINING_MMD_FILENAME)
+    write_mermaid_file(training_path, render_training_mermaid(config, title=training_title))
+
+    paths = [training_path]
+    for infer_type in config.infer_types:
+        path = os.path.join(vis_dir, generation_mmd_filename(infer_type))
+        body = render_generation_mermaid(config, title=f"{generation_title} — {infer_type}", infer_type=infer_type)
+        write_mermaid_file(path, body)
+        paths.append(path)
+    return paths
+
+
+__all__ = [
+    "GRAPH_VIS_SUBDIR",
+    "TRAINING_MMD_FILENAME",
+    "generation_mmd_filename",
+    "render_generation_mermaid",
+    "render_training_mermaid",
+    "save_graph_mermaid_diagrams",
+    "write_mermaid_file",
+]


### PR DESCRIPTION
## Summary

Part of #1057 (SeedOmni V2 upstreaming plan) — implements #1062: the V2 core primitives, with no concrete model attached, so the graph/config/processing contracts get reviewed on their own terms before the Wave 3 model PRs start depending on them.

Depends on: #1058 (merged), #1060 (merged via #1090).

## What's in scope here

- `configuration_omni.py` / `modeling_omni.py` / `omni_pretrained_model.py` — `OmniConfig` (a plain HF `PretrainedConfig`), the eager graph forward/generate `OmniModel`, and the base `PreTrainedModel` wrapper.
- `graphs/` — training + generation FSM definitions (node/edge/end semantics), validation, mermaid export.
- `processing/` + `processing_omni.py` — `OmniProcessor.from_config()` composing the active modules' CPU preprocessors.
- `mixins/` — `base_mixin`, `training_module_mixin`, `inference_module_mixin`, `metric_meter_mixin`, `offline_encoding_mixin`, `emb_parallel_mixin`.
- `utils/` — `OmniModuleCheckpointManager`, conversation carrier, graph profiler, visualize, offline cache, convert registry, and a new `model_path.py::resolve_model_path` helper.
- `modules/` — `OMNI_{CONFIG,MODEL,PROCESSOR}_REGISTRY` plus the shared `modules/base/` (`text_encoder/` + `llm_packing.py`), which later Wave-3 model PRs (bagel, janus, qwen3, qwen3_moe, qwen3vl) register into without touching this PR's code.
- `loader.py` — consults the OMNI registries so `build_foundation_model` / `build_processor` work for an OmniModule sub-module exactly like any other model.

## What's deliberately out of scope

- `accelerator/` (`ModuleRuntime`, `OmniModelRuntime`, `execute_train_node`/`execute_generation_node`) — the FSDP-aware runtime layer is #1061/#1064.
- `OmniTrainer` / `OmniInferencer` / `OmniArguments` (the launcher argument schema) — #1064.
- The SeedOmni V2 data pipeline (`SeedOmniCollator`, conversation transform) — #1063.

The `omniv2` draft branch (#1056) doesn't actually split cleanly along these lines yet, so a few of the test files nominally listed under #1062's CI section needed adjustment against this PR's narrower scope:

- `test_graph.py` and `test_offline_encoding_mixin.py`: kept, with the handful of cases that exercised `OmniModelRuntime`/`execute_train_node`/`OmniTrainer`/`GraphProfileCallback` (i.e. #1064) or a concrete `bagel` module removed. Everything that exercises pure graph FSM / `OmniModel` / mixin behavior is kept.
- `test_omni_config_paths.py`: kept, but its target (`_resolve_model_path`) is extracted standalone into `seed_omni/utils/model_path.py` rather than pulled in via the full ~1000-line `OmniArguments` schema (#1064's file).
- `test_modules_mixin.py` and `test_preprocessor.py`: dropped from this PR — the large majority of both files' cases directly exercise `bagel`/`janus`/`qwen3`/`qwen3vl` concrete modules that don't exist until their respective Wave-3 PRs land.
- `test_img_tag.py` and `test_offline_cache_writer.py`: dropped — both test the SeedOmni V2 data pipeline (`veomni.data.seed_omni.*`), which is #1063's file scope, not #1062's.

Happy to move any of these back in, or split further, if a maintainer would rather see them land differently.

## CI

Wires `tests/seed_omni/` into `.github/workflows/gpu_unit_tests.yml` and `.github/workflows/npu_unit_tests.yml` — all CPU-only, no GPU/NPU-specific code touched.

## Test plan

```
pytest -q tests/seed_omni/
```
73 passed. Ran in a clean Python 3.12 container on Modal (torch 2.14.0, transformers 5.16.1, plus the repo's non-GPU base dependencies — the `gpu` extra's CUDA-pinned wheels weren't needed since nothing in this PR touches CUDA/Triton kernels).

`ruff check` and `ruff format --check` both clean on all new/changed files.

## Acceptance checklist (from #1062)

- [x] `pytest tests/seed_omni/` green on CPU
- [x] `OmniConfig` round-trips through `save_pretrained` / `from_pretrained` — independently verified beyond the test suite with a standalone script (multi-module config, `infer_type`/`generation_kwargs` set, checked all public accessors after reload, plus a second save→load pass for stability). `save_pretrained` writes `config.json` + `training_graph.yaml` + `generation_graph.yaml` + a `graphs/` dir (not a single flat JSON), and all of it round-tripped correctly.
- [x] Graph validation rejects dangling nodes, unknown endpoints and unreachable ends with actionable errors (see `test_graph.py`)
- [x] No import of `veomni.arguments` from `configuration_omni.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SeedOmni V2 support for composing, loading, generating with, and saving multimodal models.
  - Added conversation processing for text and images, including tokenization, chat templates, and batched requests.
  - Added configurable training and generation graphs with Mermaid visualization.
  - Added checkpoint conversion, per-module checkpoint management, offline caching, and model asset handling.
  - Added text encoder support with sampling, parallel execution, and metric collection.

- **Tests**
  - Added comprehensive coverage for conversations, graphs, processors, checkpoint handling, configuration, and offline encoding.
  - Added SeedOmni V2 test suites to GPU and NPU workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
